### PR TITLE
Fix masking for geotiff writer

### DIFF
--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -89,11 +89,11 @@ class GeoTIFFWriter(ImageWriter):
                 ds = chan.filled(fill_value[i])
                 dst_ds.GetRasterBand(i + 1).WriteArray(ds)
         else:
-            mask = np.zeros(datasets[0].shape, dtype=np.bool)
+            mask = np.ones(datasets[0].shape, dtype=np.bool)
             i = 0
             for i, chan in enumerate(datasets):
                 dst_ds.GetRasterBand(i + 1).WriteArray(chan.filled(0))
-                mask |= np.ma.getmaskarray(chan)
+                mask &= np.ma.getmaskarray(chan)
             try:
                 mask |= np.ma.getmaskarray(opacity)
             except AttributeError:


### PR DESCRIPTION
This PR fixes the masking in GeoTIFF writer so that the result is equal to when saving in PNG format.

 - [x] Closes #200 
 - [x] Tests passed
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` for the updated parts
