### PR TITLE
Allow readers to accept pathlib.Path instances as filenames.

### DIFF
--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -67,7 +67,7 @@ def get_filebase(path, pattern):
     """Get the end of *path* of same length as *pattern*."""
     # A pattern can include directories
     tail_len = len(pattern.split(os.path.sep))
-    return os.path.join(*path.split(os.path.sep)[-tail_len:])
+    return os.path.join(*str(path).split(os.path.sep)[-tail_len:])
 
 
 def match_filenames(filenames, pattern):

--- a/satpy/tests/reader_tests/test_hdf5_utils.py
+++ b/satpy/tests/reader_tests/test_hdf5_utils.py
@@ -27,20 +27,21 @@ class FakeHDF5FileHandler(HDF5FileHandler):
         if HDF5FileHandler is object:
             raise ImportError("Base 'HDF5FileHandler' could not be "
                               "imported.")
+        filename = str(filename)
         super(HDF5FileHandler, self).__init__(filename, filename_info, filetype_info)
         self.file_content = self.get_test_content(filename, filename_info, filetype_info)
         self.file_content.update(kwargs)
 
     def get_test_content(self, filename, filename_info, filetype_info):
         """Mimic reader input file content
-        
+
         Args:
-            filename (str): input filename 
+            filename (str): input filename
             filename_info (dict): Dict of metadata pulled from filename
             filetype_info (dict): Dict of metadata from the reader's yaml config for this file type
 
         Returns: dict of file content with keys like:
-        
+
             - 'dataset'
             - '/attr/global_attr'
             - 'dataset/attr/global_attr'

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -212,7 +212,7 @@ class TestReaderLoader(unittest.TestCase):
 
     def test_no_args(self):
         """Test no args provided.
-        
+
         This should check the local directory which should have no files.
         """
         from satpy.readers import load_readers
@@ -242,6 +242,17 @@ class TestReaderLoader(unittest.TestCase):
         self.assertRaises(ValueError, load_readers, reader='i_dont_exist', filenames=[
             'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
             ])
+
+    def test_filenames_as_path(self):
+        """Test with filenames specified as pathlib.Path"""
+        if sys.version_info < (3, 4):
+            return
+        from pathlib import Path
+        from satpy.readers import load_readers
+        ri = load_readers(filenames=[
+            Path('SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'),
+        ])
+        self.assertListEqual(list(ri.keys()), ['viirs_sdr'])
 
     def test_filenames_as_dict(self):
         """Test loading readers where filenames are organized by reader"""

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -243,10 +243,9 @@ class TestReaderLoader(unittest.TestCase):
             'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
             ])
 
+    @unittest.skipIf(sys.version_info < (3, 4), "pathlib added in Python 3.4")
     def test_filenames_as_path(self):
         """Test with filenames specified as pathlib.Path"""
-        if sys.version_info < (3, 4):
-            return
         from pathlib import Path
         from satpy.readers import load_readers
         ri = load_readers(filenames=[


### PR DESCRIPTION
Allow readers to accept pathlib.Path instances as filenames. 

 - [x] Closes #450
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff``
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
