### PR TITLE
Check for OS and IO error when creating filehandlers, and log a warning

### DIFF
--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -392,8 +392,11 @@ class FileYAMLReader(AbstractYAMLReader):
             except KeyError:
                 logger.warning("Missing requirements for %s", filename)
                 continue
-
-            yield filetype_cls(filename, filename_info, filetype_info, *req_fh)
+            try:
+                yield filetype_cls(filename, filename_info, filetype_info, *req_fh)
+            except (IOError, OSError) as err:
+                logger.warning("Problem loading file %s: %s", filename, str(err))
+                continue
 
     def time_matches(self, fstart, fend):
         start_time = self.filter_parameters.get('start_time')

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -488,6 +488,18 @@ class TestFileFileYAMLReader(unittest.TestCase):
 
         self.assertIs(proj, xarray.concat.return_value)
 
+    def test_file_loading(self):
+        def foo_reader(filename, *args, **kwargs):
+            raise OSError('No file named %s', filename)
+
+        res = self.reader.new_filehandler_instances({'file_reader': foo_reader}, [('a_file.ext', {'some': 'info'})])
+        self.assertListEqual(list(res), [])
+
+        def foo_reader(filename, *args, **kwargs):
+            return 'All good'
+        res = self.reader.new_filehandler_instances({'file_reader': foo_reader}, [('a_file.ext', {'some': 'info'})])
+        self.assertListEqual(list(res), ['All good'])
+
 
 def suite():
     """The test suite for test_scene."""


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->
<!-- Describe what your PR does, and why -->
Instead of crashing satpy, this PR proposes to check for OS and IO error on creation of the filehandlers. A warning is logged, but the loading operation is resumed so that other valid files can still be read.


 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

