### PR TITLE
Wrap solar and satellite angles in xarray

### DIFF
--- a/satpy/readers/aapp_l1b.py
+++ b/satpy/readers/aapp_l1b.py
@@ -127,7 +127,7 @@ class AVHRRAAPPL1BFile(BaseFileHandler):
         else:  # Get sun-sat angles
             if key.name in ANGLES:
                 if isinstance(getattr(self, ANGLES[key.name]), np.ndarray):
-                    dataset = getattr(self, ANGLES[key.name])
+                    dataset = create_xarray(getattr(self, ANGLES[key.name]))
                 else:
                     dataset = self.get_angles(key.name)
             else:


### PR DESCRIPTION
In the initial xarray/dask conversion the solar and satellite angles were missed and were not properly converted to xarrays. This PR adds the wrapping.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
