### PR TITLE
Bugfix hrit_jma

### DIFF
--- a/satpy/etc/readers/hrit_jma.yaml
+++ b/satpy/etc/readers/hrit_jma.yaml
@@ -113,7 +113,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: hrit_b04
+    file_type: hrit_b03
 
   B04:
     name: B04

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -201,9 +201,7 @@ class HRITJMAFileHandler(HRITFileHandler):
             out = res
 
         self.calibrate(out, key.calibration)
-        out.info['units'] = info['units']
-        out.info['standard_name'] = info['standard_name']
-        #out.info['platform_name'] = self.platform_name
+        out.info.update(info)
         out.info['platform_name'] = 'Himawari-8'
         out.info['sensor'] = 'ahi'
 


### PR DESCRIPTION
 - [x] Tests passed (for all non-documentation changes)
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` (remove if you did not edit any Python files)

This PR fixes the hrit_jma reader.