### PR TITLE
Fix standard name when ABI L1B data is calibrated

### DIFF
--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -184,7 +184,7 @@ class NC_ABI_L1B(BaseFileHandler):
         res = data * factor
         res.attrs = data.attrs
         res.attrs['units'] = '1'
-
+        res.attrs['standard_name'] = 'toa_bidirectional_reflectance'
         return res
 
     def _ir_calibrate(self, data):
@@ -197,7 +197,7 @@ class NC_ABI_L1B(BaseFileHandler):
         res = (fk2 / xu.log(fk1 / data + 1) - bc1) / bc2
         res.attrs = data.attrs
         res.attrs['units'] = 'K'
-
+        res.attrs['standard_name'] = 'toa_brightness_temperature'
         return res
 
     @property

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -102,6 +102,8 @@ class Test_NC_ABI_L1B_ir_cal(unittest.TestCase):
         # make sure the attributes from the file are in the data array
         self.assertIn('scale_factor', res.attrs)
         self.assertIn('_FillValue', res.attrs)
+        self.assertEqual(res.attrs['standard_name'],
+                         'toa_brightness_temperature')
 
 
 class Test_NC_ABI_L1B_vis_cal(unittest.TestCase):
@@ -184,6 +186,8 @@ class Test_NC_ABI_L1B_vis_cal(unittest.TestCase):
         self.assertTrue(np.allclose(res.data, expected, equal_nan=True))
         self.assertIn('scale_factor', res.attrs)
         self.assertIn('_FillValue', res.attrs)
+        self.assertEqual(res.attrs['standard_name'],
+                         'toa_bidirectional_reflectance')
 
 
 class Test_NC_ABI_L1B_area(unittest.TestCase):


### PR DESCRIPTION
ABI L1B calibration does not set the proper standard_name attribute so you get weird metadata where reflectance and BT data has a radiance standard_name.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->