### PR TITLE
Truecolor red channel corr

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -336,8 +336,8 @@ class PSPRayleighReflectance(CompositeBase):
         """
         from pyspectral.rayleigh import Rayleigh
 
-        (vis, blue) = projectables
-        if vis.shape != blue.shape:
+        (vis, red) = projectables
+        if vis.shape != red.shape:
             raise IncompatibleAreas
         try:
             (sata, satz, suna, sunz) = optional_datasets
@@ -371,12 +371,12 @@ class PSPRayleighReflectance(CompositeBase):
                              aerosol_type=aerosol_type)
 
         try:
-            refl_cor_band = corrector.get_reflectance(sunz, satz, ssadiff, vis.id.name, blue)
+            refl_cor_band = corrector.get_reflectance(sunz, satz, ssadiff, vis.id.name, red)
         except KeyError:
             LOG.warning("Could not get the reflectance correction using band name: %s", vis.id.name)
             LOG.warning("Will try use the wavelength, however, this may be ambiguous!")
             refl_cor_band = corrector.get_reflectance(sunz, satz, ssadiff,
-                                                      vis.id.wavelength[1], blue)
+                                                      vis.id.wavelength[1], red)
 
         proj = Dataset(vis - refl_cor_band,
                        copy=False,

--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -11,11 +11,36 @@ modifiers:
     compositor: !!python/name:satpy.composites.ahi.Expander
     factor: 2
 
-
   rayleigh_corrected:
     compositor: !!python/name:satpy.composites.PSPRayleighReflectance
-    atmosphere: midlatitude summer
+    atmosphere: us-standard
+    aerosol_type: marine_clean_aerosol
+    prerequisites:
+    - name: C02
+      modifiers: [reducer4, effective_solar_pathlength_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
+  rayleigh_corrected_marine_tropical:
+    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: tropical
     aerosol_type: marine_tropical_aerosol
+    prerequisites:
+    - name: C02
+      modifiers: [reducer4, effective_solar_pathlength_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
+  rayleigh_corrected_land:
+    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: continental_average_aerosol
     prerequisites:
     - name: C02
       modifiers: [reducer4, effective_solar_pathlength_corrected]
@@ -62,6 +87,29 @@ composites:
     - name: C03
       modifiers: [reducer2, effective_solar_pathlength_corrected]
     standard_name: true_color
+
+  true_color_2km_marine_tropical:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - name: C01
+      modifiers: [reducer2, effective_solar_pathlength_corrected, rayleigh_corrected_marine_tropical]
+    - name: C02
+      modifiers: [reducer4, effective_solar_pathlength_corrected, rayleigh_corrected_marine_tropical]
+    - name: C03
+      modifiers: [reducer2, effective_solar_pathlength_corrected]
+    standard_name: true_color
+
+  true_color_2km_land:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - name: C01
+      modifiers: [reducer2, effective_solar_pathlength_corrected, rayleigh_corrected_land]
+    - name: C02
+      modifiers: [reducer4, effective_solar_pathlength_corrected, rayleigh_corrected_land]
+    - name: C03
+      modifiers: [reducer2, effective_solar_pathlength_corrected]
+    standard_name: true_color
+
   true_color:
     compositor: !!python/name:satpy.composites.abi.TrueColor
     prerequisites:

--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -89,7 +89,7 @@ composites:
     standard_name: true_color
 
   true_color_2km_marine_tropical:
-    compositor: !!python/name:satpy.composites.RGBCompositor
+    compositor: !!python/name:satpy.composites.abi.TrueColor2km
     prerequisites:
     - name: C01
       modifiers: [reducer2, effective_solar_pathlength_corrected, rayleigh_corrected_marine_tropical]
@@ -100,7 +100,7 @@ composites:
     standard_name: true_color
 
   true_color_2km_land:
-    compositor: !!python/name:satpy.composites.RGBCompositor
+    compositor: !!python/name:satpy.composites.abi.TrueColor2km
     prerequisites:
     - name: C01
       modifiers: [reducer2, effective_solar_pathlength_corrected, rayleigh_corrected_land]

--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -17,8 +17,8 @@ modifiers:
     atmosphere: midlatitude summer
     aerosol_type: marine_tropical_aerosol
     prerequisites:
-    - name: C01
-      modifiers: [reducer2, effective_solar_pathlength_corrected]
+    - name: C02
+      modifiers: [reducer4, effective_solar_pathlength_corrected]
     optional_prerequisites:
     - satellite_azimuth_angle
     - satellite_zenith_angle
@@ -30,8 +30,8 @@ modifiers:
     atmosphere: midlatitude summer
     aerosol_type: marine_tropical_aerosol
     prerequisites:
-    - name: C01
-      modifiers: [effective_solar_pathlength_corrected]
+    - name: C02
+      modifiers: [reducer2, effective_solar_pathlength_corrected]
     optional_prerequisites:
     - satellite_azimuth_angle
     - satellite_zenith_angle
@@ -43,8 +43,8 @@ modifiers:
     atmosphere: midlatitude summer
     aerosol_type: marine_tropical_aerosol
     prerequisites:
-    - name: C01
-      modifiers: [expander2, effective_solar_pathlength_corrected]
+    - name: C02
+      modifiers: [effective_solar_pathlength_corrected]
     optional_prerequisites:
     - satellite_azimuth_angle
     - satellite_zenith_angle

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -23,8 +23,47 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: marine_clean_aerosol
     prerequisites:
-    - wavelength: 0.46
+    - wavelength: 0.65
       modifiers: [reducer2, sunz_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
+  rayleigh_corrected_reducedsize:
+    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: marine_clean_aerosol
+    prerequisites:
+    - wavelength: 0.65
+      modifiers: [reducer4, sunz_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
+  rayleigh_corrected_reducedsize_land:
+    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: continental_average_aerosol
+    prerequisites:
+    - wavelength: 0.65
+      modifiers: [reducer4, sunz_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
+  rayleigh_corrected_reducedsize_marine_tropical:
+    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: marine_tropical_aerosol
+    prerequisites:
+    - wavelength: 0.65
+      modifiers: [reducer4, sunz_corrected]
     optional_prerequisites:
     - satellite_azimuth_angle
     - satellite_zenith_angle
@@ -49,18 +88,50 @@ composites:
       modifiers: [vegetation_corrected, effective_solar_pathlength_corrected, rayleigh_corrected]
     - wavelength: 0.46
       modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
-    standard_name: true_color_ahi
+    standard_name: true_color
 
   true_color_reducedsize:
     compositor: !!python/name:satpy.composites.RGBCompositor
     prerequisites:
     - wavelength: 0.65
-      modifiers: [reducer4, effective_solar_pathlength_corrected, rayleigh_corrected]
+      modifiers: [reducer4, effective_solar_pathlength_corrected,
+                  rayleigh_corrected_reducedsize]
     - wavelength: 0.51
-      modifiers: [reducer2, vegetation_corrected_reduced, effective_solar_pathlength_corrected, rayleigh_corrected]
+      modifiers: [reducer2, vegetation_corrected_reduced, effective_solar_pathlength_corrected,
+                  rayleigh_corrected_reducedsize]
     - wavelength: 0.46
-      modifiers: [reducer2, effective_solar_pathlength_corrected, rayleigh_corrected]
-    standard_name: true_color_reducedsize
+      modifiers: [reducer2, effective_solar_pathlength_corrected,
+                  rayleigh_corrected_reducedsize]
+    standard_name: true_color
+
+  true_color_reducedsize_land:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - wavelength: 0.65
+      modifiers: [reducer4, effective_solar_pathlength_corrected,
+                  rayleigh_corrected_reducedsize_land]
+    - wavelength: 0.51
+      modifiers: [reducer2, vegetation_corrected_reduced, effective_solar_pathlength_corrected,
+                  rayleigh_corrected_reducedsize_land]
+    - wavelength: 0.46
+      modifiers: [reducer2, effective_solar_pathlength_corrected,
+                  rayleigh_corrected_reducedsize_land]
+    standard_name: true_color
+
+  true_color_reducedsize_marine_tropical:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - wavelength: 0.65
+      modifiers: [reducer4, effective_solar_pathlength_corrected,
+                  rayleigh_corrected_reducedsize_marine_tropical]
+    - wavelength: 0.51
+      modifiers: [reducer2, vegetation_corrected_reduced, effective_solar_pathlength_corrected,
+                  rayleigh_corrected_reducedsize_marine_tropical]
+    - wavelength: 0.46
+      modifiers: [reducer2, effective_solar_pathlength_corrected,
+                  rayleigh_corrected_reducedsize_marine_tropical]
+    standard_name: true_color
+
 
   true_color_norayleigh:
     compositor: !!python/name:satpy.composites.RGBCompositor
@@ -71,7 +142,7 @@ composites:
       modifiers: [vegetation_corrected, effective_solar_pathlength_corrected]
     - wavelength: 0.46
       modifiers: [effective_solar_pathlength_corrected]
-    standard_name: true_color_norayleigh
+    standard_name: true_color
 
   day_microphysics_eum:
     compositor: !!python/name:satpy.composites.RGBCompositor

--- a/satpy/etc/composites/olci.yaml
+++ b/satpy/etc/composites/olci.yaml
@@ -16,6 +16,19 @@ modifiers:
     - solar_azimuth_angle
     - solar_zenith_angle
 
+  rayleigh_corrected_marine_clean:
+    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: marine_clean_aerosol
+    prerequisites:
+    - name: 'Oa08'
+      modifiers: [sunz_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
   rayleigh_corrected_marine_tropical:
     compositor: !!python/name:satpy.composites.PSPRayleighReflectance
     atmosphere: tropical
@@ -68,6 +81,17 @@ composites:
       modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
     standard_name: true_color
 
+  true_color_land:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - name: 'Oa08'
+      modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_land]
+    - name: 'Oa06'
+      modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_land]
+    - name: 'Oa03'
+      modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_land]
+    standard_name: true_color
+
   true_color_desert:
     compositor: !!python/name:satpy.composites.RGBCompositor
     prerequisites:
@@ -77,6 +101,17 @@ composites:
       modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_desert]
     - name: 'Oa03'
       modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_desert]
+    standard_name: true_color
+
+  true_color_marine_clean:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - name: 'Oa08'
+      modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_clean]
+    - name: 'Oa06'
+      modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_clean]
+    - name: 'Oa03'
+      modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_clean]
     standard_name: true_color
 
   true_color_marine_tropical:

--- a/satpy/etc/composites/olci.yaml
+++ b/satpy/etc/composites/olci.yaml
@@ -1,5 +1,61 @@
 sensor_name: visir/olci
 
+
+modifiers:
+
+  rayleigh_corrected:
+    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: marine_clean_aerosol
+    prerequisites:
+    - name: 'Oa08'
+      modifiers: [sunz_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
+  rayleigh_corrected_marine_tropical:
+    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: tropical
+    aerosol_type: marine_tropical_aerosol
+    prerequisites:
+    - name: 'Oa08'
+      modifiers: [sunz_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
+  rayleigh_corrected_desert:
+    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: tropical
+    aerosol_type: desert_aerosol
+    prerequisites:
+    - name: 'Oa08'
+      modifiers: [sunz_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
+  rayleigh_corrected_land:
+    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: continental_average_aerosol
+    prerequisites:
+    - name: 'Oa08'
+      modifiers: [sunz_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
+
 composites:
   true_color:
     compositor: !!python/name:satpy.composites.RGBCompositor

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -36,6 +36,19 @@ modifiers:
     - solar_azimuth_angle
     - solar_zenith_angle
 
+  rayleigh_corrected_marine_clean:
+    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: marine_clean_aerosol
+    prerequisites:
+    - name: M05
+      modifiers: [sunz_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
   sunz_corrected:
     compositor: !!python/name:satpy.composites.SunZenithCorrector
     prerequisites:
@@ -128,6 +141,17 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected_land]
     - name: M03
       modifiers: [sunz_corrected, rayleigh_corrected_land]
+    standard_name: true_color
+
+true_color_lowres_marine_clean:
+    compositor: !!python/name:satpy.composites.RGBCompositor
+    prerequisites:
+    - name: M05
+      modifiers: [sunz_corrected, rayleigh_corrected_marine_clean]
+    - name: M04
+      modifiers: [sunz_corrected, rayleigh_corrected_marine_clean]
+    - name: M03
+      modifiers: [sunz_corrected, rayleigh_corrected_marine_clean]
     standard_name: true_color
 
   natural_color:

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -23,10 +23,10 @@ modifiers:
     - solar_azimuth_angle
     - solar_zenith_angle
 
-  rayleigh_corrected_land:
+  rayleigh_corrected_marine_tropical:
     compositor: !!python/name:satpy.composites.PSPRayleighReflectance
     atmosphere: us-standard
-    aerosol_type: continental_average_aerosol
+    aerosol_type: marine_tropical_aerosol
     prerequisites:
     - name: M05
       modifiers: [sunz_corrected]
@@ -36,10 +36,10 @@ modifiers:
     - solar_azimuth_angle
     - solar_zenith_angle
 
-  rayleigh_corrected_marine_clean:
+  rayleigh_corrected_land:
     compositor: !!python/name:satpy.composites.PSPRayleighReflectance
     atmosphere: us-standard
-    aerosol_type: marine_clean_aerosol
+    aerosol_type: continental_average_aerosol
     prerequisites:
     - name: M05
       modifiers: [sunz_corrected]
@@ -143,15 +143,15 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected_land]
     standard_name: true_color
 
-true_color_lowres_marine_clean:
+true_color_lowres_marine_tropical:
     compositor: !!python/name:satpy.composites.RGBCompositor
     prerequisites:
     - name: M05
-      modifiers: [sunz_corrected, rayleigh_corrected_marine_clean]
+      modifiers: [sunz_corrected, rayleigh_corrected_marine_tropical]
     - name: M04
-      modifiers: [sunz_corrected, rayleigh_corrected_marine_clean]
+      modifiers: [sunz_corrected, rayleigh_corrected_marine_tropical]
     - name: M03
-      modifiers: [sunz_corrected, rayleigh_corrected_marine_clean]
+      modifiers: [sunz_corrected, rayleigh_corrected_marine_tropical]
     standard_name: true_color
 
   natural_color:

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -68,7 +68,7 @@ modifiers:
     optional_prerequisites:
     - name: solar_zenith_angle
       resolution: 742
-      
+
   nir_emissive_hires:
     compositor: !!python/name:satpy.composites.NIREmissivePartFromReflectance
     prerequisites:
@@ -76,7 +76,7 @@ modifiers:
     optional_prerequisites:
     - name: solar_zenith_angle
       resolution: 371
-      
+
   nir_reflectance_lowres:
     compositor: !!python/name:satpy.composites.NIRReflectance
     prerequisites:
@@ -143,7 +143,7 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected_land]
     standard_name: true_color
 
-true_color_lowres_marine_tropical:
+  true_color_lowres_marine_tropical:
     compositor: !!python/name:satpy.composites.RGBCompositor
     prerequisites:
     - name: M05
@@ -333,5 +333,3 @@ true_color_lowres_marine_tropical:
     - name: M11
       modifiers: [sunz_corrected]
     standard_name: snow_age
-
-

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -10,6 +10,32 @@ modifiers:
     - solar_azimuth_angle
     - solar_zenith_angle
 
+  rayleigh_corrected:
+    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: marine_clean_aerosol
+    prerequisites:
+    - name: M05
+      modifiers: [sunz_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
+  rayleigh_corrected_land:
+    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: continental_average_aerosol
+    prerequisites:
+    - name: M05
+      modifiers: [sunz_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
   sunz_corrected:
     compositor: !!python/name:satpy.composites.SunZenithCorrector
     prerequisites:

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -40,7 +40,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: marine_clean_aerosol
     prerequisites:
-    - wavelength: 0.44
+    - wavelength: 0.67
       modifiers: [sunz_corrected]
     optional_prerequisites:
     - satellite_azimuth_angle
@@ -53,7 +53,7 @@ modifiers:
     atmosphere: tropical
     aerosol_type: marine_tropical_aerosol
     prerequisites:
-    - wavelength: 0.44
+    - wavelength: 0.67
       modifiers: [sunz_corrected]
     optional_prerequisites:
     - satellite_azimuth_angle
@@ -66,7 +66,7 @@ modifiers:
     atmosphere: tropical
     aerosol_type: desert_aerosol
     prerequisites:
-    - wavelength: 0.44
+    - wavelength: 0.67
       modifiers: [sunz_corrected]
     optional_prerequisites:
     - satellite_azimuth_angle
@@ -79,7 +79,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: continental_average_aerosol
     prerequisites:
-    - wavelength: 0.44
+    - wavelength: 0.67
       modifiers: [sunz_corrected]
     optional_prerequisites:
     - satellite_azimuth_angle


### PR DESCRIPTION
Always use the red channel as the optional band in the true color recipes.
The red channel is used to reduce the correction over reflective targets.

 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` 
