### PR TITLE
Allow use of non-dask pyresample get_proj_vectors method

### DIFF
--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -736,8 +736,11 @@ class FileYAMLReader(AbstractYAMLReader):
 
         if area is not None:
             ds.attrs['area'] = area
-            if (('x' not in ds.coords) or('y' not in ds.coords)) and \
-                    hasattr(area, 'get_proj_vectors_dask'):
+            calc_coords = (('x' not in ds.coords) or('y' not in ds.coords)) and hasattr(area, 'get_proj_vectors_dask')
+            if calc_coords and hasattr(area, 'get_proj_vectors'):
+                ds['x'], ds['y'] = area.get_proj_vectors()
+            elif calc_coords:
+                # older pyresample with dask-only method
                 ds['x'], ds['y'] = area.get_proj_vectors_dask(CHUNK_SIZE)
         return ds
 

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -778,8 +778,11 @@ class NativeResampler(BaseResampler):
         # Update coords if we can
         if ('y' in data.coords or 'x' in data.coords) and isinstance(target_geo_def, AreaDefinition):
             coord_chunks = (d_arr.chunks[y_axis], d_arr.chunks[x_axis])
-            x_coord, y_coord = target_geo_def.get_proj_vectors_dask(
-                chunks=coord_chunks)
+            if hasattr(target_geo_def, 'get_proj_vectors'):
+                x_coord, y_coord = target_geo_def.get_proj_vectors()
+            else:
+                # older version of pyresample
+                x_coord, y_coord = target_geo_def.get_proj_vectors_dask(chunks=coord_chunks)
             if 'y' in data.coords:
                 coords['y'] = y_coord
             if 'x' in data.coords:


### PR DESCRIPTION
XArray coordinates must be computed so creating a dask array that is
immediately computed seems unnecessary. It also produces multiple
progress bars if using dask's ProgressBar context manager which can be
confusing for some users.

Depends on https://github.com/pytroll/pyresample/pull/145 but should be backwards compatible.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
