### PR TITLE
Fix native resampling when RGBs are resampled

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -756,8 +756,7 @@ class NativeResampler(BaseResampler):
         # convert xarray backed with numpy array to dask array
         if 'x' not in data.dims or 'y' not in data.dims:
             if data.ndim not in [2, 3]:
-                raise ValueError("Can only handle 2D or 3D arrays without "
-                                 "dimensions.")
+                raise ValueError("Can only handle 2D or 3D arrays without dimensions.")
             # assume rows is the second to last axis
             y_axis = data.ndim - 2
             x_axis = data.ndim - 1
@@ -769,17 +768,15 @@ class NativeResampler(BaseResampler):
         in_shape = data.shape
         y_repeats = out_shape[0] / float(in_shape[y_axis])
         x_repeats = out_shape[1] / float(in_shape[x_axis])
-        repeats = {
-            y_axis: y_repeats,
-            x_axis: x_repeats,
-        }
+        repeats = {axis_idx: 1. for axis_idx in range(data.ndim) if axis_idx not in [y_axis, x_axis]}
+        repeats[y_axis] = y_repeats
+        repeats[x_axis] = x_repeats
 
         d_arr = self.expand_reduce(data.data, repeats)
 
         coords = {}
         # Update coords if we can
-        if ('y' in data.coords or 'x' in data.coords) and \
-                isinstance(target_geo_def, AreaDefinition):
+        if ('y' in data.coords or 'x' in data.coords) and isinstance(target_geo_def, AreaDefinition):
             coord_chunks = (d_arr.chunks[y_axis], d_arr.chunks[x_axis])
             x_coord, y_coord = target_geo_def.get_proj_vectors_dask(
                 chunks=coord_chunks)

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -221,7 +221,10 @@ class TestEWAResampler(unittest.TestCase):
 
 
 class TestNativeResampler(unittest.TestCase):
+    """Tests for the 'native' resampling method."""
+
     def test_expand_reduce(self):
+        """Test class method 'expand_reduce' basics."""
         from satpy.resample import NativeResampler
         import numpy as np
         import dask.array as da
@@ -245,6 +248,7 @@ class TestNativeResampler(unittest.TestCase):
         self.assertTrue(np.all(new_arr.compute()[::2, :] == n_arr))
 
     def test_expand_dims(self):
+        """Test expanding native resampling with 2D data."""
         from satpy.resample import NativeResampler
         import numpy as np
         import dask.array as da
@@ -273,7 +277,39 @@ class TestNativeResampler(unittest.TestCase):
         new_arr2 = resampler.resample(ds1.compute())
         self.assertTrue(np.all(new_arr == new_arr2))
 
+    def test_expand_dims_3d(self):
+        """Test expanding native resampling with 3D data."""
+        from satpy.resample import NativeResampler
+        import numpy as np
+        import dask.array as da
+        from xarray import DataArray
+        from pyresample.geometry import AreaDefinition
+        from pyresample.utils import proj4_str_to_dict
+        ds1 = DataArray(da.zeros((3, 100, 50), chunks=85), dims=('bands', 'y', 'x'),
+                        coords={'bands': ['R', 'G', 'B'],
+                                'y': da.arange(100, chunks=85),
+                                'x': da.arange(50, chunks=85)})
+        proj_dict = proj4_str_to_dict('+proj=lcc +datum=WGS84 +ellps=WGS84 '
+                                      '+lon_0=-95. +lat_0=25 +lat_1=25 '
+                                      '+units=m +no_defs')
+        target = AreaDefinition(
+            'test',
+            'test',
+            'test',
+            proj_dict,
+            x_size=100,
+            y_size=200,
+            area_extent=(-1000., -1500., 1000., 1500.),
+        )
+        # source geo def doesn't actually matter
+        resampler = NativeResampler(None, target)
+        new_arr = resampler.resample(ds1)
+        self.assertEqual(new_arr.shape, (3, 200, 100))
+        new_arr2 = resampler.resample(ds1.compute())
+        self.assertTrue(np.all(new_arr == new_arr2))
+
     def test_expand_without_dims(self):
+        """Test expanding native resampling with no dimensions specified."""
         from satpy.resample import NativeResampler
         import numpy as np
         import dask.array as da
@@ -299,6 +335,30 @@ class TestNativeResampler(unittest.TestCase):
         self.assertEqual(new_arr.shape, (200, 100))
         new_arr2 = resampler.resample(ds1.compute())
         self.assertTrue(np.all(new_arr == new_arr2))
+
+    def test_expand_without_dims_4D(self):
+        """Test expanding native resampling with 4D data with no dimensions specified."""
+        from satpy.resample import NativeResampler
+        import dask.array as da
+        from xarray import DataArray
+        from pyresample.geometry import AreaDefinition
+        from pyresample.utils import proj4_str_to_dict
+        ds1 = DataArray(da.zeros((2, 3, 100, 50), chunks=85))
+        proj_dict = proj4_str_to_dict('+proj=lcc +datum=WGS84 +ellps=WGS84 '
+                                      '+lon_0=-95. +lat_0=25 +lat_1=25 '
+                                      '+units=m +no_defs')
+        target = AreaDefinition(
+            'test',
+            'test',
+            'test',
+            proj_dict,
+            x_size=100,
+            y_size=200,
+            area_extent=(-1000., -1500., 1000., 1500.),
+        )
+        # source geo def doesn't actually matter
+        resampler = NativeResampler(None, target)
+        self.assertRaises(ValueError, resampler.resample, ds1)
 
 
 def suite():


### PR DESCRIPTION
See #465 for details.

 - [x] Closes #465  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
