### PR TITLE
Fix resampling when a dataset was added via setitem and a test for it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
 - '2.7'
-- '3.3'
 - '3.4'
 - '3.5'
 - '3.6'

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -199,6 +199,11 @@ class DependencyTree(Node):
         Node.add_child(parent, child)
         self._all_nodes[child.name] = child
 
+    def add_leaf(self, ds_id, parent=None):
+        if parent is None:
+            parent = self
+        self.add_child(parent, Node(ds_id))
+
     def copy(self):
         """Copy the this node tree
 

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -307,7 +307,9 @@ class Scene(InfoObject):
         if not isinstance(value, Dataset):
             raise ValueError("Only 'Dataset' objects can be assigned")
         self.datasets[key] = value
-        self.wishlist.add(self.datasets.get_key(key))
+        ds_id = self.datasets.get_key(key)
+        self.wishlist.add(ds_id)
+        self.dep_tree.add_leaf(ds_id)
 
     def __delitem__(self, key):
         """Remove the item from the scene."""

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1066,6 +1066,31 @@ class TestSceneResample(unittest.TestCase):
         self.assertTupleEqual(
             tuple(loaded_ids[0]), tuple(DatasetID(name='ds1')))
 
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_resample_added_ds(self, cri, cl):
+        """Test loading and resampling a single dataset"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy import DatasetID, Dataset
+        cri.return_value = {'fake_reader': create_fake_reader(
+            'fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames='bla',
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load(['ds1'])
+        scene['new_ds'] = scene['ds1'] + 1.
+        with mock.patch.object(Dataset, 'resample', autospec=True) as r:
+            r.side_effect = lambda self, x, **kwargs: self
+            # None is our fake Area destination
+            new_scene = scene.resample(None)
+        loaded_ids = list(new_scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 2)
+        self.assertSetEqual(
+            set(loaded_ids), set([DatasetID(name='ds1'), DatasetID(name='new_ds')]))
+
 
 def suite():
     """The test suite for test_scene.


### PR DESCRIPTION
Includes removing python 3.3 from travis tests