### PR TITLE
Use more descriptive error message when reader can't be loaded

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -517,6 +517,9 @@ def find_files_and_readers(start_time=None, end_time=None, base_dir=None,
         except (KeyError, IOError, yaml.YAMLError) as err:
             LOG.info('Cannot use %s', str(reader_configs))
             LOG.debug(str(err))
+            if reader and (isinstance(reader, str) or len(reader) == 1):
+                # if it is a single reader then give a more usable error
+                raise
             continue
 
         if not reader_instance.supports_sensor(sensor):

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -437,6 +437,16 @@ class TestFindFilesAndReaders(unittest.TestCase):
         self.assertRaises(ValueError, find_files_and_readers,
                           sensor='viirs')
 
+    def test_reader_load_failed(self):
+        """Test that an exception is raised when a reader can't be loaded."""
+        from satpy.readers import find_files_and_readers
+        import yaml
+        # touch the file so it exists on disk
+        with mock.patch('yaml.load') as load:
+            load.side_effect = yaml.YAMLError("Import problems")
+            self.assertRaises(yaml.YAMLError, find_files_and_readers,
+                              reader='viirs_sdr')
+
 
 class TestYAMLFiles(unittest.TestCase):
     """Test and analyze the reader configuration files."""


### PR DESCRIPTION
We've gotten multiple new users who have run in to the error of "No supported files found" when the actual issue was that they didn't have an optional dependency that a reader needed. This adds an extra if statement to solve this common case when only one reader was provided but it can't be loaded.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->