### PR TITLE
Use rasterio for reading generic image formats

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff'
-        - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital'
+        - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital libtiff'
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
     MINICONDA_VERSION: "latest"
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
     CONDA_DEPENDENCIES: "xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coverage netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff"
-    PIP_DEPENDENCIES: "trollsift trollimage pyspectral pyorbital"
+    PIP_DEPENDENCIES: "trollsift trollimage pyspectral pyorbital libtiff"
     CONDA_CHANNELS: "conda-forge"
 
   matrix:

--- a/satpy/etc/readers/generic_image.yaml
+++ b/satpy/etc/readers/generic_image.yaml
@@ -10,16 +10,14 @@ datasets:
     name: image
     file_type: graphic
 
-
-
 file_types:
     graphic:
         file_reader: !!python/name:satpy.readers.generic_image.GenericImageFileHandler
         file_patterns:
-         - '{start_time:%Y%m%d%H%M}{filename}.png'
+         - '{start_time:%Y%m%d_%H%M}{filename}.png'
          - '{start_time:%Y%m%d_%H%M}{filename}.jpg'
          - '{start_time:%Y%m%d_%H%M}{filename}.tif'
-         - '{filename}{start_time:%Y%m%d%H%M}.png'
+         - '{filename}{start_time:%Y%m%d_%H%M}.png'
          - '{filename}{start_time:%Y%m%d_%H%M}.jpg'
          - '{filename}{start_time:%Y%m%d_%H%M}.tif'
          - '{filename}.png'

--- a/satpy/etc/readers/generic_image.yaml
+++ b/satpy/etc/readers/generic_image.yaml
@@ -16,8 +16,12 @@ file_types:
     graphic:
         file_reader: !!python/name:satpy.readers.generic_image.GenericImageFileHandler
         file_patterns:
-         - '{start_time:%Y%m%d%H%M}{filename}.{format}'
-         - '{start_time:%Y%m%d_%H%M}{filename}.{format}'
-         - '{filename}{start_time:%Y%m%d%H%M}.{format}'
-         - '{filename}{start_time:%Y%m%d_%H%M}.{format}'
-         - '{filename}.{format}'
+         - '{start_time:%Y%m%d%H%M}{filename}.png'
+         - '{start_time:%Y%m%d_%H%M}{filename}.jpg'
+         - '{start_time:%Y%m%d_%H%M}{filename}.tif'
+         - '{filename}{start_time:%Y%m%d%H%M}.png'
+         - '{filename}{start_time:%Y%m%d_%H%M}.jpg'
+         - '{filename}{start_time:%Y%m%d_%H%M}.tif'
+         - '{filename}.png'
+         - '{filename}.jpg'
+         - '{filename}.tif'

--- a/satpy/etc/readers/generic_image.yaml
+++ b/satpy/etc/readers/generic_image.yaml
@@ -16,8 +16,8 @@ file_types:
     graphic:
         file_reader: !!python/name:satpy.readers.generic_image.GenericImageFileHandler
         file_patterns:
-         - '{filename}_{start_time:%Y%m%d%H%M}.png'
-         - '{filename}_{start_time:%Y%m%d%H%M}.jpg'
-         - '{filename}{start_time:%Y%m%d%H%M}.gif'
-         - '{filename}{start_time:%Y%m%d%H%M}.tif'
-
+         - '{start_time:%Y%m%d%H%M}{filename}.{format}'
+         - '{start_time:%Y%m%d_%H%M}{filename}.{format}'
+         - '{filename}{start_time:%Y%m%d%H%M}.{format}'
+         - '{filename}{start_time:%Y%m%d_%H%M}.{format}'
+         - '{filename}.{format}'

--- a/satpy/etc/readers/generic_image.yaml
+++ b/satpy/etc/readers/generic_image.yaml
@@ -10,16 +10,14 @@ datasets:
     name: image
     file_type: graphic
 
+
+
 file_types:
     graphic:
         file_reader: !!python/name:satpy.readers.generic_image.GenericImageFileHandler
         file_patterns:
-         - '{start_time:%Y%m%d_%H%M}{filename}.png'
-         - '{start_time:%Y%m%d_%H%M}{filename}.jpg'
-         - '{start_time:%Y%m%d_%H%M}{filename}.tif'
-         - '{filename}{start_time:%Y%m%d_%H%M}.png'
-         - '{filename}{start_time:%Y%m%d_%H%M}.jpg'
-         - '{filename}{start_time:%Y%m%d_%H%M}.tif'
-         - '{filename}.png'
-         - '{filename}.jpg'
-         - '{filename}.tif'
+         - '{start_time:%Y%m%d%H%M}{filename}.{format}'
+         - '{start_time:%Y%m%d_%H%M}{filename}.{format}'
+         - '{filename}{start_time:%Y%m%d%H%M}.{format}'
+         - '{filename}{start_time:%Y%m%d_%H%M}.{format}'
+         - '{filename}.{format}'

--- a/satpy/readers/generic_image.py
+++ b/satpy/readers/generic_image.py
@@ -103,7 +103,7 @@ class GenericImageFileHandler(BaseFileHandler):
 
 
 def get_geotiff_area_def(filename, crs):
-    """"""
+    """Read area definition from a geotiff."""
     from osgeo import gdal
     from pyresample.geometry import AreaDefinition
     from pyresample.utils import proj4_str_to_dict

--- a/satpy/readers/generic_image.py
+++ b/satpy/readers/generic_image.py
@@ -1,6 +1,7 @@
 # Author(s):
 
 #   Lorenzo Clementi <lorenzo.clementi@meteoswiss.ch>
+#   Panu Lahtinen <panu.lahtinen@fmi.fi>
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -16,17 +17,25 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 """
-Reader for generic image (e.g. gif, png, jpg).
+Reader for generic image (e.g. gif, png, jpg, tif, geotiff, ...).
 
-It returns a dataset without coordinates and calibration.
+Returns a dataset without calibration.  Includes coordinates if
+available in the file (eg. geotiff).
 """
 
-
-from PIL import Image
-import numpy as np
 import logging
-from satpy.dataset import Dataset
+
+import xarray as xr
+import dask.array as da
+import numpy as np
+
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy import CHUNK_SIZE
+
+BANDS = {1: ['L'],
+         2: ['L', 'A'],
+         3: ['R', 'G', 'B'],
+         4: ['R', 'G', 'B', 'A']}
 
 logger = logging.getLogger(__name__)
 
@@ -37,15 +46,47 @@ class GenericImageFileHandler(BaseFileHandler):
         super(GenericImageFileHandler, self).__init__(
             filename, filename_info, filetype_info)
         self.finfo = filename_info
-        self.finfo['end_time'] =  self.finfo['start_time']
+        try:
+            self.finfo['end_time'] =  self.finfo['start_time']
+        except KeyError:
+            pass
         self.finfo['filename'] = filename
-        self.selected = None
-        self.read(filename)
-
-    def read(self, filename):
         self.file_content = {}
-        img = Image.open(filename)
-        self.file_content['image'] = img
+        self.area = None
+        self.read()
+
+    def read(self):
+        """Read the image"""
+        data = xr.open_rasterio(self.finfo["filename"],
+                                chunks=(1, CHUNK_SIZE, CHUNK_SIZE))
+        attrs = data.attrs.copy()
+        # Create area definition
+        if hasattr(data, 'crs'):
+            self.area = self.get_geotiff_area_def(data.crs)
+
+        # Rename to SatPy convention
+        data = data.rename({'band': 'bands'})
+
+        # Rename bands to [R, G, B, A], or a subset of those
+        data['bands'] = BANDS[data.bands.size]
+
+        # Mask data if alpha channel is present
+        if data.bands.size in (2, 4):
+            mask = data.data[-1, :, :] == np.iinfo(data.dtype).min
+            data = data.astype(np.float64)
+            masked_data = da.stack([da.where(mask, np.nan, data.data[i, :, :])
+                                    for i in range(data.shape[0])])
+            data.data = masked_data
+            data = data.sel(bands=BANDS[data.bands.size - 1])
+        data.attrs = attrs
+        self.file_content['image'] = data
+
+    def get_area_def(self, dsid):
+        return self.area
+
+    def get_geotiff_area_def(self, crs):
+        """Get extents from GeoTIFF file"""
+        return get_geotiff_area_def(self.finfo['filename'], crs)
 
     @property
     def start_time(self):
@@ -55,14 +96,28 @@ class GenericImageFileHandler(BaseFileHandler):
     def end_time(self):
         return self.finfo['end_time']
 
-    def get_dataset(self, key, info, out=None):
+    def get_dataset(self, key, info):
         """Get a dataset from the file."""
+        logger.debug("Reading %s.", key)
+        return self.file_content[key.name]
 
-        logger.debug("Reading %s.", key.name)
-        values = self.file_content[key.name]
-        selected = np.array(values)
-        out = np.rot90(np.fliplr(np.transpose(selected)))
-        info['filename'] = self.finfo['filename']
-        ds = Dataset(out, copy=False, **info)
-        return ds
 
+def get_geotiff_area_def(filename, crs):
+    """"""
+    from osgeo import gdal
+    from pyresample.geometry import AreaDefinition
+    from pyresample.utils import proj4_str_to_dict
+    fid = gdal.Open(filename)
+    geo_transform = fid.GetGeoTransform()
+    pcs_id = fid.GetProjection().split('"')[1]
+    min_x = geo_transform[0]
+    max_y = geo_transform[3]
+    x_size = fid.RasterXSize
+    y_size = fid.RasterYSize
+    max_x = min_x + geo_transform[1] * x_size
+    min_y = max_y + geo_transform[5] * y_size
+    area_extent = [min_x, min_y, max_x, max_y]
+    area_def = AreaDefinition('geotiff_area', pcs_id, pcs_id,
+                              proj4_str_to_dict(crs),
+                              x_size, y_size, area_extent)
+    return area_def

--- a/satpy/readers/generic_image.py
+++ b/satpy/readers/generic_image.py
@@ -47,7 +47,7 @@ class GenericImageFileHandler(BaseFileHandler):
             filename, filename_info, filetype_info)
         self.finfo = filename_info
         try:
-            self.finfo['end_time'] =  self.finfo['start_time']
+            self.finfo['end_time'] = self.finfo['start_time']
         except KeyError:
             pass
         self.finfo['filename'] = filename

--- a/satpy/tests/reader_tests/__init__.py
+++ b/satpy/tests/reader_tests/__init__.py
@@ -32,7 +32,8 @@ from satpy.tests.reader_tests import (test_abi_l1b, test_hrit_base,
                                       test_acspo, test_amsr2_l1b,
                                       test_omps_edr, test_nucaps, test_geocat,
                                       test_seviri_calibration, test_clavrx,
-                                      test_grib, test_hrit_goes, test_ahi_hsd)
+                                      test_grib, test_hrit_goes, test_ahi_hsd,
+                                      test_generic_image)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -63,5 +64,6 @@ def suite():
     mysuite.addTests(test_grib.suite())
     mysuite.addTests(test_hrit_goes.suite())
     mysuite.addTests(test_ahi_hsd.suite())
+    mysuite.addTests(test_generic_image.suite())
 
     return mysuite

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -29,7 +29,6 @@ import xarray as xr
 import dask.array as da
 import numpy as np
 
-
 class TestGenericImage(unittest.TestCase):
     """Test generic image reader."""
 

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -214,6 +214,7 @@ class TestGenericImage(unittest.TestCase):
         self.assertTrue(data.bands.size == 3)
 
 
+
 def suite():
     """The test suite for test_writers."""
     loader = unittest.TestLoader()

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -214,7 +214,6 @@ class TestGenericImage(unittest.TestCase):
         self.assertTrue(data.bands.size == 3)
 
 
-
 def suite():
     """The test suite for test_writers."""
     loader = unittest.TestLoader()

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -92,11 +92,11 @@ class TestGenericImage(unittest.TestCase):
         scn['l'] = ds_l
         scn['l'].attrs['area'] = self.area_def
         scn['la'] = ds_la
-        scn['l'].attrs['area'] = self.area_def
+        scn['la'].attrs['area'] = self.area_def
         scn['rgb'] = ds_rgb
-        scn['l'].attrs['area'] = self.area_def
+        scn['rgb'].attrs['area'] = self.area_def
         scn['rgba'] = ds_rgba
-        scn['l'].attrs['area'] = self.area_def
+        scn['rgba'].attrs['area'] = self.area_def
 
         # Save the images.  Two images in PNG and two in GeoTIFF
         scn.save_dataset('l', os.path.join(self.base_dir, 'test_l.png'),
@@ -148,7 +148,7 @@ class TestGenericImage(unittest.TestCase):
         self.assertEqual(scn.attrs['sensor'], set(['images']))
         self.assertEqual(scn.attrs['start_time'], self.date)
         self.assertEqual(scn.attrs['end_time'], self.date)
-        # self.assertEqual(scn['image'].area, self.area_def)
+        self.assertEqual(scn['image'].area, self.area_def)
 
         fname = os.path.join(self.base_dir, 'test_rgba.tif')
         scn = Scene(reader='generic_image', filenames=[fname])
@@ -157,7 +157,7 @@ class TestGenericImage(unittest.TestCase):
         self.assertEqual(scn.attrs['sensor'], set(['images']))
         self.assertEqual(scn.attrs['start_time'], None)
         self.assertEqual(scn.attrs['end_time'], None)
-        # self.assertEqual(scn['image'].area, self.area_def)
+        self.assertEqual(scn['image'].area, self.area_def)
 
 
 def suite():

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -23,7 +23,6 @@
 """
 
 import os
-import shutil
 import unittest
 
 import xarray as xr
@@ -116,7 +115,7 @@ class TestGenericImage(unittest.TestCase):
         """Remove the temporary directory created for a test"""
         try:
             import shutil
-            # shutil.rmtree(self.base_dir, ignore_errors=True)
+            shutil.rmtree(self.base_dir, ignore_errors=True)
         except OSError:
             pass
 
@@ -159,6 +158,7 @@ class TestGenericImage(unittest.TestCase):
         self.assertEqual(scn.attrs['start_time'], None)
         self.assertEqual(scn.attrs['end_time'], None)
         # self.assertEqual(scn['image'].area, self.area_def)
+
 
 def suite():
     """The test suite for test_writers."""

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -1,0 +1,172 @@
+#!/usr/bin/python
+# Copyright (c) 2018.
+#
+
+# Author(s):
+#   Panu Lahtinen <panu.lahtinen@fmi.fi>
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+
+"""
+"""
+
+import os
+import shutil
+import unittest
+
+import xarray as xr
+import dask.array as da
+import numpy as np
+
+from satpy.scene import Scene
+
+
+class TestGenericImage(unittest.TestCase):
+    """Test generic image reader."""
+
+    def setUp(self):
+        """Create temporary images to test on."""
+        import tempfile
+        from datetime import datetime
+
+        from pyresample.geometry import AreaDefinition
+
+        self.date = datetime(2018, 1, 1)
+
+        # Create area definition
+        pcs_id = 'ETRS89 / LAEA Europe'
+        proj4_dict = {'init': 'epsg:3035'}
+        self.x_size = 100
+        self.y_size = 100
+        area_extent = (2426378.0132, 1528101.2618, 6293974.6215, 5446513.5222)
+        self.area_def = AreaDefinition('geotiff_area', pcs_id, pcs_id,
+                                       proj4_dict, self.x_size, self.y_size,
+                                       area_extent)
+
+        # Create datasets for L, LA, RGB and RGBA mode images
+        r__ = da.random.randint(0, 256, size=(self.y_size, self.x_size),
+                                chunks=(50, 50))
+        g__ = da.random.randint(0, 256, size=(self.y_size, self.x_size),
+                                chunks=(50, 50))
+        b__ = da.random.randint(0, 256, size=(self.y_size, self.x_size),
+                                chunks=(50, 50))
+        a__ = 255 * np.ones((self.y_size, self.x_size))
+        a__[:10, :10] = 0
+        a__ = da.from_array(a__, chunks=(50, 50))
+
+        ds_l = xr.DataArray(da.stack([r__]), dims=('bands', 'y', 'x'),
+                            attrs={'name': 'test_l',
+                                   'start_time': self.date})
+        ds_l['bands'] = ['L']
+        ds_la = xr.DataArray(da.stack([r__, a__]), dims=('bands', 'y', 'x'),
+                             attrs={'name': 'test_la',
+                                    'start_time': self.date})
+        ds_la['bands'] = ['L', 'A']
+        ds_rgb = xr.DataArray(da.stack([r__, g__, b__]),
+                              dims=('bands', 'y', 'x'),
+                              attrs={'name': 'test_rgb',
+                                     'start_time': self.date})
+        ds_rgb['bands'] = ['R', 'G', 'B']
+        ds_rgba = xr.DataArray(da.stack([r__, g__, b__, a__]),
+                               dims=('bands', 'y', 'x'),
+                               attrs={'name': 'test_rgba',
+                                      'start_time': self.date})
+        ds_rgba['bands'] = ['R', 'G', 'B', 'A']
+
+        # Temp dir for the saved images
+        self.base_dir = tempfile.mkdtemp()
+
+        # Put the datasets to Scene for easy saving
+        scn = Scene()
+        scn['l'] = ds_l
+        scn['l'].attrs['area'] = self.area_def
+        scn['la'] = ds_la
+        scn['l'].attrs['area'] = self.area_def
+        scn['rgb'] = ds_rgb
+        scn['l'].attrs['area'] = self.area_def
+        scn['rgba'] = ds_rgba
+        scn['l'].attrs['area'] = self.area_def
+
+        # Save the images.  Two images in PNG and two in GeoTIFF
+        scn.save_dataset('l', os.path.join(self.base_dir, 'test_l.png'),
+                         writer='simple_image')
+        scn.save_dataset('la', os.path.join(self.base_dir,
+                                            '20180101_0000_test_la.png'),
+                         writer='simple_image')
+        scn.save_dataset('rgb', os.path.join(self.base_dir,
+                                             '20180101_0000_test_rgb.tif'),
+                         writer='geotiff')
+        scn.save_dataset('rgba', os.path.join(self.base_dir,
+                                              'test_rgba.tif'),
+                         writer='geotiff')
+
+    def tearDown(self):
+        """Remove the temporary directory created for a test"""
+        try:
+            import shutil
+            # shutil.rmtree(self.base_dir, ignore_errors=True)
+        except OSError:
+            pass
+
+    def test_png(self):
+        """Test reading PNG images."""
+        fname = os.path.join(self.base_dir, 'test_l.png')
+        scn = Scene(reader='generic_image', filenames=[fname])
+        scn.load(['image'])
+        self.assertEqual(scn['image'].shape, (1, self.y_size, self.x_size))
+        self.assertEqual(scn.attrs['sensor'], set(['images']))
+        self.assertEqual(scn.attrs['start_time'], None)
+        self.assertEqual(scn.attrs['end_time'], None)
+
+        fname = os.path.join(self.base_dir, '20180101_0000_test_la.png')
+        scn = Scene(reader='generic_image', filenames=[fname])
+        scn.load(['image'])
+        data = da.compute(scn['image'].data)
+        self.assertEqual(scn['image'].shape, (1, self.y_size, self.x_size))
+        self.assertEqual(scn.attrs['sensor'], set(['images']))
+        self.assertEqual(scn.attrs['start_time'], self.date)
+        self.assertEqual(scn.attrs['end_time'], self.date)
+        self.assertEqual(np.sum(np.isnan(data)), 100)
+
+    def test_geotiff(self):
+        """Test reading PNG images."""
+        fname = os.path.join(self.base_dir, '20180101_0000_test_rgb.tif')
+        scn = Scene(reader='generic_image', filenames=[fname])
+        scn.load(['image'])
+        self.assertEqual(scn['image'].shape, (3, self.y_size, self.x_size))
+        self.assertEqual(scn.attrs['sensor'], set(['images']))
+        self.assertEqual(scn.attrs['start_time'], self.date)
+        self.assertEqual(scn.attrs['end_time'], self.date)
+        # self.assertEqual(scn['image'].area, self.area_def)
+
+        fname = os.path.join(self.base_dir, 'test_rgba.tif')
+        scn = Scene(reader='generic_image', filenames=[fname])
+        scn.load(['image'])
+        self.assertEqual(scn['image'].shape, (3, self.y_size, self.x_size))
+        self.assertEqual(scn.attrs['sensor'], set(['images']))
+        self.assertEqual(scn.attrs['start_time'], None)
+        self.assertEqual(scn.attrs['end_time'], None)
+        # self.assertEqual(scn['image'].area, self.area_def)
+
+def suite():
+    """The test suite for test_writers."""
+    loader = unittest.TestLoader()
+    my_suite = unittest.TestSuite()
+    my_suite.addTest(loader.loadTestsFromTestCase(TestGenericImage))
+
+    return my_suite
+
+if __name__ == '__main__':
+    unittest.main()

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -168,5 +168,6 @@ def suite():
 
     return my_suite
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -32,6 +32,7 @@ import numpy as np
 from satpy.scene import Scene
 from satpy.readers.generic_image import GenericImageFileHandler
 from satpy.readers.generic_image import get_geotiff_area_def
+from satpy.readers.generic_image import mask_image_data
 from satpy import CHUNK_SIZE
 
 
@@ -113,6 +114,8 @@ class TestGenericImage(unittest.TestCase):
         scn.save_dataset('rgba', os.path.join(self.base_dir,
                                               'test_rgba.tif'),
                          writer='geotiff')
+
+        self.scn = scn
 
     def tearDown(self):
         """Remove the temporary directory created for a test"""
@@ -197,6 +200,14 @@ class TestGenericImage(unittest.TestCase):
         self.assertTrue('crs' in dataset.attrs)
         self.assertTrue('transform' in dataset.attrs)
         self.assertTrue(np.all(np.isnan(dataset.data[:, :10, :10].compute())))
+
+        # Test masking
+        data = self.scn['rgba']
+        self.assertRaises(ValueError, mask_image_data, data)
+        data = data.astype(np.uint32)
+        self.assertTrue(data.bands.size == 4)
+        data = mask_image_data(data)
+        self.assertTrue(data.bands.size == 3)
 
 
 def suite():

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -29,6 +29,7 @@ import xarray as xr
 import dask.array as da
 import numpy as np
 
+
 class TestGenericImage(unittest.TestCase):
     """Test generic image reader."""
 

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -19,7 +19,7 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-"""
+"""Unittests for generic image reader.
 """
 
 import os

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -176,10 +176,12 @@ class TestGenericImage(unittest.TestCase):
         fname_info = {'start_time': self.date}
         ftype_info = {}
         reader = GenericImageFileHandler(fname, fname_info, ftype_info)
+
         class Foo(object):
             """Mock class for dataset id"""
             def __init__(self):
                 self.name = 'image'
+
         foo = Foo()
         self.assertTrue(reader.file_content)
         self.assertEqual(reader.finfo['filename'], fname)

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -29,12 +29,6 @@ import xarray as xr
 import dask.array as da
 import numpy as np
 
-from satpy.scene import Scene
-from satpy.readers.generic_image import GenericImageFileHandler
-from satpy.readers.generic_image import get_geotiff_area_def
-from satpy.readers.generic_image import mask_image_data
-from satpy import CHUNK_SIZE
-
 
 class TestGenericImage(unittest.TestCase):
     """Test generic image reader."""
@@ -45,6 +39,7 @@ class TestGenericImage(unittest.TestCase):
         from datetime import datetime
 
         from pyresample.geometry import AreaDefinition
+        from satpy.scene import Scene
 
         self.date = datetime(2018, 1, 1)
 
@@ -127,6 +122,8 @@ class TestGenericImage(unittest.TestCase):
 
     def test_png_scene(self):
         """Test reading PNG images via satpy.Scene()."""
+        from satpy import Scene
+
         fname = os.path.join(self.base_dir, 'test_l.png')
         scn = Scene(reader='generic_image', filenames=[fname])
         scn.load(['image'])
@@ -147,6 +144,8 @@ class TestGenericImage(unittest.TestCase):
 
     def test_geotiff_scene(self):
         """Test reading PNG images via satpy.Scene()."""
+        from satpy import Scene
+
         fname = os.path.join(self.base_dir, '20180101_0000_test_rgb.tif')
         scn = Scene(reader='generic_image', filenames=[fname])
         scn.load(['image'])
@@ -167,6 +166,9 @@ class TestGenericImage(unittest.TestCase):
 
     def test_get_geotiff_area_def(self):
         """Test reading area definition from a geotiff"""
+        from satpy.readers.generic_image import get_geotiff_area_def
+        from satpy import CHUNK_SIZE
+
         fname = os.path.join(self.base_dir, '20180101_0000_test_rgb.tif')
         data = xr.open_rasterio(fname,
                                 chunks=(1, CHUNK_SIZE, CHUNK_SIZE))
@@ -175,6 +177,9 @@ class TestGenericImage(unittest.TestCase):
 
     def test_GenericImageFileHandler(self):
         """Test direct use of the reader."""
+        from satpy.readers.generic_image import GenericImageFileHandler
+        from satpy.readers.generic_image import mask_image_data
+
         fname = os.path.join(self.base_dir, 'test_rgba.tif')
         fname_info = {'start_time': self.date}
         ftype_info = {}

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -318,7 +318,6 @@ class TestComputeWriterResults(unittest.TestCase):
         from datetime import datetime
 
         from satpy.scene import Scene
-        import xarray as xr
         import dask.array as da
 
         ds1 = xr.DataArray(
@@ -336,7 +335,6 @@ class TestComputeWriterResults(unittest.TestCase):
     def tearDown(self):
         """Remove the temporary directory created for a test"""
         try:
-            import shutil
             shutil.rmtree(self.base_dir, ignore_errors=True)
         except OSError:
             pass


### PR DESCRIPTION
This PR makes it possible to read generic image formats in a lazy way using `rasterio`.

If the image has georeferencing that `rasterio` and GDAL can read, like in GeoTIFF, the information is parsed and stored in the `Scene` so that the scene can be resampled.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
