### PR TITLE
Fix MODIS file handler not being able to assign to resolution property

### DIFF
--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -129,11 +129,6 @@ class BaseFileHandler(six.with_metaclass(ABCMeta, object)):
         """List of sensors represented in this file."""
         raise NotImplementedError
 
-    @property
-    def resolution(self):
-        """Scalar of resolution for all datasets in this file."""
-        raise NotImplementedError
-
     def available_datasets(self):
         """Get information of available datasets in file.
 

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -508,9 +508,8 @@ class FileYAMLReader(AbstractYAMLReader):
         for file_handlers in self.file_handlers.values():
             fh = file_handlers[0]
             # update resolution in the dataset IDs for this files resolution
-            try:
-                res = fh.resolution
-            except NotImplementedError:
+            res = getattr(fh, 'resolution', None)
+            if res is None:
                 continue
 
             for ds_id, ds_info in list(self.ids.items()):


### PR DESCRIPTION
I was using a property in the base file handler class but other file handlers (modis) were assigning a instance attribute which was failing because it was already a property. This changes the yaml reader's use of resolution to accept if it is there or not. This is less official and may change in the future when this kind of stuff is more well defined (abstract properties, etc).

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes) -->
 - [x] Passes ``git diff origin/develop **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
