### PR TITLE
Palette enhancement

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -212,6 +212,53 @@ To save the custom composite, the following procedure can be used:
 
 With that, you should be able to load your new composite directly.
 
+
+Colorizing using user-supplied colormaps
+========================================
+
+It is possible to create single channel "composites" that are then colorized 
+using users' own colormaps.  The colormaps are Numpy arrays with shape 
+(num, 3), see the example below how to create the mapping file(s).
+
+This example creates a 2-color colormap, and we set the temperature ranges 
+so that temperature values below 0 deg Celsius are colored white and above 
+that black. 
+
+    >>> import numpy as np
+    >>> from satpy.composites import BWCompositor
+    >>> from satpy.enhancemetns import colorize
+    >>> from satpy.writers import to_image
+    >>> arr = np.array([[0, 0, 0], [255, 255, 255]])
+    >>> np.save("/tmp/binary_colormap.npy", arr)
+    >>> compositor = BWCompositor("test", standard_name="colorized_ir_clouds")
+    >>> composite = compositor((local_scene[10.8], ))
+    >>> img = to_image(composite)
+    >>> kwargs = {"palettes": [{"filename": "/tmp/binary_colormap.npy",
+    ...           "min_value": 273.15, "max_value": 273.150001}]}
+    >>> colorize(img, **kwargs)
+    >>> img.show()
+
+You can define several colormaps and ranges in the `palettes` list and they 
+are merged together.  See trollimage_ documentation for more information how 
+colormaps and color ranges are merged.
+
+This can be used in enhancements YAML config like this:
+
+.. code-block:: yaml
+
+  hot_or_cold:
+    standard_name: hot_or_cold
+    operations:
+      - name: colorize
+        method: &colorizefun !!python/name:satpy.enhancements.colorize ''
+        kwargs:
+          palettes:
+            - {filename: /tmp/binary_colormap.npy, min_value: 273.15, max_value: 273.150001}
+
+
+.. _trollimage: http://trollimage.readthedocs.io/en/latest/
+
+
 .. todo::
    How to save custom-made composites
 

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -213,16 +213,16 @@ To save the custom composite, the following procedure can be used:
 With that, you should be able to load your new composite directly.
 
 
-Colorizing using user-supplied colormaps
-========================================
+Colorizing and Palettizing using user-supplied colormaps
+========================================================
 
 It is possible to create single channel "composites" that are then colorized 
 using users' own colormaps.  The colormaps are Numpy arrays with shape 
 (num, 3), see the example below how to create the mapping file(s).
 
-This example creates a 2-color colormap, and we set the temperature ranges 
-so that temperature values below 0 deg Celsius are colored white and above 
-that black. 
+This example creates a 2-color colormap, and we interpolate the colors between 
+the defined temperature ranges.  Beyond those limits the image clipped to 
+the specified colors.
 
     >>> import numpy as np
     >>> from satpy.composites import BWCompositor
@@ -234,15 +234,18 @@ that black.
     >>> composite = compositor((local_scene[10.8], ))
     >>> img = to_image(composite)
     >>> kwargs = {"palettes": [{"filename": "/tmp/binary_colormap.npy",
-    ...           "min_value": 273.15, "max_value": 273.150001}]}
+    ...           "min_value": 223.15, "max_value": 303.15}]}
     >>> colorize(img, **kwargs)
     >>> img.show()
+
+Similarly it is possible to use discreet values without color interpolation 
+using `palettize()` instead of `colorize()`
 
 You can define several colormaps and ranges in the `palettes` list and they 
 are merged together.  See trollimage_ documentation for more information how 
 colormaps and color ranges are merged.
 
-This can be used in enhancements YAML config like this:
+The above example can be used in enhancements YAML config like this:
 
 .. code-block:: yaml
 
@@ -253,7 +256,7 @@ This can be used in enhancements YAML config like this:
         method: &colorizefun !!python/name:satpy.enhancements.colorize ''
         kwargs:
           palettes:
-            - {filename: /tmp/binary_colormap.npy, min_value: 273.15, max_value: 273.150001}
+            - {filename: /tmp/binary_colormap.npy, min_value: 223.15, max_value: 303.15}
 
 
 .. _trollimage: http://trollimage.readthedocs.io/en/latest/

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -226,7 +226,7 @@ that black.
 
     >>> import numpy as np
     >>> from satpy.composites import BWCompositor
-    >>> from satpy.enhancemetns import colorize
+    >>> from satpy.enhancements import colorize
     >>> from satpy.writers import to_image
     >>> arr = np.array([[0, 0, 0], [255, 255, 255]])
     >>> np.save("/tmp/binary_colormap.npy", arr)

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -48,3 +48,32 @@ def cira_stretch(img, **kwargs):
         chn -= np.log10(0.0223)
         chn /= 1.0 - np.log10(0.0223)
         chn /= 0.75
+
+
+def colorize(img, **kwargs):
+    """Colorize the given image."""
+    full_cmap = None
+
+    for itm in kwargs["palettes"]:
+        cmap = create_colormap(itm["filename"])
+        cmap.set_range(itm["min_value"], itm["max_value"])
+        if full_cmap is None:
+            full_cmap = cmap
+        else:
+            full_cmap = full_cmap + cmap
+
+    img.colorize(full_cmap)
+
+
+def create_colormap(fname):
+    """Create colormap of the given numpy file."""
+
+    from trollimage.colormap import Colormap
+
+    data = np.load(fname)
+    cmap = []
+    num = 1.0 * data.shape[0]
+    for i in range(int(num)):
+        cmap.append((i / num, (data[i, 0] / 255., data[i, 1] / 255.,
+                               data[i, 2] / 255.)))
+    return Colormap(*cmap)

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -52,21 +52,20 @@ def cira_stretch(img, **kwargs):
 
 def colorize(img, **kwargs):
     """Colorize the given image."""
-    full_cmap = None
 
-    for itm in kwargs["palettes"]:
-        cmap = create_colormap(itm["filename"])
-        cmap.set_range(itm["min_value"], itm["max_value"])
-        if full_cmap is None:
-            full_cmap = cmap
-        else:
-            full_cmap = full_cmap + cmap
-
+    full_cmap = _merge_colormaps(kwargs)
     img.colorize(full_cmap)
 
 
 def palettize(img, **kwargs):
-    """Palettize the given image."""
+    """Palettize the given image (no color interpolation)."""
+
+    full_cmap = _merge_colormaps(kwargs)
+    img.palettize(full_cmap)
+
+
+def _merge_colormaps(kwargs):
+    """Merge colormaps listed in kwargs."""
     full_cmap = None
 
     for itm in kwargs["palettes"]:
@@ -77,7 +76,7 @@ def palettize(img, **kwargs):
         else:
             full_cmap = full_cmap + cmap
 
-    img.palettize(full_cmap)
+    return full_cmap
 
 
 def create_colormap(fname):

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -65,6 +65,21 @@ def colorize(img, **kwargs):
     img.colorize(full_cmap)
 
 
+def palettize(img, **kwargs):
+    """Palettize the given image."""
+    full_cmap = None
+
+    for itm in kwargs["palettes"]:
+        cmap = create_colormap(itm["filename"])
+        cmap.set_range(itm["min_value"], itm["max_value"])
+        if full_cmap is None:
+            full_cmap = cmap
+        else:
+            full_cmap = full_cmap + cmap
+
+    img.palettize(full_cmap)
+
+
 def create_colormap(fname):
     """Create colormap of the given numpy file."""
 


### PR DESCRIPTION
This PR makes it possible to use users' own palettes for colorizing single channel composites. Documentation has examples for creating the palette file(s) and how to configure them in the enhancement YAML file.