### PR TITLE
Add reader for NWCSAF/PPS which can also be used by NWCSAF/MSG

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -72,6 +72,11 @@ distribution, we provide support for the following readers:
     * - NWCSAF MSG 2016 products in netCDF4 format
       - `nc_nwcsaf_msg`
       - Nominal
+    * - NWCSAF PPS 2014 products in netCDF4 format
+      - `nc_nwcsaf_pps`
+      - | Not yet support for remapped netCDF products. 
+        | Only the standard swath based output is supported.
+        | CPP products not supported yet
     * - Sentinel-1 A and B SAR-C data in SAFE format
       - `sar_c`
       - Nominal

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -40,19 +40,19 @@ composites:
     - 12.0
     standard_name: night_fog
 
-  cloud_mask:
+  cloudmask:
     compositor: !!python/name:satpy.composites.PaletteCompositor
     prerequisites:
     - cma
     - cma_pal
-    standard_name: cloud_mask
+    standard_name: cloudmask
 
-  cloud_type:
+  cloudtype:
     compositor: !!python/name:satpy.composites.PaletteCompositor
     prerequisites:
     - ct
     - ct_pal
-    standard_name: cloud_type
+    standard_name: cloudtype
 
   cloud_top_height:
     compositor: !!python/name:satpy.composites.PaletteCompositor

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -140,3 +140,10 @@ composites:
     - 0.5
     - 0.45
     standard_name: true_color
+
+  cloudtype:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ct
+    - ct_pal
+    standard_name: cloudtype

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -141,9 +141,44 @@ composites:
     - 0.45
     standard_name: true_color
 
+  cloudmask:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cma
+    - cma_pal
+    standard_name: cloudmask
+
+  cloudmask_extended:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cma_extended
+    - cma_extended_pal
+    standard_name: cloudmask_extended
+
   cloudtype:
     compositor: !!python/name:satpy.composites.PaletteCompositor
     prerequisites:
     - ct
     - ct_pal
     standard_name: cloudtype
+
+  cloud_top_height:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ctth_alti
+    - ctth_alti_pal
+    standard_name: cloud_top_height
+
+  cloud_top_pressure:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ctth_pres
+    - ctth_pres_pal
+    standard_name: cloud_top_pressure
+
+  cloud_top_temperature:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ctth_tempe
+    - ctth_tempe_pal
+    standard_name: cloud_top_temperature

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -153,7 +153,7 @@ composites:
     prerequisites:
     - cma_extended
     - cma_extended_pal
-    standard_name: cloudmask_extended
+    standard_name: cloudmask
 
   cloudtype:
     compositor: !!python/name:satpy.composites.PaletteCompositor

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -182,3 +182,18 @@ composites:
     - ctth_tempe
     - ctth_tempe_pal
     standard_name: cloud_top_temperature
+
+  cloud_top_phase:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cpp_phase
+    - cpp_phase_pal
+    standard_name: cloud_top_phase
+
+  cloud_drop_effective_radius:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cpp_reff
+    - cpp_reff_pal
+    standard_name: cloud_drop_effective_radius
+

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -179,8 +179,9 @@ enhancements:
       method: *gammafun
       kwargs:
         gamma: [1, 1.2, 1]
-  cloud_type:
-    standard_name: cloud_type
+
+  cloudtype:
+    standard_name: cloudtype
     operations:
     - name: stretch
       method: *stretchfun
@@ -188,8 +189,8 @@ enhancements:
         stretch: crude
         min_stretch: [0, 0, 0]
         max_stretch: [1, 1, 1]
-  cloud_mask:
-    standard_name: cloud_mask
+  cloudmask:
+    standard_name: cloudmask
     operations:
     - name: stretch
       method: *stretchfun
@@ -197,6 +198,7 @@ enhancements:
         stretch: crude
         min_stretch: [0, 0, 0]
         max_stretch: [1, 1, 1]
+
   cloud_top_height:
     standard_name: cloud_top_height
     operations:

--- a/satpy/etc/readers/nc_nwcsaf_pps.yaml
+++ b/satpy/etc/readers/nc_nwcsaf_pps.yaml
@@ -1,0 +1,51 @@
+reader:
+  description: NetCDF4 reader for the NWCSAF/PPS 2014 format
+  name: nc_nwcsaf
+  sensors: ['avhrr-3', 'viirs']
+  default_channels: []
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
+
+file_types:
+    nc_nwcsaf_cma:
+        file_reader: !!python/name:satpy.readers.nc_nwcsaf.NcNWCSAF
+        file_patterns: ['S_NWC_CMA_{platform_id}_{orbit_number}_{start_time:%Y%m%dT%H%M%S%f}Z_{end_time:%Y%m%dT%H%M%S%f}Z.nc']
+
+    nc_nwcsaf_ct:
+        file_reader: !!python/name:satpy.readers.nc_nwcsaf.NcNWCSAF
+        file_patterns: ['S_NWC_CT_{platform_id}_{orbit_number}_{start_time:%Y%m%dT%H%M%S%f}Z_{end_time:%Y%m%dT%H%M%S%f}Z.nc']
+
+
+datasets:
+
+  lon:
+    name: lon
+    file_type: nc_nwcsaf_cma
+    units: "degrees"
+    standard_name: longitude
+  lat:
+    name: lat
+    file_type: nc_nwcsaf_cma
+    units: "degrees"
+    standard_name: latitude
+
+# ---- CMA products ------------
+
+  cma:
+    name: cma
+    file_type: nc_nwcsaf_cma
+    coordinates: [lon, lat]
+
+  cma_pal:
+    name: cma_pal
+    file_type: nc_nwcsaf_cma
+
+# ---- CT products ------------
+
+  ct:
+    name: ct
+    file_type: nc_nwcsaf_ct
+    coordinates: [lon, lat]
+
+  ct_pal:
+    name: ct_pal
+    file_type: nc_nwcsaf_ct

--- a/satpy/etc/readers/nc_nwcsaf_pps.yaml
+++ b/satpy/etc/readers/nc_nwcsaf_pps.yaml
@@ -22,6 +22,11 @@ file_types:
         file_reader: !!python/name:satpy.readers.nc_nwcsaf.NcNWCSAF
         file_patterns: ['S_NWC_PC_{platform_id}_{orbit_number}_{start_time:%Y%m%dT%H%M%S%f}Z_{end_time:%Y%m%dT%H%M%S%f}Z.nc']
 
+    nc_nwcsaf_cpp:
+        file_reader: !!python/name:satpy.readers.nc_nwcsaf.NcNWCSAF
+        file_patterns: ['S_NWC_CPP_{platform_id}_{orbit_number}_{start_time:%Y%m%dT%H%M%S%f}Z_{end_time:%Y%m%dT%H%M%S%f}Z.nc']
+
+
 
 datasets:
 
@@ -127,3 +132,22 @@ datasets:
   ctth_tempe_pal:
     name: ctth_tempe_pal
     file_type: nc_nwcsaf_ctth
+
+
+# ---- CPP products ------------
+
+  cpp_phase:
+    name: cpp_phase
+    file_type: nc_nwcsaf_cpp
+
+  cmic_phase_pal:
+    name: cpp_phase_pal
+    file_type: nc_nwcsaf_cpp
+
+  cpp_reff:
+    name: cpp_reff
+    file_type: nc_nwcsaf_cpp
+
+  cpp_reff_pal:
+    name: cpp_reff_pal
+    file_type: nc_nwcsaf_cpp

--- a/satpy/etc/readers/nc_nwcsaf_pps.yaml
+++ b/satpy/etc/readers/nc_nwcsaf_pps.yaml
@@ -14,6 +14,14 @@ file_types:
         file_reader: !!python/name:satpy.readers.nc_nwcsaf.NcNWCSAF
         file_patterns: ['S_NWC_CT_{platform_id}_{orbit_number}_{start_time:%Y%m%dT%H%M%S%f}Z_{end_time:%Y%m%dT%H%M%S%f}Z.nc']
 
+    nc_nwcsaf_ctth:
+        file_reader: !!python/name:satpy.readers.nc_nwcsaf.NcNWCSAF
+        file_patterns: ['S_NWC_CTTH_{platform_id}_{orbit_number}_{start_time:%Y%m%dT%H%M%S%f}Z_{end_time:%Y%m%dT%H%M%S%f}Z.nc']
+
+    nc_nwcsaf_pc:
+        file_reader: !!python/name:satpy.readers.nc_nwcsaf.NcNWCSAF
+        file_patterns: ['S_NWC_PC_{platform_id}_{orbit_number}_{start_time:%Y%m%dT%H%M%S%f}Z_{end_time:%Y%m%dT%H%M%S%f}Z.nc']
+
 
 datasets:
 
@@ -39,6 +47,15 @@ datasets:
     name: cma_pal
     file_type: nc_nwcsaf_cma
 
+  cma_extended:
+    name: cma_extended
+    file_type: nc_nwcsaf_cma
+    coordinates: [lon, lat]
+
+  cma_extended_pal:
+    name: cma_extended_pal
+    file_type: nc_nwcsaf_cma
+
 # ---- CT products ------------
 
   ct:
@@ -49,3 +66,64 @@ datasets:
   ct_pal:
     name: ct_pal
     file_type: nc_nwcsaf_ct
+
+# ---- PC products ------------
+
+  pc_conditions:
+    name: pc_conditions
+    file_type: nc_nwcsaf_pc
+    coordinates: [lon, lat]
+
+  pc_precip_intense:
+    name: pc_precip_intense
+    file_type: nc_nwcsaf_pc
+    coordinates: [lon, lat]
+
+  pc_precip_moderate:
+    name: pc_precip_moderate
+    file_type: nc_nwcsaf_pc
+    coordinates: [lon, lat]
+
+  pc_precip_light:
+    name: pc_precip_light
+    file_type: nc_nwcsaf_pc
+    coordinates: [lon, lat]
+
+  pc_status_flag:
+    name: pc_status_flag
+    file_type: nc_nwcsaf_pc
+    coordinates: [lon, lat]
+
+  pc_quality:
+    name: pc_quality
+    file_type: nc_nwcsaf_pc
+    coordinates: [lon, lat]
+
+# ---- CTTH products ------------
+
+  ctth_alti:
+    name: ctth_alti
+    file_type: nc_nwcsaf_ctth
+    coordinates: [lon, lat]
+
+  ctth_alti_pal:
+    name: ctth_alti_pal
+    file_type: nc_nwcsaf_ctth
+
+  ctth_pres:
+    name: ctth_pres
+    file_type: nc_nwcsaf_ctth
+    coordinates: [lon, lat]
+
+  ctth_pres_pal:
+    name: ctth_pres_pal
+    file_type: nc_nwcsaf_ctth
+
+  ctth_tempe:
+    name: ctth_tempe
+    file_type: nc_nwcsaf_ctth
+    coordinates: [lon, lat]
+
+  ctth_tempe_pal:
+    name: ctth_tempe_pal
+    file_type: nc_nwcsaf_ctth

--- a/satpy/etc/readers/nc_nwcsaf_pps.yaml
+++ b/satpy/etc/readers/nc_nwcsaf_pps.yaml
@@ -1,7 +1,7 @@
 reader:
   description: NetCDF4 reader for the NWCSAF/PPS 2014 format
   name: nc_nwcsaf
-  sensors: ['avhrr-3', 'viirs']
+  sensors: ['avhrr-3', 'viirs', 'modis']
   default_channels: []
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
 

--- a/satpy/readers/nc_nwcsaf.py
+++ b/satpy/readers/nc_nwcsaf.py
@@ -99,13 +99,17 @@ class NcNWCSAF(BaseFileHandler):
         if 'add_offset' in variable.attrs:
             values = values + variable.attrs['add_offset']
             info['add_offset'] = variable.attrs['add_offset']
-
         if 'valid_range' in variable.attrs:
             info['valid_range'] = variable.attrs['valid_range']
         if 'units' in variable.attrs:
             info['units'] = variable.attrs['units']
         if 'standard_name' in variable.attrs:
             info['standard_name'] = variable.attrs['standard_name']
+
+        if self.pps and dsid.name == 'ctth_alti':
+            info['valid_range'] = (0., 8500.)
+        if self.pps and dsid.name == 'ctth_alti_pal':
+            values = values[1:, :]
 
         proj = Dataset(np.squeeze(values),
                        copy=False,

--- a/satpy/readers/nc_nwcsaf.py
+++ b/satpy/readers/nc_nwcsaf.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2017 Pytroll
+
+# Author(s):
+
+#   Martin Raspaud <martin.raspaud@smhi.se>
+#   Adam.Dybbroe <adam.dybbroe@smhi.se>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Nowcasting SAF common PPS&MSG NetCDF/CF format reader
+"""
+
+import logging
+from datetime import datetime
+
+import h5netcdf
+import numpy as np
+
+from satpy.dataset import Dataset
+from satpy.readers.file_handlers import BaseFileHandler
+
+logger = logging.getLogger(__name__)
+
+SENSOR = {'NOAA-19': 'avhrr/3',
+          'NOAA-18': 'avhrr/3',
+          'NOAA-15': 'avhrr/3',
+          'Metop-A': 'avhrr/3',
+          'Metop-B': 'avhrr/3',
+          'Metop-C': 'avhrr/3',
+          'EOS-Aqua': 'modis',
+          'EOS-Terra': 'modis',
+          'Suomi-NPP': 'viirs',
+          'JPSS-1': 'viirs', }
+
+PLATFORM_NAMES = {'MSG1': 'Meteosat-8',
+                  'MSG2': 'Meteosat-9',
+                  'MSG3': 'Meteosat-10',
+                  'MSG4': 'Meteosat-11', }
+
+
+class NcNWCSAF(BaseFileHandler):
+
+    """NWCSAF PPS&MSG NetCDF reader."""
+
+    def __init__(self, filename, filename_info, filetype_info):
+        """Init method"""
+        super(NcNWCSAF, self).__init__(filename, filename_info,
+                                       filetype_info)
+        self.nc = h5netcdf.File(filename, 'r')
+        self.pps = False
+
+        try:
+            # MSG:
+            sat_id = self.nc.attrs['satellite_identifier']
+            self.platform_name = PLATFORM_NAMES[sat_id]
+        except KeyError:
+            # PPS:
+            self.platform_name = self.nc.attrs['platform']
+            self.pps = True
+
+        self.sensor = SENSOR.get(self.platform_name, 'seviri')
+
+    def get_shape(self, dsid, ds_info):
+        """Get the shape of the data."""
+        raise NotImplementedError
+        #     return self.nc[dsid.name].shape
+
+    def get_dataset(self, dsid, info, out=None):
+        """Load a dataset."""
+
+        logger.debug('Reading %s.', dsid.name)
+        variable = self.nc[dsid.name]
+
+        info = {'platform_name': self.platform_name,
+                'sensor': self.sensor}
+
+        try:
+            values = np.ma.masked_equal(variable[:],
+                                        variable.attrs['_FillValue'], copy=False)
+        except KeyError:
+            values = np.ma.array(variable[:], copy=False)
+        if 'scale_factor' in variable.attrs:
+            values = values * variable.attrs['scale_factor']
+            info['scale_factor'] = variable.attrs['scale_factor']
+        if 'add_offset' in variable.attrs:
+            values = values + variable.attrs['add_offset']
+            info['add_offset'] = variable.attrs['add_offset']
+
+        if 'valid_range' in variable.attrs:
+            info['valid_range'] = variable.attrs['valid_range']
+        if 'units' in variable.attrs:
+            info['units'] = variable.attrs['units']
+        if 'standard_name' in variable.attrs:
+            info['standard_name'] = variable.attrs['standard_name']
+
+        proj = Dataset(np.squeeze(values),
+                       copy=False,
+                       **info)
+        return proj
+
+    def get_area_def(self, dsid):
+        """Get the area definition of the datasets in the file. 
+        Only applicable for MSG products!"""
+        if self.pps:
+            # PPS:
+            raise NotImplementedError
+
+        if dsid.name.endswith('_pal'):
+            raise NotImplementedError
+
+        proj_str = self.nc.attrs['gdal_projection'] + ' +units=km'
+
+        nlines, ncols = self.nc[dsid.name].shape
+
+        area_extent = (float(self.nc.attrs['gdal_xgeo_up_left']) / 1000,
+                       float(self.nc.attrs['gdal_ygeo_low_right']) / 1000,
+                       float(self.nc.attrs['gdal_xgeo_low_right']) / 1000,
+                       float(self.nc.attrs['gdal_ygeo_up_left']) / 1000)
+
+        area = get_area_def('some_area_name',
+                            "On-the-fly area",
+                            'geosmsg',
+                            proj_str,
+                            ncols,
+                            nlines,
+                            area_extent)
+
+        return area
+
+    @property
+    def start_time(self):
+        try:
+            # MSG:
+            return datetime.strptime(self.nc.attrs['time_coverage_start'], '%Y-%m-%dT%H:%M:%SZ')
+        except ValueError:
+            # PPS:
+            return datetime.strptime(self.nc.attrs['time_coverage_start'], '%Y%m%dT%H%M%S%fZ')
+
+    @property
+    def end_time(self):
+        try:
+            # MSG:
+            return datetime.strptime(self.nc.attrs['time_coverage_end'], '%Y-%m-%dT%H:%M:%SZ')
+        except ValueError:
+            # PPS:
+            return datetime.strptime(self.nc.attrs['time_coverage_end'], '%Y%m%dT%H%M%S%fZ')

--- a/satpy/readers/nc_nwcsaf.py
+++ b/satpy/readers/nc_nwcsaf.py
@@ -74,10 +74,10 @@ class NcNWCSAF(BaseFileHandler):
 
         self.sensor = SENSOR.get(self.platform_name, 'seviri')
 
-    def get_shape(self, dsid, ds_info):
-        """Get the shape of the data."""
-        raise NotImplementedError
-        #     return self.nc[dsid.name].shape
+    # def get_shape(self, dsid, ds_info):
+    #     """Get the shape of the data."""
+    #     raise NotImplementedError
+    #     #     return self.nc[dsid.name].shape
 
     def get_dataset(self, dsid, info, out=None):
         """Load a dataset."""


### PR DESCRIPTION
Added a yaml-reader plugin for NWCSAF/PPS cloud mask and type.
Added a common reader or msg & pps products. 

Remaining issues: The NWCSAF-MSG yaml file is still using the msg-reader, but should be tested using the new common reader, and then removed when tested successful. Also, the remaining PPS products should be added.

Signed-off-by: Adam.Dybbroe <a000680@c20671.ad.smhi.se>