### PR TITLE
Fix datetime-based file selection when filename only has a start time

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -476,6 +476,13 @@ def find_files_and_readers(start_time=None, end_time=None, base_dir=None,
     The returned dictionary can be passed directly to the `Scene` object
     through the `filenames` keyword argument.
 
+    The behaviour of time-based filtering depends on whether or not the filename
+    contains information about the end time of the data or not:
+
+      - if the end time is not present in the filename, the start time of the filename
+        is used and has to fall between (inclusive) the requested start and end times
+      - otherwise, the timespan of the filename has to overlap the requested timespan
+
     Args:
         start_time (datetime): Limit used files by starting time.
         end_time (datetime): Limit used files by ending time.

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -393,6 +393,7 @@ class FileYAMLReader(AbstractYAMLReader):
     def time_matches(self, fstart, fend):
         start_time = self.filter_parameters.get('start_time')
         end_time = self.filter_parameters.get('end_time')
+        fend = fend or fstart
         if start_time and fend and fend < start_time:
             return False
         if end_time and fstart and fstart > end_time:

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -296,6 +296,10 @@ class TestFileFileYAMLReader(unittest.TestCase):
             # only the first one should be false
             self.assertEqual(res, idx not in [0, 4])
 
+        for idx, fh in enumerate([fh0, fh1, fh2, fh3, fh4, fh5]):
+            res = self.reader.time_matches(fh.start_time, None)
+            self.assertEqual(res, idx not in [0, 1, 4, 5])
+
     @patch('satpy.readers.yaml_reader.get_area_def')
     @patch('satpy.readers.yaml_reader.AreaDefBoundary')
     @patch('satpy.readers.yaml_reader.Boundary')


### PR DESCRIPTION
 
 - [x] Closes #344 
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
