### PR TITLE
Fix the readers table in the sphinx docs so it wraps text

### DIFF
--- a/doc/source/_static/theme_overrides.css
+++ b/doc/source/_static/theme_overrides.css
@@ -1,0 +1,13 @@
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      /* !important prevents the common CSS stylesheets from overriding
+         this as on RTD they are loaded after this stylesheet */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: visible !important;
+   }
+}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -126,7 +126,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  Major themes that come with
 # Sphinx are currently 'default' and 'sphinxdoc'.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -156,6 +156,12 @@ html_theme = 'default'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+
+html_context = {
+    'css_files': [
+        '_static/theme_overrides.css',  # override wide tables in RTD theme
+        ],
+     }
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -48,6 +48,7 @@ installation.
 
 .. list-table:: SatPy Readers
     :header-rows: 1
+    :widths: 45 25 30
 
     * - Description
       - Reader name

--- a/doc/source/writers.rst
+++ b/doc/source/writers.rst
@@ -83,8 +83,8 @@ the specified colors.
     >>> colorize(img, **kwargs)
     >>> img.show()
 
-Similarly it is possible to use discreet values without color interpolation
-using `palettize()` instead of `colorize()`
+Similarly it is possible to use discrete values without color interpolation
+using `palettize()` instead of `colorize()`.
 
 You can define several colormaps and ranges in the `palettes` list and they
 are merged together.  See trollimage_ documentation for more information how
@@ -109,9 +109,9 @@ The above example can be used in enhancements YAML config like this:
 Saving multiple Scenes in one go
 ================================
 
-As mentioned earlier, it is possible to save ``Scene`` datasets directly
+As mentioned earlier, it is possible to save `Scene` datasets directly
 using :meth:`~satpy.scene.Scene.save_datasets` method.  However,
-sometimes it is beneficial to collect more ``Scene``s together and process
+sometimes it is beneficial to collect more `Scene`\ s together and process
 and save them all at once.
 
 ::

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -408,7 +408,7 @@ def compute_writer_results(results):
 
     Args:
         results (iterable): Iterable of dask graphs resulting from calls to
-                            `scn.save_datasets(..., compute=False)
+                            `scn.save_datasets(..., compute=False)`
     """
     if not results:
         return


### PR DESCRIPTION
Took the solution from here: https://github.com/rtfd/sphinx_rtd_theme/issues/117
And walked through here: https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html

Basically the default RTD theme doesn't wrap table text which was making our table of readers on the home page look really bad.
