### PR TITLE
Fix enhancement config loading when user configs are present

### DIFF
--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -22,6 +22,9 @@
 """
 """
 
+import os
+import errno
+import shutil
 import unittest
 import numpy as np
 from satpy import dataset
@@ -32,6 +35,21 @@ try:
 except ImportError:
     import mock
 
+
+def mkdir_p(path):
+    if not path or path == '.':
+        return
+
+    # Use for python 2.7 compatibility
+    # When python 2.7 support is dropped just use
+    # `os.makedirs(path, exist_ok=True)`
+    try:
+        os.makedirs(path)
+    except OSError as exc:  # Python >2.5
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise
 
 
 class TestWritersModule(unittest.TestCase):
@@ -82,17 +100,21 @@ class TestWritersModule(unittest.TestCase):
 
 
 class TestEnhancer(unittest.TestCase):
+    """Test basic `Enhancer` functionality with builtin configs"""
     def test_basic_init_no_args(self):
+        """Test Enhancer init with no arguments passed"""
         from satpy.writers import Enhancer
         e = Enhancer()
         self.assertIsNotNone(e.enhancement_tree)
 
     def test_basic_init_no_enh(self):
+        """Test Enhancer init requesting no enhancements"""
         from satpy.writers import Enhancer
         e = Enhancer(enhancement_config_file=False)
         self.assertIsNone(e.enhancement_tree)
 
     def test_basic_init_provided_enh(self):
+        """Test Enhancer init with string enhancement configs"""
         from satpy.writers import Enhancer
         e = Enhancer(enhancement_config_file=["""enhancements:
   enh1:
@@ -105,8 +127,104 @@ class TestEnhancer(unittest.TestCase):
         self.assertIsNotNone(e.enhancement_tree)
 
     def test_init_nonexistent_enh_file(self):
+        """Test Enhancer init with a nonexistent enhancement configuration file"""
         from satpy.writers import Enhancer
         self.assertRaises(ValueError, Enhancer, enhancement_config_file="is_not_a_valid_filename_?.yaml")
+
+
+class TestEnhancerUserConfigs(unittest.TestCase):
+    """Test `Enhancer` functionality when user's custom configurations are present"""
+
+    TEST_CONFIGS = {
+        'test_sensor.yaml': """
+sensor_name: visir/test_sensor
+enhancements:
+  test1_default:
+    name: test1
+    operations:
+    - name: stretch
+      method: !!python/name:satpy.enhancements.stretch ''
+      kwargs: {stretch: linear, cutoffs: [0., 0.]}
+        
+        """,
+        'enhancements/test_sensor.yaml': """
+sensor_name: visir/test_sensor
+enhancements:
+  test1_kelvin:
+    name: test1
+    units: kelvin
+    operations:
+    - name: stretch
+      method: !!python/name:satpy.enhancements.stretch ''
+      kwargs: {stretch: crude, min_stretch: 0, max_stretch: 20}
+
+        """,
+        'test_sensor2.yaml': """
+sensor_name: visir/test_sensor2
+
+
+        """,
+        'enhancements/test_sensor2.yaml': """
+sensor_name: visir/test_sensor2
+
+        """,
+    }
+
+    @classmethod
+    def setUpClass(cls):
+        """Create fake user configurations"""
+        for fn, content in cls.TEST_CONFIGS.items():
+            base_dir = os.path.dirname(fn)
+            mkdir_p(base_dir)
+            with open(fn, 'w') as f:
+                f.write(content)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Remove fake user configurations"""
+        for fn, content in cls.TEST_CONFIGS.items():
+            base_dir = os.path.dirname(fn)
+            if base_dir not in ['.', ''] and os.path.isdir(base_dir):
+                shutil.rmtree(base_dir)
+            elif os.path.isfile(fn):
+                os.remove(fn)
+
+    def test_enhance_with_sensor_no_entry(self):
+        """Test enhancing an image that has no configuration sections"""
+        from satpy.writers import Enhancer, get_enhanced_image
+        from satpy import Dataset
+        ds = Dataset(np.arange(1, 11.).reshape((2, 5)), sensor='test_sensor2', mode='L')
+        e = Enhancer()
+        self.assertIsNotNone(e.enhancement_tree)
+        get_enhanced_image(ds, enhancer=e)
+        self.assertSetEqual(set(e.sensor_enhancement_configs),
+                            {'test_sensor2.yaml', 'enhancements/test_sensor2.yaml'})
+
+    def test_enhance_with_sensor_entry(self):
+        """Test enhancing an image with a configuration section"""
+        from satpy.writers import Enhancer, get_enhanced_image
+        from satpy import Dataset
+        ds = Dataset(np.arange(1, 11.).reshape((2, 5)),
+                     name='test1', sensor='test_sensor', mode='L')
+        e = Enhancer()
+        self.assertIsNotNone(e.enhancement_tree)
+        img = get_enhanced_image(ds, enhancer=e)
+        self.assertSetEqual(set(e.sensor_enhancement_configs),
+                            {'test_sensor.yaml', 'enhancements/test_sensor.yaml'})
+        np.testing.assert_almost_equal(img.channels[0].max(), 1.)
+
+    def test_enhance_with_sensor_entry2(self):
+        """Test enhancing an image with a more detailed configuration section"""
+        from satpy.writers import Enhancer, get_enhanced_image
+        from satpy import Dataset
+        ds = Dataset(np.arange(1, 11.).reshape((2, 5)),
+                     name='test1', units='kelvin', sensor='test_sensor', mode='L')
+        e = Enhancer()
+        self.assertIsNotNone(e.enhancement_tree)
+        img = get_enhanced_image(ds, enhancer=e)
+        self.assertSetEqual(set(e.sensor_enhancement_configs),
+                            {'test_sensor.yaml', 'enhancements/test_sensor.yaml'})
+        np.testing.assert_almost_equal(img.channels[0].max(), 0.5)
 
 
 def suite():
@@ -116,5 +234,6 @@ def suite():
     my_suite = unittest.TestSuite()
     my_suite.addTest(loader.loadTestsFromTestCase(TestWritersModule))
     my_suite.addTest(loader.loadTestsFromTestCase(TestEnhancer))
+    my_suite.addTest(loader.loadTestsFromTestCase(TestEnhancerUserConfigs))
 
     return my_suite

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -360,7 +360,11 @@ class EnhancementDecisionTree(DecisionTree):
         for config_file in decision_dict:
             if os.path.isfile(config_file):
                 with open(config_file) as fd:
-                    conf = recursive_dict_update(conf, yaml.load(fd)[self.prefix])
+                    enhancement_section = yaml.load(fd).get(self.prefix, {})
+                    if not enhancement_section:
+                        LOG.debug("Config '{}' has no '{}' section or it is empty".format(config_file, self.prefix))
+                        continue
+                    conf = recursive_dict_update(conf, enhancement_section)
             elif isinstance(config_file, dict):
                 conf = recursive_dict_update(conf, config_file)
             else:
@@ -431,8 +435,7 @@ class Enhancer(object):
         # XXX: Should we just load all enhancements from the base directory?
         new_configs = []
         for config_file in self.get_sensor_enhancement_config(sensor):
-            if config_file not in self.sensor_enhancement_configs.append(
-                    config_file):
+            if config_file not in self.sensor_enhancement_configs:
                 self.sensor_enhancement_configs.append(config_file)
                 new_configs.append(config_file)
 


### PR DESCRIPTION
@eysteinn found this bug. This adds tests that failed before the fix and pass after the fix. Basically there was a bug when loading user provided custom enhancement configuration files. If any sensor-based configuration files were present in the current directory (even if for composites) then the enhancement config loading would try to load it as an enhancement configuration and fail.