### PR TITLE
Deprecate 'enhancement_config' keyword argument in favor of 'enhance'

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1037,8 +1037,7 @@ class Scene(MetadataObject):
             if ds_id in self.wishlist:
                 yield projectable.to_image()
 
-    def save_dataset(self, dataset_id, filename=None, writer=None,
-                     overlay=None, compute=True, **kwargs):
+    def save_dataset(self, dataset_id, filename=None, writer=None, overlay=None, compute=True, **kwargs):
         """Save the *dataset_id* to file using *writer* (default: geotiff)."""
         if writer is None and filename is None:
             writer = 'geotiff'
@@ -1053,8 +1052,7 @@ class Scene(MetadataObject):
                                    overlay=overlay, compute=compute,
                                    **save_kwargs)
 
-    def save_datasets(self, writer="geotiff", datasets=None, compute=True,
-                      **kwargs):
+    def save_datasets(self, writer="geotiff", datasets=None, compute=True, **kwargs):
         """Save all the datasets present in a scene to disk using *writer*."""
         if datasets is not None:
             datasets = [self[ds] for ds in datasets]
@@ -1066,9 +1064,7 @@ class Scene(MetadataObject):
                                "generated or could not be loaded. Requested "
                                "composite inputs may need to have matching "
                                "dimensions (eg. through resampling).")
-        writer, save_kwargs = load_writer(writer,
-                                          ppp_config_dir=self.ppp_config_dir,
-                                          **kwargs)
+        writer, save_kwargs = load_writer(writer, ppp_config_dir=self.ppp_config_dir, **kwargs)
         return writer.save_datasets(datasets, compute=compute, **save_kwargs)
 
     @classmethod

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1066,7 +1066,6 @@ class TestSceneLoading(unittest.TestCase):
         # it is fine that an optional prereq doesn't exist
         scene.load(['comp18'])
         loaded_ids = list(scene.datasets.keys())
-        print(loaded_ids)
         # depends on:
         #   ds3
         #   ds4 (mod1, mod3)

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -210,7 +210,7 @@ sensor_name: visir/test_sensor2
                        dims=['y', 'x'])
         e = Enhancer()
         self.assertIsNotNone(e.enhancement_tree)
-        get_enhanced_image(ds, enhancer=e)
+        get_enhanced_image(ds, enhance=e)
         self.assertSetEqual(set(e.sensor_enhancement_configs),
                             {self.ENH_FN3})
 
@@ -223,7 +223,7 @@ sensor_name: visir/test_sensor2
                        dims=['y', 'x'])
         e = Enhancer()
         self.assertIsNotNone(e.enhancement_tree)
-        get_enhanced_image(ds, enhancer=e)
+        get_enhanced_image(ds, enhance=e)
         self.assertSetEqual(set(e.sensor_enhancement_configs),
                             {self.ENH_FN2, self.ENH_ENH_FN2})
 
@@ -237,7 +237,7 @@ sensor_name: visir/test_sensor2
                        dims=['y', 'x'])
         e = Enhancer()
         self.assertIsNotNone(e.enhancement_tree)
-        img = get_enhanced_image(ds, enhancer=e)
+        img = get_enhanced_image(ds, enhance=e)
         self.assertSetEqual(
             set(e.sensor_enhancement_configs),
             {self.ENH_FN, self.ENH_ENH_FN})
@@ -249,7 +249,7 @@ sensor_name: visir/test_sensor2
                        dims=['y', 'x'])
         e = Enhancer()
         self.assertIsNotNone(e.enhancement_tree)
-        img = get_enhanced_image(ds, enhancer=e)
+        img = get_enhanced_image(ds, enhance=e)
         self.assertSetEqual(set(e.sensor_enhancement_configs),
                             {self.ENH_FN, self.ENH_ENH_FN})
         np.testing.assert_almost_equal(img.data.isel(bands=0).max().values, 1.)
@@ -264,7 +264,7 @@ sensor_name: visir/test_sensor2
                        dims=['y', 'x'])
         e = Enhancer()
         self.assertIsNotNone(e.enhancement_tree)
-        img = get_enhanced_image(ds, enhancer=e)
+        img = get_enhanced_image(ds, enhance=e)
         self.assertSetEqual(set(e.sensor_enhancement_configs),
                             {self.ENH_FN, self.ENH_ENH_FN})
         np.testing.assert_almost_equal(img.data.isel(bands=0).max().values, 0.5)

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -227,6 +227,25 @@ sensor_name: visir/test_sensor2
         self.assertSetEqual(set(e.sensor_enhancement_configs),
                             {self.ENH_FN2, self.ENH_ENH_FN2})
 
+    def test_deprecated_enhance_with_file_specified(self):
+        """Test enhancing an image when config file is specified."""
+        from satpy.writers import get_enhanced_image
+        from xarray import DataArray
+        ds = DataArray(np.arange(1, 11.).reshape((2, 5)),
+                       attrs=dict(name='test1', sensor='test_sensor', mode='L'),
+                       dims=['y', 'x'])
+        get_enhanced_image(ds, enhancement_config_file=self.ENH_ENH_FN)
+
+    def test_no_enhance(self):
+        """Test turning off enhancements."""
+        from satpy.writers import get_enhanced_image
+        from xarray import DataArray
+        ds = DataArray(np.arange(1, 11.).reshape((2, 5)),
+                       attrs=dict(name='test1', sensor='test_sensor', mode='L'),
+                       dims=['y', 'x'])
+        img = get_enhanced_image(ds, enhance=False)
+        np.testing.assert_allclose(img.data.data.compute().squeeze(), ds.data)
+
     def test_enhance_with_sensor_entry(self):
         """Test enhancing an image with a configuration section."""
         from satpy.writers import Enhancer, get_enhanced_image

--- a/satpy/tests/writer_tests/test_mitiff.py
+++ b/satpy/tests/writer_tests/test_mitiff.py
@@ -131,7 +131,6 @@ class TestMITIFFWriter(unittest.TestCase):
                                   dims=('y', 'x'),
                                   attrs={'calibration': 'reflectance'})
 
-        print(scene)
         data = xr.concat(scene, 'bands', coords='minimal')
         bands = []
         calibration = []

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -697,7 +697,7 @@ class ImageWriter(Writer):
             instead.
 
         """
-        Writer.__init__(self, name, filename, base_dir, **kwargs)
+        super(ImageWriter, self).__init__(name, filename, base_dir, **kwargs)
         if enhancement_config is not None:
             warnings.warn("'enhancement_config' has been deprecated. Pass an instance of the "
                           "'Enhancer' class to the 'enhance' keyword argument instead.", DeprecationWarning)
@@ -729,9 +729,8 @@ class ImageWriter(Writer):
         more details on the arguments passed to this method.
 
         """
-        img = get_enhanced_image(
-            dataset.squeeze(), self.enhancer, overlay=overlay,
-            decorate=decorate, fill_value=fill_value)
+        img = get_enhanced_image(dataset.squeeze(), enhance=self.enhancer, overlay=overlay,
+                                 decorate=decorate, fill_value=fill_value)
         return self.save_image(img, filename=filename, compute=compute, fill_value=fill_value, **kwargs)
 
     def save_image(self, img, filename=None, compute=True, **kwargs):

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -329,23 +329,59 @@ def add_decorate(orig, fill_value=None, **decorate):
                 add_text(orig, dc, img_orig, text=dec['text'])
 
 
-def get_enhanced_image(dataset,
-                       enhancer=None,
-                       ppp_config_dir=None,
-                       enhancement_config_file=None,
-                       overlay=None,
-                       decorate=None,
-                       fill_value=None):
+def get_enhanced_image(dataset, ppp_config_dir=None, enhance=None, enhancement_config_file=None,
+                       overlay=None, decorate=None, fill_value=None):
+    """Get an enhanced version of `dataset` as an :class:`~trollimage.xrimage.XRImage` instance.
+
+    Args:
+        dataset (xarray.DataArray): Data to be enhanced and converted to an image.
+        ppp_config_dir (str): Root configuration directory.
+        enhance (bool or Enhancer): Whether to automatically enhance
+            data to be more visually useful and to fit inside the file
+            format being saved to. By default this will default to using
+            the enhancement configuration files found using the default
+            :class:`~satpy.writers.Enhancer` class. This can be set to
+            `False` so that no enhancments are performed. This can also
+            be an instance of the :class:`~satpy.writers.Enhancer` class
+            if further custom enhancement is needed.
+        enhancement_config_file (str): Deprecated.
+        overlay (dict): Options for image overlays. See :func:`add_overlay`
+            for available options.
+        decorate (dict): Options for decorating the image. See
+            :func:`add_decorate` for available options.
+        fill_value (int or float): Value to use when pixels are masked or
+            invalid. Default of `None` means to create an alpha channel.
+            See :method:`~trollimage.xrimage.XRImage.finalize` for more
+            details. Only used when adding overlays or decorations. Otherwise
+            it is up to the caller to "finalize" the image before using it
+            except if calling ``img.show()`` or providing the image to
+            a writer as these will finalize the image.
+
+    .. versionchanged:: 0.10
+
+        Deprecated `enhancement_config_file` and 'enhancer' in favor of
+        `enhance`. Pass an instance of the `Enhancer` class to `enhance`
+        instead.
+
+    """
     if ppp_config_dir is None:
         ppp_config_dir = get_environ_config_dir()
 
-    if enhancer is None:
+    if enhancement_config_file is not None:
+        warnings.warn("'enhancement_config_file' has been deprecated. Pass an instance of the "
+                      "'Enhancer' class to the 'enhance' keyword argument instead.", DeprecationWarning)
+
+    if enhance is False:
+        enhancer = None
+    elif enhance is None:
         enhancer = Enhancer(ppp_config_dir, enhancement_config_file)
+    else:
+        enhancer = enhance
 
     # Create an image for enhancement
     img = to_image(dataset)
 
-    if enhancer.enhancement_tree is None:
+    if enhancer is None or enhancer.enhancement_tree is None:
         LOG.debug("No enhancement being applied to dataset")
     else:
         if dataset.attrs.get("sensor", None):
@@ -618,20 +654,67 @@ class Writer(Plugin):
 
 
 class ImageWriter(Writer):
+    """Base writer for image file formats."""
 
-    def __init__(self, name=None, filename=None, enhancement_config=None, base_dir=None, **kwargs):
+    def __init__(self, name=None, filename=None, base_dir=None, enhance=None, enhancement_config=None, **kwargs):
+        """Initialize image writer object.
+
+        Args:
+            name (str): A name for this writer for log and error messages.
+                If this writer is configured in a YAML file its name should
+                match the name of the YAML file. Writer names may also appear
+                in output file attributes.
+            filename (str): Filename to save data to. This filename can and
+                should specify certain python string formatting fields to
+                differentiate between data written to the files. Any
+                attributes provided by the ``.attrs`` of a DataArray object
+                may be included. Format and conversion specifiers provided by
+                the :class:`trollsift <trollsift.parser.StringFormatter>`
+                package may also be used. Any directories in the provided
+                pattern will be created if they do not exist. Example::
+
+                    {platform_name}_{sensor}_{name}_{start_time:%Y%m%d_%H%M%S.tif
+
+            base_dir (str):
+                Base destination directories for all created files.
+            enhance (bool or Enhancer): Whether to automatically enhance
+                data to be more visually useful and to fit inside the file
+                format being saved to. By default this will default to using
+                the enhancement configuration files found using the default
+                :class:`~satpy.writers.Enhancer` class. This can be set to
+                `False` so that no enhancments are performed. This can also
+                be an instance of the :class:`~satpy.writers.Enhancer` class
+                if further custom enhancement is needed.
+            enhancement_config (str): Deprecated.
+
+            kwargs (dict): Additional keyword arguments to pass to the
+                :class:`~satpy.writer.Writer` base class.
+
+        .. versionchanged:: 0.10
+
+            Deprecated `enhancement_config_file` and 'enhancer' in favor of
+            `enhance`. Pass an instance of the `Enhancer` class to `enhance`
+            instead.
+
+        """
         Writer.__init__(self, name, filename, base_dir, **kwargs)
-        enhancement_config = self.info.get(
-            "enhancement_config", None) if enhancement_config is None else enhancement_config
+        if enhancement_config is not None:
+            warnings.warn("'enhancement_config' has been deprecated. Pass an instance of the "
+                          "'Enhancer' class to the 'enhance' keyword argument instead.", DeprecationWarning)
+        else:
+            enhancement_config = self.info.get("enhancement_config", None)
 
-        self.enhancer = Enhancer(ppp_config_dir=self.ppp_config_dir,
-                                 enhancement_config_file=enhancement_config)
+        if enhance is False:
+            self.enhancer = None
+        elif enhance is None:
+            self.enhancer = Enhancer(ppp_config_dir=self.ppp_config_dir, enhancement_config_file=enhancement_config)
+        else:
+            self.enhancer = None
 
     @classmethod
     def separate_init_kwargs(cls, kwargs):
         # FUTURE: Don't pass Scene.save_datasets kwargs to init and here
-        init_kwargs, kwargs = super(ImageWriter, cls).separate_init_kwargs(
-            kwargs)
+        init_kwargs, kwargs = super(ImageWriter, cls).separate_init_kwargs(kwargs)
         for kw in ['enhancement_config']:
             if kw in kwargs:
                 init_kwargs[kw] = kwargs.pop(kw)
@@ -649,8 +732,7 @@ class ImageWriter(Writer):
         img = get_enhanced_image(
             dataset.squeeze(), self.enhancer, overlay=overlay,
             decorate=decorate, fill_value=fill_value)
-        return self.save_image(img, filename=filename, compute=compute,
-                               fill_value=fill_value, **kwargs)
+        return self.save_image(img, filename=filename, compute=compute, fill_value=fill_value, **kwargs)
 
     def save_image(self, img, filename=None, compute=True, **kwargs):
         """Save Image object to a given ``filename``.
@@ -679,8 +761,7 @@ class ImageWriter(Writer):
             this method.
 
         """
-        raise NotImplementedError(
-            "Writer '%s' has not implemented image saving" % (self.name, ))
+        raise NotImplementedError("Writer '%s' has not implemented image saving" % (self.name,))
 
 
 class DecisionTree(object):
@@ -803,7 +884,6 @@ class EnhancementDecisionTree(DecisionTree):
 
 
 class Enhancer(object):
-
     """Helper class to get enhancement information for images."""
 
     def __init__(self, ppp_config_dir=None, enhancement_config_file=None):
@@ -811,8 +891,7 @@ class Enhancer(object):
 
         Args:
             ppp_config_dir: Points to the base configuration directory
-            enhancement_config_file: The enhancement configuration to
-                apply, False to leave as is.
+            enhancement_config_file: The enhancement configuration to apply, False to leave as is.
         """
         self.ppp_config_dir = ppp_config_dir or get_environ_config_dir()
         self.enhancement_config_file = enhancement_config_file
@@ -821,8 +900,7 @@ class Enhancer(object):
             # it wasn't specified in the config or in the kwargs, we should
             # provide a default
             config_fn = os.path.join("enhancements", "generic.yaml")
-            self.enhancement_config_file = config_search_paths(
-                config_fn, self.ppp_config_dir)
+            self.enhancement_config_file = config_search_paths(config_fn, self.ppp_config_dir)
 
         if not self.enhancement_config_file:
             # They don't want any automatic enhancements
@@ -831,8 +909,7 @@ class Enhancer(object):
             if not isinstance(self.enhancement_config_file, (list, tuple)):
                 self.enhancement_config_file = [self.enhancement_config_file]
 
-            self.enhancement_tree = EnhancementDecisionTree(
-                *self.enhancement_config_file)
+            self.enhancement_tree = EnhancementDecisionTree(*self.enhancement_config_file)
 
         self.sensor_enhancement_configs = []
 

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -86,13 +86,9 @@ class GeoTIFFWriter(ImageWriter):
                     "copy_src_overviews", )
 
     def __init__(self, dtype=None, tags=None, **kwargs):
-        ImageWriter.__init__(self,
-                             default_config_filename="writers/geotiff.yaml",
-                             **kwargs)
-
+        super(GeoTIFFWriter, self).__init__(default_config_filename="writers/geotiff.yaml", **kwargs)
         self.dtype = self.info.get("dtype") if dtype is None else dtype
-        self.tags = self.info.get("tags",
-                                  None) if tags is None else tags
+        self.tags = self.info.get("tags", None) if tags is None else tags
         if self.tags is None:
             self.tags = {}
         elif not isinstance(self.tags, dict):

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -50,7 +50,6 @@ NP2GDAL = {
 
 
 class GeoTIFFWriter(ImageWriter):
-
     """Writer to save GeoTIFF images.
 
     Basic example from Scene:
@@ -59,8 +58,7 @@ class GeoTIFFWriter(ImageWriter):
 
     Un-enhanced float geotiff with NaN for fill values:
 
-        scn.save_datasets(writer='geotiff', dtype=np.float32,
-                          enhancement_config=False)
+        scn.save_datasets(writer='geotiff', dtype=np.float32, enhance=False)
 
     """
 

--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -639,7 +639,7 @@ class MITIFFWriter(ImageWriter):
 
         else:
             LOG.debug("Saving datasets as enhanced image")
-            img = get_enhanced_image(datasets.squeeze(), self.enhancer)
+            img = get_enhanced_image(datasets.squeeze(), enhance=self.enhancer)
             for i, band in enumerate(img.data['bands']):
                 chn = img.data.sel(bands=band)
                 data = chn.values * 254. + 1

--- a/satpy/writers/scmi.py
+++ b/satpy/writers/scmi.py
@@ -941,7 +941,7 @@ class SCMIWriter(Writer):
                           "that aren't RGBs to SCMI format: {}".format(ds.name))
             else:
                 # this is an RGB
-                img = get_enhanced_image(ds.squeeze(), self.enhancer)
+                img = get_enhanced_image(ds.squeeze(), enhance=self.enhancer)
                 res_data = img.finalize(fill_value=0, dtype=np.float32)[0]
                 new_datasets.extend(self._split_rgbs(res_data))
 


### PR DESCRIPTION
Current ways of specifying custom enhancement are inconsistent between `save_dataset`-type methods and `get_enhanced_image` and the `Enhancer` class that actually applies the enhancement. There is `enhancement_config` and `enhancement_config_file`, but most of the time the user just wants to say "don't enhance anything". To me the clearest way that a user could ask for this would be:

```python
scn.save_dataset(..., enhance=False)
```

which is now how it works. A user can also provide a `Enhancer` instance if they really want to. This PR also sets things up for the future where I would like to reinvent the enhancement interface to make it a separate step for the user.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
