### PR TITLE
Fix DNB enhancement compositors

### DIFF
--- a/satpy/composites/crefl_utils.py
+++ b/satpy/composites/crefl_utils.py
@@ -366,10 +366,11 @@ def run_crefl(refl, coeffs,
         #height = np.zeros(lon.shape, dtype=np.float)
         height = 0.
     else:
-        row = np.int32((90.0 - lat) * avg_elevation.shape[0] / 180.0)
-        col = np.int32((lon + 180.0) * avg_elevation.shape[1] / 360.0)
-        height = np.float64(avg_elevation[row, col])
-        height[height < 0.] = 0.0
+        row = ((90.0 - lat) * avg_elevation.shape[0] / 180.0).astype(np.int32)
+        col = ((lon + 180.0) * avg_elevation.shape[1] / 360.0).astype(np.int32)
+        height = avg_elevation[row, col].astype(np.float64)
+        # negative heights aren't allowed, clip to 0
+        height = height.where(height >= 0., 0.0)
         del lat, lon, row, col
 
     mus = xu.cos(xu.deg2rad(solar_zenith))

--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -27,8 +27,10 @@ import logging
 import os
 
 import numpy as np
+import dask
+import dask.array as da
 
-from satpy.composites import CompositeBase, RGBCompositor
+from satpy.composites import CompositeBase, GenericCompositor
 from satpy.config import get_environ_ancpath
 from satpy.dataset import combine_metadata
 
@@ -127,7 +129,6 @@ class ReflectanceCorrector(CompositeBase):
 
 
 class HistogramDNB(CompositeBase):
-
     """Histogram equalized DNB composite.
 
     The logic for this code was taken from Polar2Grid and was originally developed by Eva Schiffer (SSEC).
@@ -152,6 +153,54 @@ class HistogramDNB(CompositeBase):
             "mixed_degree_step")) if "mixed_degree_step" in kwargs else None
         super(HistogramDNB, self).__init__(*args, **kwargs)
 
+    def _run_dnb_normalization(self, dnb_data, sza_data):
+        """Scale the DNB data using a histogram equalization method.
+
+        Args:
+            dnb_data (ndarray): Day/Night Band data array
+            sza_data (ndarray): Solar Zenith Angle data array
+
+        """
+        good_mask = ~(dnb_data.isnull() | sza_data.isnull())
+        # good_mask = ~(dnb_data.mask | sza_data.mask)
+        output_dataset = dnb_data.where(good_mask)
+        # we only need the numpy array
+        output_dataset = output_dataset.values.copy()
+        dnb_data = dnb_data.values
+        sza_data = sza_data.values
+
+        day_mask, mixed_mask, night_mask = make_day_night_masks(
+            sza_data,
+            good_mask,
+            self.high_angle_cutoff,
+            self.low_angle_cutoff,
+            stepsDegrees=self.mixed_degree_step)
+
+        did_equalize = False
+        if day_mask.any():
+            LOG.debug("Histogram equalizing DNB day data...")
+            histogram_equalization(dnb_data, day_mask, out=output_dataset)
+            did_equalize = True
+        if mixed_mask:
+            for mask in mixed_mask:
+                if mask.any():
+                    LOG.debug("Histogram equalizing DNB mixed data...")
+                    histogram_equalization(dnb_data,
+                                           mask,
+                                           out=output_dataset)
+                    did_equalize = True
+        if night_mask.any():
+            LOG.debug("Histogram equalizing DNB night data...")
+            histogram_equalization(dnb_data,
+                                   night_mask,
+                                   out=output_dataset)
+            did_equalize = True
+
+        if not did_equalize:
+            raise RuntimeError("No valid data found to histogram equalize")
+
+        return dnb_data
+
     def __call__(self, datasets, **info):
         """Create the composite by scaling the DNB data using a histogram equalization method.
 
@@ -163,49 +212,20 @@ class HistogramDNB(CompositeBase):
 
         dnb_data = datasets[0]
         sza_data = datasets[1]
-        good_mask = ~(dnb_data.mask | sza_data.mask)
+        delayed = dask.delayed(self._run_dnb_normalization)(dnb_data, sza_data)
         output_dataset = dnb_data.copy()
-        output_dataset.mask = ~good_mask
-        day_mask, mixed_mask, night_mask = make_day_night_masks(
-            sza_data,
-            good_mask,
-            self.high_angle_cutoff,
-            self.low_angle_cutoff,
-            stepsDegrees=self.mixed_degree_step)
+        output_data = da.from_delayed(delayed, dnb_data.shape, dnb_data.dtype)
+        output_dataset.data = output_data.rechunk(dnb_data.data.chunks)
 
-        did_equalize = False
-        if day_mask.any():
-            LOG.debug("Histogram equalizing DNB day data...")
-            histogram_equalization(dnb_data.data, day_mask, out=output_dataset)
-            did_equalize = True
-        if mixed_mask:
-            for mask in mixed_mask:
-                if mask.any():
-                    LOG.debug("Histogram equalizing DNB mixed data...")
-                    histogram_equalization(dnb_data.data,
-                                           mask,
-                                           out=output_dataset)
-                    did_equalize = True
-        if night_mask.any():
-            LOG.debug("Histogram equalizing DNB night data...")
-            histogram_equalization(dnb_data.data,
-                                   night_mask,
-                                   out=output_dataset)
-            did_equalize = True
-
-        if not did_equalize:
-            raise RuntimeError("No valid data found to histogram equalize")
-
-        info = dnb_data.info.copy()
+        info = dnb_data.attrs.copy()
         info.update(self.attrs)
         info["standard_name"] = "equalized_radiance"
         info["mode"] = "L"
-        output_dataset.info = info
+        output_dataset.attrs = info
         return output_dataset
 
 
 class AdaptiveDNB(HistogramDNB):
-
     """Adaptive histogram equalized DNB composite.
 
     The logic for this code was taken from Polar2Grid and was originally developed by Eva Schiffer (SSEC).
@@ -238,20 +258,22 @@ class AdaptiveDNB(HistogramDNB):
 
         super(AdaptiveDNB, self).__init__(*args, **kwargs)
 
-    def __call__(self, datasets, **info):
-        """Create the composite by scaling the DNB data using an adaptive histogram equalization method.
+    def _run_dnb_normalization(self, dnb_data, sza_data):
+        """Scale the DNB data using a adaptive histogram equalization method.
 
-        :param datasets: 2-element tuple (Day/Night Band data, Solar Zenith Angle data)
-        :param **info: Miscellaneous metadata for the newly produced composite
+        Args:
+            dnb_data (ndarray): Day/Night Band data array
+            sza_data (ndarray): Solar Zenith Angle data array
+
         """
-        if len(datasets) != 2:
-            raise ValueError("Expected 2 datasets, got %d" % (len(datasets), ))
+        good_mask = ~(dnb_data.isnull() | sza_data.isnull())
+        # good_mask = ~(dnb_data.mask | sza_data.mask)
+        output_dataset = dnb_data.where(good_mask)
+        # we only need the numpy array
+        output_dataset = output_dataset.values.copy()
+        dnb_data = dnb_data.values
+        sza_data = sza_data.values
 
-        dnb_data = datasets[0]
-        sza_data = datasets[1]
-        good_mask = ~(dnb_data.mask | sza_data.mask)
-        output_dataset = dnb_data.copy()
-        output_dataset.mask = ~good_mask
         day_mask, mixed_mask, night_mask = make_day_night_masks(
             sza_data,
             good_mask,
@@ -267,14 +289,14 @@ class AdaptiveDNB(HistogramDNB):
                     has_multi_times and self.adaptive_day == "multiple"):
                 LOG.debug("Adaptive histogram equalizing DNB day data...")
                 local_histogram_equalization(
-                    dnb_data.data,
+                    dnb_data,
                     day_mask,
                     valid_data_mask=good_mask,
                     local_radius_px=self.day_radius_pixels,
                     out=output_dataset)
             else:
                 LOG.debug("Histogram equalizing DNB day data...")
-                histogram_equalization(dnb_data.data,
+                histogram_equalization(dnb_data,
                                        day_mask,
                                        out=output_dataset)
         if mixed_mask:
@@ -287,14 +309,14 @@ class AdaptiveDNB(HistogramDNB):
                         LOG.debug(
                             "Adaptive histogram equalizing DNB mixed data...")
                         local_histogram_equalization(
-                            dnb_data.data,
+                            dnb_data,
                             mask,
                             valid_data_mask=good_mask,
                             local_radius_px=self.mixed_radius_pixels,
                             out=output_dataset)
                     else:
                         LOG.debug("Histogram equalizing DNB mixed data...")
-                        histogram_equalization(dnb_data.data,
+                        histogram_equalization(dnb_data,
                                                day_mask,
                                                out=output_dataset)
         if night_mask.any():
@@ -303,40 +325,53 @@ class AdaptiveDNB(HistogramDNB):
                     has_multi_times and self.adaptive_night == "multiple"):
                 LOG.debug("Adaptive histogram equalizing DNB night data...")
                 local_histogram_equalization(
-                    dnb_data.data,
+                    dnb_data,
                     night_mask,
                     valid_data_mask=good_mask,
                     local_radius_px=self.night_radius_pixels,
                     out=output_dataset)
             else:
                 LOG.debug("Histogram equalizing DNB night data...")
-                histogram_equalization(dnb_data.data,
+                histogram_equalization(dnb_data,
                                        night_mask,
                                        out=output_dataset)
 
         if not did_equalize:
             raise RuntimeError("No valid data found to histogram equalize")
 
-        info = dnb_data.info.copy()
-        info.update(self.attrs)
-        info["standard_name"] = "equalized_radiance"
-        info["mode"] = "L"
-        output_dataset.info = info
         return output_dataset
 
 
 class ERFDNB(CompositeBase):
-
     """Equalized DNB composite using the error function (erf).
 
-    The logic for this code was taken from Polar2Grid and was originally developed by Curtis Seaman and Steve Miller.
-    The original code was written in IDL and is included as comments in the code below.
+    The logic for this code was taken from Polar2Grid and was originally
+    developed by Curtis Seaman and Steve Miller. The original code was
+    written in IDL and is included as comments in the code below.
+
     """
 
     def __init__(self, *args, **kwargs):
-        self.saturation_correction = kwargs.pop(
-            "saturation_correction", False) in [True, "True", "true"]
+        self.saturation_correction = kwargs.pop("saturation_correction",
+                                                False)
         super(ERFDNB, self).__init__(*args, **kwargs)
+
+    def _saturation_correction(self, dnb_data, unit_factor, min_val,
+                               max_val):
+        saturation_pct = float(np.count_nonzero(dnb_data >
+                                                max_val)) / dnb_data.size
+        LOG.debug("Dynamic DNB saturation percentage: %f", saturation_pct)
+        while saturation_pct > 0.005:
+            max_val *= 1.1 * unit_factor
+            saturation_pct = float(np.count_nonzero(
+                dnb_data > max_val)) / dnb_data.size
+            LOG.debug("Dynamic DNB saturation percentage: %f",
+                      saturation_pct)
+
+        inner_sqrt = (dnb_data - min_val) / (max_val - min_val)
+        # clip negative values to 0 before the sqrt
+        inner_sqrt[inner_sqrt < 0] = 0
+        return np.sqrt(inner_sqrt)
 
     def __call__(self, datasets, **info):
         if len(datasets) != 4:
@@ -346,18 +381,17 @@ class ERFDNB(CompositeBase):
         dnb_data = datasets[0]
         sza_data = datasets[1]
         lza_data = datasets[2]
-        good_mask = ~(dnb_data.mask | sza_data.mask)
-        output_dataset = dnb_data.copy()
-        output_dataset.mask = ~good_mask
+        output_dataset = dnb_data.where(
+            ~(dnb_data.isnull() | sza_data.isnull()))
         # this algorithm assumes units of "W cm-2 sr-1" so if there are other
         # units we need to adjust for that
-        if dnb_data.info.get("units", "W m-2 sr-1") == "W m-2 sr-1":
+        if dnb_data.attrs.get("units", "W m-2 sr-1") == "W m-2 sr-1":
             unit_factor = 10000.
         else:
             unit_factor = 1.
 
         # convert to decimal instead of %
-        moon_illum_fraction = np.mean(datasets[3]) * 0.01
+        moon_illum_fraction = da.mean(datasets[3].data) * 0.01
 
         # From Steve Miller and Curtis Seaman
         # maxval = 10.^(-1.7 - (((2.65+moon_factor1+moon_factor2))*(1+erf((solar_zenith-95.)/(5.*sqrt(2.0))))))
@@ -383,37 +417,36 @@ class ERFDNB(CompositeBase):
         # radiance = sqrt(scaled_radiance)
 
         moon_factor1 = 0.7 * (1.0 - moon_illum_fraction)
-        moon_factor2 = 0.0022 * lza_data
-        erf_portion = 1 + erf((sza_data - 95.0) / (5.0 * np.sqrt(2.0)))
-        max_val = np.power(
+        moon_factor2 = 0.0022 * lza_data.data
+        erf_portion = 1 + erf((sza_data.data - 95.0) / (5.0 * np.sqrt(2.0)))
+        max_val = da.power(
             10, -1.7 -
             (2.65 + moon_factor1 + moon_factor2) * erf_portion) * unit_factor
-        min_val = np.power(10, -4.0 -
+        min_val = da.power(10, -4.0 -
                            (2.95 + moon_factor2) * erf_portion) * unit_factor
 
         # Update from Curtis Seaman, increase max radiance curve until less
         # than 0.5% is saturated
         if self.saturation_correction:
-            saturation_pct = float(np.count_nonzero(dnb_data >
-                                                    max_val)) / dnb_data.size
-            LOG.debug("Dynamic DNB saturation percentage: %f", saturation_pct)
-            while saturation_pct > 0.005:
-                max_val *= 1.1 * unit_factor
-                saturation_pct = float(np.count_nonzero(
-                    dnb_data > max_val)) / dnb_data.size
-                LOG.debug("Dynamic DNB saturation percentage: %f",
-                          saturation_pct)
+            delayed = dask.delayed(self._saturation_correction)(
+                output_dataset.data, unit_factor,
+                min_val, max_val)
+            output_dataset.data = da.from_delayed(delayed,
+                                                  output_dataset.shape,
+                                                  output_dataset.dtype)
+            output_dataset.data = output_dataset.data.rechunk(
+                dnb_data.data.chunks)
+        else:
+            inner_sqrt = (output_dataset - min_val) / (max_val - min_val)
+            # clip negative values to 0 before the sqrt
+            inner_sqrt = inner_sqrt.where(inner_sqrt > 0, 0)
+            output_dataset.data = da.sqrt(inner_sqrt)
 
-        inner_sqrt = (dnb_data - min_val) / (max_val - min_val)
-        # clip negative values to 0 before the sqrt
-        inner_sqrt[inner_sqrt < 0] = 0
-        np.sqrt(inner_sqrt, out=output_dataset)
-
-        info = dnb_data.info.copy()
+        info = dnb_data.attrs.copy()
         info.update(self.attrs)
         info["standard_name"] = "equalized_radiance"
         info["mode"] = "L"
-        output_dataset.info = info
+        output_dataset.attrs = info
         return output_dataset
 
 
@@ -441,7 +474,7 @@ def make_day_night_masks(solarZenithAngle,
     night_mask = (solarZenithAngle > highAngleCutoff) & good_mask
     day_mask = (solarZenithAngle <= lowAngleCutoff) & good_mask
     mixed_mask = []
-    steps = range(lowAngleCutoff, highAngleCutoff + 1, stepsDegrees)
+    steps = list(range(lowAngleCutoff, highAngleCutoff + 1, stepsDegrees))
     if steps[-1] >= highAngleCutoff:
         steps[-1] = highAngleCutoff
     steps = zip(steps, steps[1:])
@@ -942,7 +975,6 @@ def _linear_normalization_from_0to1(
 
 
 class NCCZinke(CompositeBase):
-
     """Equalized DNB composite using the Zinke algorithm.
 
     http://www.tandfonline.com/doi/full/10.1080/01431161.2017.1338838
@@ -952,29 +984,25 @@ class NCCZinke(CompositeBase):
 
     def __call__(self, datasets, **info):
         if len(datasets) != 4:
-            raise ValueError("Expected 4 datasets, got %d" % (len(datasets), ))
+            raise ValueError("Expected 4 datasets, got %d" % (len(datasets),))
 
         dnb_data = datasets[0]
         sza_data = datasets[1]
         lza_data = datasets[2]
-        #good_mask = ~(dnb_data.mask | sza_data.mask)
-        #output_dataset = dnb_data.copy()
-        #output_dataset.mask = ~good_mask
         # this algorithm assumes units of "W cm-2 sr-1" so if there are other
         # units we need to adjust for that
-        if dnb_data.info.get("units", "W m-2 sr-1") == "W m-2 sr-1":
+        if dnb_data.attrs.get("units", "W m-2 sr-1") == "W m-2 sr-1":
             unit_factor = 10000.
         else:
             unit_factor = 1.
 
-        mda = dnb_data.info.copy()
-
-        dnb_data = dnb_data / unit_factor
+        mda = dnb_data.attrs.copy()
+        dnb_data = dnb_data.copy() / unit_factor
 
         # convert to decimal instead of %
-        moon_illum_fraction = np.mean(datasets[3]) * 0.01
+        moon_illum_fraction = da.mean(datasets[3]) * 0.01
 
-        phi = np.rad2deg(np.arccos(2. * moon_illum_fraction - 1))
+        phi = da.rad2deg(da.arccos(2. * moon_illum_fraction - 1))
 
         vfl = 0.026 * phi + 4.0e-9 * (phi ** 4.)
 
@@ -982,10 +1010,10 @@ class NCCZinke(CompositeBase):
         m_sun = -26.74
         m_moon = vfl + m_fullmoon
 
-        gs_ = self.gain_factor(sza_data)
+        gs_ = self.gain_factor(sza_data.data)
 
         r_sun_moon = 10.**((m_sun - m_moon) / -2.5)
-        gl_ = r_sun_moon * self.gain_factor(lza_data)
+        gl_ = r_sun_moon * self.gain_factor(lza_data.data)
         gtot = 1. / (1. / gs_ + 1. / gl_)
 
         dnb_data += 2.6e-10
@@ -995,11 +1023,15 @@ class NCCZinke(CompositeBase):
         mda.pop('calibration')
         mda.pop('wavelength')
         mda['standard_name'] = 'ncc_radiance'
+        dnb_data.attrs = mda
+        return dnb_data
 
-        return Dataset(dnb_data, copy=False, **mda)
+    def gain_factor(self, theta):
+        return theta.map_blocks(self._gain_factor,
+                                dtype=theta.dtype)
 
     @staticmethod
-    def gain_factor(theta):
+    def _gain_factor(theta):
         gain = np.empty_like(theta)
 
         mask = theta <= 87.541
@@ -1021,11 +1053,12 @@ class NCCZinke(CompositeBase):
         return gain
 
 
-class SnowAge(RGBCompositor):
+class SnowAge(GenericCompositor):
+    """Create RGB snow product.
 
-    """Returns RGB snow product based on method presented at the second
+    Product is based on method presented at the second
     CSPP/IMAPP users' meeting at Eumetsat in Darmstadt on 14-16 April 2015
-    """
+
     # Bernard Bellec snow Look-Up Tables V 1.0 (c) Meteo-France
     # These Look-up Tables allow you to create the RGB snow product
     # for SUOMI-NPP VIIRS Imager according to the algorithm
@@ -1038,6 +1071,7 @@ class SnowAge(RGBCompositor):
     # Bernard Bellec at Bernard.Bellec@meteo.fr
     # or
     # Pascale Roquet at Pascale.Roquet@meteo.fr
+    """
 
     def __call__(self, projectables, nonprojectables=None, **info):
         """Generate a SnowAge RGB composite.
@@ -1073,5 +1107,9 @@ class SnowAge(RGBCompositor):
         ch1 = m07 - refcu / 2. - m09 / 4.
         ch2 = m08 + refcu / 4. + m09 / 4.
         ch3 = m11 + m09
+        # GenericCompositor needs valid DataArrays with 'area' metadata
+        ch1.attrs = info
+        ch2.attrs = info
+        ch3.attrs = info
 
-        return RGBCompositor.__call__(self, [ch1, ch2, ch3], **info)
+        return super(SnowAge, self).__call__([ch1, ch2, ch3], **info)


### PR DESCRIPTION
Convert VIIRS DNB compositors to work with xarray and dask. This PR takes the easy road for some of them by running `delayed(func)` then `da.from_delayed`. These algorithms/enhancements aren't vectorized so they aren't simple to completely dask-ify. They also involve histogram calculations which make dask-ifying not super useful unless done really really well.

Note the VIIRS true color (or anything using the ratio sharpening from the viirs_sdr reader) fails currently due to a bug in XArray or what I consider a bug (https://github.com/pydata/xarray/issues/2060). My `viirs_sdr` reader assigns a "coordinates" attribute to the datasets with either `[m_longitude, m_latitude]` or `[i_longitude, i_latitude]`. Due to the bug this raises an exception when datasets are concatenated together.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
