### PR TITLE
Fix AMSR-2 L1B reader loading bytes incorrectly

### DIFF
--- a/satpy/etc/composites/amsr2.yaml
+++ b/satpy/etc/composites/amsr2.yaml
@@ -2,7 +2,7 @@ sensor_name: amsr2
 
 composites:
   rgb_color:
-    compositor: !!python/name:satpy.composites.GenericCompositor
+    compositor: !!python/name:satpy.composites.RGBCompositor
     prerequisites:
     - name: 'btemp_10.7h'
     - name: 'btemp_36.5h'

--- a/satpy/readers/amsr2_l1b.py
+++ b/satpy/readers/amsr2_l1b.py
@@ -14,10 +14,10 @@ class AMSR2L1BFileHandler(HDF5FileHandler):
         info.update({
             "shape": self.get_shape(ds_id, ds_info),
             "units": self[var_path + "/attr/UNIT"],
-            "platform_name": self["/attr/PlatformShortName"].item(),
-            "sensor": self["/attr/SensorShortName"].item(),
-            "start_orbit": int(self["/attr/StartOrbitNumber"].item()),
-            "end_orbit": int(self["/attr/StopOrbitNumber"].item()),
+            "platform_name": self["/attr/PlatformShortName"],
+            "sensor": self["/attr/SensorShortName"],
+            "start_orbit": int(self["/attr/StartOrbitNumber"]),
+            "end_orbit": int(self["/attr/StopOrbitNumber"]),
         })
         info.update(ds_id.to_dict())
         return info

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -48,7 +48,7 @@ def np2str(value):
 
     """
     if hasattr(value, 'dtype') and \
-            issubclass(value.dtype.type, np.string_) and value.size == 1:
+            issubclass(value.dtype.type, (np.string_, np.object_)) and value.size == 1:
         value = np.asscalar(value)
         if not isinstance(value, str):
             # python 3 - was scalar numpy array of bytes

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -272,8 +272,6 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
             "end_orbit": self.end_orbit_number,
         })
         i.update(dataset_id.to_dict())
-        # xarray bug does not allow differing list attributes
-        i.pop('coordinates', None)
         data.attrs.update(i)
         return data
 

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -200,6 +200,11 @@ class AbstractYAMLReader(six.with_metaclass(ABCMeta, object)):
         """Get the dataset ids from the config."""
         ids = []
         for dataset in self.datasets.values():
+            # xarray doesn't like concatenating attributes that are lists
+            # https://github.com/pydata/xarray/issues/2060
+            if 'coordinates' in dataset and \
+                    isinstance(dataset['coordinates'], list):
+                dataset['coordinates'] = tuple(dataset['coordinates'])
             # Build each permutation/product of the dataset
             id_kwargs = []
             for key in DATASET_KEYS:
@@ -535,6 +540,11 @@ class FileYAMLReader(AbstractYAMLReader):
             for ds_id, ds_info in avail_ids:
                 # don't overwrite an existing dataset
                 # especially from the yaml config
+                coordinates = ds_info.get('coordinates')
+                if isinstance(coordinates, list):
+                    # xarray doesn't like concatenating attributes that are
+                    # lists: https://github.com/pydata/xarray/issues/2060
+                    ds_info['coordinates'] = tuple(ds_info['coordinates'])
                 self.ids.setdefault(ds_id, ds_info)
 
     @staticmethod

--- a/satpy/tests/reader_tests/test_amsr2_l1b.py
+++ b/satpy/tests/reader_tests/test_amsr2_l1b.py
@@ -34,10 +34,10 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
     def get_test_content(self, filename, filename_info, filetype_info):
         """Mimic reader input file content"""
         file_content = {
-            '/attr/PlatformShortName': np.array('GCOM-W1'),
-            '/attr/SensorShortName': np.array('AMSR2'),
-            '/attr/StartOrbitNumber': np.array('22210'),
-            '/attr/StopOrbitNumber': np.array('22210'),
+            '/attr/PlatformShortName': 'GCOM-W1',
+            '/attr/SensorShortName': 'AMSR2',
+            '/attr/StartOrbitNumber': '22210',
+            '/attr/StopOrbitNumber': '22210',
         }
         for bt_chan in [
             '(10.7GHz,H)',


### PR DESCRIPTION
I think this is due to a recent change in numpy where bytes arrays are no longer considered `np.string_` types. This was causing AMSR-2 L1B attributes read from the file to stay as bytes objects when they should have been strings.

Additionally, AMSR-2 L1B composites were running in to the same issue that VIIRS SDR had run in a while ago where xarray doesn't like that the 'coordinates' attribute is a list and when you concatenate DataArrays that have different 'coordinates' attributes, it fails. See https://github.com/pydata/xarray/issues/2060 for more details.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->

