### PR TITLE
Fix SCMI writer not writing fill values properly

### DIFF
--- a/satpy/readers/clavrx.py
+++ b/satpy/readers/clavrx.py
@@ -152,10 +152,10 @@ class CLAVRXFileHandler(HDF4FileHandler):
         if dataset_id.resolution:
             data.attrs['resolution'] = dataset_id.resolution
         data.attrs = self.get_metadata(data, ds_info)
-        fill = data.attrs.pop('_FillValue')
-        factor = data.attrs.pop('scale_factor')
-        offset = data.attrs.pop('add_offset')
-        valid_range = data.attrs.pop('valid_range')
+        fill = data.attrs.pop('_FillValue', None)
+        factor = data.attrs.pop('scale_factor', None)
+        offset = data.attrs.pop('add_offset', None)
+        valid_range = data.attrs.pop('valid_range', None)
 
         if factor is not None and offset is not None:
             def scale_inplace(data):

--- a/satpy/readers/clavrx.py
+++ b/satpy/readers/clavrx.py
@@ -152,10 +152,10 @@ class CLAVRXFileHandler(HDF4FileHandler):
         if dataset_id.resolution:
             data.attrs['resolution'] = dataset_id.resolution
         data.attrs = self.get_metadata(data, ds_info)
-        fill = data.attrs.get('_FillValue')
-        factor = data.attrs.get('scale_factor')
-        offset = data.attrs.get('add_offset')
-        valid_range = data.attrs.get('valid_range')
+        fill = data.attrs.pop('_FillValue')
+        factor = data.attrs.pop('scale_factor')
+        offset = data.attrs.pop('add_offset')
+        valid_range = data.attrs.pop('valid_range')
 
         if factor is not None and offset is not None:
             def scale_inplace(data):

--- a/satpy/writers/scmi.py
+++ b/satpy/writers/scmi.py
@@ -590,7 +590,7 @@ class NetCDFWriter(object):
         LOG.info('writing image data')
         # note: autoscaling will be applied to make int16
         assert(hasattr(data, 'mask'))
-        self.image_data[:, :] = np.require(data.filled(fill_value), dtype=np.float32)
+        self.image_data[:, :] = np.require(data, dtype=np.float32)
 
     def set_projection_attrs(self, area_id, proj4_info):
         """


### PR DESCRIPTION
@rayg-ssec found out that SCMI files generated did not respect fill values from the original data. I'm not exactly sure how this ever worked.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master **/*py | flake8 --diff`` <!-- remove if you did not edit any Python files -->
