### PR TITLE
Allow datasets without areas to be concatenated

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -297,7 +297,9 @@ class CompositeBase(MetadataObject):
             raise IncompatibleAreas("Y dimension has different sizes")
 
         areas = [ds.attrs.get('area') for ds in data_arrays]
-        if not areas or any(a is None for a in areas):
+        if all(a is None for a in areas):
+            return data_arrays
+        elif any(a is None for a in areas):
             raise ValueError("Missing 'area' attribute")
 
         if not all(areas[0] == x for x in areas[1:]):


### PR DESCRIPTION
<!-- Please make the PR against the `develop` branch. -->

<!-- Describe what your PR does, and why -->
Allow arealess datasets to be combined into composites (fixing `check_areas`)

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
