### PR TITLE
Fix enhancement config loading when yaml file is empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ matrix:
 install:
     - git clone --depth 1 git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
+    # See https://github.com/conda/conda/issues/7626#issuecomment-412922028
+    - conda config --remove channels defaults
+    - conda install -y $CONDA_DEPENDENCIES
 script:
 - coverage run --source=satpy setup.py test
 - coverage run -a --source=satpy -m behave satpy/tests/features --tags=-download

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
         - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff kealib'
+        - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff'
         - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital'
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
         - MAIN_CMD='python setup.py'
         # 'krb5' is added as a workaround for an issue with gdal
         # see: https://github.com/conda-forge/gdal-feedstock/issues/205
-        - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock krb5 libtiff'
+        - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock krb5 libtiff libkea'
         - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital'
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ env:
         - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        # 'krb5' is added as a workaround for an issue with gdal
-        # see: https://github.com/conda-forge/gdal-feedstock/issues/205
-        - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock krb5 libtiff libkea'
+        - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff kealib'
         - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital'
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -141,6 +141,7 @@ class TestEnhancerUserConfigs(unittest.TestCase):
     ENH_ENH_FN = os.path.join('enhancements', ENH_FN)
     ENH_FN2 = 'test_sensor2.yaml'
     ENH_ENH_FN2 = os.path.join('enhancements', ENH_FN2)
+    ENH_FN3 = 'test_empty.yaml'
 
     TEST_CONFIGS = {
         ENH_FN: """
@@ -175,6 +176,7 @@ sensor_name: visir/test_sensor2
 sensor_name: visir/test_sensor2
 
         """,
+        ENH_FN3: """""",
     }
 
     @classmethod
@@ -195,6 +197,19 @@ sensor_name: visir/test_sensor2
                 shutil.rmtree(base_dir)
             elif os.path.isfile(fn):
                 os.remove(fn)
+
+    def test_enhance_empty_config(self):
+        """Test Enhancer doesn't fail with empty enhancement file."""
+        from satpy.writers import Enhancer, get_enhanced_image
+        from xarray import DataArray
+        ds = DataArray(np.arange(1, 11.).reshape((2, 5)),
+                       attrs=dict(sensor='test_empty', mode='L'),
+                       dims=['y', 'x'])
+        e = Enhancer()
+        self.assertIsNotNone(e.enhancement_tree)
+        get_enhanced_image(ds, enhancer=e)
+        self.assertSetEqual(set(e.sensor_enhancement_configs),
+                            {self.ENH_FN3})
 
     def test_enhance_with_sensor_no_entry(self):
         """Test enhancing an image that has no configuration sections."""

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -682,7 +682,12 @@ class EnhancementDecisionTree(DecisionTree):
         for config_file in decision_dict:
             if os.path.isfile(config_file):
                 with open(config_file) as fd:
-                    enhancement_section = yaml.load(fd).get(self.prefix, {})
+                    enhancement_config = yaml.load(fd)
+                    if enhancement_config is None:
+                        # empty file
+                        continue
+                    enhancement_section = enhancement_config.get(
+                        self.prefix, {})
                     if not enhancement_section:
                         LOG.debug("Config '{}' has no '{}' section or it is empty".format(config_file, self.prefix))
                         continue


### PR DESCRIPTION
I was playing around with making my own enhancement configuration files and noticed this small bug. If you have a completely empty enhancement config then you get an exception and nothing happens.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->