### PR TITLE
Remove VIIRS SDR IR modifiers

### DIFF
--- a/satpy/etc/readers/viirs_sdr.yaml
+++ b/satpy/etc/readers/viirs_sdr.yaml
@@ -93,7 +93,6 @@ datasets:
   I04:
     name: I04
     wavelength: [3.580, 3.740, 3.900]
-    modifiers: [sunz_corrected]
     file_type: svi04
     resolution: 371
     coordinates: [i_longitude, i_latitude]
@@ -107,7 +106,6 @@ datasets:
   I05:
     name: I05
     wavelength: [10.500, 11.450, 12.300]
-    modifiers: [sunz_corrected]
     file_type: svi05
     resolution: 371
     coordinates: [i_longitude, i_latitude]
@@ -275,7 +273,6 @@ datasets:
   M12:
     name: M12
     wavelength: [3.610, 3.700, 3.790]
-    modifiers: [sunz_corrected]
     file_type: svm12
     resolution: 742
     coordinates: [m_longitude, m_latitude]
@@ -289,7 +286,6 @@ datasets:
   M13:
     name: M13
     wavelength: [3.973, 4.050, 4.128]
-    modifiers: [sunz_corrected]
     file_type: svm13
     resolution: 742
     coordinates: [m_longitude, m_latitude]
@@ -303,7 +299,6 @@ datasets:
   M14:
     name: M14
     wavelength: [8.400, 8.550, 8.700]
-    modifiers: [sunz_corrected]
     file_type: svm14
     resolution: 742
     coordinates: [m_longitude, m_latitude]
@@ -317,7 +312,6 @@ datasets:
   M15:
     name: M15
     wavelength: [10.263, 10.763, 11.263]
-    modifiers: [sunz_corrected]
     file_type: svm15
     resolution: 742
     coordinates: [m_longitude, m_latitude]
@@ -331,7 +325,6 @@ datasets:
   M16:
     name: M16
     wavelength: [11.538, 12.013, 12.489]
-    modifiers: [sunz_corrected]
     file_type: svm16
     resolution: 742
     coordinates: [m_longitude, m_latitude]


### PR DESCRIPTION
This PR removes the Sun zenith-angle correction from the infrared channels in the VIIRS SDR reader. Fixes #120 .