### PR TITLE
Fix unicode-named data loading

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -35,9 +35,9 @@ from satpy.dataset import DATASET_KEYS, DatasetID
 from satpy import CALIBRATION_ORDER
 
 try:
-    import configparser
+    import configparser  # noqa
 except ImportError:
-    from six.moves import configparser
+    from six.moves import configparser  # noqa
 
 LOG = logging.getLogger(__name__)
 
@@ -197,7 +197,7 @@ def get_key(key, key_container, num_results=1, best=True,
         # we want this ID to act as a query so we set modifiers to None
         # meaning "we don't care how many modifiers it has".
         key = DatasetID(wavelength=key, modifiers=None)
-    elif isinstance(key, str):
+    elif isinstance(key, (str, six.text_type)):
         # ID should act as a query (see wl comment above)
         key = DatasetID(name=key, modifiers=None)
 


### PR DESCRIPTION
<!-- Please make the PR against the `develop` branch. -->

<!-- Describe what your PR does, and why -->

Dataset loading was failing in python 2 if the query was done by name with a unicode name.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
