### PR TITLE
Fix SCMI writer and add more tiled grids

### DIFF
--- a/satpy/etc/writers/scmi.yaml
+++ b/satpy/etc/writers/scmi.yaml
@@ -28,11 +28,26 @@ sectors:
     upper_right_lonlat: [-135, 50]
     resolution: [2150000, 2150000]
     projection: '+proj=merc +datum=WGS84 +ellps=WGS84 +lon_0=170 +lat_0=0 +units=m +no_defs'
-  GOESR_FLDK:
+  GOES_TEST:
     lower_left_xy: [-5433892.6923244298, -5433893.2095645051]
     upper_right_xy: [5433893.2095645051, 5433892.6923244298]
     resolution: [2500000, 2500000]
     projection: '+proj=geos +lon_0=-89.5 +h=35786023.0 +a=6378137.0 +b=6356752.31414 +sweep=x +units=m +no_defs'
+  GOES_EAST:
+    lower_left_xy: [-5433892.6923244298, -5433893.2095645051]
+    upper_right_xy: [5433893.2095645051, 5433892.6923244298]
+    resolution: [2500000, 2500000]
+    projection: '+proj=geos +lon_0=-75.0 +h=35786023.0 +a=6378137.0 +b=6356752.31414 +sweep=x +units=m +no_defs'
+  GOES_WEST:
+    lower_left_xy: [-5433892.6923244298, -5433893.2095645051]
+    upper_right_xy: [5433893.2095645051, 5433892.6923244298]
+    resolution: [2500000, 2500000]
+    projection: '+proj=geos +lon_0=-137.0 +h=35786023.0 +a=6378137.0 +b=6356752.31414 +sweep=x +units=m +no_defs'
+  GOES_STORE:
+    lower_left_xy: [-5433892.6923244298, -5433893.2095645051]
+    upper_right_xy: [5433893.2095645051, 5433892.6923244298]
+    resolution: [2500000, 2500000]
+    projection: '+proj=geos +lon_0=-105.0 +h=35786023.0 +a=6378137.0 +b=6356752.31414 +sweep=x +units=m +no_defs'
 datasets:
     default:
        physical_element: '{name}'

--- a/satpy/writers/scmi.py
+++ b/satpy/writers/scmi.py
@@ -399,8 +399,8 @@ class LetteredTileGenerator(NumberedTileGenerator):
                 # theoretically we can precompute the X/Y now
                 # instead of taking the x/y data and mapping it
                 # to the tile
-                tmp_x = np.arange(x_left + cw / 2., x_right, cw)
-                tmp_y = np.arange(y_top - ch / 2., y_bot, -ch)
+                tmp_x = np.ma.arange(x_left + cw / 2., x_right, cw)
+                tmp_y = np.ma.arange(y_top - ch / 2., y_bot, -ch)
                 data_x_idx_min = np.nonzero(np.isclose(tmp_x, x[x_slice.start]))[0][0]
                 data_x_idx_max = np.nonzero(np.isclose(tmp_x, x[x_slice.stop - 1]))[0][0]
                 # I have a half pixel error some where


### PR DESCRIPTION
Even more fixes...

After talking with some of the folks in charge of the AWIPS stations around the SSEC it became clear that I needed more tiled lettered grids for each of the GOES locations.

The bug fix is for a weird situation that I could never find the exact cause for where certain numpy arrays being assigned to a netcdf variable would produce all masked values even though they weren't bad values in the original numpy array. Previously (before my last PR where I optimized some of the writing) these geolocation arrays were masked arrays. Switching back to masked arrays worked fine.