### PR TITLE
Add 'python_requires' to setup.py to specify python support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -130,5 +130,6 @@ setup(name=NAME,
       zip_safe=False,
       install_requires=requires,
       tests_require=test_requires,
+      python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
       extras_require=extras_require,
       )


### PR DESCRIPTION
Add what versions of python are supported by satpy to the package metadata (setup.py). This should help us in the future when we drop certain versions of python and will stop users' pip environments installing newer versions of satpy on older versions of python.

 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
