### PR TITLE
Fix VIIRS L1B to work with JPSS-1 and new NASA filenames

### DIFF
--- a/satpy/etc/readers/viirs_l1b.yaml
+++ b/satpy/etc/readers/viirs_l1b.yaml
@@ -31,22 +31,34 @@ navigations:
 file_types:
   vgeoi:
     file_reader: !!python/name:satpy.readers.viirs_l1b.VIIRSL1BFileHandler
-    file_patterns: ['VGEOI_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S}_c{creation_time:%Y%m%d%H%M%S}.nc']
+    file_patterns:
+    - 'VGEOI_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S}_c{creation_time:%Y%m%d%H%M%S}.nc'
+    - 'V{platform_shortname:2s}03IMG.A{start_time:%Y%j.%H%M}.{collection_number:3d}.{creation_time:%Y%j%H%M%S}{creator}.nc'
   vgeom:
     file_reader: !!python/name:satpy.readers.viirs_l1b.VIIRSL1BFileHandler
-    file_patterns: ['VGEOM_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S}_c{creation_time:%Y%m%d%H%M%S}.nc']
+    file_patterns:
+    - 'VGEOM_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S}_c{creation_time:%Y%m%d%H%M%S}.nc'
+    - 'V{platform_shortname:2s}03MOD.A{start_time:%Y%j.%H%M}.{collection_number:3d}.{creation_time:%Y%j%H%M%S}{creator}.nc'
   vgeod:
     file_reader: !!python/name:satpy.readers.viirs_l1b.VIIRSL1BFileHandler
-    file_patterns: ['VGEOD_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S}_c{creation_time:%Y%m%d%H%M%S}.nc']
+    file_patterns:
+    - 'VGEOD_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S}_c{creation_time:%Y%m%d%H%M%S}.nc'
+    - 'V{platform_shortname:2s}03DNB.A{start_time:%Y%j.%H%M}.{collection_number:3d}.{creation_time:%Y%j%H%M%S}{creator}.nc'
   vl1bi:
     file_reader: !!python/name:satpy.readers.viirs_l1b.VIIRSL1BFileHandler
-    file_patterns: ['VL1BI_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S}_c{creation_time:%Y%m%d%H%M%S}.nc']
+    file_patterns:
+    - 'VL1BI_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S}_c{creation_time:%Y%m%d%H%M%S}.nc'
+    - 'V{platform_shortname:2s}02IMG.A{start_time:%Y%j.%H%M}.{collection_number:3d}.{creation_time:%Y%j%H%M%S}{creator}.nc'
   vl1bm:
     file_reader: !!python/name:satpy.readers.viirs_l1b.VIIRSL1BFileHandler
-    file_patterns: ['VL1BM_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S}_c{creation_time:%Y%m%d%H%M%S}.nc']
+    file_patterns:
+    - 'VL1BM_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S}_c{creation_time:%Y%m%d%H%M%S}.nc'
+    - 'V{platform_shortname:2s}02MOD.A{start_time:%Y%j.%H%M}.{collection_number:3d}.{creation_time:%Y%j%H%M%S}{creator}.nc'
   vl1bd:
     file_reader: !!python/name:satpy.readers.viirs_l1b.VIIRSL1BFileHandler
-    file_patterns: ['VL1BD_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S}_c{creation_time:%Y%m%d%H%M%S}.nc']
+    file_patterns:
+    - 'VL1BD_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S}_c{creation_time:%Y%m%d%H%M%S}.nc'
+    - 'V{platform_shortname:2s}02DNB.A{start_time:%Y%j.%H%M}.{collection_number:3d}.{creation_time:%Y%j%H%M%S}{creator}.nc'
 
 datasets:
   i_lon:

--- a/satpy/readers/viirs_l1b.py
+++ b/satpy/readers/viirs_l1b.py
@@ -59,11 +59,16 @@ class VIIRSL1BFileHandler(NetCDF4FileHandler):
     @property
     def platform_name(self):
         try:
-            res = self['/attr/platform']
+            res = self.get('/attr/platform',
+                           self.filename_info['platform_shortname'])
         except KeyError:
             res = 'Suomi-NPP'
+
         return {
             'Suomi-NPP': 'NPP',
+            'JPSS-1': 'J01',
+            'NP': 'NPP',
+            'J1': 'J01',
         }.get(res, res)
 
     @property


### PR DESCRIPTION
<!-- Please make the PR against the `develop` branch. -->

<!-- Describe what your PR does, and why -->
NASA changed the final file naming scheme for the VIIRS L1B file format. This PR adds those new patterns. This PR also adds information to handle the JPSS-1 platform from VIIRS L1B files.

 - [x] Closes #124  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->