### PR TITLE
Add utility function to save delayed writer results in one go

### DIFF
--- a/doc/source/writers.rst
+++ b/doc/source/writers.rst
@@ -101,4 +101,18 @@ The above example can be used in enhancements YAML config like this:
 
 .. _trollimage: http://trollimage.readthedocs.io/en/latest/
 
+Saving multiple Scenes in one go
+================================
 
+As mentioned earlier, it is possible to save ``Scene`` datasets directly
+using :meth:`~satpy.scene.Scene.save_datasets` method:.  However,
+sometimes it is beneficial to collect more ``Scene``s together and process
+and save them all at once.
+
+    >>> from satpy.writers import compute_writer_results
+    >>> res1 = scn.save_datasets(file_pattern="/tmp/{name}.png",
+    ...                          writer='simple_image')
+    >>> res2 = scn.save_datasets(file_pattern="/tmp/{name}.tif",
+    ...                          writer='geotiff')
+    >>> results = [res1, res2]
+    >>> compute_writer_results(results)

--- a/doc/source/writers.rst
+++ b/doc/source/writers.rst
@@ -105,9 +105,11 @@ Saving multiple Scenes in one go
 ================================
 
 As mentioned earlier, it is possible to save ``Scene`` datasets directly
-using :meth:`~satpy.scene.Scene.save_datasets` method:.  However,
+using :meth:`~satpy.scene.Scene.save_datasets` method.  However,
 sometimes it is beneficial to collect more ``Scene``s together and process
 and save them all at once.
+
+::
 
     >>> from satpy.writers import compute_writer_results
     >>> res1 = scn.save_datasets(file_pattern="/tmp/{name}.png",

--- a/doc/source/writers.rst
+++ b/doc/source/writers.rst
@@ -111,8 +111,10 @@ and save them all at once.
 
     >>> from satpy.writers import compute_writer_results
     >>> res1 = scn.save_datasets(file_pattern="/tmp/{name}.png",
-    ...                          writer='simple_image')
+    ...                          writer='simple_image',
+    ...                          compute=False)
     >>> res2 = scn.save_datasets(file_pattern="/tmp/{name}.tif",
-    ...                          writer='geotiff')
+    ...                          writer='geotiff',
+    ...                          compute=False)
     >>> results = [res1, res2]
     >>> compute_writer_results(results)

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -30,8 +30,6 @@ import unittest
 import numpy as np
 import xarray as xr
 
-from satpy.writers import show, to_image, compute_writer_results
-
 try:
     from unittest import mock
 except ImportError:
@@ -61,12 +59,14 @@ class TestWritersModule(unittest.TestCase):
     def test_to_image_1D(self):
         """Conversion to image."""
         # 1D
+        from satpy.writers import to_image
         p = xr.DataArray(np.arange(25), dims=['y'])
         self.assertRaises(ValueError, to_image, p)
 
     @mock.patch('satpy.writers.XRImage')
     def test_to_image_2D(self, mock_geoimage):
         """Conversion to image."""
+        from satpy.writers import to_image
         # 2D
         data = np.arange(25).reshape((5, 5))
         p = xr.DataArray(data, attrs=dict(mode="L", fill_value=0,
@@ -82,6 +82,7 @@ class TestWritersModule(unittest.TestCase):
     def test_to_image_3D(self, mock_geoimage):
         """Conversion to image."""
         # 3D
+        from satpy.writers import to_image
         data = np.arange(75).reshape((3, 5, 5))
         p = xr.DataArray(data, dims=['bands', 'y', 'x'])
         p['bands'] = ['R', 'G', 'B']
@@ -93,6 +94,8 @@ class TestWritersModule(unittest.TestCase):
     @mock.patch('satpy.writers.get_enhanced_image')
     def test_show(self, mock_get_image):
         """Check showing."""
+        from satpy.writers import show
+
         data = np.arange(25).reshape((5, 5))
         p = xr.DataArray(data, dims=['y', 'x'])
         show(p)
@@ -325,10 +328,12 @@ class TestComputeWriterResults(unittest.TestCase):
 
     def test_empty(self):
         """Test empty result list"""
+        from satpy.writers import compute_writer_results
         compute_writer_results([])
 
     def test_simple_image(self):
         """Test writing to PNG file"""
+        from satpy.writers import compute_writer_results
         fname = os.path.join(self.base_dir, 'simple_image.png')
         res = self.scn.save_datasets(filename=fname,
                                      datasets=['test'],
@@ -339,6 +344,7 @@ class TestComputeWriterResults(unittest.TestCase):
 
     def test_geotiff(self):
         """Test writing to mitiff file"""
+        from satpy.writers import compute_writer_results
         fname = os.path.join(self.base_dir, 'geotiff.tif')
         res = self.scn.save_datasets(filename=fname,
                                      datasets=['test'],
@@ -368,6 +374,7 @@ class TestComputeWriterResults(unittest.TestCase):
 
     def test_multiple_geotiff(self):
         """Test writing to mitiff file"""
+        from satpy.writers import compute_writer_results
         fname1 = os.path.join(self.base_dir, 'geotiff1.tif')
         res1 = self.scn.save_datasets(filename=fname1,
                                       datasets=['test'],
@@ -382,6 +389,7 @@ class TestComputeWriterResults(unittest.TestCase):
 
     def test_multiple_simple(self):
         """Test writing to geotiff files"""
+        from satpy.writers import compute_writer_results
         fname1 = os.path.join(self.base_dir, 'simple_image1.png')
         res1 = self.scn.save_datasets(filename=fname1,
                                       datasets=['test'],
@@ -396,6 +404,7 @@ class TestComputeWriterResults(unittest.TestCase):
 
     def test_mixed(self):
         """Test writing to multiple mixed-type files"""
+        from satpy.writers import compute_writer_results
         fname1 = os.path.join(self.base_dir, 'simple_image3.png')
         res1 = self.scn.save_datasets(filename=fname1,
                                       datasets=['test'],

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -330,7 +330,6 @@ class TestComputeWriterResults(unittest.TestCase):
 
     def test_empty(self):
         """Test empty result list"""
-        fname = os.path.join(self.base_dir, 'geotiff.tif')
         compute_writer_results([])
 
     def test_simple_image(self):

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -56,7 +56,6 @@ def mkdir_p(path):
 
 
 class TestWritersModule(unittest.TestCase):
-
     """Test the writers module."""
 
     def test_to_image_1D(self):
@@ -101,7 +100,6 @@ class TestWritersModule(unittest.TestCase):
 
 
 class TestEnhancer(unittest.TestCase):
-
     """Test basic `Enhancer` functionality with builtin configs."""
 
     def test_basic_init_no_args(self):
@@ -137,7 +135,6 @@ class TestEnhancer(unittest.TestCase):
 
 
 class TestEnhancerUserConfigs(unittest.TestCase):
-
     """Test `Enhancer` functionality when user's custom configurations are present."""
 
     ENH_FN = 'test_sensor.yaml'
@@ -256,7 +253,6 @@ sensor_name: visir/test_sensor2
 
 
 class TestYAMLFiles(unittest.TestCase):
-
     """Test and analyze the writer configuration files."""
 
     def test_filename_matches_reader_name(self):
@@ -296,7 +292,6 @@ class TestYAMLFiles(unittest.TestCase):
 
 
 class TestComputeWriterResults(unittest.TestCase):
-
     """Test compute_writer_results()."""
 
     def setUp(self):

--- a/satpy/tests/writer_tests/test_simple_image.py
+++ b/satpy/tests/writer_tests/test_simple_image.py
@@ -77,12 +77,14 @@ class TestPillowWriter(unittest.TestCase):
     def test_simple_delayed_write(self):
         from dask.delayed import Delayed
         from satpy.writers.simple_image import PillowWriter
+        from satpy.writers import compute_writer_results
         datasets = self._get_test_datasets()
         w = PillowWriter(base_dir=self.base_dir)
         res = w.save_datasets(datasets, compute=False)
-        self.assertIsInstance(res, Delayed)
-        res.compute()
-
+        for r__ in res:
+            self.assertIsInstance(r__, Delayed)
+            r__.compute()
+        compute_writer_results(res)
 
 def suite():
     """The test suite for this writer's tests.

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -381,27 +381,31 @@ def to_image(dataset, copy=False, **kwargs):
         return XRImage(dataset)
 
 
-def compute_writer_results(results):
-    """Compute all the given dask graphs `results` so that the files are
-    saved.
-
-    Args:
-        results (iterable): Iterable of dask graphs resulting from call to
-                            `scn.save_datasets(..., compute=False)
-    """
+def split_results(results):
+    """Get sources, targets and delayed objects to separate lists from a
+    list of lists of results collected from multiple writers."""
     sources = []
     targets = []
     delayeds = []
     for res in results:
         if isinstance(res, tuple):
-            # source, target to be passed to da.store
-            # Check for empty results
             for src, tgt in zip(*res):
                 sources.append(src)
                 targets.append(tgt)
         else:
-            # delayed object
             delayeds.append(res)
+    return sources, targets, delayeds
+
+
+def compute_writer_results(results):
+    """Compute all the given dask graphs `results` so that the files are
+    saved.
+
+    Args:
+        results (iterable): Iterable of dask graphs resulting from calls to
+                            `scn.save_datasets(..., compute=False)
+    """
+    sources, targets, delayeds = split_results(results)
 
     # one or more writers have targets that we need to close in the future
     if targets:
@@ -497,34 +501,20 @@ class Writer(Plugin):
             close any objects that have a "close" method.
 
         """
-        sources = []
-        targets = []
+        results = []
         for ds in datasets:
-            res = self.save_dataset(ds, compute=False, **kwargs)
-            if isinstance(res, tuple):
-                # source, target to be passed to da.store
-                sources.append(res[0])
-                targets.append(res[1])
-            else:
-                # delayed object
-                sources.append(res)
+            results.append(self.save_dataset(ds, compute=False, **kwargs))
 
-        # we have targets, we should save sources to targets
-        if targets and compute:
-            LOG.info("Computing and writing results...")
-            res = da.store(sources, targets)
-            for target in targets:
-                if hasattr(target, 'close'):
-                    target.close()
-            return res
-        elif targets:
-            return sources, targets
-
-        delayed = dask.delayed(sources)
         if compute:
             LOG.info("Computing and writing results...")
-            return delayed.compute()
-        return delayed
+            return compute_writer_results([results])
+
+        targets, sources, delayeds = split_results([results])
+        if delayeds:
+            # This writer had only delayed writes
+            return delayeds
+        else:
+            return targets, sources
 
     def save_dataset(self, dataset, filename=None, fill_value=None,
                      compute=True, **kwargs):

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -386,7 +386,8 @@ def compute_writer_results(results):
     saved.
 
     Args:
-        results (iterable): Iterable of dask graphs
+        results (iterable): Iterable of dask graphs resulting from call to
+                            `scn.save_datasets(..., compute=False)
     """
     sources = []
     targets = []
@@ -394,8 +395,15 @@ def compute_writer_results(results):
     for res in results:
         if isinstance(res, tuple):
             # source, target to be passed to da.store
-            sources.append(res[0])
-            targets.append(res[1])
+            # Check for empty results
+            if len(res) == 0:
+                continue
+            num = len(res[0])
+            if num == 0:
+                continue
+            for i in range(num):
+                sources.append(res[0][i])
+                targets.append(res[1][i])
         else:
             # delayed object
             delayeds.append(res)

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -396,14 +396,9 @@ def compute_writer_results(results):
         if isinstance(res, tuple):
             # source, target to be passed to da.store
             # Check for empty results
-            if len(res) == 0:
-                continue
-            num = len(res[0])
-            if num == 0:
-                continue
-            for i in range(num):
-                sources.append(res[0][i])
-                targets.append(res[1][i])
+            for src, tgt in zip(*res):
+                sources.append(src)
+                targets.append(tgt)
         else:
             # delayed object
             delayeds.append(res)


### PR DESCRIPTION
This PR adds an slightly modified utility function from Polar2Grid that computes/saves all given delayed results from (multiple) calls to `res = scn.save_datasets(..., compute=False)` in one go.

 - [x] Tests added
 - [x] Tests passed
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff``
 - [x] Fully documented
