### PR TITLE
Fix nucaps reader for NUCAPS EDR v2 files

### DIFF
--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -51,9 +51,6 @@ class BaseFileHandler(six.with_metaclass(ABCMeta, object)):
                     xslice=slice(None), yslice=slice(None)):
         raise NotImplementedError
 
-    def get_shape(self, dataset_id, ds_info):
-        raise NotImplementedError
-
     def get_area_def(self, dsid):
         raise NotImplementedError
 

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -65,7 +65,8 @@ class NetCDF4FileHandler(BaseFileHandler):
 
     """
 
-    def __init__(self, filename, filename_info, filetype_info, auto_maskandscale=False):
+    def __init__(self, filename, filename_info, filetype_info,
+                 auto_maskandscale=False, xarray_kwargs=None):
         super(NetCDF4FileHandler, self).__init__(
             filename, filename_info, filetype_info)
         self.file_content = {}
@@ -83,6 +84,9 @@ class NetCDF4FileHandler(BaseFileHandler):
         self.collect_metadata("", file_handle)
         self.collect_dimensions("", file_handle)
         file_handle.close()
+        self._xarray_kwargs = xarray_kwargs or {}
+        self._xarray_kwargs.setdefault('chunks', CHUNK_SIZE)
+        self._xarray_kwargs.setdefault('mask_and_scale', self.auto_maskandscale)
 
     def _collect_attrs(self, name, obj):
         """Collect all the attributes for the provided file object.
@@ -129,8 +133,7 @@ class NetCDF4FileHandler(BaseFileHandler):
             else:
                 group = None
             with xr.open_dataset(self.filename, group=group,
-                                 chunks=CHUNK_SIZE,
-                                 mask_and_scale=self.auto_maskandscale) as nc:
+                                 **self._xarray_kwargs) as nc:
                 val = nc[key]
         return val
 

--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -100,7 +100,7 @@ class NUCAPSFileHandler(NetCDF4FileHandler):
             return res
 
     @property
-    def sensor_name(self):
+    def sensor_names(self):
         """Return standard sensor or instrument name for the file's data.
         """
         res = self['/attr/instrument_name']
@@ -142,7 +142,7 @@ class NUCAPSFileHandler(NetCDF4FileHandler):
             "shape": shape,
             "units": ds_info.get("units", file_units),
             "platform_name": self.platform_name,
-            "sensor": self.sensor_name,
+            "sensor": self.sensor_names,
             "start_orbit": self.start_orbit_number,
             "end_orbit": self.end_orbit_number,
         })

--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -105,9 +105,11 @@ class NUCAPSFileHandler(NetCDF4FileHandler):
         """
         res = self['/attr/instrument_name']
         if isinstance(res, np.ndarray):
-            return str(res.astype(str))
-        else:
-            return res
+            res = str(res.astype(str))
+        res = [x.strip() for x in res.split(',')]
+        if len(res) == 1:
+            return res[0]
+        return res
 
     def get_shape(self, ds_id, ds_info):
         """Return data array shape for item specified.

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -736,7 +736,7 @@ class FileYAMLReader(AbstractYAMLReader):
         for dataset in datasets.values():
             ancillary_variables = dataset.attrs.get('ancillary_variables', [])
             if not isinstance(ancillary_variables, (list, tuple, set)):
-                ancillary_variables = ancillary_variables.split(',')
+                ancillary_variables = ancillary_variables.split(' ')
             av_ids = []
             for key in ancillary_variables:
                 try:
@@ -746,16 +746,17 @@ class FileYAMLReader(AbstractYAMLReader):
 
             all_av_ids |= set(av_ids)
             dataset.attrs['ancillary_variables'] = av_ids
-        all_av_ids = [av_id for av_id in all_av_ids if av_id not in datasets]
+        loadable_av_ids = [av_id for av_id in all_av_ids if av_id not in datasets]
         if not all_av_ids:
             return
-        av_ds = self.load(all_av_ids, datasets)
+        if loadable_av_ids:
+            self.load(loadable_av_ids, previous_datasets=datasets)
+
         for dataset in datasets.values():
             new_vars = []
             for av_id in dataset.attrs.get('ancillary_variables', []):
-                new_vars.append(av_ds.get(av_id, datasets.get(av_id, av_id)))
+                new_vars.append(datasets.get(av_id, av_id))
             dataset.attrs['ancillary_variables'] = new_vars
-        datasets.update(av_ds)
 
     def load(self, dataset_keys, previous_datasets=None):
         """Load `dataset_keys`.

--- a/satpy/tests/reader_tests/test_nucaps.py
+++ b/satpy/tests/reader_tests/test_nucaps.py
@@ -57,7 +57,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
             '/attr/start_orbit_number': 1,
             '/attr/end_orbit_number': 2,
             '/attr/platform_name': 'NPP',
-            '/attr/instrument_name': 'CrIS',
+            '/attr/instrument_name': 'CrIS, ATMS, VIIRS',
         }
         for k, units, standard_name in [
             ('Solar_Zenith', 'degrees', 'solar_zenith_angle'),
@@ -197,6 +197,7 @@ class TestNUCAPSReader(unittest.TestCase):
             # self.assertNotEqual(v.info['resolution'], 0)
             # self.assertEqual(v.info['units'], 'degrees')
             self.assertEqual(v.ndim, 1)
+            self.assertEqual(v.attrs['sensor'], ['CrIS', 'ATMS', 'VIIRS'])
 
     def test_load_pressure_based(self):
         """Test loading all channels based on pressure"""


### PR DESCRIPTION
Includes fix for loading ancillary variables when the ancillary variable is being loaded alongside the dataset that needs it. Also fixes handling of CF standard ancillary variable attributes with multiple variables listed. They were comma-separated, but space separated seems to be the standard: http://cfconventions.org/Data/cf-conventions/cf-conventions-1.6/build/cf-conventions.html#ancillary-data

Additionally this fixes #244 which was mainly worried about the instrument name attribute which changed from 'CrIS' to 'CrIS, ATMS, VIIRS' from v1 to v2 of the NUCAPS EDR files.

 - [x] Closes #244 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
