### PR TITLE
Fix parsing of platform_name in viirs_compact reader

### DIFF
--- a/satpy/readers/viirs_compact.py
+++ b/satpy/readers/viirs_compact.py
@@ -32,6 +32,7 @@ import xarray.ufuncs as xu
 import dask.array as da
 
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.readers.utils import np2str
 from satpy.utils import angle2xyz, lonlat2xyz, xyz2angle, xyz2lonlat
 from satpy import CHUNK_SIZE
 
@@ -116,7 +117,7 @@ class VIIRSCompactFileHandler(BaseFileHandler):
         self.cache = {}
 
         self.mda = {}
-        short_name = self.h5f.attrs['Platform_Short_Name'][0][0]
+        short_name = np2str(self.h5f.attrs['Platform_Short_Name'])
         self.mda['platform_name'] = short_names.get(short_name, short_name)
         self.mda['sensor'] = 'viirs'
 


### PR DESCRIPTION

The `viirs_compact` reader doesn't translate `platform_name` read from the files properly with Python 3, thus `pyspectral` fails to find the proper RSR files. This PR fixes the parsing and makes it possible to create composites like `true_color` that are using `pyspectral`.

 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
