### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/satpy/instruments/sarx.py
+++ b/satpy/instruments/sarx.py
@@ -58,7 +58,7 @@ class SarxCompositer(Compositer):
 
         self.check_channels(9.65)
 
-        if average_window == None:
+        if average_window is None:
             average_window = downscaling_factor
 
         LOG.info("Downsampling a factor %d and averaging " % downscaling_factor +

--- a/satpy/tests/test_channel.py
+++ b/satpy/tests/test_channel.py
@@ -71,7 +71,7 @@ class TestGenericChannel(unittest.TestCase):
         self.assert_(self.chan.area == "bla")
 
         self.chan.area = None
-        self.assert_(self.chan.area == None)
+        self.assert_(self.chan.area is None)
 
         class DummyArea(object):
             def __init__(self, area_extent, x_size, y_size, proj_id, proj_dict):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:pytroll:satpy?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:pytroll:satpy?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)