### PR TITLE
Mock pyresample.ewa

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -39,7 +39,7 @@ class Mock(object):
             return Mock()
 
 MOCK_MODULES = ['Image', 'pyhdf.SD', 'pyhdf.error', 'numpy', 'numpy.core',
-                'numpy.core.multiarray', 'pyresample', 'pyresample.utils',
+                'numpy.core.multiarray', 'pyresample', 'pyresample.utils', 'pyresample.ewa',
                 'pyresample.geometry', 'pyresample.kd_tree', 'h5py',
                 'trollsift', 'trollsift.parser', 'trollimage', 'trollimage.image', 'netCDF4',
                 'pyproj', 'scipy', 'scipy.special', 'mipp', 'osgeo']


### PR DESCRIPTION
Mock pyresample.ewa to prevent sphinx from importing the module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytroll/satpy/21)
<!-- Reviewable:end -->
