### PR TITLE
Add AWIPS-style BT piecewise enhancement 'btemp_threshold'

### DIFF
--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -247,9 +247,19 @@ def btemp_threshold(img, min_in, max_in, threshold, threshold_out=None,
 
     This enhancement scales the input data linearly by splitting the data
     into two regions; min_in to threshold and threshold to max_in. These
-    regions are mapped to 0 to threshold_out and threshold_out to 1. A
-    default threshold_out is set to `176.0 / 255.0` to match the behavior
-    of the US National Weather Service's forecasting tool called AWIPS.
+    regions are mapped to 1 to threshold_out and threshold_out to 0
+    respectively, resulting in the data being "flipped" around the
+    threshold. A default threshold_out is set to `176.0 / 255.0` to
+    match the behavior of the US National Weather Service's forecasting
+    tool called AWIPS.
+
+    Args:
+        img (XRImage): Image object to be scaled
+        min_in (float): Minimum input value to scale
+        max_in (float): Maximum input value to scale
+        threshold (float): Input value where to split data in to two regions
+        threshold_out (float): Output value to map the input `threshold`
+            to. Optional, defaults to 176.0 / 255.0.
 
     """
     threshold_out = threshold_out if threshold_out is not None else (176 / 255.0)

--- a/satpy/tests/test_enhancements.py
+++ b/satpy/tests/test_enhancements.py
@@ -115,6 +115,16 @@ class TestEnhancementStretch(unittest.TestCase):
             [np.nan, np.nan, 85.5, 180.5, 1301.5]]])
         self._test_enhancement(three_d_effect, self.ch1, expected)
 
+    def test_btemp_threshold(self):
+        """Test applying the cira_stretch"""
+        from satpy.enhancements import btemp_threshold
+
+        expected = np.array([[
+            [np.nan, 0.946207, 0.892695, 0.839184, 0.785672],
+            [0.73216, 0.595869, 0.158745, -0.278379, -0.715503]]])
+        self._test_enhancement(btemp_threshold, self.ch1, expected,
+                               min_in=-200, max_in=500, threshold=350)
+
     def tearDown(self):
         """Clean up"""
         pass


### PR DESCRIPTION
In my Polar2Grid project we use a 2-element piecewise function to linearly scale brightness temperature data. In addition to splitting the data in to two regions based on a threshold, it flips the data so that cold temperatures are bright and hot temperatures are dark. This results in an image where clouds are white and the ground is dark which is expected by most forecasters (at least US forecasters).

A typical configuration would look like (which I am using in my geo2grid project):

```yaml
  brightness_temperature_default:
    standard_name: toa_brightness_temperature
    operations:
    - name: btemp_threshold
      method: !!python/name:satpy.enhancements.btemp_threshold
      kwargs:
        threshold: 242.0
        min_in: 163.0
        max_in: 330.0
  brightness_temperature_default_celsius:
    standard_name: toa_brightness_temperature
    units: celsius
    operations:
    - name: btemp_threshold
      method: !!python/name:satpy.enhancements.btemp_threshold
      kwargs:
        threshold: -31.15
        min_in: -110.15
        max_in: 56.85
```

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
