### PR TITLE
Switch to netcdf4 as engine for nc nwcsaf reading

### DIFF
--- a/satpy/readers/nc_nwcsaf.py
+++ b/satpy/readers/nc_nwcsaf.py
@@ -73,7 +73,6 @@ class NcNWCSAF(BaseFileHandler):
         self.nc = xr.open_dataset(filename,
                                   decode_cf=True,
                                   mask_and_scale=False,
-                                  engine='h5netcdf',
                                   chunks=CHUNK_SIZE)
 
         self.nc = self.nc.rename({'nx': 'x', 'ny': 'y'})

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ extras_require = {
     'pyspectral': ['pyspectral >= 0.7.0'],
     'pyorbital': ['pyorbital >= 1.3.1'],
     'hrit_msg': ['pytroll-schedule'],
-    'nc_nwcsaf_msg': ['h5netcdf'],
+    'nc_nwcsaf_msg': ['netCDF4 >= 1.1.8'],
     'sar_c': ['python-geotiepoints', 'gdal'],
     'abi_l1b': ['h5netcdf'],
     # Writers:


### PR DESCRIPTION
<!-- Please make the PR against the `develop` branch. -->

<!-- Describe what your PR does, and why -->
Switch to netcdf4 as engine for nc nwcsaf reading as h5netcdf sometimes has trouble reading the files.

 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
