### PR TITLE
Fix 'platform_name' metadata in ACSPO and CLAVR-x readers

### DIFF
--- a/satpy/readers/acspo.py
+++ b/satpy/readers/acspo.py
@@ -109,7 +109,7 @@ class ACSPOFileHandler(NetCDF4FileHandler):
         info.update({
             'shape': shape,
             'units': units,
-            'platform': self.platform_name,
+            'platform_name': self.platform_name,
             'sensor': self.sensor_name,
             'standard_name': standard_name,
             'resolution': resolution,

--- a/satpy/readers/clavrx.py
+++ b/satpy/readers/clavrx.py
@@ -120,7 +120,7 @@ class CLAVRXFileHandler(HDF4FileHandler):
             i['units'] = CF_UNITS[u]
 
         i['sensor'] = self.get_sensor(self['/attr/sensor'])
-        i['platform'] = self.get_platform(self['/attr/platform'])
+        i['platform_name'] = self.get_platform(self['/attr/platform'])
         i['resolution'] = i.get('resolution') or self.get_nadir_resolution(i['sensor'])
         i['rows_per_scan'] = self.get_rows_per_scan(i['sensor'])
         i['reader'] = 'clavrx'


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

<!-- Describe what your PR does, and why -->
This is a minor fix that changes a variable name in two of the readers to make it consistent across all of them. 

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
