### PR TITLE
Cut radiances array depending on number of scans

### DIFF
--- a/satpy/readers/viirs_compact.py
+++ b/satpy/readers/viirs_compact.py
@@ -211,7 +211,8 @@ class VIIRSCompactFileHandler(BaseFileHandler):
                             name=dataset_key.name,
                             dims=['y', 'x']).astype(np.float32)
         h5attrs = h5rads.attrs
-        # scans = h5f["All_Data"]["NumberOfScans"][0]
+        scans = h5f["All_Data"]["NumberOfScans"][0]
+        rads = rads[:scans * 16, :]
         # if channel in ("M9", ):
         #     arr = rads[:scans * 16, :].astype(np.float32)
         #     arr[arr > 65526] = np.nan


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

<!-- Describe what your PR does, and why -->

This fixes the problem with reading compact viirs granules that have a lower number of scans.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
