### PR TITLE
Remove loose print statement and fix future warning

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2015-2017.
+# Copyright (c) 2015-2018.
 
 # Author(s):
 
@@ -574,7 +574,6 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None,
 
     for idx, reader_configs in enumerate(configs_for_reader(reader, ppp_config_dir)):
         if isinstance(filenames, dict):
-            print(idx, reader_configs, reader)
             readers_files = set(filenames[reader[idx]])
         else:
             readers_files = remaining_filenames


### PR DESCRIPTION
Signed-off-by: Adam.Dybbroe <adam.dybbroe@smhi.se>

Fixing issue 345. A loose print statement is removed. And a future warning from xarray is dealt with in the ears-nwc reader

 - [x] Closes #345
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->

