### PR TITLE
Fix "Consider an iterator instead of materializing the list" issue

### DIFF
--- a/satpy/tests/test_image.py
+++ b/satpy/tests/test_image.py
@@ -457,8 +457,8 @@ class TestRegularImage(unittest.TestCase):
             histo = np.array([[0.0, 0.99951171875, 0.99951171875], 
                               [0.99951171875, 0.39990234375, 0.39990234375]])
             self.img.stretch()
-            self.assert_(all([np.all(self.img.channels[i] == old_channels[i])
-                         for i in range(len(self.img.channels))]))
+            self.assert_(all(np.all(self.img.channels[i] == old_channels[i])
+                         for i in range(len(self.img.channels))))
             self.img.stretch("linear")
             self.assert_(np.all((self.img.channels[0] - linear) < EPSILON))
             self.img.stretch("crude")


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider an iterator instead of materializing the list](https://www.quantifiedcode.com/app/issue_class/53lnAzfW)
Issue details: [https://www.quantifiedcode.com/app/project/gh:pytroll:satpy?groups=code_patterns/%3A53lnAzfW](https://www.quantifiedcode.com/app/project/gh:pytroll:satpy?groups=code_patterns/%3A53lnAzfW)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)