### PR TITLE
Add 'native' resampler

### DIFF
--- a/satpy/composites/abi.py
+++ b/satpy/composites/abi.py
@@ -23,73 +23,29 @@
 """
 
 import logging
-import numpy as np
-
-from satpy.composites import GenericCompositor
+from satpy.composites import GenericCompositor, IncompatibleAreas
 
 LOG = logging.getLogger(__name__)
 
 
-def four_element_average(d):
-    """Average every 4 elements (2x2) in a 2D array"""
-    rows, cols = d.shape
-    new_shape = (int(rows / 2.), 2, int(cols / 2.), 2)
-    return np.ma.mean(d.reshape(new_shape), axis=(1, 3))
+class SimulatedGreen(GenericCompositor):
 
+    """A single-band dataset resembles a Green (0.55 µm)."""
 
-def simulated_green(c01, c02, c03):
-    # Kaba:
-    # return (c01 + c02) * 0.45 + 0.1 * c03
-    # EDC:
-    # return c01 * 0.45706946 + c02 * 0.48358168 + 0.06038137 * c03
-    # Original:
-    return (c01 + c02) / 2 * 0.93 + 0.07 * c03
-
-
-class TrueColor2km(GenericCompositor):
-    """True Color ABI compositor assuming all bands are the same resolution"""
-
-    def __call__(self, projectables, **info):
-
+    def __call__(self, projectables, optional_datasets=None, **attrs):
         c01, c02, c03 = projectables
+        if not all(c.shape == projectables[0].shape
+                   for c in projectables[1:]):
+            raise IncompatibleAreas("Simulated green can only be made from "
+                                    "bands of the same size. Resample "
+                                    "first.")
 
-        # c02 = c02.sel(x=c01.coords['x'], y=c01.coords[
-        #               'y'], method='nearest', tolerance=0.1)
+        # Kaba:
+        # res = (c01 + c02) * 0.45 + 0.1 * c03
+        # EDC:
+        # res = c01 * 0.45706946 + c02 * 0.48358168 + 0.06038137 * c03
+        # Original attempt:
+        res = (c01 + c02) / 2 * 0.93 + 0.07 * c03
+        res.attrs = c03.attrs.copy()
 
-
-        r = c02[::2, ::2]
-        b = c01
-        r.coords['x'] = b.coords['x']
-        r.coords['y'] = b.coords['y']
-        r.data = r.data.rechunk(b.chunks)
-        g = simulated_green(c01, c02, c03)
-        g.attrs = b.attrs
-        g.coords['t'] = b.coords['t']
-        del g.attrs['wavelength']
-
-        return super(TrueColor2km, self).__call__((r, g, b), **info)
-
-
-class TrueColor(GenericCompositor):
-    """Ratio sharpened full resolution true color"""
-
-    def __call__(self, projectables, **info):
-        c01, c02, c03 = projectables
-        r = c02
-        b = np.repeat(np.repeat(c01, 2, axis=0), 2, axis=1)
-        c03_high = np.repeat(np.repeat(c03, 2, axis=0), 2, axis=1)
-        g = simulated_green(b, r, c03_high)
-
-        low_res_red = four_element_average(r)
-        low_res_red = np.repeat(np.repeat(low_res_red, 2, axis=0), 2, axis=1)
-        ratio = r / low_res_red
-
-        # make sure metadata is copied over
-        # copy red channel area to get correct resolution
-        g *= ratio
-        g.info = c03.info.copy()
-        g.info['area'] = r.info['area']
-        b *= ratio
-        b.info = c01.info.copy()
-        b.info['area'] = r.info['area']
-        return super(TrueColor, self).__call__((r, g, b), **info)
+        return super(SimulatedGreen, self).__call__((res,), **attrs)

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -23,6 +23,7 @@
 """Enhancements."""
 
 import numpy as np
+import xarray.ufuncs as xu
 import logging
 
 LOG = logging.getLogger(__name__)
@@ -49,12 +50,12 @@ def cira_stretch(img, **kwargs):
     Applicable only for visible channels.
     """
     LOG.debug("Applying the cira-stretch")
-    for chn in img.channels:
-        chn /= 100
-        np.log10(chn.data, out=chn.data)
-        chn -= np.log10(0.0223)
-        chn /= 1.0 - np.log10(0.0223)
-        chn /= 0.75
+    attrs = img.data.attrs
+    img.data /= 100
+    img.data = xu.log10(img.data)
+    img.data -= np.log10(0.02223)
+    img.data /= (1.0 - np.log10(0.02223)) * 0.75
+    img.data.attrs = attrs
 
 
 def lookup(img, **kwargs):

--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -91,38 +91,27 @@ composites:
       modifiers: [sunz_corrected]
     standard_name: toa_bidirection_reflectance
 
-  true_color_2km:
-    compositor: !!python/name:satpy.composites.abi.TrueColor2km
-    prerequisites:
-    - name: C01
-      modifiers: [reducer2, effective_solar_pathlength_corrected, rayleigh_corrected]
-    - name: C02
-      modifiers: [reducer4, effective_solar_pathlength_corrected, rayleigh_corrected]
-    - name: C03
-      modifiers: [reducer2, effective_solar_pathlength_corrected]
-    standard_name: true_color
-
-  true_color_2km_marine_tropical:
-    compositor: !!python/name:satpy.composites.abi.TrueColor2km
-    prerequisites:
-    - name: C01
-      modifiers: [reducer2, effective_solar_pathlength_corrected, rayleigh_corrected_marine_tropical]
-    - name: C02
-      modifiers: [reducer4, effective_solar_pathlength_corrected, rayleigh_corrected_marine_tropical]
-    - name: C03
-      modifiers: [reducer2, effective_solar_pathlength_corrected]
-    standard_name: true_color
-
-  true_color_2km_land:
-    compositor: !!python/name:satpy.composites.abi.TrueColor2km
-    prerequisites:
-    - name: C01
-      modifiers: [reducer2, effective_solar_pathlength_corrected, rayleigh_corrected_land]
-    - name: C02
-      modifiers: [reducer4, effective_solar_pathlength_corrected, rayleigh_corrected_land]
-    - name: C03
-      modifiers: [reducer2, effective_solar_pathlength_corrected]
-    standard_name: true_color
+#  true_color_2km_marine_tropical:
+#    compositor: !!python/name:satpy.composites.abi.TrueColor2km
+#    prerequisites:
+#    - name: C01
+#      modifiers: [reducer2, effective_solar_pathlength_corrected, rayleigh_corrected_marine_tropical]
+#    - name: C02
+#      modifiers: [reducer4, effective_solar_pathlength_corrected, rayleigh_corrected_marine_tropical]
+#    - name: C03
+#      modifiers: [reducer2, effective_solar_pathlength_corrected]
+#    standard_name: true_color
+#
+#  true_color_2km_land:
+#    compositor: !!python/name:satpy.composites.abi.TrueColor2km
+#    prerequisites:
+#    - name: C01
+#      modifiers: [reducer2, effective_solar_pathlength_corrected, rayleigh_corrected_land]
+#    - name: C02
+#      modifiers: [reducer4, effective_solar_pathlength_corrected, rayleigh_corrected_land]
+#    - name: C03
+#      modifiers: [reducer2, effective_solar_pathlength_corrected]
+#    standard_name: true_color
 
   true_color:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB

--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -77,6 +77,20 @@ modifiers:
     - solar_zenith_angle
 
 composites:
+  green:
+    compositor: !!python/name:satpy.composites.abi.SimulatedGreen
+    # FUTURE: Set a wavelength...see what happens. Dependency finding
+    #         probably wouldn't work.
+    prerequisites:
+    # should we be using the most corrected or least corrected inputs?
+    - name: C01
+      modifiers: [sunz_corrected]
+    - name: C02
+      modifiers: [sunz_corrected]
+    - name: C03
+      modifiers: [sunz_corrected]
+    standard_name: toa_bidirection_reflectance
+
   true_color_2km:
     compositor: !!python/name:satpy.composites.abi.TrueColor2km
     prerequisites:
@@ -111,14 +125,13 @@ composites:
     standard_name: true_color
 
   true_color:
-    compositor: !!python/name:satpy.composites.abi.TrueColor
+    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
-    - name: C01
-      modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_1km]
     - name: C02
-      modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_500m]
-    - name: C03
-      modifiers: [effective_solar_pathlength_corrected]
+      modifiers: [sunz_corrected]
+    - name: green
+    - name: C01
+      modifiers: [sunz_corrected]
     standard_name: true_color
 
   natural:

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -234,15 +234,13 @@ class DependencyTree(Node):
     def get_compositor(self, key):
         for sensor_name in self.compositors.keys():
             try:
-                comp = self.compositors[sensor_name][key]
-                return comp
+                return self.compositors[sensor_name][key]
             except KeyError:
                 continue
 
         if isinstance(key, DatasetID) and key.modifiers:
             # we must be generating a modifier composite
-            mod = self.get_modifier(key)
-            return mod
+            return self.get_modifier(key)
 
         raise KeyError("Could not find compositor '{}'".format(key))
 

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -153,7 +153,6 @@ class BaseResampler(object):
             # use `da.isnull` for now, then `data.isnull()` should be fine
             kwargs['mask'] = da.isnull(data).all(dim=flat_dims)
         cache_id = self.precompute(cache_dir=cache_dir, **kwargs)
-        data.attrs['_last_resampler'] = self
         return self.compute(data, cache_id=cache_id, **kwargs)
 
     # FIXME: there should be only one obvious way to resample

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -585,12 +585,8 @@ class NativeResampler(BaseResampler):
             if 'x' in data.coords:
                 coords['x'] = x_coord
 
-        new_attrs = data.attrs.copy()
-        # FIXME: This is assigned by the caller
-        # new_attrs['area'] = target_geo_def
         return xr.DataArray(d_arr,
                             dims=data.dims,
-                            attrs=new_attrs,
                             coords=coords or None)
 
 
@@ -653,8 +649,6 @@ def resample_dataset(dataset, destination_area, **kwargs):
         return dataset
 
     new_data = resample(source_area, dataset, destination_area, **kwargs)
-    # FIXME: Resamplers are probably already copying attrs, can we
-    #        leave this logic to the resamplers?
     new_data.attrs = dataset.attrs.copy()
     new_data.attrs['area'] = destination_area
 

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -488,6 +488,7 @@ class NativeResampler(BaseResampler):
                                                      cache_dir=cache_dir,
                                                      mask_area=mask_area,
                                                      **kwargs)
+
     @staticmethod
     def aggregate(d, y_size, x_size):
         """Average every 4 elements (2x2) in a 2D array"""

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -586,6 +586,18 @@ class Scene(MetadataObject):
         """Generate a new scene with resampled *datasets*."""
         new_scn = cls()
 
+        # special case for 'native'
+        # FIXME: This should go in the resampler, but currently the
+        # `resample_dataset` function assigns the area which we can't
+        # do for the native resampler because it gets a list
+        if destination is None:
+            # find the highest/lowest area among the provided
+            expand = resample_kwargs.get('expand', True)
+            test_func = max if expand else min
+            destination = [ds.attrs['area'] for ds in datasets]
+            destination = test_func(destination,
+                                    key=lambda x: x.shape)
+
         new_datasets = {}
         destination_area = None
         for dataset, parent_dataset in dataset_walker(datasets):
@@ -616,9 +628,8 @@ class Scene(MetadataObject):
 
         return new_scn
 
-
     def resample(self,
-                 destination,
+                 destination=None,
                  datasets=None,
                  compute=True,
                  unload=True,

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -232,8 +232,8 @@ class Scene(MetadataObject):
         if not check_datasets:
             raise ValueError("No dataset areas available")
 
-        areas = [ds.attrs['area'] for ds in check_datasets]
-        if not all(type(x) is type(areas[0])
+        areas = [x.attrs['area'] for x in check_datasets]
+        if not all(isinstance(x, type(areas[0]))
                    for x in areas[1:]):
             raise ValueError("Can't compare areas of different types")
         elif isinstance(areas[0], AreaDefinition):

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -224,7 +224,6 @@ class Scene(MetadataObject):
         else:
             check_datasets = []
             for ds in datasets:
-                print(type(ds))
                 if not isinstance(ds, DataArray):
                     ds = self[ds]
                 check_datasets.append(ds)

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -285,6 +285,48 @@ class TestScene(unittest.TestCase):
         self.assertEquals(len(scene.datasets.keys()), 0)
         self.assertRaises(KeyError, scene.__delitem__, 0.2)
 
+    def test_min_max_area(self):
+        """Test 'min_area' and 'max_area' methods."""
+        from satpy import Scene
+        from xarray import DataArray
+        from pyresample.geometry import AreaDefinition
+        from pyresample.utils import proj4_str_to_dict
+        import numpy as np
+        scene = Scene()
+        scene["1"] = ds1 = DataArray(np.arange(10).reshape((2, 5)),
+                                     attrs={'wavelength': (0.1, 0.2, 0.3)})
+        scene["2"] = ds2 = DataArray(np.arange(40).reshape((4, 10)),
+                                     attrs={'wavelength': (0.4, 0.5, 0.6)})
+        scene["3"] = ds3 = DataArray(np.arange(40).reshape((4, 10)),
+                                     attrs={'wavelength': (0.7, 0.8, 0.9)})
+        proj_dict = proj4_str_to_dict('+proj=lcc +datum=WGS84 +ellps=WGS84 '
+                                      '+lon_0=-95. +lat_0=25 +lat_1=25 '
+                                      '+units=m +no_defs')
+        area_def1 = AreaDefinition(
+            'test',
+            'test',
+            'test',
+            proj_dict,
+            x_size=100,
+            y_size=200,
+            area_extent=(-1000., -1500., 1000., 1500.),
+        )
+        area_def2 = AreaDefinition(
+            'test',
+            'test',
+            'test',
+            proj_dict,
+            x_size=200,
+            y_size=400,
+            area_extent=(-1000., -1500., 1000., 1500.),
+        )
+        ds1.attrs['area'] = area_def1
+        ds2.attrs['area'] = area_def2
+        ds3.attrs['area'] = area_def2
+        self.assertIs(scene.min_area(), area_def1)
+        self.assertIs(scene.max_area(), area_def2)
+        self.assertIs(scene.min_area(['2', '3']), area_def2)
+
     def test_all_datasets_no_readers(self):
         from satpy import Scene
         scene = Scene()

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -923,12 +923,10 @@ class TestSceneLoading(unittest.TestCase):
         # initialize the dep tree without loading the data
         scene.dep_tree.find_dependencies({'comp19'})
         this_node = scene.dep_tree['comp19']
-        print(scene.dep_tree.display())
         shared_dep_id = DatasetID(name='ds5', modifiers=('res_change',))
         shared_dep_expected_node = scene.dep_tree[shared_dep_id]
         # get the node for the first dep in the prereqs list of the
         # comp13 node
-        print("comp13 data: ", scene.dep_tree['comp13'].data)
         shared_dep_node = scene.dep_tree['comp13'].data[1][0]
         shared_dep_node2 = this_node.data[1][0]
         self.assertIs(shared_dep_expected_node, shared_dep_node)

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -85,10 +85,18 @@ def _create_fake_modifiers(name, prereqs, opt_prereqs):
     from satpy.composites import CompositeBase, IncompatibleAreas
     from satpy import DatasetID
 
+    attrs = {
+        'name': name,
+        'prerequisites': tuple(prereqs),
+        'optional_prerequisites': tuple(opt_prereqs)
+    }
+
     def _mod_loader(*args, **kwargs):
         class FakeMod(CompositeBase):
             def __init__(self, *args, **kwargs):
-                self.attrs = {}
+
+                print(args, kwargs)
+                super(FakeMod, self).__init__(*args, **kwargs)
 
             def __call__(self, datasets, optional_datasets, **info):
                 resolution = DatasetID.from_dict(datasets[0].attrs).resolution
@@ -104,16 +112,13 @@ def _create_fake_modifiers(name, prereqs, opt_prereqs):
                 self.apply_modifier_info(i, info)
                 return DataArray(np.ma.MaskedArray(datasets[0]), attrs=info)
 
-        m = FakeMod()
-        m.attrs = {
-            'prerequisites': tuple(prereqs),
-            'optional_prerequisites': tuple(opt_prereqs)
-        }
+        m = FakeMod(*args, **kwargs)
+        # m.attrs = attrs
         m._call_mock = mock.patch.object(
             FakeMod, '__call__', wraps=m.__call__).start()
         return m
 
-    return _mod_loader, {}
+    return _mod_loader, attrs
 
 
 def test_composites(sensor_name):

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -141,6 +141,7 @@ def test_composites(sensor_name):
         DatasetID(name='comp16'): (['ds1'], ['ds9_fail_load']),
         DatasetID(name='comp17'): (['ds1', 'comp15'], []),
         DatasetID(name='comp18'): ([DatasetID(name='ds1', modifiers=('incomp_areas',))], []),
+        DatasetID(name='comp19'): ([DatasetID('ds5', modifiers=('res_change',)), 'comp13', 'ds2'], [])
     }
     # Modifier name -> (prereqs (not including to-be-modified), opt_prereqs)
     mods = {

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -95,7 +95,6 @@ def _create_fake_modifiers(name, prereqs, opt_prereqs):
         class FakeMod(CompositeBase):
             def __init__(self, *args, **kwargs):
 
-                print(args, kwargs)
                 super(FakeMod, self).__init__(*args, **kwargs)
 
             def __call__(self, datasets, optional_datasets, **info):

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -34,8 +34,15 @@ import yaml
 from satpy.config import (config_search_paths, get_environ_config_dir,
                           recursive_dict_update)
 from satpy.plugin_base import Plugin
-from trollimage.xrimage import XRImage
 from trollsift import parser
+
+try:
+    from trollimage.xrimage import XRImage as Image
+except ImportError:
+    import warnings
+    warnings.warn("Please update to the newest version of trollimage "
+                  "for best writer performance")
+    from trollimage.image import Image
 
 LOG = logging.getLogger(__name__)
 
@@ -274,7 +281,7 @@ def to_image(dataset, copy=False, **kwargs):
     if dataset.ndim < 2:
         raise ValueError("Need at least a 2D array to make an image.")
     else:
-        return XRImage(dataset)
+        return Image(dataset)
 
 
 class Writer(Plugin):


### PR DESCRIPTION
This PR adds a 'native' resampler class and adjusts how the destination area is treated if it is `None`. There are a couple FIXMEs because how and where things are assigned or used doesn't seem to support this functionality. This screams more "the resampler design needs refactoring" rather than "the native resampler should be accessed through a separate method".

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes) -->
 - [ ] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
