### PR TITLE
Fix enhancements to work with xarray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
 - pip install python-hdf4
 - "pip install --no-binary :all: netCDF4"
 - pip install gdal==1.10.0
+- pip install scipy
 addons:
   apt_packages:
     - libgdal-dev

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -104,7 +104,7 @@ def apply_enhancement(data, func, exclude=None, separate=False,
         # combine the new data with the excluded data
         new_data = xr.concat([band_data, data.sel(bands=exclude)],
                              dim='bands')
-        data.data = new_data.sel(bands=bands)
+        data.data = new_data.sel(bands=bands).data
         data.attrs = attrs
 
     return data

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -133,7 +133,7 @@ modifiers:
 composites:
 
   true_color:
-    compositor: !!python/name:satpy.composites.viirs.RatioSharpenedRGB
+    compositor: !!python/name:satpy.composites.RatioSharpenedRGB
     prerequisites:
     - name: M05
       modifiers: [sunz_corrected, rayleigh_corrected]

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -160,8 +160,7 @@ class BaseResampler(object):
         if mask_area:
             flat_dims = [dim for dim in data.dims if dim not in ['x', 'y']]
             # xarray <= 0.10.1 computes dask arrays during isnull
-            # use `da.isnull` for now, then `data.isnull()` should be fine
-            kwargs['mask'] = da.isnull(data).all(dim=flat_dims)
+            kwargs['mask'] = data.isnull().all(dim=flat_dims)
         cache_id = self.precompute(cache_dir=cache_dir, **kwargs)
         return self.compute(data, cache_id=cache_id, **kwargs)
 

--- a/satpy/tests/test_enhancements.py
+++ b/satpy/tests/test_enhancements.py
@@ -26,6 +26,7 @@
 import unittest
 import numpy as np
 import xarray as xr
+import dask.array as da
 
 
 class TestEnhancementStretch(unittest.TestCase):
@@ -49,6 +50,7 @@ class TestEnhancementStretch(unittest.TestCase):
         img = XRImage(data)
         func(img, **kwargs)
 
+        self.assertIsInstance(img.data.data, da.Array)
         self.assertListEqual(sorted(pre_attrs.keys()),
                              sorted(img.data.attrs.keys()),
                              "DataArray attributes were not preserved")

--- a/satpy/tests/test_enhancements.py
+++ b/satpy/tests/test_enhancements.py
@@ -37,20 +37,74 @@ class TestEnhancementStretch(unittest.TestCase):
         data = np.arange(-210, 790, 100).reshape((2, 5)) * 0.95
         data[0, 0] = np.nan  # one bad value for testing
         self.ch1 = xr.DataArray(data, dims=('y', 'x'), attrs={'test': 'test'})
+        rgb_data = np.stack([data, data, data])
+        self.rgb = xr.DataArray(rgb_data, dims=('bands', 'y', 'x'),
+                                coords={'bands': ['R', 'G', 'B']})
+
+    def _test_enhancement(self, func, data, expected, **kwargs):
+        """Helper for testing enhancement functions."""
+        from trollimage.xrimage import XRImage
+
+        pre_attrs = data.attrs
+        img = XRImage(data)
+        func(img, **kwargs)
+
+        self.assertListEqual(sorted(pre_attrs.keys()),
+                             sorted(img.data.attrs.keys()),
+                             "DataArray attributes were not preserved")
+
+        np.testing.assert_allclose(img.data.values, expected, atol=1.e-6, rtol=0)
 
     def test_cira_stretch(self):
         """Test applying the cira_stretch"""
-        from trollimage.xrimage import XRImage
         from satpy.enhancements import cira_stretch
-
-        img = XRImage(self.ch1)
-        cira_stretch(img)
 
         expected = np.array([[
             [np.nan, np.nan, np.nan, 0.79630132, 0.95947296],
             [1.05181359, 1.11651012, 1.16635571, 1.20691137, 1.24110186]]])
-        np.testing.assert_allclose(img.data.values, expected)
-        self.assertEqual(img.data.attrs, self.ch1.attrs)
+        self._test_enhancement(cira_stretch, self.ch1, expected)
+
+    def test_lookup(self):
+        from satpy.enhancements import lookup
+        expected = np.array([[
+            [0., 0., 0., 0.333333, 0.705882],
+            [1., 1., 1., 1., 1.]]])
+        lut = np.arange(256.)
+        self._test_enhancement(lookup, self.ch1, expected, luts=lut)
+
+    def test_colorize(self):
+        from satpy.enhancements import colorize
+        from trollimage.colormap import brbg
+        expected = np.array([[
+            [          np.nan,   3.29409498e-01,   3.29409498e-01,
+               4.35952940e-06,   4.35952940e-06],
+            [  4.35952940e-06,   4.35952940e-06,   4.35952940e-06,
+               4.35952940e-06,   4.35952940e-06]],
+
+           [[          np.nan,   1.88249866e-01,   1.88249866e-01,
+               2.35302110e-01,   2.35302110e-01],
+            [  2.35302110e-01,   2.35302110e-01,   2.35302110e-01,
+               2.35302110e-01,   2.35302110e-01]],
+
+           [[          np.nan,   1.96102817e-02,   1.96102817e-02,
+               1.88238767e-01,   1.88238767e-01],
+            [  1.88238767e-01,   1.88238767e-01,   1.88238767e-01,
+               1.88238767e-01,   1.88238767e-01]]])
+        self._test_enhancement(colorize, self.ch1, expected, palettes=brbg)
+
+    def test_palettize(self):
+        from satpy.enhancements import palettize
+        from trollimage.colormap import brbg
+        expected = np.array([[
+            [11, -1, -1, 10, 10], [10, 10, 10, 10, 10]]])
+        self._test_enhancement(palettize, self.ch1, expected, palettes=brbg)
+
+    def test_three_d_effect(self):
+        from satpy.enhancements import three_d_effect
+        expected = np.array([[
+            [np.nan, np.nan, -389.5, -294.5, 826.5],
+            [np.nan, np.nan, 85.5, 180.5, 1301.5]]])
+        self._test_enhancement(three_d_effect, self.ch1, expected)
 
     def tearDown(self):
         """Clean up"""


### PR DESCRIPTION
Convert remaining enhancements to work with xarray. Any features that used these enhancements outside of the Writers has not been tested (like enhancing RGBs in a compositor).

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
