### PR TITLE
Bugfix scmi signed

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -108,6 +108,9 @@ class Scene(InfoObject):
         self.wishlist = set()
         self.dep_tree = DependencyTree(self.readers, comps, mods)
 
+    def _ipython_key_completions_(self):
+        return [x.name for x in self.datasets.keys()]
+
     def _compute_metadata_from_readers(self):
         mda = {}
         mda['sensor'] = self._get_sensor_names()

--- a/satpy/writers/scmi.py
+++ b/satpy/writers/scmi.py
@@ -83,6 +83,7 @@ except ImportError:
 LOG = logging.getLogger(__name__)
 # AWIPS 2 seems to not like data values under 0
 AWIPS_USES_NEGATIVES = False
+AWIPS_DATA_DTYPE = np.int16
 DEFAULT_OUTPUT_PATTERN = '{source_name}_AII_{platform}_{sensor}_{name}_{sector_id}_{tile_id}_{start_time:%Y%m%d_%H%M}.nc'
 
 # misc. global attributes
@@ -193,7 +194,9 @@ class NumberedTileGenerator(object):
         if y.shape[0] > 2**15:
             # awips uses 0, 1, 2, 3 so we can't use the negative end of the variable space
             raise ValueError("Y variable too large for AWIPS-version of 16-bit integer space")
-        return x, y
+        # NetCDF library doesn't handle numpy arrays nicely anymore for some
+        # reason and has been masking values that shouldn't be
+        return np.ma.masked_array(x), np.ma.masked_array(y)
 
     def _get_xy_scaling_parameters(self):
         """Get the X/Y coordinate limits for the full resulting image"""
@@ -524,7 +527,11 @@ class NetCDFWriter(object):
                          valid_min=None, valid_max=None):
         fgf_coords = "%s %s" % (self.y_var_name, self.x_var_name)
 
-        self.image_data = self._nc.createVariable(self.image_var_name, 'u2', dimensions=(self.row_dim_name, self.col_dim_name), fill_value=fill_value, zlib=self._compress)
+        self.image_data = self._nc.createVariable(self.image_var_name,
+                                                  AWIPS_DATA_DTYPE,
+                                                  dimensions=(self.row_dim_name, self.col_dim_name),
+                                                  fill_value=fill_value,
+                                                  zlib=self._compress)
         self.image_data.coordinates = fgf_coords
         self.apply_data_attributes(bitdepth, scale_factor, add_offset,
                                    valid_min=valid_min, valid_max=valid_max)
@@ -825,7 +832,7 @@ class SCMIWriter(Writer):
             ds_list.append(x)
 
         output_filenames = []
-        dtype = np.dtype(np.uint16)
+        dtype = AWIPS_DATA_DTYPE
         fill_value = np.nan
         for area_id, (area_def, ds_list) in area_datasets.items():
             tile_gen = self._get_tile_generator(area_def, lettered_grid, sector_id, num_subtiles, tile_size, tile_count)


### PR DESCRIPTION
<!-- Please make the PR against the `develop` branch. -->

<!-- Describe what your PR does, and why -->
See commit message. Basically AWIPS doesn't like unsigned 16-bit integer data over 32k. There are no additional tests for this because it can only be seen with a complicated AWIPS usage.

I'm also sneaking in a change to the Scene to add ipython tab completion when you do `scn['my_dat<tab>`.

 - [ ] Tests passed <!-- for all non-documentation changes) -->
