### PR TITLE
Add CSPP Geo (geocat) AHI reading support

### DIFF
--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -1,69 +1,13 @@
 sensor_name: visir/ahi
 
 modifiers:
-  reducer2:
-    compositor: !!python/name:satpy.composites.ahi.Reducer2
-
-  reducer4:
-    compositor: !!python/name:satpy.composites.ahi.Reducer4
-
-  vegetation_corrected:
-    compositor: !!python/name:satpy.composites.ahi.GreenCorrector
-    prerequisites:
-    - wavelength: 0.85
-
-  vegetation_corrected_reduced:
-    compositor: !!python/name:satpy.composites.ahi.GreenCorrector
-    prerequisites:
-    - wavelength: 0.85
-      modifiers: [reducer2,]
-
   rayleigh_corrected:
     compositor: !!python/name:satpy.composites.PSPRayleighReflectance
     atmosphere: us-standard
     aerosol_type: marine_clean_aerosol
     prerequisites:
     - wavelength: 0.65
-      modifiers: [reducer2, sunz_corrected]
-    optional_prerequisites:
-    - satellite_azimuth_angle
-    - satellite_zenith_angle
-    - solar_azimuth_angle
-    - solar_zenith_angle
-
-  rayleigh_corrected_reducedsize:
-    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
-    atmosphere: us-standard
-    aerosol_type: marine_clean_aerosol
-    prerequisites:
-    - wavelength: 0.65
-      modifiers: [reducer4, sunz_corrected]
-    optional_prerequisites:
-    - satellite_azimuth_angle
-    - satellite_zenith_angle
-    - solar_azimuth_angle
-    - solar_zenith_angle
-
-  rayleigh_corrected_reducedsize_land:
-    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
-    atmosphere: us-standard
-    aerosol_type: continental_average_aerosol
-    prerequisites:
-    - wavelength: 0.65
-      modifiers: [reducer4, sunz_corrected]
-    optional_prerequisites:
-    - satellite_azimuth_angle
-    - satellite_zenith_angle
-    - solar_azimuth_angle
-    - solar_zenith_angle
-
-  rayleigh_corrected_reducedsize_marine_tropical:
-    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
-    atmosphere: us-standard
-    aerosol_type: marine_tropical_aerosol
-    prerequisites:
-    - wavelength: 0.65
-      modifiers: [reducer4, sunz_corrected]
+      modifiers: [sunz_corrected]
     optional_prerequisites:
     - satellite_azimuth_angle
     - satellite_zenith_angle
@@ -71,6 +15,19 @@ modifiers:
     - solar_zenith_angle
 
 composites:
+  green:
+    compositor: !!python/name:satpy.composites.ahi.GreenCorrector
+    # FUTURE: Set a wavelength...see what happens. Dependency finding
+    #         probably wouldn't work.
+    prerequisites:
+    # should we be using the most corrected or least corrected inputs?
+    # what happens if something requests more modifiers on top of this?
+    - wavelength: 0.51
+      modifiers: [sunz_corrected]
+    - wavelength: 0.85
+      modifiers: [sunz_corrected]
+    standard_name: toa_bidirection_reflectance
+
   overview:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
@@ -79,90 +36,71 @@ composites:
     - 10.4
     standard_name: overview
 
+  natural:
+    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
+    prerequisites:
+    - wavelength: 1.63
+      modifiers: [sunz_corrected] #, rayleigh_corrected]
+    - wavelength: 0.85
+      modifiers: [sunz_corrected] #, rayleigh_corrected]
+    - wavelength: 0.635
+      modifiers: [sunz_corrected] #, rayleigh_corrected]
+    high_resolution_band: blue
+    standard_name: natural
+
   true_color:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - wavelength: 0.65
-      modifiers: [reducer2, effective_solar_pathlength_corrected, rayleigh_corrected]
-    - wavelength: 0.51
-      modifiers: [vegetation_corrected, effective_solar_pathlength_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected]  #, rayleigh_corrected]
+    - name: green
     - wavelength: 0.46
-      modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected]  #, rayleigh_corrected]
     standard_name: true_color
 
-  true_color_reducedsize:
-    compositor: !!python/name:satpy.composites.GenericCompositor
-    prerequisites:
-    - wavelength: 0.65
-      modifiers: [reducer4, effective_solar_pathlength_corrected,
-                  rayleigh_corrected_reducedsize]
-    - wavelength: 0.51
-      modifiers: [reducer2, vegetation_corrected_reduced, effective_solar_pathlength_corrected,
-                  rayleigh_corrected_reducedsize]
-    - wavelength: 0.46
-      modifiers: [reducer2, effective_solar_pathlength_corrected,
-                  rayleigh_corrected_reducedsize]
-    standard_name: true_color
-
-  true_color_reducedsize_land:
-    compositor: !!python/name:satpy.composites.GenericCompositor
-    prerequisites:
-    - wavelength: 0.65
-      modifiers: [reducer4, effective_solar_pathlength_corrected,
-                  rayleigh_corrected_reducedsize_land]
-    - wavelength: 0.51
-      modifiers: [reducer2, vegetation_corrected_reduced, effective_solar_pathlength_corrected,
-                  rayleigh_corrected_reducedsize_land]
-    - wavelength: 0.46
-      modifiers: [reducer2, effective_solar_pathlength_corrected,
-                  rayleigh_corrected_reducedsize_land]
-    standard_name: true_color
-
-  true_color_reducedsize_marine_tropical:
-    compositor: !!python/name:satpy.composites.GenericCompositor
-    prerequisites:
-    - wavelength: 0.65
-      modifiers: [reducer4, effective_solar_pathlength_corrected,
-                  rayleigh_corrected_reducedsize_marine_tropical]
-    - wavelength: 0.51
-      modifiers: [reducer2, vegetation_corrected_reduced, effective_solar_pathlength_corrected,
-                  rayleigh_corrected_reducedsize_marine_tropical]
-    - wavelength: 0.46
-      modifiers: [reducer2, effective_solar_pathlength_corrected,
-                  rayleigh_corrected_reducedsize_marine_tropical]
-    standard_name: true_color
-
-  true_color_norayleigh:
-    compositor: !!python/name:satpy.composites.GenericCompositor
-    prerequisites:
-    - wavelength: 0.65
-      modifiers: [reducer2, effective_solar_pathlength_corrected]
-    - wavelength: 0.51
-      modifiers: [vegetation_corrected, effective_solar_pathlength_corrected]
-    - wavelength: 0.46
-      modifiers: [effective_solar_pathlength_corrected]
-    standard_name: true_color
+#  true_color_reducedsize_land:
+#    compositor: !!python/name:satpy.composites.GenericCompositor
+#    prerequisites:
+#    - wavelength: 0.65
+#      modifiers: [reducer4, effective_solar_pathlength_corrected,
+#                  rayleigh_corrected_reducedsize_land]
+#    - wavelength: 0.51
+#      modifiers: [reducer2, vegetation_corrected_reduced, effective_solar_pathlength_corrected,
+#                  rayleigh_corrected_reducedsize_land]
+#    - wavelength: 0.46
+#      modifiers: [reducer2, effective_solar_pathlength_corrected,
+#                  rayleigh_corrected_reducedsize_land]
+#    standard_name: true_color
+#
+#  true_color_reducedsize_marine_tropical:
+#    compositor: !!python/name:satpy.composites.GenericCompositor
+#    prerequisites:
+#    - wavelength: 0.65
+#      modifiers: [reducer4, effective_solar_pathlength_corrected,
+#                  rayleigh_corrected_reducedsize_marine_tropical]
+#    - wavelength: 0.51
+#      modifiers: [reducer2, vegetation_corrected_reduced, effective_solar_pathlength_corrected,
+#                  rayleigh_corrected_reducedsize_marine_tropical]
+#    - wavelength: 0.46
+#      modifiers: [reducer2, effective_solar_pathlength_corrected,
+#                  rayleigh_corrected_reducedsize_marine_tropical]
+#    standard_name: true_color
 
   day_microphysics_eum:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - wavelength: 0.86
-      modifiers: [reducer4, ]
     - wavelength: 3.9
-      modifiers: [nir_reflectance, reducer2]
+      modifiers: [nir_reflectance]
     - wavelength: 10.4
-      modifiers: [reducer2, ]
     standard_name: day_microphysics
 
   day_microphysics_ahi:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - wavelength: 0.86
-      modifiers: [reducer4, ]
     - wavelength: 2.3
-      modifiers: [reducer2]
     - wavelength: 10.4
-      modifiers: [reducer2, ]
     standard_name: day_microphysics
 
   cloud_phase_distinction:
@@ -170,7 +108,6 @@ composites:
     prerequisites:
     - wavelength: 10.4
     - wavelength: 0.64
-      modifiers: [reducer4]
     - wavelength: 1.6
     standard_name: cloud_phase_distinction
 
@@ -200,8 +137,7 @@ composites:
   convection:
     compositor: !!python/name:satpy.composites.Convection
     prerequisites:
-    - wavelength: 0.635
-      modifiers: [reducer4]
+    - 0.635
     - 1.63
     - 3.75
     - 6.7

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -49,13 +49,14 @@ composites:
     standard_name: natural
 
   true_color:
-    compositor: !!python/name:satpy.composites.GenericCompositor
+    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
     - wavelength: 0.65
       modifiers: [sunz_corrected]  #, rayleigh_corrected]
     - name: green
     - wavelength: 0.46
       modifiers: [sunz_corrected]  #, rayleigh_corrected]
+    high_resolution_band: red
     standard_name: true_color
 
 #  true_color_reducedsize_land:

--- a/satpy/etc/readers/geocat.yaml
+++ b/satpy/etc/readers/geocat.yaml
@@ -1,5 +1,5 @@
 reader:
-  description: GEOCAT
+  description: CSPP Geo and GEOCAT file reader
   name: geocat
   reader: !!python/name:satpy.readers.geocat.GEOCATYAMLReader
   sensors: [abi, ahi, goes_imager]
@@ -11,9 +11,243 @@ file_types:
      - 'geocatL{processing_level:1d}.{platform_shortname}.{start_time:%Y%j.%H%M%S}.hdf'
      - 'geocatL{processing_level:1d}.{platform_shortname}.{start_time:%Y%j.%H%M%S}.nc'
      # Himawari 8 files:
-     - 'geocatL{processing_level:1d}.{platform_shortname}.{start_time:%Y%j.%H%M%S}.{sector_id}.{res_id}.hdf'
-     - 'geocatL{processing_level:1d}.{platform_shortname}.{start_time:%Y%j.%H%M%S}.{sector_id}.{res_id}.nc'
+     - 'geocatL2.{platform_shortname}.{start_time:%Y%j.%H%M%S}.{sector_id}.{res_id}.hdf'
+     - 'geocatL2.{platform_shortname}.{start_time:%Y%j.%H%M%S}.{sector_id}.{res_id}.nc'
      # GOES-16 ABI files:
      - 'geocatL{processing_level:1d}.{platform_shortname}.{sector_id}.{start_time:%Y%j.%H%M%S}.hdf'
      - 'geocatL{processing_level:1d}.{platform_shortname}.{sector_id}.{start_time:%Y%j.%H%M%S}.nc'
+  ahi_level1:
+    file_reader: !!python/name:satpy.readers.geocat.GEOCATFileHandler
+    file_patterns:
+     # we could use the H8 pattern above, but then the datasets listed below
+     # would always be "available"
+     - 'geocatL1.HIMAWARI-8.{start_time:%Y%j.%H%M%S}.{sector_id}.{res_id}.hdf'
+     - 'geocatL1.HIMAWARI-8.{start_time:%Y%j.%H%M%S}.{sector_id}.{res_id}.nc'
 
+datasets:
+  # AHI Level 1 Datasets (need to define here so wavelengths can be used)
+  B01:
+    name: B01
+    sensor: ahi
+    wavelength: [0.45,0.47,0.49]
+    # FIXME: The resolution depends on the input files
+    resolution: 1000
+    calibration:
+      reflectance:
+        file_key: himawari_8_ahi_channel_1_reflectance
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B02:
+    name: B02
+    sensor: ahi
+    wavelength: [0.49,0.51,0.53]
+    resolution: 1000
+    calibration:
+      reflectance:
+        file_key: himawari_8_ahi_channel_2_reflectance
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B03:
+    name: B03
+    sensor: ahi
+    wavelength: [0.62,0.64,0.66]
+    resolution: 500
+    calibration:
+      reflectance:
+        file_key: himawari_8_ahi_channel_3_reflectance
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B04:
+    name: B04
+    sensor: ahi
+    wavelength: [0.83, 0.85, 0.87]
+    resolution: 1000
+    calibration:
+      reflectance:
+        file_key: himawari_8_ahi_channel_4_reflectance
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B05:
+    name: B05
+    sensor: ahi
+    wavelength: [1.5, 1.6, 1.7]
+    resolution: 2000
+    calibration:
+      reflectance:
+        file_key: himawari_8_ahi_channel_5_reflectance
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B06:
+    name: B06
+    sensor: ahi
+    wavelength: [2.2, 2.3, 2.4]
+    resolution: 2000
+    calibration:
+      reflectance:
+        file_key: himawari_8_ahi_channel_6_reflectance
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B07:
+    name: B07
+    sensor: ahi
+    wavelength: [3.7, 3.9, 4.1]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        file_key: himawari_8_ahi_channel_7_brightness_temperature
+        standard_name: toa_brightness_temperature
+        units: "K"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B08:
+    name: B08
+    sensor: ahi
+    wavelength: [6.0, 6.2, 6.4]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        file_key: himawari_8_ahi_channel_8_brightness_temperature
+        standard_name: toa_brightness_temperature
+        units: "K"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B09:
+    name: B09
+    sensor: ahi
+    wavelength: [6.7, 6.9, 7.1]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        file_key: himawari_8_ahi_channel_9_brightness_temperature
+        standard_name: toa_brightness_temperature
+        units: "K"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B10:
+    name: B10
+    sensor: ahi
+    wavelength: [7.1, 7.3, 7.5]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        file_key: himawari_8_ahi_channel_10_brightness_temperature
+        standard_name: toa_brightness_temperature
+        units: "K"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B11:
+    name: B11
+    sensor: ahi
+    wavelength: [8.4, 8.6, 8.8]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        file_key: himawari_8_ahi_channel_11_brightness_temperature
+        standard_name: toa_brightness_temperature
+        units: "K"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B12:
+    name: B12
+    sensor: ahi
+    wavelength: [9.4, 9.6, 9.8]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        file_key: himawari_8_ahi_channel_12_brightness_temperature
+        standard_name: toa_brightness_temperature
+        units: "K"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B13:
+    name: B13
+    sensor: ahi
+    wavelength: [10.2, 10.4, 10.6]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        file_key: himawari_8_ahi_channel_13_brightness_temperature
+        standard_name: toa_brightness_temperature
+        units: "K"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B14:
+    name: B14
+    sensor: ahi
+    wavelength: [11.0, 11.2, 11.4]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        file_key: himawari_8_ahi_channel_14_brightness_temperature
+        standard_name: toa_brightness_temperature
+        units: "K"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B15:
+    name: B15
+    sensor: ahi
+    wavelength: [12.2, 12.4, 12.6]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        file_key: himawari_8_ahi_channel_15_brightness_temperature
+        standard_name: toa_brightness_temperature
+        units: "K"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1
+  B16:
+    name: B16
+    sensor: ahi
+    wavelength: [13.1, 13.3, 13.5]
+    resolution: 2000
+    calibration:
+      brightness_temperature:
+        file_key: himawari_8_ahi_channel_16_brightness_temperature
+        standard_name: toa_brightness_temperature
+        units: "K"
+#      radiance:
+#        standard_name: toa_outgoing_radiance_per_unit_wavelength
+#        units: W m-2 um-1 sr-1
+    file_type: ahi_level1

--- a/satpy/etc/readers/geocat.yaml
+++ b/satpy/etc/readers/geocat.yaml
@@ -30,8 +30,6 @@ datasets:
     name: B01
     sensor: ahi
     wavelength: [0.45,0.47,0.49]
-    # FIXME: The resolution depends on the input files
-    resolution: 1000
     calibration:
       reflectance:
         file_key: himawari_8_ahi_channel_1_reflectance
@@ -45,7 +43,6 @@ datasets:
     name: B02
     sensor: ahi
     wavelength: [0.49,0.51,0.53]
-    resolution: 1000
     calibration:
       reflectance:
         file_key: himawari_8_ahi_channel_2_reflectance
@@ -59,7 +56,6 @@ datasets:
     name: B03
     sensor: ahi
     wavelength: [0.62,0.64,0.66]
-    resolution: 500
     calibration:
       reflectance:
         file_key: himawari_8_ahi_channel_3_reflectance
@@ -73,7 +69,6 @@ datasets:
     name: B04
     sensor: ahi
     wavelength: [0.83, 0.85, 0.87]
-    resolution: 1000
     calibration:
       reflectance:
         file_key: himawari_8_ahi_channel_4_reflectance
@@ -87,7 +82,6 @@ datasets:
     name: B05
     sensor: ahi
     wavelength: [1.5, 1.6, 1.7]
-    resolution: 2000
     calibration:
       reflectance:
         file_key: himawari_8_ahi_channel_5_reflectance
@@ -101,7 +95,6 @@ datasets:
     name: B06
     sensor: ahi
     wavelength: [2.2, 2.3, 2.4]
-    resolution: 2000
     calibration:
       reflectance:
         file_key: himawari_8_ahi_channel_6_reflectance
@@ -115,7 +108,6 @@ datasets:
     name: B07
     sensor: ahi
     wavelength: [3.7, 3.9, 4.1]
-    resolution: 2000
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_7_brightness_temperature
@@ -129,7 +121,6 @@ datasets:
     name: B08
     sensor: ahi
     wavelength: [6.0, 6.2, 6.4]
-    resolution: 2000
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_8_brightness_temperature
@@ -143,7 +134,6 @@ datasets:
     name: B09
     sensor: ahi
     wavelength: [6.7, 6.9, 7.1]
-    resolution: 2000
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_9_brightness_temperature
@@ -157,7 +147,6 @@ datasets:
     name: B10
     sensor: ahi
     wavelength: [7.1, 7.3, 7.5]
-    resolution: 2000
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_10_brightness_temperature
@@ -171,7 +160,6 @@ datasets:
     name: B11
     sensor: ahi
     wavelength: [8.4, 8.6, 8.8]
-    resolution: 2000
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_11_brightness_temperature
@@ -185,7 +173,6 @@ datasets:
     name: B12
     sensor: ahi
     wavelength: [9.4, 9.6, 9.8]
-    resolution: 2000
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_12_brightness_temperature
@@ -199,7 +186,6 @@ datasets:
     name: B13
     sensor: ahi
     wavelength: [10.2, 10.4, 10.6]
-    resolution: 2000
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_13_brightness_temperature
@@ -213,7 +199,6 @@ datasets:
     name: B14
     sensor: ahi
     wavelength: [11.0, 11.2, 11.4]
-    resolution: 2000
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_14_brightness_temperature
@@ -227,7 +212,6 @@ datasets:
     name: B15
     sensor: ahi
     wavelength: [12.2, 12.4, 12.6]
-    resolution: 2000
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_15_brightness_temperature
@@ -241,7 +225,6 @@ datasets:
     name: B16
     sensor: ahi
     wavelength: [13.1, 13.3, 13.5]
-    resolution: 2000
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_16_brightness_temperature

--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -114,3 +114,8 @@ class BaseFileHandler(six.with_metaclass(ABCMeta, object)):
     @property
     def end_time(self):
         return self.filename_info.get('end_time', self.start_time)
+
+    @property
+    def sensor_names(self):
+        """List of sensors represented in this file."""
+        raise NotImplementedError

--- a/satpy/readers/geocat.py
+++ b/satpy/readers/geocat.py
@@ -102,6 +102,10 @@ class GEOCATFileHandler(NetCDF4FileHandler):
         return GEO_PROJS[platform].format(lon_0=ref_lon)
 
     @property
+    def sensor_names(self):
+        return [self.get_sensor(self['/attr/Sensor_Name'])]
+
+    @property
     def start_time(self):
         return self.filename_info['start_time']
 
@@ -232,6 +236,7 @@ class GEOCATFileHandler(NetCDF4FileHandler):
             data = data * factor + offset
 
         data.attrs.update(info)
+        data = data.rename({'lines': 'y', 'elements': 'x'})
         return data
 
 

--- a/satpy/readers/geocat.py
+++ b/satpy/readers/geocat.py
@@ -74,6 +74,7 @@ class GEOCATFileHandler(NetCDF4FileHandler):
         'ahi': {
             1: 999.9999820317674,  # assumption
             2: 1999.999964063535,
+            4: 3999.99992812707,
         }
     }
 
@@ -118,11 +119,20 @@ class GEOCATFileHandler(NetCDF4FileHandler):
         platform = self.get_platform(self['/attr/Platform_Name'])
         return platform in GEO_PROJS
 
+    @property
+    def resolution(self):
+        elem_res = self['/attr/Element_Resolution']
+        return int(elem_res * 1000)
+
+    def _calc_area_resolution(self, ds_res):
+        elem_res = round(ds_res / 1000.)  # mimic 'Element_Resolution' attribute from above
+        sensor = self.get_sensor(self['/attr/Sensor_Name'])
+        return self.resolutions.get(sensor, {}).get(int(elem_res),
+                                                    elem_res * 1000.)
+
     def available_dataset_ids(self):
         """Automatically determine datasets provided by this file"""
-        elem_res = self['/attr/Element_Resolution']
-        sensor = self.get_sensor(self['/attr/Sensor_Name'])
-        res = self.resolutions.get(sensor, {}).get(int(elem_res), elem_res * 1000.)
+        res = self.resolution
         coordinates = ['pixel_longitude', 'pixel_latitude']
         for var_name, val in self.file_content.items():
             if isinstance(val, netCDF4.Variable):
@@ -178,7 +188,7 @@ class GEOCATFileHandler(NetCDF4FileHandler):
             raise NotImplementedError("Don't know how to get the Area Definition for this file")
 
         platform = self.get_platform(self['/attr/Platform_Name'])
-        res = dsid.resolution
+        res = self._calc_area_resolution(dsid.resolution)
         proj = self._get_proj(platform, float(self['/attr/Subsatellite_Longitude']))
         area_name = '{} {} Area at {}m'.format(
             platform,
@@ -248,8 +258,22 @@ class GEOCATYAMLReader(FileYAMLReader):
     def load_ds_ids_from_files(self):
         for file_handlers in self.file_handlers.values():
             fh = file_handlers[0]
+            # update resolution in the dataset IDs for this files resolution
+            res = fh.resolution
+            for ds_id, ds_info in list(self.ids.items()):
+                if fh.filetype_info['file_type'] != ds_info['file_type']:
+                    continue
+                if ds_id.resolution is not None:
+                    continue
+                ds_info['resolution'] = res
+                new_id = DatasetID.from_dict(ds_info)
+                self.ids[new_id] = ds_info
+                del self.ids[ds_id]
+
+            # dynamically discover other available datasets
             for ds_id, ds_info in fh.available_dataset_ids():
                 # don't overwrite an existing dataset
                 # especially from the yaml config
                 self.ids.setdefault(ds_id, ds_info)
+
 

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -577,8 +577,8 @@ class NativeResampler(BaseResampler):
 
         out_shape = target_geo_def.shape
         in_shape = data.shape
-        y_repeats = out_shape[y_axis] / float(in_shape[y_axis])
-        x_repeats = out_shape[x_axis] / float(in_shape[x_axis])
+        y_repeats = out_shape[0] / float(in_shape[y_axis])
+        x_repeats = out_shape[1] / float(in_shape[x_axis])
         repeats = {
             y_axis: y_repeats,
             x_axis: x_repeats,
@@ -597,6 +597,9 @@ class NativeResampler(BaseResampler):
                 coords['y'] = y_coord
             if 'x' in data.coords:
                 coords['x'] = x_coord
+        for dim in data.dims:
+            if dim not in ['y', 'x'] and dim in data.coords:
+                coords[dim] = data.coords[dim]
 
         return xr.DataArray(d_arr,
                             dims=data.dims,

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -22,7 +22,7 @@
 
 import sys
 
-from satpy.tests.compositor_tests import test_abi
+from satpy.tests.compositor_tests import test_abi, test_ahi
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -119,6 +119,7 @@ def suite():
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTests(test_abi.suite())
+    mysuite.addTests(test_ahi.suite())
     mysuite.addTest(loader.loadTestsFromTestCase(TestCheckArea))
 
     return mysuite

--- a/satpy/tests/compositor_tests/test_ahi.py
+++ b/satpy/tests/compositor_tests/test_ahi.py
@@ -62,8 +62,7 @@ class TestAHIComposites(unittest.TestCase):
         self.assertEqual(res.attrs['standard_name'],
                          'toa_bidirectional_reflectance')
         data = res.compute()
-        print(data)
-        np.testing.assert_allclose(data, 0.28025)
+        np.testing.assert_allclose(data, 0.2575)
 
 
 def suite():

--- a/satpy/tests/compositor_tests/test_ahi.py
+++ b/satpy/tests/compositor_tests/test_ahi.py
@@ -16,7 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Tests for ABI compositors.
+"""Tests for AHI compositors.
 """
 
 import sys
@@ -27,16 +27,16 @@ else:
     import unittest
 
 
-class TestABIComposites(unittest.TestCase):
+class TestAHIComposites(unittest.TestCase):
 
-    """Test ABI-specific composites."""
+    """Test AHI-specific composites."""
 
-    def test_simulated_green(self):
-        """Test creating a fake 'green' band."""
+    def test_corrected_green(self):
+        """Test adjusting the 'green' band."""
         import xarray as xr
         import dask.array as da
         import numpy as np
-        from satpy.composites.abi import SimulatedGreen
+        from satpy.composites.ahi import GreenCorrector
         from pyresample.geometry import AreaDefinition
         rows = 5
         cols = 10
@@ -47,7 +47,7 @@ class TestABIComposites(unittest.TestCase):
             cols, rows,
             (-20037508.34, -10018754.17, 20037508.34, 10018754.17))
 
-        comp = SimulatedGreen('green', prerequisites=('C01', 'C02', 'C03'),
+        comp = GreenCorrector('green', prerequisites=(0.51, 0.85),
                               standard_name='toa_bidirectional_reflectance')
         c01 = xr.DataArray(da.zeros((rows, cols), chunks=25) + 0.25,
                            dims=('y', 'x'),
@@ -55,23 +55,21 @@ class TestABIComposites(unittest.TestCase):
         c02 = xr.DataArray(da.zeros((rows, cols), chunks=25) + 0.30,
                            dims=('y', 'x'),
                            attrs={'name': 'C02', 'area': area})
-        c03 = xr.DataArray(da.zeros((rows, cols), chunks=25) + 0.35,
-                           dims=('y', 'x'),
-                           attrs={'name': 'C03', 'area': area})
-        res = comp((c01, c02, c03))
+        res = comp((c01, c02))
         self.assertIsInstance(res, xr.DataArray)
         self.assertIsInstance(res.data, da.Array)
         self.assertEqual(res.attrs['name'], 'green')
         self.assertEqual(res.attrs['standard_name'],
                          'toa_bidirectional_reflectance')
         data = res.compute()
+        print(data)
         np.testing.assert_allclose(data, 0.28025)
 
 
 def suite():
-    """The test suite for test_abi.
+    """The test suite for test_ahi.
     """
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
-    mysuite.addTest(loader.loadTestsFromTestCase(TestABIComposites))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestAHIComposites))
     return mysuite

--- a/satpy/tests/reader_tests/test_geocat.py
+++ b/satpy/tests/reader_tests/test_geocat.py
@@ -96,7 +96,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
                     if key + '/attr/' + a in file_content:
                         attrs[a] = file_content[key + '/attr/' + a]
                 if val.ndim > 1:
-                    file_content[key] = DataArray(val, dims=('y', 'x'), attrs=attrs)
+                    file_content[key] = DataArray(val, dims=('lines', 'elements'), attrs=attrs)
                 else:
                     file_content[key] = DataArray(val, attrs=attrs)
 


### PR DESCRIPTION
This PR adds AHI dataset identifiers to the geocat reader which will allow full support for CSPP Geo AHI products. Without this added to the reader config the datasets would not have an associated wavelength.

This PR also includes a large-ish change to the base readers and file handlers with a `sensor_names` property. Previously this was just an instance attribute. The default behavior is the same as before. The difference happens for any file handler that redefines `sensor_names` which will be used to determine what sensor's files have been loaded. This was needed for the geocat reader which supports multiple sensors including ABI and AHI. Some of the composite entries for these sensors conflict and in the previous implementation it was loading both ABI and AHI configs and which one took priority was unspecified.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
