### PR TITLE
Add IASI instrument name to IASI L2 reader dataset attributes

### DIFF
--- a/satpy/readers/iasi_l2.py
+++ b/satpy/readers/iasi_l2.py
@@ -89,6 +89,7 @@ class IASIL2HDF5(BaseFileHandler):
         self.finfo = filename_info
         self.lons = None
         self.lats = None
+        self.sensor = 'iasi'
 
         self.mda = {}
         short_name = filename_info['platform_id']
@@ -116,6 +117,7 @@ class IASIL2HDF5(BaseFileHandler):
             else:
                 m_data = read_geo(fid, key)
         m_data.attrs.update(info)
+        m_data.attrs['sensor'] = self.sensor
 
         return m_data
 


### PR DESCRIPTION
Sensor name was missing from the dataset attributes when using IASI L2 reader. This resulted in that when creating a composite of e.g. `surface_skin_temperature` custom enhancement configuration wasn't found from `$PPP_CONFIG_DIR/enhancements/iasi.yaml`, but was found if the same was put inside `generic.yaml`.

This PR sets the `sensor` attribute for each dataset to `'iasi'`.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
