### PR TITLE
Add additional metadata to ABI L1B DataArrays

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,35 @@
+# Project Contributors
+
+The following people have made contributions to this project:
+
+<!--- Use your GitHub account or any other personal reference URL --->
+<!--- See https://gist.github.com/djhoese/52220272ec73b12eb8f4a29709be110d for auto-generating parts of this list --->
+
+- [Trygve Aspenes (TAlonglong)](https://github.com/TAlonglong)
+- [ColinDuff (ColinDuff)](https://github.com/ColinDuff)
+- [Radar, Satellite and Nowcasting Division (meteoswiss-mdr)](https://github.com/meteoswiss-mdr)
+- [Adam Dybbroe (adybbroe)](https://github.com/adybbroe)
+- [Ulrik Egede (egede)](https://github.com/egede)
+- [Stephan Finkensieper (sfinkens)](https://github.com/sfinkens)
+- [David Hoese (djhoese)](https://github.com/djhoese)
+- [Marc Honnorat (honnorat)](https://github.com/honnorat)
+- [Mikhail Itkin (mitkin)](https://github.com/mitkin)
+- [JohannesSMHI (JohannesSMHI)](https://github.com/JohannesSMHI)
+- [Panu Lahtinen (pnuu)](https://github.com/pnuu)
+- [Thomas Leppelt (m4sth0)](https://github.com/m4sth0)
+- [Tom Parker (tparker-usgs)](https://github.com/tparker-usgs)
+- [Lars Ørum Rasmussen (loerum)](https://github.com/loerum)
+- [Martin Raspaud (mraspaud)](https://github.com/mraspaud)
+- [William Roberts (wroberts4)](https://github.com/wroberts4)
+- [RutgerK (RutgerK)](https://github.com/RutgerK)
+- [Eysteinn Sigurðsson (eysteinn)](https://github.com/eysteinn)
+- [lorenzo clementi (loreclem)](https://github.com/loreclem)
+- [hazbottles (hazbottles)](https://github.com/hazbottles)
+- [howff (howff)](https://github.com/howff)
+- [oananicola (oananicola)](https://github.com/oananicola)
+- [praerien (praerien)](https://github.com/praerien)
+- [ralphk11 (ralphk11)](https://github.com/ralphk11)
+- [roquetp (roquetp)](https://github.com/roquetp)
+- [sjoro (sjoro)](https://github.com/sjoro)
+- Guido della Bruna - meteoswiss
+- Marco Sassi - meteoswiss

--- a/satpy/etc/readers/abi_l1b.yaml
+++ b/satpy/etc/readers/abi_l1b.yaml
@@ -1,4 +1,5 @@
 reader:
+  # PUG: https://www.goes-r.gov/users/docs/PUG-L1b-vol3.pdf
   description: NC Reader for ABI data
   name: abi_l1b
   sensors: [abi]
@@ -6,58 +7,59 @@ reader:
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
 
 file_types:
+    # NOTE: observation_type == product acronym in PUG document
     c01:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C01_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc',
-                        '{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C01_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-{chid:6d}_0.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C01_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc',
+                        '{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C01_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-{chid:6d}_0.nc']
     c02:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C02_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc',
-                        '{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C02_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-{chid:6d}_0.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C02_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc',
+                        '{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C02_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-{chid:6d}_0.nc']
     c03:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C03_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc',
-                        '{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C03_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-{chid:6d}_0.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C03_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc',
+                        '{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C03_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-{chid:6d}_0.nc']
     c04:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C04_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C04_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     c05:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C05_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc',
-                        '{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C05_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-{chid:6d}_0.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C05_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc',
+                        '{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C05_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-{chid:6d}_0.nc']
     c06:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C06_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C06_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     c07:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C07_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C07_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     c08:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C08_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C08_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     c09:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C09_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C09_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     c10:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C10_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C10_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     c11:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C11_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C11_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     c12:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C12_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C12_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     c13:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C13_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C13_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     c14:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C14_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C14_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     c15:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C15_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C15_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     c16:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{dataset_name:3s}{area_code:s}-{scan_mode:2s}C16_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C16_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
 datasets:
   C01:

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -134,11 +134,9 @@ class NC_ABI_L1B(BaseFileHandler):
         # add in information from the filename that may be useful to the user
         for key in ('observation_type', 'scene_abbr', 'scan_mode', 'platform_shortname'):
             res.attrs[key] = self.filename_info[key]
-        res.attrs['scene_id'] = self.nc.attrs.get('scene_id')
-        res.attrs['orbital_slot'] = self.nc.attrs.get('orbital_slot')
-        res.attrs['instrument_ID'] = self.nc.attrs.get('instrument_ID')
-        res.attrs['production_site'] = self.nc.attrs.get('production_site')
-        res.attrs['timeline_ID'] = self.nc.attrs.get('timeline_ID')
+        # copy global attributes to metadata
+        for key in ('scene_id', 'orbital_slot', 'instrument_ID', 'production_site', 'timeline_ID'):
+            res.attrs[key] = self.nc.attrs.get(key)
 
         return res
 

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -1,28 +1,26 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-# Copyright (c) 2016-2018 PyTroll developers
-
-# Author(s):
-
-#   Guido della Bruna <Guido.DellaBruna@meteoswiss.ch>
-#   Marco Sassi       <Marco.Sassi@meteoswiss.ch>
-#   Martin Raspaud    <Martin.Raspaud@smhi.se>
-
+#
+# Copyright (c) 2016-2018 SatPy developers
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
-Advance Baseline Imager reader
+"""Advance Baseline Imager reader for the Level 1b format
+
+The files read by this reader are described in the official PUG document:
+
+    https://www.goes-r.gov/users/docs/PUG-L1b-vol3.pdf
+
 """
 
 import logging
@@ -102,11 +100,10 @@ class NC_ABI_L1B(BaseFileHandler):
         """Get the shape of the data."""
         return self.nlines, self.ncols
 
-    def get_dataset(self, key, info,
-                    xslice=slice(None), yslice=slice(None)):
+    def get_dataset(self, key, info):
         """Load a dataset."""
         logger.debug('Reading in get_dataset %s.', key.name)
-        radiances = self['Rad'][yslice, xslice]
+        radiances = self['Rad']
 
         if key.calibration == 'reflectance':
             logger.debug("Calibrating to reflectances")
@@ -134,6 +131,14 @@ class NC_ABI_L1B(BaseFileHandler):
         res.attrs.pop('_FillValue', None)
         res.attrs.pop('scale_factor', None)
         res.attrs.pop('add_offset', None)
+        # add in information from the filename that may be useful to the user
+        for key in ('observation_type', 'scene_abbr', 'scan_mode', 'platform_shortname'):
+            res.attrs[key] = self.filename_info[key]
+        res.attrs['scene_id'] = self.nc.attrs.get('scene_id')
+        res.attrs['orbital_slot'] = self.nc.attrs.get('orbital_slot')
+        res.attrs['instrument_ID'] = self.nc.attrs.get('instrument_ID')
+        res.attrs['production_site'] = self.nc.attrs.get('production_site')
+        res.attrs['timeline_ID'] = self.nc.attrs.get('timeline_ID')
 
         return res
 
@@ -168,8 +173,8 @@ class NC_ABI_L1B(BaseFileHandler):
                      'sweep': sweep_axis}
 
         area = geometry.AreaDefinition(
-            'abi_geos',
-            "ABI L1B file area",
+            self.nc.attrs.get('orbital_slot', 'abi_geos'),
+            self.nc.attrs.get('spatial_resolution', 'ABI L1B file area'),
             'abi_geos',
             proj_dict,
             self.ncols,

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -85,7 +85,8 @@ class Test_NC_ABI_L1B_ir_cal(unittest.TestCase):
             "earth_sun_distance_anomaly_in_AU": np.array(0.99)}, {})
 
         self.reader = NC_ABI_L1B('filename',
-                                 {'platform_shortname': 'G16'},
+                                 {'platform_shortname': 'G16', 'observation_type': 'Rad',
+                                  'scene_abbr': 'C', 'scan_mode': 'M3'},
                                  {'filetype': 'info'})
 
     def test_ir_calibrate(self):
@@ -153,7 +154,8 @@ class Test_NC_ABI_L1B_vis_cal(unittest.TestCase):
             })
 
         self.reader = NC_ABI_L1B('filename',
-                                 {'platform_shortname': 'G16'},
+                                 {'platform_shortname': 'G16', 'observation_type': 'Rad',
+                                  'scene_abbr': 'C', 'scan_mode': 'M3'},
                                  {'filetype': 'info'})
 
     def test_bad_calibration(self):
@@ -221,7 +223,8 @@ class Test_NC_ABI_L1B_area(unittest.TestCase):
             'Rad': np.ones((2, 2))}, {})
 
         self.reader = NC_ABI_L1B('filename',
-                                 {'platform_shortname': 'G16'},
+                                 {'platform_shortname': 'G16', 'observation_type': 'Rad',
+                                  'scene_abbr': 'C', 'scan_mode': 'M3'},
                                  {'filetype': 'info'})
 
     @mock.patch('satpy.readers.abi_l1b.geometry.AreaDefinition')


### PR DESCRIPTION
This additional metadata could be useful to projects like my geo2grid and SIFT projects. Specifically the information from the filename could be used in geo2grid to provide a filename that resembles the original L1B file. This could help users identify output files as coming from certain input files.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
