### PR TITLE
Fix exception when Scene is given reader and base_dir

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -553,11 +553,17 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None,
         # filenames is a dictionary of reader_name -> filenames
         reader = list(filenames.keys())
         remaining_filenames = set(f for fl in filenames.values() for f in fl)
+    elif reader and isinstance(filenames, dict):
+        # filenames is a dictionary of reader_name -> filenames
+        # but they only want one of the readers
+        filenames = filenames[reader]
+        remaining_filenames = set(filenames or [])
     else:
         remaining_filenames = set(filenames or [])
 
     for idx, reader_configs in enumerate(configs_for_reader(reader, ppp_config_dir)):
         if isinstance(filenames, dict):
+            print(idx, reader_configs, reader)
             readers_files = set(filenames[reader[idx]])
         else:
             readers_files = remaining_filenames

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -252,6 +252,20 @@ class TestReaderLoader(unittest.TestCase):
         ri = load_readers(filenames=filenames)
         self.assertListEqual(list(ri.keys()), ['viirs_sdr'])
 
+    def test_filenames_as_dict_with_reader(self):
+        """Test loading from a filenames dict with a single reader specified.
+
+        This can happen in the deprecated Scene behavior of passing a reader
+        and a base_dir.
+
+        """
+        from satpy.readers import load_readers
+        filenames = {
+            'viirs_sdr': ['SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'],
+        }
+        ri = load_readers(reader='viirs_sdr', filenames=filenames)
+        self.assertListEqual(list(ri.keys()), ['viirs_sdr'])
+
 
 class TestFindFilesAndReaders(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
See #167 for details.

 - [x] Closes #167 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
