### PR TITLE
Fix attributes not being preserved when adding overlays or decorations

### DIFF
--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -236,7 +236,8 @@ def add_overlay(orig, area, coast_dir, color=(0, 0, 0), width=0.5, resolution=No
     orig.data = xr.DataArray(arr, dims=['y', 'x', 'bands'],
                              coords={'y': orig.data.coords['y'],
                                      'x': orig.data.coords['x'],
-                                     'bands': list(img.mode)})
+                                     'bands': list(img.mode)},
+                             attrs=orig.data.attrs)
 
 
 def add_text(orig, dc, img, text=None):
@@ -255,7 +256,8 @@ def add_text(orig, dc, img, text=None):
     orig.data = xr.DataArray(arr, dims=['y', 'x', 'bands'],
                              coords={'y': orig.data.coords['y'],
                                      'x': orig.data.coords['x'],
-                                     'bands': list(img.mode)})
+                                     'bands': list(img.mode)},
+                             attrs=orig.data.attrs)
 
 
 def add_logo(orig, dc, img, logo=None):
@@ -274,7 +276,8 @@ def add_logo(orig, dc, img, logo=None):
     orig.data = xr.DataArray(arr, dims=['y', 'x', 'bands'],
                              coords={'y': orig.data.coords['y'],
                                      'x': orig.data.coords['x'],
-                                     'bands': list(img.mode)})
+                                     'bands': list(img.mode)},
+                             attrs=orig.data.attrs)
 
 
 def add_decorate(orig, fill_value=None, **decorate):


### PR DESCRIPTION
See #464 for details. Basically using `save_datasets` or any filename pattern will fail when adding coastlines or decorations because the attributes weren't be preserved and the filename formatting was failing.

 - [x] Closes #464 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
