### PR TITLE
WIP: Refactor Scene dependency tree

### DIFF
--- a/satpy/__init__.py
+++ b/satpy/__init__.py
@@ -30,6 +30,6 @@
 """
 
 from satpy.version import __version__
-from satpy.scene import Scene
 from satpy.projectable import Dataset, Projectable
-from satpy.readers import DatasetID, DatasetDict
+from satpy.readers import DatasetID, DatasetDict, DATASET_KEYS
+from satpy.scene import Scene

--- a/satpy/__init__.py
+++ b/satpy/__init__.py
@@ -32,3 +32,4 @@
 from satpy.version import __version__
 from satpy.scene import Scene
 from satpy.projectable import Dataset, Projectable
+from satpy.readers import DatasetID, DatasetDict

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -63,14 +63,15 @@ class CompositorLoader(object):
         self.ppp_config_dir = ppp_config_dir
 
     def load_sensor_composites(self, sensor_name):
+        """Load all compositor configs for the provided sensor."""
         config_filename = sensor_name + ".yaml"
         LOG.debug("Looking for composites config file %s", config_filename)
         composite_configs = config_search_paths(
             os.path.join("composites", config_filename),
             self.ppp_config_dir, check_exists=True)
         if not composite_configs:
-            LOG.debug("No composite config found called %s",
-                      config_filename)
+            LOG.debug("No composite config found called {}".format(
+                config_filename))
             return
         self._load_config(composite_configs)
 
@@ -80,7 +81,7 @@ class CompositorLoader(object):
                 return self.compositors[sensor_name][key]
             except KeyError:
                 continue
-        raise KeyError("Could not find compositor '%s'" % (key,))
+        raise KeyError("Could not find compositor '{}'".format(key))
 
     def get_modifier(self, key, sensor_names):
         for sensor_name in sensor_names:
@@ -88,9 +89,28 @@ class CompositorLoader(object):
                 return self.modifiers[sensor_name][key]
             except KeyError:
                 continue
-        raise KeyError("Could not find modifier '%s'" % (key,))
+        raise KeyError("Could not find modifier '{}'".format(key))
 
     def load_compositors(self, sensor_names):
+        """Load all compositor configs for the provided sensors.
+
+        Args:
+            sensor_names (list of strings): Sensor names that have matching
+                                            ``sensor_name.yaml`` config files.
+
+        Returns:
+            (comps, mods): Where `comps` is a dictionary:
+
+                    sensor_name -> composite ID -> compositor object
+
+                And `mods` is a dictionary:
+
+                    sensor_name -> modifier name -> (modifier class,
+                    modifiers options)
+
+                Note that these dictionaries are copies of those cached in
+                this object.
+        """
         comps = {}
         mods = {}
         for sensor_name in sensor_names:

--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -27,7 +27,6 @@ import logging
 import os
 
 import numpy as np
-from scipy.special import erf
 
 from satpy.composites import CompositeBase, IncompatibleAreas
 from satpy.config import get_environ_ancpath
@@ -181,9 +180,8 @@ class ReflectanceCorrector(CompositeBase):
         self.dem_sds = kwargs.pop("dem_sds", "averaged elevation")
         super(ReflectanceCorrector, self).__init__(*args, **kwargs)
 
-    def __call__(self, (refl_data, sensor_aa, sensor_za, solar_aa, solar_za),
-                 **info):
-
+    def __call__(self, datasets, **info):
+        refl_data, sensor_aa, sensor_za, solar_aa, solar_za = datasets
         if refl_data.info.get("rayleigh_corrected"):
             return refl_data
 
@@ -191,6 +189,7 @@ class ReflectanceCorrector(CompositeBase):
             LOG.debug("Loading CREFL averaged elevation information from: %s",
                       self.dem_file)
             from netCDF4 import Dataset
+            # HDF4 file, NetCDF library needs to be compiled with HDF4 support
             nc = Dataset(self.dem_file, "r")
             avg_elevation = nc.variables[self.dem_sds][:]
         else:
@@ -444,6 +443,7 @@ class ERFDNB(CompositeBase):
         if len(datasets) != 4:
             raise ValueError("Expected 4 datasets, got %d" % (len(datasets), ))
 
+        from scipy.special import erf
         dnb_data = datasets[0]
         sza_data = datasets[1]
         lza_data = datasets[2]

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -306,18 +306,19 @@ class DependencyTree(Node):
         for key in dataset_keys.copy():
             if key in self:
                 n = self[key]
+                unknowns = None
             else:
                 n, unknowns = self._find_dependencies(key,
                                                       calibration=calibration,
                                                       polarization=polarization,
                                                       resolution=resolution)
 
-                dataset_keys.discard(key)  # remove old non-DatasetID
-                if n is not None:
-                    dataset_keys.add(n.name)  # add equivalent DatasetID
-                if unknowns:
-                    unknown_datasets.update(unknowns)
-                    continue
+            dataset_keys.discard(key)  # remove old non-DatasetID
+            if n is not None:
+                dataset_keys.add(n.name)  # add equivalent DatasetID
+            if unknowns:
+                unknown_datasets.update(unknowns)
+                continue
 
             self.add_child(self, n)
 

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -21,6 +21,11 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Nodes to build trees."""
 
+import logging
+from satpy import DatasetID, DatasetDict
+
+LOG = logging.getLogger(__name__)
+
 
 class Node(object):
     """A node object."""
@@ -40,6 +45,13 @@ class Node(object):
         for child in self.children:
             child.flatten(d=d)
         return d
+
+    def copy(self):
+        s = Node(self.name, self.data)
+        for c in self.children:
+            c = c.copy()
+            s.add_child(c)
+        return s
 
     def add_child(self, obj):
         """Add a child to the node."""
@@ -91,29 +103,223 @@ class Node(object):
 
 
 class DependencyTree(Node):
-    def __init__(self):  #, readers, compositors, modifiers):
-        # self.readers = readers
-        # self.compositors = compositors
-        # self.modifiers = modifiers
+    def __init__(self, readers, compositors, modifiers):
+        self.readers = readers
+        self.compositors = compositors
+        self.modifiers = modifiers
         # we act as the root node of the tree
         super(DependencyTree, self).__init__(None)
+
         # keep a flat dictionary of nodes contained in the tree for better
         # __contains__
-        self._flattened = {}
+        self._all_nodes = DatasetDict()
 
-    def add_child(self, obj):
-        ret = super(DependencyTree, self).add_child(obj)
-        # only works if children are added bottom to top (leaves first)
-        obj.flatten(d=self._flattened)
-        return ret
+    def add_child(self, parent, child):
+        Node.add_child(parent, child)
+        self._all_nodes[child.name] = child
 
-    def flatten(self, d=None):
-        return super(DependencyTree, self).flatten(d=self._flattened)
+    def copy(self):
+        """Copy the this node tree
+
+        Note all references to readers are removed. This is meant to avoid
+        tree copies accessing readers that would return incompatible (Area)
+        data. Theoretically it should be possible for tree copies to request
+        compositor or modifier information as long as they don't depend on
+        any datasets not already existing in the dependency tree.
+        """
+        new_tree = DependencyTree({}, self.compositors, self.modifiers)
+        for c in self.children:
+            c = c.copy()
+            new_tree.add_child(new_tree, c)
+        new_tree._all_nodes = new_tree.flatten(d=self._all_nodes)
+        return new_tree
 
     def __contains__(self, item):
-        return item in self._flattened
+        return item in self._all_nodes
 
-    def update(self, other):
-        self.flatten()
-        for child in other.children:
-            self.children.append(child)
+    def __getitem__(self, item):
+        return self._all_nodes[item]
+
+    # def update(self, other):
+    #     self.flatten()
+    #     for child in other.children:
+    #         self.children.append(child)
+
+    def get_compositor(self, key):
+        for sensor_name in self.compositors.keys():
+            try:
+                return self.compositors[sensor_name][key]
+            except KeyError:
+                continue
+
+        if isinstance(key, DatasetID) and key.modifiers:
+            # we must be generating a modifier composite
+            return self.get_modifier(key)
+
+        raise KeyError("Could not find compositor '%s'" % (key,))
+
+    def get_modifier(self, comp_id):
+        # create a DatasetID for the compositor we are generating
+        modifier = comp_id.modifiers[-1]
+        # source_id = DatasetID(*comp_id[:-1] + (comp_id.modifiers[:-1]))
+        for sensor_name in self.modifiers.keys():
+            modifiers = self.modifiers[sensor_name]
+            compositors = self.compositors[sensor_name]
+            if modifier not in modifiers:
+                continue
+
+            mloader, moptions = modifiers[modifier]
+            moptions = moptions.copy()
+            moptions.update(comp_id.to_dict())
+            moptions['id'] = comp_id
+            # moptions['prerequisites'] = (
+            #     [source_id] + moptions['prerequisites'])
+            moptions['sensor'] = sensor_name
+            compositors[comp_id] = mloader(**moptions)
+            return compositors[comp_id]
+
+        return KeyError("Could not find modifier '%s'" % (modifier,))
+
+    def _find_reader_dataset(self,
+                             dataset_key,
+                             calibration=None,
+                             polarization=None,
+                             resolution=None):
+        for reader_name, reader_instance in self.readers.items():
+            try:
+                ds_id = reader_instance.get_dataset_key(dataset_key,
+                                                        calibration=calibration,
+                                                        polarization=polarization,
+                                                        resolution=resolution)
+            except KeyError as err:
+                # LOG.debug("Can't find dataset %s in reader %s",
+                #           str(dataset_key), reader_name)
+                pass
+            else:
+                # LOG.debug("Found {} in reader {}".format(str(ds_id), reader_name))
+                return Node(ds_id, {'reader_name': reader_name})
+
+    def _get_compositor_prereqs(self, prereq_names, skip=False, **kwargs):
+        prereq_ids = []
+        unknowns = set()
+        for prereq in prereq_names:
+            n, u = self._find_dependencies(prereq, **kwargs)
+            if u:
+                unknowns.update(u)
+                if skip:
+                    u_str = ", ".join([str(x) for x in u])
+                    LOG.debug('Skipping optional %s: Unknown dataset %s',
+                              str(prereq), u_str)
+            else:
+                prereq_ids.append(n)
+        return prereq_ids, unknowns
+
+    def _find_compositor(self, dataset_key, **kwargs):
+        # NOTE: This function can not find a modifier that performs one or more modifications
+        # if it has modifiers see if we can find the unmodified version first
+        src_node = None
+        if isinstance(dataset_key, DatasetID) and dataset_key.modifiers:
+            new_prereq = DatasetID(*dataset_key[:-1] + (dataset_key.modifiers[:-1],))
+            src_node, u = self._find_dependencies(new_prereq, **kwargs)
+            if u:
+                return None, u
+            dataset_key = DatasetID(*src_node.name[:-1] + (dataset_key.modifiers,))
+
+        try:
+            compositor = self.get_compositor(dataset_key)
+        except KeyError:
+            raise KeyError("Can't find anything called %s" %
+                           (str(dataset_key),))
+
+        dataset_key = compositor.info['id']
+        # 2.1 get the prerequisites
+        prereqs, unknowns = self._get_compositor_prereqs(
+            compositor.info['prerequisites'],
+            **kwargs)
+        if unknowns:
+            return None, unknowns
+
+        optional_prereqs, _ = self._get_compositor_prereqs(
+            compositor.info['optional_prerequisites'],
+            skip=True,
+            **kwargs)
+
+        # Is this the right place for that?
+        if src_node is not None:
+            prereqs = [src_node] + prereqs
+        root = Node(dataset_key, data=(compositor, prereqs, optional_prereqs))
+        # LOG.debug("Found composite {}".format(str(dataset_key)))
+        for prereq in prereqs + optional_prereqs:
+            if prereq is not None:
+                self.add_child(root, prereq)
+
+        return root, set()
+
+    def _find_dependencies(self,
+                           dataset_key,
+                           calibration=None,
+                           polarization=None,
+                           resolution=None,
+                           **kwargs):
+        """Find the dependencies for *dataset_key*."""
+        # 0 check if the dataset is already loaded
+        try:
+            if dataset_key in self:
+                return self[dataset_key], set()
+        except KeyError:
+            # there could be more than one matching dataset, which is fine
+            pass
+
+        # 1 try to get dataset from reader
+        node = self._find_reader_dataset(dataset_key,
+                                         calibration=calibration,
+                                         polarization=polarization,
+                                         resolution=resolution)
+        if node is not None:
+            return node, set()
+
+        # 2 try to find a composite that matches
+        try:
+            node, unknowns = self._find_compositor(dataset_key, **kwargs)
+        except KeyError:
+            node = None
+            unknowns = set([dataset_key])
+
+        return node, unknowns
+
+    def find_dependencies(self,
+                          dataset_keys,
+                          calibration=None,
+                          polarization=None,
+                          resolution=None):
+        """Create the dependency tree.
+
+        Args:
+            dataset_keys (iterable): Strings or DatasetIDs to find dependencies for
+            calibration (iterable or None):
+
+        Returns:
+            (Node, set): Root node of the dependency tree and a set of unknown datasets
+
+        """
+        unknown_datasets = set()
+        for key in dataset_keys.copy():
+            if key in self:
+                n = self[key]
+            else:
+                n, unknowns = self._find_dependencies(key,
+                                                      calibration=calibration,
+                                                      polarization=polarization,
+                                                      resolution=resolution)
+
+                dataset_keys.discard(key)  # remove old non-DatasetID
+                if n is not None:
+                    dataset_keys.add(n.name)  # add equivalent DatasetID
+                if unknowns:
+                    unknown_datasets.update(unknowns)
+                    continue
+
+            self.add_child(self, n)
+
+        return unknown_datasets
+

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -25,8 +25,9 @@
 class Node(object):
     """A node object."""
 
-    def __init__(self, data):
+    def __init__(self, name, data=None):
         """Init the node object."""
+        self.name = name
         self.data = data
         self.children = []
         self.parents = []
@@ -40,10 +41,11 @@ class Node(object):
         """Display the node."""
         return self.display()
 
-    def display(self, previous=0):
+    def display(self, previous=0, include_data=False):
         """Display the node."""
+        no_data = " (No Data)" if self.data is None else ""
         return (
-            (" +" * previous) + str(self.data) + '\n' +
+            (" +" * previous) + str(self.name) + no_data + '\n' +
             ''.join([child.display(previous + 1) for child in self.children]))
 
     def leaves(self):
@@ -60,7 +62,7 @@ class Node(object):
         """Get the trunk of the tree starting at this root."""
         res = []
         if self.children:
-            if self.data is not None:
+            if self.name is not None:
                 res.append(self)
             for child in self.children:
                 res.extend(child.trunk())

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -41,6 +41,12 @@ class Node(object):
         """Display the node."""
         return self.display()
 
+    def __eq__(self, other):
+        return self.name == other.name
+
+    def __hash__(self):
+        return hash(self.name)
+
     def display(self, previous=0, include_data=False):
         """Display the node."""
         no_data = " (No Data)" if self.data is None else ""
@@ -48,22 +54,26 @@ class Node(object):
             (" +" * previous) + str(self.name) + no_data + '\n' +
             ''.join([child.display(previous + 1) for child in self.children]))
 
-    def leaves(self):
+    def leaves(self, unique=True):
         """Get the leaves of the tree starting at this root."""
         if not self.children:
             return [self]
         else:
             res = list()
             for child in self.children:
-                res.extend(child.leaves())
+                for sub_child in child.leaves(unique=unique):
+                    if not unique or sub_child not in res:
+                        res.append(sub_child)
             return res
 
-    def trunk(self):
+    def trunk(self, unique=True):
         """Get the trunk of the tree starting at this root."""
         res = []
         if self.children:
             if self.name is not None:
                 res.append(self)
             for child in self.children:
-                res.extend(child.trunk())
+                for sub_child in child.trunk(unique=unique):
+                    if not unique or sub_child not in res:
+                        res.append(sub_child)
         return res

--- a/satpy/projectable.py
+++ b/satpy/projectable.py
@@ -370,7 +370,7 @@ class Dataset(np.ma.MaskedArray):
             pass
 
         for key in sorted(self.info.keys()):
-            if key == "wavelength_range":
+            if key == "wavelength":
                 res.append("{0}: {1} μm".format(key, self.info[key]))
             elif key == "resolution":
                 res.append("{0}: {1} m".format(key, self.info[key]))

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -105,6 +105,9 @@ class DatasetID(DatasetID):
 
         return cls(*args)
 
+    def to_dict(self):
+        return dict(zip(DATASET_KEYS, self))
+
 AREA_KEYS = ("name", "resolution", "terrain_correction")
 AreaID = namedtuple("AreaID", " ".join(AREA_KEYS))
 AreaID.__new__.__defaults__ = (None, None, None, None, None)

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -260,16 +260,17 @@ class DatasetDict(dict):
                         "One of 'name' or 'wavelength' info values should be set.")
 
         # update the 'value' with the information contained in the key
-        d["name"] = key.name
-        # XXX: What should users be allowed to modify?
-        d["resolution"] = key.resolution
-        d["calibration"] = key.calibration
-        d["polarization"] = key.polarization
-        d["modifiers"] = key.modifiers
-        d['id'] = key
-        # you can't change the wavelength of a dataset, that doesn't make sense
-        if "wavelength" in d and d["wavelength"] != key.wavelength:
-            raise TypeError("Can't change the wavelength of a dataset")
+        if hasattr(d, '__setitem__'):
+            d["name"] = key.name
+            # XXX: What should users be allowed to modify?
+            d["resolution"] = key.resolution
+            d["calibration"] = key.calibration
+            d["polarization"] = key.polarization
+            d["modifiers"] = key.modifiers
+            d['id'] = key
+            # you can't change the wavelength of a dataset, that doesn't make sense
+            if "wavelength" in d and d["wavelength"] != key.wavelength:
+                raise TypeError("Can't change the wavelength of a dataset")
 
         return super(DatasetDict, self).__setitem__(key, value)
 

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -63,6 +63,21 @@ class MalformedConfigError(Exception):
     pass
 
 
+def dataset_name_match(a, b):
+    return a == b
+
+
+def dataset_wavelength_match(a, b):
+    if type(a) == type(b):
+        return a == b
+    elif isinstance(a, (list, tuple)) and len(a) == 3:
+        return a[0] <= b <= a[2]
+    elif isinstance(b, (list, tuple)) and len(b) == 3:
+        return b[0] <= a <= b[2]
+    else:
+        raise ValueError("Can only compare wavelengths of length 1 or 3")
+
+
 class DatasetDict(dict):
     """Special dictionary object that can handle dict operations based on dataset name, wavelength, or DatasetID
 
@@ -81,19 +96,6 @@ class DatasetDict(dict):
         else:
             return keys
 
-    def _name_match(self, a, b):
-        return a == b
-
-    def _wl_match(self, a, b):
-        if type(a) == type(b):
-            return a == b
-        elif isinstance(a, (list, tuple)) and len(a) == 3:
-            return a[0] <= b <= a[2]
-        elif isinstance(b, (list, tuple)) and len(b) == 3:
-            return b[0] <= a <= b[2]
-        else:
-            raise ValueError("Can only compare wavelengths of length 1 or 3")
-
     def get_key(self, key):
         if isinstance(key, DatasetID):
             res = self.get_keys_by_datasetid(key)
@@ -106,13 +108,13 @@ class DatasetDict(dict):
         # get by wavelength
         elif isinstance(key, numbers.Number):
             for k in self.keys():
-                if k.wavelength is not None and self._wl_match(k.wavelength,
-                                                               key):
+                if k.wavelength is not None and \
+                        dataset_wavelength_match(k.wavelength, key):
                     return k
         # get by name
         else:
             for k in self.keys():
-                if self._name_match(k.name, key):
+                if dataset_name_match(k.name, key):
                     return k
 
     def get_keys(self,
@@ -124,10 +126,10 @@ class DatasetDict(dict):
         # Get things that match at least the name_or_wl
         if isinstance(name_or_wl, numbers.Number):
             keys = [k for k in self.keys()
-                    if self._wl_match(k.wavelength, name_or_wl)]
+                    if dataset_wavelength_match(k.wavelength, name_or_wl)]
         elif isinstance(name_or_wl, (str, six.text_type)):
             keys = [k for k in self.keys()
-                    if self._name_match(k.name, name_or_wl)]
+                    if dataset_name_match(k.name, name_or_wl)]
         else:
             raise TypeError("First argument must be a wavelength or name")
 
@@ -163,7 +165,7 @@ class DatasetDict(dict):
             if getattr(did, key) is not None:
                 if key == "wavelength":
                     keys = [k for k in keys
-                            if getattr(k, key) is not None and self._wl_match(
+                            if getattr(k, key) is not None and dataset_wavelength_match(
                                 getattr(k, key), getattr(did, key))]
 
                 else:

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -53,7 +53,48 @@ DATASET_KEYS = ("name", "wavelength", "resolution", "polarization",
                 "calibration", "modifiers")
 DatasetID = namedtuple("DatasetID", " ".join(DATASET_KEYS))
 DatasetID.__new__.__defaults__ = (None, None, None, None, None, None)
+
+
 class DatasetID(DatasetID):
+    """Identifier for all `Dataset` objects.
+
+    DatasetID is a namedtuple that holds identifying and classifying
+    information about a Dataset. There are two identifying elements,
+    ``name`` and ``wavelength``. These can be used to generically refer to a
+    Dataset. The other elements of a DatasetID are meant to further
+    distinguish a Dataset from the possible variations it may have. For
+    example multiple Datasets may be called by one ``name`` but may exist
+    in multiple resolutions or with different calibrations such as "radiance"
+    and "reflectance". If an element is `None` then it is considered not
+    applicable.
+
+    A DatasetID can also be used in SatPy to query for a Dataset. This way
+    a fully qualified DatasetID can be found even if some of the DatasetID
+    elements are unknown. In this case a `None` signifies something that is
+    unknown or not applicable to the requested Dataset.
+
+    Args:
+        name (str): String identifier for the Dataset
+        wavelength (float, tuple): Single float wavelength when querying for
+                                   a Dataset. Otherwise 3-element tuple of
+                                   floats specifying the minimum, nominal,
+                                   and maximum wavelength for a Dataset.
+                                   `None` if not applicable.
+        resolution (int, float): Per data pixel/area resolution. If resolution
+                                 varies across the Dataset then nadir view
+                                 resolution is preferred. Usually this is in
+                                 meters, but for lon/lat gridded data angle
+                                 degrees may be used.
+        polarization (str): 'V' or 'H' polarizations of a microwave channel.
+                            `None` if not applicable.
+        calibration (str): String identifying the calibration level of the
+                           Dataset (ex. 'radiance', 'reflectance', etc).
+                           `None` if not applicable.
+        modifiers (tuple): Tuple of strings identifying what corrections or
+                           other modifications have been performed on this
+                           Dataset (ex. 'sunz_corrected', 'rayleigh_corrected',
+                           etc). `None` or empty tuple if not applicable.
+    """
     @staticmethod
     def name_match(a, b):
         """Return if two string names are equal

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -90,6 +90,9 @@ class DatasetID(DatasetID):
         else:
             return super(DatasetID, self).__eq__(other)
 
+    def __hash__(self):
+        return tuple.__hash__(self)
+
 
 AREA_KEYS = ("name", "resolution", "terrain_correction")
 AreaID = namedtuple("AreaID", " ".join(AREA_KEYS))

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -352,7 +352,7 @@ class Scene(InfoObject):
             composite = compositor(prereq_datasets,
                                    optional_datasets=optional_datasets,
                                    **self.info)
-
+            self.datasets[composite.info['id']] = composite
         except IncompatibleAreas:
             LOG.warning("Delaying generation of %s "
                         "because of incompatible areas",
@@ -363,8 +363,6 @@ class Scene(InfoObject):
             # might be needed in other compositors
             keepables.add(comp_node.name)
             return
-
-        self.datasets[composite.info['id']] = composite
 
     def read_composites(self, compositor_nodes):
         """Read (generate) composites.

--- a/satpy/tests/features/steps/steps-load.py
+++ b/satpy/tests/features/steps/steps-load.py
@@ -23,23 +23,27 @@
 """
 
 import os
-
+import sys
 from behave import *
+
+if sys.version_info < (3, 0):
+    from urllib2 import urlopen
+else:
+    from urllib.request import urlopen
 
 use_step_matcher("re")
 
 
 @given(u'data is available')
 def step_impl(context):
-    import urllib2
     if not os.path.exists('/tmp/SVM02_npp_d20150311_t1122204_e1123446_b17451_c20150311113206961730_cspp_dev.h5'):
-        response = urllib2.urlopen(
+        response = urlopen(
             'https://zenodo.org/record/16355/files/SVM02_npp_d20150311_t1122204_e1123446_b17451_c20150311113206961730_cspp_dev.h5')
         with open('/tmp/SVM02_npp_d20150311_t1122204_e1123446_b17451_c20150311113206961730_cspp_dev.h5',
                   mode="w") as fp:
             fp.write(response.read())
     if not os.path.exists('/tmp/GMTCO_npp_d20150311_t1122204_e1123446_b17451_c20150311113205873710_cspp_dev.h5'):
-        response = urllib2.urlopen(
+        response = urlopen(
             'https://zenodo.org/record/16355/files/GMTCO_npp_d20150311_t1122204_e1123446_b17451_c20150311113205873710_cspp_dev.h5')
         with open('/tmp/GMTCO_npp_d20150311_t1122204_e1123446_b17451_c20150311113205873710_cspp_dev.h5',
                   mode="w") as fp:
@@ -81,7 +85,7 @@ def step_impl(context):
     scn = Scene(platform_name="Suomi-NPP", sensor="viirs",
                 start_time=datetime(2015, 3, 11, 11, 20),
                 end_time=datetime(2015, 3, 11, 11, 26))
-    context.available_dataset_ids = scn.available_datasets()
+    context.available_dataset_ids = scn.available_dataset_ids()
 
 
 @then(u'available datasets is returned')

--- a/satpy/tests/test_projectable.py
+++ b/satpy/tests/test_projectable.py
@@ -380,7 +380,7 @@ class TestProjectable(unittest.TestCase):
         # Normal situation
         p = projectable.Projectable(np.arange(25),
                                     sensor="fake_sensor",
-                                    wavelength_range=500,
+                                    wavelength=500,
                                     resolution=250,
                                     fake_attr="fakeattr",
                                     area=FakeArea(),

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -156,10 +156,29 @@ class TestScene(unittest.TestCase):
         for x in scene:
             self.assertIsInstance(x, Projectable)
 
+
+class TestSceneLoading(unittest.TestCase):
+    """Test the Scene objects `.load` method
+    """
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
-    def test_load_no_comps(self, cri):
+    def test_load_no_exist(self, cri, cl):
+        """Test loading a dataset that doesn't exist"""
         import satpy.scene
         from satpy.tests.utils import create_fake_reader, test_composites
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        self.assertRaises(KeyError, scene.load, ['im_a_dataset_that_doesnt_exist'])
+
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_ds1_no_comps(self, cri):
+        """Test loading one dataset with no loaded compositors"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader
         from satpy import DatasetID
         cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
         scene = satpy.scene.Scene(filenames='bla',
@@ -170,10 +189,44 @@ class TestScene(unittest.TestCase):
         self.assertEquals(len(loaded_ids), 1)
         self.assertTupleEqual(tuple(loaded_ids[0]), tuple(DatasetID(name='ds1')))
 
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_ds4_cal(self, cri, cl):
+        """Test loading a dataset that has two calibration variations"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load(['ds4'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 1)
+        self.assertEquals(loaded_ids[0].calibration, 'reflectance')
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_ds6_wl(self, cri, cl):
+        """Test loading a dataset by wavelength"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load([0.22])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 1)
+        self.assertEquals(loaded_ids[0].name, 'ds6')
 
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp1(self, cri, cl):
+        """Test loading a composite with one required prereq"""
         import satpy.scene
         from satpy.tests.utils import create_fake_reader, test_composites
         from satpy import DatasetID
@@ -188,6 +241,226 @@ class TestScene(unittest.TestCase):
         self.assertEquals(len(loaded_ids), 1)
         self.assertTupleEqual(tuple(loaded_ids[0]), tuple(DatasetID(name='comp1')))
 
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_comp4(self, cri, cl):
+        """Test loading a composite that depends on a composite"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy import DatasetID
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load(['comp4'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 1)
+        self.assertTupleEqual(tuple(loaded_ids[0]), tuple(DatasetID(name='comp4')))
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_comp5(self, cri, cl):
+        """Test loading a composite that has an optional prerequisite"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy import DatasetID
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load(['comp5'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 1)
+        self.assertTupleEqual(tuple(loaded_ids[0]), tuple(DatasetID(name='comp5')))
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_comp6(self, cri, cl):
+        """Test loading a composite that has an optional composite prerequisite"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy import DatasetID
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load(['comp6'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 1)
+        self.assertTupleEqual(tuple(loaded_ids[0]), tuple(DatasetID(name='comp6')))
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_comp8(self, cri, cl):
+        """Test loading a composite that has a non-existent prereq"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        self.assertRaises(KeyError, scene.load, ['comp8'])
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_comp9(self, cri, cl):
+        """Test loading a composite that has a non-existent optional prereq"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy import DatasetID
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        # it is fine that an optional prereq doesn't exist
+        scene.load(['comp9'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 1)
+        self.assertTupleEqual(tuple(loaded_ids[0]), tuple(DatasetID(name='comp9')))
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_comp10(self, cri, cl):
+        """Test loading a composite that depends on a modified dataset"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy import DatasetID
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        # it is fine that an optional prereq doesn't exist
+        scene.load(['comp10'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 1)
+        self.assertTupleEqual(tuple(loaded_ids[0]), tuple(DatasetID(name='comp10')))
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_multiple_comps(self, cri, cl):
+        """Test loading multiple composites"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load(['comp1', 'comp2', 'comp3', 'comp4', 'comp5', 'comp6',
+                    'comp7', 'comp9', 'comp10'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 9)
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_multiple_comps_separate(self, cri, cl):
+        """Test loading multiple composites, one at a time"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load(['comp1'])
+        scene.load(['comp2'])
+        scene.load(['comp3'])
+        scene.load(['comp4'])
+        scene.load(['comp5'])
+        scene.load(['comp6'])
+        scene.load(['comp7'])
+        scene.load(['comp9'])
+        scene.load(['comp10'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 9)
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_modified(self, cri, cl):
+        """Test loading a modified dataset"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy import DatasetID
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load([DatasetID(name='ds1', modifiers=('mod1', 'mod2'))])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 1)
+        self.assertTupleEqual(loaded_ids[0].modifiers, ('mod1', 'mod2'))
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_multiple_modified(self, cri, cl):
+        """Test loading multiple modified datasets"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy import DatasetID
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load([
+            DatasetID(name='ds1', modifiers=('mod1', 'mod2')),
+            DatasetID(name='ds2', modifiers=('mod2', 'mod1')),
+        ])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 2)
+        for i in loaded_ids:
+            if i.name == 'ds1':
+                self.assertTupleEqual(i.modifiers, ('mod1', 'mod2'))
+            else:
+                self.assertEqual(i.name, 'ds2')
+                self.assertTupleEqual(i.modifiers, ('mod2', 'mod1'))
+
+
+class TestSceneResample(unittest.TestCase):
+    """Test the `.resample` method of Scene
+
+    Note this does not actually run the resampling algorithms. It only tests
+    how the Scene handles dependencies and delayed composites surrounding
+    resampling.
+    """
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_resample_comp1(self, cri, cl):
+        """Test loading and resampling a single dataset"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy import DatasetID, Projectable
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load(['ds1'])
+        with mock.patch.object(Projectable, 'resample', autospec=True) as r:
+            r.side_effect = lambda self, x, **kwargs: self
+            new_scene = scene.resample(None)  # None is our fake Area destination
+        loaded_ids = list(new_scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 1)
+        self.assertTupleEqual(tuple(loaded_ids[0]), tuple(DatasetID(name='ds1')))
+
 
 def suite():
     """The test suite for test_scene.
@@ -195,6 +468,8 @@ def suite():
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestScene))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestSceneLoading))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestSceneResample))
 
     return mysuite
 

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -376,15 +376,15 @@ class TestSceneLoading(unittest.TestCase):
         scene = satpy.scene.Scene(filenames='bla',
                                   base_dir='bli',
                                   reader='fake_reader')
-        scene.load(['comp1'])
-        scene.load(['comp2'])
-        scene.load(['comp3'])
-        scene.load(['comp4'])
-        scene.load(['comp5'])
-        scene.load(['comp6'])
-        scene.load(['comp7'])
-        scene.load(['comp9'])
         scene.load(['comp10'])
+        scene.load(['comp9'])
+        scene.load(['comp7'])
+        scene.load(['comp6'])
+        scene.load(['comp5'])
+        scene.load(['comp4'])
+        scene.load(['comp3'])
+        scene.load(['comp2'])
+        scene.load(['comp1'])
         loaded_ids = list(scene.datasets.keys())
         self.assertEquals(len(loaded_ids), 9)
 

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -156,6 +156,38 @@ class TestScene(unittest.TestCase):
         for x in scene:
             self.assertIsInstance(x, Projectable)
 
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_no_comps(self, cri):
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy import DatasetID
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load(['ds1'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 1)
+        self.assertTupleEqual(tuple(loaded_ids[0]), tuple(DatasetID(name='ds1')))
+
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_comp1(self, cri, cl):
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy import DatasetID
+        cri.return_value = {'fake_reader': create_fake_reader('fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load(['comp1'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 1)
+        self.assertTupleEqual(tuple(loaded_ids[0]), tuple(DatasetID(name='comp1')))
+
 
 def suite():
     """The test suite for test_scene.

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2017.
+
+# Author(s):
+
+#   Martin Raspaud <martin.raspaud@smhi.se>
+#   David Hoese <david.hoese@ssec.wisc.edu>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Utilities for various satpy tests.
+"""
+
+import mock
+from datetime import datetime, timedelta
+
+
+def test_datasets():
+    from satpy import DatasetID
+    d = [
+        DatasetID(name='ds1'),
+        DatasetID(name='ds2'),
+        DatasetID(name='ds3'),
+        DatasetID(name='ds4', calibration='radiance'),
+        DatasetID(name='ds4', calibration='reflectance'),
+        DatasetID(name='ds5', resolution=250),
+        DatasetID(name='ds5', resolution=500),
+        DatasetID(name='ds5', resolution=1000),
+        DatasetID(name='ds6', wavelength=(0.1, 0.2, 0.3)),
+        DatasetID(name='ds7', wavelength=(0.4, 0.5, 0.6)),
+    ]
+    return d
+
+
+def _create_fake_compositor(ds_id, prereqs, opt_prereqs):
+    import numpy as np
+    from satpy import Projectable
+    c = mock.MagicMock()
+    c.info = {
+        'id': ds_id,
+        'prerequisites': tuple(prereqs),
+        'optional_prerequisites': tuple(opt_prereqs),
+    }
+    c.return_value = Projectable(data=np.arange(5),
+                                 id=ds_id,
+                                 **ds_id.to_dict())
+    # c.prerequisites = tuple(prereqs)
+    # c.optional_prerequisites = tuple(opt_prereqs)
+    return c
+
+
+def _create_fake_modifiers(name, prereqs, opt_prereqs):
+    import numpy as np
+    from satpy import Projectable
+    m = mock.MagicMock()
+    m.info = {}
+    def call_func(self, datasets, optional_datasets, **info):
+        info = datasets[0].info.copy()
+        info['id'] = self.info['id']
+        info.update(**self.info['id'].to_dict())
+        return Projectable(data=np.ma.MaskedArray(datasets[0]), **info)
+    m.__call__ = call_func
+    return m
+
+
+def test_composites(sensor_name):
+    from satpy import DatasetID, DatasetDict
+    # Composite ID -> (prereqs, optional_prereqs)
+    # TODO: Composites with DatasetIDs as prereqs
+    comps = {
+        DatasetID(name='comp1'): (['ds1'], []),
+        DatasetID(name='comp2'): (['ds1', 'ds2'], []),
+        DatasetID(name='comp3'): (['ds1', 'ds2', 'ds3'], []),
+        DatasetID(name='comp4'): (['comp2', 'ds3'], []),
+        DatasetID(name='comp5'): (['ds1', 'ds2'], ['ds3']),
+        DatasetID(name='comp6'): (['ds1', 'ds2'], ['comp2']),
+        DatasetID(name='comp7'): (['ds1', 'comp2'], ['ds2']),
+        DatasetID(name='comp8'): (['ds_NOPE', 'comp2'], []),
+        DatasetID(name='comp9'): (['ds1', 'comp2'], ['ds_NOPE']),
+    }
+    # Modifier name -> (prereqs (not including to-be-modified), opt_prereqs)
+    mods = {
+        'mod1': (['ds2'], []),
+        'mod2': (['comp3'], []),
+    }
+
+    comps = {sensor_name: DatasetDict((k, _create_fake_compositor(k, *v)) for k, v in comps.items())}
+    mods = {sensor_name: dict((k, _create_fake_modifiers(k, *v)) for k, v in mods.items())}
+
+    return comps, mods
+
+def _get_dataset_key(key,
+                     calibration=None,
+                     resolution=None,
+                     polarization=None,
+                     modifiers=None,
+                     aslist=False):
+    from satpy import DatasetID
+    dataset_ids = test_datasets()
+    for ds in dataset_ids:
+        # should do wavelength and string matching for equality
+        if key == ds:
+            return ds
+    raise KeyError("No fake test key '%s'" % (key,))
+
+
+def _reader_load(dataset_keys):
+    from satpy import DatasetDict, Projectable
+    import numpy as np
+    dataset_ids = test_datasets()
+    loaded_datasets = DatasetDict()
+    for k in dataset_keys:
+        for ds in dataset_ids:
+            if ds == k:
+                loaded_datasets[ds] = Projectable(data=np.arange(5),
+                                                  id=ds,
+                                                  **ds.to_dict())
+    return loaded_datasets
+
+
+def create_fake_reader(reader_name, sensor_name='fake_sensor'):
+    r = mock.MagicMock()
+    r.start_time = r.end_time = datetime.utcnow()
+    r.sensor_names = set([sensor_name])
+    r.get_dataset_key = _get_dataset_key
+    r.load = _reader_load
+    return r

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -130,7 +130,7 @@ def _get_dataset_key(key,
         # should do wavelength and string matching for equality
         if key == ds:
             return ds
-    raise KeyError("No fake test key '%s'" % (key,))
+    raise KeyError("No fake test key '{}'".format(key))
 
 
 def _reader_load(dataset_keys):


### PR DESCRIPTION
Summary of changes made in this PR:
 - [x] Fix `Scene.available_composites` so it properly lists composites with modifiers
 - [x] Remove a majority of the dependency tree logic out of the Scene and in to another object (subclass of `Node` called `DependencyTree` that acts as root?)
 - [x] Create DatasetID static comparison method for names and wavelengths and `__eq__` for better handling of DatasetIDs in `list`.
 - [x] Allow modified composites to be loaded via `scn.load([DatasetID(..., modifiers=(...))])`
 - [x] Fix creation of dependency tree and loading of composites so that prereqs DatasetIDs are fully qualified as soon as possible.

Questions:
1. What is the correct DatasetID for a `true_color`?
    a. `DatasetID(name='true_color')`
    b. `DatasetID(name='true_color', resolution=742, calibration='reflectance', modifiers=('sunz_corrected', 'rayleigh_corrected'))`
2. Is a composite's DatasetID known before it creates a Dataset? Can a DatasetID be modified by a compositor during creation?
    - Examples may include a composite that changes the resolution of a prereq, or performs some sort of special calibration?
3. Does a `Dataset.info` have keys for every element in a `DatasetID` (which is held in `Dataset.info['id']`? What keeps them in sync? Should they be assumed to never change? `DatasetID` is a tuple so it could be a special case in `Dataset.info.__getitem__` but that requires yet another `dict` subclass.