### PR TITLE
Fix so UMARF files (with extention .nat) are found as well

### DIFF
--- a/satpy/etc/readers/avhrr_eps_l1b.yaml
+++ b/satpy/etc/readers/avhrr_eps_l1b.yaml
@@ -130,4 +130,6 @@ datasets:
 file_types:
     avhrr_eps:
         file_reader: !!python/name:satpy.readers.eps_l1b.EPSAVHRRFile ''
-        file_patterns: ['AVHR_xxx_1B_{platform_short_name}_{start_time:%Y%m%d%H%M%SZ}_{end_time:%Y%m%d%H%M%SZ}_N_O_{creation_time:%Y%m%d%H%M%SZ}']
+        file_patterns: [
+                       'AVHR_xxx_1B_{platform_short_name}_{start_time:%Y%m%d%H%M%SZ}_{end_time:%Y%m%d%H%M%SZ}_N_O_{creation_time:%Y%m%d%H%M%SZ}',
+                       'AVHR_xxx_1B_{platform_short_name}_{start_time:%Y%m%d%H%M%SZ}_{end_time:%Y%m%d%H%M%SZ}_N_O_{creation_time:%Y%m%d%H%M%SZ}.nat']


### PR DESCRIPTION
Signed-off-by: Adam.Dybbroe <adam.dybbroe@smhi.se>

Also locates the global Metop GDS .nat files that are retrieved from UMARF

 - [x] Tests passed
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` 