### PR TITLE
Solar pathlength correction and Rayleigh correction interface

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -363,14 +363,8 @@ class PSPRayleighReflectance(CompositeBase):
         ssadiff = np.where(np.greater(ssadiff, 180), 360 - ssadiff, ssadiff)
         del sata, suna
 
-        if 'atmosphere' not in self.info:
-            atmosphere = 'us-standard'
-        else:
-            atmosphere = self.info['atmosphere']
-        if 'aerosol_type' not in self.info:
-            aerosol_type = 'marine_clean_aerosol'
-        else:
-            aerosol_type = self.info['aerosol_type']
+        atmosphere = self.info.get('atmosphere', 'us-standard')
+        aerosol_type = self.info.get('aerosol_type', 'marine_clean_aerosol')
 
         corrector = Rayleigh(vis.info['platform_name'], vis.info['sensor'],
                              atmosphere=atmosphere,

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -25,6 +25,7 @@
 
 import logging
 import os
+import time
 
 import numpy as np
 import six
@@ -36,6 +37,7 @@ from satpy.dataset import (DATASET_KEYS, Dataset, DatasetID, InfoObject,
                            combine_info)
 from satpy.readers import DatasetDict
 from satpy.tools import sunzen_corr_cos
+from satpy.tools import atmospheric_path_length_correction
 from satpy.writers import get_enhanced_image
 
 try:
@@ -238,7 +240,10 @@ class CompositeBase(InfoObject):
                     d[k] = o[k]
 
 
-class SunZenithCorrector(CompositeBase):
+class SunZenithCorrectorBase(CompositeBase):
+
+    """Base class for sun zenith correction"""
+
     # FIXME: the cache should be cleaned up
     coszen = {}
 
@@ -253,6 +258,7 @@ class SunZenithCorrector(CompositeBase):
         else:
             area_name = 'swath' + str(vis.shape)
         key = (vis.info["start_time"], area_name)
+        tic = time.time()
         LOG.debug("Applying sun zen correction")
         if len(projectables) == 1:
             if key not in self.coszen:
@@ -278,10 +284,36 @@ class SunZenithCorrector(CompositeBase):
 
         # sunz correction will be in place so we need a copy
         proj = vis.copy()
-        proj = sunzen_corr_cos(proj, coszen)
+        proj = self._apply_correction(proj, coszen)
         vis.mask[coszen < 0] = True
         self.apply_modifier_info(vis, proj)
+        LOG.debug(
+            "Sun-zenith correction applied. Computation time: %5.1f (sec)", time.time() - tic)
         return proj
+
+    def _apply_correction(self, proj, coszen):
+        raise NotImplementedError("Correction method shall be defined!")
+
+
+class SunZenithCorrector(SunZenithCorrectorBase):
+
+    """Standard sun zenith correction, 1/cos(sunz)"""
+
+    def _apply_correction(self, proj, coszen):
+        LOG.debug("Apply the standard sun-zenith correction [1/cos(sunz)]")
+        return sunzen_corr_cos(proj, coszen)
+
+
+class EffectiveSolarPathLengthCorrector(SunZenithCorrectorBase):
+
+    """Special sun zenith correction with the method proposed by Li and Shibata
+    (2006): https://doi.org/10.1175/JAS3682.1
+    """
+
+    def _apply_correction(self, proj, coszen):
+        LOG.debug(
+            "Apply the effective solar atmospheric path length correction method by Li and Shibata")
+        return atmospheric_path_length_correction(proj, coszen)
 
 
 def show(data, filename=None):
@@ -325,14 +357,24 @@ class PSPRayleighReflectance(CompositeBase):
                                             lons, lats, 0)
             satz = 90 - satel
             del satel
-        LOG.info('Removing Rayleigh scattering')
+        LOG.info('Removing Rayleigh scattering and aerosol absorption')
 
         ssadiff = np.abs(suna - sata)
         ssadiff = np.where(np.greater(ssadiff, 180), 360 - ssadiff, ssadiff)
         del sata, suna
 
+        if 'atmosphere' not in self.info:
+            atmosphere = 'us-standard'
+        else:
+            atmosphere = self.info['atmosphere']
+        if 'aerosol_type' not in self.info:
+            aerosol_type = 'marine_clean_aerosol'
+        else:
+            aerosol_type = self.info['aerosol_type']
+
         corrector = Rayleigh(vis.info['platform_name'], vis.info['sensor'],
-                             atmosphere='us-standard', rural_aerosol=False)
+                             atmosphere=atmosphere,
+                             aerosol_type=aerosol_type)
 
         refl_cor_band = corrector.get_reflectance(
             sunz, satz, ssadiff, vis.id.wavelength[1], blue)
@@ -788,6 +830,7 @@ class RealisticColors(RGBCompositor):
         except ValueError:
             raise IncompatibleAreas
         return res
+
 
 def enhance2dataset(dset):
     """Apply enhancements to dataset *dset* and convert the image data

--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -10,9 +10,11 @@ modifiers:
 
   rayleigh_corrected:
     compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: midlatitude summer
+    aerosol_type: marine_tropical_aerosol      
     prerequisites:
     - name: C01
-      modifiers: [reducer2, sunz_corrected]
+      modifiers: [reducer2, effective_solar_pathlength_corrected]
     optional_prerequisites:
     - satellite_azimuth_angle
     - satellite_zenith_angle
@@ -25,13 +27,11 @@ composites:
     compositor: !!python/name:satpy.composites.abi.TrueColor
     prerequisites:
     - name: C01
-      modifiers: [reducer2, sunz_corrected, rayleigh_corrected]
-      #modifiers: [reducer2, sunz_corrected]
+      modifiers: [reducer2, effective_solar_pathlength_corrected, rayleigh_corrected]
     - name: C02
-      modifiers: [reducer4, sunz_corrected, rayleigh_corrected]
-      #modifiers: [reducer4, sunz_corrected]
+      modifiers: [reducer4, effective_solar_pathlength_corrected, rayleigh_corrected]
     - name: C03
-      modifiers: [reducer2, sunz_corrected]
+      modifiers: [reducer2, effective_solar_pathlength_corrected]
     standard_name: true_color
 
   overview:

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -15,6 +15,12 @@ modifiers:
     prerequisites:
     - solar_zenith_angle
 
+  effective_solar_pathlength_corrected:
+    compositor: !!python/name:satpy.composites.EffectiveSolarPathLengthCorrector
+    prerequisites:
+    - solar_zenith_angle
+
+
 composites:
 
   true_color:

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -4,6 +4,10 @@ modifiers:
   sunz_corrected:
     compositor: !!python/name:satpy.composites.SunZenithCorrector
 
+  effective_solar_pathlength_corrected:
+    compositor: !!python/name:satpy.composites.EffectiveSolarPathLengthCorrector
+
+
   co2_corrected:
     compositor: !!python/name:satpy.composites.CO2Corrector
     prerequisites:
@@ -25,6 +29,9 @@ modifiers:
 
   rayleigh_corrected:
     compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: midlatitude summer
+    #aerosol_type: marine_clean_aerosol
+    aerosol_type: rayleigh_only
     prerequisites:
     - wavelength: 0.44
       modifiers: [sunz_corrected]

--- a/satpy/tools.py
+++ b/satpy/tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2014, 2016
+# Copyright (c) 2014, 2016, 2017
 #
 # Author(s):
 #
@@ -25,6 +25,12 @@
 import numpy as np
 
 
+def _get_sunz_corr_li_and_shibata(cos_zen):
+
+    return 24.35 / (2. * cos_zen +
+                    np.sqrt(498.5225 * cos_zen**2 + 1))
+
+
 def sunzen_corr_cos(data, cos_zen, limit=88.):
     '''Perform Sun zenith angle correction to the given *data* using
     cosine of the zenith angle (*cos_zen*).  The correction is limited
@@ -44,5 +50,33 @@ def sunzen_corr_cos(data, cos_zen, limit=88.):
     # angles
     lim_y, lim_x = np.where(cos_zen <= limit)
     data[lim_y, lim_x] /= limit
+
+    return data
+
+
+def atmospheric_path_length_correction(data, cos_zen, limit=88.):
+    '''Perform Sun zenith angle correction to the given *data* using
+    the method proposed by Li and Shibata (2006): https://doi.org/10.1175/JAS3682.1
+
+    The correction is limited to *limit* degrees (default: 88.0 degrees). For
+    larger zenith angles, the correction is the same as at the *limit*. Both
+    *data* and *cos_zen* are given as 2-dimensional Numpy arrays or Numpy
+    MaskedArrays, and they should have equal shapes.
+
+    '''
+
+    # Convert the zenith angle limit to cosine of zenith angle
+    limit = np.cos(np.radians(limit))
+
+    # Cosine correction
+    lim_y, lim_x = np.where(cos_zen > limit)
+
+    corr = _get_sunz_corr_li_and_shibata(cos_zen)
+    data[lim_y, lim_x] *= corr[lim_y, lim_x]
+    # Use constant value (the limit) for larger zenith
+    # angles
+    lim_y, lim_x = np.where(cos_zen <= limit)
+    corr_lim = _get_sunz_corr_li_and_shibata(limit)
+    data[lim_y, lim_x] *= corr_lim
 
     return data


### PR DESCRIPTION
Added the solar path length correction method of Li and Shibata, 2006.
Also, made it possible to configure the atmosphere and aerosol-type for the Rayleigh scattering with Pyspectral
