### PR TITLE
Add 'available_readers' and 'available_writers' utility functions

### DIFF
--- a/satpy/__init__.py
+++ b/satpy/__init__.py
@@ -50,7 +50,7 @@ CALIBRATION_ORDER = {cal: idx for idx, cal in enumerate(CALIBRATION_ORDER)}
 
 from satpy.version import __version__  # noqa
 from satpy.dataset import Dataset, DatasetID, DATASET_KEYS  # noqa
-from satpy.readers import (DatasetDict, find_files_and_readers,
+from satpy.readers import (DatasetDict, find_files_and_readers,  # noqa
                            available_readers)  # noqa
-from satpy.writers import available_writers
+from satpy.writers import available_writers  # noqa
 from satpy.scene import Scene  # noqa

--- a/satpy/__init__.py
+++ b/satpy/__init__.py
@@ -50,5 +50,7 @@ CALIBRATION_ORDER = {cal: idx for idx, cal in enumerate(CALIBRATION_ORDER)}
 
 from satpy.version import __version__  # noqa
 from satpy.dataset import Dataset, DatasetID, DATASET_KEYS  # noqa
-from satpy.readers import DatasetDict, find_files_and_readers  # noqa
+from satpy.readers import (DatasetDict, find_files_and_readers,
+                           available_readers)  # noqa
+from satpy.writers import available_writers
 from satpy.scene import Scene  # noqa

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -447,6 +447,19 @@ class TestYAMLFiles(unittest.TestCase):
                              "Reader YAML filename doesn't match reader "
                              "name in the YAML file.")
 
+    def test_available_readers(self):
+        """Test the 'available_readers' function."""
+        from satpy import available_readers
+        reader_names = available_readers()
+        self.assertGreater(len(reader_names), 0)
+        self.assertIsInstance(reader_names[0], str)
+
+        reader_infos = available_readers(as_dict=True)
+        self.assertEqual(len(reader_names), len(reader_infos))
+        self.assertIsInstance(reader_infos[0], dict)
+        for reader_info in reader_infos:
+            self.assertIn('name', reader_info)
+
 
 def suite():
     """The test suite for test_scene.

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -252,12 +252,50 @@ sensor_name: visir/test_sensor2
         np.testing.assert_almost_equal(img.data.isel(bands=0).max().values, 0.5)
 
 
+class TestYAMLFiles(unittest.TestCase):
+    """Test and analyze the writer configuration files."""
+
+    def test_filename_matches_reader_name(self):
+        """Test that every writer filename matches the name in the YAML."""
+        import yaml
+
+        class IgnoreLoader(yaml.SafeLoader):
+            def _ignore_all_tags(self, tag_suffix, node):
+                return tag_suffix + ' ' + node.value
+        IgnoreLoader.add_multi_constructor('', IgnoreLoader._ignore_all_tags)
+
+        from satpy.config import glob_config
+        from satpy.writers import read_writer_config
+        for writer_config in glob_config('writers/*.yaml'):
+            writer_fn = os.path.basename(writer_config)
+            writer_fn_name = os.path.splitext(writer_fn)[0]
+            writer_info = read_writer_config([writer_config],
+                                             loader=IgnoreLoader)
+            self.assertEqual(writer_fn_name, writer_info['name'],
+                             "Writer YAML filename doesn't match writer "
+                             "name in the YAML file.")
+
+    def test_available_writers(self):
+        """Test the 'available_writers' function."""
+        from satpy import available_writers
+        writer_names = available_writers()
+        self.assertGreater(len(writer_names), 0)
+        self.assertIsInstance(writer_names[0], str)
+
+        writer_infos = available_writers(as_dict=True)
+        self.assertEqual(len(writer_names), len(writer_infos))
+        self.assertIsInstance(writer_infos[0], dict)
+        for writer_info in writer_infos:
+            self.assertIn('name', writer_info)
+
+
 def suite():
-    """The test suite for test_projector."""
+    """The test suite for test_writers."""
     loader = unittest.TestLoader()
     my_suite = unittest.TestSuite()
     my_suite.addTest(loader.loadTestsFromTestCase(TestWritersModule))
     my_suite.addTest(loader.loadTestsFromTestCase(TestEnhancer))
     my_suite.addTest(loader.loadTestsFromTestCase(TestEnhancerUserConfigs))
+    my_suite.addTest(loader.loadTestsFromTestCase(TestYAMLFiles))
 
     return my_suite


### PR DESCRIPTION
As the title says this adds an 'available_readers' and 'available_writers' function to satpy that can be imported using `from satpy import available_readers, available_writers`. By default it returns a list of the readers/writers that it can find. You can also use `as_dict=True` to return the entire 'reader' or 'writer' section of the YAML config which could be useful for filling in a GUI (like I will do with SIFT) or in a table like we should probably do in the documentation or in a jupyter notebook.

Note: This function should have a `ppp_config_dir` parameter to match the rest of the functions in their modules, but I plan to follow this PR up with a `set_options` PR to add a real config dictionary like dask has so users can do `satpy.set_options(chunk_size=2048)` or `satpy.set_options(ppp_config_dir=X)`.

I still need to write some examples in the documentation about these functions.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
