### PR TITLE
Fix radiance units of geostationary satellites

### DIFF
--- a/satpy/etc/readers/abi_l1b.yaml
+++ b/satpy/etc/readers/abi_l1b.yaml
@@ -1,3 +1,8 @@
+# References:
+#  - GOES-R Series Data Book, Chapter 3
+#
+# Note: Channels < 3 microns have different units than channels > 3 microns
+
 reader:
   # PUG: https://www.goes-r.gov/users/docs/PUG-L1b-vol3.pdf
   description: NC Reader for ABI data
@@ -153,8 +158,8 @@ datasets:
     resolution: 2000
     calibration:
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
@@ -167,8 +172,8 @@ datasets:
     resolution: 2000
     calibration:
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
@@ -181,8 +186,8 @@ datasets:
     resolution: 2000
     calibration:
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
@@ -195,8 +200,8 @@ datasets:
     resolution: 2000
     calibration:
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
@@ -209,8 +214,8 @@ datasets:
     resolution: 2000
     calibration:
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
@@ -223,8 +228,8 @@ datasets:
     resolution: 2000
     calibration:
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
@@ -237,8 +242,8 @@ datasets:
     resolution: 2000
     calibration:
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
@@ -251,8 +256,8 @@ datasets:
     resolution: 2000
     calibration:
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
@@ -265,8 +270,8 @@ datasets:
     resolution: 2000
     calibration:
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
@@ -279,8 +284,8 @@ datasets:
     resolution: 2000
     calibration:
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K

--- a/satpy/etc/readers/ahi_hsd.yaml
+++ b/satpy/etc/readers/ahi_hsd.yaml
@@ -1,3 +1,6 @@
+# References:
+#  - Himawari-8/9 Himawari Standard Data User's Guide
+
 reader:
   description: Generic HSD AHI Reader
   name: ahi_hsd

--- a/satpy/etc/readers/hrit_msg.yaml
+++ b/satpy/etc/readers/hrit_msg.yaml
@@ -1,3 +1,8 @@
+# References:
+# - MSG Level 1.5 Image Data Format Description
+# - Radiometric Calibration of MSG SEVIRI Level 1.5 Image Data in Equivalent
+#   Spectral Blackbody Radiance
+
 reader:
   description: MSG HRIT Reader
   name: hrit_msg
@@ -84,8 +89,8 @@ datasets:
         standard_name: toa_bidirectional_reflectance
         units: "%"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -100,8 +105,8 @@ datasets:
         standard_name: reflectance
         units: "%"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -116,8 +121,8 @@ datasets:
         standard_name: brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -132,8 +137,8 @@ datasets:
         standard_name: brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -148,8 +153,8 @@ datasets:
         standard_name: brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -164,8 +169,8 @@ datasets:
         standard_name: brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -180,8 +185,8 @@ datasets:
         standard_name: brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -196,8 +201,8 @@ datasets:
         standard_name: brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -212,8 +217,8 @@ datasets:
         standard_name: toa_bidirectional_reflectance
         units: "%"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -228,8 +233,8 @@ datasets:
         standard_name: toa_bidirectional_reflectance
         units: "%"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -244,8 +249,8 @@ datasets:
         standard_name: brightness_temperature
         units: "K"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -260,8 +265,8 @@ datasets:
         standard_name: brightness_temperature
         units: "K"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -22,10 +22,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Advanced Himawari Imager (AHI) standard format data reader. The HSD format
-that this reader reads are described at the URL below:
+"""Advanced Himawari Imager (AHI) standard format data reader.
 
-http://www.data.jma.go.jp/mscweb/en/himawari89/space_segment/spsg_ahi.html
+References:
+    - Himawari-8/9 Himawari Standard Data User's Guide
+    - http://www.data.jma.go.jp/mscweb/en/himawari89/space_segment/spsg_ahi.html
 
 Time Information
 ****************

--- a/satpy/readers/hrit_msg.py
+++ b/satpy/readers/hrit_msg.py
@@ -25,7 +25,10 @@
 """SEVIRI HRIT format reader.
 
 References:
-    MSG Level 1.5 Image Data FormatDescription
+    - MSG Level 1.5 Image Data Format Description
+    - Radiometric Calibration of MSG SEVIRI Level 1.5 Image Data in Equivalent
+      Spectral Blackbody Radiance
+
 
 TODO:
 - HRV navigation


### PR DESCRIPTION
Fix radiance units of geostationary satellites and add references where missing. Now the value ranges of SEVIRI, ABI and AHI radiances are consistent (taking into account that ``toa_radiance_per_unit_wavenumber = wavelength^2 * toa_radiance_per_unit_wavelength``).

 - [x] Closes #414 
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

