### PR TITLE
Fix DayNightCompositor masking imagery incorrectly

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -885,8 +885,8 @@ def enhance2dataset(dset):
     array of the image."""
     attrs = dset.attrs
     img = get_enhanced_image(dset)
-    # Clip image data to interval [0.0, 1.0] and replace nan values
-    data = img.data.clip(0.0, 1.0).fillna(0.0)
+    # Clip image data to interval [0.0, 1.0]
+    data = img.data.clip(0.0, 1.0)
     data.attrs = attrs
 
     return data


### PR DESCRIPTION
This PR fixes the behaviour of `DayNightCompositor`, which was masking the imagery incorrectly.

 - [x] Closes #377 
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
