### PR TITLE
Fix ancillary variable loading when anc var is already loaded

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -200,6 +200,9 @@ def get_key(key, key_container, num_results=1, best=True,
     elif isinstance(key, (str, six.text_type)):
         # ID should act as a query (see wl comment above)
         key = DatasetID(name=key, modifiers=None)
+    elif not isinstance(key, DatasetID):
+        raise ValueError("Expected 'DatasetID', str, or number dict key, "
+                         "not {}".format(str(type(key))))
 
     res = filter_keys_by_dataset_id(key, key_container)
 

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -755,7 +755,10 @@ class FileYAMLReader(AbstractYAMLReader):
         for dataset in datasets.values():
             new_vars = []
             for av_id in dataset.attrs.get('ancillary_variables', []):
-                new_vars.append(datasets.get(av_id, av_id))
+                if isinstance(av_id, DatasetID):
+                    new_vars.append(datasets[av_id])
+                else:
+                    new_vars.append(av_id)
             dataset.attrs['ancillary_variables'] = new_vars
 
     def load(self, dataset_keys, previous_datasets=None):


### PR DESCRIPTION
In a previous PR I broke ancillary variable loading if the anc var is loaded multiple times. This PR fixes that as well as makes it "illegal" to request a key from a DatasetDict that isn't a str, number, or DatasetID.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
