### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/satpy/satin/aapp1b.py
+++ b/satpy/satin/aapp1b.py
@@ -422,8 +422,8 @@ class AAPP1b(object):
 
     def __init__(self, fname):
         self.filename = fname
-        self.channels = dict([(i, None) for i in AVHRR_CHANNEL_NAMES])
-        self.units = dict([(i, 'counts') for i in AVHRR_CHANNEL_NAMES])
+        self.channels = {i: None for i in AVHRR_CHANNEL_NAMES}
+        self.units = {i: 'counts' for i in AVHRR_CHANNEL_NAMES}
 
         self._data = None
         self._header = None

--- a/satpy/satin/viirs_compact.py
+++ b/satpy/satin/viirs_compact.py
@@ -157,9 +157,9 @@ def load(satscene, *args, **kwargs):
 
 def read(h5f, channels, calibrate=1):
 
-    chan_dict = dict([(key.split("-")[1], key)
+    chan_dict = {key.split("-")[1]: key
                       for key in h5f["All_Data"].keys()
-                      if key.startswith("VIIRS")])
+                      if key.startswith("VIIRS")}
 
     scans = h5f["All_Data"]["NumberOfScans"][0]
     res = []


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:pytroll:satpy?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:pytroll:satpy?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)