### PR TITLE
Use rasterio to save geotiffs when available

### DIFF
--- a/satpy/tests/writer_tests/test_geotiff.py
+++ b/satpy/tests/writer_tests/test_geotiff.py
@@ -100,7 +100,7 @@ class TestGeoTIFFWriter(unittest.TestCase):
         datasets = self._get_test_datasets()
         w = GeoTIFFWriter()
         w.save_datasets(datasets,
-                        floating_point=True,
+                        dtype=np.float32,
                         enhancement_config=False,
                         base_dir=self.base_dir)
 

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -221,7 +221,7 @@ class GeoTIFFWriter(ImageWriter):
                 fill_value = np.nan
 
         try:
-            import rasterio
+            import rasterio  # noqa
             # we can use the faster rasterio-based save
             return img.save(filename, fformat='tif', fill_value=fill_value,
                             dtype=dtype, compute=compute, **gdal_options)


### PR DESCRIPTION
This refactors the geotiff writer in a couple new ways:

1. Replace `floating_point` with `dtype` which expects a numpy dtype and will figure everything else out after that.
2. Adds a check to see if rasterio is available and if so use the `XRImage.save` method for better performance.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
