### PR TITLE
Bugfix: Explicitly set the resolution for sun-satellite geometry

### DIFF
--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -5,10 +5,14 @@ modifiers:
     compositor: !!python/name:satpy.composites.viirs.ReflectanceCorrector
     dem_filename: CMGDEM.hdf
     prerequisites:
-    - satellite_azimuth_angle
-    - satellite_zenith_angle
-    - solar_azimuth_angle
-    - solar_zenith_angle
+    - name: satellite_azimuth_angle
+      resolution: 742    
+    - name: satellite_zenith_angle
+      resolution: 742
+    - name: solar_azimuth_angle
+      resolution: 742
+    - name: solar_zenith_angle
+      resolution: 742
 
   rayleigh_corrected:
     compositor: !!python/name:satpy.composites.PSPRayleighReflectance
@@ -16,12 +20,17 @@ modifiers:
     aerosol_type: marine_clean_aerosol
     prerequisites:
     - name: M05
+      resolution: 742
       modifiers: [sunz_corrected]
     optional_prerequisites:
-    - satellite_azimuth_angle
-    - satellite_zenith_angle
-    - solar_azimuth_angle
-    - solar_zenith_angle
+    - name: satellite_azimuth_angle
+      resolution: 742    
+    - name: satellite_zenith_angle
+      resolution: 742
+    - name: solar_azimuth_angle
+      resolution: 742
+    - name: solar_zenith_angle
+      resolution: 742
 
   rayleigh_corrected_marine_tropical:
     compositor: !!python/name:satpy.composites.PSPRayleighReflectance
@@ -29,12 +38,17 @@ modifiers:
     aerosol_type: marine_tropical_aerosol
     prerequisites:
     - name: M05
+      resolution: 742
       modifiers: [sunz_corrected]
     optional_prerequisites:
-    - satellite_azimuth_angle
-    - satellite_zenith_angle
-    - solar_azimuth_angle
-    - solar_zenith_angle
+    - name: satellite_azimuth_angle
+      resolution: 742    
+    - name: satellite_zenith_angle
+      resolution: 742
+    - name: solar_azimuth_angle
+      resolution: 742
+    - name: solar_zenith_angle
+      resolution: 742
 
   rayleigh_corrected_land:
     compositor: !!python/name:satpy.composites.PSPRayleighReflectance
@@ -42,12 +56,17 @@ modifiers:
     aerosol_type: continental_average_aerosol
     prerequisites:
     - name: M05
+      resolution: 742
       modifiers: [sunz_corrected]
     optional_prerequisites:
-    - satellite_azimuth_angle
-    - satellite_zenith_angle
-    - solar_azimuth_angle
-    - solar_zenith_angle
+    - name: satellite_azimuth_angle
+      resolution: 742    
+    - name: satellite_zenith_angle
+      resolution: 742
+    - name: solar_azimuth_angle
+      resolution: 742
+    - name: solar_zenith_angle
+      resolution: 742
 
   sunz_corrected:
     compositor: !!python/name:satpy.composites.SunZenithCorrector

--- a/satpy/etc/readers/viirs_sdr.yaml
+++ b/satpy/etc/readers/viirs_sdr.yaml
@@ -51,7 +51,7 @@ datasets:
   I01:
     name: I01
     wavelength: [0.600, 0.640, 0.680]
-    modifiers: [sunz_corrected]
+    modifiers: [sunz_corrected_iband]
     file_type: svi01
     resolution: 371
     coordinates: [i_longitude, i_latitude]
@@ -65,7 +65,7 @@ datasets:
   I02:
     name: I02
     wavelength: [0.845, 0.865, 0.884]
-    modifiers: [sunz_corrected]
+    modifiers: [sunz_corrected_iband]
     file_type: svi02
     resolution: 371
     coordinates: [i_longitude, i_latitude]
@@ -79,7 +79,7 @@ datasets:
   I03:
     name: I03
     wavelength: [1.580, 1.610, 1.640]
-    modifiers: [sunz_corrected]
+    modifiers: [sunz_corrected_iband]
     file_type: svi03
     resolution: 371
     coordinates: [i_longitude, i_latitude]


### PR DESCRIPTION
for the Rayleigh correction modifiers needed for True Color imagery

Signed-off-by: Adam.Dybbroe <adam.dybbroe@smhi.se>

After having added support for reading the I-band resolution sun-satellite angles in the viirs_sdr reader
the true color recipes didn't work anymore. The rayleigh correction modifiers assumed the sun-satellite angles in high resolution was required. Now, we specify explicitly the the angles are needed at M-band resolution.

 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff``
