### PR TITLE
Add GRIB Reader

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,16 +10,8 @@ Satpy
 .. image:: https://coveralls.io/repos/github/pytroll/satpy/badge.svg?branch=develop
     :target: https://coveralls.io/github/pytroll/satpy?branch=develop
 
-.. image:: https://landscape.io/github/pytroll/satpy/develop/landscape.svg?style=flat
-    :target: https://landscape.io/github/pytroll/satpy/develop
-    :alt: Code Health
-
 .. image:: https://badge.fury.io/py/satpy.svg
     :target: https://badge.fury.io/py/satpy
-
-.. image:: https://www.quantifiedcode.com/api/v1/project/87e41e5e8fa045dba2cb4912df5c4fad/snapshot/origin:develop:HEAD/badge.svg
-    :target: https://www.quantifiedcode.com/app/project/87e41e5e8fa045dba2cb4912df5c4fad
-    :alt: Code issues
 
 
 The SatPy package is a python library for reading and manipulating

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -139,6 +139,9 @@ installation.
     * - AAPP MAIA VIIRS and AVHRR products in hdf5 format
       - `maia`
       - Nominal
+    * - GRIB2 format
+      - `grib`
+      - Beta
 
 Indices and tables
 ==================

--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -89,9 +89,9 @@ def combine_metadata(*metadata_objects):
 
 
 DATASET_KEYS = ("name", "wavelength", "resolution", "polarization",
-                "calibration", "modifiers")
+                "calibration", "level", "modifiers")
 DatasetID = namedtuple("DatasetID", " ".join(DATASET_KEYS))
-DatasetID.__new__.__defaults__ = (None, None, None, None, None, tuple())
+DatasetID.__new__.__defaults__ = (None, None, None, None, None, None, tuple())
 
 
 class DatasetID(DatasetID):
@@ -129,6 +129,9 @@ class DatasetID(DatasetID):
         calibration (str): String identifying the calibration level of the
                            Dataset (ex. 'radiance', 'reflectance', etc).
                            `None` if not applicable.
+        level (int, float): Pressure/altitude level of the dataset. This is
+                            typically in hPa, but may be in inverse meters
+                            for altitude datasets (1/meters).
         modifiers (tuple): Tuple of strings identifying what corrections or
                            other modifications have been performed on this
                            Dataset (ex. 'sunz_corrected', 'rayleigh_corrected',

--- a/satpy/etc/readers/grib.yaml
+++ b/satpy/etc/readers/grib.yaml
@@ -1,0 +1,16 @@
+reader:
+  description: GRIB2 file reader
+  name: grib
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
+  sensors: [_generic_]
+
+file_types:
+  grib:
+    file_reader: !!python/name:satpy.readers.grib.GRIBFileHandler
+    file_patterns:
+     # NOAA NCEP:
+     # gfs.t18z.sfluxgrbf106.grib2
+     - '{stem}.grib2'
+     # EUMETSAT:
+     # S-OSI_-NOR_-MULT-AHLDLI_FIELD-201805011200Z.grb.gz
+     - '{stem}.grb'

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -103,6 +103,12 @@ def get_best_dataset_key(key, choices):
         if low_res:
             low_res = min(low_res)
             choices = [c for c in choices if c.resolution == low_res]
+    if key.level is None and choices:
+        low_level = [x.level for x in choices if x.level]
+        if low_level:
+            low_level = max(low_level)
+            choices = [c for c in choices if c.level == low_level]
+
     return choices
 
 
@@ -140,7 +146,7 @@ def filter_keys_by_dataset_id(did, key_container):
 
 def get_key(key, key_container, num_results=1, best=True,
             resolution=None, calibration=None, polarization=None,
-            modifiers=None):
+            level=None, modifiers=None):
     """Get the fully-specified key best matching the provided key.
 
     Only the best match is returned if `best` is `True` (default). See
@@ -173,6 +179,8 @@ def get_key(key, key_container, num_results=1, best=True,
         polarization (str or list): Dataset polarization
                                    (ex.'V'). This can also be a
                                     list of these strings.
+        level (number or list): Dataset level (ex. 100). This can also be a
+                                list of these numbers.
         modifiers (list): Modifiers applied to the dataset. Unlike
                           resolution and calibration this is the exact
                           desired list of modifiers for one dataset, not
@@ -212,6 +220,11 @@ def get_key(key, key_container, num_results=1, best=True,
             calibration = (calibration, )
         res = [k for k in res
                if k.calibration is not None and k.calibration in calibration]
+    if level is not None:
+        if not isinstance(level, (list, tuple)):
+            level = (level, )
+        res = [k for k in res
+               if k.level is not None and k.level in level]
     if modifiers is not None:
         res = [k for k in res
                if k.modifiers is not None and k.modifiers == modifiers]
@@ -312,6 +325,7 @@ class DatasetDict(dict):
                                 wavelength=d.get("wavelength"),
                                 polarization=d.get("polarization"),
                                 calibration=d.get("calibration"),
+                                level=d.get("level"),
                                 modifiers=d.get("modifiers", tuple()))
                 if key.name is None and key.wavelength is None:
                     raise ValueError("One of 'name' or 'wavelength' attrs "
@@ -324,6 +338,7 @@ class DatasetDict(dict):
             d["resolution"] = key.resolution
             d["calibration"] = key.calibration
             d["polarization"] = key.polarization
+            d["level"] = key.level
             d["modifiers"] = key.modifiers
             # you can't change the wavelength of a dataset, that doesn't make
             # sense

--- a/satpy/readers/grib.py
+++ b/satpy/readers/grib.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2017.
+#
+# Author(s):
+#
+#   David Hoese <david.hoese@ssec.wisc.edu>
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Generic Reader for GRIB2 files.
+
+Currently this reader depends on the `pygrib` python package. The `eccodes`
+package from ECMWF is preferred, but does not support python 3 at the time
+of writing.
+
+"""
+import logging
+import numpy as np
+import xarray as xr
+import dask.array as da
+from pyproj import Proj
+from pyresample import geometry
+from datetime import datetime
+
+from satpy import DatasetID, CHUNK_SIZE
+from satpy.readers.file_handlers import BaseFileHandler
+import pygrib
+
+LOG = logging.getLogger(__name__)
+
+
+CF_UNITS = {
+    'none': '1',
+}
+
+
+class GRIBFileHandler(BaseFileHandler):
+
+    def __init__(self, filename, filename_info, filetype_info):
+        super(GRIBFileHandler, self).__init__(filename, filename_info, filetype_info)
+
+        self._msg_datasets = {}
+        self._start_time = None
+        self._end_time = None
+        try:
+            with pygrib.open(filename) as grib_file:
+                for idx, msg in enumerate(grib_file):
+                    # FIXME: Add a 'level' field to DatasetID
+                    name = "{}_{:d}".format(msg['shortName'], msg['level'])
+                    msg_id = DatasetID(name=name)
+                    start_time = datetime.strptime(
+                        msg['dataDate'] + msg['dataTime'],
+                        '%Y%m%d%H%M')
+                    ds_info = {
+                        'message': idx,
+                        'name': name,
+                        'long_name': msg['name'],
+                        'level': msg['level'],
+                        'pressureUnits': msg['pressureUnits'],
+                        'standard_name': msg['cfName'],
+                        'units': msg['units'],
+                        'start_time': start_time,
+                        'end_time': start_time,
+                        'file_type': self.filetype_info['file_type'],
+                    }
+                    self._msg_datasets[msg_id] = ds_info
+
+                    if self._start_time is None:
+                        self._start_time = start_time
+                    if idx == grib_file.messages - 1:
+                        self._end_time = start_time
+        except (RuntimeError, KeyError):
+            raise IOError("Unknown GRIB file format: {}".format(filename))
+
+    @property
+    def start_time(self):
+        """Get start time of this entire file.
+
+        Assumes the first message is the earliest message.
+
+        """
+        return self._start_time
+
+    @property
+    def end_time(self):
+        """Get end time of this entire file.
+
+        Assumes the last message is the latest message.
+
+        """
+        return self._end_time
+
+    def available_datasets(self):
+        """Automatically determine datasets provided by this file"""
+        return self._msg_datasets.items()
+
+    def _area_def_from_msg(self, msg):
+        proj_params = msg.projparams.copy()
+        if proj_params['proj'] == 'cyl':
+            proj_params['proj'] = 'eqc'
+            proj = Proj(**proj_params)
+            lons = msg['distinctLongitudes']
+            lats = msg['distinctLatitudes']
+            min_lon = lons[0]
+            max_lon = lons[1]
+            min_lat = lats[0]
+            max_lat = lats[1]
+            shape = (lats.shape[0], lons.shape[0])
+            min_x, min_y = proj(min_lon, min_lat)
+            max_x, max_y = proj(max_lon, max_lat)
+            pixel_size_x = (max_x - min_x) / (shape[1] - 1)
+            pixel_size_y = (max_y - min_y) / (shape[0] - 1)
+            extents = (
+                min_x - pixel_size_x / 2.,
+                min_y - pixel_size_y / 2.,
+                max_x + pixel_size_x / 2.,
+                max_y + pixel_size_y / 2.,
+            )
+        else:
+            lats, lons = msg.latlons()
+            shape = lats.shape
+            proj = Proj(**proj_params)
+            min_x, min_y = proj(lons[-1, 0], lats[-1, 0])
+            max_x, max_y = proj(lons[0, -1], lats[0, -1])
+            extents = (min_x, min_y, max_x, max_y)
+
+        return geometry.AreaDefinition(
+            'on-the-fly grib area',
+            'on-the-fly grib area',
+            'on-the-fly grib area',
+            proj_params,
+            shape[1],
+            shape[0],
+            extents,
+        )
+
+    def get_area_def(self, dsid):
+        """Get area definition for message.
+
+        If latlong grid then convert to valid eqc grid.
+
+        """
+        msg_num = self._msg_datasets[dsid]['message']
+        with pygrib.open(self.filename) as grib_file:
+            msg = grib_file.message(msg_num)
+            try:
+                return self._area_def_from_msg(msg)
+            except (RuntimeError, KeyError):
+                raise RuntimeError("Unknown GRIB projection information")
+
+    def get_dataset(self, dataset_id, ds_info):
+        """Read a GRIB message into an xarray DataArray."""
+        msg_num = self._msg_datasets[dataset_id]['message']
+        with pygrib.open(self.filename) as grib_file:
+            msg = grib_file.message(msg_num)
+            fill = msg['missingValue']
+            data = msg.values
+
+        if isinstance(data, np.ma.MaskedArray):
+            data = data.filled(np.nan)
+            data = da.from_array(data, chunks=CHUNK_SIZE)
+        else:
+            data[data == fill] = np.nan
+            data = da.from_array(data, chunks=CHUNK_SIZE)
+
+        return xr.DataArray(data, attrs=ds_info, dims=('y', 'x'))

--- a/satpy/readers/grib.py
+++ b/satpy/readers/grib.py
@@ -57,15 +57,15 @@ class GRIBFileHandler(BaseFileHandler):
         try:
             with pygrib.open(filename) as grib_file:
                 for idx, msg in enumerate(grib_file):
-                    # FIXME: Add a 'level' field to DatasetID
-                    name = "{}_{:d}".format(msg['shortName'], msg['level'])
-                    msg_id = DatasetID(name=name)
+                    msg_id = DatasetID(name=msg['shortName'],
+                                       level=msg['level'])
                     start_time = datetime.strptime(
                         msg['dataDate'] + msg['dataTime'],
                         '%Y%m%d%H%M')
                     ds_info = {
                         'message': idx,
-                        'name': name,
+                        'filename': self.filename,
+                        'name': msg['shortName'],
                         'long_name': msg['name'],
                         'level': msg['level'],
                         'pressureUnits': msg['pressureUnits'],

--- a/satpy/tests/reader_tests/__init__.py
+++ b/satpy/tests/reader_tests/__init__.py
@@ -31,7 +31,8 @@ from satpy.tests.reader_tests import (test_abi_l1b, test_hrit_base,
                                       test_hdf4_utils, test_utils,
                                       test_acspo, test_amsr2_l1b,
                                       test_omps_edr, test_nucaps, test_geocat,
-                                      test_seviri_calibration, test_clavrx)
+                                      test_seviri_calibration, test_clavrx,
+                                      test_grib)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -59,5 +60,6 @@ def suite():
     mysuite.addTests(test_geocat.suite())
     mysuite.addTests(test_seviri_calibration.suite())
     mysuite.addTests(test_clavrx.suite())
+    mysuite.addTests(test_grib.suite())
 
     return mysuite

--- a/satpy/tests/reader_tests/test_clavrx.py
+++ b/satpy/tests/reader_tests/test_clavrx.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Module for testing the satpy.readers.viirs_l1b module.
+"""Module for testing the satpy.readers.clavrx module.
 """
 
 import os

--- a/satpy/tests/reader_tests/test_geocat.py
+++ b/satpy/tests/reader_tests/test_geocat.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Module for testing the satpy.readers.viirs_l1b module.
+"""Module for testing the satpy.readers.geocat module.
 """
 
 import os

--- a/satpy/tests/reader_tests/test_grib.py
+++ b/satpy/tests/reader_tests/test_grib.py
@@ -129,7 +129,6 @@ class TestGRIBReader(unittest.TestCase):
         """Test loading all test datasets"""
         pg.open.return_value = FakeGRIB()
         from satpy.readers import load_reader
-        import xarray as xr
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
             'gfs.t18z.sfluxgrbf106.grib2',

--- a/satpy/tests/reader_tests/test_grib.py
+++ b/satpy/tests/reader_tests/test_grib.py
@@ -140,12 +140,16 @@ class TestGRIBReader(unittest.TestCase):
         """Test loading all test datasets"""
         pg.open.return_value = FakeGRIB()
         from satpy.readers import load_reader
+        from satpy import DatasetID
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
             'gfs.t18z.sfluxgrbf106.grib2',
         ])
         r.create_filehandlers(loadables)
-        datasets = r.load(['t_100', 't_200', 't_300'])
+        datasets = r.load([
+            DatasetID(name='t', level=100),
+            DatasetID(name='t', level=200),
+            DatasetID(name='t', level=300)])
         self.assertEqual(len(datasets), 3)
         for v in datasets.values():
             self.assertEqual(v.attrs['units'], 'K')

--- a/satpy/tests/reader_tests/test_grib.py
+++ b/satpy/tests/reader_tests/test_grib.py
@@ -110,6 +110,17 @@ class TestGRIBReader(unittest.TestCase):
         from satpy.config import config_search_paths
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
 
+        try:
+            import pygrib
+        except ImportError:
+            pygrib = None
+        self.orig_pygrib = pygrib
+        sys.modules['pygrib'] = mock.MagicMock()
+
+    def tearDown(self):
+        """Re-enable pygrib import."""
+        sys.modules['pygrib'] = self.orig_pygrib
+
     @mock.patch('satpy.readers.grib.pygrib')
     def test_init(self, pg):
         """Test basic init with no extra parameters."""

--- a/satpy/tests/reader_tests/test_grib.py
+++ b/satpy/tests/reader_tests/test_grib.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""Module for testing the satpy.readers.grib module.
+"""
+
+import os
+import sys
+import numpy as np
+import xarray as xr
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+class FakeMessage(object):
+    """Fake message returned by pygrib.open().message(x)."""
+
+    def __init__(self, values, proj_params=None, **attrs):
+        super(FakeMessage, self).__init__()
+        self.attrs = attrs
+        self.values = values
+        if proj_params is None:
+            proj_params = {'a': 6371229, 'b': 6371229, 'proj': 'cyl'}
+        self.projparams = proj_params
+
+    def __getitem__(self, item):
+        return self.attrs[item]
+
+
+class FakeGRIB(object):
+    """Fake GRIB file returned by pygrib.open."""
+
+    def __init__(self, messages=None):
+        super(FakeGRIB, self).__init__()
+        if messages is not None:
+            self._messages = messages
+        else:
+            self._messages = [
+                FakeMessage(
+                    values=np.arange(25.).reshape((5, 5)),
+                    name='TEST',
+                    shortName='t',
+                    level=100,
+                    pressureUnits='hPa',
+                    cfName='air_temperature',
+                    units='K',
+                    dataDate='20180504',
+                    dataTime='1200',
+                    distinctLongitudes=np.arange(5.),
+                    distinctLatitudes=np.arange(5.),
+                    missingValue=9999,
+                ),
+                FakeMessage(
+                    values=np.arange(25.).reshape((5, 5)),
+                    name='TEST',
+                    shortName='t',
+                    level=200,
+                    pressureUnits='hPa',
+                    cfName='air_temperature',
+                    units='K',
+                    dataDate='20180504',
+                    dataTime='1200',
+                    distinctLongitudes=np.arange(5.),
+                    distinctLatitudes=np.arange(5.),
+                    missingValue=9999,
+                ),
+                FakeMessage(
+                    values=np.arange(25.).reshape((5, 5)),
+                    name='TEST',
+                    shortName='t',
+                    level=300,
+                    pressureUnits='hPa',
+                    cfName='air_temperature',
+                    units='K',
+                    dataDate='20180504',
+                    dataTime='1200',
+                    distinctLongitudes=np.arange(5.),
+                    distinctLatitudes=np.arange(5.),
+                    missingValue=9999,
+                ),
+            ]
+        self.messages = len(self._messages)
+
+    def message(self, msg_num):
+        return self._messages[msg_num - 1]
+
+    def __iter__(self):
+        return iter(self._messages)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
+
+
+class TestGRIBReader(unittest.TestCase):
+    """Test GRIB Reader"""
+    yaml_file = "grib.yaml"
+
+    def setUp(self):
+        """Wrap pygrib to read fake data"""
+        from satpy.config import config_search_paths
+        self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
+
+    @mock.patch('satpy.readers.grib.pygrib')
+    def test_init(self, pg):
+        """Test basic init with no extra parameters."""
+        pg.open.return_value = FakeGRIB()
+        from satpy.readers import load_reader
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'gfs.t18z.sfluxgrbf106.grib2',
+        ])
+        self.assertTrue(len(loadables), 1)
+        r.create_filehandlers(loadables)
+        # make sure we have some files
+        self.assertTrue(r.file_handlers)
+
+    @mock.patch('satpy.readers.grib.pygrib')
+    def test_load_all(self, pg):
+        """Test loading all test datasets"""
+        pg.open.return_value = FakeGRIB()
+        from satpy.readers import load_reader
+        import xarray as xr
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'gfs.t18z.sfluxgrbf106.grib2',
+        ])
+        r.create_filehandlers(loadables)
+        datasets = r.load(['t_100', 't_200', 't_300'])
+        self.assertEqual(len(datasets), 3)
+        for v in datasets.values():
+            self.assertEqual(v.attrs['units'], 'K')
+            self.assertIsInstance(v, xr.DataArray)
+
+
+def suite():
+    """The test suite for test_viirs_l1b.
+    """
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(TestGRIBReader))
+
+    return mysuite

--- a/satpy/tests/reader_tests/test_hdf4_utils.py
+++ b/satpy/tests/reader_tests/test_hdf4_utils.py
@@ -7,7 +7,13 @@ import os
 import sys
 import numpy as np
 import xarray as xr
-from satpy.readers.hdf4_utils import HDF4FileHandler
+
+try:
+    from satpy.readers.hdf4_utils import HDF4FileHandler
+except ImportError:
+    # fake the import so we can at least run the tests in this file
+    HDF4FileHandler = None
+
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -16,8 +22,12 @@ else:
 
 class FakeHDF4FileHandler(HDF4FileHandler):
     """Swap-in NetCDF4 File Handler for reader tests to use"""
+
     def __init__(self, filename, filename_info, filetype_info, **kwargs):
         """Get fake file content from 'get_test_content'"""
+        if HDF4FileHandler is object:
+            raise ImportError("Base 'HDF4FileHandler' could not be "
+                              "imported.")
         super(HDF4FileHandler, self).__init__(filename, filename_info, filetype_info)
         self.file_content = self.get_test_content(filename, filename_info, filetype_info)
         self.file_content.update(kwargs)

--- a/satpy/tests/reader_tests/test_hdf5_utils.py
+++ b/satpy/tests/reader_tests/test_hdf5_utils.py
@@ -6,7 +6,13 @@
 import os
 import sys
 import numpy as np
-from satpy.readers.hdf5_utils import HDF5FileHandler
+
+try:
+    from satpy.readers.hdf5_utils import HDF5FileHandler
+except ImportError:
+    # fake the import so we can at least run the tests in this file
+    HDF5FileHandler = object
+
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -15,8 +21,12 @@ else:
 
 class FakeHDF5FileHandler(HDF5FileHandler):
     """Swap-in HDF5 File Handler for reader tests to use"""
+
     def __init__(self, filename, filename_info, filetype_info, **kwargs):
         """Get fake file content from 'get_test_content'"""
+        if HDF5FileHandler is object:
+            raise ImportError("Base 'HDF5FileHandler' could not be "
+                              "imported.")
         super(HDF5FileHandler, self).__init__(filename, filename_info, filetype_info)
         self.file_content = self.get_test_content(filename, filename_info, filetype_info)
         self.file_content.update(kwargs)

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -6,7 +6,13 @@
 import os
 import sys
 import numpy as np
-from satpy.readers.netcdf_utils import NetCDF4FileHandler
+
+try:
+    from satpy.readers.netcdf_utils import NetCDF4FileHandler
+except ImportError:
+    # fake the import so we can at least run the tests in this file
+    NetCDF4FileHandler = object
+
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -15,8 +21,12 @@ else:
 
 class FakeNetCDF4FileHandler(NetCDF4FileHandler):
     """Swap-in NetCDF4 File Handler for reader tests to use"""
+
     def __init__(self, filename, filename_info, filetype_info, **kwargs):
         """Get fake file content from 'get_test_content'"""
+        if NetCDF4FileHandler is object:
+            raise ImportError("Base 'NetCDF4FileHandler' could not be "
+                              "imported.")
         super(NetCDF4FileHandler, self).__init__(filename, filename_info, filetype_info)
         self.file_content = self.get_test_content(filename, filename_info, filetype_info)
         self.file_content.update(kwargs)

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -65,6 +65,8 @@ class TestDatasetDict(unittest.TestCase):
                       modifiers=('mod1', 'mod2')): "5_2mod",
             DatasetID(name="test5",
                       modifiers=('mod2',)): "5_1mod",
+            DatasetID(name='test6', level=100): '6_100',
+            DatasetID(name='test6', level=200): '6_200',
         }
         self.test_dict = DatasetDict(regular_dict)
 
@@ -94,10 +96,15 @@ class TestDatasetDict(unittest.TestCase):
         self.assertEqual(d[1.55], "2")
         # access by near wavelength of another dataset
         self.assertEqual(d[1.65], "3")
+        # access by name with multiple levels
+        self.assertEqual(d['test6'], '6_200')
 
         self.assertEqual(d[DatasetID(wavelength=1.5)], "2")
         self.assertEqual(d[DatasetID(wavelength=0.5, resolution=1000)], "1")
         self.assertEqual(d[DatasetID(wavelength=0.5, resolution=500)], "1h")
+        self.assertEqual(d[DatasetID(name='test6', level=100)], '6_100')
+        self.assertEqual(d[DatasetID(name='test6', level=200)], '6_200')
+
         # higher resolution is returned
         self.assertEqual(d[0.5], "1h")
         self.assertEqual(d['test4'], '4refl')
@@ -129,6 +136,10 @@ class TestDatasetDict(unittest.TestCase):
         self.assertEqual(res1, DatasetID(name='testh',
                                          wavelength=(0, 0.5, 1),
                                          resolution=500))
+
+        res1 = get_key('test6', d, level=100)
+        self.assertEqual(res1, DatasetID(name='test6',
+                                         level=100))
 
         res1 = get_key('test5', d)
         res2 = get_key('test5', d, modifiers=('mod2',))

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ requires = ['numpy >=1.4.1', 'pillow', 'pyresample >=1.9.1', 'trollsift',
             'trollimage >=1.5.1', 'pykdtree', 'six', 'pyyaml', 'xarray >=0.10.1',
             'dask[array] >=0.17.1']
 
-test_requires = ['behave', 'h5py', 'netCDF4', 'python-hdf4']
+# pyhdf (conda) == python-hdf4 (pip)
+test_requires = ['behave', 'h5py', 'netCDF4', 'pyhdf']
 
 if sys.version < '3.0':
     test_requires.append('mock')

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ requires = ['numpy >=1.4.1', 'pillow', 'pyresample >=1.9.1', 'trollsift',
             'trollimage >=1.5.1', 'pykdtree', 'six', 'pyyaml', 'xarray >=0.10.1',
             'dask[array] >=0.17.1']
 
-test_requires = ['behave']
+test_requires = ['behave', 'h5py', 'netCDF4', 'python-hdf4']
 
 if sys.version < '3.0':
     test_requires.append('mock')


### PR DESCRIPTION
This adds a very basic/limited GRIB2 reader using pygrib. Once ecCodes from ECMWF is python 3 compatible I will switch to using that. I currently need this for NCEP GFS GRIB files.

TODO:

 - [x] Add 'level' key to DatasetID (see #279) to support pressure levels.
 - [x] Closes #279  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
