### PR TITLE
Add missing nodata tiff tag

### DIFF
--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -100,8 +100,10 @@ class GeoTIFFWriter(ImageWriter):
         """
         if fill_value is not None:
             for i, chan in enumerate(datasets):
-                ds = chan.filled(fill_value[i])
-                dst_ds.GetRasterBand(i + 1).WriteArray(ds)
+                chn = chan.filled(fill_value[i])
+                bnd = dst_ds.GetRasterBand(i + 1)
+                bnd.SetNoDataValue(fill_value[i])
+                bnd.WriteArray(chn)
         else:
             mask = np.zeros(datasets[0].shape, dtype=np.bool)
             i = 0


### PR DESCRIPTION
Adding missing nodata tiff tag in geotiff.py if fill_value is not None as already exists in mpop (see [corresponding commit](https://github.com/pytroll/mpop/commit/2897f7581b27c69d2fdf8c71bd057da4e756b367))

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
