### PR TITLE
Update ABI area definition name to be more descriptive

### DIFF
--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -164,9 +164,9 @@ class NC_ABI_L1B(BaseFileHandler):
                      'sweep': sweep_axis}
 
         area = geometry.AreaDefinition(
-            'some_area_name',
-            "On-the-fly area",
-            'geosabii',
+            'abi_geos',
+            "ABI L1B file area",
+            'abi_geos',
             proj_dict,
             self.ncols,
             self.nlines,


### PR DESCRIPTION
This is a really small PR just to change the name of the AreaDefinition created in the ABI reader to something a little better. I thought it would be bad to push directly to master.