### PR TITLE
Fix all flake8 errors in satpy package code

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,3 +1,4 @@
 linters:
   flake8:
-    max-line-length: 120
+    python: 3
+    config: setup.cfg

--- a/satpy/composites/abi.py
+++ b/satpy/composites/abi.py
@@ -23,7 +23,7 @@
 """
 
 import logging
-from satpy.composites import GenericCompositor, IncompatibleAreas
+from satpy.composites import GenericCompositor
 
 LOG = logging.getLogger(__name__)
 

--- a/satpy/composites/crefl_utils.py
+++ b/satpy/composites/crefl_utils.py
@@ -26,12 +26,8 @@ Original code written by Ralph Kuehn with modifications by David Hoese and Marti
 Ralph's code was originally based on the C crefl code distributed for VIIRS and MODIS.
 """
 import logging
-import os
-import sys
 
 import numpy as np
-# from memory_profiler import profile
-import xarray.ufuncs as xu
 import xarray as xr
 import dask.array as da
 
@@ -62,8 +58,8 @@ def csalbr(tau):
     # Previously 3 functions csalbr fintexp1, fintexp3
     a = [-.57721566, 0.99999193, -0.24991055, 0.05519968, -0.00976004,
          0.00107857]
-    #xx = a[0] + a[1] * tau + a[2] * tau**2 + a[3] * tau**3 + a[4] * tau**4 + a[5] * tau**5
-    #xx = np.polyval(a[::-1], tau)
+    # xx = a[0] + a[1] * tau + a[2] * tau**2 + a[3] * tau**3 + a[4] * tau**4 + a[5] * tau**5
+    # xx = np.polyval(a[::-1], tau)
 
     # xx = a[0]
     # xftau = 1.0
@@ -75,6 +71,7 @@ def csalbr(tau):
 
     return (3.0 * tau - fintexp3 *
             (4.0 + 2.0 * tau) + 2.0 * np.exp(-tau)) / (4.0 + 3.0 * tau)
+
 
 # From crefl.1.7.1
 if bUseV171:
@@ -414,7 +411,7 @@ def run_crefl(refl, coeffs,
     # Get digital elevation map data for our granule, set ocean fill value to 0
     if avg_elevation is None:
         LOG.debug("No average elevation information provided in CREFL")
-        #height = np.zeros(lon.shape, dtype=np.float)
+        # height = np.zeros(lon.shape, dtype=np.float)
         height = 0.
     else:
         LOG.debug("Using average elevation information provided to CREFL")

--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -608,16 +608,22 @@ def local_histogram_equalization(data, mask_to_equalize, valid_data_mask=None, n
                                  log_offset=0.00001,
                                  out=None
                                  ):
-    """
-    equalize the provided data (in the mask_to_equalize) using adaptive histogram equalization
-    tiles of width/height (2 * local_radius_px + 1) will be calculated and results for each pixel will be bilinerarly interpolated from the nearest 4 tiles
-    when pixels fall near the edge of the image (there is no adjacent tile) the resultant interpolated sum from the available tiles will be multipled to
-    account for the weight of any missing tiles (pixel total interpolated value = pixel available interpolated value / (1 - missing interpolation weight))
+    """Equalize the provided data (in the mask_to_equalize) using adaptive histogram equalization.
 
-    if do_zerotoone_normalization is True the data will be scaled so that all data in the mask_to_equalize falls between 0 and 1; otherwise the data
-    in mask_to_equalize will all fall between 0 and number_of_bins
+    tiles of width/height (2 * local_radius_px + 1) will be calculated and results for each pixel will be bilinerarly
+    interpolated from the nearest 4 tiles when pixels fall near the edge of the image (there is no adjacent tile) the
+    resultant interpolated sum from the available tiles will be multipled to account for the weight of any missing
+    tiles::
 
-    returns the equalized data
+        pixel total interpolated value = pixel available interpolated value / (1 - missing interpolation weight)
+
+    if ``do_zerotoone_normalization`` is True the data will be scaled so that all data in the mask_to_equalize falls
+    between 0 and 1; otherwise the data in mask_to_equalize will all fall between 0 and number_of_bins
+
+    Returns:
+
+        The equalized data
+
     """
 
     out = out if out is not None else np.zeros_like(data)
@@ -804,12 +810,10 @@ def local_histogram_equalization(data, mask_to_equalize, valid_data_mask=None, n
                 # it in our data array
                 out[min_row:max_row, min_col:max_col][
                     temp_mask_to_equalize] = temp_sum
-                """
                 # TEMP, test without using weights
-                data[min_row:max_row, min_col:max_col][temp_mask_to_equalize] = np.interp(temp_data_to_equalize,
-                                                                                             all_bin_information          [num_row_tile  ][num_col_tile][:-1],
-                                                                                             all_cumulative_dist_functions[num_row_tile  ][num_col_tile])
-                """
+                # data[min_row:max_row, min_col:max_col][temp_mask_to_equalize] = \
+                #     np.interp(temp_data_to_equalize, all_bin_information[num_row_tile][num_col_tile][:-1],
+                #               all_cumulative_dist_functions[num_row_tile][num_col_tile])
 
     # if we were asked to, normalize our data to be between zero and one,
     # rather than zero and number_of_bins
@@ -819,14 +823,12 @@ def local_histogram_equalization(data, mask_to_equalize, valid_data_mask=None, n
     return out
 
 
-def _histogram_equalization_helper(valid_data,
-                                   number_of_bins,
-                                   clip_limit=None,
-                                   slope_limit=None):
-    """
-    calculate the simplest possible histogram equalization, using only valid data
+def _histogram_equalization_helper(valid_data, number_of_bins, clip_limit=None, slope_limit=None):
+    """Calculate the simplest possible histogram equalization, using only valid data.
 
-    returns the cumulative distribution function and bin information
+    Returns:
+        cumulative distribution function and bin information
+
     """
 
     # bucket all the selected data using np's histogram function
@@ -834,15 +836,13 @@ def _histogram_equalization_helper(valid_data,
 
     # if we have a clip limit and we should do our clipping before building
     # the cumulative distribution function, clip off our histogram
-    if (clip_limit is not None):
-
+    if clip_limit is not None:
         # clip our histogram and remember how much we removed
         pixels_to_clip_at = int(clip_limit *
                                 (valid_data.size / float(number_of_bins)))
         mask_to_clip = temp_histogram > clip_limit
-        num_bins_clipped = sum(mask_to_clip)
-        num_pixels_clipped = sum(temp_histogram[mask_to_clip]) - (
-            num_bins_clipped * pixels_to_clip_at)
+        # num_bins_clipped = sum(mask_to_clip)
+        # num_pixels_clipped = sum(temp_histogram[mask_to_clip]) - (num_bins_clipped * pixels_to_clip_at)
         temp_histogram[mask_to_clip] = pixels_to_clip_at
 
     # calculate the cumulative distribution function
@@ -850,8 +850,7 @@ def _histogram_equalization_helper(valid_data,
 
     # if we have a clip limit and we should do our clipping after building the
     # cumulative distribution function, clip off our cdf
-    if (slope_limit is not None):
-
+    if slope_limit is not None:
         # clip our cdf and remember how much we removed
         pixel_height_limit = int(slope_limit *
                                  (valid_data.size / float(number_of_bins)))
@@ -874,12 +873,9 @@ def _histogram_equalization_helper(valid_data,
             num_clipped_pixels = num_clipped_pixels + cumulative_excess_height
 
     # now normalize the overall distribution function
-    cumulative_dist_function = (
-        number_of_bins -
-        1) * cumulative_dist_function / cumulative_dist_function[-1]
+    cumulative_dist_function = (number_of_bins - 1) * cumulative_dist_function / cumulative_dist_function[-1]
 
-    # return what someone else will need in order to apply the equalization
-    # later
+    # return what someone else will need in order to apply the equalization later
     return cumulative_dist_function, temp_bins
 
 
@@ -1127,7 +1123,7 @@ class SnowAge(GenericCompositor):
         Bernard Bellec at Bernard.Bellec@meteo.fr
         or
         Pascale Roquet at Pascale.Roquet@meteo.fr
-        
+
         """
         if len(projectables) != 5:
             raise ValueError("Expected 5 datasets, got %d" %

--- a/satpy/etc/readers/geocat.yaml
+++ b/satpy/etc/readers/geocat.yaml
@@ -1,7 +1,7 @@
 reader:
   description: CSPP Geo and GEOCAT file reader
   name: geocat
-  reader: !!python/name:satpy.readers.geocat.FileYAMLReader
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
   sensors: [abi, ahi, goes_imager]
 
 file_types:

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -24,7 +24,6 @@ The files read by this reader are described in the official PUG document:
 """
 
 import logging
-import os
 from datetime import datetime
 
 import numpy as np

--- a/satpy/readers/acspo.py
+++ b/satpy/readers/acspo.py
@@ -63,14 +63,14 @@ class ACSPOFileHandler(NetCDF4FileHandler):
 
     def get_shape(self, ds_id, ds_info):
         """Get numpy array shape for the specified dataset.
-        
+
         Args:
             ds_id (DatasetID): ID of dataset that will be loaded
             ds_info (dict): Dictionary of dataset information from config file
-            
+
         Returns:
             tuple: (rows, cols)
-            
+
         """
         var_path = ds_info.get('file_key', '{}'.format(ds_id.name))
         if var_path + '/shape' not in self:

--- a/satpy/readers/amsr2_l1b.py
+++ b/satpy/readers/amsr2_l1b.py
@@ -23,17 +23,16 @@ class AMSR2L1BFileHandler(HDF5FileHandler):
         return info
 
     def get_shape(self, ds_id, ds_info):
-        """Get output shape of specified dataset"""
+        """Get output shape of specified dataset."""
         var_path = ds_info['file_key']
         shape = self[var_path + '/shape']
-        if ((ds_info.get('standard_name') == "longitude" or
-                     ds_info.get('standard_name') == "latitude") and
-                    ds_id.resolution == 10000):
+        if ((ds_info.get('standard_name') == "longitude" or ds_info.get('standard_name') == "latitude") and
+                ds_id.resolution == 10000):
             return shape[0], int(shape[1] / 2)
         return shape
 
     def get_dataset(self, ds_id, ds_info):
-        """Get output data and metadata of specified dataset"""
+        """Get output data and metadata of specified dataset."""
         var_path = ds_info['file_key']
         fill_value = ds_info.get('fill_value', 65535)
         metadata = self.get_metadata(ds_id, ds_info)
@@ -49,4 +48,3 @@ class AMSR2L1BFileHandler(HDF5FileHandler):
         data = data.where(data != fill_value)
         data.attrs.update(metadata)
         return data
-

--- a/satpy/readers/fci_fdhsi.py
+++ b/satpy/readers/fci_fdhsi.py
@@ -60,8 +60,7 @@ class FCIFDHSIFileHandler(BaseFileHandler):
         return self.filename_info['end_time']
 
     def get_dataset(self, key, info=None):
-        """Load a dataset
-        """
+        """Load a dataset."""
         if key in self.cache:
             return self.cache[key]
 
@@ -80,7 +79,7 @@ class FCIFDHSIFileHandler(BaseFileHandler):
         # Apply scale factor and offset
         radiances = radiances * (radiances.attrs['scale_factor'] * 1.0) + radiances.attrs['offset']
 
-        #TODO Calibration is disabled, waiting for calibration parameters from EUMETSAT
+        # TODO: Calibration is disabled, waiting for calibration parameters from EUMETSAT
         res = self.calibrate(radiances, key)
 
         self.cache[key] = res
@@ -89,8 +88,7 @@ class FCIFDHSIFileHandler(BaseFileHandler):
         return res
 
     def calc_area_extent(self, key):
-        """Calculate area extent for a dataset.
-        """
+        """Calculate area extent for a dataset."""
         # Calculate the area extent of the swath based on start line and column
         # information, total number of segments and channel resolution
         xyres = {500: 22272, 1000: 11136, 2000: 5568}
@@ -109,11 +107,9 @@ class FCIFDHSIFileHandler(BaseFileHandler):
 
         logger.debug('Channel {} resolution: {}'.format(key.name, chkres))
         logger.debug('Row/Cols: {} / {}'.format(self.nlines, self.ncols))
-        logger.debug('Start/End row: {} / {}'.format(self.startline,
-                                                     self.endline))
-        logger.debug('Start/End col: {} / {}'.format(self.startcol,
-                                                     self.endcol))
-        total_segments = 70
+        logger.debug('Start/End row: {} / {}'.format(self.startline, self.endline))
+        logger.debug('Start/End col: {} / {}'.format(self.startcol, self.endcol))
+        # total_segments = 70
 
         # Calculate full globe line extent
         max_y = 5432229.9317116784
@@ -130,38 +126,36 @@ class FCIFDHSIFileHandler(BaseFileHandler):
         return(chk_extent)
 
     def get_area_def(self, key, info=None):
-        """Calculate on-fly area definition for 0 degree geos-projection
-        for a dataset
-        """
+        """Calculate on-fly area definition for 0 degree geos-projection for a dataset."""
         # TODO Projection information are hard coded for 0 degree geos projection
         # Test dataset doen't provide the values in the file container.
         # Only fill values are inserted
-        #cfac = np.uint32(self.proj_info['CFAC'])
-        #lfac = np.uint32(self.proj_info['LFAC'])
-        #coff = np.float32(self.proj_info['COFF'])
-        #loff = np.float32(self.proj_info['LOFF'])
-        #a = self.nc['/state/processor/earth_equatorial_radius']
+        # cfac = np.uint32(self.proj_info['CFAC'])
+        # lfac = np.uint32(self.proj_info['LFAC'])
+        # coff = np.float32(self.proj_info['COFF'])
+        # loff = np.float32(self.proj_info['LOFF'])
+        # a = self.nc['/state/processor/earth_equatorial_radius']
         a = 6378169.
-        #h = self.nc['/state/processor/reference_altitude'] * 1000 - a
+        # h = self.nc['/state/processor/reference_altitude'] * 1000 - a
         h = 35785831.
-        #b = self.nc['/state/processor/earth_polar_radius']
+        # b = self.nc['/state/processor/earth_polar_radius']
         b = 6356583.8
-        #lon_0 = self.nc['/state/processor/projection_origin_longitude']
+        # lon_0 = self.nc['/state/processor/projection_origin_longitude']
         lon_0 = 0.
-        #nlines = self.nc['/state/processor/reference_grid_number_of_columns']
-        #ncols = self.nc['/state/processor/reference_grid_number_of_rows']
-        #nlines = 5568
-        #ncols = 5568
+        # nlines = self.nc['/state/processor/reference_grid_number_of_columns']
+        # ncols = self.nc['/state/processor/reference_grid_number_of_rows']
+        # nlines = 5568
+        # ncols = 5568
         # Channel dependent swath resoultion
         area_extent = self.calc_area_extent(key)
         logger.debug('Calculated area extent: {}'
                      .format(''.join(str(area_extent))))
 
-        #c, l = 0, (1 + self.total_segments - self.segment_number) * nlines
-        #ll_x, ll_y = (c - coff) / cfac * 2**16, (l - loff) / lfac * 2**16
-        # c, l = ncols, (1 + self.total_segments -
-        #                self.segment_number) * nlines - nlines
-        #ur_x, ur_y = (c - coff) / cfac * 2**16, (l - loff) / lfac * 2**16
+        # c, l = 0, (1 + self.total_segments - self.segment_number) * nlines
+        # ll_x, ll_y = (c - coff) / cfac * 2**16, (l - loff) / lfac * 2**16
+        #  c, l = ncols, (1 + self.total_segments -
+        #                 self.segment_number) * nlines - nlines
+        # ur_x, ur_y = (c - coff) / cfac * 2**16, (l - loff) / lfac * 2**16
 
         # area_extent = (np.deg2rad(ll_x) * h, np.deg2rad(ur_y) * h,
         #               np.deg2rad(ur_x) * h, np.deg2rad(ll_y) * h)
@@ -185,29 +179,26 @@ class FCIFDHSIFileHandler(BaseFileHandler):
             area_extent)
 
         self.area = area
-
         return area
 
     def calibrate(self, data, key):
-        """Data calibration.
-        """
+        """Data calibration."""
 
-#        logger.debug('Calibration: %s' % key.calibration)
+        # logger.debug('Calibration: %s' % key.calibration)
         logger.warning('Calibration disabled!')
         if key.calibration == 'brightness_temperature':
+            # self._ir_calibrate(data, key)
             pass
-#            self._ir_calibrate(data, key)
         elif key.calibration == 'reflectance':
+            # self._vis_calibrate(data, key)
             pass
-#            self._vis_calibrate(data, key)
         else:
             pass
 
-        return(data)
+        return data
 
     def _ir_calibrate(self, data, key):
-        """IR channel calibration
-        """
+        """IR channel calibration."""
         # Not sure if Lv is correct, FCI User Guide is a bit unclear
 
         Lv = data.data * \
@@ -230,8 +221,7 @@ class FCIFDHSIFileHandler(BaseFileHandler):
         data.data[:] = nom / denom - b / a
 
     def _vis_calibrate(self, data, key):
-        """VIS channel calibration
-        """
+        """VIS channel calibration."""
         # radiance to reflectance taken as in mipp/xrit/MSG.py
         # again FCI User Guide is not clear on how to do this
 

--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -29,9 +29,6 @@ from pyresample.geometry import SwathDefinition
 from satpy.dataset import combine_metadata
 
 
-# what about file pattern and config ?
-
-
 class BaseFileHandler(six.with_metaclass(ABCMeta, object)):
 
     def __init__(self, filename, filename_info, filetype_info):
@@ -47,8 +44,7 @@ class BaseFileHandler(six.with_metaclass(ABCMeta, object)):
     def __repr__(self):
         return str(self)
 
-    def get_dataset(self, dataset_id, ds_info, out=None,
-                    xslice=slice(None), yslice=slice(None)):
+    def get_dataset(self, dataset_id, ds_info):
         raise NotImplementedError
 
     def get_area_def(self, dsid):

--- a/satpy/readers/gac_lac_l1.py
+++ b/satpy/readers/gac_lac_l1.py
@@ -19,20 +19,16 @@
 
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""
-Reading and calibrating GAC and LAC avhrr data.
-Todo:
-- Fine grained calibration
+"""Reading and calibrating GAC and LAC avhrr data.
+
+.. todo::
+
+    Fine grained calibration
 
 """
 
 import logging
 from datetime import datetime, timedelta
-
-import numpy as np
-from pyresample.geometry import SwathDefinition
-
-from pygac.gac_calibration import calibrate_solar, calibrate_thermal
 from pygac.gac_klm import GACKLMReader
 from pygac.gac_pod import GACPODReader
 import xarray as xr
@@ -49,8 +45,7 @@ AVHRR_CHANNEL_NAMES = {"1": 0, "2": 1, "3": 2, "4": 3, "5": 4}
 
 
 class GACLACFile(BaseFileHandler):
-    """Reader for GAC and LAC data.
-    """
+    """Reader for GAC and LAC data."""
 
     def __init__(self, filename, filename_info, filetype_info):
         super(GACLACFile, self).__init__(
@@ -65,11 +60,8 @@ class GACLACFile(BaseFileHandler):
         if self._end_time < self._start_time:
             self._end_time += timedelta(days=1)
 
-
     def get_dataset(self, key, info):
-
         if self.reader is None:
-
             with open(self.filename) as fdes:
                 data = fdes.read(3)
             if data in ["CMS", "NSS", "UKM", "DSS"]:
@@ -84,7 +76,7 @@ class GACLACFile(BaseFileHandler):
 
         if key.name in ['latitude', 'longitude']:
             if self.reader.lons is None or self.reader.lats is None:
-                #self.reader.get_lonlat(clock_drift_adjust=False)
+                # self.reader.get_lonlat(clock_drift_adjust=False)
                 self.reader.get_lonlat()
             if key.name == 'latitude':
                 return xr.DataArray(da.from_array(self.reader.lats, chunks=1000),

--- a/satpy/readers/geocat.py
+++ b/satpy/readers/geocat.py
@@ -40,7 +40,6 @@ from pyresample import geometry
 from pyresample.utils import proj4_str_to_dict
 
 from satpy.dataset import DatasetID
-from satpy.readers.yaml_reader import FileYAMLReader
 from satpy.readers.netcdf_utils import NetCDF4FileHandler, netCDF4
 
 LOG = logging.getLogger(__name__)

--- a/satpy/readers/ghrsst_osisaf.py
+++ b/satpy/readers/ghrsst_osisaf.py
@@ -38,9 +38,7 @@ SENSOR_NAME = {'VIIRS': 'viirs',
 
 
 class GHRSST_OSISAFL2(NetCDF4FileHandler):
-
-    """Reader for the OSISAF SST GHRSST format
-    """
+    """Reader for the OSISAF SST GHRSST format."""
 
     def _parse_datetime(self, datestr):
         return datetime.strptime(datestr, '%Y%m%dT%H%M%SZ')
@@ -50,9 +48,7 @@ class GHRSST_OSISAFL2(NetCDF4FileHandler):
         raise NotImplementedError
 
     def get_dataset(self, dataset_id, ds_info, out=None):
-        """Load a dataset
-        """
-
+        """Load a dataset."""
         var_path = ds_info.get('file_key', '{}'.format(dataset_id.name))
         dtype = ds_info.get('dtype', np.float32)
         if var_path + '/shape' not in self:
@@ -79,9 +75,7 @@ class GHRSST_OSISAFL2(NetCDF4FileHandler):
             out = np.ma.empty(shape, dtype=dtype)
             out.mask = np.zeros(shape, dtype=np.bool)
 
-        #out.data[:] = np.require(self[var_path][:][0][::-1], dtype=dtype)
         out.data[:] = np.require(self[var_path][0][::-1], dtype=dtype)
-
         valid_min = self[var_path + '/attr/valid_min']
         valid_max = self[var_path + '/attr/valid_max']
         try:
@@ -100,10 +94,8 @@ class GHRSST_OSISAFL2(NetCDF4FileHandler):
 
         ds_info.update({
             "units": ds_info.get("units", file_units),
-            "platform_name": PLATFORM_NAME.get(self['/attr/platform'],
-                                          self['/attr/platform']),
-            "sensor": SENSOR_NAME.get(self['/attr/sensor'],
-                                      self['/attr/sensor']),
+            "platform_name": PLATFORM_NAME.get(self['/attr/platform'], self['/attr/platform']),
+            "sensor": SENSOR_NAME.get(self['/attr/sensor'], self['/attr/sensor']),
         })
         ds_info.update(dataset_id.to_dict())
         cls = ds_info.pop("container", Dataset)

--- a/satpy/readers/li_l2.py
+++ b/satpy/readers/li_l2.py
@@ -36,6 +36,7 @@ from datetime import datetime
 from pyresample import geometry
 from satpy.readers.file_handlers import BaseFileHandler
 # FIXME: This is not xarray/dask compatible
+# TODO: Once migrated to xarray/dask, remove ignored path in setup.cfg
 from satpy.dataset import Dataset
 
 logger = logging.getLogger(__name__)

--- a/satpy/readers/li_l2.py
+++ b/satpy/readers/li_l2.py
@@ -34,20 +34,18 @@ import logging
 import numpy as np
 from datetime import datetime
 from pyresample import geometry
-from satpy.dataset import Dataset
 from satpy.readers.file_handlers import BaseFileHandler
+# FIXME: This is not xarray/dask compatible
+from satpy.dataset import Dataset
 
 logger = logging.getLogger(__name__)
 
 
 class LIFileHandler(BaseFileHandler):
-    """MTG LI File Reader
-    """
+    """MTG LI File Reader."""
 
     def __init__(self, filename, filename_info, filetype_info):
-        super(LIFileHandler, self).__init__(filename, filename_info,
-                                            filetype_info)
-
+        super(LIFileHandler, self).__init__(filename, filename_info, filetype_info)
         self.nc = h5netcdf.File(self.filename, 'r')
         # Get grid dimensions from file
         refdim = self.nc['grid_position'][:]
@@ -123,17 +121,20 @@ class LIFileHandler(BaseFileHandler):
         return(out)
 
     def get_area_def(self, key, info=None):
-        """ Projection information are hard coded for 0 degree geos projection
-        Test dataset doen't provide the values in the file container.
-        Only fill values are inserted
+        """Create AreaDefinition for specified product.
+
+        Projection information are hard coded for 0 degree geos projection
+        Test dataset doesn't provide the values in the file container.
+        Only fill values are inserted.
+
         """
         # TODO Get projection information from input file
         a = 6378169.
         h = 35785831.
         b = 6356583.8
         lon_0 = 0.
-        #area_extent = (-5432229.9317116784, -5429229.5285458621,
-        #               5429229.5285458621, 5432229.9317116784)
+        # area_extent = (-5432229.9317116784, -5429229.5285458621,
+        #                5429229.5285458621, 5432229.9317116784)
         area_extent = (-5570248.4773392612, -5567248.074173444,
                        5567248.074173444, 5570248.4773392612)
         proj_dict = {'a': float(a),
@@ -154,6 +155,3 @@ class LIFileHandler(BaseFileHandler):
         self.area = area
         logger.debug("Dataset area definition: \n {}".format(area))
         return area
-
-    def get_shape(self, dsid, ds_info):
-        return int(self.nlines), int(self.ncols)

--- a/satpy/readers/nc_goes.py
+++ b/satpy/readers/nc_goes.py
@@ -527,7 +527,7 @@ class GOESNCFileHandler(BaseFileHandler):
     @staticmethod
     def _get_platform_name(ncattr):
         """Determine name of the platform"""
-        match = re.match('G-(\d+)', ncattr)
+        match = re.match(r'G-(\d+)', ncattr)
         if match:
             return SPACECRAFTS.get(int(match.groups()[0]))
 
@@ -1071,7 +1071,7 @@ class GOESCoefficientReader(object):
         Take care of numbers in exponential format
         """
         string = self._denoise(string)
-        exp_match = re.match('^[-.\d]+x10-(\d)$', string)
+        exp_match = re.match(r'^[-.\d]+x10-(\d)$', string)
         if exp_match:
             exp = int(exp_match.groups()[0])
             fac = 10 ** -exp

--- a/satpy/readers/nc_olci.py
+++ b/satpy/readers/nc_olci.py
@@ -33,6 +33,7 @@ import xarray as xr
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.utils import angle2xyz, xyz2angle
 from satpy import CHUNK_SIZE
+from functools import reduce
 
 logger = logging.getLogger(__name__)
 

--- a/satpy/readers/scatsat1_l2b.py
+++ b/satpy/readers/scatsat1_l2b.py
@@ -17,10 +17,10 @@
 
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-""" ScatSat-1 L2B Reader, distributed by Eumetsat in HDF5 format
+"""ScatSat-1 L2B Reader, distributed by Eumetsat in HDF5 format
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime
 import h5py
 
 from satpy.dataset import Dataset
@@ -30,13 +30,12 @@ from satpy.readers.file_handlers import BaseFileHandler
 class SCATSAT1L2BFileHandler(BaseFileHandler):
 
     def __init__(self, filename, filename_info, filetype_info):
-        super(SCATSAT1L2BFileHandler, self).__init__(filename, filename_info,
-                                                      filetype_info)
+        super(SCATSAT1L2BFileHandler, self).__init__(filename, filename_info, filetype_info)
         self.h5f = h5py.File(self.filename, "r")
-        h5data=self.h5f['science_data']
+        h5data = self.h5f['science_data']
 
-        self.filename_info['start_time'] = datetime.strptime(h5data.attrs['Range Beginning Date'],'%Y-%jT%H:%M:%S.%f')
-        self.filename_info['end_time'] = datetime.strptime(h5data.attrs['Range Ending Date'],'%Y-%jT%H:%M:%S.%f')
+        self.filename_info['start_time'] = datetime.strptime(h5data.attrs['Range Beginning Date'], '%Y-%jT%H:%M:%S.%f')
+        self.filename_info['end_time'] = datetime.strptime(h5data.attrs['Range Ending Date'], '%Y-%jT%H:%M:%S.%f')
 
         self.lons = None
         self.lats = None
@@ -62,14 +61,9 @@ class SCATSAT1L2BFileHandler(BaseFileHandler):
                 return Dataset(self.lats, id=key, **info)
 
         if stdname in ['wind_speed']:
-            windspeed=h5data['Wind_speed_selection'][:,:]*self.wind_speed_scale
+            windspeed = h5data['Wind_speed_selection'][:, :] * self.wind_speed_scale
             return Dataset(windspeed, id=key, **info)
 
         if stdname in ['wind_direction']:
-            wind_direction = h5data['Wind_direction_selection'][:,:]*self.wind_direction_scale
+            wind_direction = h5data['Wind_direction_selection'][:, :] * self.wind_direction_scale
             return Dataset(wind_direction, id=key, **info)
-
-
-
-
-

--- a/satpy/tests/features/steps/steps-load.py
+++ b/satpy/tests/features/steps/steps-load.py
@@ -35,23 +35,23 @@ use_step_matcher("re")
 
 
 @given(u'data is available')
-def step_impl(context):
+def step_impl_data_available(context):
     if not os.path.exists('/tmp/SVM02_npp_d20150311_t1122204_e1123446_b17451_c20150311113206961730_cspp_dev.h5'):
-        response = urlopen(
-            'https://zenodo.org/record/16355/files/SVM02_npp_d20150311_t1122204_e1123446_b17451_c20150311113206961730_cspp_dev.h5')
+        response = urlopen('https://zenodo.org/record/16355/files/'
+                           'SVM02_npp_d20150311_t1122204_e1123446_b17451_c20150311113206961730_cspp_dev.h5')
         with open('/tmp/SVM02_npp_d20150311_t1122204_e1123446_b17451_c20150311113206961730_cspp_dev.h5',
                   mode="w") as fp:
             fp.write(response.read())
     if not os.path.exists('/tmp/GMTCO_npp_d20150311_t1122204_e1123446_b17451_c20150311113205873710_cspp_dev.h5'):
-        response = urlopen(
-            'https://zenodo.org/record/16355/files/GMTCO_npp_d20150311_t1122204_e1123446_b17451_c20150311113205873710_cspp_dev.h5')
+        response = urlopen('https://zenodo.org/record/16355/files/'
+                           'GMTCO_npp_d20150311_t1122204_e1123446_b17451_c20150311113205873710_cspp_dev.h5')
         with open('/tmp/GMTCO_npp_d20150311_t1122204_e1123446_b17451_c20150311113205873710_cspp_dev.h5',
                   mode="w") as fp:
             fp.write(response.read())
 
 
 @when(u'user loads the data without providing a config file')
-def step_impl(context):
+def step_impl_user_loads_no_config(context):
     from satpy import Scene, find_files_and_readers
     from datetime import datetime
     os.chdir("/tmp/")
@@ -64,22 +64,22 @@ def step_impl(context):
 
 
 @then(u'the data is available in a scene object')
-def step_impl(context):
+def step_impl_data_available_in_scene(context):
     assert (context.scene["M02"] is not None)
     try:
         context.scene["M01"] is None
-        assert (False)
+        assert False
     except KeyError:
-        assert (True)
+        assert True
 
 
 @when(u'some items are not available')
-def step_impl(context):
+def step_impl_items_not_available(context):
     context.scene.load(["M01"])
 
 
 @when(u'user wants to know what data is available')
-def step_impl(context):
+def step_impl_user_checks_availability(context):
     from satpy import Scene, find_files_and_readers
     from datetime import datetime
     os.chdir("/tmp/")
@@ -90,14 +90,14 @@ def step_impl(context):
     context.available_dataset_ids = scn.available_dataset_ids()
 
 
-@then(u'available datasets is returned')
-def step_impl(context):
+@then(u'available datasets are returned')
+def step_impl_available_datasets_are_returned(context):
     assert (len(context.available_dataset_ids) >= 5)
 
 
 @given("datasets with the same name")
-def step_impl(context):
-    """Datasets with the same name but different other ID parameters"""
+def step_impl_datasets_with_same_name(context):
+    """Datasets with the same name but different other ID parameters."""
     from satpy import Scene
     from xarray import DataArray
     from satpy.dataset import DatasetID
@@ -107,17 +107,18 @@ def step_impl(context):
     scn[DatasetID('ds1', resolution=250, calibration='reflectance')] = DataArray([[5, 6], [7, 8]])
     scn[DatasetID('ds1', resolution=1000, calibration='reflectance')] = DataArray([[5, 6], [7, 8]])
     scn[DatasetID('ds1', resolution=500, calibration='radiance', modifiers=('mod1',))] = DataArray([[5, 6], [7, 8]])
-    scn[DatasetID('ds1', resolution=1000, calibration='radiance', modifiers=('mod1', 'mod2'))] = DataArray([[5, 6], [7, 8]])
+    ds_id = DatasetID('ds1', resolution=1000, calibration='radiance', modifiers=('mod1', 'mod2'))
+    scn[ds_id] = DataArray([[5, 6], [7, 8]])
     context.scene = scn
 
 
 @when("a dataset is retrieved by name")
-def step_impl(context):
-    """Use the Scene's getitem method to get a dataset"""
+def step_impl_dataset_retrieved_by_name(context):
+    """Use the Scene's getitem method to get a dataset."""
     context.returned_dataset = context.scene['ds1']
 
 
 @then("the least modified version of the dataset is returned")
-def step_impl(context):
-    """The dataset should be one of the least modified datasets"""
+def step_impl_least_modified_dataset_returned(context):
+    """The dataset should be one of the least modified datasets."""
     assert(len(context.returned_dataset.attrs['modifiers']) == 0)

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -95,10 +95,8 @@ class Test_NC_ABI_L1B_ir_cal(unittest.TestCase):
         res = self.reader.get_dataset(
             DatasetID(name='C05', calibration='brightness_temperature'), {})
 
-        expected = np.array([[267.55572248, 305.15576503, 332.37383249,
-                                 354.73895301, 374.19710115],
-                                [391.68679226, 407.74064808, 422.69329105,
-                                 436.77021913, np.nan]])
+        expected = np.array([[267.55572248, 305.15576503, 332.37383249, 354.73895301, 374.19710115],
+                             [391.68679226, 407.74064808, 422.69329105, 436.77021913, np.nan]])
         self.assertTrue(np.allclose(res.data, expected, equal_nan=True))
         # make sure the attributes from the file are in the data array
         self.assertNotIn('scale_factor', res.attrs)
@@ -181,10 +179,8 @@ class Test_NC_ABI_L1B_vis_cal(unittest.TestCase):
         res = self.reader.get_dataset(
             DatasetID(name='C05', calibration='reflectance'), {})
 
-        expected = np.array([[0.15265617, 0.30531234, 0.45796851,
-                                 0.61062468, 0.76328085],
-                                [0.91593702, 1.06859319, 1.22124936,
-                                 np.nan, 1.52656171]])
+        expected = np.array([[0.15265617, 0.30531234, 0.45796851, 0.61062468, 0.76328085],
+                             [0.91593702, 1.06859319, 1.22124936, np.nan, 1.52656171]])
         self.assertTrue(np.allclose(res.data, expected, equal_nan=True))
         self.assertNotIn('scale_factor', res.attrs)
         self.assertNotIn('_FillValue', res.attrs)
@@ -194,6 +190,7 @@ class Test_NC_ABI_L1B_vis_cal(unittest.TestCase):
 
 class Test_NC_ABI_L1B_area(unittest.TestCase):
     """Test the NC_ABI_L1B reader."""
+
     @mock.patch('satpy.readers.abi_l1b.xr')
     def setUp(self, xr_):
         """Setup for test."""
@@ -234,17 +231,15 @@ class Test_NC_ABI_L1B_area(unittest.TestCase):
 
         self.assertEqual(adef.call_count, 1)
         call_args = tuple(adef.call_args)[0]
-        self.assertDictEqual(call_args[3], {'a': 1.0, 'b': 1.0, 'h': 1.0,
-                                      'lon_0': -90.0, 'proj': 'geos',
-                                      'sweep': 'x', 'units': 'm'})
+        self.assertDictEqual(call_args[3], {'a': 1.0, 'b': 1.0, 'h': 1.0, 'lon_0': -90.0, 'proj': 'geos',
+                                            'sweep': 'x', 'units': 'm'})
         self.assertEqual(call_args[4], self.reader.ncols)
         self.assertEqual(call_args[5], self.reader.nlines)
         np.testing.assert_allclose(call_args[6], (-2, -2, 2, 2))
 
 
 def suite():
-    """The test suite for test_scene.
-    """
+    """The test suite for test_scene."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(Test_NC_ABI_L1B_ir_cal))

--- a/satpy/tests/reader_tests/test_acspo.py
+++ b/satpy/tests/reader_tests/test_acspo.py
@@ -5,6 +5,10 @@
 
 import os
 import sys
+from datetime import datetime, timedelta
+import numpy as np
+from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
+
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -14,10 +18,6 @@ try:
     from unittest import mock
 except ImportError:
     import mock
-
-from datetime import datetime, timedelta
-import numpy as np
-from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
 
 DEFAULT_FILE_DTYPE = np.uint16
 DEFAULT_FILE_SHAPE = (10, 300)

--- a/satpy/tests/reader_tests/test_amsr2_l1b.py
+++ b/satpy/tests/reader_tests/test_amsr2_l1b.py
@@ -5,6 +5,9 @@
 
 import os
 import sys
+import numpy as np
+from satpy.tests.reader_tests.test_hdf5_utils import FakeHDF5FileHandler
+
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -14,9 +17,6 @@ try:
     from unittest import mock
 except ImportError:
     import mock
-
-import numpy as np
-from satpy.tests.reader_tests.test_hdf5_utils import FakeHDF5FileHandler
 
 DEFAULT_FILE_DTYPE = np.uint16
 DEFAULT_FILE_SHAPE = (10, 300)

--- a/satpy/tests/reader_tests/test_geocat.py
+++ b/satpy/tests/reader_tests/test_geocat.py
@@ -5,6 +5,9 @@
 
 import os
 import sys
+import numpy as np
+from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
+
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -14,9 +17,6 @@ try:
     from unittest import mock
 except ImportError:
     import mock
-
-import numpy as np
-from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
 
 DEFAULT_FILE_DTYPE = np.uint16
 DEFAULT_FILE_SHAPE = (10, 300)
@@ -172,9 +172,9 @@ class TestGEOCATReader(unittest.TestCase):
             self.assertEqual(v.attrs['units'], '1')
         self.assertIsNotNone(datasets['variable3'].attrs.get('flag_meanings'))
 
+
 def suite():
-    """The test suite for test_viirs_l1b.
-    """
+    """The test suite for test_viirs_l1b."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestGEOCATReader))

--- a/satpy/tests/reader_tests/test_hdf4_utils.py
+++ b/satpy/tests/reader_tests/test_hdf4_utils.py
@@ -21,7 +21,7 @@ else:
 
 
 class FakeHDF4FileHandler(HDF4FileHandler):
-    """Swap-in NetCDF4 File Handler for reader tests to use"""
+    """Swap-in NetCDF4 File Handler for reader tests to use."""
 
     def __init__(self, filename, filename_info, filetype_info, **kwargs):
         """Get fake file content from 'get_test_content'"""
@@ -33,15 +33,15 @@ class FakeHDF4FileHandler(HDF4FileHandler):
         self.file_content.update(kwargs)
 
     def get_test_content(self, filename, filename_info, filetype_info):
-        """Mimic reader input file content
-        
+        """Mimic reader input file content.
+
         Args:
-            filename (str): input filename 
+            filename (str): input filename
             filename_info (dict): Dict of metadata pulled from filename
             filetype_info (dict): Dict of metadata from the reader's yaml config for this file type
 
         Returns: dict of file content with keys like:
-        
+
             - 'dataset'
             - '/attr/global_attr'
             - 'dataset/attr/global_attr'
@@ -107,8 +107,7 @@ class TestHDF4FileHandler(unittest.TestCase):
 
 
 def suite():
-    """The test suite for test_netcdf_utils.
-    """
+    """The test suite for test_hdf4_utils."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestHDF4FileHandler))

--- a/satpy/tests/reader_tests/test_hdf5_utils.py
+++ b/satpy/tests/reader_tests/test_hdf5_utils.py
@@ -126,11 +126,9 @@ class TestHDF5FileHandler(unittest.TestCase):
 
 
 def suite():
-    """The test suite for test_hdf5_utils.
-    """
+    """The test suite for test_hdf5_utils."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestHDF5FileHandler))
 
     return mysuite
-

--- a/satpy/tests/reader_tests/test_iasi_l2.py
+++ b/satpy/tests/reader_tests/test_iasi_l2.py
@@ -35,59 +35,45 @@ TEST_DATA = {
     # Not implemented in the reader
     'Amsu': {
         'FLG_AMSUBAD': {'data': np.zeros((NUM_SCANLINES, 30), dtype=np.uint8),
-                        'attrs': {}
-        }
+                        'attrs': {}}
     },
-# Not implemented in the reader
+    # Not implemented in the reader
     'INFO': {
         'OmC': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
                 'attrs': {'long_name': "Cloud signal. Predicted average window channel 'Obs minus Calc",
-                          'units': 'K'}
-        },
+                          'units': 'K'}},
         'mdist': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-                  'attrs': {}
-        }
+                  'attrs': {}}
     },
     'L1C': {
         'Latitude': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-                     'attrs': {'units': 'degrees_north'}
-        },
+                     'attrs': {'units': 'degrees_north'}},
         'Longitude': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-                      'attrs': {'units': 'degrees_north'}
-        },
+                      'attrs': {'units': 'degrees_north'}},
         'SatAzimuth': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-                       'attrs': {'units': 'degrees'}
-        },
+                       'attrs': {'units': 'degrees'}},
         'SatZenith': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-                      'attrs': {'units': 'degrees'}
-        },
+                      'attrs': {'units': 'degrees'}},
         'SensingTime_day': {'data': np.array([6472], dtype=np.uint16),
-                            'attrs': {}
-        },
+                            'attrs': {}},
         'SensingTime_msec': {'data': np.array([37337532], dtype=np.uint32),
-                             'attrs': {}
-        },
+                             'attrs': {}},
         'SunAzimuth': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-                       'attrs': {'units': 'degrees'}
-        },
+                       'attrs': {'units': 'degrees'}},
         'SunZenith': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-                      'attrs': {'units': 'degrees'}
-        },
+                      'attrs': {'units': 'degrees'}},
     },
     # Not implemented in the reader
     'Maps': {
         'Height': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-                   'attrs': {'units': 'm'}
-        },
+                   'attrs': {'units': 'm'}},
         'HeightStd': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-                   'attrs': {'units': 'm'}
-        },
+                      'attrs': {'units': 'm'}},
     },
     # Not implemented in the reader
     'Mhs': {
         'FLG_MHSBAD': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.uint8),
-                       'attrs': {}
-        }
+                       'attrs': {}}
     },
     'PWLR': {
         'E': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH, 10), dtype=np.float32),
@@ -96,53 +82,36 @@ TEST_DATA = {
                                                             1204.8, 1315.7,
                                                             1724.1, 2000.0,
                                                             2325.5, 2702.7],
-                                                           dtype=np.float32)}
-        },
+                                                           dtype=np.float32)}},
         'O': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH, NUM_LEVELS), dtype=np.float32),
               'attrs': {'long_name': 'Ozone mixing ratio vertical profile',
-                        'units': 'kg/kg'}
-        },
+                        'units': 'kg/kg'}},
         'OC': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-               'attrs': {}
-        },
+               'attrs': {}},
         'P': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH, NUM_LEVELS), dtype=np.float32),
-              'attrs': {'long_name': 'Atmospheric pressures at which the vertical profiles are given. Last value is the surface pressure',
-                        'units': 'hpa'}
-        },
+              'attrs': {'long_name': 'Atmospheric pressures at which the vertical profiles are given. '
+                                     'Last value is the surface pressure',
+                        'units': 'hpa'}},
         'QE': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-               'attrs': {}
-        },
+               'attrs': {}},
         'QO': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-               'attrs': {}
-        },
+               'attrs': {}},
         'QP': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-               'attrs': {}
-        },
+               'attrs': {}},
         'QT': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-               'attrs': {}
-        },
+               'attrs': {}},
         'QTs': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-                'attrs': {}
-        },
+                'attrs': {}},
         'QW': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-               'attrs': {}
-        },
+               'attrs': {}},
         'T': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH, NUM_LEVELS), dtype=np.float32),
-              'attrs': {'long_name': 'Temperature vertical profile',
-                        'units': 'K'}
-        },
+              'attrs': {'long_name': 'Temperature vertical profile', 'units': 'K'}},
         'Ts': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-               'attrs': {'long_name': 'Surface skin temperature',
-                        'units': 'K'}
-        },
+               'attrs': {'long_name': 'Surface skin temperature', 'units': 'K'}},
         'W': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH, NUM_LEVELS), dtype=np.float32),
-              'attrs': {'long_name': 'Water vapour mixing ratio vertical profile',
-                        'units': 'kg/kg'}
-        },
+              'attrs': {'long_name': 'Water vapour mixing ratio vertical profile', 'units': 'kg/kg'}},
         'WC': {'data': np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-               'attrs': {'long_name': 'Water vapour total columnar amount',
-                         'units': 'mm'}
-        },
+               'attrs': {'long_name': 'Water vapour total columnar amount', 'units': 'mm'}},
     }
 }
 
@@ -199,7 +168,7 @@ class TestIasiL2(unittest.TestCase):
         """Test scene creation"""
         from satpy import Scene
         fname = os.path.join(self.base_dir, FNAME)
-        scn = Scene(reader='iasi_l2', filenames=[fname,])
+        scn = Scene(reader='iasi_l2', filenames=[fname])
         self.assertTrue('start_time' in scn.attrs)
         self.assertTrue('end_time' in scn.attrs)
         self.assertTrue('sensor' in scn.attrs)
@@ -209,14 +178,14 @@ class TestIasiL2(unittest.TestCase):
         """Test that all datasets are available"""
         from satpy import Scene
         fname = os.path.join(self.base_dir, FNAME)
-        scn = Scene(reader='iasi_l2', filenames=[fname,])
+        scn = Scene(reader='iasi_l2', filenames=[fname])
         scn.load(scn.available_dataset_names())
 
     def test_scene_load_pressure(self):
         """Test loading pressure data"""
         from satpy import Scene
         fname = os.path.join(self.base_dir, FNAME)
-        scn = Scene(reader='iasi_l2', filenames=[fname,])
+        scn = Scene(reader='iasi_l2', filenames=[fname])
         scn.load(['pressure'])
         pres = scn['pressure'].compute()
         self.check_pressure(pres, scn.attrs)
@@ -225,7 +194,7 @@ class TestIasiL2(unittest.TestCase):
         """Test loading emissivity data"""
         from satpy import Scene
         fname = os.path.join(self.base_dir, FNAME)
-        scn = Scene(reader='iasi_l2', filenames=[fname,])
+        scn = Scene(reader='iasi_l2', filenames=[fname])
         scn.load(['emissivity'])
         emis = scn['emissivity'].compute()
         self.check_emissivity(emis)
@@ -234,7 +203,7 @@ class TestIasiL2(unittest.TestCase):
         """Test loading sensing times"""
         from satpy import Scene
         fname = os.path.join(self.base_dir, FNAME)
-        scn = Scene(reader='iasi_l2', filenames=[fname,])
+        scn = Scene(reader='iasi_l2', filenames=[fname])
         scn.load(['sensing_time'])
         times = scn['sensing_time'].compute()
         self.check_sensing_times(times)
@@ -337,8 +306,7 @@ class TestIasiL2(unittest.TestCase):
 
 
 def suite():
-    """The test suite for test_scene.
-    """
+    """The test suite for test_iasi_l2."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestIasiL2))

--- a/satpy/tests/reader_tests/test_msg_base.py
+++ b/satpy/tests/reader_tests/test_msg_base.py
@@ -24,9 +24,7 @@
 """
 
 import sys
-
 import numpy as np
-
 from satpy.readers.msg_base import dec10216
 
 if sys.version_info < (2, 7):
@@ -34,16 +32,9 @@ if sys.version_info < (2, 7):
 else:
     import unittest
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
 
 class TestDec10216(unittest.TestCase):
-
-    """Test the dec10216 function.
-    """
+    """Test the dec10216 function."""
 
     def test_dec10216(self):
         res = dec10216(np.array([255, 255, 255, 255, 255], dtype=np.uint8))
@@ -55,14 +46,8 @@ class TestDec10216(unittest.TestCase):
 
 
 def suite():
-    """The test suite for test_scene.
-    """
+    """The test suite for test_scene."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestDec10216))
     return mysuite
-
-
-if __name__ == "__main__":
-    # So you can run tests from this module individually.
-    unittest.main()

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -20,10 +20,10 @@ else:
 
 
 class FakeNetCDF4FileHandler(NetCDF4FileHandler):
-    """Swap-in NetCDF4 File Handler for reader tests to use"""
+    """Swap-in NetCDF4 File Handler for reader tests to use."""
 
     def __init__(self, filename, filename_info, filetype_info, **kwargs):
-        """Get fake file content from 'get_test_content'"""
+        """Get fake file content from 'get_test_content'."""
         if NetCDF4FileHandler is object:
             raise ImportError("Base 'NetCDF4FileHandler' could not be "
                               "imported.")
@@ -32,15 +32,15 @@ class FakeNetCDF4FileHandler(NetCDF4FileHandler):
         self.file_content.update(kwargs)
 
     def get_test_content(self, filename, filename_info, filetype_info):
-        """Mimic reader input file content
-        
+        """Mimic reader input file content.
+
         Args:
-            filename (str): input filename 
+            filename (str): input filename
             filename_info (dict): Dict of metadata pulled from filename
             filetype_info (dict): Dict of metadata from the reader's yaml config for this file type
 
         Returns: dict of file content with keys like:
-        
+
             - 'dataset'
             - '/attr/global_attr'
             - 'dataset/attr/global_attr'
@@ -52,9 +52,10 @@ class FakeNetCDF4FileHandler(NetCDF4FileHandler):
 
 
 class TestNetCDF4FileHandler(unittest.TestCase):
-    """Test NetCDF4 File Handler Utility class"""
+    """Test NetCDF4 File Handler Utility class."""
+
     def setUp(self):
-        """Create a test NetCDF4 file"""
+        """Create a test NetCDF4 file."""
         from netCDF4 import Dataset
         with Dataset('test.nc', 'w') as nc:
             # Create dimensions
@@ -92,11 +93,11 @@ class TestNetCDF4FileHandler(unittest.TestCase):
                 d.test_attr_float = 1.2
 
     def tearDown(self):
-        """Remove the previously created test file"""
+        """Remove the previously created test file."""
         os.remove('test.nc')
 
     def test_all_basic(self):
-        """Test everything about the NetCDF4 class"""
+        """Test everything about the NetCDF4 class."""
         from satpy.readers.netcdf_utils import NetCDF4FileHandler
         import xarray as xr
         file_handler = NetCDF4FileHandler('test.nc', {}, {})
@@ -125,8 +126,7 @@ class TestNetCDF4FileHandler(unittest.TestCase):
 
 
 def suite():
-    """The test suite for test_netcdf_utils.
-    """
+    """The test suite for test_netcdf_utils."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestNetCDF4FileHandler))

--- a/satpy/tests/reader_tests/test_nucaps.py
+++ b/satpy/tests/reader_tests/test_nucaps.py
@@ -5,13 +5,13 @@
 
 import os
 import sys
+import numpy as np
+from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
+
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
-
-import numpy as np
-from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
 
 try:
     from unittest import mock

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -22,7 +22,6 @@
 """Testing of helper functions."""
 
 
-import random
 import unittest
 
 try:
@@ -36,12 +35,10 @@ from satpy.readers import utils as hf
 
 
 class TestSatinHelpers(unittest.TestCase):
-    '''Class for testing satpy.satin'''
+    """Class for testing satpy.satin."""
 
     def test_boundaries_to_extent(self):
-        '''Test conversion of area boundaries to area extent.
-        '''
-
+        """Test conversion of area boundaries to area extent."""
         from satpy.satin.helper_functions import boundaries_to_extent
 
         # MSG3 proj4 string from

--- a/satpy/tests/reader_tests/test_viirs_l1b.py
+++ b/satpy/tests/reader_tests/test_viirs_l1b.py
@@ -5,13 +5,14 @@
 
 import os
 import sys
+from datetime import datetime, timedelta
+import numpy as np
+from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
+
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
     import unittest
-from datetime import datetime, timedelta
-import numpy as np
-from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
 
 try:
     from unittest import mock

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -5,6 +5,9 @@
 
 import os
 import sys
+import numpy as np
+from satpy.tests.reader_tests.test_hdf5_utils import FakeHDF5FileHandler
+
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -14,9 +17,6 @@ try:
     from unittest import mock
 except ImportError:
     import mock
-
-import numpy as np
-from satpy.tests.reader_tests.test_hdf5_utils import FakeHDF5FileHandler
 
 DEFAULT_FILE_DTYPE = np.uint16
 DEFAULT_FILE_SHAPE = (10, 300)

--- a/satpy/tests/test_file_handlers.py
+++ b/satpy/tests/test_file_handlers.py
@@ -23,7 +23,6 @@
 """test file handler baseclass.
 """
 
-import sys
 import unittest
 
 try:

--- a/satpy/tests/test_plugin.py
+++ b/satpy/tests/test_plugin.py
@@ -3,11 +3,11 @@
 
 # SMHI,
 # Folkborgsvägen 1,
-# Norrköping, 
+# Norrköping,
 # Sweden
 
 # Author(s):
- 
+
 #   Martin Raspaud <martin.raspaud@smhi.se>
 
 # This file is part of satpy.
@@ -29,13 +29,13 @@
 
 import numpy as np
 
+
 def get_lat_lon(*args, **kwargs):
-    """Dummy get_lat_lon function.
-    """
+    """Dummy get_lat_lon function."""
     del args, kwargs
-    return (np.zeros((3, 3)), np.zeros((3, 3)))
+    return np.zeros((3, 3)), np.zeros((3, 3))
+
 
 def load(satscene):
-    """Dummy load function.
-    """
+    """Dummy load function."""
     pass

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -231,9 +231,7 @@ class TestReaderLoader(unittest.TestCase):
         """Test with filenames and reader specified"""
         from satpy.readers import load_readers
         ri = load_readers(reader='viirs_sdr',
-                filenames=[
-                    'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
-        ])
+                          filenames=['SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'])
         self.assertListEqual(list(ri.keys()), ['viirs_sdr'])
 
     def test_bad_reader_name_with_filenames(self):
@@ -278,8 +276,10 @@ class TestReaderLoader(unittest.TestCase):
 
 
 class TestFindFilesAndReaders(unittest.TestCase):
+    """Test the find_files_and_readers utility function."""
+
     def setUp(self):
-        """Wrap HDF5 file handler with our own fake handler"""
+        """Wrap HDF5 file handler with our own fake handler."""
         from satpy.readers.viirs_sdr import VIIRSSDRFileHandler
         from satpy.tests.reader_tests.test_viirs_sdr import FakeHDF5FileHandler2
         # http://stackoverflow.com/questions/12219967/how-to-mock-a-base-class-with-python-mock-library
@@ -288,7 +288,7 @@ class TestFindFilesAndReaders(unittest.TestCase):
         self.p.is_local = True
 
     def tearDown(self):
-        """Stop wrapping the HDF5 file handler"""
+        """Stop wrapping the HDF5 file handler."""
         self.p.stop()
 
     # def test_sensor(self):
@@ -302,7 +302,7 @@ class TestFindFilesAndReaders(unittest.TestCase):
     #
 
     def test_reader_name(self):
-        """Test with default base_dir and reader specified"""
+        """Test with default base_dir and reader specified."""
         from satpy.readers import find_files_and_readers
         fn = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
         # touch the file so it exists on disk
@@ -315,7 +315,7 @@ class TestFindFilesAndReaders(unittest.TestCase):
             os.remove(fn)
 
     def test_reader_other_name(self):
-        """Test with default base_dir and reader specified"""
+        """Test with default base_dir and reader specified."""
         from satpy.readers import find_files_and_readers
         fn = 'S_NWC_CPP_npp_32505_20180204T1114116Z_20180204T1128227Z.nc'
         # touch the file so it exists on disk
@@ -328,9 +328,9 @@ class TestFindFilesAndReaders(unittest.TestCase):
             os.remove(fn)
 
     def test_reader_name_matched_start_end_time(self):
-        """Test with start and end time matching the filename"""
+        """Test with start and end time matching the filename."""
         from satpy.readers import find_files_and_readers
-        from datetime import datetime, timedelta
+        from datetime import datetime
         fn = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
         # touch the file so it exists on disk
         open(fn, 'w')
@@ -350,14 +350,12 @@ class TestFindFilesAndReaders(unittest.TestCase):
         Start time in the middle of the file time should still match the file.
         """
         from satpy.readers import find_files_and_readers
-        from datetime import datetime, timedelta
+        from datetime import datetime
         fn = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
         # touch the file so it exists on disk
         open(fn, 'w')
         try:
-            ri = find_files_and_readers(reader='viirs_sdr',
-                                        start_time=datetime(2012, 2, 25, 18, 1, 30),
-                                        )
+            ri = find_files_and_readers(reader='viirs_sdr', start_time=datetime(2012, 2, 25, 18, 1, 30))
             self.assertListEqual(list(ri.keys()), ['viirs_sdr'])
             self.assertListEqual(ri['viirs_sdr'], [fn])
         finally:
@@ -370,21 +368,19 @@ class TestFindFilesAndReaders(unittest.TestCase):
 
         """
         from satpy.readers import find_files_and_readers
-        from datetime import datetime, timedelta
+        from datetime import datetime
         fn = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
         # touch the file so it exists on disk
         open(fn, 'w')
         try:
-            ri = find_files_and_readers(reader='viirs_sdr',
-                                        end_time=datetime(2012, 2, 25, 18, 1, 30),
-                                        )
+            ri = find_files_and_readers(reader='viirs_sdr', end_time=datetime(2012, 2, 25, 18, 1, 30))
             self.assertListEqual(list(ri.keys()), ['viirs_sdr'])
             self.assertListEqual(ri['viirs_sdr'], [fn])
         finally:
             os.remove(fn)
 
     def test_reader_name_unmatched_start_end_time(self):
-        """Test with start and end time matching the filename"""
+        """Test with start and end time matching the filename."""
         from satpy.readers import find_files_and_readers
         from datetime import datetime
         fn = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -40,15 +40,13 @@ os.environ.pop("PPP_CONFIG_DIR", None)
 
 
 class TestScene(unittest.TestCase):
-    """
-    Test the scene class
-    """
+    """Test the scene class."""
 
     def test_init(self):
         import satpy.scene
         with mock.patch('satpy.scene.Scene.create_reader_instances') as cri:
             cri.return_value = {}
-            scene = satpy.scene.Scene(filenames=['bla'], reader='blo')
+            satpy.scene.Scene(filenames=['bla'], reader='blo')
             cri.assert_called_once_with(filenames=['bla'], reader='blo',
                                         reader_kwargs=None)
 
@@ -112,7 +110,7 @@ class TestScene(unittest.TestCase):
         with mock.patch('satpy.scene.Scene._compute_metadata_from_readers') as md:
             md.return_value = {'sensor': {'sensor'}}
             with mock.patch('satpy.scene.load_readers') as findermock:
-                scene = satpy.scene.Scene(filenames=filenames)
+                satpy.scene.Scene(filenames=filenames)
                 findermock.assert_called_once_with(
                     filenames=filenames,
                     reader=reader_name,
@@ -161,10 +159,9 @@ class TestScene(unittest.TestCase):
         from satpy.scene import Scene
         reader = "foo"
         filenames = ["1", "2", "3"]
-        sensors = set()
         with mock.patch('satpy.scene.load_readers') as findermock:
             findermock.return_value = {}
-            scene = Scene(reader=reader, filenames=filenames)
+            Scene(reader=reader, filenames=filenames)
             findermock.assert_called_once_with(ppp_config_dir=mock.ANY,
                                                reader=reader,
                                                filenames=filenames,
@@ -417,7 +414,7 @@ class TestScene(unittest.TestCase):
         from xarray import DataArray
         import numpy as np
         scene = Scene()
-        scene["1"] = ds1 = DataArray(np.arange(5), attrs={'wavelength': (0.1, 0.2, 0.3)})
+        scene["1"] = DataArray(np.arange(5), attrs={'wavelength': (0.1, 0.2, 0.3)})
         self.assertTrue('1' in scene)
         self.assertTrue(0.15 in scene)
         self.assertFalse('2' in scene)
@@ -428,9 +425,9 @@ class TestScene(unittest.TestCase):
         from xarray import DataArray
         import numpy as np
         scene = Scene()
-        scene["1"] = ds1 = DataArray(np.arange(5), attrs={'wavelength': (0.1, 0.2, 0.3)})
-        scene["2"] = ds2 = DataArray(np.arange(5), attrs={'wavelength': (0.4, 0.5, 0.6)})
-        scene["3"] = ds3 = DataArray(np.arange(5), attrs={'wavelength': (0.7, 0.8, 0.9)})
+        scene["1"] = DataArray(np.arange(5), attrs={'wavelength': (0.1, 0.2, 0.3)})
+        scene["2"] = DataArray(np.arange(5), attrs={'wavelength': (0.4, 0.5, 0.6)})
+        scene["3"] = DataArray(np.arange(5), attrs={'wavelength': (0.7, 0.8, 0.9)})
         del scene['1']
         del scene['3']
         del scene[0.45]

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -21,15 +21,11 @@
 """Testing of utils."""
 
 import unittest
-
 from numpy import sqrt
-
-from satpy.utils import (angle2xyz, lonlat2xyz, xyz2angle, xyz2lonlat,
-                         proj_units_to_meters)
+from satpy.utils import angle2xyz, lonlat2xyz, xyz2angle, xyz2lonlat, proj_units_to_meters
 
 
 class TestUtils(unittest.TestCase):
-
     """Testing utils."""
 
     def test_lonlat2xyz(self):

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -22,7 +22,7 @@
 """Utilities for various satpy tests.
 """
 
-from datetime import datetime, timedelta
+from datetime import datetime
 
 try:
     from unittest import mock
@@ -64,6 +64,7 @@ def _create_fake_compositor(ds_id, prereqs, opt_prereqs):
     c.id = ds_id
 
     se = mock.MagicMock()
+
     def _se(datasets, optional_datasets=None, ds_id=ds_id, **kwargs):
         if ds_id.name == 'comp14':
             # used as a test when composites update the dataset id with
@@ -144,18 +145,15 @@ def test_composites(sensor_name):
         DatasetID(name='comp11'): ([0.22, 0.48, 0.85], []),
         DatasetID(name='comp12'): ([DatasetID(wavelength=0.22, modifiers=('mod1',)),
                                     DatasetID(wavelength=0.48, modifiers=('mod1',)),
-                                    DatasetID(wavelength=0.85, modifiers=('mod1',))],
-                                    []),
+                                    DatasetID(wavelength=0.85, modifiers=('mod1',))], []),
         DatasetID(name='comp13'): ([DatasetID(name='ds5', modifiers=('res_change',))], []),
         DatasetID(name='comp14'): (['ds1'], []),
         DatasetID(name='comp15'): (['ds1', 'ds9_fail_load'], []),
         DatasetID(name='comp16'): (['ds1'], ['ds9_fail_load']),
         DatasetID(name='comp17'): (['ds1', 'comp15'], []),
         DatasetID(name='comp18'): (['ds3',
-                                    DatasetID(name='ds4',
-                                              modifiers=('mod1', 'mod3',)),
-                                    DatasetID(name='ds5',
-                                              modifiers=('mod1', 'incomp_areas'))], []),
+                                    DatasetID(name='ds4', modifiers=('mod1', 'mod3',)),
+                                    DatasetID(name='ds5', modifiers=('mod1', 'incomp_areas'))], []),
         DatasetID(name='comp19'): ([DatasetID('ds5', modifiers=('res_change',)), 'comp13', 'ds2'], []),
         DatasetID(name='comp20'): ([DatasetID(name='ds5', modifiers=('mod_opt_prereq',))], []),
         DatasetID(name='comp21'): ([DatasetID(name='ds5', modifiers=('mod_bad_opt',))], []),

--- a/satpy/tests/writer_tests/__init__.py
+++ b/satpy/tests/writer_tests/__init__.py
@@ -25,8 +25,10 @@
 import sys
 
 from satpy.tests.writer_tests import (test_cf, test_geotiff,
-                                      test_ninjotiff, test_simple_image,
+                                      test_simple_image,
                                       test_scmi, test_mitiff)
+# FIXME: pyninjotiff is not xarray/dask friendly
+from satpy.tests.writer_tests import test_ninjotiff  # noqa
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest

--- a/satpy/tests/writer_tests/test_geotiff.py
+++ b/satpy/tests/writer_tests/test_geotiff.py
@@ -21,15 +21,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for the geotiff writer.
 """
-import os
 import sys
-
 import numpy as np
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -41,12 +34,12 @@ class TestGeoTIFFWriter(unittest.TestCase):
     """Test the GeoTIFF Writer class."""
 
     def setUp(self):
-        """Create temporary directory to save files to"""
+        """Create temporary directory to save files to."""
         import tempfile
         self.base_dir = tempfile.mkdtemp()
 
     def tearDown(self):
-        """Remove the temporary directory created for a test"""
+        """Remove the temporary directory created for a test."""
         try:
             import shutil
             shutil.rmtree(self.base_dir, ignore_errors=True)
@@ -69,7 +62,7 @@ class TestGeoTIFFWriter(unittest.TestCase):
     def test_init(self):
         """Test creating the writer with no arguments."""
         from satpy.writers.geotiff import GeoTIFFWriter
-        w = GeoTIFFWriter()
+        GeoTIFFWriter()
 
     def test_simple_write(self):
         """Test basic writer operation."""
@@ -114,8 +107,7 @@ class TestGeoTIFFWriter(unittest.TestCase):
 
 
 def suite():
-    """The test suite for this writer's tests.
-    """
+    """The test suite for this writer's tests."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestGeoTIFFWriter))

--- a/satpy/tests/writer_tests/test_mitiff.py
+++ b/satpy/tests/writer_tests/test_mitiff.py
@@ -24,13 +24,6 @@ Based on the test for geotiff writer
 """
 import sys
 
-import logging
-
-logger = logging.getLogger()
-logger.level = logging.DEBUG
-stream_handler = logging.StreamHandler(sys.stdout)
-logger.addHandler(stream_handler)
-
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -167,7 +160,6 @@ class TestMITIFFWriter(unittest.TestCase):
             calibration.append(p.attrs['calibration'])
             bands.append(p.attrs['name'])
         data['bands'] = list(bands)
-        new_attrs = {}
         new_attrs = {'name': 'datasets',
                      'start_time': datetime.utcnow(),
                      'platform_name': "TEST_PLATFORM_NAME",

--- a/satpy/tests/writer_tests/test_ninjotiff.py
+++ b/satpy/tests/writer_tests/test_ninjotiff.py
@@ -21,15 +21,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for the NinJoTIFF writer.
 """
-import os
 import sys
-
-import numpy as np
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -40,12 +32,11 @@ else:
 class TestNinjoTIFFWriter(unittest.TestCase):
     def test_init(self):
         from satpy.writers.ninjotiff import NinjoTIFFWriter
-        w = NinjoTIFFWriter()
+        NinjoTIFFWriter()
 
 
 def suite():
-    """The test suite for this writer's tests.
-    """
+    """The test suite for this writer's tests."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestNinjoTIFFWriter))

--- a/satpy/tests/writer_tests/test_scmi.py
+++ b/satpy/tests/writer_tests/test_scmi.py
@@ -25,11 +25,6 @@ from datetime import datetime, timedelta
 import numpy as np
 import dask.array as da
 
-try:
-    from unittest import mock
-except ImportError:
-    import mock
-
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -37,15 +32,15 @@ else:
 
 
 class TestSCMIWriter(unittest.TestCase):
-    """Test basic functionality of SCMI writer"""
+    """Test basic functionality of SCMI writer."""
 
     def setUp(self):
-        """Create temporary directory to save files to"""
+        """Create temporary directory to save files to."""
         import tempfile
         self.base_dir = tempfile.mkdtemp()
 
     def tearDown(self):
-        """Remove the temporary directory created for a test"""
+        """Remove the temporary directory created for a test."""
         try:
             import shutil
             shutil.rmtree(self.base_dir, ignore_errors=True)
@@ -53,12 +48,12 @@ class TestSCMIWriter(unittest.TestCase):
             pass
 
     def test_init(self):
-        """Test basic init method of writer"""
+        """Test basic init method of writer."""
         from satpy.writers.scmi import SCMIWriter
-        w = SCMIWriter(base_dir=self.base_dir)
+        SCMIWriter(base_dir=self.base_dir)
 
     def test_basic_numbered_1_tile(self):
-        """Test creating a single numbered tile"""
+        """Test creating a single numbered tile."""
         from satpy.writers.scmi import SCMIWriter
         from xarray import DataArray
         from pyresample.geometry import AreaDefinition
@@ -92,7 +87,7 @@ class TestSCMIWriter(unittest.TestCase):
         self.assertEqual(os.path.basename(all_files[0]), 'TESTS_AII_PLAT_SENSOR_test_ds_TEST_T001_20180101_1200.nc')
 
     def test_basic_numbered_tiles(self):
-        """Test creating a multiple numbered tiles"""
+        """Test creating a multiple numbered tiles."""
         from satpy.writers.scmi import SCMIWriter
         from xarray import DataArray
         from pyresample.geometry import AreaDefinition
@@ -125,7 +120,7 @@ class TestSCMIWriter(unittest.TestCase):
         self.assertEqual(len(all_files), 9)
 
     def test_basic_lettered_tiles(self):
-        """Test creating a lettered grid"""
+        """Test creating a lettered grid."""
         from satpy.writers.scmi import SCMIWriter
         from xarray import DataArray
         from pyresample.geometry import AreaDefinition
@@ -158,7 +153,7 @@ class TestSCMIWriter(unittest.TestCase):
         self.assertEqual(len(all_files), 16)
 
     def test_lettered_tiles_no_fit(self):
-        """Test creating a lettered grid with no data"""
+        """Test creating a lettered grid with no data."""
         from satpy.writers.scmi import SCMIWriter
         from xarray import DataArray
         from pyresample.geometry import AreaDefinition
@@ -192,7 +187,7 @@ class TestSCMIWriter(unittest.TestCase):
         self.assertEqual(len(all_files), 0)
 
     def test_lettered_tiles_bad_filename(self):
-        """Test creating a lettered grid with a bad filename"""
+        """Test creating a lettered grid with a bad filename."""
         from satpy.writers.scmi import SCMIWriter
         from xarray import DataArray
         from pyresample.geometry import AreaDefinition
@@ -228,7 +223,7 @@ class TestSCMIWriter(unittest.TestCase):
                           lettered_grid=True)
 
     def test_basic_numbered_tiles_rgb(self):
-        """Test creating a multiple numbered tiles with RGB"""
+        """Test creating a multiple numbered tiles with RGB."""
         from satpy.writers.scmi import SCMIWriter
         from xarray import DataArray
         from pyresample.geometry import AreaDefinition

--- a/satpy/tests/writer_tests/test_simple_image.py
+++ b/satpy/tests/writer_tests/test_simple_image.py
@@ -21,15 +21,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for the CF writer.
 """
-import os
 import sys
-
-import numpy as np
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -40,19 +32,21 @@ else:
 class TestPillowWriter(unittest.TestCase):
 
     def setUp(self):
-        """Create temporary directory to save files to"""
+        """Create temporary directory to save files to."""
         import tempfile
         self.base_dir = tempfile.mkdtemp()
 
     def tearDown(self):
-        """Remove the temporary directory created for a test"""
+        """Remove the temporary directory created for a test."""
         try:
             import shutil
             shutil.rmtree(self.base_dir, ignore_errors=True)
         except OSError:
             pass
 
-    def _get_test_datasets(self):
+    @staticmethod
+    def _get_test_datasets():
+        """Create DataArray for testing."""
         import xarray as xr
         import dask.array as da
         from datetime import datetime
@@ -65,16 +59,19 @@ class TestPillowWriter(unittest.TestCase):
         return [ds1]
 
     def test_init(self):
+        """Test creating the default writer."""
         from satpy.writers.simple_image import PillowWriter
-        w = PillowWriter()
+        PillowWriter()
 
     def test_simple_write(self):
+        """Test writing datasets with default behavior."""
         from satpy.writers.simple_image import PillowWriter
         datasets = self._get_test_datasets()
         w = PillowWriter(base_dir=self.base_dir)
         w.save_datasets(datasets)
 
     def test_simple_delayed_write(self):
+        """Test writing datasets with delayed computation."""
         from dask.delayed import Delayed
         from satpy.writers.simple_image import PillowWriter
         from satpy.writers import compute_writer_results
@@ -86,9 +83,9 @@ class TestPillowWriter(unittest.TestCase):
             r__.compute()
         compute_writer_results(res)
 
+
 def suite():
-    """The test suite for this writer's tests.
-    """
+    """The test suite for this writer's tests."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestPillowWriter))

--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -104,7 +104,7 @@ class MITIFFWriter(ImageWriter):
                 LOG.info("Saving mitiff to: %s ...", gen_filename)
                 self._save_datasets_as_mitiff(dataset, image_description,
                                               gen_filename, **kwargs)
-            except:
+            except (KeyError, ValueError, RuntimeError):
                 raise
 
         create_opts = ()
@@ -151,7 +151,7 @@ class MITIFFWriter(ImageWriter):
                 gen_filename = filename or self.get_filename(**kwargs)
                 LOG.info("Saving mitiff to: %s ...", gen_filename)
                 self._save_datasets_as_mitiff(datasets, image_description, gen_filename, **kwargs)
-            except:
+            except (KeyError, ValueError, RuntimeError):
                 raise
 
         create_opts = ()

--- a/satpy/writers/ninjotiff.py
+++ b/satpy/writers/ninjotiff.py
@@ -26,50 +26,18 @@
 """
 
 import logging
-
-import numpy as np
-
 import pyninjotiff.ninjotiff as nt
-from satpy.utils import ensure_dir
 from satpy.writers import ImageWriter
 
 LOG = logging.getLogger(__name__)
 
 
 class NinjoTIFFWriter(ImageWriter):
-    GDAL_OPTIONS = ("tfw",
-                    "rpb",
-                    "rpctxt",
-                    "interleave",
-                    "tiled",
-                    "blockxsize",
-                    "blockysize",
-                    "nbits",
-                    "compress",
-                    "num_threads",
-                    "predictor",
-                    "discard_lsb",
-                    "sparse_ok",
-                    "jpeg_quality",
-                    "jpegtablesmode",
-                    "zlevel",
-                    "photometric",
-                    "alpha",
-                    "profile",
-                    "bigtiff",
-                    "pixeltype",
-                    "copy_src_overviews", )
 
-    def __init__(self, floating_point=False, tags=None, **kwargs):
-        ImageWriter.__init__(self,
-                             default_config_filename="writers/ninjotiff.yaml",
-                             **kwargs)
+    def __init__(self, tags=None, **kwargs):
+        ImageWriter.__init__(self, default_config_filename="writers/ninjotiff.yaml", **kwargs)
 
-        # self.floating_point = bool(self.config_options.get(
-        #     "floating_point", None) if floating_point is None else
-        #     floating_point)
-        self.tags = self.info.get("tags",
-                                  None) if tags is None else tags
+        self.tags = self.info.get("tags", None) if tags is None else tags
         if self.tags is None:
             self.tags = {}
         elif not isinstance(self.tags, dict):
@@ -81,6 +49,5 @@ class NinjoTIFFWriter(ImageWriter):
 
         .. _ninjotiff: http://www.ssec.wisc.edu/~davidh/polar2grid/misc/NinJo_Satellite_Import_Formats.html
         """
-
         filename = filename or self.get_filename(**img.info)
         nt.save(img, filename, **kwargs)

--- a/satpy/writers/scmi.py
+++ b/satpy/writers/scmi.py
@@ -149,9 +149,11 @@ class NumberedTileGenerator(object):
     def _get_tile_properties(self, tile_shape, tile_count):
         if tile_shape is not None:
             tile_shape = (int(min(tile_shape[0], self._rows)), int(min(tile_shape[1], self._cols)))
-            tile_count = (int(np.ceil(self._rows / float(tile_shape[0]))), int(np.ceil(self._cols / float(tile_shape[1]))))
+            tile_count = (int(np.ceil(self._rows / float(tile_shape[0]))),
+                          int(np.ceil(self._cols / float(tile_shape[1]))))
         elif tile_count:
-            tile_shape = (int(np.ceil(self._rows / float(tile_count[0]))), int(np.ceil(self._cols / float(tile_count[1]))))
+            tile_shape = (int(np.ceil(self._rows / float(tile_count[0]))),
+                          int(np.ceil(self._cols / float(tile_count[1]))))
         else:
             raise ValueError("Either 'tile_count' or 'tile_shape' must be provided")
 
@@ -347,7 +349,8 @@ class LetteredTileGenerator(NumberedTileGenerator):
 
         total_alphas = (max_cols * max_rows) / (st[0] * st[1])
         if total_alphas > 26:
-            raise ValueError("Too many lettered grid cells '{}' (sector cell size too small). Maximum of 26".format(total_alphas))
+            raise ValueError("Too many lettered grid cells '{}' (sector cell size too small). "
+                             "Maximum of 26".format(total_alphas))
 
         self.tile_shape = (num_pixels_y, num_pixels_x)
         self.total_tile_count = (max_rows, max_cols)
@@ -1025,12 +1028,12 @@ def _create_debug_array(sector_info, num_subtiles, font_path='Verdana.ttf'):
     total_cells_y = np.ceil(total_meters_y / fcs_y)
     total_cells_x = np.ceil(total_cells_x / num_subtiles[1]) * num_subtiles[1]
     total_cells_y = np.ceil(total_cells_y / num_subtiles[0]) * num_subtiles[0]
-    total_alpha_cells_x = int(total_cells_x / num_subtiles[1])
-    total_alpha_cells_y = int(total_cells_y / num_subtiles[0])
+    # total_alpha_cells_x = int(total_cells_x / num_subtiles[1])
+    # total_alpha_cells_y = int(total_cells_y / num_subtiles[0])
 
     # "round" the total meters up to the number of alpha cells
-    total_meters_x = total_cells_x * fcs_x
-    total_meters_y = total_cells_y * fcs_y
+    # total_meters_x = total_cells_x * fcs_x
+    # total_meters_y = total_cells_y * fcs_y
 
     # Pixels per tile
     ppt_x = np.floor(float(size[0]) / total_cells_x)
@@ -1125,28 +1128,28 @@ def create_debug_lettered_tiles(init_args, create_args):
 def add_backend_argument_groups(parser):
     group_1 = parser.add_argument_group(title="Backend Initialization")
     group_1.add_argument("--backend-configs", nargs="*", dest="backend_configs",
-                       help="alternative backend configuration files")
+                         help="alternative backend configuration files")
     group_1.add_argument("--compress", action="store_true",
-                       help="zlib compress each netcdf file")
+                         help="zlib compress each netcdf file")
     group_1.add_argument("--fix-awips", action="store_true",
-                       help="modify NetCDF output to work with the old/broken AWIPS NetCDF library")
+                         help="modify NetCDF output to work with the old/broken AWIPS NetCDF library")
     group_2 = parser.add_argument_group(title="Backend Output Creation")
     group_2.add_argument("--tiles", dest="tile_count", nargs=2, type=int, default=[1, 1],
-                       help="Number of tiles to produce in Y (rows) and X (cols) direction respectively")
+                         help="Number of tiles to produce in Y (rows) and X (cols) direction respectively")
     group_2.add_argument("--tile-size", dest="tile_size", nargs=2, type=int, default=None,
-                       help="Specify how many pixels are in each tile (overrides '--tiles')")
+                         help="Specify how many pixels are in each tile (overrides '--tiles')")
     # group.add_argument('--tile-offset', nargs=2, default=(0, 0),
     #                    help="Start counting tiles from this offset ('row_offset col_offset')")
     group_2.add_argument("--letters", dest="lettered_grid", action='store_true',
-                       help="Create tiles from a static letter-based grid based on the product projection")
+                         help="Create tiles from a static letter-based grid based on the product projection")
     group_2.add_argument("--letter-subtiles", nargs=2, type=int, default=(2, 2),
-                       help="Specify number of subtiles in each lettered tile: \'row col\'")
+                         help="Specify number of subtiles in each lettered tile: \'row col\'")
     group_2.add_argument("--output-pattern", default=DEFAULT_OUTPUT_PATTERN,
-                       help="output filenaming pattern")
+                         help="output filenaming pattern")
     group_2.add_argument("--source-name", default='SSEC',
-                       help="specify processing source name used in attributes and filename (default 'SSEC')")
+                         help="specify processing source name used in attributes and filename (default 'SSEC')")
     group_2.add_argument("--sector-id", required=True,
-                       help="specify name for sector/region used in attributes and filename (example 'LCC')")
+                         help="specify name for sector/region used in attributes and filename (example 'LCC')")
     return group_1, group_2
 
 
@@ -1157,7 +1160,8 @@ def main():
     parser.add_argument("--create-debug", action='store_true',
                         help='Create debug NetCDF files to show tile locations in AWIPS')
     parser.add_argument('-v', '--verbose', dest='verbosity', action="count", default=0,
-                        help='each occurrence increases verbosity 1 level through ERROR-WARNING-INFO-DEBUG (default INFO)')
+                        help='each occurrence increases verbosity 1 level through '
+                             'ERROR-WARNING-INFO-DEBUG (default INFO)')
     parser.add_argument('-l', '--log', dest="log_fn", default=None,
                         help="specify the log filename")
     args = parser.parse_args()

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,8 @@ universal=1
 
 [flake8]
 max-line-length = 120
+exclude =
+    satpy/readers/li_l2.py
 
 [versioneer]
 VCS = git


### PR DESCRIPTION
I ran `flake8 satpy` from the root of the repository and got a lot of errors. I walked through these errors and fixed all but one of them. All of them were style changes except one.

The one I didn't fix is the `li_l2` reader which hasn't been migrated to xarray/dask yet. Instead of removing the failing import I added the reader to the ignored paths in setup.cfg.

The only non-style change was in the mitiff writer (@TAlonglong) where there were bare except statements (`except:`). I changed these to `except (KeyError, ValueError, RuntimeError):` to make flake8 happy and hopefully not change any functionality of the writer. @TAlonglong please verify that these exceptions are what you expected. Catching *all* errors by doing `except:` or `except Exception:` is considered bad practice.

Lastly, some of these changes were just personal preference changes, but still changes that I think go along with the conventions that @pytroll/core have talked about in the past on slack. Some were also to reduce number of broken lines now that we've agreed on 120 max line length.

 - [x] Closes #467 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
