### PR TITLE
Fix native resampler using SwathDefinition as an AreaDefinition

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -778,7 +778,7 @@ class NativeResampler(BaseResampler):
 
         coords = {}
         # Update coords if we can
-        if 'y' in data.coords or 'x' in data.coords and \
+        if ('y' in data.coords or 'x' in data.coords) and \
                 isinstance(target_geo_def, AreaDefinition):
             coord_chunks = (d_arr.chunks[y_axis], d_arr.chunks[x_axis])
             x_coord, y_coord = target_geo_def.get_proj_vectors_dask(


### PR DESCRIPTION
First fixed by @wroberts4 in #317 but was not cherry-pick-able

If a dataset had a SwathDefinition for an area and also had a 'y' coordinate then the associated if statement was entered when it shouldn't be.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->