### PR TITLE
Fix abil1b reader close files

### DIFF
--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from pip.util import file_contents
-
 # Copyright (c) 2017 Martin Raspaud
 
 # Author(s):


### PR DESCRIPTION
This fix ensures that *.nc files are closed. It's not nice, but works for now (Some attributes should be read in advance to avoid extensive file opening and closing). 