### PR TITLE
Add snow RGB, add r37-based and natural RGB recipes specific to

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -370,8 +370,13 @@ class PSPRayleighReflectance(CompositeBase):
                              atmosphere=atmosphere,
                              aerosol_type=aerosol_type)
 
-        refl_cor_band = corrector.get_reflectance(
-            sunz, satz, ssadiff, vis.id.wavelength[1], blue)
+        try:
+            refl_cor_band = corrector.get_reflectance(sunz, satz, ssadiff, vis.id.name, blue)
+        except KeyError:
+            LOG.warning("Could not get the reflectance correction using band name: %s", vis.id.name)
+            LOG.warning("Will try use the wavelength, however, this may be ambiguous!")
+            refl_cor_band = corrector.get_reflectance(sunz, satz, ssadiff,
+                                                      vis.id.wavelength[1], blue)
 
         proj = Dataset(vis - refl_cor_band,
                        copy=False,

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -416,7 +416,7 @@ class NIRReflectance(CompositeBase):
         refl39 = Calculator(nir.info['platform_name'], nir.info['sensor'], nir.id.name)
         # nir.info['sensor'], nir.id.wavelength[1])
 
-        proj = Dataset(refl39.reflectance_from_tbs(sun_zenith, nir, tb11, tb13_4) * 100, **nir.info)
+        proj = Dataset(refl39.reflectance_from_tbs(sun_zenith, nir, tb11, tb_ir_co2=tb13_4) * 100, **nir.info)
         proj.info['units'] = '%'
         self.apply_modifier_info(nir, proj)
 

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -413,12 +413,10 @@ class NIRReflectance(CompositeBase):
             lons, lats = nir.info["area"].get_lonlats()
             sun_zenith = sza(nir.info['start_time'], lons, lats)
 
-        refl39 = Calculator(nir.info['platform_name'],
-                            nir.info['sensor'], nir.id.wavelength[1])
+        refl39 = Calculator(nir.info['platform_name'], nir.info['sensor'], nir.id.name)
+        # nir.info['sensor'], nir.id.wavelength[1])
 
-        proj = Dataset(refl39.reflectance_from_tbs(sun_zenith, nir,
-                                                   tb11, tb13_4) * 100,
-                       **nir.info)
+        proj = Dataset(refl39.reflectance_from_tbs(sun_zenith, nir, tb11, tb13_4) * 100, **nir.info)
         proj.info['units'] = '%'
         self.apply_modifier_info(nir, proj)
 

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -439,6 +439,10 @@ class NIREmissivePartFromReflectance(NIRReflectance):
         Not supposed to be used for wavelength outside [3, 4] µm.
         """
         self._init_refl3x(projectables)
+        # Derive the sun-zenith angles, and use the nir and thermal ir
+        # brightness tempertures and derive the reflectance using
+        # PySpectral. The reflectance is stored internally in PySpectral and
+        # needs to be derived first in order to get the emissive part.
         _ = self._get_reflectance(projectables, optional_datasets)
         _nir, _ = projectables
         proj = Dataset(self._refl3x.emissive_part_3x(), **_nir.info)

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2015-2017
+# Copyright (c) 2015-2018
 
 # Author(s):
 

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -387,7 +387,7 @@ class NIRReflectance(CompositeBase):
         """Get the reflectance part of an NIR channel. Not supposed to be used
         for wavelength outside [3, 4] µm.
         """
-        nir, dummy = projectables
+        nir, _ = projectables
         proj = Dataset(self._get_reflectance(projectables, optional_datasets) * 100, **nir.info)
 
         proj.info['units'] = '%'
@@ -433,8 +433,8 @@ class NIREmissivePartFromReflectance(NIRReflectance):
         """Get the emissive part an NIR channel after having derived the reflectance. 
         Not supposed to be used for wavelength outside [3, 4] µm.
         """
-        nir, dummy = projectables
-        dummy = self._get_reflectance(projectables, optional_datasets)
+        nir, _ = projectables
+        _ = self._get_reflectance(projectables, optional_datasets)
         proj = Dataset(self._refl3x.emissive_part_3x(), **nir.info)
 
         proj.info['units'] = 'K'

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -22,6 +22,15 @@ composites:
     - 12.0
     standard_name: cloudtop
 
+  cloudtop_daytime:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - wavelength: 3.7
+      modifiers: [nir_emissive]
+    - 10.8
+    - 12.0
+    standard_name: cloudtop
+
   convection:
     compositor: !!python/name:satpy.composites.Convection
     prerequisites:

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -1,6 +1,9 @@
 sensor_name: visir/seviri
 
 modifiers:
+  sunz_corrected:
+    compositor: !!python/name:satpy.composites.SunZenithCorrector
+
   co2_corrected:
     compositor: !!python/name:satpy.composites.CO2Corrector
     sensor: [seviri]
@@ -39,6 +42,56 @@ composites:
     - 10.8
     - 12.0
     standard_name: night_fog
+
+  snow:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - name: VIS008
+      modifiers: [sunz_corrected]
+    - wavelength: 1.63
+      modifiers: [sunz_corrected]
+    - wavelength: 3.7
+      modifiers: [nir_reflectance]
+    standard_name: snow
+
+  day_microphysics:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - name: VIS008
+      modifiers: [sunz_corrected]
+    - wavelength: 3.7
+      modifiers: [nir_reflectance]
+    - 10.8
+    standard_name: day_microphysics
+
+  day_microphysics_winter:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - name: VIS008
+      modifiers: [sunz_corrected]
+    - wavelength: 3.7
+      modifiers: [nir_reflectance]
+    - 10.8
+    standard_name: day_microphysics_winter
+
+  natural:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - 1.63
+    - name: VIS008
+    - name: VIS006
+    standard_name: natural
+
+  natural_sun:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - wavelength: 1.63
+      modifiers: [sunz_corrected]
+    - name: VIS008
+      modifiers: [sunz_corrected]
+    - name: VIS006
+      modifiers: [sunz_corrected]
+    standard_name: natural
 
   cloudmask:
     compositor: !!python/name:satpy.composites.PaletteCompositor

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -13,21 +13,29 @@ modifiers:
   sunz_corrected:
     compositor: !!python/name:satpy.composites.SunZenithCorrector
     prerequisites:
-    - solar_zenith_angle
+    - name: solar_zenith_angle
+      resolution: 742
+
+  sunz_corrected_iband:
+    compositor: !!python/name:satpy.composites.SunZenithCorrector
+    prerequisites:
+    - name: solar_zenith_angle
+      resolution: 371
 
   nir_reflectance_lowres:
     compositor: !!python/name:satpy.composites.NIRReflectance
     prerequisites:
     - M15
     optional_prerequisites:
-    - solar_zenith_angle
-
+    - name: solar_zenith_angle
+      resolution: 742
   nir_reflectance_hires:
     compositor: !!python/name:satpy.composites.NIRReflectance
     prerequisites:
     - I05
     optional_prerequisites:
-    - solar_zenith_angle
+    - name: solar_zenith_angle
+      resolution: 371
 
 
 composites:
@@ -43,7 +51,7 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected]
     optional_prerequisites:
     - name: I01
-      modifiers: [sunz_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected_iband, rayleigh_corrected]
     standard_name: true_color
     high_resolution_band: red
 
@@ -91,7 +99,7 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected]
     optional_prerequisites:
     - name: I01
-      modifiers: [sunz_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected_iband, rayleigh_corrected]
     standard_name: natural_color
     high_resolution_band: blue
 
@@ -176,9 +184,9 @@ composites:
     compositor: !!python/name:satpy.composites.RGBCompositor
     prerequisites:
     - name: I02
-      modifiers: [sunz_corrected]
+      modifiers: [sunz_corrected_iband]
     - name: I03
-      modifiers: [sunz_corrected]
+      modifiers: [sunz_corrected_iband]
     - name: I04
       modifiers: [nir_reflectance_hires]
     standard_name: snow

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -22,6 +22,22 @@ modifiers:
     - name: solar_zenith_angle
       resolution: 371
 
+  nir_emissive_lowres:
+    compositor: !!python/name:satpy.composites.NIREmissivePartFromReflectance
+    prerequisites:
+    - M15
+    optional_prerequisites:
+    - name: solar_zenith_angle
+      resolution: 742
+      
+  nir_emissive_hires:
+    compositor: !!python/name:satpy.composites.NIREmissivePartFromReflectance
+    prerequisites:
+    - I05
+    optional_prerequisites:
+    - name: solar_zenith_angle
+      resolution: 371
+      
   nir_reflectance_lowres:
     compositor: !!python/name:satpy.composites.NIRReflectance
     prerequisites:
@@ -29,6 +45,7 @@ modifiers:
     optional_prerequisites:
     - name: solar_zenith_angle
       resolution: 742
+
   nir_reflectance_hires:
     compositor: !!python/name:satpy.composites.NIRReflectance
     prerequisites:
@@ -36,7 +53,6 @@ modifiers:
     optional_prerequisites:
     - name: solar_zenith_angle
       resolution: 371
-
 
 composites:
 
@@ -168,6 +184,24 @@ composites:
     - I05
     - I04
     standard_name: temperature_difference
+
+  cloudtop_daytime:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - name: M12
+      modifiers: [nir_emissive_lowres]
+    - name: M15
+    - name: M16
+    standard_name: cloudtop
+
+  hr_cloudtop_daytime:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - name: I04
+      modifiers: [nir_emissive_hires]
+    - name: I05
+    - name: I05
+    standard_name: cloudtop
 
   snow_lowres:
     compositor: !!python/name:satpy.composites.RGBCompositor

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -15,6 +15,20 @@ modifiers:
     prerequisites:
     - solar_zenith_angle
 
+  nir_reflectance_lowres:
+    compositor: !!python/name:satpy.composites.NIRReflectance
+    prerequisites:
+    - M15
+    optional_prerequisites:
+    - solar_zenith_angle
+
+  nir_reflectance_hires:
+    compositor: !!python/name:satpy.composites.NIRReflectance
+    prerequisites:
+    - I05
+    optional_prerequisites:
+    - solar_zenith_angle
+
 
 composites:
 
@@ -146,6 +160,29 @@ composites:
     - I05
     - I04
     standard_name: temperature_difference
+
+  snow_lowres:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - name: M07
+      modifiers: [sunz_corrected]
+    - name: M10
+      modifiers: [sunz_corrected]
+    - name: M12
+      modifiers: [nir_reflectance_lowres]
+    standard_name: snow
+
+  snow_hires:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - name: I02
+      modifiers: [sunz_corrected]
+    - name: I03
+      modifiers: [sunz_corrected]
+    - name: I04
+      modifiers: [nir_reflectance_hires]
+    standard_name: snow
+
   histogram_dnb:
     compositor: !!python/name:satpy.composites.viirs.HistogramDNB
     prerequisites:

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -124,14 +124,28 @@ composites:
     - 7.3
     - 10.8
     standard_name: convection
+    
+  snow:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - wavelength: 0.8
+      modifiers: [sunz_corrected]
+    - wavelength: 1.63
+      modifiers: [sunz_corrected]
+    - wavelength: 3.7
+      modifiers: [nir_reflectance]
+    standard_name: snow
+    
   day_microphysics:
     compositor: !!python/name:satpy.composites.RGBCompositor
     prerequisites:
-    - 0.85
+    - wavelength: 0.85
+      modifiers: [sunz_corrected]
     - wavelength: 3.7
       modifiers: [nir_reflectance]
     - 10.8
     standard_name: day_microphysics
+    
   dust:
     compositor: !!python/name:satpy.composites.Dust
     prerequisites:

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -22,6 +22,14 @@ modifiers:
     - solar_zenith_angle
     - 13.4
 
+  nir_emissive:
+    compositor: !!python/name:satpy.composites.NIREmissivePartFromReflectance
+    prerequisites:
+    - 11
+    optional_prerequisites:
+    - solar_zenith_angle
+    - 13.4
+
   atm_correction:
     compositor: !!python/name:satpy.composites.PSPAtmosphericalCorrection
     optional_prerequisites:

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -137,6 +137,21 @@ enhancements:
       method: *gammafun
       kwargs:
         gamma: [1, 2, 1]
+        
+  snow_default:
+    standard_name: snow
+    operations:
+    - name: stretch
+      method: *stretchfun
+      kwargs:
+        stretch: crude
+        min_stretch: [0, 0, 0]
+        max_stretch: [100, 70, 30]
+    - name: gamma
+      method: *gammafun
+      kwargs:
+        gamma: [1.7, 1.7, 1.7]
+        
   day_microphysics_default:
     standard_name: day_microphysics
     operations:
@@ -150,6 +165,21 @@ enhancements:
       method: *gammafun
       kwargs:
         gamma: [1, 2.5, 1]
+        
+  day_microphysics_winter:
+    standard_name: day_microphysics_winter
+    operations:
+    - name: stretch
+      method: *stretchfun
+      kwargs:
+        stretch: crude
+        min_stretch: [0, 0, 203]
+        max_stretch: [100, 25, 323]
+    - name: gamma
+      method: *gammafun
+      kwargs:
+        gamma: [1, 1.5, 1]
+
   cloudtop_default:
     standard_name: cloudtop
     operations:

--- a/satpy/etc/readers/viirs_sdr.yaml
+++ b/satpy/etc/readers/viirs_sdr.yaml
@@ -336,6 +336,38 @@ datasets:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
 
+  I_SOLZ:
+    name: solar_zenith_angle
+    standard_name: solar_zenith_angle
+    resolution: 371
+    coordinates: [i_longitude, i_latitude]
+    units: degrees
+    file_type: [gitco, gimgo]
+    file_key: 'All_Data/{file_group}_All/SolarZenithAngle'
+  I_SOLA:
+    name: solar_azimuth_angle
+    standard_name: solar_azimuth_angle
+    resolution: 371
+    coordinates: [i_longitude, i_latitude]
+    units: degrees
+    file_type: [gitco, gimgo]
+    file_key: 'All_Data/{file_group}_All/SolarAzimuthAngle'
+  I_SENZ:
+    name: satellite_zenith_angle
+    standard_name: sensor_zenith_angle
+    resolution: 371
+    coordinates: [i_longitude, i_latitude]
+    units: degrees
+    file_type: [gitco, gimgo]
+    file_key: 'All_Data/{file_group}_All/SatelliteZenithAngle'
+  I_SENA:
+    name: satellite_azimuth_angle
+    standard_name: sensor_azimuth_angle
+    resolution: 371
+    coordinates: [i_longitude, i_latitude]
+    units: degrees
+    file_type: [gitco, gimgo]
+    file_key: 'All_Data/{file_group}_All/SatelliteAzimuthAngle'
   M_SOLZ:
     name: solar_zenith_angle
     standard_name: solar_zenith_angle


### PR DESCRIPTION
SEVIRI, and fix sun-zenith correction

Signed-off-by: Adam.Dybbroe <adam.dybbroe@smhi.se>

Fixing the RGBs using the 3.75 reflectance as derived with PySpectral.

 - [x] Closes #144 
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff``

