### PR TITLE
meteosat native HRV georeferencing

### DIFF
--- a/satpy/tests/reader_tests/test_native_msg.py
+++ b/satpy/tests/reader_tests/test_native_msg.py
@@ -125,7 +125,13 @@ class TestNativeMSGAreaExtent(unittest.TestCase):
                         'ColumnDirGridStep': 3.0004032,
                         'LineDirGridStep': 3.0004032,
                         'GridOrigin': 2,  # south-east corner
-                    }
+                    },
+                    'ReferenceGridHRV': {
+                        'ColumnDirGridStep': 1.0001343,
+                        'LineDirGridStep': 1.0001343,
+                        'NumberOfLines': 11136,
+                        'NumberOfColumns': 11136,
+                    },
                 },
                 'GeometricProcessing': {
                     'EarthModel': {'TypeOfEarthModel': earth_model}
@@ -167,6 +173,21 @@ class TestNativeMSGAreaExtent(unittest.TestCase):
         expected_area_extent = (
             -5570248.477339745, -5567248.074173927,
             5567248.074173927, 5570248.477339745
+        )
+        assertNumpyArraysEqual(
+            np.array(calc_area_extent), np.array(expected_area_extent)
+        )
+
+    def test_HRV(self):
+        """HRV area extent"""
+        dsid = mock.Mock()
+        dsid.name = 'HRV'
+        calc_area_extent = NativeMSGFileHandler.get_area_extent(
+            self.get_mock_file_handler(earth_model=2), dsid
+        )
+        expected_area_extent = (
+            -5571248.390376568, -5566247.718632221,
+            5566247.718632221, 5571248.390376568
         )
         assertNumpyArraysEqual(
             np.array(calc_area_extent), np.array(expected_area_extent)


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

<!-- Describe what your PR does, and why -->
Georeferences the HRV imagery of meteosat native (`.nat`) files by embedding the HRV-Upper and HRV-Lower images in the HRV full-disk reference grid.

![image](https://user-images.githubusercontent.com/14136435/43396660-21d5fb6c-93fa-11e8-80f3-c0eeae20eba4.png)

![image](https://user-images.githubusercontent.com/14136435/43396667-26915020-93fa-11e8-8946-124b53091828.png)

HRV scenes can now be `.resample`d easily.

Here are some scenes (different times) I used the new code on to demonstrate that the georeferencing seems decent:
![image](https://user-images.githubusercontent.com/14136435/43397434-c1a5a014-93fc-11e8-95fe-5143077935a6.png)


 - [X] Tests added for calculating HRV reference grid area_extent
 - NB: no tests for correctly placing the HRV-Upper/HRV-Lower in the reference grid. For my project, I have a bunch of integration tests that read + resample `.nat` files and compare to a pre-generated netcdf output, along with automated generation of georeferencing validation images like the above.
 - [ ] Tests passed
 - [X] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [] Fully documented. Any documentation required?
