### PR TITLE
Add xarray/dask bilinear resampling

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -38,6 +38,7 @@ Resampling algorithms
     "nearest", "Nearest Neighbor", :class:`~satpy.resample.KDTreeResampler`
     "ewa", "Elliptical Weighted Averaging", :class:`~satpy.resample.EWAResampler`
     "native", "Native", :class:`~satpy.resample.NativeResampler`
+    "bilinear", "Bilinear", :class`~satpy.resample.BilinearResampler`
 
 The resampling algorithm used can be specified with the ``resampler`` keyword
 argument and defaults to ``nearest``:
@@ -84,7 +85,7 @@ Caching for geostationary data
 SatPy will do its best to reuse calculations performed to resample datasets,
 but it can only do this for the current processing and will lose this
 information when the process/script ends. Some resampling algorithms, like
-``nearest``, can benefit by caching intermediate data on disk in the directory
+``nearest`` and ``bilinear``, can benefit by caching intermediate data on disk in the directory
 specified by `cache_dir` and using it next time. This is most beneficial with
 geostationary satellite data where the locations of the source data and the
 target pixels don't change over time.

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -616,7 +616,6 @@ class BilinearResampler(BaseResampler):
                           reduce_data=reduce_data)
 
             self.resampler = XArrayResamplerBilinear(**kwargs)
-
             try:
                 self.load_bil_info(cache_dir, **kwargs)
                 LOG.debug("Loaded bilinear parameters")

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -910,6 +910,7 @@ def mask_source_lonlats(source_def, mask):
     # let's compare them to see if we can use the same area
     # assume lons and lats mask are the same
     if mask is not None and mask is not False and isinstance(source_geo_def, SwathDefinition):
+        import xarray.ufuncs as xu
         if np.issubsctype(mask.dtype, np.bool):
             # copy the source area and use it for the rest of the calculations
             LOG.debug("Copying source area to mask invalid dataset points")

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -387,13 +387,11 @@ class TestNativeResampler(unittest.TestCase):
 class TestBilinearResampler(unittest.TestCase):
     """Test the bilinear resampler."""
 
-    @mock.patch('satpy.resample.BilinearResampler.load_bil_info')
     @mock.patch('satpy.resample.np.savez')
     @mock.patch('satpy.resample.np.load')
     @mock.patch('satpy.resample.BilinearResampler._create_cache_filename')
     @mock.patch('satpy.resample.XArrayResamplerBilinear')
-    def test_bil_resampling(self, resampler, create_filename, load, savez,
-                            load_bil_info):
+    def test_bil_resampling(self, resampler, create_filename, load, savez):
         """Test the bilinear resampler."""
         import numpy as np
         import dask.array as da
@@ -406,7 +404,7 @@ class TestBilinearResampler(unittest.TestCase):
 
         # Test that bilinear resampling info calculation is called,
         # and the info is saved
-        load_bil_info.side_effect = IOError()
+        load.side_effect = IOError()
         resampler = BilinearResampler(source_swath, target_area)
         resampler.precompute(
             mask=da.arange(5, chunks=5).astype(np.bool))
@@ -414,7 +412,8 @@ class TestBilinearResampler(unittest.TestCase):
         resampler.resampler.get_bil_info.assert_called_with()
         self.assertFalse(len(savez.mock_calls), 1)
         resampler.resampler.reset_mock()
-        load_bil_info.reset_mock()
+        load.reset_mock()
+        load.side_effect = None
 
         # Test that get_sample_from_bil_info is called properly
         data = mock.MagicMock()
@@ -424,6 +423,55 @@ class TestBilinearResampler(unittest.TestCase):
         resampler.compute(data, fill_value=fill_value)
         resampler.resampler.get_sample_from_bil_info.assert_called_with(
             data, fill_value=fill_value, output_shape=target_area.shape)
+
+        # Test that the resampling info is tried to read from the disk
+        resampler = BilinearResampler(source_swath, target_area)
+        resampler.precompute(cache_dir='.')
+        load.assert_called()
+
+        # Test caching the resampling info
+        try:
+            the_dir = tempfile.mkdtemp()
+            resampler = BilinearResampler(source_area, target_area)
+            create_filename.return_value = os.path.join(the_dir, 'test_cache.npz')
+            load.reset_mock()
+            load.side_effect = IOError()
+
+            resampler.precompute(cache_dir=the_dir)
+            savez.assert_called()
+            # assert data was saved to the on-disk cache
+            self.assertEqual(len(savez.mock_calls), 1)
+            # assert that load was called to try to load something from disk
+            self.assertEqual(len(load.mock_calls), 1)
+
+            nbcalls = len(resampler.resampler.get_bil_info.mock_calls)
+            # test reusing the resampler
+            load.side_effect = None
+
+            class FakeNPZ(dict):
+                def close(self):
+                    pass
+
+            load.return_value = FakeNPZ(bilinear_s=1,
+                                        bilinear_t=2,
+                                        valid_input_index=3,
+                                        index_array=4)
+            resampler.precompute(cache_dir=the_dir)
+            # we already have things cached in-memory, no need to save again
+            self.assertEqual(len(savez.mock_calls), 1)
+            # we already have things cached in-memory, don't need to load
+            # self.assertEqual(len(load.mock_calls), 1)
+            self.assertEqual(len(resampler.resampler.get_bil_info.mock_calls), nbcalls)
+
+            # test loading saved resampler
+            resampler = BilinearResampler(source_area, target_area)
+            resampler.precompute(cache_dir=the_dir)
+            self.assertEqual(len(load.mock_calls), 2)
+            self.assertEqual(len(resampler.resampler.get_bil_info.mock_calls), nbcalls)
+            # we should have cached things in-memory now
+            # self.assertEqual(len(resampler._index_caches), 1)
+        finally:
+            shutil.rmtree(the_dir)
 
 
 def suite():

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -422,7 +422,8 @@ class TestBilinearResampler(unittest.TestCase):
         data.data = [1, 2, 3]
         fill_value = 8
         resampler.compute(data, fill_value=fill_value)
-        resampler.resampler.get_sample_from_bil_info.assert_called_with(data, fill_value=fill_value, output_shape=target_area.shape)
+        resampler.resampler.get_sample_from_bil_info.assert_called_with(
+            data, fill_value=fill_value, output_shape=target_area.shape)
 
 
 def suite():
@@ -434,6 +435,7 @@ def suite():
     mysuite.addTest(loader.loadTestsFromTestCase(TestKDTreeResampler))
     mysuite.addTest(loader.loadTestsFromTestCase(TestEWAResampler))
     mysuite.addTest(loader.loadTestsFromTestCase(TestHLResample))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestBilinearResampler))
 
     return mysuite
 


### PR DESCRIPTION
This PR adds bilinear interpolation by interfacing the corresponding functionality from pyresample. Note also https://github.com/pytroll/pyresample/issues/148 which is actually the bottleneck killing the performance.

 - [x] Closes #518 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
