### PR TITLE
Bilinear interpolation

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -165,7 +165,19 @@ The image is automatically saved here in GeoTiff_ format.
 
 .. _GeoTiff: http://trac.osgeo.org/geotiff/
 
+The default resampling method is nearest neighbour. Also bilinear interpolation
+is available, which can be used by adding `resampler="bilinear"` keyword:
 
+    >>> local_scene = global_scene.resample("euro4", resampler="bilinear")
+    >>>
+
+To make resampling faster next time (when resampling geostationary satellite
+data), it is possible to save the resampling coefficients and use more CPUs
+when calculating the coefficients on the first go:
+
+    >>> local_scene = global_scene.resample("euro4", resampler="bilinear",
+    ...                                     nprocs=4, cache_dir="/var/tmp")
+    >>>
 
 Making custom composites
 ========================

--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -121,6 +121,7 @@ DatasetID.__new__.__defaults__ = (None, None, None, None, None, None)
 
 
 class DatasetID(DatasetID):
+
     """Identifier for all `Dataset` objects.
 
     DatasetID is a namedtuple that holds identifying and classifying

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -467,13 +467,28 @@ class BilinearResampler(BaseResampler):
         """Resample the given data using bilinear interpolation"""
         del kwargs
 
-        res = np.ma.masked_invalid(
-            get_sample_from_bil_info(data.ravel(),
-                                     self.cache['bilinear_t'],
-                                     self.cache['bilinear_s'],
-                                     self.cache['input_idxs'],
-                                     self.cache['idx_arr'],
-                                     output_shape=self.target_geo_def.shape))
+        target_shape = self.target_geo_def.shape
+        if data.ndim == 3:
+            output_shape = list(target_shape)
+            output_shape.append(data.shape[-1])
+            res = np.zeros(output_shape, dtype=data.dtype)
+            for i in range(data.shape[-1]):
+                res[:, :, i] = \
+                    get_sample_from_bil_info(data[:, :, i].ravel(),
+                                             self.cache['bilinear_t'],
+                                             self.cache['bilinear_s'],
+                                             self.cache['input_idxs'],
+                                             self.cache['idx_arr'],
+                                             output_shape=target_shape)
+
+        else:
+            res = \
+                get_sample_from_bil_info(data.ravel(),
+                                         self.cache['bilinear_t'],
+                                         self.cache['bilinear_s'],
+                                         self.cache['input_idxs'],
+                                         self.cache['idx_arr'],
+                                         output_shape=target_shape)
         res = np.ma.masked_invalid(res)
 
         return res


### PR DESCRIPTION
Added access to bilinear resampling from pyresample.

Major changes:
- moved _caches_ OrderedDict from individual resamplers to a base class attribute
- moved multiple copies of cache handling (reading, updating) from individual resamplers to base class
- moved multiple copies of lonlat masking to a function
- added bilinear interpolation, multiprocessing and caching to documentation
