### PR TITLE
Add MTG-FCI Level 1C netCDF reader

### DIFF
--- a/etc/readers/fci_fdhsi.yaml
+++ b/etc/readers/fci_fdhsi.yaml
@@ -1,0 +1,298 @@
+reader:
+  description: Generic FCI FDSHI Data Reader
+  name: fci_fdhsi
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader ''
+  sensors: [fci]
+  default_datasets:
+
+datasets:
+
+  vis_04:
+    name: vis_04
+    sensor: fci
+    wavelength: [0.384, 0.444, 0.504]
+    resolution: 1000
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  vis_05:
+    name: vis_05
+    sensor: fci
+    wavelength: [0.470, 0.510, 0.550]
+    resolution: 1000
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  vis_06:
+    name: vis_06
+    sensor: fci
+    wavelength: [0.590, 0.640, 0.690]
+    resolution: 1000
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  vis_06_hr:
+    name: vis_06_hr
+    sensor: fci
+    wavelength: [0.590, 0.640, 0.690]
+    resolution: 500
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  vis_08:
+    name: vis_08
+    sensor: fci
+    wavelength: [0.815, 0.865, 0.915]
+    resolution: 1000
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  vis_09:
+    name: vis_09
+    sensor: fci
+    wavelength: [0.894, 0.914, 0.934]
+    resolution: 1000
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  nir_13:
+    name: nir_13
+    sensor: fci
+    wavelength: [1.350, 1.380, 1.410]
+    resolution: 1000
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  nir_16:
+    name: nir_16
+    sensor: fci
+    wavelength: [1.560, 1.610, 1.660]
+    resolution: 1000
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  nir_22:
+    name: nir_22
+    sensor: fci
+    wavelength: [2.200, 2.250, 2.300]
+    resolution: 1000
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  nir_22_hr:
+    name: nir_22_hr
+    sensor: fci
+    wavelength: [2.200, 2.250, 2.300]
+    resolution: 500
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  ir_38:
+    name: ir_38
+    sensor: fci
+    wavelength: [3.400, 3.800, 4.200]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        standard_name: toa_brightness_temperature
+        units: "K"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  ir_38_hr:
+    name: ir_38_hr
+    sensor: fci
+    wavelength: [3.400, 3.800, 4.200]
+    resolution: 1000
+    calibration:
+      brightness_temperature:
+        standard_name: toa_brightness_temperature
+        units: "K"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+
+  wv_63:
+    name: ir_63
+    sensor: fci
+    wavelength: [5.300, 6.300, 7.300]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        standard_name: toa_brightness_temperature
+        units: "K"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fdhsi
+
+  wv_73:
+    name: ir_73
+    sensor: fci
+    wavelength: [6.850, 7.350, 7.850]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        standard_name: toa_brightness_temperature
+        units: "K"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fdhsi
+
+  ir_87:
+    name: ir_87
+    sensor: fci
+    wavelength: [8.300, 8.700, 9.100]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        standard_name: toa_brightness_temperature
+        units: "K"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  ir_97:
+    name: ir_97
+    sensor: fci
+    wavelength: [9.360, 9.660, 9.960]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        standard_name: toa_brightness_temperature
+        units: "K"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  ir_105:
+    name: ir_105
+    sensor: fci
+    wavelength: [9.800, 10.500, 11.200]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        standard_name: toa_brightness_temperature
+        units: "K"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  ir_105_hr:
+    name: ir_105_hr
+    sensor: fci
+    wavelength: [9.800, 10.500, 11.200]
+    resolution: 1000
+    calibration:
+      brightness_temperature:
+        standard_name: toa_brightness_temperature
+        units: "K"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+
+  ir_123:
+    name: ir_123
+    sensor: fci
+    wavelength: [11.800, 12.300, 12.800]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        standard_name: toa_brightness_temperature
+        units: "K"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+  ir_133:
+    name: ir_133
+    sensor: fci
+    wavelength: [12.700, 13.300, 13.900]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        standard_name: toa_brightness_temperature
+        units: "K"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+    file_type: fci_fdhsi
+
+
+# Source: FCI L1 Dataset User Guide [FCIL1DUG]
+# ftp://ftp.eumetsat.int/pub/OPS/out/test-data/FCI_L1C_Format_Familiarisation/FCI_L1_Dataset_User_Guide_[FCIL1DUG].pdf
+file_types:
+  fci_fdhsi:
+    file_reader: !!python/name:satpy.readers.fci_fdhsi.FCIFDHSIFileHandler ''
+    file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_evel}-{type}-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}-{oflag}-{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{accumulation_interval_in_day}.nc']

--- a/satpy/readers/fci_fdhsi.py
+++ b/satpy/readers/fci_fdhsi.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2016.
+
+# Author(s):
+
+#
+#   Thomas Leppelt <thomas.leppelt@dwd.de>
+#   Sauli Joro <sauli.joro@icloud.com>
+
+# This file is part of satpy.
+
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Interface to MTG-FCI Retrieval NetCDF files
+
+"""
+import os.path
+from datetime import datetime, timedelta
+import numpy as np
+from pyresample import geometry
+import h5netcdf
+import logging
+from collections import defaultdict
+
+from satpy.projectable import Projectable
+from satpy.readers.file_handlers import BaseFileHandler
+
+logger = logging.getLogger(__name__)
+
+
+class FCIFDHSIFileHandler(BaseFileHandler):
+    """MTG FCI FDHSI File Reader
+    """
+
+    def __init__(self, filename, filename_info, filetype_info):
+        super(FCIFDHSIFileHandler, self).__init__(filename, filename_info,
+                                        filetype_info)
+        logger.debug("READING: %s" % filename)
+        logger.debug("START: %s" % self.start_time)
+        logger.debug("START: %s" % self.end_time)
+        
+        self.nc = h5netcdf.File(filename, 'r')
+        print('OPENING')
+        self.filename = filename
+        self.cache = {}
+
+    @property
+    def start_time(self):
+        
+        return self.filename_info['start_time']
+        #return datetime.strptime(self.nc.attrs['/attr/end_time'], '%Y%m%d%H%M%S')
+
+    @property
+    def end_time(self):
+        return self.filename_info['end_time']
+        #return datetime.strptime(self.nc.attrs['/attr/start_time'], '%Y%m%d%H%M%S')
+
+    def get_dataset(self, key, info=None):
+        """Load a dataset
+        """
+        if key in self.cache:
+            return self.cache[key]
+
+        logger.debug('Reading %s.', key.name)
+        measured = self.nc['/data/%s/measured' % key.name]
+        variable = self.nc['/data/%s/measured/effective_radiance' % key.name]
+
+        # Get start/end line and column of loaded swath.
+
+        self.startline = int(measured.variables['start_position_row'][...])
+        self.endline = int(measured.variables['end_position_row'][...])
+        self.startcol = int(measured.variables['start_position_column'][...])
+        self.endcol = int(measured.variables['end_position_column'][...])
+        
+        ds = (np.ma.masked_equal(variable[:],
+                                 variable.attrs['_FillValue']) *
+              (variable.attrs['scale_factor'] * 1.0) +
+              variable.attrs.get('add_offset', 0))
+        out = Projectable(ds, dtype=np.float32)
+
+        self.cache[key] = out
+        self.nlines, self.ncols = ds.shape
+
+        return out
+
+    def calc_area_extent(self, key):
+        # Calculate the area extent of the swath based on start line and column
+        # information, total number of segments and channel resolution
+        xyres = {500 : 22272, 1000 : 11136, 2000 : 5568}
+        chkres = xyres[key.resolution]
+        logger.debug(chkres)
+        logger.debug("ROW/COLS: %d / %d" % (self.nlines, self.ncols))
+        logger.debug("START/END ROW: %d / %d" % (self.startline, self.endline))
+        logger.debug("START/END COL: %d / %d" % (self.startcol, self.endcol))
+        total_segments = 70 
+
+        # Calculate full globe line extent
+        max_y = 5432229.9317116784
+        min_y = -5429229.5285458621
+        full_y = max_y + abs(min_y)
+        # Single swath line extent
+        res_y = full_y / chkres # Extent per pixel resolution
+        startl = min_y + res_y * self.startline - 0.5 * (res_y)
+        endl = min_y + res_y * self.endline + 0.5 * (res_y)
+        logger.debug("START / END EXTENT: %d / %d" % (startl, endl))
+
+        chk_extent = (-5432229.9317116784, endl,
+                        5429229.5285458621, startl)
+        return(chk_extent)
+
+    def get_area_def(self, key, info):
+        #TODO Projection information are hard coded for 0 degree geos projection
+        # Test dataset doen't provide the values in the file container.
+        # Only fill values are inserted
+        #cfac = np.uint32(self.proj_info['CFAC'])
+        #lfac = np.uint32(self.proj_info['LFAC'])
+        #coff = np.float32(self.proj_info['COFF'])
+        #loff = np.float32(self.proj_info['LOFF'])
+        #a = self.nc['/state/processor/earth_equatorial_radius']
+        a = 6378169.
+        #h = self.nc['/state/processor/reference_altitude'] * 1000 - a
+        h=35785831.
+        #b = self.nc['/state/processor/earth_polar_radius']
+        b=6356583.8
+        #lon_0 = self.nc['/state/processor/projection_origin_longitude']
+        lon_0 = 0.
+        #nlines = self.nc['/state/processor/reference_grid_number_of_columns']
+        #ncols = self.nc['/state/processor/reference_grid_number_of_rows']
+        #nlines = 5568
+        #ncols = 5568
+        # Channel dependent swath resoultion
+        area_extent = self.calc_area_extent(key)
+        logger.debug("Calculated area extent: %s" % ''.join(str(area_extent)))
+
+        #c, l = 0, (1 + self.total_segments - self.segment_number) * nlines
+        #ll_x, ll_y = (c - coff) / cfac * 2**16, (l - loff) / lfac * 2**16
+        #c, l = ncols, (1 + self.total_segments -
+        #                self.segment_number) * nlines - nlines
+        #ur_x, ur_y = (c - coff) / cfac * 2**16, (l - loff) / lfac * 2**16
+
+        #area_extent = (np.deg2rad(ll_x) * h, np.deg2rad(ur_y) * h,
+        #               np.deg2rad(ur_x) * h, np.deg2rad(ll_y) * h)
+        #area_extent = (-5432229.9317116784, -5429229.5285458621,
+        #                5429229.5285458621, 5432229.9317116784)
+
+        proj_dict = {'a': float(a),
+                     'b': float(b),
+                     'lon_0': float(lon_0),
+                     'h': float(h),
+                     'proj': 'geos',
+                     'units': 'm'}
+
+        area = geometry.AreaDefinition(
+            'some_area_name',
+            "On-the-fly area",
+            'geosfci',
+            proj_dict,
+            self.ncols,
+            self.nlines,
+            area_extent)
+
+        self.area = area
+        return area
+

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -461,7 +461,7 @@ class FileYAMLReader(AbstractYAMLReader):
                     break
                 if (final_area.area_extent[0] == area_def.area_extent[0] and
                         final_area.area_extent[2] == area_def.area_extent[2] and
-                        final_area.area_extent[1] == area_def.area_extent[3]):
+                        np.isclose(final_area.area_extent[1], area_def.area_extent[3])):
                     current_extent = list(final_area.area_extent)
                     current_extent[1] = area_def.area_extent[1]
                     final_area.area_extent = current_extent


### PR DESCRIPTION
The test dataset from EUMETSAT for the FCI Level 1C Format Familiarisation
is used to implement the reader in satpy. Limitations due to missing
meta data for satellite georeferencing and calibration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytroll/satpy/13)
<!-- Reviewable:end -->
