### PR TITLE
Add the check_satpy function to find missing dependencies

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,7 +27,8 @@ If applicable, add screenshots to help explain your problem.
 **Environment Info:**
  - OS: [e.g. OSX, Windows, Linux]
  - SatPy Version: [e.g. 0.9.0]
- - PyResample Version: 
+ - PyResample Version:
+ - Readers and writers dependencies (when relevant): [run `from satpy.config import check_satpy; check_satpy()`]
 
 **Additional context**
 Add any other context about the problem here.

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -219,6 +219,16 @@ on saving datasets and customizing enhancements see the documentation on
 Troubleshooting
 ===============
 
+When something goes wrong, a first step to take is check that the latest Version
+of satpy and its dependencies are installed. Satpy drags in a few packages as
+dependencies per default, but each reader and writer has it's own dependencies
+which can be unfortunately easy to miss when just doing a regular `pip install`.
+To check the missing dependencies for the readers and writers, a utility
+function called `check_satpy` can be used:
+
+  >>> from satpy.config import check_satpy
+  >>> check_satpy()
+
 Due to the way SatPy works, producing as many datasets as possible, there are
 times that behavior can be unexpected but with no exceptions raised. To help
 troubleshoot these situations log messages can be turned on. To do this run

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -212,7 +212,7 @@ sensor_name: visir/test_sensor2
         self.assertIsNotNone(e.enhancement_tree)
         get_enhanced_image(ds, enhancer=e)
         self.assertSetEqual(set(e.sensor_enhancement_configs),
-                            {self.ENH_FN3})
+                            {os.path.abspath(self.ENH_FN3)})
 
     def test_enhance_with_sensor_no_entry(self):
         """Test enhancing an image that has no configuration sections."""
@@ -225,7 +225,8 @@ sensor_name: visir/test_sensor2
         self.assertIsNotNone(e.enhancement_tree)
         get_enhanced_image(ds, enhancer=e)
         self.assertSetEqual(set(e.sensor_enhancement_configs),
-                            {self.ENH_FN2, self.ENH_ENH_FN2})
+                            {os.path.abspath(self.ENH_FN2),
+                             os.path.abspath(self.ENH_ENH_FN2)})
 
     def test_enhance_with_sensor_entry(self):
         """Test enhancing an image with a configuration section."""
@@ -240,7 +241,8 @@ sensor_name: visir/test_sensor2
         img = get_enhanced_image(ds, enhancer=e)
         self.assertSetEqual(
             set(e.sensor_enhancement_configs),
-            {self.ENH_FN, self.ENH_ENH_FN})
+            {os.path.abspath(self.ENH_FN),
+             os.path.abspath(self.ENH_ENH_FN)})
         np.testing.assert_almost_equal(img.data.isel(bands=0).max().values,
                                        1.)
 
@@ -251,7 +253,8 @@ sensor_name: visir/test_sensor2
         self.assertIsNotNone(e.enhancement_tree)
         img = get_enhanced_image(ds, enhancer=e)
         self.assertSetEqual(set(e.sensor_enhancement_configs),
-                            {self.ENH_FN, self.ENH_ENH_FN})
+                            {os.path.abspath(self.ENH_FN),
+                             os.path.abspath(self.ENH_ENH_FN)})
         np.testing.assert_almost_equal(img.data.isel(bands=0).max().values, 1.)
 
     def test_enhance_with_sensor_entry2(self):
@@ -266,7 +269,8 @@ sensor_name: visir/test_sensor2
         self.assertIsNotNone(e.enhancement_tree)
         img = get_enhanced_image(ds, enhancer=e)
         self.assertSetEqual(set(e.sensor_enhancement_configs),
-                            {self.ENH_FN, self.ENH_ENH_FN})
+                            {os.path.abspath(self.ENH_FN),
+                             os.path.abspath(self.ENH_ENH_FN)})
         np.testing.assert_almost_equal(img.data.isel(bands=0).max().values, 0.5)
 
 


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

This PR add a `check_satpy` function to diagnose the satpy installation and flag possible dependency problems with readers and writers

<!-- Describe what your PR does, and why -->

An example of the output of the function is:
```
Readers
=======
abi_l1b: ok
acspo: ok
ahi_hsd: ok
amsr2_l1b: ok
avhrr_aapp_l1b: ok
avhrr_eps_l1b: ok
avhrr_hrpt_l1b: cannot find module 'satpy.readers.hrpt' (No module named 'pygac')
clavrx: ok
fci_fdhsi: ok
gac_lac_l1: cannot find module 'satpy.readers.gac_lac_l1' (No module named 'pygac')
generic_image: ok
geocat: ok
ghrsst_osisaf: ok
grib: cannot find module 'satpy.readers.grib' (No module named 'pygrib')
hdf4_caliopv3: ok
hdfeos_l1b: ok
hrit_electrol: ok
hrit_goes: ok
hrit_jma: ok
hrit_msg: ok
iasi_l2: ok
li_l2: ok
maia: ok
native_msg: ok
nc_goes: ok
nc_nwcsaf_msg: ok
nc_nwcsaf_pps: ok
nc_olci_l1b: ok
nc_olci_l2: ok
nc_slstr: ok
nucaps: ok
omps_edr: ok
safe_msi: ok
safe_sar_c: cannot find module 'satpy.readers.safe_sar_c' (No module named 'osgeo')
scatsat1_l2b: ok
scmi_abi_l1b: ok
viirs_compact: ok
viirs_edr_flood: ok
viirs_l1b: ok
viirs_sdr: ok

Writers
=======
cf: ok
geotiff: cannot find module 'satpy.writers.geotiff' (No module named 'osgeo')
mitiff: ok
ninjotiff: cannot find module 'satpy.writers.ninjotiff' (No module named 'pyninjotiff')
scmi: ok
simple_image: ok
```

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
