### PR TITLE
Check that the areas have same shapes

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -832,6 +832,9 @@ class DayNightCompositor(GenericCompositor):
         day_data = projectables[0]
         night_data = projectables[1]
 
+        if day_data.shape != night_data.shape:
+            raise IncompatibleAreas
+
         lim_low = np.cos(np.deg2rad(self.lim_low))
         lim_high = np.cos(np.deg2rad(self.lim_high))
         try:


### PR DESCRIPTION
This PR fixes an oversight in DayNightCompositor that results in zero-sized composite if the areas of the two unresampled composites do not match.

 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
