### PR TITLE
correct calibration coefficients when not all channels present

### DIFF
--- a/satpy/readers/native_msg.py
+++ b/satpy/readers/native_msg.py
@@ -332,8 +332,9 @@ class NativeMSGFileHandler(BaseFileHandler):
 
     def convert_to_radiance(self, data, key_name):
         """Calibrate to radiance."""
-
-        channel_index = self.channel_order_list.index(key_name)
+        # all 12 channels are in calibration coefficients
+        # regardless of how many channels are in file
+        channel_index = CHANNEL_LIST.index(key_name)
         calMode = 'NOMINAL'
         # determine the required calibration coefficients to use
         # for the Level 1.5 Header


### PR DESCRIPTION
`.nat` files can have a variable number of channels. `native_msg.py` was assuming that the calibration coefficients for non-present channels would be dropped. This is not the case - `.nat` files with a subset of the full 12 data channels still have the calibration coefficients for all the channels. Before this change, `native_msg` would silently read the wrong coefficients for files with a subset of the full 12 data channels.

I've tested this locally by comparing `netcdf`, `.nat` file with only VIS_006, IR_039, IR_108 & HRV channels, and `.nat` file with all channels, for the same timestep downloaded from the EUMETSAT archive, not sure how this should be tested in codebase.
 
 - [ 0 ] Tests added - any ideas on how this should be tested?<!-- for all bug fixes or enhancements -->
 - [ X ] Tests passed <!-- for all non-documentation changes) -->
 - [ X ] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->

