### PR TITLE
Fix masking and simplify avhrr_aapp_l1b reader

### DIFF
--- a/satpy/readers/aapp_l1b.py
+++ b/satpy/readers/aapp_l1b.py
@@ -237,7 +237,7 @@ class AVHRRAAPPL1BFile(BaseFileHandler):
                  'counts': '',
                  'radiance': 'W*m-2*sr-1*cm ?'}
 
-        if dataset_id.name in ("3a","3b") and self._is3b is None:
+        if dataset_id.name in ("3a", "3b") and self._is3b is None:
             # Is it 3a or 3b:
             is3b = np.expand_dims(
                 np.bitwise_and(

--- a/satpy/readers/aapp_l1b.py
+++ b/satpy/readers/aapp_l1b.py
@@ -246,29 +246,29 @@ class AVHRRAAPPL1BFile(BaseFileHandler):
                                    self._data['hrpt'][0].shape[0], axis=1)
 
         try:
-            idx = ['1', '2', '3a'].index(dataset_id.name)
+            vis_idx = ['1', '2', '3a'].index(dataset_id.name)
+            ir_idx = None
+        except ValueError:
+            vis_idx = None
+            ir_idx = ['3b', '4', '5'].index(dataset_id.name)
+
+        if vis_idx is not None:
             coeffs = calib_coeffs.get('ch' + dataset_id.name)
             ds = create_xarray(
                 _vis_calibrate(self._data,
-                               idx,
+                               vis_idx,
                                dataset_id.calibration,
                                pre_launch_coeffs,
                                coeffs,
                                mask=(dataset_id.name == '3a' and self._is3b)))
-        except ValueError:
-            pass
-
-        try:
-            idx = ['3b', '4', '5'].index(dataset_id.name)
+        else:
             ds = create_xarray(
                 _ir_calibrate(self._header,
                               self._data,
-                              idx,
+                              ir_idx,
                               dataset_id.calibration,
                               mask=(dataset_id.name == '3b' and
                                     np.logical_not(self._is3b))))
-        except ValueError:
-            pass
 
         if dataset_id.name == '3a' and np.all(np.isnan(ds)):
             raise ValueError("Empty dataset for channel 3A")

--- a/satpy/readers/aapp_l1b.py
+++ b/satpy/readers/aapp_l1b.py
@@ -115,7 +115,7 @@ class AVHRRAAPPL1BFile(BaseFileHandler):
         """Get a dataset from the file."""
 
         if key.name in CHANNEL_NAMES:
-            dataset = self.calibrate([key])[0]
+            dataset = self.calibrate(key)
         elif key.name in ['longitude', 'latitude']:
             if self.lons is None or self.lats is None:
                 self.navigate()
@@ -222,7 +222,7 @@ class AVHRRAAPPL1BFile(BaseFileHandler):
             logger.debug("Navigation time %s", str(datetime.now() - tic))
 
     def calibrate(self,
-                  dataset_ids,
+                  dataset_id,
                   pre_launch_coeffs=False,
                   calib_coeffs=None):
         """Calibrate the data
@@ -232,17 +232,12 @@ class AVHRRAAPPL1BFile(BaseFileHandler):
         if calib_coeffs is None:
             calib_coeffs = {}
 
-        chns = dict((dataset_id.name, dataset_id)
-                    for dataset_id in dataset_ids)
-
-        res = []
-        # FIXME this should be done in _vis_calibrate
         units = {'reflectance': '%',
                  'brightness_temperature': 'K',
                  'counts': '',
                  'radiance': 'W*m-2*sr-1*cm ?'}
 
-        if ("3a" in chns or "3b" in chns) and self._is3b is None:
+        if dataset_id.name in ("3a","3b") and self._is3b is None:
             # Is it 3a or 3b:
             is3b = np.expand_dims(
                 np.bitwise_and(
@@ -250,39 +245,42 @@ class AVHRRAAPPL1BFile(BaseFileHandler):
             self._is3b = np.repeat(is3b,
                                    self._data['hrpt'][0].shape[0], axis=1)
 
-        for idx, name in enumerate(['1', '2', '3a']):
-            if name in chns:
-                coeffs = calib_coeffs.get('ch' + name)
-                # FIXME data should be masked before calibration
-                ds = create_xarray(
-                    _vis_calibrate(self._data,
-                                   idx,
-                                   chns[name].calibration,
-                                   pre_launch_coeffs,
-                                   coeffs,
-                                   mask=(name == '3a' and self._is3b)).filled(np.nan))
+        try:
+            idx = ['1', '2', '3a'].index(dataset_id.name)
+            coeffs = calib_coeffs.get('ch' + dataset_id.name)
+            ds = create_xarray(
+                _vis_calibrate(self._data,
+                               idx,
+                               dataset_id.calibration,
+                               pre_launch_coeffs,
+                               coeffs,
+                               mask=(dataset_id.name == '3a' and self._is3b)))
+        except ValueError:
+            pass
 
-                ds.attrs['units'] = units[chns[name].calibration]
-                ds.attrs.update(chns[name]._asdict())
-                res.append(ds)
+        try:
+            idx = ['3b', '4', '5'].index(dataset_id.name)
+            ds = create_xarray(
+                _ir_calibrate(self._header,
+                              self._data,
+                              idx,
+                              dataset_id.calibration,
+                              mask=(dataset_id.name == '3b' and
+                                    np.logical_not(self._is3b))))
+        except ValueError:
+            pass
 
-        for idx, name in enumerate(['3b', '4', '5']):
-            if name in chns:
-                ds = create_xarray(
-                    _ir_calibrate(self._header,
-                                  self._data,
-                                  idx,
-                                  chns[name].calibration,
-                                  mask=(name == '3b' and
-                                        (np.logical_not(self._is3b)))).filled(np.nan))
+        if dataset_id.name == '3a' and np.all(np.isnan(ds)):
+            raise ValueError("Empty dataset for channel 3A")
+        if dataset_id.name == '3b' and np.all(np.isnan(ds)):
+            raise ValueError("Empty dataset for channel 3B")
 
-                ds.attrs['units'] = units[chns[name].calibration]
-                ds.attrs.update(chns[name]._asdict())
-                res.append(ds)
+        ds.attrs['units'] = units[dataset_id.calibration]
+        ds.attrs.update(dataset_id._asdict())
 
         logger.debug("Calibration time %s", str(datetime.now() - tic))
 
-        return res
+        return ds
 
 
 AVHRR_CHANNEL_NAMES = ("1", "2", "3a", "3b", "4", "5")
@@ -480,7 +478,9 @@ def _vis_calibrate(data,
         raise ValueError('Calibration ' + calib_type + ' unknown!')
 
     arr = data["hrpt"][:, :, chn]
-    channel = np.ma.array(arr.astype(np.float), mask=mask * arr)
+    mask |= arr == 0
+
+    channel = arr.astype(np.float)
     if calib_type == 'counts':
         return channel
 
@@ -529,7 +529,8 @@ def _vis_calibrate(data,
     channel[mask2] = (channel * slope2 + intercept2)[mask2]
 
     channel = channel.clip(min=0)
-    return np.ma.masked_invalid(channel)
+
+    return np.where(mask, np.nan, channel)
 
 
 def _ir_calibrate(header, data, irchn, calib_type, mask=False):
@@ -537,10 +538,13 @@ def _ir_calibrate(header, data, irchn, calib_type, mask=False):
     *calib_type* in brightness_temperature, radiance, count
     """
 
-    count = data['hrpt'][:, :, irchn + 2].astype(np.float)
+    count = data["hrpt"][:, :, irchn + 2].astype(np.float)
 
     if calib_type == 0:
         return count
+
+    # Mask unnaturally low values
+    mask |= count == 0.0
 
     k1_ = np.expand_dims(data['calir'][:, irchn, 0, 0] / 1.0e9, 1)
     k2_ = np.expand_dims(data['calir'][:, irchn, 0, 1] / 1.0e6, 1)
@@ -558,7 +562,8 @@ def _ir_calibrate(header, data, irchn, calib_type, mask=False):
         logger.info("Suspicious scan lines: %s", str(suspect_line_nums))
 
     if calib_type == 2:
-        return rad
+        mask |= rad <= 0.0
+        return np.where(mask, np.nan, rad)
 
     # Central wavenumber:
     cwnum = header['radtempcnv'][0, irchn, 0]
@@ -569,20 +574,6 @@ def _ir_calibrate(header, data, irchn, calib_type, mask=False):
 
     bandcor_2 = header['radtempcnv'][0, irchn, 1] / 1e5
     bandcor_3 = header['radtempcnv'][0, irchn, 2] / 1e6
-
-    # Count to radiance conversion:
-    rad = k1_ * count * count + k2_ * count + k3_
-
-    if calib_type == 2:
-        return rad
-
-    all_zero = np.logical_and(
-        np.logical_and(
-            np.equal(k1_, 0), np.equal(k2_, 0)), np.equal(k3_, 0))
-    idx = np.indices((all_zero.shape[0], ))
-    suspect_line_nums = np.repeat(idx[0], all_zero[:, 0])
-    if suspect_line_nums.any():
-        logger.info("Suspect scan lines: %s", str(suspect_line_nums))
 
     ir_const_1 = 1.1910659e-5
     ir_const_2 = 1.438833
@@ -597,15 +588,7 @@ def _ir_calibrate(header, data, irchn, calib_type, mask=False):
     else:  # AAPP 1 to 4
         tb_ = (t_planck - bandcor_2) / bandcor_3
 
-    # tb_[tb_ <= 0] = np.nan
-    # Data with count=0 are often related to erroneous (bad) lines, but in case
-    # of saturation (channel 3b) count=0 can be observed and associated to a
-    # real measurement. So we leave out this filtering to the user!
-    # tb_[count == 0] = np.nan
-    # tb_[rad == 0] = np.nan
-    tb_ = np.ma.masked_array(tb_, copy=False, mask=mask)
-    tb_ = np.ma.masked_invalid(tb_, copy=False)
-    if calib_type == 'brightness_temperature':
-        tb_ = np.ma.masked_less(tb_, 0.1, copy=False)
+    # Mask unnaturally low values
+    # mask |= tb_ < 0.1
 
-    return tb_
+    return np.where(mask, np.nan, tb_)


### PR DESCRIPTION
The masking of missing AVHRR AAPP L1b data wasn't working, as the conversion from masked arrays to dask arrays (`da.from_array()`) discarded the mask. Masking is also adjusted so that completely empty channels are not returned. This happened as 3A and 3B can alternate at day and night side of the terminator. In this way composites using the missing channels are not created.

At the same time, this PR simplifies the AVHRR AAPP L1b reader by
- removing usage of NumPy masked arrays
- removing duplicate calculations
- removing unnecessary iteration over one dataset ID

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
