### PR TITLE
Fix bug in dep tree when modifier deps are modified wavelengths

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -617,6 +617,7 @@ class Scene(MetadataObject):
                   if ds_id not in self.wishlist and (not keepables or ds_id
                                                      not in keepables)]
         for ds_id in to_del:
+            LOG.debug("Unloading dataset: %r", ds_id)
             del self.datasets[ds_id]
 
     def load(self,

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -165,6 +165,7 @@ def test_composites(sensor_name):
         'mod_opt_prereq': (['ds1'], ['ds2']),
         'mod_bad_opt': (['ds1'], ['ds9_fail_load']),
         'mod_opt_only': ([], ['ds2']),
+        'mod_wl': ([DatasetID(wavelength=0.2, modifiers=('mod1',))], []),
     }
 
     comps = {sensor_name: DatasetDict((k, _create_fake_compositor(k, *v)) for k, v in comps.items())}


### PR DESCRIPTION
This PR fixes a bug I encountered when trying to add rayleigh correction to the ABI natural composite. The default rayleigh corrector/modifier in `visir.yaml` depends on a `sunz_corrected` 0.67 band. This is C02 for ABI. C02 is also needed to make the natural RGB and is specified by name.

Before this PR these dependencies would show up in the dependency tree as two separate nodes. One as the 0.67 modified key, one as the C02 modified key. From what I can tell this happens because when the dep tree checks if C02 is in the dep tree it thinks it isn't there, but it is actually there as the 0.67 dependency. The key for the 0.67 dependency is never "filled in" with the details of it's unmodified dataset (name, resolution, calibration, etc). This PR fixes this. I think I had this behavior implemented in the past but removed it for some reason. Tests pass, so I don't know.

This bug comes up semi-randomly based on the order that dependencies are loaded/processed.

P.S. I thought I'd start making PRs from my own fork instead of the satpy one. Maintainers should still have push permissions to my branch through this PR. This follows how I've seen other projects do it where they only have a master branch instead of a develop/master branch pair.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->