### PR TITLE
Add caching at the scene level, and handle saving/loading from disk

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -602,13 +602,15 @@ def prepare_resampler(source_area, destination_area, resampler=None, **resample_
     else:
         resampler_class = resampler
 
+    key = (resampler_class,
+           source_area, destination_area,
+           hash_dict(resample_kwargs))
     try:
-        key = (resampler_class,
-               source_area, destination_area,
-               hash_dict(resample_kwargs))
-        return resamplers_cache[key]
+        resampler_instance = resamplers_cache[key]
     except KeyError:
-        return resampler_class(source_area, destination_area)
+        resampler_instance = resampler_class(source_area, destination_area)
+        resamplers_cache[key] = resampler_instance
+    return key, resampler_instance
 
 
 def resample(source_area, data, destination_area,

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -467,8 +467,8 @@ class NativeResampler(BaseResampler):
         """Average every 4 elements (2x2) in a 2D array"""
         def _mean(data):
             rows, cols = data.shape
-            new_shape = (int(rows / y_size), y_size,
-                         int(cols / x_size), x_size)
+            new_shape = (int(rows / y_size), int(y_size),
+                         int(cols / x_size), int(x_size))
             data_mean = np.ma.mean(data.reshape(new_shape), axis=(1, 3))
             return data_mean
 

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -192,6 +192,11 @@ class KDTreeResampler(BaseResampler):
         del kwargs
         source_geo_def = mask_source_lonlats(self.source_geo_def, mask)
 
+        if radius_of_influence is None:
+            try:
+                radius_of_influence = source_geo_def.lons.resolution * 3
+            except AttributeError:
+                radius_of_influence = 10000
         if self.resampler is None:
             kwargs = dict(source_geo_def=source_geo_def,
                           target_geo_def=self.target_geo_def,

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -673,10 +673,9 @@ class Scene(MetadataObject):
         if unload:
             self.unload(keepables=keepables)
 
-    @classmethod
-    def _resampled_scene(cls, datasets, destination, **resample_kwargs):
+    def _resampled_scene(self, datasets, destination, **resample_kwargs):
         """Generate a new scene with resampled *datasets*."""
-        new_scn = cls()
+        new_scn = self.__class__()
         new_datasets = {}
         destination_area = None
         resamplers = {}
@@ -703,10 +702,12 @@ class Scene(MetadataObject):
             LOG.debug("Resampling %s", ds_id)
             source_area = dataset.attrs['area']
             if source_area not in resamplers:
-                resamplers[source_area] = prepare_resampler(
-                    source_area, destination_area, resampler=resampler,
-                    **resample_kwargs)
-            resample_kwargs['resampler'] = resamplers[source_area][1]
+                key, resampler = prepare_resampler(
+                        source_area, destination_area, resampler=resampler,
+                        **resample_kwargs)
+                resamplers[source_area] = resampler
+                self.resamplers[key] = resampler
+            resample_kwargs['resampler'] = resamplers[source_area]
             res = resample_dataset(dataset, destination_area,
                                    **resample_kwargs)
             new_datasets[ds_id] = res

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -703,13 +703,13 @@ class Scene(MetadataObject):
             source_area = dataset.attrs['area']
             if source_area not in resamplers:
                 key, resampler = prepare_resampler(
-                        source_area, destination_area, resampler=resampler,
-                        **resample_kwargs)
+                        source_area, destination_area, **resample_kwargs)
                 resamplers[source_area] = resampler
                 self.resamplers[key] = resampler
-            resample_kwargs['resampler'] = resamplers[source_area]
+            kwargs = resample_kwargs.copy()
+            kwargs['resampler'] = resamplers[source_area]
             res = resample_dataset(dataset, destination_area,
-                                   **resample_kwargs)
+                                   **kwargs)
             new_datasets[ds_id] = res
             if parent_dataset is None:
                 new_scn[ds_id] = res

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -34,7 +34,7 @@ from satpy.dataset import (DatasetID, MetadataObject, dataset_walker,
 from satpy.node import DependencyTree
 from satpy.readers import DatasetDict, load_readers
 from satpy.resample import (resample_dataset, get_frozen_area,
-                            prepare_resampler, resamplers_cache, hash_dict)
+                            prepare_resampler)
 from satpy.writers import load_writer
 from pyresample.geometry import AreaDefinition
 from xarray import DataArray
@@ -706,7 +706,7 @@ class Scene(MetadataObject):
                 resamplers[source_area] = prepare_resampler(
                     source_area, destination_area, resampler=resampler,
                     **resample_kwargs)
-            resample_kwargs['resampler'] = resamplers[source_area]
+            resample_kwargs['resampler'] = resamplers[source_area][1]
             res = resample_dataset(dataset, destination_area,
                                    **resample_kwargs)
             new_datasets[ds_id] = res
@@ -731,11 +731,7 @@ class Scene(MetadataObject):
             destination = self.max_area(to_resample)
         new_scn, resamplers, destination_area = self._resampled_scene(to_resample, destination,
                                                                       **resample_kwargs)
-        for source, resampler in resamplers.items():
-            key = (resampler.__class__,
-                   source, destination_area,
-                   hash_dict(resample_kwargs))
-            resamplers_cache[key] = resampler
+        for source, (key, resampler) in resamplers.items():
             self.resamplers[key] = resampler
 
         new_scn.attrs = self.attrs.copy()

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -716,7 +716,7 @@ class Scene(MetadataObject):
             else:
                 replace_anc(res, pres)
 
-        return new_scn, resamplers, destination_area
+        return new_scn, destination_area
 
     def resample(self,
                  destination=None,
@@ -730,10 +730,8 @@ class Scene(MetadataObject):
 
         if destination is None:
             destination = self.max_area(to_resample)
-        new_scn, resamplers, destination_area = self._resampled_scene(to_resample, destination,
-                                                                      **resample_kwargs)
-        for source, (key, resampler) in resamplers.items():
-            self.resamplers[key] = resampler
+        new_scn, destination_area = self._resampled_scene(to_resample, destination,
+                                                          **resample_kwargs)
 
         new_scn.attrs = self.attrs.copy()
         new_scn.dep_tree = self.dep_tree.copy()

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ version = imp.load_source('satpy.version', 'satpy/version.py')
 BASE_PATH = os.path.sep.join(os.path.dirname(os.path.realpath(__file__)).split(
     os.path.sep))
 
-requires = ['numpy >=1.4.1', 'pillow', 'pyresample >=1.4.0', 'trollsift',
+requires = ['numpy >=1.4.1', 'pillow', 'pyresample >=1.9.0', 'trollsift',
             'trollimage >=1.5.1', 'pykdtree', 'six', 'pyyaml', 'xarray >=0.10.1',
             'dask[array] >=0.17.1']
 


### PR DESCRIPTION
This PR restructures the caching to store resamplers in the scene, and have a weak global resampler index.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
