### PR TITLE
Add more descriptive names to AHI readers AreaDefinition names

### DIFF
--- a/satpy/etc/readers/hrit_jma.yaml
+++ b/satpy/etc/readers/hrit_jma.yaml
@@ -102,8 +102,6 @@ file_types:
         - 'IMG_DK01B16_{start_time:%Y%m%d%H%M}_{segment:03d}'
         - 'IMG_DK01B16_{start_time:%Y%m%d%H%M}'
 
-
-
 datasets:
   B01:
     name: B01

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -252,6 +252,7 @@ class AHIHSDFileHandler(BaseFileHandler):
                                         dtype=_NAV_INFO_TYPE,
                                         count=1)[0]
         self.platform_name = np2str(self.basic_info['satellite'])
+        self.observation_area = np2str(self.basic_info['observation_area'])
         self.sensor = 'ahi'
 
     @property
@@ -305,8 +306,8 @@ class AHIHSDFileHandler(BaseFileHandler):
                      'units': 'm'}
 
         area = geometry.AreaDefinition(
-            'some_area_name',
-            "On-the-fly area",
+            self.observation_area,
+            "AHI {} area".format(self.observation_area),
             'geosh8',
             proj_dict,
             ncols,

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -119,8 +119,8 @@ class HRITJMAFileHandler(HRITFileHandler):
 
             self.calibration_table = np.array(self.calibration_table)
 
-        projection_name = self.mda['projection_name'].decode()
-        sublon = float(projection_name.strip().split('(')[1][:-1])
+        self.projection_name = self.mda['projection_name'].decode().strip()
+        sublon = float(self.projection_name.split('(')[1][:-1])
         self.mda['projection_parameters']['SSP_longitude'] = sublon
 
     def get_area_def(self, dsid):
@@ -155,8 +155,8 @@ class HRITJMAFileHandler(HRITFileHandler):
                      'units': 'm'}
 
         area = geometry.AreaDefinition(
-            'some_area_name',
-            "On-the-fly area",
+            "FLDK",
+            "HRIT FLDK Area: {}".format(self.projection_name),
             'geosmsg',
             proj_dict,
             ncols,


### PR DESCRIPTION
The previous names were things like "some_area_name". For users who want to put area names in their filenames (`{area.area_id}`) this makes the filename extremely ugly and not very useful. I took the information that I could find from the file and put it in the area definition. As far as everyone seems to know AHI HRIT files (himawaricast) these files only come in full disk (FLDK) variants so I hardcoded that name.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->