### PR TITLE
Fix Scene save_datasets to only save datasets from the wishlist

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1011,7 +1011,13 @@ class Scene(MetadataObject):
         if datasets is not None:
             datasets = [self[ds] for ds in datasets]
         else:
-            datasets = self.datasets.values()
+            datasets = [self.datasets.get(ds) for ds in self.wishlist]
+            datasets = [ds for ds in datasets if ds is not None]
+        if not datasets:
+            raise RuntimeError("None of the requested datasets have been "
+                               "generated or could not be loaded. Requested "
+                               "composite inputs may need to have matching "
+                               "dimensions (eg. through resampling).")
         writer, save_kwargs = load_writer(writer,
                                           ppp_config_dir=self.ppp_config_dir,
                                           **kwargs)

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1621,7 +1621,7 @@ class TestSceneSaving(unittest.TestCase):
             os.path.join(self.base_dir, 'test_20180101_000000.tif')))
 
     def test_save_datasets_bad_writer(self):
-        """Save a dataset using 'save_datasets'."""
+        """Save a dataset using 'save_datasets' and a bad writer."""
         from satpy.scene import Scene
         import xarray as xr
         import dask.array as da
@@ -1638,6 +1638,19 @@ class TestSceneSaving(unittest.TestCase):
                           scn.save_datasets,
                           writer='_bad_writer_',
                           base_dir=self.base_dir)
+
+    def test_save_datasets_missing_wishlist(self):
+        """Calling 'save_datasets' with no valid datasets."""
+        from satpy.scene import Scene, DatasetID
+        scn = Scene()
+        scn.wishlist.add(DatasetID(name='true_color'))
+        self.assertRaises(RuntimeError,
+                          scn.save_datasets,
+                          writer='geotiff',
+                          base_dir=self.base_dir)
+        self.assertRaises(KeyError,
+                          scn.save_datasets,
+                          datasets=['no_exist'])
 
     def test_save_dataset_default(self):
         """Save a dataset using 'save_dataset'."""


### PR DESCRIPTION
See the associated issue for more details. Basically if you have datasets in your Scene that were not manually added or and aren't in the wishlist (ex. composite prerequisites) then calling `save_datasets` would save those datasets too which is unexpected. Now a RuntimeError is raised.

 - [x] Closes #332 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->