### PR TITLE
Add helper method for checking areas in compositors

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -44,7 +44,6 @@ from satpy.readers import DatasetDict
 from satpy.utils import sunzen_corr_cos, atmospheric_path_length_correction
 from satpy.writers import get_enhanced_image
 from satpy import CHUNK_SIZE
-from pyresample.geometry import AreaDefinition
 
 LOG = logging.getLogger(__name__)
 

--- a/satpy/composites/abi.py
+++ b/satpy/composites/abi.py
@@ -33,12 +33,7 @@ class SimulatedGreen(GenericCompositor):
     """A single-band dataset resembles a Green (0.55 µm)."""
 
     def __call__(self, projectables, optional_datasets=None, **attrs):
-        c01, c02, c03 = projectables
-        if not all(c.shape == projectables[0].shape
-                   for c in projectables[1:]):
-            raise IncompatibleAreas("Simulated green can only be made from "
-                                    "bands of the same size. Resample "
-                                    "first.")
+        c01, c02, c03 = self.check_areas(projectables)
 
         # Kaba:
         # res = (c01 + c02) * 0.45 + 0.1 * c03

--- a/satpy/tests/__init__.py
+++ b/satpy/tests/__init__.py
@@ -29,7 +29,7 @@ from satpy.tests import (reader_tests, test_dataset, test_file_handlers,
                          test_readers, test_resample,
                          test_scene, test_utils, test_writers,
                          test_yaml_reader, writer_tests,
-                         test_enhancements)
+                         test_enhancements, compositor_tests)
 
 
 if sys.version_info < (2, 7):
@@ -55,6 +55,7 @@ def suite():
     mysuite.addTests(test_file_handlers.suite())
     mysuite.addTests(test_utils.suite())
     mysuite.addTests(test_enhancements.suite())
+    mysuite.addTests(compositor_tests.suite())
 
     return mysuite
 

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018 PyTroll developers
+#
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for compositors.
+"""
+
+
+import sys
+
+from satpy.tests.compositor_tests import test_abi
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class TestCheckArea(unittest.TestCase):
+
+    """Test the utility method 'check_areas'."""
+
+    def _get_test_ds(self, shape=(50, 100), dims=('y', 'x')):
+        """Helper method to get a fake DataArray."""
+        import xarray as xr
+        import dask.array as da
+        from pyresample.geometry import AreaDefinition
+        data = da.random.random(shape, chunks=25)
+        area = AreaDefinition(
+            'test', 'test', 'test',
+            {'proj': 'eqc', 'lon_0': 0.0,
+             'lat_0': 0.0},
+            shape[dims.index('x')], shape[dims.index('y')],
+            (-20037508.34, -10018754.17, 20037508.34, 10018754.17))
+        attrs = {'area': area}
+        return xr.DataArray(data, dims=dims, attrs=attrs)
+
+    def test_single_ds(self):
+        """Test a single dataset is returned unharmed."""
+        from satpy.composites import CompositeBase
+        ds1 = self._get_test_ds()
+        comp = CompositeBase('test_comp')
+        ret_datasets = comp.check_areas((ds1,))
+        self.assertIs(ret_datasets[0], ds1)
+
+    def test_mult_ds_area(self):
+        """Test multiple datasets successfully pass."""
+        from satpy.composites import CompositeBase
+        ds1 = self._get_test_ds()
+        ds2 = self._get_test_ds()
+        comp = CompositeBase('test_comp')
+        ret_datasets = comp.check_areas((ds1, ds2))
+        self.assertIs(ret_datasets[0], ds1)
+        self.assertIs(ret_datasets[1], ds2)
+
+    def test_mult_ds_no_area(self):
+        """Test that all datasets must have an area attribute."""
+        from satpy.composites import CompositeBase
+        ds1 = self._get_test_ds()
+        ds2 = self._get_test_ds()
+        del ds2.attrs['area']
+        comp = CompositeBase('test_comp')
+        self.assertRaises(ValueError, comp.check_areas, (ds1, ds2))
+
+    def test_mult_ds_diff_area(self):
+        """Test that datasets with different areas fail."""
+        from satpy.composites import CompositeBase, IncompatibleAreas
+        from pyresample.geometry import AreaDefinition
+        ds1 = self._get_test_ds()
+        ds2 = self._get_test_ds()
+        ds2.attrs['area'] = AreaDefinition(
+            'test', 'test', 'test',
+            {'proj': 'eqc', 'lon_0': 0.0,
+             'lat_0': 0.0},
+            100, 50,
+            (-30037508.34, -20018754.17, 10037508.34, 18754.17))
+        comp = CompositeBase('test_comp')
+        self.assertRaises(IncompatibleAreas, comp.check_areas, (ds1, ds2))
+
+    def test_mult_ds_diff_dims(self):
+        """Test that datasets with different dimensions still pass."""
+        from satpy.composites import CompositeBase, IncompatibleAreas
+        # x is still 50, y is still 100, even though they are in
+        # different order
+        ds1 = self._get_test_ds(shape=(50, 100), dims=('y', 'x'))
+        ds2 = self._get_test_ds(shape=(3, 100, 50), dims=('bands', 'x', 'y'))
+        comp = CompositeBase('test_comp')
+        ret_datasets = comp.check_areas((ds1, ds2))
+        self.assertIs(ret_datasets[0], ds1)
+        self.assertIs(ret_datasets[1], ds2)
+
+    def test_mult_ds_diff_size(self):
+        """Test that datasets with different sizes fail."""
+        from satpy.composites import CompositeBase, IncompatibleAreas
+        # x is 50 in this one, 100 in ds2
+        # y is 100 in this one, 50 in ds2
+        ds1 = self._get_test_ds(shape=(50, 100), dims=('x', 'y'))
+        ds2 = self._get_test_ds(shape=(3, 50, 100), dims=('bands', 'y', 'x'))
+        comp = CompositeBase('test_comp')
+        self.assertRaises(IncompatibleAreas, comp.check_areas, (ds1, ds2))
+
+
+def suite():
+    """Test suite for all reader tests"""
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTests(test_abi.suite())
+    mysuite.addTest(loader.loadTestsFromTestCase(TestCheckArea))
+
+    return mysuite

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -93,7 +93,7 @@ class TestCheckArea(unittest.TestCase):
 
     def test_mult_ds_diff_dims(self):
         """Test that datasets with different dimensions still pass."""
-        from satpy.composites import CompositeBase, IncompatibleAreas
+        from satpy.composites import CompositeBase
         # x is still 50, y is still 100, even though they are in
         # different order
         ds1 = self._get_test_ds(shape=(50, 100), dims=('y', 'x'))

--- a/satpy/tests/compositor_tests/test_abi.py
+++ b/satpy/tests/compositor_tests/test_abi.py
@@ -33,19 +33,27 @@ class TestABIComposites(unittest.TestCase):
         import dask.array as da
         import numpy as np
         from satpy.composites.abi import SimulatedGreen
-        comp = SimulatedGreen('green', prerequisites=('C01', 'C02', 'C03'),
-                              standard_name='toa_bidirectional_reflectance')
+        from pyresample.geometry import AreaDefinition
         rows = 5
         cols = 10
+        area = AreaDefinition(
+            'test', 'test', 'test',
+            {'proj': 'eqc', 'lon_0': 0.0,
+             'lat_0': 0.0},
+            cols, rows,
+            (-20037508.34, -10018754.17, 20037508.34, 10018754.17))
+
+        comp = SimulatedGreen('green', prerequisites=('C01', 'C02', 'C03'),
+                              standard_name='toa_bidirectional_reflectance')
         c01 = xr.DataArray(da.zeros((rows, cols), chunks=25) + 0.25,
                            dims=('y', 'x'),
-                           attrs={'name': 'C01'})
+                           attrs={'name': 'C01', 'area': area})
         c02 = xr.DataArray(da.zeros((rows, cols), chunks=25) + 0.30,
                            dims=('y', 'x'),
-                           attrs={'name': 'C01'})
+                           attrs={'name': 'C02', 'area': area})
         c03 = xr.DataArray(da.zeros((rows, cols), chunks=25) + 0.35,
                            dims=('y', 'x'),
-                           attrs={'name': 'C01'})
+                           attrs={'name': 'C03', 'area': area})
         res = comp((c01, c02, c03))
         self.assertIsInstance(res, xr.DataArray)
         self.assertIsInstance(res.data, da.Array)

--- a/satpy/tests/compositor_tests/test_abi.py
+++ b/satpy/tests/compositor_tests/test_abi.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018 PyTroll developers
+#
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for ABI compositors.
+"""
+
+import sys
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class TestABIComposites(unittest.TestCase):
+    def test_simulated_green(self):
+        import xarray as xr
+        import dask.array as da
+        import numpy as np
+        from satpy.composites.abi import SimulatedGreen
+        comp = SimulatedGreen('green', prerequisites=('C01', 'C02', 'C03'),
+                              standard_name='toa_bidirectional_reflectance')
+        rows = 5
+        cols = 10
+        c01 = xr.DataArray(da.zeros((rows, cols), chunks=25) + 0.25,
+                           dims=('y', 'x'),
+                           attrs={'name': 'C01'})
+        c02 = xr.DataArray(da.zeros((rows, cols), chunks=25) + 0.30,
+                           dims=('y', 'x'),
+                           attrs={'name': 'C01'})
+        c03 = xr.DataArray(da.zeros((rows, cols), chunks=25) + 0.35,
+                           dims=('y', 'x'),
+                           attrs={'name': 'C01'})
+        res = comp((c01, c02, c03))
+        self.assertIsInstance(res, xr.DataArray)
+        self.assertIsInstance(res.data, da.Array)
+        self.assertEqual(res.attrs['name'], 'green')
+        self.assertEqual(res.attrs['standard_name'],
+                         'toa_bidirectional_reflectance')
+        data = res.compute()
+        np.testing.assert_allclose(data, 0.28025)
+
+
+def suite():
+    """The test suite for test_scene.
+    """
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(TestABIComposites))
+    return mysuite


### PR DESCRIPTION
I made this PR early so that @mraspaud and I and others could discuss this because it may be controversial and I wanted to figure this out before I spent time implementing everything.

Right now this PRs solution for datasets with equal resolutions but different coordinates is to just remove the coordinates. @mraspaud voted to have it just choose the first datasets coordinates. I had already implemented what is in this PR currently so I didn't do this yet. My argument is that this may be a bad idea because coordinates for multiple composites may not be the same depending on what the input datasets were.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
