### PR TITLE
Fix geotiff and png writers to save to a temporary directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ deploy:
     tags: true
     repo: pytroll/satpy
     python: 3.6
+    distributions: "sdist bdist_wheel"
 sudo: true
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,17 @@ install:
 - pip install behave
 - pip install h5netcdf
 - pip install python-hdf4
-- "pip install --no-binary :all: netCDF4"
+- 'pip install --no-binary :all: netCDF4'
 - pip install gdal==1.10.0
 - pip install scipy
 addons:
   apt_packages:
-    - libgdal-dev
-    - libhdf5-serial-dev
-    - libhdf4-alt-dev
-    - netcdf-bin
-    - libnetcdf-dev
-    - cython
+  - libgdal-dev
+  - libhdf5-serial-dev
+  - libhdf4-alt-dev
+  - netcdf-bin
+  - libnetcdf-dev
+  - cython
 script:
 - coverage run --source=satpy setup.py test
 - coverage run -a --source=satpy -m behave satpy/tests/features --tags=-download
@@ -36,14 +36,15 @@ after_success:
 - codecov
 deploy:
   provider: pypi
-  user: Martin.Raspaud
+  user: dhoese
   password:
-    secure: RuQzdaLTY4sryIzG8Hz1KWEsyYRxrLvbyfm7DurXDPcj2vsujRwJicNwBrJajIBkzZWwdmWE8db55BPWZwCsJtVUbE53vc742wSAcci2zzCgizSb/jjlDkwk1CE/PoMl4t3JsuIU6bklgw1Y1d4Xn4+BeZe8Blol5PD/FUovxfo=
+    secure: frK+0k1STeTM7SizRseP0qdTfOVz9ZMIra+3qEytPdxCLceXAH8LxPU16zj5rdNQxasF1hZ6rAd952fly+ypw2TEf5r2WnStrt7G5QlyE7VB6XGSDpIUxKF1FYccLvYs0/R6Y35MTEPqdM51PM5yEBjoY5b4tA3RF3fDq11cqc/SiWr6DgSLB1WJZULOdtCzBbfGbm5LyJ7yeNbISASSAwVvZTGWw7kJDgi0W5zxwEX82N5tBGbfKIu59qmxyj8FxmcrUwKZ4P3rQNg1kN1utzAB+PSf3GAVvbZfWJQuAKwMqpZgaV9lX0V7eUd/AxPobzEk9WyoNBMIdrSPej5BKWTDiYvaeRTOsggoUCSQJJA/SITEvkJgLWXoKKX2OWrM8RBUO4MoZJpPGXN42PRtMJkV2sx6ZigkpJlHdn39SsIRZX31zsfv8bBhclb70bt1Ts0fDd0rVdZAI6gMI+sgUePwEUn+XbWrvI0sMfDX3QsXDMV393RHgaIPxd+lRqUlYsNOxjsWpsbsvX55ePLxYHsNrv11KKyL/iGjGotVeVUO5D78qvfd4JrsUnMalQyZfW8NTEKa5Ebcs7gYJTwYEOTCQU12BkHOv1zFkjZG5RdGwkEvG3pykLhx+qDyYEd7pKB3TvhzLPqZPSrPxirwcoc0UzCc6ocYdzpqVuViFuk=
   on:
     tags: true
     repo: pytroll/satpy
+    python: 3.6
 sudo: true
 notifications:
   slack:
     rooms:
-      - pytroll:96mNSYSI1dBjGyzVXkBT6qFt#satpy
+    - pytroll:96mNSYSI1dBjGyzVXkBT6qFt#satpy

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ install:
 - 'pip install --no-binary :all: netCDF4'
 - pip install gdal==1.10.0
 - pip install scipy
+- pip install rasterio
 addons:
   apt_packages:
   - libgdal-dev

--- a/satpy/tests/writer_tests/test_simple_image.py
+++ b/satpy/tests/writer_tests/test_simple_image.py
@@ -39,6 +39,19 @@ else:
 
 class TestPillowWriter(unittest.TestCase):
 
+    def setUp(self):
+        """Create temporary directory to save files to"""
+        import tempfile
+        self.base_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        """Remove the temporary directory created for a test"""
+        try:
+            import shutil
+            shutil.rmtree(self.base_dir, ignore_errors=True)
+        except OSError:
+            pass
+
     def _get_test_datasets(self):
         import xarray as xr
         import dask.array as da
@@ -58,14 +71,14 @@ class TestPillowWriter(unittest.TestCase):
     def test_simple_write(self):
         from satpy.writers.simple_image import PillowWriter
         datasets = self._get_test_datasets()
-        w = PillowWriter()
+        w = PillowWriter(base_dir=self.base_dir)
         w.save_datasets(datasets)
 
     def test_simple_delayed_write(self):
         from dask.delayed import Delayed
         from satpy.writers.simple_image import PillowWriter
         datasets = self._get_test_datasets()
-        w = PillowWriter()
+        w = PillowWriter(base_dir=self.base_dir)
         res = w.save_datasets(datasets, compute=False)
         self.assertIsInstance(res, Delayed)
         res.compute()

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,6 @@
 requires=h5py pyresample python2-numexpr pyhdf xarray dask h5netcdf
 release=1
 doc_files = doc/Makefile doc/source/*.rst doc/examples/*.py
+
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
This was my mistake when I originally created these tests that the `base_dir` should have been specified in the writer init instead of the `save_datasets` method. This also adds `bdist_wheel` to the travis deployment. We'll see how that works next time we tag a release.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
