### PR TITLE
Fix end time calculation in nc_goes

### DIFF
--- a/satpy/readers/nc_goes.py
+++ b/satpy/readers/nc_goes.py
@@ -658,10 +658,10 @@ class GOESNCFileHandler(BaseFileHandler):
     @property
     def end_time(self):
         """End timestamp of the dataset"""
-        if self.sector is not None:
+        try:
             return self.start_time + SCAN_DURATION[self.sector]
-
-        return self.start_time
+        except KeyError:
+            return self.start_time
 
     @property
     def resolution(self):

--- a/satpy/tests/reader_tests/test_nc_goes.py
+++ b/satpy/tests/reader_tests/test_nc_goes.py
@@ -270,8 +270,20 @@ class GOESNCFileHandlerTest(unittest.TestCase):
                         'temperature in channel {} detector {}'.format(ch, det))
 
     def test_start_time(self):
-        """Test dataset time stamp"""
+        """Test dataset start time stamp"""
         self.assertEqual(self.reader.start_time, self.time)
+
+    def test_end_time(self):
+        """Test dataset end time stamp"""
+        from satpy.readers.nc_goes import (SCAN_DURATION, FULL_DISC,
+                                           UNKNOWN_SECTOR)
+        expected = {
+            UNKNOWN_SECTOR: self.time,
+            FULL_DISC: self.time + SCAN_DURATION[FULL_DISC]
+        }
+        for sector, end_time in expected.items():
+            self.reader.sector = sector
+            self.assertEqual(self.reader.end_time, end_time)
 
     def test_get_sector(self):
         """Test sector identification"""


### PR DESCRIPTION
Currently, if the sector is unknown, a KeyError is thrown. The PR fixes this bug.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
