### PR TITLE
Fix thinned modis reading in 'hdfeos_l1b' reader

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -688,6 +688,7 @@ class GenericCompositor(CompositeBase):
 
 
 class FillingCompositor(GenericCompositor):
+    """Make a regular RGB, filling the RGB bands with the first provided dataset's values."""
 
     def __call__(self, projectables, nonprojectables=None, **info):
         projectables[1] = projectables[1].fillna(projectables[0])

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -687,6 +687,14 @@ class GenericCompositor(CompositeBase):
                             dims=data.dims, coords=data.coords)
 
 
+class FillingCompositor(GenericCompositor):
+
+    def __call__(self, projectables, nonprojectables=None, **info):
+        projectables[1] = projectables[1].fillna(projectables[0])
+        projectables[2] = projectables[2].fillna(projectables[0])
+        projectables[3] = projectables[3].fillna(projectables[0])
+        return super(FillingCompositor, self).__call__(projectables[1:], **info)
+
 class RGBCompositor(GenericCompositor):
 
     def __call__(self, projectables, nonprojectables=None, **info):

--- a/satpy/etc/composites/modis.yaml
+++ b/satpy/etc/composites/modis.yaml
@@ -33,8 +33,10 @@ composites:
     standard_name: true_color
 
   true_color_thin:
-    compositor: !!python/name:satpy.composites.GenericCompositor
+    compositor: !!python/name:satpy.composites.FillingCompositor
     prerequisites:
+    - name: '1'
+      modifiers: [sunz_corrected, rayleigh_corrected]
     - name: '1'
       modifiers: [sunz_corrected, rayleigh_corrected]
     - name: '12'

--- a/satpy/etc/composites/modis.yaml
+++ b/satpy/etc/composites/modis.yaml
@@ -32,6 +32,17 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected]
     standard_name: true_color
 
+  true_color_thin:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - name: '1'
+      modifiers: [sunz_corrected, rayleigh_corrected]
+    - name: '12'
+      modifiers: [sunz_corrected, rayleigh_corrected]
+    - name: '10'
+      modifiers: [sunz_corrected, rayleigh_corrected]
+    standard_name: true_color
+
   true_color_crefl:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:

--- a/satpy/etc/readers/hdfeos_l1b.yaml
+++ b/satpy/etc/readers/hdfeos_l1b.yaml
@@ -423,14 +423,14 @@ datasets:
   longitude5k:
     file_type: hdf_eos_data_1000m
     name: longitude
-    resolution: 5000
+    resolution: [5000, 1000]
     standard_name: longitude
     units: degree
 
   latitude5k:
     file_type: hdf_eos_data_1000m
     name: latitude
-    resolution: 5000
+    resolution: [5000, 1000]
     standard_name: latitude
     units: degree
 
@@ -439,28 +439,28 @@ datasets:
     sensor: modis
     resolution: [1000, 500, 250]
     coordinates: [longitude, latitude]
-    file_type: hdf_eos_geo
+    file_type: [hdf_eos_geo, hdf_eos_data_1000m]
 
   solar_azimuth_angle:
     name: solar_azimuth_angle
     sensor: modis
     resolution: [1000, 500, 250]
     coordinates: [longitude, latitude]
-    file_type: hdf_eos_geo
+    file_type: [hdf_eos_geo, hdf_eos_data_1000m]
 
   satellite_zenith_angle:
     name: satellite_zenith_angle
     sensor: modis
     resolution: [1000, 500, 250]
     coordinates: [longitude, latitude]
-    file_type: hdf_eos_geo
+    file_type: [hdf_eos_geo, hdf_eos_data_1000m]
 
   satellite_azimuth_angle:
     name: satellite_azimuth_angle
     sensor: modis
     resolution: [1000, 500, 250]
     coordinates: [longitude, latitude]
-    file_type: hdf_eos_geo
+    file_type: [hdf_eos_geo, hdf_eos_data_1000m]
 
 
 file_types:
@@ -488,7 +488,8 @@ file_types:
     - 'thin_M{platform_indicator:1s}D021KM.A{start_time:%Y%j.%H%M}.{collection:03d}{suffix}.hdf'
     - 'M{platform_indicator:1s}D021KM.{start_time:%y%j%H%M%S}.hdf'
     - '{platform_indicator:1s}1.{start_time:%y%j.%H%M}.1000m.hdf'
-    file_reader: !!python/name:satpy.readers.hdfeos_l1b.HDFEOSBandReader
+    - 'M{platform_indicator:1s}D021KM_A{start_time:%Y%j_%H%M}_{collection:03d}_NRT.hdf'
+    file_reader: !!python/name:satpy.readers.hdfeos_l1b.MixedHDFEOSReader
   hdf_eos_geo:
     file_patterns:
     - 'M{platform_indicator:1s}D03_A{start_time:%y%j_%H%M%S}_{processing_time:%Y%j%H%M%S}.hdf'

--- a/satpy/readers/hdfeos_l1b.py
+++ b/satpy/readers/hdfeos_l1b.py
@@ -52,6 +52,7 @@ logger = logging.getLogger(__name__)
 
 
 class HDFEOSFileReader(BaseFileHandler):
+    """Base file handler for EOS level 1 data."""
 
     def __init__(self, filename, filename_info, filetype_info):
         super(HDFEOSFileReader, self).__init__(filename, filename_info, filetype_info)
@@ -115,6 +116,7 @@ class HDFEOSFileReader(BaseFileHandler):
 
 
 class HDFEOSGeoReader(HDFEOSFileReader):
+    """Handler for the geographical files."""
 
     def __init__(self, filename, filename_info, filetype_info):
         HDFEOSFileReader.__init__(self, filename, filename_info, filetype_info)
@@ -218,6 +220,7 @@ class HDFEOSGeoReader(HDFEOSFileReader):
 
 
 class HDFEOSBandReader(HDFEOSFileReader):
+    """Handler for the regular band channels."""
 
     res = {"1": 1000,
            "Q": 250,

--- a/satpy/readers/hdfeos_l1b.py
+++ b/satpy/readers/hdfeos_l1b.py
@@ -265,6 +265,27 @@ class HDFEOSBandReader(HDFEOSFileReader):
             array = xr.DataArray(from_sds(subdata, chunks=CHUNK_SIZE)[index, :, :],
                                  dims=['y', 'x']).astype(np.float32)
             valid_range = var_attrs['valid_range']
+
+            # Fill values:
+            # Data Value Meaning
+            # 65535 Fill Value (includes reflective band data at night mode
+            # and completely missing L1A scans)
+            # 65534 L1A DN is missing within a scan
+            # 65533 Detector is saturated
+            # 65532 Cannot compute zero point DN, e.g., SV is saturated
+            # 65531 Detector is dead (see comments below)
+            # 65530 RSB dn** below the minimum of the scaling range
+            # 65529 TEB radiance or RSB dn** exceeds the maximum of the
+            # scaling range
+            # 65528 Aggregation algorithm failure
+            # 65527 Rotation of Earth view Sector from nominal science
+            # collection position
+            # 65526 Calibration coefficient b1 could not be computed
+            # 65525 Subframe is dead
+            # 65524 Both sides of the PCLW electronics on simultaneously
+            # 65501 - 65523 (reserved for future use)
+            # 65500 NAD closed upper limit
+
             array = array.where(array >= np.float32(valid_range[0]))
             array = array.where(array <= np.float32(valid_range[1]))
             array = array.where(from_sds(uncertainty, chunks=CHUNK_SIZE)[index, :, :] < 15)

--- a/satpy/readers/hdfeos_l1b.py
+++ b/satpy/readers/hdfeos_l1b.py
@@ -359,8 +359,7 @@ class MixedHDFEOSReader(HDFEOSGeoReader, HDFEOSBandReader):
                         'satellite_azimuth_angle', 'satellite_zenith_angle',
                         'solar_azimuth_angle', 'solar_zenith_angle']:
             return HDFEOSGeoReader.get_dataset(self, key, info)
-        else:
-            return HDFEOSBandReader.get_dataset(self, key, info)
+        return HDFEOSBandReader.get_dataset(self, key, info)
 
 
 def calibrate_counts(array, attributes, index):

--- a/satpy/readers/hdfeos_l1b.py
+++ b/satpy/readers/hdfeos_l1b.py
@@ -326,11 +326,6 @@ class HDFEOSBandReader(HDFEOSFileReader):
             #     orbit_idx = mda.index("ORBITNUMBER")
             #     satscene.orbit = mda[orbit_idx + 111:orbit_idx + 116]
 
-            # Get the geolocation
-            # if resolution != 1000:
-            #    logger.warning("Cannot load geolocation at this resolution (yet).")
-            #    return
-
             # Trimming out dead sensor lines (detectors) on terra:
             # (in addition channel 27, 30, 34, 35, and 36 are nosiy)
             # if satscene.satname == "terra":
@@ -348,24 +343,9 @@ class HDFEOSBandReader(HDFEOSFileReader):
             #             lats=satscene[band].area.lats[indices, :])
             return projectable
 
-    # These have to be interpolated...
-    def get_height(self):
-        return self.data.select("Height")
-
-    def get_sunz(self):
-        return self.data.select("SolarZenith")
-
-    def get_suna(self):
-        return self.data.select("SolarAzimuth")
-
-    def get_satz(self):
-        return self.data.select("SensorZenith")
-
-    def get_sata(self):
-        return self.data.select("SensorAzimuth")
-
 
 class MixedHDFEOSReader(HDFEOSGeoReader, HDFEOSBandReader):
+    """A file handler for the files that have both regular bands and geographical information in them."""
 
     def __init__(self, filename, filename_info, filetype_info):
         HDFEOSGeoReader.__init__(self, filename, filename_info, filetype_info)
@@ -463,12 +443,3 @@ def calibrate_bt(array, attributes, index, band_name):
     array = c_2 / (cwn * xu.log(c_1 / (1000000 * array * cwn ** 5) + 1))
     array = (array - tci) / tcs
     return array
-
-
-if __name__ == '__main__':
-    from satpy.utils import debug_on
-    debug_on()
-    br = HDFEOSBandReader(
-        '/data/temp/Martin.Raspaud/MYD021km_A16220_130933_2016220132537.hdf')
-    gr = HDFEOSGeoReader(
-        '/data/temp/Martin.Raspaud/MYD03_A16220_130933_2016220132537.hdf')

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -185,6 +185,23 @@ class TestDayNightCompositor(unittest.TestCase):
         np.testing.assert_allclose(res.values[0], expected)
 
 
+class TestFillingCompositor(unittest.TestCase):
+
+    def test_fill(self):
+        import numpy as np
+        import xarray as xr
+        from satpy.composites import FillingCompositor
+        comp = FillingCompositor(name='fill_test')
+        filler = xr.DataArray(np.array([1, 2, 3, 4, 3, 2, 1]))
+        red = xr.DataArray(np.array([1, 2, 3, np.nan, 3, 2, 1]))
+        green = xr.DataArray(np.array([np.nan, 2, 3, 4, 3, 2, np.nan]))
+        blue = xr.DataArray(np.array([4, 3, 2, 1, 2, 3, 4]))
+        res = comp([filler, red, green, blue])
+        np.testing.assert_allclose(res.sel(bands='R').data, filler.data)
+        np.testing.assert_allclose(res.sel(bands='G').data, filler.data)
+        np.testing.assert_allclose(res.sel(bands='B').data, blue.data)
+
+
 def suite():
     """Test suite for all reader tests"""
     loader = unittest.TestLoader()
@@ -194,5 +211,9 @@ def suite():
     mysuite.addTests(test_viirs.suite())
     mysuite.addTest(loader.loadTestsFromTestCase(TestCheckArea))
     mysuite.addTest(loader.loadTestsFromTestCase(TestDayNightCompositor))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestFillingCompositor))
 
     return mysuite
+
+if __name__ == '__main__':
+    unittest.main()

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -210,5 +210,6 @@ def suite():
 
     return mysuite
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -19,8 +19,6 @@
 """Tests for compositors.
 """
 
-
-import sys
 from satpy.tests.compositor_tests import test_abi, test_ahi, test_viirs
 
 try:
@@ -28,10 +26,7 @@ try:
 except ImportError:
     import mock
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
+import unittest
 
 
 class TestCheckArea(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ if sys.version < '3.0':
 
 extras_require = {
     # Readers:
-    'xRIT': ['mipp >= 0.6.0'],
     'hdfeos_l1b': ['python-hdf4', 'python-geotiepoints >= 1.1.7'],
     'geocat': ['python-hdf4'],
     'acspo': ['netCDF4 >= 1.1.8'],


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->
Thinned modis files, eg as received via eumetcast, were not working with the current implementation of the hdfeos reader, since it wasn't capable of reading both navigation and band data from the same file. This PR addresses the issue.

<!-- Describe what your PR does, and why -->

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

