### PR TITLE
Fix handling of area creation in the grib reader

### DIFF
--- a/satpy/readers/grib.py
+++ b/satpy/readers/grib.py
@@ -184,13 +184,15 @@ class GRIBFileHandler(BaseFileHandler):
 
             proj = Proj(**proj_params)
             x, y = proj(lons, lats)
-            x[np.abs(x) >= 1e30] = np.nan
-            y[np.abs(y) >= 1e30] = np.nan
-            min_x = np.nanmin(x)
-            max_x = np.nanmax(x)
-            min_y = np.nanmin(y)
-            max_y = np.nanmax(y)
-            extents = (min_x, min_y, max_x, max_y)
+            if msg.has_key('jScansPositively') and msg['jScansPositively'] == 1:
+                min_x, min_y = x[0], y[0]
+                max_x, max_y = x[3], y[3]
+            else:
+                min_x, min_y = x[2], y[2]
+                max_x, max_y = x[1], y[1]
+            half_x = abs((max_x - min_x) / (shape[1] - 1)) / 2.
+            half_y = abs((max_y - min_y) / (shape[0] - 1)) / 2.
+            extents = (min_x - half_x, min_y - half_y, max_x + half_x, max_y + half_y)
 
         return geometry.AreaDefinition(
             'on-the-fly grib area',
@@ -251,6 +253,8 @@ class GRIBFileHandler(BaseFileHandler):
         ds_info = self.get_metadata(msg, ds_info)
         fill = msg['missingValue']
         data = msg.values.astype(np.float32)
+        if msg.has_key('jScansPositively') and msg['jScansPositively'] == 1:
+            data = data[::-1]
 
         if isinstance(data, np.ma.MaskedArray):
             data = data.filled(np.nan)

--- a/satpy/readers/grib.py
+++ b/satpy/readers/grib.py
@@ -184,7 +184,7 @@ class GRIBFileHandler(BaseFileHandler):
 
             proj = Proj(**proj_params)
             x, y = proj(lons, lats)
-            if msg.has_key('jScansPositively') and msg['jScansPositively'] == 1:
+            if msg.valid_key('jScansPositively') and msg['jScansPositively'] == 1:
                 min_x, min_y = x[0], y[0]
                 max_x, max_y = x[3], y[3]
             else:
@@ -253,7 +253,7 @@ class GRIBFileHandler(BaseFileHandler):
         ds_info = self.get_metadata(msg, ds_info)
         fill = msg['missingValue']
         data = msg.values.astype(np.float32)
-        if msg.has_key('jScansPositively') and msg['jScansPositively'] == 1:
+        if msg.valid_key('jScansPositively') and msg['jScansPositively'] == 1:
             data = data[::-1]
 
         if isinstance(data, np.ma.MaskedArray):

--- a/satpy/tests/reader_tests/test_grib.py
+++ b/satpy/tests/reader_tests/test_grib.py
@@ -37,6 +37,9 @@ class FakeMessage(object):
     def __getitem__(self, item):
         return self.attrs[item]
 
+    def valid_key(self, key):
+        return True
+
 
 class FakeGRIB(object):
     """Fake GRIB file returned by pygrib.open."""
@@ -66,6 +69,7 @@ class FakeGRIB(object):
                     minimum=100.,
                     maximum=200.,
                     typeOfLevel='isobaricInhPa',
+                    jScansPositively=0,
                     proj_params=proj_params,
                     latlons=latlons,
                 ),
@@ -88,6 +92,7 @@ class FakeGRIB(object):
                     minimum=100.,
                     maximum=200.,
                     typeOfLevel='isobaricInhPa',
+                    jScansPositively=0,
                     proj_params=proj_params,
                     latlons=latlons,
                 ),
@@ -110,6 +115,7 @@ class FakeGRIB(object):
                     minimum=100.,
                     maximum=200.,
                     typeOfLevel='isobaricInhPa',
+                    jScansPositively=0,
                     proj_params=proj_params,
                     latlons=latlons,
                 ),


### PR DESCRIPTION
Turns out sometimes grib files have their data flipped. This now catches that.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
