### PR TITLE
Fix hrit_jma reader not having satellite lon/lat/alt info

### DIFF
--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -189,6 +189,9 @@ class HRITJMAFileHandler(HRITFileHandler):
         res.attrs.update(info)
         res.attrs['platform_name'] = 'Himawari-8'
         res.attrs['sensor'] = 'ahi'
+        res.attrs['satellite_longitude'] = float(self.mda['projection_parameters']['SSP_longitude'])
+        res.attrs['satellite_latitude'] = 0.
+        res.attrs['satellite_altitude'] = float(self.mda['projection_parameters']['h'])
         return res
 
     def calibrate(self, data, calibration):

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -86,20 +86,6 @@ time_cds_expanded = np.dtype([('days', '>u2'),
                               ('nanoseconds', '>u2')])
 
 
-def recarray2dict(arr):
-    res = {}
-    for dtuple in arr.dtype.descr:
-        key = dtuple[0]
-        ntype = dtuple[1]
-        data = arr[key]
-        if isinstance(ntype, list):
-            res[key] = recarray2dict(data)
-        else:
-            res[key] = data
-
-    return res
-
-
 class HRITJMAFileHandler(HRITFileHandler):
     """JMA HRIT format reader."""
 
@@ -176,9 +162,6 @@ class HRITJMAFileHandler(HRITFileHandler):
             ncols,
             nlines,
             area_extent)
-
-        self.area = area
-
         return area
 
     def get_dataset(self, key, info):

--- a/satpy/tests/reader_tests/__init__.py
+++ b/satpy/tests/reader_tests/__init__.py
@@ -34,7 +34,7 @@ from satpy.tests.reader_tests import (test_abi_l1b, test_hrit_base,
                                       test_seviri_calibration, test_clavrx,
                                       test_grib, test_hrit_goes, test_ahi_hsd,
                                       test_iasi_l2, test_generic_image,
-                                      test_scmi)
+                                      test_scmi, test_hrit_jma)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -68,5 +68,6 @@ def suite():
     mysuite.addTests(test_iasi_l2.suite())
     mysuite.addTests(test_generic_image.suite())
     mysuite.addTests(test_scmi.suite())
+    mysuite.addTests(test_hrit_jma.suite())
 
     return mysuite

--- a/satpy/tests/reader_tests/test_hrit_jma.py
+++ b/satpy/tests/reader_tests/test_hrit_jma.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2018 PyTroll developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""The hrit msg reader tests package.
+"""
+
+import sys
+import numpy as np
+import dask.array as da
+from xarray import DataArray
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+class TestHRITJMAFileHandler(unittest.TestCase):
+    """Test the HRITJMAFileHandler."""
+
+    @mock.patch('satpy.readers.hrit_jma.HRITFileHandler.__init__')
+    def setUp(self, new_fh_init):
+        """Setup the hrit file handler for testing."""
+        from satpy.readers.hrit_jma import HRITJMAFileHandler
+        mda = {
+            'projection_parameters': {
+                'a': 6378169.00,
+                'b': 6356583.80,
+                'h': 35785831.00,
+            },
+            'image_data_function': b'$HALFTONE:=16\r_NAME:=VISIBLE\r_UNIT:=ALBEDO(%)\r0:=-0.10\r1023:=100.00\r65535:=100.00\r',
+            'image_segm_seq_no': 0,
+            'total_no_image_segm': 1,
+            'projection_name': b'GEOS(140.70)                    ',
+            'cfac': 40932549,
+            'lfac': 40932549,
+            'coff': 5500,
+            'loff': 5500,
+            'number_of_columns': 11000,
+            'number_of_lines': 11000,
+        }
+        HRITJMAFileHandler.filename = 'filename'
+        HRITJMAFileHandler.mda = mda
+        self.reader = HRITJMAFileHandler('filename', {}, {})
+
+    def test_init(self):
+        """Test creating the file handler."""
+        mda = {
+            'image_segm_seq_no': 0,
+            'planned_end_segment_number': 1,
+            'planned_start_segment_number': 1,
+            'segment_sequence_number': 0,
+            'total_no_image_segm': 1,
+            'unit': 'ALBEDO(%)',
+            'projection_name': b'GEOS(140.70)                    ',
+            'projection_parameters': {
+                'a': 6378169.00,
+                'b': 6356583.80,
+                'h': 35785831.00,
+                'SSP_longitude': 140.7
+            },
+            'cfac': 40932549,
+            'lfac': 40932549,
+            'coff': 5500,
+            'loff': 5500,
+            'number_of_columns': 11000,
+            'number_of_lines': 11000,
+            'image_data_function': b'$HALFTONE:=16\r_NAME:=VISIBLE\r_UNIT:=ALBEDO(%)\r0:=-0.10\r1023:=100.00\r65535:=100.00\r',
+        }
+        self.assertEqual(self.reader.mda, mda)
+
+    @mock.patch('satpy.readers.hrit_jma.HRITFileHandler.get_dataset')
+    def test_get_dataset(self, base_get_dataset):
+        """Test getting a reflectance DataArray."""
+        key = mock.MagicMock()
+        key.calibration = 'reflectance'
+        base_get_dataset.return_value = DataArray(da.arange(25, chunks=5).reshape(5, 5))
+        res = self.reader.get_dataset(key, {'units': '%'})
+        expected = np.array([
+            [np.nan, -2.15053763e-03,  9.56989247e-02, 1.93548387e-01,  2.91397849e-01],
+            [3.89247312e-01,  4.87096774e-01,  5.84946237e-01, 6.82795699e-01,  7.80645161e-01],
+            [8.78494624e-01,  9.76344086e-01,  1.07419355e+00, 1.17204301e+00,  1.26989247e+00],
+            [1.36774194e+00,  1.46559140e+00,  1.56344086e+00, 1.66129032e+00,  1.75913978e+00],
+            [1.85698925e+00,  1.95483871e+00,  2.05268817e+00, 2.15053763e+00,  2.24838710e+00]])
+        np.testing.assert_allclose(res.values, expected)
+        self.assertEqual(res.attrs['units'], '%')
+        self.assertEqual(res.attrs['satellite_longitude'], 140.7)
+
+    def test_get_area_def(self):
+        """Test getting an AreaDefinition."""
+        from satpy import DatasetID
+        area_def = self.reader.get_area_def(DatasetID(name='B03', calibration='reflectance'))
+        self.assertTupleEqual(area_def.area_extent,
+                              (-5499495.117842725, -16499485.352640428, 5500495.116954979, -5499495.117842725))
+
+
+def suite():
+    """The test suite for test_scene.
+    """
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(TestHRITJMAFileHandler))
+    return mysuite
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/satpy/tests/reader_tests/test_hrit_jma.py
+++ b/satpy/tests/reader_tests/test_hrit_jma.py
@@ -46,7 +46,8 @@ class TestHRITJMAFileHandler(unittest.TestCase):
                 'b': 6356583.80,
                 'h': 35785831.00,
             },
-            'image_data_function': b'$HALFTONE:=16\r_NAME:=VISIBLE\r_UNIT:=ALBEDO(%)\r0:=-0.10\r1023:=100.00\r65535:=100.00\r',
+            'image_data_function': b'$HALFTONE:=16\r_NAME:=VISIBLE\r_UNIT:=ALBEDO(%)\r'
+                                   b'0:=-0.10\r1023:=100.00\r65535:=100.00\r',
             'image_segm_seq_no': 0,
             'total_no_image_segm': 1,
             'projection_name': b'GEOS(140.70)                    ',
@@ -83,7 +84,8 @@ class TestHRITJMAFileHandler(unittest.TestCase):
             'loff': 5500,
             'number_of_columns': 11000,
             'number_of_lines': 11000,
-            'image_data_function': b'$HALFTONE:=16\r_NAME:=VISIBLE\r_UNIT:=ALBEDO(%)\r0:=-0.10\r1023:=100.00\r65535:=100.00\r',
+            'image_data_function': b'$HALFTONE:=16\r_NAME:=VISIBLE\r_UNIT:=ALBEDO(%)\r'
+                                   b'0:=-0.10\r1023:=100.00\r65535:=100.00\r',
         }
         self.assertEqual(self.reader.mda, mda)
 


### PR DESCRIPTION
Needed for angle generation in compositors. See #405 for more information. @honnorat this should fix your issue.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
