### PR TITLE
Fix native_msg calibration bug

### DIFF
--- a/satpy/readers/native_msg.py
+++ b/satpy/readers/native_msg.py
@@ -323,7 +323,6 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
             dataset = None
         else:
             dataset = self.calibrate(xarr, dataset_id)
-            dataset = xarr
             dataset.attrs['units'] = info['units']
             dataset.attrs['wavelength'] = info['wavelength']
             dataset.attrs['standard_name'] = info['standard_name']

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -38,6 +38,7 @@ from satpy.resample import (resample_dataset, get_frozen_area,
 from satpy.writers import load_writer
 from pyresample.geometry import AreaDefinition
 from xarray import DataArray
+import numpy as np
 
 try:
     import configparser
@@ -708,11 +709,11 @@ class Scene(MetadataObject):
                 dataset.data = dataset.data.rechunk(1024)
                 dataset = dataset.isel(x=slice_x, y=slice_y)
                 dataset.attrs['area'] = source_area
-            except NotImplementedError:
+            except (NotImplementedError, np.ma.MaskError):
                 LOG.info("Not reducing data before resampling.")
             if source_area not in resamplers:
                 key, resampler = prepare_resampler(
-                        source_area, destination_area, **resample_kwargs)
+                    source_area, destination_area, **resample_kwargs)
                 resamplers[source_area] = resampler
                 self.resamplers[key] = resampler
             kwargs = resample_kwargs.copy()

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -38,7 +38,6 @@ from satpy.resample import (resample_dataset, get_frozen_area,
 from satpy.writers import load_writer
 from pyresample.geometry import AreaDefinition
 from xarray import DataArray
-import numpy as np
 
 try:
     import configparser
@@ -709,7 +708,7 @@ class Scene(MetadataObject):
                 dataset.data = dataset.data.rechunk(1024)
                 dataset = dataset.isel(x=slice_x, y=slice_y)
                 dataset.attrs['area'] = source_area
-            except (NotImplementedError, np.ma.MaskError):
+            except NotImplementedError:
                 LOG.info("Not reducing data before resampling.")
             if source_area not in resamplers:
                 key, resampler = prepare_resampler(


### PR DESCRIPTION
Fix a bug in `get_dataset`-method in `native_msg.py`. Calibrated dataset values were accidentally set back to counts.

 - [ x] Passes ``git diff origin/develop **/*py | flake8 --diff``
