### PR TITLE
Fix ABI L1B reader losing file variable attributes

### DIFF
--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -96,7 +96,6 @@ class NC_ABI_L1B(BaseFileHandler):
                 self.coords[coord_name] = self[coord_name]
             new_coords[coord_name] = self.coords[coord_name]
         data.coords.update(new_coords)
-        print(data.coords.keys())
         return data
 
     def get_shape(self, key, info):

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -85,11 +85,10 @@ class NC_ABI_L1B(BaseFileHandler):
         data.attrs = attrs
 
         # handle coordinates (and recursive fun)
-        coords = list(data.coords.items())
         new_coords = {}
         if item in data.coords:
             self.coords[item] = data
-        for coord_name, coord_arr in coords:
+        for coord_name in data.coords.keys():
             if coord_name not in self.coords:
                 self.coords[coord_name] = self[coord_name]
             new_coords[coord_name] = self.coords[coord_name]

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -60,6 +60,7 @@ class NC_ABI_L1B(BaseFileHandler):
         self.platform_name = PLATFORM_NAMES.get(platform_shortname)
         self.sensor = 'abi'
         self.nlines, self.ncols = self.nc["Rad"].shape
+        self.coords = {}
 
     def __getitem__(self, item):
         """Wrapper around `self.nc[item]`.
@@ -82,6 +83,17 @@ class NC_ABI_L1B(BaseFileHandler):
             # and we are making it a 64-bit float
             data = data * float(factor) + offset
         data.attrs = attrs
+
+        # handle coordinates (and recursive fun)
+        coords = list(data.coords.items())
+        new_coords = {}
+        if item in data.coords:
+            self.coords[item] = data
+        for coord_name, coord_arr in coords:
+            if coord_name not in self.coords:
+                self.coords[coord_name] = self[coord_name]
+            new_coords[coord_name] = self.coords[coord_name]
+        data.coords.update(new_coords)
         return data
 
     def get_shape(self, key, info):

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -70,6 +70,7 @@ class NC_ABI_L1B(BaseFileHandler):
 
         """
         data = self.nc[item]
+        attrs = data.attrs
         factor = data.attrs.get('scale_factor')
         offset = data.attrs.get('add_offset')
         fill = data.attrs.get('_FillValue')
@@ -77,8 +78,10 @@ class NC_ABI_L1B(BaseFileHandler):
             data = data.where(data != fill)
         if factor is not None:
             # make sure the factor is a 64-bit float
-            data *= float(factor)
-            data += offset
+            # can't do this in place since data is most likely uint16
+            # and we are making it a 64-bit float
+            data = data * float(factor) + offset
+        data.attrs = attrs
         return data
 
     def get_shape(self, key, info):

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -77,7 +77,8 @@ class NC_ABI_L1B(BaseFileHandler):
             data = data.where(data != fill)
         if factor is not None:
             # make sure the factor is a 64-bit float
-            data = data * float(factor) + offset
+            data *= float(factor)
+            data += offset
         return data
 
     def get_shape(self, key, info):
@@ -98,10 +99,12 @@ class NC_ABI_L1B(BaseFileHandler):
             res = self._ir_calibrate(radiances)
         elif key.calibration != 'radiance':
             raise ValueError("Unknown calibration '{}'".format(key.calibration))
+        else:
+            res = radiances
 
         # convert to satpy standard units
         if res.attrs['units'] == '1':
-            res = res * 100
+            res *= 100
             res.attrs['units'] = '%'
 
         res.attrs.update({'platform_name': self.platform_name,

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -86,6 +86,9 @@ class NC_ABI_L1B(BaseFileHandler):
 
         # handle coordinates (and recursive fun)
         new_coords = {}
+        # 'time' dimension causes issues in other processing
+        if 'time' in data.coords:
+            del data.coords['time']
         if item in data.coords:
             self.coords[item] = data
         for coord_name in data.coords.keys():
@@ -93,6 +96,7 @@ class NC_ABI_L1B(BaseFileHandler):
                 self.coords[coord_name] = self[coord_name]
             new_coords[coord_name] = self.coords[coord_name]
         data.coords.update(new_coords)
+        print(data.coords.keys())
         return data
 
     def get_shape(self, key, info):

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -100,6 +100,9 @@ class Test_NC_ABI_L1B_ir_cal(unittest.TestCase):
                                 [391.68679226, 407.74064808, 422.69329105,
                                  436.77021913, np.nan]])
         self.assertTrue(np.allclose(res.data, expected, equal_nan=True))
+        # make sure the attributes from the file are in the data array
+        self.assertIn('scale_factor', res.attrs)
+        self.assertIn('_FillValue', res.attrs)
 
 
 class Test_NC_ABI_L1B_vis_cal(unittest.TestCase):
@@ -167,6 +170,8 @@ class Test_NC_ABI_L1B_vis_cal(unittest.TestCase):
                                 [0.91593702, 1.06859319, 1.22124936,
                                  np.nan, 1.52656171]])
         self.assertTrue(np.allclose(res.data, expected, equal_nan=True))
+        self.assertIn('scale_factor', res.attrs)
+        self.assertIn('_FillValue', res.attrs)
 
 
 class Test_NC_ABI_L1B_area(unittest.TestCase):

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -23,8 +23,6 @@
 
 import sys
 import numpy as np
-
-from satpy.readers.abi_l1b import NC_ABI_L1B
 import xarray as xr
 
 if sys.version_info < (2, 7):
@@ -62,6 +60,7 @@ class Test_NC_ABI_L1B_ir_cal(unittest.TestCase):
     @mock.patch('satpy.readers.abi_l1b.xr')
     def setUp(self, xr_):
         """Setup for test."""
+        from satpy.readers.abi_l1b import NC_ABI_L1B
         rad_data = (np.arange(10.).reshape((2, 5)) + 1.) * 50.
         rad_data = (rad_data + 1.) / 0.5
         rad_data = rad_data.astype(np.int16)
@@ -111,16 +110,27 @@ class Test_NC_ABI_L1B_vis_cal(unittest.TestCase):
     @mock.patch('satpy.readers.abi_l1b.xr')
     def setUp(self, xr_):
         """Setup for test."""
+        from satpy.readers.abi_l1b import NC_ABI_L1B
         rad_data = (np.arange(10.).reshape((2, 5)) + 1.)
         rad_data = (rad_data + 1.) / 0.5
         rad_data = rad_data.astype(np.int16)
+        x_image = xr.DataArray(0.)
+        y_image = xr.DataArray(0.)
+        time = xr.DataArray(0.)
         rad = xr.DataArray(
             rad_data,
+            dims=('y', 'x'),
             attrs={
                 'scale_factor': 0.5,
                 'add_offset': -1.,
                 '_FillValue': 20,
-            })
+            },
+            coords={
+                'time': time,
+                'x_image': x_image,
+                'y_image': y_image,
+            }
+        )
         xr_.open_dataset.return_value = FakeDataset({
             'band_id': np.array(5),
             'Rad': rad,
@@ -129,6 +139,8 @@ class Test_NC_ABI_L1B_vis_cal(unittest.TestCase):
             "planck_bc1": np.array(0.09102),
             "planck_bc2": np.array(0.99971),
             "esun": np.array(2017),
+            "x_image": x_image,
+            "y_image": y_image,
             "nominal_satellite_subpoint_lat": np.array(0.0),
             "nominal_satellite_subpoint_lon": np.array(-89.5),
             "nominal_satellite_height": np.array(35786.02),
@@ -179,7 +191,7 @@ class Test_NC_ABI_L1B_area(unittest.TestCase):
     @mock.patch('satpy.readers.abi_l1b.xr')
     def setUp(self, xr_):
         """Setup for test."""
-        import xarray as xr
+        from satpy.readers.abi_l1b import NC_ABI_L1B
         proj = xr.DataArray(
             [],
             attrs={


### PR DESCRIPTION
I noticed the abi_l1b reader was broken when trying to load a channel's radiances.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->