### PR TITLE
Fix dataset writing so computations are shared between tasks

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -146,18 +146,18 @@ composites:
   overview:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-    - 0.65
-    - 0.85
-    - 11.0
-    standard_name: overview
-
-  overview_sun:
-    compositor: !!python/name:satpy.composites.RGBCompositor
-    prerequisites:
     - wavelength: 0.65
       modifiers: [sunz_corrected]
     - wavelength: 0.85
       modifiers: [sunz_corrected]
+    - 11.0
+    standard_name: overview
+
+  overview_raw:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - 0.65
+    - 0.85
     - 11.0
     standard_name: overview
 

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -766,7 +766,7 @@ class Scene(MetadataObject):
         return writer
 
     def save_dataset(self, dataset_id, filename=None, writer=None,
-                     overlay=None, **kwargs):
+                     overlay=None, compute=True, **kwargs):
         """Save the *dataset_id* to file using *writer* (default: geotiff)."""
         if writer is None:
             if filename is None:
@@ -776,18 +776,19 @@ class Scene(MetadataObject):
                     os.path.splitext(filename)[1], **kwargs)
         else:
             writer = self.get_writer(writer, **kwargs)
-        writer.save_dataset(self[dataset_id],
-                            filename=filename,
-                            overlay=overlay, **kwargs)
+        return writer.save_dataset(self[dataset_id], filename=filename,
+                                   overlay=overlay, compute=compute,
+                                   **kwargs)
 
-    def save_datasets(self, writer="geotiff", datasets=None, **kwargs):
+    def save_datasets(self, writer="geotiff", datasets=None, compute=True,
+                      **kwargs):
         """Save all the datasets present in a scene to disk using *writer*."""
         if datasets is not None:
             datasets = [self[ds] for ds in datasets]
         else:
             datasets = self.datasets.values()
         writer = self.get_writer(writer, **kwargs)
-        writer.save_datasets(datasets, **kwargs)
+        return writer.save_datasets(datasets, compute=compute, **kwargs)
 
     def get_writer(self, writer="geotiff", **kwargs):
         """Get the writer instance."""

--- a/satpy/tests/writer_tests/test_geotiff.py
+++ b/satpy/tests/writer_tests/test_geotiff.py
@@ -38,9 +38,39 @@ else:
 
 
 class TestGeoTIFFWriter(unittest.TestCase):
+
+    def _get_test_datasets(self):
+        import xarray as xr
+        import dask.array as da
+        from datetime import datetime
+        ds1 = xr.DataArray(
+            da.zeros((100, 200), chunks=50),
+            dims=('y', 'x'),
+            attrs={'name': 'test',
+                   'start_time': datetime.utcnow()}
+        )
+        return [ds1]
+
     def test_init(self):
         from satpy.writers.geotiff import GeoTIFFWriter
         w = GeoTIFFWriter()
+
+    def test_simple_write(self):
+        from satpy.writers.geotiff import GeoTIFFWriter
+        datasets = self._get_test_datasets()
+        w = GeoTIFFWriter()
+        w.save_datasets(datasets)
+
+    def test_simple_delayed_write(self):
+        from dask.delayed import Delayed
+        from satpy.writers.geotiff import GeoTIFFWriter
+        datasets = self._get_test_datasets()
+        w = GeoTIFFWriter()
+        # when we switch to rio_save on XRImage then this will be sources
+        # and targets
+        res = w.save_datasets(datasets, compute=False)
+        self.assertIsInstance(res, Delayed)
+        res.compute()
 
 
 def suite():

--- a/satpy/tests/writer_tests/test_simple_image.py
+++ b/satpy/tests/writer_tests/test_simple_image.py
@@ -38,9 +38,37 @@ else:
 
 
 class TestPillowWriter(unittest.TestCase):
+
+    def _get_test_datasets(self):
+        import xarray as xr
+        import dask.array as da
+        from datetime import datetime
+        ds1 = xr.DataArray(
+            da.zeros((100, 200), chunks=50),
+            dims=('y', 'x'),
+            attrs={'name': 'test',
+                   'start_time': datetime.utcnow()}
+        )
+        return [ds1]
+
     def test_init(self):
         from satpy.writers.simple_image import PillowWriter
         w = PillowWriter()
+
+    def test_simple_write(self):
+        from satpy.writers.simple_image import PillowWriter
+        datasets = self._get_test_datasets()
+        w = PillowWriter()
+        w.save_datasets(datasets)
+
+    def test_simple_delayed_write(self):
+        from dask.delayed import Delayed
+        from satpy.writers.simple_image import PillowWriter
+        datasets = self._get_test_datasets()
+        w = PillowWriter()
+        res = w.save_datasets(datasets, compute=False)
+        self.assertIsInstance(res, Delayed)
+        res.compute()
 
 
 def suite():

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -335,7 +335,7 @@ class Writer(Plugin):
         """
         delayeds = []
         for ds in datasets:
-            delayeds.append(self.save_dataset(ds, compute=compute, **kwargs))
+            delayeds.append(self.save_dataset(ds, compute=False, **kwargs))
         delayed = dask.delayed(delayeds)
         if compute:
             return delayed.compute()

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -95,6 +95,17 @@ class GeoTIFFWriter(ImageWriter):
             if k in kwargs or k in self.info:
                 self.gdal_options[k] = kwargs.get(k, self.info[k])
 
+    @classmethod
+    def separate_init_kwargs(cls, kwargs):
+        # FUTURE: Don't pass Scene.save_datasets kwargs to init and here
+        init_kwargs, kwargs = super(GeoTIFFWriter, cls).separate_init_kwargs(
+            kwargs)
+        for kw in ['floating_point', 'tags']:
+            if kw in kwargs:
+                init_kwargs[kw] = kwargs.pop(kw)
+
+        return init_kwargs, kwargs
+
     def _gdal_write_datasets(self, dst_ds, datasets, opacity):
         """Write *datasets* in a gdal raster structure *dts_ds*, using
         *opacity* as alpha value for valid data, and *fill_value*.

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -237,5 +237,4 @@ class GeoTIFFWriter(ImageWriter):
                                                   mode)
         if compute:
             return delayed.compute()
-        else:
-            return delayed
+        return delayed

--- a/satpy/writers/simple_image.py
+++ b/satpy/writers/simple_image.py
@@ -40,9 +40,4 @@ class PillowWriter(ImageWriter):
         filename = filename or self.get_filename(**img.data.attrs)
 
         LOG.debug("Saving to image: %s", filename)
-        delayed = dask.delayed(img.save)(filename, compute=compute,
-                                         format_kw=kwargs)
-        if compute:
-            return delayed.compute()
-        else:
-            return delayed
+        return img.save(filename, compute=compute, format_kw=kwargs)

--- a/satpy/writers/simple_image.py
+++ b/satpy/writers/simple_image.py
@@ -23,7 +23,6 @@
 
 import logging
 
-import dask
 from satpy.writers import ImageWriter
 
 LOG = logging.getLogger(__name__)

--- a/satpy/writers/simple_image.py
+++ b/satpy/writers/simple_image.py
@@ -36,7 +36,33 @@ class PillowWriter(ImageWriter):
             **kwargs)
 
     def save_image(self, img, filename=None, compute=True, **kwargs):
+        """Save Image object to a given ``filename``.
+
+        Args:
+            img (trollimage.xrimage.XRImage): Image object to save to disk.
+            filename (str): Optionally specify the filename to save this
+                            dataset to. It may include string formatting
+                            patterns that will be filled in by dataset
+                            attributes.
+            compute (bool): If `True` (default), compute and save the dataset.
+                            If `False` return either a `dask.delayed.Delayed`
+                            object or tuple of (source, target). See the
+                            return values below for more information.
+            **kwargs: Keyword arguments to pass to the images `save` method.
+
+        Returns:
+            Value returned depends on `compute`. If `compute` is `True` then
+            the return value is the result of computing a
+            `dask.delayed.Delayed` object or running `dask.array.store`. If
+            `compute` is `False` then the returned value is either a
+            `dask.delayed.Delayed` object that can be computed using
+            `delayed.compute()` or a tuple of (source, target) that should be
+            passed to `dask.array.store`. If target is provided the the caller
+            is responsible for calling `target.close()` if the target has
+            this method.
+
+        """
         filename = filename or self.get_filename(**img.data.attrs)
 
         LOG.debug("Saving to image: %s", filename)
-        return img.save(filename, compute=compute, format_kw=kwargs)
+        return img.save(filename, compute=compute, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ BASE_PATH = os.path.sep.join(os.path.dirname(os.path.realpath(__file__)).split(
     os.path.sep))
 
 requires = ['numpy >=1.4.1', 'pillow', 'pyresample >=1.4.0', 'trollsift',
-            'trollimage >=1.3', 'pykdtree', 'six', 'pyyaml', 'xarray >=0.10.1', 'dask[array] >=0.17.1']
+            'trollimage >=1.4', 'pykdtree', 'six', 'pyyaml', 'xarray >=0.10.1', 'dask[array] >=0.17.1']
 
 test_requires = ['behave']
 
@@ -67,7 +67,7 @@ extras_require = {
     'abi_l1b': ['h5netcdf'],
     # Writers:
     'scmi': ['netCDF4 >= 1.1.8'],
-    'geotiff': ['gdal'],
+    'geotiff': ['gdal', 'trollimage[geotiff]'],
 }
 all_extras = []
 for extra_deps in extras_require.values():


### PR DESCRIPTION
This PR adds a `compute` keyword argument to all save_dataset, save_datasets, save_image methods in the Scene and Writers. It defaults to True in all of these methods so individual use cases have not changed. It is also handled by the higher level methods so that the user doesn't see a difference except in performance.

Handling writes in the way this PR implements will allow all dask objects to be computed at the same and is how it is implemented in the higher level methods. This means that if tasks share computations (input datasets) they will be shared and shouldn't have to be recalculated.

Additionally this will allow for more flexibility in the future. If a user calls `scn.save_datasets(..., compute=False)` they will get a dask `Delayed` object back which they can then use with other delayed objects.

If compute is True or a writer does not support returning a delayed object (and they don't complain about the compute keyword being passed) then functions will return whatever the result of the delayed function call was. Typically this is just None. This should also allow future flexibility if a writer should be returning something (maybe filenames of the files created?).

WIP: Docstrings and tests to make sure this functionality completely works.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
