### PR TITLE
Bugfix: The satellite azimuth returned by PyOrbital is not in the ran…

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2015-2018
+# Copyright (c) 2015-2018 PyTroll developers
 
 # Author(s):
 
 #   Martin Raspaud <martin.raspaud@smhi.se>
 #   David Hoese <david.hoese@ssec.wisc.edu>
+#   Adam Dybbroe <adam.dybbroe@smhi.se>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -344,12 +345,10 @@ class PSPRayleighReflectance(CompositeBase):
         except ValueError:
             from pyorbital.astronomy import get_alt_az, sun_zenith_angle
             from pyorbital.orbital import get_observer_look
-            sunalt, suna = get_alt_az(
-                vis.info['start_time'], *vis.info['area'].get_lonlats())
-            suna = np.rad2deg(suna)
-            sunz = sun_zenith_angle(
-                vis.info['start_time'], *vis.info['area'].get_lonlats())
             lons, lats = vis.info['area'].get_lonlats()
+            sunalt, suna = get_alt_az(vis.info['start_time'], lons, lats)
+            suna = np.rad2deg(suna)
+            sunz = sun_zenith_angle(vis.info['start_time'], lons, lats)
             sata, satel = get_observer_look(vis.info['satellite_longitude'],
                                             vis.info['satellite_latitude'],
                                             vis.info['satellite_altitude'],
@@ -359,6 +358,9 @@ class PSPRayleighReflectance(CompositeBase):
             del satel
         LOG.info('Removing Rayleigh scattering and aerosol absorption')
 
+        # First make sure the two azimuth angles are in the range 0-360:
+        sata = np.mod(sata, 360.)
+        suna = np.mod(suna, 360.)
         ssadiff = np.abs(suna - sata)
         ssadiff = np.where(ssadiff > 180, 360 - ssadiff, ssadiff)
         del sata, suna

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2016 Martin Raspaud
+# Copyright (c) 2016-2018 PyTroll developers
 
 # Author(s):
 

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2014, 2015, 2016 Adam.Dybbroe
+# Copyright (c) 2014-2018 PyTroll developers
 
 # Author(s):
 

--- a/satpy/readers/helper_functions.py
+++ b/satpy/readers/helper_functions.py
@@ -1,7 +1,7 @@
 
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2014, 2015.
+# Copyright (c) 2014-2018 PyTroll developers
 #
 # Author(s):
 #
@@ -34,7 +34,7 @@ LOGGER = logging.getLogger(__name__)
 
 def np2str(value):
     """Convert an np.string_ to str."""
-    if issubclass(value.dtype.type, np.string_) and not value.shape:
+    if issubclass(value.dtype.type, np.string_):
         value = np.asscalar(value)
         if not isinstance(value, str):
             # python 3 - was scalar numpy array of bytes

--- a/satpy/tools.py
+++ b/satpy/tools.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2014, 2016, 2017
+# Copyright (c) 2014-2018 PyTroll developers
 #
 # Author(s):
 #


### PR DESCRIPTION
…ge -180 to 180 as was expected

Signed-off-by: Adam.Dybbroe <adam.dybbroe@smhi.se>

The azimuth difference angles passed to PySpectral were not in the range of 0 to 180 as expected. 
This is because the satellite azimuth angles returned by PyOrbital is not in the range of -180 to 180 as expected, but instead seems to be in the range 0 to 360, whereas the sun-azimuth is in the range -180 to 180. An issue is raised in PyOrbital about this: pytroll/pyorbital#18

 - [x] Tests passed
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff``

