### PR TITLE
Fix resampler caching by source area

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -391,6 +391,9 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None,
     if not filenames and not reader:
         # used for an empty Scene
         return {}
+    elif reader and filenames is not None and not filenames:
+        # user made a mistake in their glob pattern
+        raise ValueError("'filenames' was provided but is empty.")
     elif not filenames:
         LOG.warning("'filenames' required to create readers and load data")
         return {}

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -615,7 +615,10 @@ def prepare_resampler(source_area, destination_area, resampler=None):
         LOG.info("Using default KDTree resampler")
         resampler = 'kd_tree'
 
-    if isinstance(resampler, str):
+    if isinstance(resampler, BaseResampler):
+        raise ValueError("Trying to create a resampler when one already "
+                         "exists.")
+    elif isinstance(resampler, str):
         resampler_class = RESAMPLERS[resampler]
     else:
         resampler_class = resampler

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -665,6 +665,7 @@ class Scene(MetadataObject):
         new_datasets = {}
         destination_area = None
         resamplers = {}
+        resampler = resample_kwargs.get('resampler')
         for dataset, parent_dataset in dataset_walker(datasets):
             ds_id = DatasetID.from_dict(dataset.attrs)
             pres = None
@@ -680,6 +681,8 @@ class Scene(MetadataObject):
                     replace_anc(dataset, pres)
                 continue
             if destination_area is None:
+                # FIXME: We should allow users to freeze based with specific
+                #        dataset
                 destination_area = get_frozen_area(destination,
                                                    dataset.attrs['area'])
             LOG.debug("Resampling %s", ds_id)
@@ -687,7 +690,7 @@ class Scene(MetadataObject):
             if source_area not in resamplers:
                 resamplers[source_area] = prepare_resampler(source_area,
                                                             destination_area,
-                                                            resampler=resample_kwargs.get('resampler'))
+                                                            resampler=resampler)
             resample_kwargs['resampler'] = resamplers[source_area]
             res = resample_dataset(dataset, destination_area, **resample_kwargs)
             new_datasets[ds_id] = res

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -688,11 +688,11 @@ class Scene(MetadataObject):
             LOG.debug("Resampling %s", ds_id)
             source_area = dataset.attrs['area']
             if source_area not in resamplers:
-                resamplers[source_area] = prepare_resampler(source_area,
-                                                            destination_area,
-                                                            resampler=resampler)
+                resamplers[source_area] = prepare_resampler(
+                    source_area, destination_area, resampler=resampler)
             resample_kwargs['resampler'] = resamplers[source_area]
-            res = resample_dataset(dataset, destination_area, **resample_kwargs)
+            res = resample_dataset(dataset, destination_area,
+                                   **resample_kwargs)
             new_datasets[ds_id] = res
             if parent_dataset is None:
                 new_scn[ds_id] = res

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -95,6 +95,11 @@ class TestScene(unittest.TestCase):
         self.assertEqual(scn.ppp_config_dir, PACKAGE_CONFIG_PATH)
         self.assertFalse(scn.readers, 'Empty scene should not load any readers')
 
+    def test_init_no_files(self):
+        """Test that providing an empty list of filenames fails."""
+        from satpy.scene import Scene
+        self.assertRaises(ValueError, Scene, reader='viirs_sdr', filenames=[])
+
     def test_init_with_ppp_config_dir(self):
         from satpy.scene import Scene
         scn = Scene(ppp_config_dir="foo")


### PR DESCRIPTION
This is a bug in the caching of resamplers by source area that occurs in the Scene. If there is more than one source area (more than one resolution in the input datasets) the `resampler` keyword argument gets overwritten with the instance of the resampler class and then reused as the *name* of the next resampler that gets created. Since resamplers have a `__call__` method this results in `prepare_resampler` calling the resampler *instance* as if it was the resampler *class* resulting in weird errors because the dataset in resampling is actually an AreaDefinition. This was a pain to debug.

@mraspaud Feel free to merge or add tests and merge or whatever.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->