### PR TITLE
Fix hrit-goes reader

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -244,7 +244,7 @@ class KDTreeResampler(BaseResampler):
         del kwargs
         LOG.debug("Resampling " + str(data.name))
         if fill_value is None:
-            fill_value = data.attrs.get('_FillValue')
+            fill_value = data.attrs.get('_FillValue', np.nan)
         res = self.resampler.get_sample_from_neighbour_info(data, fill_value)
         return res
 


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
The hrit goes reader is now calibrating and masking data correctly

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
