### PR TITLE
Start and End Time are now returned as datetime objects not Lists

### DIFF
--- a/satpy/readers/native_msg.py
+++ b/satpy/readers/native_msg.py
@@ -83,13 +83,13 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
 
     @property
     def start_time(self):
-        return [self.header['15_DATA_HEADER']['ImageAcquisition'][
-            'PlannedAcquisitionTime']['TrueRepeatCycleStart']]
+        return self.header['15_DATA_HEADER']['ImageAcquisition'][
+            'PlannedAcquisitionTime']['TrueRepeatCycleStart']
 
     @property
     def end_time(self):
-        return [self.header['15_DATA_HEADER']['ImageAcquisition'][
-            'PlannedAcquisitionTime']['PlannedRepeatCycleEnd']]
+        return self.header['15_DATA_HEADER']['ImageAcquisition'][
+            'PlannedAcquisitionTime']['PlannedRepeatCycleEnd']
 
     def _get_data_dtype(self):
         """Get the dtype of the file based on the actual available channels"""


### PR DESCRIPTION

Start Time and End Time should be returned as an object not as a list. This causes some issues when using SIFT
