### PR TITLE
Fix save_dataset not passing kwargs to the writer

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -798,7 +798,8 @@ class Scene(MetadataObject):
             writer = self.get_writer_by_ext(os.path.splitext(filename)[1])
 
         writer, save_kwargs = load_writer(writer,
-                                          ppp_config_dir=self.ppp_config_dir)
+                                          ppp_config_dir=self.ppp_config_dir,
+                                          **kwargs)
         return writer.save_dataset(self[dataset_id], filename=filename,
                                    overlay=overlay, compute=compute,
                                    **save_kwargs)

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1478,11 +1478,13 @@ class TestSceneSaving(unittest.TestCase):
             da.zeros((100, 200), chunks=50),
             dims=('y', 'x'),
             attrs={'name': 'test',
-                   'start_time': datetime.utcnow()}
+                   'start_time': datetime(2018, 1, 1, 0, 0, 0)}
         )
         scn = Scene()
         scn['test'] = ds1
         scn.save_datasets(base_dir=self.base_dir)
+        self.assertTrue(os.path.isfile(
+            os.path.join(self.base_dir, 'test_20180101_000000.tif')))
 
     def test_save_datasets_bad_writer(self):
         """Save a dataset using 'save_datasets'."""
@@ -1502,6 +1504,24 @@ class TestSceneSaving(unittest.TestCase):
                           scn.save_datasets,
                           writer='_bad_writer_',
                           base_dir=self.base_dir)
+
+    def test_save_datasets_default(self):
+        """Save a dataset using 'save_dataset'."""
+        from satpy.scene import Scene
+        import xarray as xr
+        import dask.array as da
+        from datetime import datetime
+        ds1 = xr.DataArray(
+            da.zeros((100, 200), chunks=50),
+            dims=('y', 'x'),
+            attrs={'name': 'test',
+                   'start_time': datetime(2018, 1, 1, 0, 0, 0)}
+        )
+        scn = Scene()
+        scn['test'] = ds1
+        scn.save_dataset('test', base_dir=self.base_dir)
+        self.assertTrue(os.path.isfile(
+            os.path.join(self.base_dir, 'test_20180101_000000.tif')))
 
 
 def suite():

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1505,7 +1505,7 @@ class TestSceneSaving(unittest.TestCase):
                           writer='_bad_writer_',
                           base_dir=self.base_dir)
 
-    def test_save_datasets_default(self):
+    def test_save_dataset_default(self):
         """Save a dataset using 'save_dataset'."""
         from satpy.scene import Scene
         import xarray as xr


### PR DESCRIPTION
It was pointed out that kwargs passed to `save_dataset` are not passed to the writer. This PR fixes that.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
