### PR TITLE
Remove 'id' from the info attribute in datasets and composites

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -150,9 +150,9 @@ class CompositorLoader(object):
 
         if composite_type == 'composites':
             options.update(**kwargs)
-            options['id'] = DatasetID.from_dict(options)
+            key = DatasetID.from_dict(options)
             comp = loader(**options)
-            compositors[options['id']] = comp
+            compositors[key] = comp
         elif composite_type == 'modifiers':
             modifiers[composite_name] = loader, options
 
@@ -230,7 +230,6 @@ class CompositeBase(InfoObject):
                     d[k] = self.info[k]
                 elif o.get(k) is not None:
                     d[k] = o[k]
-        d['id'] = DatasetID.from_dict(d)
 
 
 class SunZenithCorrector(CompositeBase):
@@ -326,7 +325,7 @@ class PSPRayleighReflectance(CompositeBase):
                              atmosphere='us-standard', rural_aerosol=False)
 
         refl_cor_band = corrector.get_reflectance(
-            sunz, satz, ssadiff, vis.info['id'].wavelength[1], blue)
+            sunz, satz, ssadiff, vis.id.wavelength[1], blue)
 
         proj = Projectable(vis - refl_cor_band,
                            copy=False,
@@ -369,7 +368,7 @@ class NIRReflectance(CompositeBase):
             sun_zenith = sza(nir.info['start_time'], lons, lats)
 
         refl39 = Calculator(nir.info['platform_name'],
-                            nir.info['sensor'], nir.info['id'].wavelength[1])
+                            nir.info['sensor'], nir.id.wavelength[1])
 
         proj = Projectable(refl39.reflectance_from_tbs(sun_zenith, nir,
                                                        tb11, tb13_4) * 100,
@@ -426,7 +425,6 @@ class RGBCompositor(CompositeBase):
         # info.update(projectables[2].info)
         info = combine_info(*projectables)
         info.update(self.info)
-        info['id'] = DatasetID(self.info['name'])
         # FIXME: should this be done here ?
         info["wavelength"] = None
         info.pop("units", None)

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -70,10 +70,10 @@ class MultiScene(object):
         for layer in self.layers:
             if common_datasets is None:
                 common_datasets = set(
-                    [dataset.info['id'].name for dataset in layer])
+                    [dataset.id.name for dataset in layer])
             else:
                 common_datasets &= set(
-                    [dataset.info['id'].name for dataset in layer])
+                    [dataset.id.name for dataset in layer])
         for dataset_id in common_datasets:
             datasets = [layer[dataset_id] for layer in self.layers]
             scn[dataset_id] = blend_function(datasets)

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -204,7 +204,6 @@ class DependencyTree(Node):
             mloader, moptions = modifiers[modifier]
             moptions = moptions.copy()
             moptions.update(comp_id.to_dict())
-            moptions['id'] = comp_id
             # moptions['prerequisites'] = (
             #     [source_id] + moptions['prerequisites'])
             moptions['sensor'] = sensor_name
@@ -277,7 +276,7 @@ class DependencyTree(Node):
             raise KeyError("Can't find anything called {}".format(
                 str(dataset_key)))
 
-        dataset_key = compositor.info['id']
+        dataset_key = compositor.id
         # 2.1 get the prerequisites
         prereqs, unknowns = self._get_compositor_prereqs(
             compositor.info['prerequisites'])

--- a/satpy/projectable.py
+++ b/satpy/projectable.py
@@ -264,6 +264,10 @@ class Dataset(np.ma.MaskedArray):
         super(Dataset, self).__array_finalize__(obj)
         self._update_info(obj)
 
+    @property
+    def id(self):
+        return DatasetID.from_dict(self.info)
+
     @copy_info
     def __add__(self, other):
         return super(Dataset, self).__add__(other)

--- a/satpy/projectable.py
+++ b/satpy/projectable.py
@@ -213,10 +213,13 @@ class DatasetID(DatasetID):
 
         return cls(*args)
 
-    def to_dict(self):
-        return dict(zip(DATASET_KEYS, self))
+    def to_dict(self, trim=True):
+        if trim:
+            return self._to_trimmed_dict()
+        else:
+            return dict(zip(DATASET_KEYS, self))
 
-    def to_trimmed_dict(self):
+    def _to_trimmed_dict(self):
         return {key: getattr(self, key) for key in DATASET_KEYS
                 if getattr(self, key) is not None}
 

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -24,23 +24,18 @@
 
 """
 
-import glob
 import logging
 import numbers
 import os
 from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import namedtuple
-from datetime import datetime, timedelta
-from fnmatch import fnmatch
 
 import numpy as np
 import six
 import yaml
 
 from satpy.config import config_search_paths, glob_config, runtime_import
-from satpy.plugin_base import Plugin
-from satpy.projectable import Dataset
-from trollsift.parser import Parser, globify
+from satpy.projectable import DatasetID, DATASET_KEYS
 
 try:
     import configparser
@@ -49,119 +44,14 @@ except ImportError:
 
 LOG = logging.getLogger(__name__)
 
-DATASET_KEYS = ("name", "wavelength", "resolution", "polarization",
-                "calibration", "modifiers")
-DatasetID = namedtuple("DatasetID", " ".join(DATASET_KEYS))
-DatasetID.__new__.__defaults__ = (None, None, None, None, None, None)
-
-
-class DatasetID(DatasetID):
-    """Identifier for all `Dataset` objects.
-
-    DatasetID is a namedtuple that holds identifying and classifying
-    information about a Dataset. There are two identifying elements,
-    ``name`` and ``wavelength``. These can be used to generically refer to a
-    Dataset. The other elements of a DatasetID are meant to further
-    distinguish a Dataset from the possible variations it may have. For
-    example multiple Datasets may be called by one ``name`` but may exist
-    in multiple resolutions or with different calibrations such as "radiance"
-    and "reflectance". If an element is `None` then it is considered not
-    applicable.
-
-    A DatasetID can also be used in SatPy to query for a Dataset. This way
-    a fully qualified DatasetID can be found even if some of the DatasetID
-    elements are unknown. In this case a `None` signifies something that is
-    unknown or not applicable to the requested Dataset.
-
-    Args:
-        name (str): String identifier for the Dataset
-        wavelength (float, tuple): Single float wavelength when querying for
-                                   a Dataset. Otherwise 3-element tuple of
-                                   floats specifying the minimum, nominal,
-                                   and maximum wavelength for a Dataset.
-                                   `None` if not applicable.
-        resolution (int, float): Per data pixel/area resolution. If resolution
-                                 varies across the Dataset then nadir view
-                                 resolution is preferred. Usually this is in
-                                 meters, but for lon/lat gridded data angle
-                                 degrees may be used.
-        polarization (str): 'V' or 'H' polarizations of a microwave channel.
-                            `None` if not applicable.
-        calibration (str): String identifying the calibration level of the
-                           Dataset (ex. 'radiance', 'reflectance', etc).
-                           `None` if not applicable.
-        modifiers (tuple): Tuple of strings identifying what corrections or
-                           other modifications have been performed on this
-                           Dataset (ex. 'sunz_corrected', 'rayleigh_corrected',
-                           etc). `None` or empty tuple if not applicable.
-    """
-    @staticmethod
-    def name_match(a, b):
-        """Return if two string names are equal
-
-        Args:
-            a (str): DatasetID.name or other string
-            b (str): DatasetID.name or other string
-        """
-        return a == b
-
-    @staticmethod
-    def wavelength_match(a, b):
-        """Return if two wavelengths are equal
-
-        Args:
-            a (tuple or scalar): (min wl, nominal wl, max wl) or scalar wl
-            b (tuple or scalar): (min wl, nominal wl, max wl) or scalar wl
-        """
-        if type(a) == type(b):
-            return a == b
-        elif a is None or b is None:
-            return False
-        elif isinstance(a, (list, tuple)) and len(a) == 3:
-            return a[0] <= b <= a[2]
-        elif isinstance(b, (list, tuple)) and len(b) == 3:
-            return b[0] <= a <= b[2]
-        else:
-            raise ValueError("Can only compare wavelengths of length 1 or 3")
-
-    def __eq__(self, other):
-        if isinstance(other, str):
-            return self.name_match(self.name, other)
-        elif isinstance(other, numbers.Number) or \
-                        isinstance(other, (tuple, list)) and len(other) == 3:
-            return self.wavelength_match(self.wavelength, other)
-        else:
-            return super(DatasetID, self).__eq__(other)
-
-    def __hash__(self):
-        return tuple.__hash__(self)
-
-    @classmethod
-    def from_dict(cls, d, **kwargs):
-        args = []
-        for k in DATASET_KEYS:
-            val = kwargs.get(k, d.get(k))
-            # force modifiers to tuple
-            if k == 'modifiers' and val is not None:
-                val = tuple(val)
-            args.append(val)
-
-        return cls(*args)
-
-    def to_dict(self):
-        return dict(zip(DATASET_KEYS, self))
-
-AREA_KEYS = ("name", "resolution", "terrain_correction")
-AreaID = namedtuple("AreaID", " ".join(AREA_KEYS))
-AreaID.__new__.__defaults__ = (None, None, None, None, None)
-
 
 class MalformedConfigError(Exception):
     pass
 
 
 class DatasetDict(dict):
-    """Special dictionary object that can handle dict operations based on dataset name, wavelength, or DatasetID
+    """Special dictionary object that can handle dict operations based on
+    dataset name, wavelength, or DatasetID.
 
     Note: Internal dictionary keys are `DatasetID` objects.
     """
@@ -325,8 +215,8 @@ class DatasetDict(dict):
             d["calibration"] = key.calibration
             d["polarization"] = key.polarization
             d["modifiers"] = key.modifiers
-            d['id'] = key
-            # you can't change the wavelength of a dataset, that doesn't make sense
+            # you can't change the wavelength of a dataset, that doesn't make
+            # sense
             if "wavelength" in d and d["wavelength"] != key.wavelength:
                 raise TypeError("Can't change the wavelength of a dataset")
 

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -83,8 +83,8 @@ class NC_ABI_L1B(BaseFileHandler):
         out.mask[:] = np.ma.getmask(radiances)
         out.info.update({'units': units,
                          'platform_name': self.platform_name,
-                         'sensor': self.sensor,
-                         'id': key})
+                         'sensor': self.sensor})
+        out.info.update(key.to_trimmed_dict())
 
         return out
 

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -84,7 +84,7 @@ class NC_ABI_L1B(BaseFileHandler):
         out.info.update({'units': units,
                          'platform_name': self.platform_name,
                          'sensor': self.sensor})
-        out.info.update(key.to_trimmed_dict())
+        out.info.update(key.to_dict())
 
         return out
 

--- a/satpy/readers/amsr2_l1b.py
+++ b/satpy/readers/amsr2_l1b.py
@@ -40,12 +40,11 @@ class AMSR2L1BFileHandler(HDF5FileHandler):
             mask = mask[:, ::2]
 
         ds_info.update({
-            "name": ds_key.name,
-            "id": ds_key,
             "units": self[var_path + "/attr/UNIT"],
             "platform": self["/attr/PlatformShortName"].item(),
             "sensor": self["/attr/SensorShortName"].item(),
             "start_orbit": int(self["/attr/StartOrbitNumber"].item()),
             "end_orbit": int(self["/attr/StopOrbitNumber"].item()),
         })
+        ds_info.update(ds_key.to_trimmed_dict())
         return Projectable(data, mask=mask, **ds_info)

--- a/satpy/readers/amsr2_l1b.py
+++ b/satpy/readers/amsr2_l1b.py
@@ -46,5 +46,5 @@ class AMSR2L1BFileHandler(HDF5FileHandler):
             "start_orbit": int(self["/attr/StartOrbitNumber"].item()),
             "end_orbit": int(self["/attr/StopOrbitNumber"].item()),
         })
-        ds_info.update(ds_key.to_trimmed_dict())
+        ds_info.update(ds_key.to_dict())
         return Projectable(data, mask=mask, **ds_info)

--- a/satpy/readers/ghrsst_osisaf.py
+++ b/satpy/readers/ghrsst_osisaf.py
@@ -100,14 +100,13 @@ class GHRSST_OSISAFL2(NetCDF4FileHandler):
             out.data[:] += factors[1]
 
         ds_info.update({
-            "name": dataset_id.name,
-            "id": dataset_id,
             "units": ds_info.get("units", file_units),
             "platform": PLATFORM_NAME.get(self['/attr/platform'],
                                           self['/attr/platform']),
             "sensor": SENSOR_NAME.get(self['/attr/sensor'],
                                       self['/attr/sensor']),
         })
+        ds_info.update(dataset_id.to_trimmed_dict())
         cls = ds_info.pop("container", Projectable)
         return cls(out, **ds_info)
 

--- a/satpy/readers/ghrsst_osisaf.py
+++ b/satpy/readers/ghrsst_osisaf.py
@@ -106,7 +106,7 @@ class GHRSST_OSISAFL2(NetCDF4FileHandler):
             "sensor": SENSOR_NAME.get(self['/attr/sensor'],
                                       self['/attr/sensor']),
         })
-        ds_info.update(dataset_id.to_trimmed_dict())
+        ds_info.update(dataset_id.to_dict())
         cls = ds_info.pop("container", Projectable)
         return cls(out, **ds_info)
 

--- a/satpy/readers/nc_olci.py
+++ b/satpy/readers/nc_olci.py
@@ -118,6 +118,7 @@ class NCOLCI1B(BaseFileHandler):
                            units=units,
                            platform_name=self.platform_name,
                            sensor=self.sensor)
+        proj.info.update(key.to_dict())
         return proj
 
     @property
@@ -188,6 +189,7 @@ class NCOLCIAngles(BaseFileHandler):
                            units=units,
                            platform_name=self.platform_name,
                            sensor=self.sensor)
+        proj.info.update(key.to_dict())
         return proj
 
     @property

--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -218,14 +218,13 @@ class NUCAPSFileHandler(NetCDF4FileHandler):
             out.data[:] += factors[1]
 
         ds_info.update({
-            "name": dataset_id.name,
-            "id": dataset_id,
             "units": ds_info.get("units", file_units),
             "platform": self.platform_name,
             "sensor": self.sensor_name,
             "start_orbit": self.start_orbit_number,
             "end_orbit": self.end_orbit_number,
         })
+        ds_info.update(dataset_id.to_trimmed_dict())
         if 'standard_name' not in ds_info:
             ds_info['standard_name'] = self[var_path + '/attr/standard_name']
         ds_info.update({'Quality_Flag': self['Quality_Flag'][:]})

--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -224,7 +224,7 @@ class NUCAPSFileHandler(NetCDF4FileHandler):
             "start_orbit": self.start_orbit_number,
             "end_orbit": self.end_orbit_number,
         })
-        ds_info.update(dataset_id.to_trimmed_dict())
+        ds_info.update(dataset_id.to_dict())
         if 'standard_name' not in ds_info:
             ds_info['standard_name'] = self[var_path + '/attr/standard_name']
         ds_info.update({'Quality_Flag': self['Quality_Flag'][:]})

--- a/satpy/readers/omps_edr.py
+++ b/satpy/readers/omps_edr.py
@@ -197,14 +197,13 @@ class EDRFileHandler(HDF5FileHandler):
             out.data[:] += factors[1]
 
         ds_info.update({
-            "name": dataset_id.name,
-            "id": dataset_id,
             "units": ds_info.get("units", file_units),
             "platform": self.platform_name,
             "sensor": self.sensor_name,
             "start_orbit": self.start_orbit_number,
             "end_orbit": self.end_orbit_number,
         })
+        ds_info.update(dataset_id.to_trimmed_dict())
         if 'standard_name' not in ds_info:
             ds_info['standard_name'] = self[var_path + '/attr/Title']
 

--- a/satpy/readers/omps_edr.py
+++ b/satpy/readers/omps_edr.py
@@ -203,7 +203,7 @@ class EDRFileHandler(HDF5FileHandler):
             "start_orbit": self.start_orbit_number,
             "end_orbit": self.end_orbit_number,
         })
-        ds_info.update(dataset_id.to_trimmed_dict())
+        ds_info.update(dataset_id.to_dict())
         if 'standard_name' not in ds_info:
             ds_info['standard_name'] = self[var_path + '/attr/Title']
 

--- a/satpy/readers/viirs_l1b.py
+++ b/satpy/readers/viirs_l1b.py
@@ -224,6 +224,6 @@ class VIIRSL1BFileHandler(NetCDF4FileHandler):
             "start_orbit": self.start_orbit_number,
             "end_orbit": self.end_orbit_number,
         })
-        ds_info.update(dataset_id.to_trimmed_dict())
+        ds_info.update(dataset_id.to_dict())
         cls = ds_info.pop("container", Projectable)
         return cls(out, **ds_info)

--- a/satpy/readers/viirs_l1b.py
+++ b/satpy/readers/viirs_l1b.py
@@ -218,13 +218,12 @@ class VIIRSL1BFileHandler(NetCDF4FileHandler):
             ds_info.setdefault('rows_per_scan', rows_per_scan)
 
         ds_info.update({
-            "name": dataset_id.name,
-            "id": dataset_id,
             "units": ds_info.get("units", file_units),
             "platform": self.platform_name,
             "sensor": self.sensor_name,
             "start_orbit": self.start_orbit_number,
             "end_orbit": self.end_orbit_number,
         })
+        ds_info.update(dataset_id.to_trimmed_dict())
         cls = ds_info.pop("container", Projectable)
         return cls(out, **ds_info)

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -301,12 +301,13 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
             "start_orbit": self.start_orbit_number,
             "end_orbit": self.end_orbit_number,
         })
-        ds_info.update(dataset_id.to_trimmed_dict())
+        ds_info.update(dataset_id.to_dict())
         cls = ds_info.pop("container", Projectable)
         return cls(out, **ds_info)
 
 
 class VIIRSSDRReader(FileYAMLReader):
+
     def load_navigation(self, nav_name, extra_mask=None, dep_file_type=None):
         """Load the `nav_name` navigation.
 

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -295,14 +295,13 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
             self.scale_swath_data(out.data, out.mask, factors)
 
         ds_info.update({
-            "name": dataset_id.name,
-            "id": dataset_id,
             "units": ds_info.get("units", file_units),
             "platform_name": self.platform_name,
             "sensor": self.sensor_name,
             "start_orbit": self.start_orbit_number,
             "end_orbit": self.end_orbit_number,
         })
+        ds_info.update(dataset_id.to_trimmed_dict())
         cls = ds_info.pop("container", Projectable)
         return cls(out, **ds_info)
 

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -256,7 +256,7 @@ class Scene(InfoObject):
         for ds in self:
             datasets_by_area.setdefault(
                 str(ds.info["area"]), (ds.info["area"], []))
-            datasets_by_area[str(ds.info["area"])][1].append(ds.info["id"])
+            datasets_by_area[str(ds.info["area"])][1].append(ds.id)
 
         for area_name, (area_obj, ds_list) in datasets_by_area.items():
             yield area_obj, ds_list
@@ -382,7 +382,7 @@ class Scene(InfoObject):
             composite = compositor(prereq_datasets,
                                    optional_datasets=optional_datasets,
                                    **self.info)
-            self.datasets[composite.info['id']] = composite
+            self.datasets[composite.id] = composite
         except IncompatibleAreas:
             LOG.warning("Delaying generation of %s "
                         "because of incompatible areas",
@@ -474,7 +474,7 @@ class Scene(InfoObject):
         if datasets is None:
             new_scn.wishlist = self.wishlist
         else:
-            new_scn.wishlist = set([ds.info["id"] for ds in new_scn])
+            new_scn.wishlist = set([ds.id for ds in new_scn])
 
         # recompute anything from the wishlist that needs it (combining multiple
         # resolutions, etc.)

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -52,10 +52,10 @@ def _create_fake_compositor(ds_id, prereqs, opt_prereqs):
         'prerequisites': tuple(prereqs),
         'optional_prerequisites': tuple(opt_prereqs),
     }
-    c.info.update(ds_id.to_trimmed_dict())
+    c.info.update(ds_id.to_dict())
     c.id = ds_id
     c.return_value = Projectable(data=np.arange(5),
-                                 **ds_id.to_trimmed_dict())
+                                 **ds_id.to_dict())
     # c.prerequisites = tuple(prereqs)
     # c.optional_prerequisites = tuple(opt_prereqs)
     return c
@@ -156,7 +156,7 @@ def _reader_load(dataset_keys):
         for ds in dataset_ids:
             if ds == k:
                 loaded_datasets[ds] = Projectable(data=np.arange(5),
-                                                  **ds.to_trimmed_dict())
+                                                  **ds.to_dict())
     return loaded_datasets
 
 

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -49,13 +49,12 @@ def _create_fake_compositor(ds_id, prereqs, opt_prereqs):
     from satpy import Projectable
     c = mock.MagicMock()
     c.info = {
-        'id': ds_id,
         'prerequisites': tuple(prereqs),
         'optional_prerequisites': tuple(opt_prereqs),
     }
+    c.update(ds_id.to_trimmed_dict())
     c.return_value = Projectable(data=np.arange(5),
-                                 id=ds_id,
-                                 **ds_id.to_dict())
+                                 **ds_id.to_trimmed_dict())
     # c.prerequisites = tuple(prereqs)
     # c.optional_prerequisites = tuple(opt_prereqs)
     return c
@@ -68,14 +67,14 @@ def _create_fake_modifiers(name, prereqs, opt_prereqs):
 
     def _mod_loader(*args, **kwargs):
         class FakeMod(CompositeBase):
+
             def __init__(self, *args, **kwargs):
                 self.info = {}
 
             def __call__(self, datasets, optional_datasets, **info):
-                if name == 'res_change' and datasets[0].info['id'].resolution is not None:
+                if name == 'res_change' and datasets[0].id.resolution is not None:
                     i = datasets[0].info.copy()
                     i['resolution'] = i['resolution'] * 5
-                    i['id'] = DatasetID.from_dict(i)
                 else:
                     i = datasets[0].info
                 info = datasets[0].info.copy()
@@ -156,8 +155,7 @@ def _reader_load(dataset_keys):
         for ds in dataset_ids:
             if ds == k:
                 loaded_datasets[ds] = Projectable(data=np.arange(5),
-                                                  id=ds,
-                                                  **ds.to_dict())
+                                                  **ds.to_trimmed_dict())
     return loaded_datasets
 
 

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -52,7 +52,8 @@ def _create_fake_compositor(ds_id, prereqs, opt_prereqs):
         'prerequisites': tuple(prereqs),
         'optional_prerequisites': tuple(opt_prereqs),
     }
-    c.update(ds_id.to_trimmed_dict())
+    c.info.update(ds_id.to_trimmed_dict())
+    c.id = ds_id
     c.return_value = Projectable(data=np.arange(5),
                                  **ds_id.to_trimmed_dict())
     # c.prerequisites = tuple(prereqs)


### PR DESCRIPTION
Instead, define a .id property which generates the DatasetID on-the-fly everytime from the .info metadata.