### PR TITLE
Fix writer and refactor so bad writer name raises logical exception

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ script:
 - coverage run --source=satpy setup.py test
 - coverage run -a --source=satpy -m behave satpy/tests/features --tags=-download
 after_success:
-- coveralls
-- codecov
+- if [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then coveralls; codecov; fi
 deploy:
   provider: pypi
   user: dhoese

--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -117,9 +117,9 @@ composites:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
     - wavelength: 1.63
-      modifiers: [sunz_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected]
     - wavelength: 0.85
-      modifiers: [sunz_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected]
     - wavelength: 0.635
       modifiers: [sunz_corrected, rayleigh_corrected]
     high_resolution_band: blue

--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -74,9 +74,9 @@ composites:
     prerequisites:
     # should we be using the most corrected or least corrected inputs?
     - name: C01
-      modifiers: [sunz_corrected]
+      modifiers: [sunz_corrected, rayleigh_corrected]
     - name: C02
-      modifiers: [sunz_corrected]
+      modifiers: [sunz_corrected, rayleigh_corrected]
     - name: C03
       modifiers: [sunz_corrected]
     standard_name: toa_bidirection_reflectance
@@ -107,10 +107,10 @@ composites:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
     - name: C02
-      modifiers: [sunz_corrected]
+      modifiers: [sunz_corrected, rayleigh_corrected]
     - name: green
     - name: C01
-      modifiers: [sunz_corrected]
+      modifiers: [sunz_corrected, rayleigh_corrected]
     standard_name: true_color
 
   natural:

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -26,15 +26,14 @@
 
 import logging
 import os
-import yaml
 
 from satpy.composites import CompositorLoader, IncompatibleAreas
-from satpy.config import (config_search_paths, get_environ_config_dir,
-                          recursive_dict_update)
+from satpy.config import config_search_paths, get_environ_config_dir
 from satpy.dataset import DatasetID, MetadataObject, dataset_walker, replace_anc
 from satpy.node import DependencyTree
 from satpy.readers import DatasetDict, load_readers
 from satpy.resample import resample_dataset, get_frozen_area, prepare_resampler
+from satpy.writers import load_writer
 from pyresample.geometry import AreaDefinition
 from xarray import DataArray
 
@@ -776,30 +775,16 @@ class Scene(MetadataObject):
             if ds_id in self.wishlist:
                 yield projectable.to_image()
 
-    def load_writer_config(self, config_files, **kwargs):
-        """Load the writer config for *config_files*."""
-        conf = {}
-        for conf_fn in config_files:
-            with open(conf_fn) as fd:
-                conf = recursive_dict_update(conf, yaml.load(fd))
-        writer_class = conf['writer']['writer']
-        init_kwargs, kwargs = writer_class.separate_init_kwargs(kwargs)
-        writer = writer_class(ppp_config_dir=self.ppp_config_dir,
-                              config_files=config_files,
-                              **init_kwargs)
-        return writer, kwargs
-
     def save_dataset(self, dataset_id, filename=None, writer=None,
                      overlay=None, compute=True, **kwargs):
         """Save the *dataset_id* to file using *writer* (default: geotiff)."""
-        if writer is None:
-            if filename is None:
-                writer, save_kwargs = self.get_writer("geotiff", **kwargs)
-            else:
-                writer, save_kwargs = self.get_writer_by_ext(
-                    os.path.splitext(filename)[1], **kwargs)
-        else:
-            writer, save_kwargs = self.get_writer(writer, **kwargs)
+        if writer is None and filename is None:
+            writer = 'geotiff'
+        elif writer is None:
+            writer = self.get_writer_by_ext(os.path.splitext(filename)[1])
+
+        writer, save_kwargs = load_writer(writer,
+                                          ppp_config_dir=self.ppp_config_dir)
         return writer.save_dataset(self[dataset_id], filename=filename,
                                    overlay=overlay, compute=compute,
                                    **save_kwargs)
@@ -814,16 +799,8 @@ class Scene(MetadataObject):
         writer, save_kwargs = self.get_writer(writer, **kwargs)
         return writer.save_datasets(datasets, compute=compute, **save_kwargs)
 
-    def get_writer(self, writer="geotiff", **kwargs):
-        """Get the writer instance."""
-        config_fn = writer + ".yaml" if "." not in writer else writer
-        config_files = config_search_paths(
-            os.path.join("writers", config_fn), self.ppp_config_dir)
-        kwargs.setdefault("config_files", config_files)
-        return self.load_writer_config(**kwargs)
-
-    def get_writer_by_ext(self, extension, **kwargs):
+    @classmethod
+    def get_writer_by_ext(cls, extension):
         """Find the writer matching the *extension*."""
         mapping = {".tiff": "geotiff", ".tif": "geotiff", ".nc": "cf"}
-        return self.get_writer(
-            mapping.get(extension.lower(), "simple_image"), **kwargs)
+        return mapping.get(extension.lower(), 'simple_image')

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -28,11 +28,13 @@ import logging
 import os
 
 from satpy.composites import CompositorLoader, IncompatibleAreas
-from satpy.config import config_search_paths, get_environ_config_dir
-from satpy.dataset import DatasetID, MetadataObject, dataset_walker, replace_anc
+from satpy.config import get_environ_config_dir
+from satpy.dataset import (DatasetID, MetadataObject, dataset_walker,
+                           replace_anc)
 from satpy.node import DependencyTree
 from satpy.readers import DatasetDict, load_readers
-from satpy.resample import resample_dataset, get_frozen_area, prepare_resampler
+from satpy.resample import (resample_dataset, get_frozen_area,
+                            prepare_resampler)
 from satpy.writers import load_writer
 from pyresample.geometry import AreaDefinition
 from xarray import DataArray

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -798,7 +798,9 @@ class Scene(MetadataObject):
             datasets = [self[ds] for ds in datasets]
         else:
             datasets = self.datasets.values()
-        writer, save_kwargs = self.get_writer(writer, **kwargs)
+        writer, save_kwargs = load_writer(writer,
+                                          ppp_config_dir=self.ppp_config_dir,
+                                          **kwargs)
         return writer.save_datasets(datasets, compute=compute, **save_kwargs)
 
     @classmethod

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1393,6 +1393,58 @@ class TestSceneResampling(unittest.TestCase):
         self.assertEqual(len(new_scn.missing_datasets), 0)
 
 
+class TestSceneSaving(unittest.TestCase):
+    """Test the Scene's saving method."""
+
+    def setUp(self):
+        """Create temporary directory to save files to"""
+        import tempfile
+        self.base_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        """Remove the temporary directory created for a test"""
+        try:
+            import shutil
+            shutil.rmtree(self.base_dir, ignore_errors=True)
+        except OSError:
+            pass
+
+    def test_save_datasets_default(self):
+        """Save a dataset using 'save_datasets'."""
+        from satpy.scene import Scene
+        import xarray as xr
+        import dask.array as da
+        from datetime import datetime
+        ds1 = xr.DataArray(
+            da.zeros((100, 200), chunks=50),
+            dims=('y', 'x'),
+            attrs={'name': 'test',
+                   'start_time': datetime.utcnow()}
+        )
+        scn = Scene()
+        scn['test'] = ds1
+        scn.save_datasets(base_dir=self.base_dir)
+
+    def test_save_datasets_bad_writer(self):
+        """Save a dataset using 'save_datasets'."""
+        from satpy.scene import Scene
+        import xarray as xr
+        import dask.array as da
+        from datetime import datetime
+        ds1 = xr.DataArray(
+            da.zeros((100, 200), chunks=50),
+            dims=('y', 'x'),
+            attrs={'name': 'test',
+                   'start_time': datetime.utcnow()}
+        )
+        scn = Scene()
+        scn['test'] = ds1
+        self.assertRaises(ValueError,
+                          scn.save_datasets,
+                          writer='_bad_writer_',
+                          base_dir=self.base_dir)
+
+
 def suite():
     """The test suite for test_scene.
     """
@@ -1401,6 +1453,7 @@ def suite():
     mysuite.addTest(loader.loadTestsFromTestCase(TestScene))
     mysuite.addTest(loader.loadTestsFromTestCase(TestSceneLoading))
     mysuite.addTest(loader.loadTestsFromTestCase(TestSceneResampling))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestSceneSaving))
 
     return mysuite
 

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -47,9 +47,9 @@ from trollimage.xrimage import XRImage
 LOG = logging.getLogger(__name__)
 
 
-def load_writer_configs(writer_configs, ppp_config_dir=None,
+def load_writer_configs(writer_configs, ppp_config_dir,
                         **writer_kwargs):
-    """Load the writer config for *config_files*."""
+    """Load the writer from the provided `writer_configs`."""
     conf = {}
     try:
         for conf_fn in writer_configs:
@@ -67,6 +67,10 @@ def load_writer_configs(writer_configs, ppp_config_dir=None,
 
 
 def load_writer(writer, ppp_config_dir=None, **writer_kwargs):
+    """Find and load writer `writer` in the available configuration files."""
+    if ppp_config_dir is None:
+        ppp_config_dir = get_environ_config_dir()
+
     config_fn = writer + ".yaml" if "." not in writer else writer
     config_files = config_search_paths(
         os.path.join("writers", config_fn), ppp_config_dir)


### PR DESCRIPTION
I accidentally passed the base_dir as the first argument to `save_datasets` and received a cryptic KeyError. This PR adds some logical information to the error message and refactors the writer loading functions to the `writers/__init__.py` module.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->