### PR TITLE
Change writer configs from INI (.cfg) to YAML

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
 - '3.6'
 os:
 - linux
+before_install:
+- source travis/linux_install.sh
 install:
 - pip install -U pip
 - pip install -U setuptools
@@ -18,18 +20,15 @@ install:
 - pip install h5netcdf
 - pip install python-hdf4
 - "pip install --no-binary :all: netCDF4"
-- source travis/linux_install.sh
+- pip install gdal==1.10.0
 addons:
   apt_packages:
+    - libgdal-dev
     - libhdf5-serial-dev
     - libhdf4-dev
     - netcdf-bin
     - libnetcdf-dev
     - cython
-#    - libgdal1h
-#    - proj-bin
-#    - gdal-bin
-#    - libgdal-dev
 script:
 - coverage run --source=satpy setup.py test
 - coverage run -a --source=satpy -m behave satpy/tests/features --tags=-download
@@ -42,7 +41,7 @@ deploy:
   on:
     tags: true
     repo: pytroll/satpy
-sudo: true
+sudo: false
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ python:
 - '3.6'
 os:
 - linux
-before_install:
-- source travis/linux_install.sh
 install:
 - pip install -U pip
 - pip install -U setuptools
@@ -20,7 +18,7 @@ install:
 - pip install h5netcdf
 - pip install python-hdf4
 - "pip install --no-binary :all: netCDF4"
-- pip install gdal
+- source travis/linux_install.sh
 addons:
   apt_packages:
     - libhdf5-serial-dev
@@ -28,10 +26,10 @@ addons:
     - netcdf-bin
     - libnetcdf-dev
     - cython
-    - libgdal1h
-    - proj-bin
-    - gdal-bin
-    - libgdal-dev
+#    - libgdal1h
+#    - proj-bin
+#    - gdal-bin
+#    - libgdal-dev
 script:
 - coverage run --source=satpy setup.py test
 - coverage run -a --source=satpy -m behave satpy/tests/features --tags=-download
@@ -44,7 +42,7 @@ deploy:
   on:
     tags: true
     repo: pytroll/satpy
-sudo: false
+sudo: true
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ addons:
     - libnetcdf-dev
     - cython
     - libgdal1h
+    - proj-bin
+    - gdal-bin
 script:
 - coverage run --source=satpy setup.py test
 - coverage run -a --source=satpy -m behave satpy/tests/features --tags=-download

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 - pip install h5netcdf
 - pip install python-hdf4
 - "pip install --no-binary :all: netCDF4"
+- pip install gdal
 addons:
   apt_packages:
     - libhdf5-serial-dev
@@ -25,6 +26,7 @@ addons:
     - netcdf-bin
     - libnetcdf-dev
     - cython
+    - libgdal1h
 script:
 - coverage run --source=satpy setup.py test
 - coverage run -a --source=satpy -m behave satpy/tests/features --tags=-download

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ addons:
   apt_packages:
     - libgdal-dev
     - libhdf5-serial-dev
-    - libhdf4-dev
+    - libhdf4-alt-dev
     - netcdf-bin
     - libnetcdf-dev
     - cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
 - '3.6'
 os:
 - linux
+before_install:
+- source travis/linux_install.sh
 install:
 - pip install -U pip
 - pip install -U setuptools

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ addons:
     - libgdal-dev
     - libhdf5-serial-dev
     - libhdf4-alt-dev
+    - libhdf4-dev
     - netcdf-bin
     - libnetcdf-dev
     - cython

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ addons:
     - libgdal-dev
     - libhdf5-serial-dev
     - libhdf4-alt-dev
-    - libhdf4-dev
     - netcdf-bin
     - libnetcdf-dev
     - cython
@@ -42,7 +41,7 @@ deploy:
   on:
     tags: true
     repo: pytroll/satpy
-sudo: false
+sudo: true
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ addons:
     - libgdal1h
     - proj-bin
     - gdal-bin
+    - libgdal-dev
 script:
 - coverage run --source=satpy setup.py test
 - coverage run -a --source=satpy -m behave satpy/tests/features --tags=-download

--- a/satpy/etc/writers/cf.cfg
+++ b/satpy/etc/writers/cf.cfg
@@ -1,7 +1,0 @@
-[writer:cf]
-name=cf
-description=Generic netCDF4/CF Writer
-writer=satpy.writers.cf_writer.CFWriter
-file_pattern={name}_{start_time:%Y%m%d_%H%M%S}.nc
-compress=DEFLATE
-zlevel=6

--- a/satpy/etc/writers/cf.yaml
+++ b/satpy/etc/writers/cf.yaml
@@ -1,0 +1,7 @@
+writer:
+  name: cf
+  description: Generic netCDF4/CF Writer
+  writer: !!python/name:satpy.writers.cf_writer.CFWriter
+  file_pattern: '{name}_{start_time:%Y%m%d_%H%M%S}.nc'
+  compress: DEFLATE
+  zlevel: 6

--- a/satpy/etc/writers/geotiff.cfg
+++ b/satpy/etc/writers/geotiff.cfg
@@ -1,9 +1,0 @@
-# Default geotiff writer
-
-[writer:geotiff]
-name=geotiff
-description=Generic GeoTIFF Writer
-writer=satpy.writers.geotiff.GeoTIFFWriter
-file_pattern={name}_{start_time:%Y%m%d_%H%M%S}.tif
-compress=DEFLATE
-zlevel=6

--- a/satpy/etc/writers/geotiff.yaml
+++ b/satpy/etc/writers/geotiff.yaml
@@ -1,0 +1,7 @@
+writer:
+  name: geotiff
+  description: Generic GeoTIFF Writer
+  writer: !!python/name:satpy.writers.geotiff.GeoTIFFWriter
+  file_pattern: '{name}_{start_time:%Y%m%d_%H%M%S}.tif'
+  compress: DEFLATE
+  zlevel: 6

--- a/satpy/etc/writers/ninjotiff.cfg
+++ b/satpy/etc/writers/ninjotiff.cfg
@@ -1,7 +1,0 @@
-[writer:ninjotiff]
-name=ninjotiff
-description=NinjoTIFF Writer
-writer=satpy.writers.ninjotiff.NinjoTIFFWriter
-file_pattern={name}_{start_time:%Y%m%d_%H%M%S}.tif
-compress=DEFLATE
-zlevel=6

--- a/satpy/etc/writers/ninjotiff.yaml
+++ b/satpy/etc/writers/ninjotiff.yaml
@@ -1,0 +1,7 @@
+writer:
+  name: ninjotiff
+  description: NinjoTIFF Writer
+  writer: !!python/name:satpy.writers.ninjotiff.NinjoTIFFWriter
+  file_pattern: '{name}_{start_time:%Y%m%d_%H%M%S}.tif'
+  compress: DEFLATE
+  zlevel: 6

--- a/satpy/etc/writers/simple_image.cfg
+++ b/satpy/etc/writers/simple_image.cfg
@@ -1,5 +1,0 @@
-[writer:simple_image]
-name=simple_image
-description=Generic Image Writer
-writer=satpy.writers.simple_image.PillowWriter
-file_pattern={name}_{start_time:%Y%m%d_%H%M%S}.png

--- a/satpy/etc/writers/simple_image.yaml
+++ b/satpy/etc/writers/simple_image.yaml
@@ -1,0 +1,5 @@
+writer:
+  name: simple_image
+  description: Generic Image Writer
+  writer: !!python/name:satpy.writers.simple_image.PillowWriter
+  file_pattern: '{name}_{start_time:%Y%m%d_%H%M%S}.png'

--- a/satpy/tests/__init__.py
+++ b/satpy/tests/__init__.py
@@ -28,7 +28,7 @@ import sys
 from satpy.tests import (reader_tests, test_dataset, test_file_handlers,
                          test_helper_functions, test_readers, test_resample,
                          test_scene, test_utils, test_writers,
-                         test_yaml_reader)
+                         test_yaml_reader, writer_tests)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -50,6 +50,7 @@ def suite():
     mysuite.addTests(test_yaml_reader.suite())
     mysuite.addTests(test_helper_functions.suite())
     mysuite.addTests(reader_tests.suite())
+    mysuite.addTests(writer_tests.suite())
     mysuite.addTests(test_file_handlers.suite())
     mysuite.addTests(test_utils.suite())
 

--- a/satpy/tests/writer_tests/__init__.py
+++ b/satpy/tests/writer_tests/__init__.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 David Hoese
+#
+# Author(s):
+#
+#   David Hoese <david.hoese@ssec.wisc.edu>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""The writer tests package.
+"""
+
+import sys
+
+from satpy.tests.writer_tests import (test_cf, test_geotiff,
+                                      test_ninjotiff, test_simple_image)
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+def suite():
+    """Test suite for all writer tests"""
+    mysuite = unittest.TestSuite()
+    # mysuite.addTests(test_cf.suite())
+    mysuite.addTests(test_geotiff.suite())
+    # mysuite.addTests(test_ninjotiff.suite())
+    mysuite.addTests(test_simple_image.suite())
+    return mysuite

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 David Hoese
+#
+# Author(s):
+#
+#   David Hoese <david.hoese@ssec.wisc.edu>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for the CF writer.
+"""
+import os
+import sys
+
+import numpy as np
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class TestCFWriter(unittest.TestCase):
+    def test_init(self):
+        from satpy.writers.cf_writer import CFWriter
+        w = CFWriter()
+
+
+def suite():
+    """The test suite for this writer's tests.
+    """
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(TestCFWriter))
+    return mysuite

--- a/satpy/tests/writer_tests/test_geotiff.py
+++ b/satpy/tests/writer_tests/test_geotiff.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 David Hoese
+#
+# Author(s):
+#
+#   David Hoese <david.hoese@ssec.wisc.edu>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for the CF writer.
+"""
+import os
+import sys
+
+import numpy as np
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class TestGeoTIFFWriter(unittest.TestCase):
+    def test_init(self):
+        from satpy.writers.geotiff import GeoTIFFWriter
+        w = GeoTIFFWriter()
+
+
+def suite():
+    """The test suite for this writer's tests.
+    """
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(TestGeoTIFFWriter))
+    return mysuite

--- a/satpy/tests/writer_tests/test_ninjotiff.py
+++ b/satpy/tests/writer_tests/test_ninjotiff.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 David Hoese
+#
+# Author(s):
+#
+#   David Hoese <david.hoese@ssec.wisc.edu>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for the CF writer.
+"""
+import os
+import sys
+
+import numpy as np
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class TestNinjoTIFFWriter(unittest.TestCase):
+    def test_init(self):
+        from satpy.writers.ninjotiff import NinjoTIFFWriter
+        w = NinjoTIFFWriter()
+
+
+def suite():
+    """The test suite for this writer's tests.
+    """
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(TestNinjoTIFFWriter))
+    return mysuite

--- a/satpy/tests/writer_tests/test_simple_image.py
+++ b/satpy/tests/writer_tests/test_simple_image.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2017 David Hoese
+#
+# Author(s):
+#
+#   David Hoese <david.hoese@ssec.wisc.edu>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for the CF writer.
+"""
+import os
+import sys
+
+import numpy as np
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class TestPillowWriter(unittest.TestCase):
+    def test_init(self):
+        from satpy.writers.simple_image import PillowWriter
+        w = PillowWriter()
+
+
+def suite():
+    """The test suite for this writer's tests.
+    """
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(TestPillowWriter))
+    return mysuite

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -193,13 +193,14 @@ class Writer(Plugin):
                  **kwargs):
         # Load the config
         Plugin.__init__(self, **kwargs)
+        self.info = self.config['writer']
 
         # Use options from the config file if they weren't passed as arguments
-        self.name = self.config_options.get("name",
-                                            None) if name is None else name
-        self.fill_value = self.config_options.get(
+        self.name = self.info.get("name",
+                                  None) if name is None else name
+        self.fill_value = self.info.get(
             "fill_value", None) if fill_value is None else fill_value
-        self.file_pattern = self.config_options.get(
+        self.file_pattern = self.info.get(
             "file_pattern", None) if file_pattern is None else file_pattern
 
         if self.name is None:
@@ -218,9 +219,6 @@ class Writer(Plugin):
             file_pattern = self.file_pattern
         self.filename_parser = parser.Parser(
             file_pattern) if file_pattern else None
-
-    def load_section_writer(self, section_name, section_options):
-        self.config_options = section_options
 
     def get_filename(self, **kwargs):
         if self.filename_parser is None:
@@ -256,7 +254,7 @@ class ImageWriter(Writer):
                  **kwargs):
         Writer.__init__(self, name, fill_value, file_pattern, base_dir,
                         **kwargs)
-        enhancement_config = self.config_options.get(
+        enhancement_config = self.info.get(
             "enhancement_config",
             None) if enhancement_config is None else enhancement_config
 

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -60,14 +60,14 @@ class GeoTIFFWriter(ImageWriter):
 
     def __init__(self, floating_point=False, tags=None, **kwargs):
         ImageWriter.__init__(self,
-                             default_config_filename="writers/geotiff.cfg",
+                             default_config_filename="writers/geotiff.yaml",
                              **kwargs)
 
-        self.floating_point = bool(self.config_options.get(
+        self.floating_point = bool(self.info.get(
             "floating_point", None) if floating_point is None else
             floating_point)
-        self.tags = self.config_options.get("tags",
-                                            None) if tags is None else tags
+        self.tags = self.info.get("tags",
+                                  None) if tags is None else tags
         if self.tags is None:
             self.tags = {}
         elif not isinstance(self.tags, dict):
@@ -77,8 +77,8 @@ class GeoTIFFWriter(ImageWriter):
         # GDAL specific settings
         self.gdal_options = {}
         for k in self.GDAL_OPTIONS:
-            if k in kwargs or k in self.config_options:
-                self.gdal_options[k] = kwargs.get(k, self.config_options[k])
+            if k in kwargs or k in self.info:
+                self.gdal_options[k] = kwargs.get(k, self.info[k])
 
     def _gdal_write_datasets(self, dst_ds, datasets, opacity, fill_value):
         """Write *datasets* in a gdal raster structure *dts_ds*, using

--- a/satpy/writers/ninjotiff.py
+++ b/satpy/writers/ninjotiff.py
@@ -62,14 +62,14 @@ class NinjoTIFFWriter(ImageWriter):
 
     def __init__(self, floating_point=False, tags=None, **kwargs):
         ImageWriter.__init__(self,
-                             default_config_filename="writers/ninjotiff.cfg",
+                             default_config_filename="writers/ninjotiff.yaml",
                              **kwargs)
 
         # self.floating_point = bool(self.config_options.get(
         #     "floating_point", None) if floating_point is None else
         #     floating_point)
-        self.tags = self.config_options.get("tags",
-                                            None) if tags is None else tags
+        self.tags = self.info.get("tags",
+                                  None) if tags is None else tags
         if self.tags is None:
             self.tags = {}
         elif not isinstance(self.tags, dict):

--- a/satpy/writers/simple_image.py
+++ b/satpy/writers/simple_image.py
@@ -32,7 +32,7 @@ class PillowWriter(ImageWriter):
     def __init__(self, **kwargs):
         ImageWriter.__init__(
             self,
-            default_config_filename="writers/simple_image.cfg",
+            default_config_filename="writers/simple_image.yaml",
             **kwargs)
 
     def save_image(self, img, filename=None, **kwargs):

--- a/travis/linux_install.sh
+++ b/travis/linux_install.sh
@@ -5,5 +5,9 @@ set -ex
 # needed to build Python binding for GDAL
 export CPLUS_INCLUDE_PATH=/usr/include/gdal
 export C_INCLUDE_PATH=/usr/include/gdal
+# the libhdf4-alt-dev package puts libraries in a weird place
+# it says so that it doesn't conflict with netcdf...let's see what happens
+sudo ln -s libmfhdfalt.so /usr/lib/libmfhdf.so
+sudo ln -s libdfalt.so /usr/lib/libdf.so
 
 set +ex

--- a/travis/linux_install.sh
+++ b/travis/linux_install.sh
@@ -5,15 +5,5 @@ set -ex
 # needed to build Python binding for GDAL
 export CPLUS_INCLUDE_PATH=/usr/include/gdal
 export C_INCLUDE_PATH=/usr/include/gdal
-sudo mv /etc/apt/sources.list.d/pgdg-source.list* /tmp
-sudo apt-get -qq remove postgis
-sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-sudo apt-get update -qq
-sudo apt-get install -qq bison flex python-lxml libfribidi-dev swig cmake \
-librsvg2-dev colordiff postgis postgresql-9.1-postgis-2.0-scripts libpq-dev \
-libpng12-dev libjpeg-dev libgif-dev libgeos-dev libgd2-xpm-dev \
-libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal1-dev \
-libproj-dev libxml2-dev python-dev php5-dev libexempi-dev lcov lftp
-pip install gdal
 
 set +ex

--- a/travis/linux_install.sh
+++ b/travis/linux_install.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# needed to build Python binding for GDAL
+export CPLUS_INCLUDE_PATH=/usr/include/gdal
+export C_INCLUDE_PATH=/usr/include/gdal
+
+set +ex

--- a/travis/linux_install.sh
+++ b/travis/linux_install.sh
@@ -5,5 +5,15 @@ set -ex
 # needed to build Python binding for GDAL
 export CPLUS_INCLUDE_PATH=/usr/include/gdal
 export C_INCLUDE_PATH=/usr/include/gdal
+sudo mv /etc/apt/sources.list.d/pgdg-source.list* /tmp
+sudo apt-get -qq remove postgis
+sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+sudo apt-get update -qq
+sudo apt-get install -qq bison flex python-lxml libfribidi-dev swig cmake \
+librsvg2-dev colordiff postgis postgresql-9.1-postgis-2.0-scripts libpq-dev \
+libpng12-dev libjpeg-dev libgif-dev libgeos-dev libgd2-xpm-dev \
+libfreetype6-dev libfcgi-dev libcurl4-gnutls-dev libcairo2-dev libgdal1-dev \
+libproj-dev libxml2-dev python-dev php5-dev libexempi-dev lcov lftp
+pip install gdal
 
 set +ex


### PR DESCRIPTION
In preparation for adding more complex writers it would be easier to use YAML files instead of INI files. Since all other satpy components (readers, enhancements, composites, etc) all use YAML, it just makes sense to do this.