### PR TITLE
Make parsing NetCDF date attributes Python 3 compatible

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "C:\\Miniconda3\\envs\\satpy\\python.exe"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "C:\\Miniconda3\\envs\\satpy\\python.exe"
-}

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -162,11 +162,11 @@ class NC_ABI_L1B(BaseFileHandler):
 
     @property
     def start_time(self):
-        return datetime.strptime(self.nc.attrs['time_coverage_start'], '%Y-%m-%dT%H:%M:%S.%fZ')
+        return datetime.strptime(self.nc.attrs['time_coverage_start'].decode(), '%Y-%m-%dT%H:%M:%S.%fZ')
 
     @property
     def end_time(self):
-        return datetime.strptime(self.nc.attrs['time_coverage_end'], '%Y-%m-%dT%H:%M:%S.%fZ')
+        return datetime.strptime(self.nc.attrs['time_coverage_end'].decode(), '%Y-%m-%dT%H:%M:%S.%fZ')
 
     def __del__(self):
         try:

--- a/satpy/readers/li_l2.py
+++ b/satpy/readers/li_l2.py
@@ -64,11 +64,11 @@ class LIFileHandler(BaseFileHandler):
 
     @property
     def start_time(self):
-        return datetime.strptime(self.nc.attrs['sensing_start'], '%Y%m%d%H%M%S')
+        return datetime.strptime(self.nc.attrs['sensing_start'].decode(), '%Y%m%d%H%M%S')
 
     @property
     def end_time(self):
-        return datetime.strptime(self.nc.attrs['end_time'], '%Y%m%d%H%M%S')
+        return datetime.strptime(self.nc.attrs['end_time'].decode(), '%Y%m%d%H%M%S')
 
     def get_dataset(self, key, info=None, out=None, xslice=None, yslice=None):
         """Load a dataset

--- a/satpy/readers/nc_nwcsaf.py
+++ b/satpy/readers/nc_nwcsaf.py
@@ -247,7 +247,7 @@ class NcNWCSAF(BaseFileHandler):
         try:
             # MSG:
             return datetime.strptime(self.nc.attrs['time_coverage_start'].decode(),
-                                                    '%Y-%m-%dT%H:%M:%SZ')
+                                     '%Y-%m-%dT%H:%M:%SZ')
 
         except ValueError:
             # PPS:
@@ -260,7 +260,7 @@ class NcNWCSAF(BaseFileHandler):
         try:
             # MSG:
             return datetime.strptime(self.nc.attrs['time_coverage_end'].decode(),
-                                                    '%Y-%m-%dT%H:%M:%SZ')
+                                     '%Y-%m-%dT%H:%M:%SZ')
 
         except ValueError:
             # PPS:

--- a/satpy/readers/nc_nwcsaf.py
+++ b/satpy/readers/nc_nwcsaf.py
@@ -246,15 +246,12 @@ class NcNWCSAF(BaseFileHandler):
         """Return the start time of the object."""
         try:
             # MSG:
-            try:
-                return datetime.strptime(self.nc.attrs['time_coverage_start'],
-                                         '%Y-%m-%dT%H:%M:%SZ')
-            except TypeError:
-                return datetime.strptime(self.nc.attrs['time_coverage_start'].astype(str),
-                                         '%Y-%m-%dT%H:%M:%SZ')
+            return datetime.strptime(self.nc.attrs['time_coverage_start'].decode(),
+                                                    '%Y-%m-%dT%H:%M:%SZ')
+
         except ValueError:
             # PPS:
-            return datetime.strptime(self.nc.attrs['time_coverage_start'],
+            return datetime.strptime(self.nc.attrs['time_coverage_start'].decode(),
                                      '%Y%m%dT%H%M%S%fZ')
 
     @property
@@ -262,15 +259,12 @@ class NcNWCSAF(BaseFileHandler):
         """Return the end time of the object."""
         try:
             # MSG:
-            try:
-                return datetime.strptime(self.nc.attrs['time_coverage_end'],
-                                         '%Y-%m-%dT%H:%M:%SZ')
-            except TypeError:
-                return datetime.strptime(self.nc.attrs['time_coverage_end'].astype(str),
-                                         '%Y-%m-%dT%H:%M:%SZ')
+            return datetime.strptime(self.nc.attrs['time_coverage_end'].decode(),
+                                                    '%Y-%m-%dT%H:%M:%SZ')
+
         except ValueError:
             # PPS:
-            return datetime.strptime(self.nc.attrs['time_coverage_end'],
+            return datetime.strptime(self.nc.attrs['time_coverage_end'].decode(),
                                      '%Y%m%dT%H%M%S%fZ')
 
 

--- a/satpy/readers/nc_nwcsaf_msg.py
+++ b/satpy/readers/nc_nwcsaf_msg.py
@@ -128,11 +128,11 @@ class NcNWCSAFMSG(BaseFileHandler):
     def start_time(self):
 
         return datetime.strptime(self.nc.attrs['time_coverage_start'].decode(),
-                                             '%Y-%m-%dT%H:%M:%SZ')
+                                 '%Y-%m-%dT%H:%M:%SZ')
 
 
     @property
     def end_time(self):
 
         return datetime.strptime(self.nc.attrs['time_coverage_end'].decode(),
-                                            '%Y-%m-%dT%H:%M:%SZ')
+                                 '%Y-%m-%dT%H:%M:%SZ')

--- a/satpy/readers/nc_nwcsaf_msg.py
+++ b/satpy/readers/nc_nwcsaf_msg.py
@@ -126,20 +126,14 @@ class NcNWCSAFMSG(BaseFileHandler):
 
     @property
     def start_time(self):
-        try:
-            return datetime.strptime(self.nc.attrs['time_coverage_start'],
-                                     '%Y-%m-%dT%H:%M:%SZ')
-        except TypeError:
-            return datetime.strptime(
-                self.nc.attrs['time_coverage_start'].astype(str),
-                                     '%Y-%m-%dT%H:%M:%SZ')
+
+        return datetime.strptime(self.nc.attrs['time_coverage_start'].decode(),
+                                             '%Y-%m-%dT%H:%M:%SZ')
+
 
     @property
     def end_time(self):
-        try:
-            return datetime.strptime(self.nc.attrs['time_coverage_end'],
-                                     '%Y-%m-%dT%H:%M:%SZ')
-        except TypeError:
-            return datetime.strptime(
-                self.nc.attrs['time_coverage_end'].astype(str),
-                                     '%Y-%m-%dT%H:%M:%SZ')
+
+        return datetime.strptime(self.nc.attrs['time_coverage_end'].decode(),
+                                            '%Y-%m-%dT%H:%M:%SZ')
+

--- a/satpy/readers/nc_nwcsaf_msg.py
+++ b/satpy/readers/nc_nwcsaf_msg.py
@@ -136,4 +136,3 @@ class NcNWCSAFMSG(BaseFileHandler):
 
         return datetime.strptime(self.nc.attrs['time_coverage_end'].decode(),
                                             '%Y-%m-%dT%H:%M:%SZ')
-

--- a/satpy/readers/nc_olci.py
+++ b/satpy/readers/nc_olci.py
@@ -63,12 +63,12 @@ class NCOLCIBase(BaseFileHandler):
 
     @property
     def start_time(self):
-        return datetime.strptime(self.nc.attrs['start_time'],
+        return datetime.strptime(self.nc.attrs['start_time'].decode(),
                                  '%Y-%m-%dT%H:%M:%S.%fZ')
 
     @property
     def end_time(self):
-        return datetime.strptime(self.nc.attrs['stop_time'],
+        return datetime.strptime(self.nc.attrs['stop_time'].decode(),
                                  '%Y-%m-%dT%H:%M:%S.%fZ')
 
     def get_dataset(self, key, info):

--- a/satpy/readers/nc_slstr.py
+++ b/satpy/readers/nc_slstr.py
@@ -70,11 +70,11 @@ class NCSLSTRGeo(BaseFileHandler):
 
     @property
     def start_time(self):
-        return datetime.strptime(self.nc.attrs['start_time'], '%Y-%m-%dT%H:%M:%S.%fZ')
+        return datetime.strptime(self.nc.attrs['start_time'].decode(), '%Y-%m-%dT%H:%M:%S.%fZ')
 
     @property
     def end_time(self):
-        return datetime.strptime(self.nc.attrs['stop_time'], '%Y-%m-%dT%H:%M:%S.%fZ')
+        return datetime.strptime(self.nc.attrs['stop_time'].decode(), '%Y-%m-%dT%H:%M:%S.%fZ')
 
 
 class NCSLSTR1B(BaseFileHandler):
@@ -136,11 +136,11 @@ class NCSLSTR1B(BaseFileHandler):
 
     @property
     def start_time(self):
-        return datetime.strptime(self.nc.attrs['start_time'], '%Y-%m-%dT%H:%M:%S.%fZ')
+        return datetime.strptime(self.nc.attrs['start_time'].decode(), '%Y-%m-%dT%H:%M:%S.%fZ')
 
     @property
     def end_time(self):
-        return datetime.strptime(self.nc.attrs['stop_time'], '%Y-%m-%dT%H:%M:%S.%fZ')
+        return datetime.strptime(self.nc.attrs['stop_time'].decode(), '%Y-%m-%dT%H:%M:%S.%fZ')
 
 
 class NCSLSTRAngles(BaseFileHandler):


### PR DESCRIPTION
This PR fixes the parsing of NetCDF date attributes in Python 3. It basically adds `.decode()` before using `strptime` to get a string instead of bytes.

Some readers didn't work on Python 3 at all (`nc_olci` and `nc_slstr` for example). Other readers handled it by using a try/except approach and using `.astype(str)` to convert. 

Strangely, in the master branch, the `abi_l1b` reader already uses `.decode()`. But apparently this is never committed to the develop branch.

 - [ ] Tests added
 - [ ] Tests passed
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff``

I tried running the tests on Windows and get some errors (`FAILED (failures=5, errors=3)`). But these dont seem to be related to changes in this PR.