### PR TITLE
Add examples from pytroll-examples to documentation

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -13,7 +13,23 @@ as explanations in the various sections of this documentation.
 
     * - Name
       - Description
+    * - `Quickstart with MSG data <https://github.com/pytroll/pytroll-examples/blob/master/satpy/hrit_msg_tutorial.ipynb>`_
+      - Satpy quickstart for loading and processing satellite data, with MSG data in this examples
     * - `Cartopy Plot <https://github.com/pytroll/pytroll-examples/blob/master/satpy/Cartopy%20Plot.ipynb>`_
       - Plot a single VIIRS SDR granule using Cartopy and matplotlib
     * - `Himawari-8 AHI True Color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/ahi_true_color_pyspectral.ipynb>`_
       - Generate and resample a rayleigh corrected true color RGB from Himawari-8 AHI data
+    * - `Sentinel-3 OLCI True Color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/OLCI%20L1B.ipynb>`_
+      - Reading OLCI data from Sentinel 3 with Pytroll/Satpy
+    * - `Sentinel 2 MSI true color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/Sentinel%202%20MSI%20true%20color.ipynb>`_
+      - Reading MSI data from Sentinel 2 with Pytroll/SatPy
+    * - `Suomi-NPP VIIRS SDR True Color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/satpy_rayleigh_iband_enhanced.ipynb>`_
+      - Generate a rayleigh corrected true color RGB from VIIRS I- and M-bands
+    * - `Aqua/Terra MODIS True Color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/satpy_rayleigh_modis.ipynb>`_
+      - Generate and resample a rayleigh corrected true color RGB from MODIS
+    * - `Sentinel 1 SAR-C False Color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/sentinel1-false-color.ipynb>`_
+      - Generate a false color composite RGB from SAR-C polarized datasets
+    * - `Level 2 EARS-NWC cloud products <https://github.com/pytroll/pytroll-examples/blob/master/satpy/ears-nwc.ipynb>`_
+      - Reading Level 2 EARS-NWC cloud products
+    * - `Level 2 MAIA cloud products <https://github.com/pytroll/pytroll-examples/blob/master/satpy/polar_maia.ipynb>`_
+      - Reading Level 2 MAIA cloud products


### PR DESCRIPTION
This PR adds to the documentation
