### PR TITLE
Change default enhancement for reflectance data to square root (gamma 1.5)

### DIFF
--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -6,6 +6,15 @@ enhancements:
     - name: stretch
       method: &stretchfun !!python/name:satpy.enhancements.stretch ''
       kwargs: {stretch: linear}
+  reflectance_default:
+    standard_name: toa_bidirectional_reflectance
+    operations:
+    - name: linear_stretch
+      method: !!python/name:satpy.enhancements.stretch
+      kwargs: {stretch: 'crude', min_stretch: 0.0, max_stretch: 100.}
+    - name: gamma
+      method: !!python/name:satpy.enhancements.gamma
+      kwargs: {gamma: 2.0}
   true_color_default:
     standard_name: true_color
     operations:

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -4,7 +4,7 @@ enhancements:
   default:
     operations:
     - name: stretch
-      method: &stretchfun !!python/name:satpy.enhancements.stretch ''
+      method: &stretchfun !!python/name:satpy.enhancements.stretch
       kwargs: {stretch: linear}
   reflectance_default:
     standard_name: toa_bidirectional_reflectance
@@ -218,12 +218,6 @@ enhancements:
       kwargs:
         stretch: linear
         cutoffs: [0.005, 0.005]
-  reflectance:
-    standard_name: toa_bidirectional_reflectance
-    operations:
-    - name: stretch
-      method: *stretchfun
-      kwargs: {stretch: linear}
 
   sar-ice:
     standard_name: sar-ice

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -14,7 +14,7 @@ enhancements:
       kwargs: {stretch: 'crude', min_stretch: 0.0, max_stretch: 100.}
     - name: gamma
       method: !!python/name:satpy.enhancements.gamma
-      kwargs: {gamma: 2.0}
+      kwargs: {gamma: 1.5}
   true_color_default:
     standard_name: true_color
     operations:


### PR DESCRIPTION
Having the default enhancement require the min/max of the entire array
kills performance. IMO this is a suitable default. In the future I'd like to do the same for brightness temperature data or at least *most* BT data, but that one will be harder to agree on. I'm not sure where to document this other than release notes.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
