### PR TITLE
Bugfix float geotiff

### DIFF
--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -235,17 +235,16 @@ def get_enhanced_image(dataset,
     if enhancer is None:
         enhancer = Enhancer(ppp_config_dir, enhancement_config_file)
 
-    if enhancer.enhancement_tree is None:
-        raise RuntimeError(
-            "No enhancement configuration files found or specified, cannot"
-            " automatically enhance dataset")
-
-    if dataset.attrs.get("sensor", None):
-        enhancer.add_sensor_enhancements(dataset.attrs["sensor"])
-
     # Create an image for enhancement
     img = to_image(dataset, mode=mode, fill_value=fill_value)
-    enhancer.apply(img, **dataset.attrs)
+
+    if enhancer.enhancement_tree is None:
+        LOG.debug("No enhancement being applied to dataset")
+    else:
+        if dataset.attrs.get("sensor", None):
+            enhancer.add_sensor_enhancements(dataset.attrs["sensor"])
+
+        enhancer.apply(img, **dataset.attrs)
 
     img.info.update(dataset.attrs)
 

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -35,6 +35,20 @@ LOG = logging.getLogger(__name__)
 
 
 class GeoTIFFWriter(ImageWriter):
+
+    """Writer to save GeoTIFF images.
+
+    Basic example from Scene:
+
+        scn.save_datasets(writer='geotiff')
+
+    Un-enhanced float geotiff with NaN for fill values:
+
+        scn.save_datasets(writer='geotiff', floating_point=True,
+                          enhancement_config=False, fill_value=np.nan)
+
+    """
+
     GDAL_OPTIONS = ("tfw",
                     "rpb",
                     "rpctxt",


### PR DESCRIPTION
<!-- Please make the PR against the `develop` branch. -->

<!-- Describe what your PR does, and why -->


 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

Previously there would be an exception if an ImageWriter tried to create an image with no enhancements since for most image formats this doesn't make sense (an 8-bit PNG without being scaled properly?). This PR makes it possible for users to tell satpy to not enhance the image and let the writer see try to use the un-enhanced image. Behavior is undefined for other writers, but typically the data is clipped and converted to the necessary array data type before attempting to write it to disk. Side note: the fully documented above isn't the best way to document it (I just added it to the docstring of the writer class), but we don't have any official per-writer documentation at the moment so I thought this would be ok.