### PR TITLE
Fix HDF4 utils testing when pyhdf isn't available

### DIFF
--- a/satpy/tests/reader_tests/test_hdf4_utils.py
+++ b/satpy/tests/reader_tests/test_hdf4_utils.py
@@ -12,7 +12,7 @@ try:
     from satpy.readers.hdf4_utils import HDF4FileHandler
 except ImportError:
     # fake the import so we can at least run the tests in this file
-    HDF4FileHandler = None
+    HDF4FileHandler = object
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest


### PR DESCRIPTION
I had previously updated the reader utilities tests so that if that the underlying library wasn't available it would still be able to import the module and then fail later. I apparently made a typo for the HDF4 utilities where the import issue replaces the HDF4FileHandler with `None` instead of `object`. This causes an exception when `None` is used as the parent class later in the module. I noticed this while using pyinstaller to bundle my application and having it automatically find all dependencies (very useful for all of the optional reader modules) where it raised an exception when it hit this module.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->