### PR TITLE
Bugfix nwcsaf_pps reader for file discoverability

### DIFF
--- a/satpy/etc/readers/nc_nwcsaf_pps.yaml
+++ b/satpy/etc/readers/nc_nwcsaf_pps.yaml
@@ -1,6 +1,6 @@
 reader:
   description: NetCDF4 reader for the NWCSAF/PPS 2014 format
-  name: nc_nwcsaf
+  name: nc_nwcsaf_pps
   sensors: ['avhrr-3', 'viirs', 'modis']
   default_channels: []
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -192,6 +192,20 @@ class TestFindFilesAndReaders(unittest.TestCase):
         finally:
             os.remove(fn)
 
+
+    def test_reader_other_name(self):
+        """Test with default base_dir and reader specified"""
+        from satpy.readers import find_files_and_readers
+        fn = 'S_NWC_CPP_npp_32505_20180204T1114116Z_20180204T1128227Z.nc'
+        # touch the file so it exists on disk
+        open(fn, 'w')
+        try:
+            ri = find_files_and_readers(reader='nc_nwcsaf_pps')
+            self.assertListEqual(list(ri.keys()), ['nc_nwcsaf_pps'])
+            self.assertListEqual(ri['nc_nwcsaf_pps'], [fn])
+        finally:
+            os.remove(fn)
+
     def test_reader_name_matched_start_end_time(self):
         """Test with start and end time matching the filename"""
         from satpy.readers import find_files_and_readers

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -192,7 +192,6 @@ class TestFindFilesAndReaders(unittest.TestCase):
         finally:
             os.remove(fn)
 
-
     def test_reader_other_name(self):
         """Test with default base_dir and reader specified"""
         from satpy.readers import find_files_and_readers


### PR DESCRIPTION
<!-- Please make the PR against the `develop` branch. -->

<!-- Describe what your PR does, and why -->

This PR fixes the nc_nwcsaf_pps reader config, which stated the wrong reader name. As a consequence, `find_files_and_readers` would return the wrong key for this reader.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
