### PR TITLE
Allow valid_range to be a tuple for cloud product colorization

### DIFF
--- a/satpy/composites/cloud_products.py
+++ b/satpy/composites/cloud_products.py
@@ -46,7 +46,7 @@ class CloudTopHeightCompositor(ColormapCompositor):
 
         sf = info.get('scale_factor', np.array(1))
         colormap.set_range(
-            *info['valid_range'] * sf + info.get('add_offset', 0))
+            *(np.array(info['valid_range']) * sf + info.get('add_offset', 0)))
 
         return colormap
 


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

<!-- Describe what your PR does, and why -->

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->

