### PR TITLE
Make sure a discrete data type is preserved through resampling

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -851,6 +851,14 @@ def resample(source_area, data, destination_area,
     return res
 
 
+def get_fill_value(dataset):
+    """Get the fill value of the *dataset*, defaulting to np.nan."""
+    if np.issubdtype(dataset.dtype, np.integer):
+        return dataset.attrs.get('_FillValue', np.nan)
+    else:
+        return np.nan
+
+
 def resample_dataset(dataset, destination_area, **kwargs):
     """Resample the current projectable and return the resampled one.
 
@@ -874,7 +882,8 @@ def resample_dataset(dataset, destination_area, **kwargs):
 
         return dataset
 
-    new_data = resample(source_area, dataset, destination_area, **kwargs)
+    fill_value = kwargs.pop('fill_value', get_fill_value(dataset))
+    new_data = resample(source_area, dataset, destination_area, fill_value=fill_value, **kwargs)
     new_attrs = new_data.attrs
     new_data.attrs = dataset.attrs.copy()
     new_data.attrs.update(new_attrs)

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -855,8 +855,7 @@ def get_fill_value(dataset):
     """Get the fill value of the *dataset*, defaulting to np.nan."""
     if np.issubdtype(dataset.dtype, np.integer):
         return dataset.attrs.get('_FillValue', np.nan)
-    else:
-        return np.nan
+    return np.nan
 
 
 def resample_dataset(dataset, destination_area, **kwargs):

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -860,7 +860,7 @@ def get_fill_value(dataset):
 
 
 def resample_dataset(dataset, destination_area, **kwargs):
-    """Resample the current projectable and return the resampled one.
+    """Resample *dataset* and return the resampled version.
 
     Args:
         dataset (xarray.DataArray): Data to be resampled.
@@ -870,7 +870,8 @@ def resample_dataset(dataset, destination_area, **kwargs):
         **kwargs: The extra parameters to pass to the resampler objects.
 
     Returns:
-        A resampled DataArray with updated ``.attrs["area"]`` field.
+        A resampled DataArray with updated ``.attrs["area"]`` field. The dtype
+        of the array is preserved.
 
     """
     # call the projection stuff here

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -34,8 +34,10 @@ except ImportError:
 
 
 class TestHLResample(unittest.TestCase):
+    """Test the higher level resampling functions."""
 
     def test_type_preserve(self):
+        """Check that the type of resampled datasets is preserved."""
         from satpy.resample import resample_dataset
         import xarray as xr
         import dask.array as da

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ import versioneer
 
 from setuptools import find_packages, setup
 
-requires = ['numpy >=1.12', 'pillow', 'pyresample >=1.10.0', 'trollsift',
+requires = ['numpy >=1.12', 'pillow', 'pyresample >=1.10.3', 'trollsift',
             'trollimage >=1.5.1', 'pykdtree', 'six', 'pyyaml', 'xarray >=0.10.1',
             'dask[array] >=0.17.1']
 


### PR DESCRIPTION
This PR lets satpy resample discrete dataset without converting to float. Additionally, if a `_FillValue` attribute is available, that value is passed to pyresample for filling missing data pixels (typically outside of swath).

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
