### PR TITLE
Add DOI role and reference to Zinke DNB method

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,9 +1,5 @@
 # Releasing SatPy
 
-prerequisites: `pip install bumpversion setuptools twine`
-
-NB! You do not need `mercurial`. `bumpversion` is supposed to function without it. If it still doesn't work it might be that your PATH variable is screwed up. Check that all elements of your PATH are readable!
-
 1. checkout master
 2. pull from repo
 3. run the unittests
@@ -18,7 +14,7 @@ Don't forget to commit!
 5. Create a tag with the new version number, starting with a 'v', eg:
 
 ```
-git tag v0.22.45
+git tag -a v0.22.45 -m "Version 0.22.45"
 ```
 
 See [semver.org](http://semver.org/) on how to write a version number.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -21,6 +21,7 @@ import sys
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.append(os.path.abspath('../../'))
+sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 from satpy import __version__  # noqa
 
 
@@ -58,7 +59,7 @@ autoclass_content = 'both'  # append class __init__ docstring to the class docst
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage',
-              'sphinx.ext.doctest', 'sphinx.ext.napoleon']
+              'sphinx.ext.doctest', 'sphinx.ext.napoleon', 'doi_role']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/doi_role.py
+++ b/doc/source/doi_role.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+"""
+    doilinks
+    ~~~~~~~~~~~~~~~~~~~
+    Extension to add links to DOIs. With this extension you can use e.g.
+    :doi:`10.1016/S0022-2836(05)80360-2` in your documents. This will
+    create a link to a DOI resolver
+    (``https://doi.org/10.1016/S0022-2836(05)80360-2``).
+    The link caption will be the raw DOI.
+    You can also give an explicit caption, e.g.
+    :doi:`Basic local alignment search tool <10.1016/S0022-2836(05)80360-2>`.
+
+    :copyright: Copyright 2015  Jon Lund Steffensen. Based on extlinks by
+        the Sphinx team.
+    :license: BSD.
+"""
+
+from docutils import nodes, utils
+
+from sphinx.util.nodes import split_explicit_title
+
+
+def doi_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
+    text = utils.unescape(text)
+    has_explicit_title, title, part = split_explicit_title(text)
+    full_url = 'https://doi.org/' + part
+    if not has_explicit_title:
+        title = 'DOI:' + part
+    pnode = nodes.reference(title, title, internal=False, refuri=full_url)
+    return [pnode], []
+
+
+def arxiv_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
+    text = utils.unescape(text)
+    has_explicit_title, title, part = split_explicit_title(text)
+    full_url = 'https://arxiv.org/abs/' + part
+    if not has_explicit_title:
+        title = 'arXiv:' + part
+    pnode = nodes.reference(title, title, internal=False, refuri=full_url)
+    return [pnode], []
+
+
+def setup_link_role(app):
+    app.add_role('doi', doi_role)
+    app.add_role('DOI', doi_role)
+    app.add_role('arXiv', arxiv_role)
+    app.add_role('arxiv', arxiv_role)
+
+
+def setup(app):
+    app.connect('builder-inited', setup_link_role)
+    return {'version': '0.1', 'parallel_read_safe': True}

--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -1013,10 +1013,13 @@ def _linear_normalization_from_0to1(
 
 
 class NCCZinke(CompositeBase):
-    """Equalized DNB composite using the Zinke algorithm.
+    """Equalized DNB composite using the Zinke algorithm [#ncc1]_.
 
-    http://www.tandfonline.com/doi/full/10.1080/01431161.2017.1338838
-    DOI: 10.1080/01431161.2017.1338838
+    References:
+
+        .. [#ncc1] Stephan Zinke (2017),
+               A simplified high and near-constant contrast approach for the display of VIIRS day/night band imagery
+               :doi:`10.1080/01431161.2017.1338838`
 
     """
 

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -351,7 +351,7 @@ def get_enhanced_image(dataset, ppp_config_dir=None, enhance=None, enhancement_c
             :func:`add_decorate` for available options.
         fill_value (int or float): Value to use when pixels are masked or
             invalid. Default of `None` means to create an alpha channel.
-            See :method:`~trollimage.xrimage.XRImage.finalize` for more
+            See :meth:`~trollimage.xrimage.XRImage.finalize` for more
             details. Only used when adding overlays or decorations. Otherwise
             it is up to the caller to "finalize" the image before using it
             except if calling ``img.show()`` or providing the image to


### PR DESCRIPTION
This is the ground work for #500, but I wouldn't say it closes it. I would say this is fully documented, but the role is really not fully documented. It doesn't even exist outside of scipy and the other projects that have copied it from a gist someone made a while ago. The module is copied in to the sphinx doc source. I was able to use it nicely on the NCC DNB compositor for Stephan Zinke's paper.

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
