### PR TITLE
Fix 'platform' being used instead of 'platform_name'

### DIFF
--- a/satpy/etc/writers/scmi.yaml
+++ b/satpy/etc/writers/scmi.yaml
@@ -5,7 +5,7 @@ writer:
   name: scmi
   description: AWIPS-compatible Tiled NetCDF4 Writer
   writer: !!python/name:satpy.writers.scmi.SCMIWriter
-  file_pattern: '{source_name}_AII_{platform}_{sensor}_{name}_{sector_id}_{tile_id}_{start_time:%Y%m%d_%H%M}.nc'
+  file_pattern: '{source_name}_AII_{platform_name}_{sensor}_{name}_{sector_id}_{tile_id}_{start_time:%Y%m%d_%H%M}.nc'
   compress: True
 sectors:
   LCC:

--- a/satpy/readers/amsr2_l1b.py
+++ b/satpy/readers/amsr2_l1b.py
@@ -18,7 +18,7 @@ class AMSR2L1BFileHandler(HDF5FileHandler):
         info.update({
             "shape": self.get_shape(ds_id, ds_info),
             "units": self[var_path + "/attr/UNIT"],
-            "platform": self["/attr/PlatformShortName"].item(),
+            "platform_name": self["/attr/PlatformShortName"].item(),
             "sensor": self["/attr/SensorShortName"].item(),
             "start_orbit": int(self["/attr/StartOrbitNumber"].item()),
             "end_orbit": int(self["/attr/StopOrbitNumber"].item()),

--- a/satpy/readers/geocat.py
+++ b/satpy/readers/geocat.py
@@ -206,7 +206,7 @@ class GEOCATFileHandler(NetCDF4FileHandler):
             info['units'] = CF_UNITS[u]
 
         info['sensor'] = self.get_sensor(self['/attr/Sensor_Name'])
-        info['platform'] = self.get_platform(self['/attr/Platform_Name'])
+        info['platform_name'] = self.get_platform(self['/attr/Platform_Name'])
         info['resolution'] = dataset_id.resolution
         if var_name == 'pixel_longitude':
             info['standard_name'] = 'longitude'

--- a/satpy/readers/ghrsst_osisaf.py
+++ b/satpy/readers/ghrsst_osisaf.py
@@ -100,7 +100,7 @@ class GHRSST_OSISAFL2(NetCDF4FileHandler):
 
         ds_info.update({
             "units": ds_info.get("units", file_units),
-            "platform": PLATFORM_NAME.get(self['/attr/platform'],
+            "platform_name": PLATFORM_NAME.get(self['/attr/platform'],
                                           self['/attr/platform']),
             "sensor": SENSOR_NAME.get(self['/attr/sensor'],
                                       self['/attr/sensor']),

--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -133,7 +133,7 @@ class NUCAPSFileHandler(NetCDF4FileHandler):
         info.update({
             "shape": shape,
             "units": ds_info.get("units", file_units),
-            "platform": self.platform_name,
+            "platform_name": self.platform_name,
             "sensor": self.sensor_name,
             "start_orbit": self.start_orbit_number,
             "end_orbit": self.end_orbit_number,

--- a/satpy/readers/omps_edr.py
+++ b/satpy/readers/omps_edr.py
@@ -84,7 +84,7 @@ class EDRFileHandler(HDF5FileHandler):
             "shape": self.get_shape(dataset_id, ds_info),
             "file_units": file_units,
             "units": ds_info.get("units", file_units),
-            "platform": self.platform_name,
+            "platform_name": self.platform_name,
             "sensor": self.sensor_name,
             "start_orbit": self.start_orbit_number,
             "end_orbit": self.end_orbit_number,

--- a/satpy/readers/viirs_l1b.py
+++ b/satpy/readers/viirs_l1b.py
@@ -196,7 +196,7 @@ class VIIRSL1BFileHandler(NetCDF4FileHandler):
             "shape": shape,
             "units": ds_info.get("units", file_units),
             "file_units": file_units,
-            "platform": self.platform_name,
+            "platform_name": self.platform_name,
             "sensor": self.sensor_name,
             "start_orbit": self.start_orbit_number,
             "end_orbit": self.end_orbit_number,

--- a/satpy/tests/writer_tests/test_scmi.py
+++ b/satpy/tests/writer_tests/test_scmi.py
@@ -80,7 +80,7 @@ class TestSCMIWriter(unittest.TestCase):
             np.linspace(0., 1., 20000, dtype=np.float32).reshape((200, 100)),
             attrs=dict(
                 name='test_ds',
-                platform='PLAT',
+                platform_name='PLAT',
                 sensor='SENSOR',
                 units='1',
                 area=area_def,
@@ -111,7 +111,7 @@ class TestSCMIWriter(unittest.TestCase):
             np.linspace(0., 1., 20000, dtype=np.float32).reshape((200, 100)),
             attrs=dict(
                 name='test_ds',
-                platform='PLAT',
+                platform_name='PLAT',
                 sensor='SENSOR',
                 units='1',
                 area=area_def,
@@ -147,7 +147,7 @@ class TestSCMIWriter(unittest.TestCase):
             np.linspace(0., 1., 2000000, dtype=np.float32).reshape((2000, 1000)),
             attrs=dict(
                 name='test_ds',
-                platform='PLAT',
+                platform_name='PLAT',
                 sensor='SENSOR',
                 units='1',
                 area=area_def,
@@ -183,7 +183,7 @@ class TestSCMIWriter(unittest.TestCase):
             np.linspace(0., 1., 2000000, dtype=np.float32).reshape((2000, 1000)),
             attrs=dict(
                 name='test_ds',
-                platform='PLAT',
+                platform_name='PLAT',
                 sensor='SENSOR',
                 units='1',
                 area=area_def,
@@ -220,7 +220,7 @@ class TestSCMIWriter(unittest.TestCase):
             np.linspace(0., 1., 2000000, dtype=np.float32).reshape((2000, 1000)),
             attrs=dict(
                 name='test_ds',
-                platform='PLAT',
+                platform_name='PLAT',
                 sensor='SENSOR',
                 units='1',
                 area=area_def,

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -573,7 +573,7 @@ class EnhancementDecisionTree(DecisionTree):
 
     def __init__(self, *decision_dicts, **kwargs):
         attrs = kwargs.pop("attrs", ("name",
-                                     "platform",
+                                     "platform_name",
                                      "sensor",
                                      "standard_name",
                                      "units",))

--- a/satpy/writers/scmi.py
+++ b/satpy/writers/scmi.py
@@ -84,7 +84,9 @@ LOG = logging.getLogger(__name__)
 # AWIPS 2 seems to not like data values under 0
 AWIPS_USES_NEGATIVES = False
 AWIPS_DATA_DTYPE = np.int16
-DEFAULT_OUTPUT_PATTERN = '{source_name}_AII_{platform_name}_{sensor}_{name}_{sector_id}_{tile_id}_{start_time:%Y%m%d_%H%M}.nc'
+DEFAULT_OUTPUT_PATTERN = '{source_name}_AII_{platform_name}_{sensor}_' \
+                         '{name}_{sector_id}_{tile_id}_' \
+                         '{start_time:%Y%m%d_%H%M}.nc'
 
 # misc. global attributes
 SCMI_GLOBAL_ATT = dict(

--- a/satpy/writers/scmi.py
+++ b/satpy/writers/scmi.py
@@ -84,7 +84,7 @@ LOG = logging.getLogger(__name__)
 # AWIPS 2 seems to not like data values under 0
 AWIPS_USES_NEGATIVES = False
 AWIPS_DATA_DTYPE = np.int16
-DEFAULT_OUTPUT_PATTERN = '{source_name}_AII_{platform}_{sensor}_{name}_{sector_id}_{tile_id}_{start_time:%Y%m%d_%H%M}.nc'
+DEFAULT_OUTPUT_PATTERN = '{source_name}_AII_{platform_name}_{sensor}_{name}_{sector_id}_{tile_id}_{start_time:%Y%m%d_%H%M}.nc'
 
 # misc. global attributes
 SCMI_GLOBAL_ATT = dict(
@@ -814,7 +814,7 @@ class SCMIWriter(Writer):
             if awips_info['source_name'] is None:
                 raise TypeError("'source_name' keyword must be specified")
 
-            def_ce = "{}-{}".format(ds_info["platform"].upper(), ds_info["sensor"].upper())
+            def_ce = "{}-{}".format(ds_info["platform_name"].upper(), ds_info["sensor"].upper())
             awips_info.setdefault('creating_entity', def_ce)
             return awips_info
         except KeyError as e:


### PR DESCRIPTION
It was noticed in #225 that some readers and the SCMI writer assume that the key for the platform in the attributes dictionary is "platform" when it should actually be "platform_name" to match everything else in satpy.

 - [x] Closes #225  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->