### PR TITLE
Fix freezing of areas before resampling even as strings

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -136,7 +136,6 @@ import numpy as np
 import xarray as xr
 import dask
 import dask.array as da
-import six
 
 from pyresample.bilinear import get_bil_info, get_sample_from_bil_info
 from pyresample.ewa import fornav, ll2cr
@@ -179,19 +178,6 @@ def get_area_def(area_name):
     """
     from pyresample.utils import parse_area_file
     return parse_area_file(get_area_file(), area_name)[0]
-
-
-def get_frozen_area(to_freeze, ref):
-    """Freeze the *to_freeze* area according to *ref* if applicable, otherwise
-    return *to_freeze* as an area definition instance.
-    """
-    if isinstance(to_freeze, (str, six.text_type)):
-        to_freeze = get_area_def(to_freeze)
-
-    try:
-        return to_freeze.freeze(ref)
-    except AttributeError:
-        return to_freeze
 
 
 class BaseResampler(object):

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -866,12 +866,12 @@ class Scene(MetadataObject):
         new_datasets = {}
         datasets = list(new_scn.datasets.values())
         max_area = None
-        if hasattr(destination_area, 'freeze'):
-            try:
-                max_area = new_scn.max_area()
-            except ValueError:
-                raise ValueError("No dataset areas available to freeze "
-                                 "DynamicAreaDefinition.")
+
+        try:
+            max_area = new_scn.max_area()
+        except ValueError:
+            raise ValueError("No dataset areas available to freeze "
+                             "DynamicAreaDefinition.")
         destination_area = get_frozen_area(destination_area, max_area)
 
         resamplers = {}

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -33,11 +33,12 @@ from satpy.dataset import (DatasetID, MetadataObject, dataset_walker,
                            replace_anc)
 from satpy.node import DependencyTree
 from satpy.readers import DatasetDict, load_readers
-from satpy.resample import (resample_dataset, get_frozen_area,
-                            prepare_resampler)
+from satpy.resample import (resample_dataset,
+                            prepare_resampler, get_area_def)
 from satpy.writers import load_writer
 from pyresample.geometry import AreaDefinition
 from xarray import DataArray
+import six
 
 try:
     import configparser
@@ -866,13 +867,15 @@ class Scene(MetadataObject):
         new_datasets = {}
         datasets = list(new_scn.datasets.values())
         max_area = None
-
-        try:
-            max_area = new_scn.max_area()
-        except ValueError:
-            raise ValueError("No dataset areas available to freeze "
-                             "DynamicAreaDefinition.")
-        destination_area = get_frozen_area(destination_area, max_area)
+        if isinstance(destination_area, (str, six.text_type)):
+            destination_area = get_area_def(destination_area)
+        if hasattr(destination_area, 'freeze'):
+            try:
+                max_area = new_scn.max_area()
+                destination_area = destination_area.freeze(max_area)
+            except ValueError:
+                raise ValueError("No dataset areas available to freeze "
+                                 "DynamicAreaDefinition.")
 
         resamplers = {}
         for dataset, parent_dataset in dataset_walker(datasets):


### PR DESCRIPTION
Dynamic areas passed as strings wouldn't receive the area to freeze on.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->

