### PR TITLE
Remove ABI composite reducerX modifiers

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -1,67 +1,57 @@
 sensor_name: visir/abi
 
 modifiers:
-  reducer2:
-    compositor: !!python/name:satpy.composites.ahi.Reducer2
-
-  reducer4:
-    compositor: !!python/name:satpy.composites.ahi.Reducer4
-
-  expander2:
-    compositor: !!python/name:satpy.composites.ahi.Expander
-    factor: 2
-
-  rayleigh_corrected:
-    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
-    atmosphere: us-standard
-    aerosol_type: marine_clean_aerosol
-    prerequisites:
-    - name: C02
-      modifiers: [reducer4, effective_solar_pathlength_corrected]
-    optional_prerequisites:
-    - satellite_azimuth_angle
-    - satellite_zenith_angle
-    - solar_azimuth_angle
-    - solar_zenith_angle
-
-  rayleigh_corrected_marine_tropical:
-    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
-    atmosphere: tropical
-    aerosol_type: marine_tropical_aerosol
-    prerequisites:
-    - name: C02
-      modifiers: [reducer4, effective_solar_pathlength_corrected]
-    optional_prerequisites:
-    - satellite_azimuth_angle
-    - satellite_zenith_angle
-    - solar_azimuth_angle
-    - solar_zenith_angle
-
-  rayleigh_corrected_land:
-    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
-    atmosphere: us-standard
-    aerosol_type: continental_average_aerosol
-    prerequisites:
-    - name: C02
-      modifiers: [reducer4, effective_solar_pathlength_corrected]
-    optional_prerequisites:
-    - satellite_azimuth_angle
-    - satellite_zenith_angle
-    - solar_azimuth_angle
-    - solar_zenith_angle
-
-  rayleigh_corrected_1km:
-    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
-    atmosphere: midlatitude summer
-    aerosol_type: marine_tropical_aerosol
-    prerequisites:
-    - name: C02
-      modifiers: [reducer2, effective_solar_pathlength_corrected]
-    optional_prerequisites:
-    - satellite_azimuth_angle
-    - satellite_zenith_angle
-    - solar_azimuth_angle
-    - solar_zenith_angle
+#  rayleigh_corrected:
+#    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+#    atmosphere: us-standard
+#    aerosol_type: marine_clean_aerosol
+#    prerequisites:
+#    - name: C02
+#      modifiers: [reducer4, effective_solar_pathlength_corrected]
+#    optional_prerequisites:
+#    - satellite_azimuth_angle
+#    - satellite_zenith_angle
+#    - solar_azimuth_angle
+#    - solar_zenith_angle
+#
+#  rayleigh_corrected_marine_tropical:
+#    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+#    atmosphere: tropical
+#    aerosol_type: marine_tropical_aerosol
+#    prerequisites:
+#    - name: C02
+#      modifiers: [reducer4, effective_solar_pathlength_corrected]
+#    optional_prerequisites:
+#    - satellite_azimuth_angle
+#    - satellite_zenith_angle
+#    - solar_azimuth_angle
+#    - solar_zenith_angle
+#
+#  rayleigh_corrected_land:
+#    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+#    atmosphere: us-standard
+#    aerosol_type: continental_average_aerosol
+#    prerequisites:
+#    - name: C02
+#      modifiers: [reducer4, effective_solar_pathlength_corrected]
+#    optional_prerequisites:
+#    - satellite_azimuth_angle
+#    - satellite_zenith_angle
+#    - solar_azimuth_angle
+#    - solar_zenith_angle
+#
+#  rayleigh_corrected_1km:
+#    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+#    atmosphere: midlatitude summer
+#    aerosol_type: marine_tropical_aerosol
+#    prerequisites:
+#    - name: C02
+#      modifiers: [reducer2, effective_solar_pathlength_corrected]
+#    optional_prerequisites:
+#    - satellite_azimuth_angle
+#    - satellite_zenith_angle
+#    - solar_azimuth_angle
+#    - solar_zenith_angle
 
   rayleigh_corrected_500m:
     compositor: !!python/name:satpy.composites.PSPRayleighReflectance

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -488,15 +488,7 @@ class BilinearResampler(BaseResampler):
 
 class NativeResampler(BaseResampler):
 
-    """Expand or reduce input datasets to be the same shape.
-
-    If `expand=True` (default) input datasets are replicated in both
-    dimensions to be the same as the shape provided on initialization.
-
-    If `expand=False` then input datasets are averaged to the shape
-    of the target area.
-
-    """
+    """Expand or reduce input datasets to be the same shape."""
 
     def resample(self, data, cache_dir=False, mask_area=False, **kwargs):
         # use 'mask_area' with a default of False. It wouldn't do anything.

--- a/satpy/tests/compositor_tests/test_abi.py
+++ b/satpy/tests/compositor_tests/test_abi.py
@@ -31,6 +31,12 @@ class TestABIComposites(unittest.TestCase):
 
     """Test ABI-specific composites."""
 
+    def test_load_composite_yaml(self):
+        """Test loading the yaml for this sensor."""
+        from satpy.composites import CompositorLoader
+        cl = CompositorLoader()
+        cl.load_sensor_composites('abi')
+
     def test_simulated_green(self):
         """Test creating a fake 'green' band."""
         import xarray as xr

--- a/satpy/tests/compositor_tests/test_ahi.py
+++ b/satpy/tests/compositor_tests/test_ahi.py
@@ -31,6 +31,12 @@ class TestAHIComposites(unittest.TestCase):
 
     """Test AHI-specific composites."""
 
+    def test_load_composite_yaml(self):
+        """Test loading the yaml for this sensor."""
+        from satpy.composites import CompositorLoader
+        cl = CompositorLoader()
+        cl.load_sensor_composites('abi')
+
     def test_corrected_green(self):
         """Test adjusting the 'green' band."""
         import xarray as xr


### PR DESCRIPTION
In a previous commit I removed the reducer classes from the AHI python
code, but did not notice they were being used by the ABI composites too.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->