### PR TITLE
Natural color rgb

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -113,7 +113,7 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected]
     standard_name: true_color
 
-  natural:
+  natural_color:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
     - wavelength: 1.63
@@ -123,15 +123,15 @@ composites:
     - wavelength: 0.635
       modifiers: [sunz_corrected]
     high_resolution_band: blue
-    standard_name: natural
+    standard_name: natural_color
 
-  natural_raw:
+  natural_color_raw:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - wavelength: 1.63
     - wavelength: 0.85
     - wavelength: 0.635
-    standard_name: natural
+    standard_name: natural_color
 
   overview:
     compositor: !!python/name:satpy.composites.GenericCompositor

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -36,7 +36,7 @@ composites:
     - 10.4
     standard_name: overview
 
-  natural:
+  natural_color:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
     - wavelength: 1.63
@@ -46,7 +46,7 @@ composites:
     - wavelength: 0.635
       modifiers: [sunz_corrected] #, rayleigh_corrected]
     high_resolution_band: blue
-    standard_name: natural
+    standard_name: natural_color
 
   true_color:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB

--- a/satpy/etc/composites/msi.yaml
+++ b/satpy/etc/composites/msi.yaml
@@ -70,7 +70,7 @@ modifiers:
 
 
 composites:
-  natural_sun:
+  natural_color_sun:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - name: 'B11'
@@ -78,7 +78,7 @@ composites:
       modifiers: [effective_solar_pathlength_corrected]
     - name: 'B04'
       modifiers: [effective_solar_pathlength_corrected]
-    standard_name: natural
+    standard_name: natural_color
     
   true_color:
     compositor: !!python/name:satpy.composites.GenericCompositor

--- a/satpy/etc/composites/msi.yaml
+++ b/satpy/etc/composites/msi.yaml
@@ -70,6 +70,16 @@ modifiers:
 
 
 composites:
+  natural_sun:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - name: 'B11'
+    - name: 'B08'
+      modifiers: [effective_solar_pathlength_corrected]
+    - name: 'B04'
+      modifiers: [effective_solar_pathlength_corrected]
+    standard_name: natural
+    
   true_color:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -83,15 +83,15 @@ composites:
     - 10.8
     standard_name: day_microphysics_winter
 
-  natural:
+  natural_color:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - 1.63
     - name: VIS008
     - name: VIS006
-    standard_name: natural
+    standard_name: natural_color
 
-  natural_sun:
+  natural_color_sun:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - wavelength: 1.63
@@ -100,7 +100,7 @@ composites:
       modifiers: [sunz_corrected]
     - name: VIS006
       modifiers: [sunz_corrected]
-    standard_name: natural
+    standard_name: natural_color
 
   cloudmask:
     compositor: !!python/name:satpy.composites.PaletteCompositor

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -221,7 +221,7 @@ composites:
     standard_name: natural_color
     high_resolution_band: blue
 
-  natural_sun:
+  natural_color_sun:
     compositor: !!python/name:satpy.composites.RGBCompositor
     prerequisites:
     - name: I03
@@ -230,9 +230,9 @@ composites:
       modifiers: [sunz_corrected_iband]
     - name: I01
       modifiers: [sunz_corrected_iband]
-    standard_name: natural
+    standard_name: natural_color
 
-  natural_sun_lowres:
+  natural_color_sun_lowres:
     compositor: !!python/name:satpy.composites.RGBCompositor
     prerequisites:
     - name: M10
@@ -241,7 +241,7 @@ composites:
       modifiers: [sunz_corrected]
     - name: M05
       modifiers: [sunz_corrected]
-    standard_name: natural
+    standard_name: natural_color
 
   true_color_raw:
     compositor: !!python/name:satpy.composites.GenericCompositor

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -203,7 +203,7 @@ composites:
     optional_prerequisites:
     - name: I01
       modifiers: [sunz_corrected_iband, rayleigh_corrected_iband]
-    standard_name: natural_color
+    standard_name: false_color
     high_resolution_band: blue
 
   natural_color:

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -191,10 +191,25 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected_marine_tropical]
     standard_name: true_color
 
-  natural_color:
+  false_color:
     compositor: !!python/name:satpy.composites.RatioSharpenedRGB
     prerequisites:
     - name: M11
+      modifiers: [sunz_corrected]
+    - name: M07
+      modifiers: [sunz_corrected]
+    - name: M05
+      modifiers: [sunz_corrected, rayleigh_corrected]
+    optional_prerequisites:
+    - name: I01
+      modifiers: [sunz_corrected_iband, rayleigh_corrected_iband]
+    standard_name: natural_color
+    high_resolution_band: blue
+
+  natural_color:
+    compositor: !!python/name:satpy.composites.RatioSharpenedRGB
+    prerequisites:
+    - name: M10
       modifiers: [sunz_corrected]
     - name: M07
       modifiers: [sunz_corrected]

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -177,14 +177,14 @@ composites:
     - 0.635
     - 10.8
     standard_name: green_snow
-  natural:
+  natural_color:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - 1.63
     - 0.85
     - 0.635
-    standard_name: natural
-  natural_sun:
+    standard_name: natural_color
+  natural_color_sun:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - wavelength: 1.63
@@ -193,7 +193,7 @@ composites:
       modifiers: [sunz_corrected]
     - wavelength: 0.635
       modifiers: [sunz_corrected]
-    standard_name: natural
+    standard_name: natural_color
   night_fog:
     compositor: !!python/name:satpy.composites.Dust
     prerequisites:
@@ -230,7 +230,7 @@ composites:
     compositor: !!python/name:satpy.composites.DayNightCompositor
     standard_name: natural_with_night_fog
     prerequisites:
-      - natural
+      - natural_color
       - night_fog
       - solar_zenith_angle
 
@@ -303,7 +303,8 @@ composites:
     compositor: !!python/name:satpy.composites.GenericCompositor
     standard_name: ir108_3d
     prerequisites:
-      - name: IR_108
+      - wavelength: 10.8
+    #  - name: IR_108
 
   ir_cloud_day:
     standard_name: ir_cloud_day

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -45,8 +45,8 @@ enhancements:
     - name: gamma
       method: *gammafun
       kwargs: {gamma: 1.6}
-  natural_default:
-    standard_name: natural
+  natural_color_default:
+    standard_name: natural_color
     operations:
     - name: stretch
       method: *stretchfun


### PR DESCRIPTION
Rename the natural_color RGB to false_color RGB (it was the MODIS naming of this type of RGB) and adjust the natural_color RGB to fit the EUMETSAT recipe.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->

