### PR TITLE
Add platform_name and sensor in avhrr_aapp_l1b reader

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -499,11 +499,12 @@ class NIRReflectance(CompositeBase):
         tb13_4 = None
 
         for dataset in optional_datasets:
-            if (dataset.attrs['units'] == 'K' and
-                    "wavelengh" in dataset.attrs and
+            if ('units' in dataset.attrs and dataset.attrs['units'] == 'K' and
+                "wavelengh" in dataset.attrs and
                     dataset.attrs["wavelength"][0] <= 13.4 <= dataset.attrs["wavelength"][2]):
                 tb13_4 = dataset
-            elif dataset.attrs["standard_name"] == "solar_zenith_angle":
+            elif ("standard_name" in dataset.attrs and
+                  dataset.attrs["standard_name"] == "solar_zenith_angle"):
                 sun_zenith = dataset
 
         # Check if the sun-zenith angle was provided:

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -499,9 +499,9 @@ class NIRReflectance(CompositeBase):
         tb13_4 = None
 
         for dataset in optional_datasets:
-            if ('units' in dataset.attrs and dataset.attrs['units'] == 'K' and
-                "wavelengh" in dataset.attrs and
-                    dataset.attrs["wavelength"][0] <= 13.4 <= dataset.attrs["wavelength"][2]):
+            wavelengths = dataset.attrs.get('wavelength', [100., 0, 0])
+            if (dataset.attrs.get('units') == 'K' and
+                wavelengths[0] <= 13.4 <= wavelengths[2]):
                 tb13_4 = dataset
             elif ("standard_name" in dataset.attrs and
                   dataset.attrs["standard_name"] == "solar_zenith_angle"):

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -461,7 +461,6 @@ class PSPRayleighReflectance(CompositeBase):
 
 
 class NIRReflectance(CompositeBase):
-    # TODO: Daskify
 
     def __call__(self, projectables, optional_datasets=None, **info):
         """Get the reflectance part of an NIR channel. Not supposed to be used

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -501,7 +501,7 @@ class NIRReflectance(CompositeBase):
         for dataset in optional_datasets:
             wavelengths = dataset.attrs.get('wavelength', [100., 0, 0])
             if (dataset.attrs.get('units') == 'K' and
-                wavelengths[0] <= 13.4 <= wavelengths[2]):
+                    wavelengths[0] <= 13.4 <= wavelengths[2]):
                 tb13_4 = dataset
             elif ("standard_name" in dataset.attrs and
                   dataset.attrs["standard_name"] == "solar_zenith_angle"):

--- a/satpy/etc/readers/avhrr_aapp_l1b.yaml
+++ b/satpy/etc/readers/avhrr_aapp_l1b.yaml
@@ -124,4 +124,4 @@ datasets:
 file_types:
     avhrr_aapp_l1b:
         file_reader: !!python/name:satpy.readers.aapp_l1b.AVHRRAAPPL1BFile
-        file_patterns: ['hrpt_{platform_name}_{start_time:%Y%m%d_%H%M}_{orbit_number:05d}.l1b']
+        file_patterns: ['hrpt_{platform_shortname}_{start_time:%Y%m%d_%H%M}_{orbit_number:05d}.l1b']

--- a/satpy/readers/aapp_l1b.py
+++ b/satpy/readers/aapp_l1b.py
@@ -53,6 +53,33 @@ ANGLES = {'sensor_zenith_angle': 'satz',
           'solar_zenith_angle': 'sunz',
           'sun_sensor_azimuth_difference_angle': 'azidiff'}
 
+PLATFORM_NAMES = {'noaa7': 'NOAA-7',
+                  'noaa8': 'NOAA-8',
+                  'noaa9': 'NOAA-9',
+                  'noaa10': 'NOAA-10',
+                  'noaa11': 'NOAA-11',
+                  'noaa12': 'NOAA-12',
+                  'noaa13': 'NOAA-13',
+                  'noaa14': 'NOAA-14',
+                  'noaa15': 'NOAA-15',
+                  'noaa16': 'NOAA-16',
+                  'noaa17': 'NOAA-17',
+                  'noaa18': 'NOAA-18',
+                  'noaa19': 'NOAA-19',
+                  'm01': 'Metop-B',
+                  'm02': 'Metop-A',
+                  'm03': 'Metop-C',
+                  'M01': 'Metop-B',
+                  'M02': 'Metop-A',
+                  'M03': 'Metop-C',
+                  'metop01': 'Metop-B',
+                  'metop02': 'Metop-A',
+                  'metop03': 'Metop-C',
+}
+
+AVHRR2_PLATFORM_NAMES = ['NOAA-7', 'NOAA-8', 'NOAA-9', 'NOAA-10', 'NOAA-11',
+                         'NOAA-12', 'NOAA-13', 'NOAA-14']
+
 
 def create_xarray(arr):
     res = da.from_array(arr, chunks=(CHUNK_SIZE, CHUNK_SIZE))
@@ -67,6 +94,13 @@ class AVHRRAAPPL1BFile(BaseFileHandler):
                                                filetype_info)
         self.channels = {i: None for i in AVHRR_CHANNEL_NAMES}
         self.units = {i: 'counts' for i in AVHRR_CHANNEL_NAMES}
+
+        platform_shortname = filename_info['platform_shortname']
+        self.platform_name = PLATFORM_NAMES.get(platform_shortname)
+        if self.platform_name in AVHRR2_PLATFORM_NAMES:
+            self.sensor = 'avhrr-2'
+        else:
+            self.sensor = 'avhrr-3'
 
         self._data = None
         self._header = None
@@ -119,7 +153,10 @@ class AVHRRAAPPL1BFile(BaseFileHandler):
                     "Not a supported sun-sensor viewing angle: %s", key.name)
                 raise
 
-        # TODO get metadata
+        # FIXME get metadata from the header
+        dataset.attrs.update({'platform_name': self.platform_name,
+                              'sensor': self.sensor})
+        dataset.attrs.update(key.to_dict())
 
         if not self._shape:
             self._shape = dataset.shape


### PR DESCRIPTION
This PR adds `platform_name` (read from the data header) and `sensor` to the dataset metadata. AVHRR/2 is removed from `avhrr_aapp_l1b.yaml`, as AAPP documentation doesn't mention it at all.

 - [x] Closes #385
 - [ ] Tests added
 - [x] Tests passed
 - [ ] Passes ``git diff origin/master **/*py | flake8 --diff``