### PR TITLE
Fix masking in DayNightCompositor when composites have partial missing data

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -867,6 +867,10 @@ class DayNightCompositor(GenericCompositor):
         day_data = add_bands(day_data, night_data['bands'])
         night_data = add_bands(night_data, day_data['bands'])
 
+        # Replace missing channel data with zeros
+        day_data = zero_missing_data(day_data, night_data)
+        night_data = zero_missing_data(night_data, day_data)
+
         # Get merged metadata
         attrs = combine_metadata(day_data, night_data)
 
@@ -917,6 +921,19 @@ def add_bands(data, bands):
         data = new_data
 
     return data
+
+
+def zero_missing_data(data1, data2):
+    """Replace NaN values with zeros in data1 if the data is valid in
+    data2.
+    """
+    nans = xu.logical_and(xu.isnan(data1),
+                          xu.logical_not(xu.isnan(data2)))
+    attrs = data1.attrs.copy()
+    data1 = xr.where(nans, 0, data1)
+    data1.attrs = attrs.copy()
+
+    return data1
 
 
 class Airmass(GenericCompositor):

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -810,9 +810,7 @@ class PaletteCompositor(ColormapCompositor):
 
 
 class DayNightCompositor(GenericCompositor):
-
-    """A compositor that takes one composite on the night side, another on day
-    side, and then blends them together."""
+    """A compositor that blends a day data with night data."""
 
     def __init__(self, lim_low=85., lim_high=95., **kwargs):
         """Collect custom configuration values.
@@ -828,7 +826,6 @@ class DayNightCompositor(GenericCompositor):
         super(DayNightCompositor, self).__init__(**kwargs)
 
     def __call__(self, projectables, **kwargs):
-
         projectables = self.check_areas(projectables)
 
         day_data = projectables[0]
@@ -881,9 +878,7 @@ class DayNightCompositor(GenericCompositor):
         # Split to separate bands so the mode is correct
         data = [data.sel(bands=b) for b in data['bands']]
 
-        res = super(DayNightCompositor, self).__call__(data, **kwargs)
-
-        return res
+        return super(DayNightCompositor, self).__call__(data, **kwargs)
 
 
 def enhance2dataset(dset):
@@ -924,14 +919,9 @@ def add_bands(data, bands):
 
 
 def zero_missing_data(data1, data2):
-    """Replace NaN values with zeros in data1 if the data is valid in
-    data2.
-    """
-    nans = xu.logical_and(xu.isnan(data1),
-                          xu.logical_not(xu.isnan(data2)))
-    data1 = data1.where(~nans, 0)
-
-    return data1
+    """Replace NaN values with zeros in data1 if the data is valid in data2."""
+    nans = xu.logical_and(xu.isnan(data1), xu.logical_not(xu.isnan(data2)))
+    return data1.where(~nans, 0)
 
 
 class Airmass(GenericCompositor):

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -929,9 +929,7 @@ def zero_missing_data(data1, data2):
     """
     nans = xu.logical_and(xu.isnan(data1),
                           xu.logical_not(xu.isnan(data2)))
-    attrs = data1.attrs.copy()
-    data1 = xr.where(nans, 0, data1)
-    data1.attrs = attrs.copy()
+    data1 = data1.where(~nans, 0)
 
     return data1
 

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -21,8 +21,12 @@
 
 
 import sys
-
 from satpy.tests.compositor_tests import test_abi, test_ahi, test_viirs
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -114,6 +118,73 @@ class TestCheckArea(unittest.TestCase):
         self.assertRaises(IncompatibleAreas, comp.check_areas, (ds1, ds2))
 
 
+class TestDayNightCompositor(unittest.TestCase):
+    """Test DayNightCompositor."""
+
+    def setUp(self):
+        """Create test data."""
+        import xarray as xr
+        import dask.array as da
+        import numpy as np
+        from datetime import datetime
+        bands = ['R', 'G', 'B']
+        start_time = datetime(2018, 1, 1, 18, 0, 0)
+
+        # RGB
+        a = np.zeros((3, 2, 2), dtype=np.float)
+        a[:, 0, 0] = 0.1
+        a[:, 0, 1] = 0.2
+        a[:, 1, 0] = 0.3
+        a[:, 1, 1] = 0.4
+        a = da.from_array(a, a.shape)
+        self.data_a = xr.DataArray(a, attrs={'test': 'a', 'start_time': start_time},
+                                   coords={'bands': bands}, dims=('bands', 'y', 'x'))
+        b = np.zeros((3, 2, 2), dtype=np.float)
+        b[:, 0, 0] = np.nan
+        b[:, 0, 1] = 0.25
+        b[:, 1, 0] = 0.50
+        b[:, 1, 1] = 0.75
+        b = da.from_array(b, b.shape)
+        self.data_b = xr.DataArray(b, attrs={'test': 'b', 'start_time': start_time},
+                                   coords={'bands': bands}, dims=('bands', 'y', 'x'))
+
+        sza = np.array([[80., 86.], [94., 100.]])
+        sza = da.from_array(sza, sza.shape)
+        self.sza = xr.DataArray(sza, dims=('y', 'x'))
+
+        # fake area
+        my_area = mock.MagicMock()
+        lons = np.array([[-95., -94.], [-93., -92.]])
+        lons = da.from_array(lons, lons.shape)
+        lats = np.array([[40., 41.], [42., 43.]])
+        lats = da.from_array(lats, lats.shape)
+        my_area.get_lonlats_dask.return_value = (lons, lats)
+        self.data_a.attrs['area'] = my_area
+        self.data_b.attrs['area'] = my_area
+        # not used except to check that it matches the data arrays
+        self.sza.attrs['area'] = my_area
+
+    def test_basic_sza(self):
+        """Test compositor when SZA data is included"""
+        import numpy as np
+        from satpy.composites import DayNightCompositor
+        comp = DayNightCompositor(name='dn_test')
+        res = comp((self.data_a, self.data_b, self.sza))
+        res = res.compute()
+        expected = np.array([[0., 0.2985455], [0.51680423, 1.]])
+        np.testing.assert_allclose(res.values[0], expected)
+
+    def test_basic_area(self):
+        """Test compositor when SZA data is not provided."""
+        import numpy as np
+        from satpy.composites import DayNightCompositor
+        comp = DayNightCompositor(name='dn_test')
+        res = comp((self.data_a, self.data_b))
+        res = res.compute()
+        expected = np.array([[0., 0.33164983], [0.66835017, 1.]])
+        np.testing.assert_allclose(res.values[0], expected)
+
+
 def suite():
     """Test suite for all reader tests"""
     loader = unittest.TestLoader()
@@ -122,5 +193,6 @@ def suite():
     mysuite.addTests(test_ahi.suite())
     mysuite.addTests(test_viirs.suite())
     mysuite.addTest(loader.loadTestsFromTestCase(TestCheckArea))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestDayNightCompositor))
 
     return mysuite


### PR DESCRIPTION
If one of the two composites passed to `DayNightCompositor` has partially missing data the resulting merged composite had holes at those locations. This discrepancy between the composites can be e.g. due to reflectances below zero on the night side  being masked out by the reader. This behavior can be correct for other use cases, but here it creates distracting holes in the images.

This PR replaces the masked ares with zeros if they are valid in the other composite.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
