### PR TITLE
 Fix platform name reading for ahi hsd reader in py3

### DIFF
--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -28,9 +28,6 @@ http://www.data.jma.go.jp/mscweb/en/himawari89/space_segment/spsg_ahi.html
 
 """
 
-AHI_CHANNEL_NAMES = ("1", "2", "3", "4", "5",
-                     "6", "7", "8", "9", "10",
-                     "11", "12", "13", "14", "15", "16")
 import logging
 from datetime import datetime, timedelta
 
@@ -39,7 +36,12 @@ import numpy as np
 from pyresample import geometry
 from satpy.dataset import Dataset
 from satpy.readers.file_handlers import BaseFileHandler
-from satpy.readers.helper_functions import get_geostationary_angle_extent
+from satpy.readers.helper_functions import (get_geostationary_angle_extent,
+                                            np2str)
+
+AHI_CHANNEL_NAMES = ("1", "2", "3", "4", "5",
+                     "6", "7", "8", "9", "10",
+                     "11", "12", "13", "14", "15", "16")
 
 
 class CalibrationError(Exception):
@@ -243,7 +245,7 @@ class AHIHSDFileHandler(BaseFileHandler):
             self.nav_info = np.fromfile(fd,
                                         dtype=_NAV_INFO_TYPE,
                                         count=1)[0]
-        self.platform_name = self.basic_info['satellite'][0]
+        self.platform_name = np2str(self.basic_info['satellite'])
         self.sensor = 'ahi'
 
     def get_shape(self, dsid, ds_info):

--- a/satpy/readers/hdf5_utils.py
+++ b/satpy/readers/hdf5_utils.py
@@ -31,6 +31,7 @@ import numpy as np
 import six
 
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.readers.helper_functions import np2str
 
 LOG = logging.getLogger(__name__)
 
@@ -58,15 +59,7 @@ class HDF5FileHandler(BaseFileHandler):
     def _collect_attrs(self, name, attrs):
         for key, value in six.iteritems(attrs):
             value = np.squeeze(value)
-            if issubclass(value.dtype.type, np.string_) and not value.shape:
-                value = np.asscalar(value)
-                if not isinstance(value, str):
-                    # python 3 - was scalar numpy array of bytes
-                    # otherwise python 2 - scalar numpy array of 'str'
-                    value = value.decode()
-                self.file_content["{}/attr/{}".format(name, key)] = value
-            else:
-                self.file_content["{}/attr/{}".format(name, key)] = value
+            self.file_content["{}/attr/{}".format(name, key)] = np2str(value)
 
     def collect_metadata(self, name, obj):
         if isinstance(obj, h5py.Dataset):

--- a/satpy/readers/helper_functions.py
+++ b/satpy/readers/helper_functions.py
@@ -32,6 +32,17 @@ from pyresample.geometry import AreaDefinition
 LOGGER = logging.getLogger(__name__)
 
 
+def np2str(value):
+    """Convert an np.string_ to str."""
+    if issubclass(value.dtype.type, np.string_) and not value.shape:
+        value = np.asscalar(value)
+        if not isinstance(value, str):
+            # python 3 - was scalar numpy array of bytes
+            # otherwise python 2 - scalar numpy array of 'str'
+            value = value.decode()
+    return value
+
+
 def get_geostationary_angle_extent(geos_area):
     """Get the max earth (vs space) viewing angles in x and y."""
     # TODO: take into account sweep_axis_angle parameter

--- a/satpy/tests/test_helper_functions.py
+++ b/satpy/tests/test_helper_functions.py
@@ -337,6 +337,11 @@ class TestHelpers(unittest.TestCase):
                                      3, 3,
                                      (0.75, -3.75, 5.25, 0.75))
 
+    def test_np2str(self):
+        """Test the np2str function."""
+        npstring = np.string_('hej')
+        self.assertEquals(hf.np2str(npstring), 'hej')
+
 
 def suite():
     """The test suite for test_satin_helpers.


### PR DESCRIPTION
The platform name as read with numpy is a `np.string_`, which in py3 is different from `str`, hence causing problems when the platform name is to be used elsewhere.

This PR also factorizes some code to a np2str function that takes care of converting np.string_ to str

<!-- Please make the PR against the `develop` branch. -->

<!-- Describe what your PR does, and why -->

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
