### PR TITLE
Fix CLAVR-x reader to work with xarray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ deploy:
     tags: true
     repo: pytroll/satpy
     python: 3.6
-    distributions: "sdist bdist_wheel"
+    distributions: sdist bdist_wheel
 notifications:
   slack:
     rooms:

--- a/satpy/etc/readers/clavrx.yaml
+++ b/satpy/etc/readers/clavrx.yaml
@@ -1,7 +1,7 @@
 reader:
   description: CLAVR-X Reader
   name: clavrx
-  reader: !!python/name:satpy.readers.clavrx.CLAVRXYAMLReader
+  reader: !!python/name:satpy.readers.clavrx.FileYAMLReader
   sensors: [viirs, modis, avhrr]
 
 file_types:

--- a/satpy/etc/readers/geocat.yaml
+++ b/satpy/etc/readers/geocat.yaml
@@ -1,7 +1,7 @@
 reader:
   description: CSPP Geo and GEOCAT file reader
   name: geocat
-  reader: !!python/name:satpy.readers.geocat.GEOCATYAMLReader
+  reader: !!python/name:satpy.readers.geocat.FileYAMLReader
   sensors: [abi, ahi, goes_imager]
 
 file_types:

--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -119,3 +119,21 @@ class BaseFileHandler(six.with_metaclass(ABCMeta, object)):
     def sensor_names(self):
         """List of sensors represented in this file."""
         raise NotImplementedError
+
+    @property
+    def resolution(self):
+        """Scalar of resolution for all datasets in this file."""
+        raise NotImplementedError
+
+    def available_datasets(self):
+        """Get information of available datasets in file.
+
+        This is used for dynamically specifying what datasets are available
+        from a file instead of those listed in a YAML configuration file.
+
+        Returns: Iterator of (DatasetID, dict) pairs where dict is the
+                 dataset's metadata, similar to that specified in the YAML
+                 configuration files.
+
+        """
+        raise NotImplementedError

--- a/satpy/readers/geocat.py
+++ b/satpy/readers/geocat.py
@@ -130,7 +130,7 @@ class GEOCATFileHandler(NetCDF4FileHandler):
         return self.resolutions.get(sensor, {}).get(int(elem_res),
                                                     elem_res * 1000.)
 
-    def available_dataset_ids(self):
+    def available_datasets(self):
         """Automatically determine datasets provided by this file"""
         res = self.resolution
         coordinates = ['pixel_longitude', 'pixel_latitude']
@@ -248,32 +248,3 @@ class GEOCATFileHandler(NetCDF4FileHandler):
         data.attrs.update(info)
         data = data.rename({'lines': 'y', 'elements': 'x'})
         return data
-
-
-class GEOCATYAMLReader(FileYAMLReader):
-    def create_filehandlers(self, filenames):
-        super(GEOCATYAMLReader, self).create_filehandlers(filenames)
-        self.load_ds_ids_from_files()
-
-    def load_ds_ids_from_files(self):
-        for file_handlers in self.file_handlers.values():
-            fh = file_handlers[0]
-            # update resolution in the dataset IDs for this files resolution
-            res = fh.resolution
-            for ds_id, ds_info in list(self.ids.items()):
-                if fh.filetype_info['file_type'] != ds_info['file_type']:
-                    continue
-                if ds_id.resolution is not None:
-                    continue
-                ds_info['resolution'] = res
-                new_id = DatasetID.from_dict(ds_info)
-                self.ids[new_id] = ds_info
-                del self.ids[ds_id]
-
-            # dynamically discover other available datasets
-            for ds_id, ds_info in fh.available_dataset_ids():
-                # don't overwrite an existing dataset
-                # especially from the yaml config
-                self.ids.setdefault(ds_id, ds_info)
-
-

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -495,12 +495,12 @@ class FileYAMLReader(AbstractYAMLReader):
                     key=lambda fhd: (fhd.start_time, fhd.filename))
 
         # update existing dataset IDs with information from the file handler
-        self.update_ds_info_from_files()
+        self.update_ds_ids_from_file_handlers()
 
         # load any additional dataset IDs determined dynamically from the file
-        self.update_ds_ids_from_files()
+        self.add_ds_ids_from_files()
 
-    def update_ds_info_from_files(self):
+    def update_ds_ids_from_file_handlers(self):
         """Update DatasetIDs with information from loaded files.
 
         This is useful, for example, if dataset resolution may change
@@ -525,7 +525,7 @@ class FileYAMLReader(AbstractYAMLReader):
                 self.ids[new_id] = ds_info
                 del self.ids[ds_id]
 
-    def update_ds_ids_from_files(self):
+    def add_ds_ids_from_files(self):
         """Check files for more dynamically discovered datasets."""
         for file_handlers in self.file_handlers.values():
             try:

--- a/satpy/tests/reader_tests/__init__.py
+++ b/satpy/tests/reader_tests/__init__.py
@@ -31,7 +31,7 @@ from satpy.tests.reader_tests import (test_abi_l1b, test_hrit_base,
                                       test_hdf4_utils, test_utils,
                                       test_acspo, test_amsr2_l1b,
                                       test_omps_edr, test_nucaps, test_geocat,
-                                      test_seviri_calibration)
+                                      test_seviri_calibration, test_clavrx)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -58,5 +58,6 @@ def suite():
     mysuite.addTests(test_nucaps.suite())
     mysuite.addTests(test_geocat.suite())
     mysuite.addTests(test_seviri_calibration.suite())
+    mysuite.addTests(test_clavrx.suite())
 
     return mysuite

--- a/satpy/tests/reader_tests/test_clavrx.py
+++ b/satpy/tests/reader_tests/test_clavrx.py
@@ -5,6 +5,10 @@
 
 import os
 import sys
+import numpy as np
+import xarray as xr
+from satpy.tests.reader_tests.test_hdf4_utils import FakeHDF4FileHandler
+
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -14,10 +18,6 @@ try:
     from unittest import mock
 except ImportError:
     import mock
-
-import numpy as np
-import xarray as xr
-from satpy.tests.reader_tests.test_hdf4_utils import FakeHDF4FileHandler
 
 DEFAULT_FILE_DTYPE = np.uint16
 DEFAULT_FILE_SHAPE = (10, 300)

--- a/satpy/tests/reader_tests/test_clavrx.py
+++ b/satpy/tests/reader_tests/test_clavrx.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Module for testing the satpy.readers.viirs_l1b module.
+"""
+
+import os
+import sys
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+import numpy as np
+import xarray as xr
+from satpy.tests.reader_tests.test_hdf4_utils import FakeHDF4FileHandler
+
+DEFAULT_FILE_DTYPE = np.uint16
+DEFAULT_FILE_SHAPE = (10, 300)
+DEFAULT_FILE_DATA = np.arange(DEFAULT_FILE_SHAPE[0] * DEFAULT_FILE_SHAPE[1],
+                              dtype=DEFAULT_FILE_DTYPE).reshape(DEFAULT_FILE_SHAPE)
+DEFAULT_FILE_FACTORS = np.array([2.0, 1.0], dtype=np.float32)
+DEFAULT_LAT_DATA = np.linspace(45, 65, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
+DEFAULT_LAT_DATA = np.repeat([DEFAULT_LAT_DATA], DEFAULT_FILE_SHAPE[0], axis=0)
+DEFAULT_LON_DATA = np.linspace(5, 45, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
+DEFAULT_LON_DATA = np.repeat([DEFAULT_LON_DATA], DEFAULT_FILE_SHAPE[0], axis=0)
+
+
+class FakeHDF4FileHandler2(FakeHDF4FileHandler):
+    """Swap-in HDF4 File Handler"""
+    def get_test_content(self, filename, filename_info, filetype_info):
+        """Mimic reader input file content"""
+        file_content = {
+            '/attr/platform': 'SNPP',
+            '/attr/sensor': 'VIIRS',
+        }
+
+        file_content['longitude'] = xr.DataArray(
+            DEFAULT_LON_DATA,
+            attrs={
+                '_FillValue': np.nan,
+                'scale_factor': 1.,
+                'add_offset': 0.,
+                'standard_name': 'longitude',
+            })
+        file_content['longitude/shape'] = DEFAULT_FILE_SHAPE
+
+        file_content['latitude'] = xr.DataArray(
+            DEFAULT_LON_DATA,
+            attrs={
+                '_FillValue': np.nan,
+                'scale_factor': 1.,
+                'add_offset': 0.,
+                'standard_name': 'latitude',
+            })
+        file_content['latitude/shape'] = DEFAULT_FILE_SHAPE
+
+        file_content['variable1'] = xr.DataArray(
+            DEFAULT_FILE_DATA.astype(np.float32),
+            attrs={
+                '_FillValue': -1,
+                'scale_factor': 1.,
+                'add_offset': 0.,
+                'units': '1',
+            })
+        file_content['variable1/shape'] = DEFAULT_FILE_SHAPE
+
+        # data with fill values
+        file_content['variable2'] = xr.DataArray(
+            DEFAULT_FILE_DATA.astype(np.float32),
+            attrs={
+                '_FillValue': -1,
+                'scale_factor': 1.,
+                'add_offset': 0.,
+                'units': '1',
+            })
+        file_content['variable2/shape'] = DEFAULT_FILE_SHAPE
+        file_content['variable2'] = file_content['variable2'].where(
+                                        file_content['variable2'] % 2 != 0)
+
+        # category
+        file_content['variable3'] = xr.DataArray(
+            DEFAULT_FILE_DATA.astype(np.byte),
+            attrs={
+                '_FillValue': -128,
+                'flag_meanings': 'clear water supercooled mixed ice unknown',
+                'flag_values': [0, 1, 2, 3, 4, 5],
+                'units': '1',
+            })
+        file_content['variable3/shape'] = DEFAULT_FILE_SHAPE
+
+        return file_content
+
+
+class TestCLAVRXReader(unittest.TestCase):
+    """Test CLAVR-X Reader"""
+    yaml_file = "clavrx.yaml"
+
+    def setUp(self):
+        """Wrap HDF4 file handler with our own fake handler"""
+        from satpy.config import config_search_paths
+        from satpy.readers.clavrx import CLAVRXFileHandler
+        self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
+        # http://stackoverflow.com/questions/12219967/how-to-mock-a-base-class-with-python-mock-library
+        self.p = mock.patch.object(CLAVRXFileHandler, '__bases__', (FakeHDF4FileHandler2,))
+        self.fake_handler = self.p.start()
+        self.p.is_local = True
+
+    def tearDown(self):
+        """Stop wrapping the NetCDF4 file handler"""
+        self.p.stop()
+
+    def test_init(self):
+        """Test basic init with no extra parameters."""
+        from satpy.readers import load_reader
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'clavrx_npp_d20170520_t2053581_e2055223_b28822.level2.hdf',
+        ])
+        self.assertTrue(len(loadables), 1)
+        r.create_filehandlers(loadables)
+        # make sure we have some files
+        self.assertTrue(r.file_handlers)
+
+    def test_load_all(self):
+        """Test loading all test datasets"""
+        from satpy.readers import load_reader
+        import xarray as xr
+        r = load_reader(self.reader_configs)
+        with mock.patch('satpy.readers.clavrx.SDS', xr.DataArray):
+            loadables = r.select_files_from_pathnames([
+                'clavrx_npp_d20170520_t2053581_e2055223_b28822.level2.hdf',
+            ])
+            r.create_filehandlers(loadables)
+        datasets = r.load(['variable1',
+                           'variable2',
+                           'variable3'])
+        self.assertEqual(len(datasets), 3)
+        for v in datasets.values():
+            self.assertIs(v.attrs['calibration'], None)
+            self.assertEqual(v.attrs['units'], '1')
+        self.assertIsNotNone(datasets['variable3'].attrs.get('flag_meanings'))
+
+
+def suite():
+    """The test suite for test_viirs_l1b.
+    """
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(TestCLAVRXReader))
+
+    return mysuite

--- a/satpy/tests/reader_tests/test_hdf4_utils.py
+++ b/satpy/tests/reader_tests/test_hdf4_utils.py
@@ -6,18 +6,19 @@
 import os
 import sys
 import numpy as np
-from satpy.readers.netcdf_utils import NetCDF4FileHandler
+import xarray as xr
+from satpy.readers.hdf4_utils import HDF4FileHandler
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
 
 
-class FakeNetCDF4FileHandler(NetCDF4FileHandler):
+class FakeHDF4FileHandler(HDF4FileHandler):
     """Swap-in NetCDF4 File Handler for reader tests to use"""
     def __init__(self, filename, filename_info, filetype_info, **kwargs):
         """Get fake file content from 'get_test_content'"""
-        super(NetCDF4FileHandler, self).__init__(filename, filename_info, filetype_info)
+        super(HDF4FileHandler, self).__init__(filename, filename_info, filetype_info)
         self.file_content = self.get_test_content(filename, filename_info, filetype_info)
         self.file_content.update(kwargs)
 
@@ -35,7 +36,6 @@ class FakeNetCDF4FileHandler(NetCDF4FileHandler):
             - '/attr/global_attr'
             - 'dataset/attr/global_attr'
             - 'dataset/shape'
-            - '/dimension/my_dim'
 
         """
         raise NotImplementedError("Fake File Handler subclass must implement 'get_test_content'")
@@ -43,6 +43,7 @@ class FakeNetCDF4FileHandler(NetCDF4FileHandler):
 
 class TestHDF4FileHandler(unittest.TestCase):
     """Test HDF4 File Handler Utility class"""
+
     def setUp(self):
         """Create a test HDF4 file"""
         from pyhdf.SD import SD, SDC
@@ -72,22 +73,22 @@ class TestHDF4FileHandler(unittest.TestCase):
     def test_all_basic(self):
         """Test everything about the HDF4 class"""
         from satpy.readers.hdf4_utils import HDF4FileHandler
-        from pyhdf.SD import SDC
         file_handler = HDF4FileHandler('test.hdf', {}, {})
 
         for ds in ('ds1_f', 'ds1_i'):
             self.assertEqual(file_handler[ds + '/dtype'], np.float32 if ds.endswith('f') else np.int16)
             self.assertTupleEqual(file_handler[ds + '/shape'], (10, 100))
-            self.assertEqual(file_handler[ds + '/attr/test_attr_str'], 'test_string')
-            self.assertEqual(file_handler[ds + '/attr/test_attr_int'], 0)
-            self.assertEqual(file_handler[ds + '/attr/test_attr_float'], 1.2)
+            attrs = file_handler[ds].attrs
+            self.assertEqual(attrs.get('test_attr_str'), 'test_string')
+            self.assertEqual(attrs.get('test_attr_int'), 0)
+            self.assertEqual(attrs.get('test_attr_float'), 1.2)
 
         self.assertEqual(file_handler['/attr/test_attr_str'], 'test_string')
         # self.assertEqual(file_handler['/attr/test_attr_str_arr'], 'test_string2')
         self.assertEqual(file_handler['/attr/test_attr_int'], 0)
         self.assertEqual(file_handler['/attr/test_attr_float'], 1.2)
 
-        self.assertIsInstance(file_handler.get('ds1_f')[:], np.ndarray)
+        self.assertIsInstance(file_handler.get('ds1_f'), xr.DataArray)
         self.assertIsNone(file_handler.get('fake_ds'))
         self.assertEqual(file_handler.get('fake_ds', 'test'), 'test')
 

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -28,7 +28,8 @@ from datetime import datetime
 from tempfile import mkdtemp
 
 import satpy.readers.yaml_reader as yr
-from satpy.dataset import DATASET_KEYS, DatasetID
+from satpy.readers.file_handlers import BaseFileHandler
+from satpy.dataset import DatasetID
 
 try:
     from unittest.mock import MagicMock, patch
@@ -36,16 +37,25 @@ except ImportError:
     from mock import MagicMock, patch
 
 
-class FakeFH(object):
+class FakeFH(BaseFileHandler):
 
     def __init__(self, start_time, end_time):
-        self.start_time = start_time
-        self.end_time = end_time
+        super(FakeFH, self).__init__("", {}, {})
+        self._start_time = start_time
+        self._end_time = end_time
         self.get_bounding_box = MagicMock()
         fake_ds = MagicMock()
         fake_ds.return_value.dims = ['x', 'y']
         self.get_dataset = fake_ds
         self.combine_info = MagicMock()
+
+    @property
+    def start_time(self):
+        return self._start_time
+
+    @property
+    def end_time(self):
+        return self._end_time
 
 
 class TestUtils(unittest.TestCase):
@@ -93,14 +103,24 @@ class TestUtils(unittest.TestCase):
                          ['some', 'string'])
 
 
-class DummyReader():
+class DummyReader(BaseFileHandler):
     def __init__(self, filename, filename_info, filetype_info):
+        super(DummyReader, self).__init__(
+            filename, filename_info, filetype_info)
         self.filename = filename
         self.filename_info = filename_info
         self.filetype_info = filetype_info
-        self.start_time = datetime(2000, 1, 1, 12, 1)
-        self.end_time = datetime(2000, 1, 1, 12, 2)
+        self._start_time = datetime(2000, 1, 1, 12, 1)
+        self._end_time = datetime(2000, 1, 1, 12, 2)
         self.metadata = {}
+
+    @property
+    def start_time(self):
+        return self._start_time
+
+    @property
+    def end_time(self):
+        return self._end_time
 
 
 class TestFileFileYAMLReaderMultiplePatterns(unittest.TestCase):


### PR DESCRIPTION
I was working on adding another reader when I realized my clavrx reader hadn't been converted to use xarray yet. This PR does that. This PR also includes adding the functionality needed to dynamically define datasets in file handlers, this is the main reason I would like @mraspaud and @adybbroe to review this PR. @sjoro may also be interested in the `available_datasets` functionality.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->