### PR TITLE
Remove Rayleigh correction from abi natural composite

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -121,7 +121,7 @@ composites:
     - wavelength: 0.85
       modifiers: [sunz_corrected]
     - wavelength: 0.635
-      modifiers: [sunz_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected]
     high_resolution_band: blue
     standard_name: natural
 


### PR DESCRIPTION
This was giving a green hue close the day terminator

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
