### PR TITLE
Fix ABI L1B reader masking data improperly

### DIFF
--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -73,11 +73,11 @@ class NC_ABI_L1B(BaseFileHandler):
         factor = data.attrs.get('scale_factor')
         offset = data.attrs.get('add_offset')
         fill = data.attrs.get('_FillValue')
+        if fill is not None:
+            data = data.where(data != fill)
         if factor is not None:
             # make sure the factor is a 64-bit float
             data = data * float(factor) + offset
-        if fill is not None:
-            data = data.where(data != fill)
         return data
 
     def get_shape(self, key, info):

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -39,11 +39,12 @@ except ImportError:
 
 
 class FakeDataset(object):
-    def __init__(self, info):
+    def __init__(self, info, attrs):
         for var_name, var_data in list(info.items()):
             if isinstance(var_data, np.ndarray):
                 info[var_name] = xr.DataArray(var_data)
         self.info = info
+        self.attrs = attrs
 
     def __getitem__(self, key):
         return self.info[key]
@@ -57,18 +58,32 @@ class FakeDataset(object):
 
 class Test_NC_ABI_L1B_ir_cal(unittest.TestCase):
     """Test the NC_ABI_L1B reader."""
+
     @mock.patch('satpy.readers.abi_l1b.xr')
-    def setUp(self, xr):
+    def setUp(self, xr_):
         """Setup for test."""
-        xr.open_dataset.return_value = FakeDataset({
+        rad_data = (np.arange(10.).reshape((2, 5)) + 1.) * 50.
+        rad_data = (rad_data + 1.) / 0.5
+        rad_data = rad_data.astype(np.int16)
+        rad = xr.DataArray(
+            rad_data,
+            attrs={
+                'scale_factor': 0.5,
+                'add_offset': -1.,
+                '_FillValue': 1002.,
+            })
+        xr_.open_dataset.return_value = FakeDataset({
             'band_id': np.array(8),
-            'Rad': np.arange(10.).reshape((2, 5)),
+            'Rad': rad,
             "planck_fk1": np.array(13432.1),
             "planck_fk2": np.array(1497.61),
             "planck_bc1": np.array(0.09102),
             "planck_bc2": np.array(0.99971),
             "esun": np.array(2017),
-            "earth_sun_distance_anomaly_in_AU": np.array(0.99)})
+            "nominal_satellite_subpoint_lat": np.array(0.0),
+            "nominal_satellite_subpoint_lon": np.array(-89.5),
+            "nominal_satellite_height": np.array(35786.02),
+            "earth_sun_distance_anomaly_in_AU": np.array(0.99)}, {})
 
         self.reader = NC_ABI_L1B('filename',
                                  {'platform_shortname': 'G16'},
@@ -76,48 +91,82 @@ class Test_NC_ABI_L1B_ir_cal(unittest.TestCase):
 
     def test_ir_calibrate(self):
         """Test IR calibration."""
-        data = xr.DataArray((np.arange(10.).reshape((2, 5)) + 1) * 50)
-
-        res = self.reader._ir_calibrate(data)
+        from satpy import DatasetID
+        res = self.reader.get_dataset(
+            DatasetID(name='C05', calibration='brightness_temperature'), {})
 
         expected = np.array([[267.55572248, 305.15576503, 332.37383249,
                                  354.73895301, 374.19710115],
                                 [391.68679226, 407.74064808, 422.69329105,
-                                 436.77021913, 450.13141732]])
-        self.assertTrue(np.allclose(res.data, expected))
+                                 436.77021913, np.nan]])
+        self.assertTrue(np.allclose(res.data, expected, equal_nan=True))
 
 
 class Test_NC_ABI_L1B_vis_cal(unittest.TestCase):
     """Test the NC_ABI_L1B reader."""
 
     @mock.patch('satpy.readers.abi_l1b.xr')
-    def setUp(self, xr):
+    def setUp(self, xr_):
         """Setup for test."""
-        xr.open_dataset.return_value = FakeDataset({
+        rad_data = (np.arange(10.).reshape((2, 5)) + 1.)
+        rad_data = (rad_data + 1.) / 0.5
+        rad_data = rad_data.astype(np.int16)
+        rad = xr.DataArray(
+            rad_data,
+            attrs={
+                'scale_factor': 0.5,
+                'add_offset': -1.,
+                '_FillValue': 20,
+            })
+        xr_.open_dataset.return_value = FakeDataset({
             'band_id': np.array(5),
-            'Rad': np.arange(10.).reshape((2, 5)),
+            'Rad': rad,
             "planck_fk1": np.array(13432.1),
             "planck_fk2": np.array(1497.61),
             "planck_bc1": np.array(0.09102),
             "planck_bc2": np.array(0.99971),
             "esun": np.array(2017),
-            "earth_sun_distance_anomaly_in_AU": np.array(0.99)})
+            "nominal_satellite_subpoint_lat": np.array(0.0),
+            "nominal_satellite_subpoint_lon": np.array(-89.5),
+            "nominal_satellite_height": np.array(35786.02),
+            "earth_sun_distance_anomaly_in_AU": np.array(0.99)},
+            {
+                "time_coverage_start": "2017-09-20T17:30:40.8Z",
+                "time_coverage_end": "2017-09-20T17:41:17.5Z",
+            })
 
         self.reader = NC_ABI_L1B('filename',
                                  {'platform_shortname': 'G16'},
                                  {'filetype': 'info'})
 
+    def test_bad_calibration(self):
+        """Test that asking for a bad calibration fails."""
+        from satpy import DatasetID
+        self.assertRaises(ValueError, self.reader.get_dataset,
+                          DatasetID(name='C05', calibration='_bad_'), {})
+
+    def test_basic_attributes(self):
+        """Test getting basic file attributes."""
+        from datetime import datetime
+        from satpy import DatasetID
+        self.assertEqual(self.reader.start_time,
+                         datetime(2017, 9, 20, 17, 30, 40, 800000))
+        self.assertEqual(self.reader.end_time,
+                         datetime(2017, 9, 20, 17, 41, 17, 500000))
+        self.assertEqual(self.reader.get_shape(DatasetID(name='C05'), {}),
+                         (2, 5))
+
     def test_vis_calibrate(self):
         """Test VIS calibration."""
-        data = xr.DataArray((np.arange(10.).reshape((2, 5)) + 1) * 100)
-
-        res = self.reader._vis_calibrate(data)
+        from satpy import DatasetID
+        res = self.reader.get_dataset(
+            DatasetID(name='C05', calibration='reflectance'), {})
 
         expected = np.array([[0.15265617, 0.30531234, 0.45796851,
                                  0.61062468, 0.76328085],
                                 [0.91593702, 1.06859319, 1.22124936,
-                                 1.37390553, 1.52656171]])
-        self.assertTrue(np.allclose(res.data, expected))
+                                 np.nan, 1.52656171]])
+        self.assertTrue(np.allclose(res.data, expected, equal_nan=True))
 
 
 class Test_NC_ABI_L1B_area(unittest.TestCase):
@@ -148,7 +197,7 @@ class Test_NC_ABI_L1B_area(unittest.TestCase):
             'goes_imager_projection': proj,
             'x': x__,
             'y': y__,
-            'Rad': np.ones((10, 10))})
+            'Rad': np.ones((10, 10))}, {})
 
         self.reader = NC_ABI_L1B('filename',
                                  {'platform_shortname': 'G16'},


### PR DESCRIPTION
Last time I updated the ABI L1B reader I set the reader to mask invalid data *after* it was scaled which changes any pixels that were set to the fill value. The check should happen *before* scaling. This PR fixes that.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->