### PR TITLE
Ensures BaseFileHandler.filename is a str and is used by its subclasses.

### DIFF
--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -51,7 +51,7 @@ class NC_ABI_L1B(BaseFileHandler):
         super(NC_ABI_L1B, self).__init__(filename, filename_info,
                                          filetype_info)
         # xarray's default netcdf4 engine
-        self.nc = xr.open_dataset(filename,
+        self.nc = xr.open_dataset(self.filename,
                                   decode_cf=True,
                                   mask_and_scale=False,
                                   chunks={'x': CHUNK_SIZE, 'y': CHUNK_SIZE})

--- a/satpy/readers/fci_fdhsi.py
+++ b/satpy/readers/fci_fdhsi.py
@@ -44,12 +44,11 @@ class FCIFDHSIFileHandler(BaseFileHandler):
     def __init__(self, filename, filename_info, filetype_info):
         super(FCIFDHSIFileHandler, self).__init__(filename, filename_info,
                                                   filetype_info)
-        logger.debug('Reading: {}'.format(filename))
+        logger.debug('Reading: {}'.format(self.filename))
         logger.debug('Start: {}'.format(self.start_time))
         logger.debug('End: {}'.format(self.end_time))
 
-        self.nc = h5py.File(filename, 'r')
-        self.filename = filename
+        self.nc = h5py.File(self.filename, 'r')
         self.cache = {}
 
     @property

--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -35,7 +35,7 @@ from satpy.dataset import combine_metadata
 class BaseFileHandler(six.with_metaclass(ABCMeta, object)):
 
     def __init__(self, filename, filename_info, filetype_info):
-        self.filename = filename
+        self.filename = str(filename)
         self.navigation_reader = None
         self.filename_info = filename_info
         self.filetype_info = filetype_info

--- a/satpy/readers/generic_image.py
+++ b/satpy/readers/generic_image.py
@@ -50,7 +50,7 @@ class GenericImageFileHandler(BaseFileHandler):
             self.finfo['end_time'] = self.finfo['start_time']
         except KeyError:
             pass
-        self.finfo['filename'] = filename
+        self.finfo['filename'] = self.filename
         self.file_content = {}
         self.area = None
         self.read()

--- a/satpy/readers/grib.py
+++ b/satpy/readers/grib.py
@@ -55,7 +55,7 @@ class GRIBFileHandler(BaseFileHandler):
         self._start_time = None
         self._end_time = None
         try:
-            with pygrib.open(filename) as grib_file:
+            with pygrib.open(self.filename) as grib_file:
                 first_msg = grib_file.message(1)
                 last_msg = grib_file.message(grib_file.messages)
                 start_time = self._convert_datetime(
@@ -69,10 +69,10 @@ class GRIBFileHandler(BaseFileHandler):
                     self._idx = None
                 else:
                     self._create_dataset_ids(filetype_info['keys'])
-                    self._idx = pygrib.index(filename,
+                    self._idx = pygrib.index(self.filename,
                                              *filetype_info['keys'].keys())
         except (RuntimeError, KeyError):
-            raise IOError("Unknown GRIB file format: {}".format(filename))
+            raise IOError("Unknown GRIB file format: {}".format(self.filename))
 
     def _analyze_messages(self, grib_file):
         grib_file.seek(0)

--- a/satpy/readers/hdf4_caliopv3.py
+++ b/satpy/readers/hdf4_caliopv3.py
@@ -43,7 +43,6 @@ class HDF4BandReader(BaseFileHandler):
         self._start_time = None
         self._end_time = None
 
-        self.filename = filename
         self.get_filehandle()
 
         self._start_time = filename_info['start_time']

--- a/satpy/readers/hdfeos_l1b.py
+++ b/satpy/readers/hdfeos_l1b.py
@@ -57,9 +57,9 @@ class HDFEOSFileReader(BaseFileHandler):
     def __init__(self, filename, filename_info, filetype_info):
         super(HDFEOSFileReader, self).__init__(filename, filename_info, filetype_info)
         try:
-            self.sd = SD(str(self.filename))
+            self.sd = SD(self.filename)
         except HDF4Error as err:
-            raise ValueError("Could not load data from " + str(self.filename)
+            raise ValueError("Could not load data from " + self.filename
                              + ": " + str(err))
         self.metadata = self.read_mda(self.sd.attributes()['CoreMetadata.0'])
         self.metadata.update(self.read_mda(

--- a/satpy/readers/iasi_l2.py
+++ b/satpy/readers/iasi_l2.py
@@ -86,7 +86,6 @@ class IASIL2HDF5(BaseFileHandler):
         super(IASIL2HDF5, self).__init__(filename, filename_info,
                                          filetype_info)
 
-        self.filename = filename
         self.finfo = filename_info
         self.lons = None
         self.lats = None

--- a/satpy/readers/li_l2.py
+++ b/satpy/readers/li_l2.py
@@ -48,17 +48,16 @@ class LIFileHandler(BaseFileHandler):
         super(LIFileHandler, self).__init__(filename, filename_info,
                                             filetype_info)
 
-        self.nc = h5netcdf.File(filename, 'r')
+        self.nc = h5netcdf.File(self.filename, 'r')
         # Get grid dimensions from file
         refdim = self.nc['grid_position'][:]
         # Get number of lines and columns
         self.nlines = int(refdim[2])
         self.ncols = int(refdim[3])
-        self.filename = filename
         self.cache = {}
         logger.debug('Dimension : {}'.format(refdim))
         logger.debug('Row/Cols: {} / {}'.format(self.nlines, self.ncols))
-        logger.debug('Reading: {}'.format(filename))
+        logger.debug('Reading: {}'.format(self.filename))
         logger.debug('Start: {}'.format(self.start_time))
         logger.debug('End: {}'.format(self.end_time))
 

--- a/satpy/readers/maia.py
+++ b/satpy/readers/maia.py
@@ -58,7 +58,7 @@ class MAIAFileHandler(BaseFileHandler):
             self.finfo['end_time'] = self.finfo['end_time'].replace(
                 day=myday + 1)
         self.selected = None
-        self.read(filename)
+        self.read(self.filename)
 
     def read(self, filename):
         self.h5 = h5py.File(filename, 'r')

--- a/satpy/readers/native_msg.py
+++ b/satpy/readers/native_msg.py
@@ -64,7 +64,6 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
         super(NativeMSGFileHandler, self).__init__(filename,
                                                    filename_info,
                                                    filetype_info)
-        self.filename = filename
         self.platform_name = None
 
         # The available channels are only known after the header

--- a/satpy/readers/nc_goes.py
+++ b/satpy/readers/nc_goes.py
@@ -508,7 +508,7 @@ class GOESNCFileHandler(BaseFileHandler):
         """Initialize the reader."""
         super(GOESNCFileHandler, self).__init__(filename, filename_info,
                                                 filetype_info)
-        self.nc = xr.open_dataset(filename,
+        self.nc = xr.open_dataset(self.filename,
                                   decode_cf=True,
                                   mask_and_scale=False,
                                   chunks={'xc': CHUNK_SIZE, 'yc': CHUNK_SIZE})

--- a/satpy/readers/nc_nwcsaf.py
+++ b/satpy/readers/nc_nwcsaf.py
@@ -65,12 +65,12 @@ class NcNWCSAF(BaseFileHandler):
         super(NcNWCSAF, self).__init__(filename, filename_info,
                                        filetype_info)
 
-        self._unzipped = unzip_file(filename)
+        self._unzipped = unzip_file(self.filename)
         if self._unzipped:
-            filename = self._unzipped
+            self.filename = self._unzipped
 
         self.cache = {}
-        self.nc = xr.open_dataset(filename,
+        self.nc = xr.open_dataset(self.filename,
                                   decode_cf=True,
                                   mask_and_scale=False,
                                   chunks=CHUNK_SIZE)

--- a/satpy/readers/nc_nwcsaf_msg.py
+++ b/satpy/readers/nc_nwcsaf_msg.py
@@ -50,7 +50,7 @@ class NcNWCSAFMSG(BaseFileHandler):
         """Init method."""
         super(NcNWCSAFMSG, self).__init__(filename, filename_info,
                                           filetype_info)
-        self.nc = h5netcdf.File(filename, 'r')
+        self.nc = h5netcdf.File(self.filename, 'r')
         self.sensor = 'seviri'
         sat_id = self.nc.attrs['satellite_identifier']
         try:

--- a/satpy/readers/nc_olci.py
+++ b/satpy/readers/nc_olci.py
@@ -71,7 +71,7 @@ class NCOLCIBase(BaseFileHandler):
     def __init__(self, filename, filename_info, filetype_info):
         super(NCOLCIBase, self).__init__(filename, filename_info,
                                          filetype_info)
-        self.nc = xr.open_dataset(filename,
+        self.nc = xr.open_dataset(self.filename,
                                   decode_cf=True,
                                   mask_and_scale=True,
                                   engine='h5netcdf',

--- a/satpy/readers/nc_slstr.py
+++ b/satpy/readers/nc_slstr.py
@@ -47,7 +47,7 @@ class NCSLSTRGeo(BaseFileHandler):
     def __init__(self, filename, filename_info, filetype_info):
         super(NCSLSTRGeo, self).__init__(filename, filename_info,
                                          filetype_info)
-        self.nc = xr.open_dataset(filename,
+        self.nc = xr.open_dataset(self.filename,
                                   decode_cf=True,
                                   mask_and_scale=True,
                                   chunks={'columns': CHUNK_SIZE,
@@ -87,22 +87,21 @@ class NCSLSTR1B(BaseFileHandler):
         super(NCSLSTR1B, self).__init__(filename, filename_info,
                                         filetype_info)
 
-        self.nc = xr.open_dataset(filename,
+        self.nc = xr.open_dataset(self.filename,
                                   decode_cf=True,
                                   mask_and_scale=True,
                                   chunks={'columns': CHUNK_SIZE,
                                           'rows': CHUNK_SIZE})
         self.nc = self.nc.rename({'columns': 'x', 'rows': 'y'})
         self.channel = filename_info['dataset_name']
-        self.stripe = filename[-5]
-        self.view = filename[-4]
-        cal_file = os.path.join(os.path.dirname(
-            filename), 'viscal.nc')
+        self.stripe = self.filename[-5]
+        self.view = self.filename[-4]
+        cal_file = os.path.join(os.path.dirname(self.filename), 'viscal.nc')
         self.cal = xr.open_dataset(cal_file,
                                    decode_cf=True,
                                    mask_and_scale=True,
                                    chunks={'views': CHUNK_SIZE})
-        indices_file = os.path.join(os.path.dirname(filename),
+        indices_file = os.path.join(os.path.dirname(self.filename),
                                     'indices_{}{}.nc'.format(self.stripe, self.view))
         self.indices = xr.open_dataset(indices_file,
                                        decode_cf=True,
@@ -172,7 +171,7 @@ class NCSLSTRAngles(BaseFileHandler):
         super(NCSLSTRAngles, self).__init__(filename, filename_info,
                                             filetype_info)
 
-        self.nc = xr.open_dataset(filename,
+        self.nc = xr.open_dataset(self.filename,
                                   decode_cf=True,
                                   mask_and_scale=True,
                                   chunks={'columns': CHUNK_SIZE,
@@ -268,14 +267,14 @@ class NCSLSTRFlag(BaseFileHandler):
     def __init__(self, filename, filename_info, filetype_info):
         super(NCSLSTRFlag, self).__init__(filename, filename_info,
                                           filetype_info)
-        self.nc = xr.open_dataset(filename,
+        self.nc = xr.open_dataset(self.filename,
                                   decode_cf=True,
                                   mask_and_scale=True,
                                   chunks={'columns': CHUNK_SIZE,
                                           'rows': CHUNK_SIZE})
         self.nc = self.nc.rename({'columns': 'x', 'rows': 'y'})
-        self.stripe = filename[-5]
-        self.view = filename[-4]
+        self.stripe = self.filename[-5]
+        self.view = self.filename[-4]
         # TODO: get metadata from the manifest file (xfdumanifest.xml)
         self.platform_name = PLATFORM_NAMES[filename_info['mission_id']]
         self.sensor = 'slstr'

--- a/satpy/readers/safe_sar_c.py
+++ b/satpy/readers/safe_sar_c.py
@@ -224,7 +224,6 @@ class SAFEGRD(BaseFileHandler):
         self.calibration = calfh
         self.noise = noisefh
 
-        self.filename = filename
         self.get_gdal_filehandle()
 
     def get_gdal_filehandle(self):

--- a/satpy/readers/scmi.py
+++ b/satpy/readers/scmi.py
@@ -64,7 +64,7 @@ class SCMIFileHandler(BaseFileHandler):
         super(SCMIFileHandler, self).__init__(filename, filename_info,
                                               filetype_info)
         # xarray's default netcdf4 engine
-        self.nc = xr.open_dataset(filename,
+        self.nc = xr.open_dataset(self.filename,
                                   decode_cf=True,
                                   mask_and_scale=False,
                                   chunks={'x': LOAD_CHUNK_SIZE, 'y': LOAD_CHUNK_SIZE})

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -109,9 +109,6 @@ class DummyReader(BaseFileHandler):
     def __init__(self, filename, filename_info, filetype_info):
         super(DummyReader, self).__init__(
             filename, filename_info, filetype_info)
-        self.filename = filename
-        self.filename_info = filename_info
-        self.filetype_info = filetype_info
         self._start_time = datetime(2000, 1, 1, 12, 1)
         self._end_time = datetime(2000, 1, 1, 12, 2)
         self.metadata = {}


### PR DESCRIPTION
All subclasses of BaseFileHandler have been reviewed to be sure that their constructor `Subclass.__init__` uses `BaseFileHandler.filename` instead of the constructor argument.

BaseFileHandler.filename is forced to be a string. The result is that `pathlib.Path` or strings can be used equally for building an instance of any subclass.

 - [x] Closes #453
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master '**/*py' | flake8 --diff``
