### PR TITLE
Add ll_bbox and xy_bbox to any cropped DataArray attributes

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -186,10 +186,7 @@ class Scene(MetadataObject):
         else:
             return set(self.attrs['sensor'])
 
-    def create_reader_instances(self,
-                                filenames=None,
-                                reader=None,
-                                reader_kwargs=None):
+    def create_reader_instances(self, filenames=None, reader=None, reader_kwargs=None):
         """Find readers and return their instances."""
         return load_readers(filenames=filenames,
                             reader=reader,
@@ -575,8 +572,7 @@ class Scene(MetadataObject):
         # get the lowest resolution area, use it as the base of the slice
         # this makes sure that the other areas *should* be a consistent factor
         min_area = new_scn.min_area()
-        new_min_area, min_y_slice, min_x_slice = self._slice_area_from_bbox(
-            min_area, area, ll_bbox, xy_bbox)
+        new_min_area, min_y_slice, min_x_slice = self._slice_area_from_bbox(min_area, area, ll_bbox, xy_bbox)
         new_target_areas = {}
         for src_area, dataset_ids in new_scn.iter_by_area():
             if src_area is None:
@@ -584,24 +580,27 @@ class Scene(MetadataObject):
                     new_scn.datasets[ds_id] = self[ds_id]
                 continue
 
-            y_factor, y_remainder = np.divmod(float(src_area.shape[0]),
-                                              min_area.shape[0])
-            x_factor, x_remainder = np.divmod(float(src_area.shape[1]),
-                                              min_area.shape[1])
+            y_factor, y_remainder = np.divmod(float(src_area.shape[0]), min_area.shape[0])
+            x_factor, x_remainder = np.divmod(float(src_area.shape[1]), min_area.shape[1])
             y_factor = int(y_factor)
             x_factor = int(x_factor)
             if y_remainder == 0 and x_remainder == 0:
-                y_slice = slice(min_y_slice.start * y_factor,
-                                min_y_slice.stop * y_factor)
-                x_slice = slice(min_x_slice.start * x_factor,
-                                min_x_slice.stop * x_factor)
+                y_slice = slice(min_y_slice.start * y_factor, min_y_slice.stop * y_factor)
+                x_slice = slice(min_x_slice.start * x_factor, min_x_slice.stop * x_factor)
                 new_area = src_area[y_slice, x_slice]
                 slice_key = (y_slice, x_slice)
                 new_scn._slice_datasets(dataset_ids, slice_key, new_area)
             else:
-                new_target_areas[src_area] = self._slice_area_from_bbox(
-                    src_area, area, ll_bbox, xy_bbox
-                )
+                new_target_areas[src_area] = self._slice_area_from_bbox(src_area, area, ll_bbox, xy_bbox)
+
+            # add metadata to specify what the bounding box was
+            for ds in new_scn:
+                if ds.attrs.get('area') is None:
+                    continue
+                elif ll_bbox is not None:
+                    ds.attrs['ll_bbox'] = ll_bbox
+                elif xy_bbox is not None:
+                    ds.attrs['xy_bbox'] = xy_bbox
 
         return new_scn
 

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -207,6 +207,46 @@ def proj_units_to_meters(proj_str):
     return ' '.join(new_parts)
 
 
+def ll_bbox_to_str(ll_bbox, sep='_', float_format='{:0.02f}'):
+    """Convert 4-element bbox to a human-readable string.
+
+    Args:
+        ll_bbox (iterable): (lon_min, lat_min, lon_max, lat_max)
+        sep (str): String used to join elements together
+        float_format (str): Format specified for each element
+
+    Longitude and latitude coordinates are converted to W/E and N/S floats
+    with 2 decimal points.
+
+    """
+    elements = [
+        float_format.format(abs(ll_bbox[0])) + ('W' if ll_bbox[0] < 0 else 'E'),
+        float_format.format(abs(ll_bbox[1])) + ('S' if ll_bbox[1] < 0 else 'N'),
+        float_format.format(abs(ll_bbox[2])) + ('W' if ll_bbox[2] < 0 else 'E'),
+        float_format.format(abs(ll_bbox[3])) + ('S' if ll_bbox[3] < 0 else 'N'),
+    ]
+    return sep.join(elements)
+
+
+def xy_bbox_to_str(xy_bbox, sep='_', float_format='{+0.0f}', units='m'):
+    """Convert 4-elemnet bbox to a human-readable string.
+
+    Args:
+        xy_bbox (iterable): (x_min, y_min, x_max, y_max)
+        sep (str): String used to join elements together
+        float_format (str): Format specified for each element
+        units (str): Units to suffix each element with
+
+    """
+    elements = [
+        float_format.format(xy_bbox[0]) + units,
+        float_format.format(xy_bbox[1]) + units,
+        float_format.format(xy_bbox[2]) + units,
+        float_format.format(xy_bbox[3]) + units,
+    ]
+    return sep.join(elements)
+
+
 def _get_sunz_corr_li_and_shibata(cos_zen):
 
     return 24.35 / (2. * cos_zen +


### PR DESCRIPTION
This adds metadata to any DataArray that is cropped using the `Scene.crop` method. Adds `ll_bbox` if provided to crop, adds `xy_bbox` if provided, otherwise nothing is added. This can be useful in later processing or in filename patterns for differentiating cropped data from the original data. I also added some utility methods for converting bboxes to strings. These may exist elsewhere but I couldn't find them.

Another option is to add a suffix to the area_id of the new AreaDefinition like `-cropped` or something.

Honestly, I'm not super happy with this solution but this is important information to provide to the user. Time to discuss.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
