### PR TITLE
Fix optional dependencies not being passed to modifiers with opts only

### DIFF
--- a/satpy/node.py
+++ b/satpy/node.py
@@ -363,7 +363,7 @@ class DependencyTree(Node):
             root, compositor.attrs['optional_prerequisites'], skip=True,
             calibration=calibration, polarization=polarization,
             resolution=resolution)
-        root.data[2].extend(prereqs)
+        root.data[2].extend(optional_prereqs)
 
         return root, set()
 

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -612,7 +612,7 @@ class TestSceneLoading(unittest.TestCase):
                                   reader='fake_reader')
         scene.load(['comp1'])
         loaded_ids = list(scene.datasets.keys())
-        self.assertEquals(len(loaded_ids), 1)
+        self.assertEqual(len(loaded_ids), 1)
         self.assertTupleEqual(
             tuple(loaded_ids[0]), tuple(DatasetID(name='comp1')))
 
@@ -1099,6 +1099,69 @@ class TestSceneLoading(unittest.TestCase):
         self.assertEqual(comps['fake_sensor']['ds1']._call_mock.call_count, 1)
         loaded_ids = list(scene.datasets.keys())
         self.assertEquals(len(loaded_ids), 2)
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_comp20(self, cri, cl):
+        """Test loading composite with optional modifier dependencies"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy import DatasetID
+        cri.return_value = {'fake_reader': create_fake_reader(
+            'fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames=['bla'],
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        # it is fine that an optional prereq doesn't exist
+        scene.load(['comp20'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 1)
+        self.assertTupleEqual(
+            tuple(loaded_ids[0]), tuple(DatasetID(name='comp20')))
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_comp21(self, cri, cl):
+        """Test loading composite with optional modifier dependencies"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy import DatasetID
+        cri.return_value = {'fake_reader': create_fake_reader(
+            'fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames=['bla'],
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        # it is fine that an optional prereq doesn't exist
+        scene.load(['comp21'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 1)
+        self.assertTupleEqual(
+            tuple(loaded_ids[0]), tuple(DatasetID(name='comp21')))
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_comp22(self, cri, cl):
+        """Test loading composite with optional modifier dependencies"""
+        import satpy.scene
+        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy import DatasetID
+        cri.return_value = {'fake_reader': create_fake_reader(
+            'fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames=['bla'],
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        # it is fine that an optional prereq doesn't exist
+        scene.load(['comp22'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEquals(len(loaded_ids), 1)
+        self.assertTupleEqual(
+            tuple(loaded_ids[0]), tuple(DatasetID(name='comp22')))
 
 
 def suite():

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -98,6 +98,12 @@ def _create_fake_modifiers(name, prereqs, opt_prereqs):
                 super(FakeMod, self).__init__(*args, **kwargs)
 
             def __call__(self, datasets, optional_datasets, **info):
+                if self.attrs['optional_prerequisites']:
+                    for opt_dep in self.attrs['optional_prerequisites']:
+                        if 'NOPE' in opt_dep or 'fail' in opt_dep:
+                            continue
+                        assert optional_datasets is not None and \
+                            len(optional_datasets)
                 resolution = DatasetID.from_dict(datasets[0].attrs).resolution
                 if name == 'res_change' and resolution is not None:
                     i = datasets[0].attrs.copy()
@@ -145,7 +151,10 @@ def test_composites(sensor_name):
         DatasetID(name='comp16'): (['ds1'], ['ds9_fail_load']),
         DatasetID(name='comp17'): (['ds1', 'comp15'], []),
         DatasetID(name='comp18'): ([DatasetID(name='ds1', modifiers=('incomp_areas',))], []),
-        DatasetID(name='comp19'): ([DatasetID('ds5', modifiers=('res_change',)), 'comp13', 'ds2'], [])
+        DatasetID(name='comp19'): ([DatasetID('ds5', modifiers=('res_change',)), 'comp13', 'ds2'], []),
+        DatasetID(name='comp20'): ([DatasetID(name='ds5', modifiers=('mod_opt_prereq',))], []),
+        DatasetID(name='comp21'): ([DatasetID(name='ds5', modifiers=('mod_bad_opt',))], []),
+        DatasetID(name='comp22'): ([DatasetID(name='ds5', modifiers=('mod_opt_only',))], []),
     }
     # Modifier name -> (prereqs (not including to-be-modified), opt_prereqs)
     mods = {
@@ -153,6 +162,9 @@ def test_composites(sensor_name):
         'mod2': (['comp3'], []),
         'res_change': ([], []),
         'incomp_areas': (['ds1'], []),
+        'mod_opt_prereq': (['ds1'], ['ds2']),
+        'mod_bad_opt': (['ds1'], ['ds9_fail_load']),
+        'mod_opt_only': ([], ['ds2']),
     }
 
     comps = {sensor_name: DatasetDict((k, _create_fake_compositor(k, *v)) for k, v in comps.items())}


### PR DESCRIPTION
In a recent fix I made to fix a dependency issue I made a typo which caused optional dependencies to break. @mraspaud noticed it when working on a modifier with only optional dependencies.

This was all caused by a typo, see diff.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->