### PR TITLE
Add procedural solar_zenith_angle

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -36,8 +36,7 @@ from satpy.config import (CONFIG_PATH, config_search_paths,
 from satpy.dataset import (DATASET_KEYS, Dataset, DatasetID, InfoObject,
                            combine_info)
 from satpy.readers import DatasetDict
-from satpy.tools import sunzen_corr_cos
-from satpy.tools import atmospheric_path_length_correction
+from satpy.tools import atmospheric_path_length_correction, sunzen_corr_cos
 from satpy.writers import get_enhanced_image
 
 try:
@@ -561,6 +560,25 @@ class BWCompositor(CompositeBase):
         info = combine_info(*projectables)
         info['name'] = self.info['name']
         info['standard_name'] = self.info['standard_name']
+
+        return Dataset(projectables[0], **info)
+
+
+class SunZenithComputer(CompositeBase):
+
+    def __call__(self, projectables, nonprojectables=None, **info):
+        lons, lats = projectables
+
+        info = combine_info(*projectables)
+        info['name'] = self.info['name']
+        info['standard_name'] = self.info['standard_name']
+        dummy, satel = get_observer_look(lons.info['satellite_longitude'],
+                                         lons.info[
+                                             'satellite_latitude'],
+                                         lons.info[
+                                             'satellite_altitude'],
+                                         lons.info['start_time'],
+                                         lons, lats, 0)
 
         return Dataset(projectables[0], **info)
 

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -42,6 +42,13 @@ modifiers:
     - solar_zenith_angle
 
 composites:
+  solar_zenith_angle:
+    compositor: !!python/name:satpy.composites.SunZenithComputer
+    prerequitisites:
+      - longitude
+      - latitude
+    standard_name: solar_zenith_angle
+    
   airmass_corr:
     compositor: !!python/name:satpy.composites.Airmass
     prerequisites:


### PR DESCRIPTION
This PR is a proof on concept for procedural channels in satpy. Since original datasets are loaded before composites, have custom build composites for eg solar_zenith_angle would allow these composites to be generated if they are not provided in the dataset.