### PR TITLE
Fix ahi_hsd reader opening memmaps in read/write mode

### DIFF
--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -425,7 +425,7 @@ class AHIHSDFileHandler(BaseFileHandler):
             ncols = int(header["block2"]['number_of_columns'][0])
 
             res = da.from_array(np.memmap(self.filename, offset=fp_.tell(),
-                                          dtype='<u2',  shape=(nlines, ncols)),
+                                          dtype='<u2',  shape=(nlines, ncols), mode='r'),
                                 chunks=CHUNK_SIZE)
         res = da.where(res == 65535, np.float32(np.nan), res)
 


### PR DESCRIPTION
According to the numpy.memmap documentation (v1.14) The default open mode for the file is 'r+', open for both reading and writing. If the user does not have write permission for the data file, the result is a failure to open the data file and a failure of the Scene generation. 

Set memmap 'mode' to read only.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` 
 - [x] Fully documented 