### PR TITLE
Fix reader config loading so it raises exception for bad reader name

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -432,8 +432,9 @@ def configs_for_reader(reader=None, ppp_config_dir=None):
             os.path.join("readers", config_basename), *search_paths)
 
         if not reader_configs:
-            LOG.warning("No reader configs found for '%s'", reader)
-            continue
+            # either the reader they asked for does not exist
+            # or satpy is improperly configured and can't find its own readers
+            raise ValueError("No reader(s) named: {}".format(reader))
 
         yield reader_configs
 


### PR DESCRIPTION
I tried loading data with a reader I didn't know the name of and guessed. Instead of being told that the reader didn't exist I was told the files didn't match. The actual problem was the reader name did not exist. This makes it so the exception makes more sense.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
