### PR TITLE
Change unnecessary warning messages to debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
         - CONDA_CHANNELS='conda-forge'
+        - CONDA_CHANNEL_PRIORITY='True'
 matrix:
   include:
   - env: PYTHON_VERSION=2.7
@@ -26,9 +27,6 @@ matrix:
 install:
     - git clone --depth 1 git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
-    # See https://github.com/conda/conda/issues/7626#issuecomment-412922028
-    - conda config --remove channels defaults
-    - conda install -y $CONDA_DEPENDENCIES
 script:
 - coverage run --source=satpy setup.py test
 - coverage run -a --source=satpy -m behave satpy/tests/features --tags=-download

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -243,7 +243,7 @@ intersphinx_mapping = {
     'numpy': ('https://docs.scipy.org/doc/numpy', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'xarray': ('https://xarray.pydata.org/en/stable', None),
-    'dask': ('https://dask.pydata.org/en/latest', None),
+    'dask': ('https://docs.dask.org/en/latest', None),
     'pyresample': ('https://pyresample.readthedocs.io/en/stable', None),
     'trollsift': ('https://trollsift.readthedocs.io/en/stable', None),
     'trollimage': ('https://trollimage.readthedocs.io/en/stable', None),

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -124,9 +124,6 @@ def crefl_scaling(img, **kwargs):
                                  attrs=band_data.attrs)
         return band_data
 
-    # mask reflectances that are below 0
-    bad_mask = (img.data < 0).any(axis=0)
-    img.data = img.data.where(~bad_mask)
     return apply_enhancement(img.data, func, separate=True)
 
 

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -124,6 +124,9 @@ def crefl_scaling(img, **kwargs):
                                  attrs=band_data.attrs)
         return band_data
 
+    # mask reflectances that are below 0
+    bad_mask = (img.data < 0).any(axis=0)
+    img.data = img.data.where(~bad_mask)
     return apply_enhancement(img.data, func, separate=True)
 
 

--- a/satpy/etc/readers/abi_l1b.yaml
+++ b/satpy/etc/readers/abi_l1b.yaml
@@ -69,7 +69,6 @@ file_types:
 datasets:
   C01:
     name: C01
-    sensor: abi
     wavelength: [0.450, 0.470, 0.490]
     resolution: 1000
     calibration:
@@ -83,7 +82,6 @@ datasets:
 
   C02:
     name: C02
-    sensor: abi
     wavelength: [0.590, 0.640, 0.690]
     resolution: 500
     calibration:
@@ -97,7 +95,6 @@ datasets:
 
   C03:
     name: C03
-    sensor: abi
     wavelength: [0.8455, 0.865, 0.8845]
     resolution: 1000
     calibration:
@@ -111,7 +108,6 @@ datasets:
 
   C04:
     name: C04
-    sensor: abi
     wavelength: [1.3705, 1.378, 1.3855]
     resolution: 2000
     calibration:
@@ -125,7 +121,6 @@ datasets:
 
   C05:
     name: C05
-    sensor: abi
     wavelength: [1.580, 1.610, 1.640]
     resolution: 1000
     calibration:
@@ -139,7 +134,6 @@ datasets:
 
   C06:
     name: C06
-    sensor: abi
     wavelength: [2.225, 2.250, 2.275]
     resolution: 2000
     calibration:
@@ -153,7 +147,6 @@ datasets:
 
   C07:
     name: C07
-    sensor: abi
     wavelength: [3.80, 3.90, 4.00]
     resolution: 2000
     calibration:
@@ -167,7 +160,6 @@ datasets:
 
   C08:
     name: C08
-    sensor: abi
     wavelength: [5.770, 6.185, 6.600]
     resolution: 2000
     calibration:
@@ -181,7 +173,6 @@ datasets:
 
   C09:
     name: C09
-    sensor: abi
     wavelength: [6.75, 6.95, 7.15]
     resolution: 2000
     calibration:
@@ -195,7 +186,6 @@ datasets:
 
   C10:
     name: C10
-    sensor: abi
     wavelength: [7.24, 7.34, 7.44]
     resolution: 2000
     calibration:
@@ -209,7 +199,6 @@ datasets:
 
   C11:
     name: C11
-    sensor: abi
     wavelength: [8.30, 8.50, 8.70]
     resolution: 2000
     calibration:
@@ -223,7 +212,6 @@ datasets:
 
   C12:
     name: C12
-    sensor: abi
     wavelength: [9.42, 9.61, 9.80]
     resolution: 2000
     calibration:
@@ -237,7 +225,6 @@ datasets:
 
   C13:
     name: C13
-    sensor: abi
     wavelength: [10.10, 10.35, 10.60]
     resolution: 2000
     calibration:
@@ -251,7 +238,6 @@ datasets:
 
   C14:
     name: C14
-    sensor: abi
     wavelength: [10.80, 11.20, 11.60]
     resolution: 2000
     calibration:
@@ -265,7 +251,6 @@ datasets:
 
   C15:
     name: C15
-    sensor: abi
     wavelength: [11.80, 12.30, 12.80]
     resolution: 2000
     calibration:
@@ -279,7 +264,6 @@ datasets:
 
   C16:
     name: C16
-    sensor: abi
     wavelength: [13.00, 13.30, 13.60]
     resolution: 2000
     calibration:

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -131,6 +131,7 @@ class NC_ABI_L1B(BaseFileHandler):
         res.attrs.pop('_FillValue', None)
         res.attrs.pop('scale_factor', None)
         res.attrs.pop('add_offset', None)
+        res.attrs.pop('ancillary_variables', None)  # Can't currently load DQF
         # add in information from the filename that may be useful to the user
         for key in ('observation_type', 'scene_abbr', 'scan_mode', 'platform_shortname'):
             res.attrs[key] = self.filename_info[key]

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -892,7 +892,8 @@ class Scene(MetadataObject):
             missing = self.missing_datasets.copy()
             self._remove_failed_datasets(keepables)
             missing_str = ", ".join(str(x) for x in missing)
-            LOG.debug("The following datasets were not created: {}".format(missing_str))
+            LOG.warning("The following datasets were not created and may require "
+                        "resampling to be generated: {}".format(missing_str))
         if unload:
             self.unload(keepables=keepables)
 

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -694,26 +694,20 @@ class Scene(MetadataObject):
                 delayed_gen = True
                 continue
             elif not skip:
-                LOG.warning("Missing prerequisite for '{}': '{}'".format(
-                    comp_id, prereq_id))
+                LOG.debug("Missing prerequisite for '{}': '{}'".format(comp_id, prereq_id))
                 raise KeyError("Missing composite prerequisite")
             else:
-                LOG.debug("Missing optional prerequisite for {}: {}".format(
-                    comp_id, prereq_id))
+                LOG.debug("Missing optional prerequisite for {}: {}".format(comp_id, prereq_id))
 
         if delayed_gen:
             keepables.add(comp_id)
             keepables.update([x.name for x in prereq_nodes])
-            LOG.warning("Delaying generation of %s "
-                        "because of dependency's delayed generation: %s",
-                        comp_id, prereq_id)
+            LOG.debug("Delaying generation of %s because of dependency's delayed generation: %s", comp_id, prereq_id)
             if not skip:
-                LOG.warning("Missing prerequisite for '{}': '{}'".format(
-                    comp_id, prereq_id))
+                LOG.debug("Missing prerequisite for '{}': '{}'".format(comp_id, prereq_id))
                 raise KeyError("Missing composite prerequisite")
             else:
-                LOG.debug("Missing optional prerequisite for {}: {}".format(
-                    comp_id, prereq_id))
+                LOG.debug("Missing optional prerequisite for {}: {}".format(comp_id, prereq_id))
 
         return prereq_datasets
 
@@ -763,9 +757,7 @@ class Scene(MetadataObject):
                 self.wishlist.add(cid)
             comp_node.name = cid
         except IncompatibleAreas:
-            LOG.warning("Delaying generation of %s "
-                        "because of incompatible areas",
-                        str(compositor.id))
+            LOG.debug("Delaying generation of %s because of incompatible areas", str(compositor.id))
             preservable_datasets = set(self.datasets.keys())
             prereq_ids = set(p.name for p in prereqs)
             opt_prereq_ids = set(p.name for p in optional_prereqs)
@@ -900,8 +892,7 @@ class Scene(MetadataObject):
             missing = self.missing_datasets.copy()
             self._remove_failed_datasets(keepables)
             missing_str = ", ".join(str(x) for x in missing)
-            LOG.warning(
-                "The following datasets were not created: {}".format(missing_str))
+            LOG.debug("The following datasets were not created: {}".format(missing_str))
         if unload:
             self.unload(keepables=keepables)
 

--- a/satpy/tests/test_enhancements.py
+++ b/satpy/tests/test_enhancements.py
@@ -122,7 +122,7 @@ class TestEnhancementStretch(unittest.TestCase):
     def test_crefl_scaling(self):
         from satpy.enhancements import crefl_scaling
         expected = np.array([[
-            [np.nan, 0., np.nan, 0.44378, 0.631734],
+            [np.nan, 0., 0., 0.44378, 0.631734],
             [0.737562, 0.825041, 0.912521, 1., 1.]]])
         self._test_enhancement(crefl_scaling, self.ch2, expected, idx=[0., 25., 55., 100., 255.],
                                sc=[0., 90., 140., 175., 255.])

--- a/satpy/tests/test_enhancements.py
+++ b/satpy/tests/test_enhancements.py
@@ -30,8 +30,7 @@ import dask.array as da
 
 
 class TestEnhancementStretch(unittest.TestCase):
-
-    """Class for testing enhancements in satpy.enhancements"""
+    """Class for testing enhancements in satpy.enhancements."""
 
     def setUp(self):
         """Setup the test"""
@@ -123,7 +122,7 @@ class TestEnhancementStretch(unittest.TestCase):
     def test_crefl_scaling(self):
         from satpy.enhancements import crefl_scaling
         expected = np.array([[
-            [np.nan, 0., 0., 0.44378, 0.631734],
+            [np.nan, 0., np.nan, 0.44378, 0.631734],
             [0.737562, 0.825041, 0.912521, 1., 1.]]])
         self._test_enhancement(crefl_scaling, self.ch2, expected, idx=[0., 25., 55., 100., 255.],
                                sc=[0., 90., 140., 175., 255.])


### PR DESCRIPTION
There were a lot of warnings that always show up when doing certain types of processing. It was important when features were first developed, but as things have stabilized these types of messages are more for satpy developers rather than for users. If a user is curious why their product wasn't generated they will still enable debug logging to get the most information as possible.

Additionally there are a couple small changes in this PR:
 - Remove conda-forge workaround in travis for conda-forge/defaults incompatibility. Uses channel priority instead
 - Remove unnecessary 'abi' sensor in abi_l1b.yaml. The sensor is already added in the code.
 - Other small code style changes

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
