### PR TITLE
When opening/reading a file fails, be verbose telling which file it i…

### DIFF
--- a/satpy/readers/hdf5_utils.py
+++ b/satpy/readers/hdf5_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2016.
+# Copyright (c) 2016-2017.
 
 # Author(s):
 
@@ -36,13 +36,21 @@ LOG = logging.getLogger(__name__)
 
 
 class HDF5FileHandler(BaseFileHandler):
+
     """Small class for inspecting a HDF5 file and retrieve its metadata/header data.
     """
 
     def __init__(self, filename, filename_info, filetype_info):
-        super(HDF5FileHandler, self).__init__(filename, filename_info, filetype_info)
+        super(HDF5FileHandler, self).__init__(
+            filename, filename_info, filetype_info)
         self.file_content = {}
-        file_handle = h5py.File(self.filename, 'r')
+        try:
+            file_handle = h5py.File(self.filename, 'r')
+        except IOError:
+            LOG.exception(
+                'Failed reading file %s. Possibly corrupted file', self.filename)
+            raise
+
         file_handle.visititems(self.collect_metadata)
         self._collect_attrs('', file_handle.attrs)
         file_handle.close()
@@ -70,7 +78,8 @@ class HDF5FileHandler(BaseFileHandler):
     def __getitem__(self, key):
         val = self.file_content[key]
         if isinstance(val, h5py.Dataset):
-            # these datasets are closed and inaccessible when the file is closed, need to reopen
+            # these datasets are closed and inaccessible when the file is
+            # closed, need to reopen
             return h5py.File(self.filename, 'r')[key].value
         return val
 

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2016.
+# Copyright (c) 2016-2017.
 
 # Author(s):
 
@@ -67,7 +67,12 @@ class NetCDF4FileHandler(BaseFileHandler):
         super(NetCDF4FileHandler, self).__init__(
             filename, filename_info, filetype_info)
         self.file_content = {}
-        file_handle = netCDF4.Dataset(self.filename, 'r')
+        try:
+            file_handle = netCDF4.Dataset(self.filename, 'r')
+        except IOError:
+            LOG.exception(
+                'Failed reading file %s. Possibly corrupted file', self.filename)
+            raise
 
         self.auto_maskandscale = auto_maskandscale
         if hasattr(file_handle, "set_auto_maskandscale"):


### PR DESCRIPTION
…s that fails

Signed-off-by: Adam.Dybbroe <adam.dybbroe@smhi.se>

This PR adds try-except clauses in the hdf5 and netcdf4 utilities, so that if a file is corrupt and the file cannot be opened or read, it prints a log-message telling which file is causing the problem

 - [x] Closes #136 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` 
