### PR TITLE
Add HRV area extent definition for a ROI (area of interest) files

### DIFF
--- a/satpy/readers/native_msg.py
+++ b/satpy/readers/native_msg.py
@@ -277,7 +277,7 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
         # section 3.1.4.2 of MSG Level 1.5 Image Data Format Description
         earth_model = data15hd['GeometricProcessing']['EarthModel'][
             'TypeOfEarthModel']
-        if earth_model not in [1,2]:
+        if earth_model not in [1, 2]:
             raise NotImplementedError(
                 'Unrecognised Earth model: {}'.format(earth_model)
             )
@@ -359,8 +359,6 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
 
             else:
                 raise NotImplementedError('HRV not supported!')
-
-
 
         return area_extent
 

--- a/satpy/readers/native_msg.py
+++ b/satpy/readers/native_msg.py
@@ -84,9 +84,6 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
         self.trailer = {}
         self._read_trailer()
 
-        data15hd = self.header['15_DATA_HEADER']['ImageDescription']['PlannedCoverageHRV']
-        trail = self.trailer['15TRAILER']['ImageProductionStats']['ActualL15CoverageHRV']
-
     @property
     def start_time(self):
         return self.header['15_DATA_HEADER']['ImageAcquisition'][

--- a/satpy/readers/native_msg.py
+++ b/satpy/readers/native_msg.py
@@ -66,6 +66,10 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
                                                    filetype_info)
         self.platform_name = None
 
+        # to be (re)set in read_header in order to keep track whether
+        # we're dealing with a file with an area of interest
+        self.roi = False
+
         # The available channels are only known after the header
         # has been read, after that we know what the indices are for each channel
         self.header = {}
@@ -79,6 +83,9 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
         # Read trailer
         self.trailer = {}
         self._read_trailer()
+
+        data15hd = self.header['15_DATA_HEADER']['ImageDescription']['PlannedCoverageHRV']
+        trail = self.trailer['15TRAILER']['ImageProductionStats']['ActualL15CoverageHRV']
 
     @property
     def start_time(self):
@@ -116,7 +123,9 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
 
             return lrec
 
-        visir_rec = get_lrec(int(self.mda['number_of_columns']*1.25))
+        # each pixel is 10-bits -> one line of data has 25% more bytes
+        # than the number of columns suggest (10/8 = 1.25)
+        visir_rec = get_lrec(int(self.mda['number_of_columns'] * 1.25))
         number_of_lowres_channels = len(
             [s for s in self._channel_list if not s == 'HRV'])
         drec = [('visir', (visir_rec, number_of_lowres_channels))]
@@ -174,51 +183,47 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
                                              'h': 35785831.00,
                                              'ssp_longitude': ssp_lon}
 
-        west = int(sec15hd['WestColumnSelectedRectangle']['Value'])
+        north = int(sec15hd['NorthLineSelectedRectangle']['Value'])
         east = int(sec15hd['EastColumnSelectedRectangle']['Value'])
-        ncols_hrv_hdr = int(sec15hd['NumberColumnsHRV']['Value'])
-        # We suspect the UMARF will pad out any ROI colums that
-        # arent divisible by 4 so here we work out how many pixels have
-        # been added to the column.
-        x = ((west - east + 1) * (10.0 / 8) % 1)
-        y = int((1 - x) * 4)
+        south = int(sec15hd['SouthLineSelectedRectangle']['Value'])
+        west = int(sec15hd['WestColumnSelectedRectangle']['Value'])
 
-        if y < 4:
-            # column has been padded with y pixels
-            cols_visir = int((west - east + 1 + y) * 1.25)
-        else:
-            # no padding has occurred
-            cols_visir = int((west - east + 1) * 1.25)
+        # check if the file has less rows or columns than
+        # the maximum, if so it is an area of interest file
+        # columns and rows start at 1 -> 3712 - 1 = 3711
+        if (north - south < 3711) or (west - east < 3711):
+            self.roi = True
 
-        # HRV Channel - check if an ROI
+        # If the number of columns in the file is not divisible by 4,
+        # UMARF will add extra columns to the file
+        modulo = (west - east + 1) % 4
+        padding = 0
+        if modulo > 0:
+            padding = 4 - modulo
+        cols_visir = west - east + 1 + padding
+
+        # Check the VISIR calculated column dimension against
+        # the header information
+        cols_visir_hdr = int(sec15hd['NumberColumnsVISIR']['Value'])
+        if cols_visir_hdr != cols_visir:
+            logger.warning(
+                "Number of VISIR columns from the header is incorrect!")
+            logger.warning("Header: %d", cols_visir_hdr)
+            logger.warning("Calculated: = %d", cols_visir)
+
+        # HRV Channel - check if the area is reduced in east west
+        # direction as this affects the number of columns in the file
+        cols_hrv_hdr = int(sec15hd['NumberColumnsHRV']['Value'])
         if (west - east) < 3711:
-            cols_hrv = int(np.ceil(ncols_hrv_hdr * 10.0 / 8))  # 6960
+            cols_hrv = cols_hrv_hdr
         else:
-            cols_hrv = int(np.ceil(5568 * 10.0 / 8))  # 6960
+            cols_hrv = int(cols_hrv_hdr / 2)
 
-        # self.mda should represent the 16bit dimensions not 10bit
+        # self.mda represents the 16bit dimensions not 10bit
         self.mda['number_of_lines'] = int(sec15hd['NumberLinesVISIR']['Value'])
-        self.mda['number_of_columns'] = int(cols_visir / 1.25)
+        self.mda['number_of_columns'] = cols_visir
         self.mda['hrv_number_of_lines'] = int(sec15hd["NumberLinesHRV"]['Value'])
-        self.mda['hrv_number_of_columns'] = int(cols_hrv / 1.25)
-
-        # Check the calculated row,column dimensions against the header information:
-        ncols = self.mda['number_of_columns']
-        ncols_hdr = int(sec15hd['NumberLinesVISIR']['Value'])
-
-        if ncols != ncols_hdr:
-            logger.warning(
-                "Number of VISIR columns from header and derived from data are not consistent!")
-            logger.warning("Number of columns read from header = %d", ncols_hdr)
-            logger.warning("Number of columns calculated from data = %d", ncols)
-
-        ncols_hrv = self.mda['hrv_number_of_columns']
-
-        if ncols_hrv != ncols_hrv_hdr:
-            logger.warning(
-                "Number of HRV columns from header and derived from data are not consistent!")
-            logger.warning("Number of columns read from header = %d", ncols_hrv_hdr)
-            logger.warning("Number of columns calculated from data = %d", ncols_hrv)
+        self.mda['hrv_number_of_columns'] = cols_hrv
 
     def _read_trailer(self):
 
@@ -270,43 +275,49 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
         data15hd = self.header['15_DATA_HEADER']
         sec15hd = self.header['15_SECONDARY_PRODUCT_HEADER']
 
-        if dsid.name != 'HRV':
+        # check for Earth model as this affects the north-south and
+        # west-east offsets
+        # section 3.1.4.2 of MSG Level 1.5 Image Data Format Description
+        earth_model = data15hd['GeometricProcessing']['EarthModel'][
+            'TypeOfEarthModel']
+        if earth_model not in [1,2]:
+            raise NotImplementedError(
+                'Unrecognised Earth model: {}'.format(earth_model)
+            )
+        else:
+            # initialize offset assuming no correction needs to be done
+            ns_offset = 0
+            we_offset = 0
 
-            # following calculations assume grid origin is south-east corner
-            # section 7.2.4 of MSG Level 1.5 Image Data Format Description
-            origins = {0: 'NW', 1: 'SW', 2: 'SE', 3: 'NE'}
-            grid_origin = data15hd['ImageDescription'][
-                "ReferenceGridVIS_IR"]["GridOrigin"]
-            if grid_origin != 2:
-                raise NotImplementedError(
-                    'Grid origin not supported number: {}, {} corner'
-                    .format(grid_origin, origins[grid_origin])
-                )
+        # Calculations assume grid origin is south-east corner
+        # section 7.2.4 of MSG Level 1.5 Image Data Format Description
+        origins = {0: 'NW', 1: 'SW', 2: 'SE', 3: 'NE'}
+        grid_origin = data15hd['ImageDescription'][
+            "ReferenceGridVIS_IR"]["GridOrigin"]
+        if grid_origin != 2:
+            raise NotImplementedError(
+                'Grid origin not supported number: {}, {} corner'
+                .format(grid_origin, origins[grid_origin])
+            )
+
+        if dsid.name != 'HRV':
 
             center_point = 3712/2
 
-            north = int(sec15hd["NorthLineSelectedRectangle"]['Value'])
+            north = int(sec15hd['NorthLineSelectedRectangle']['Value'])
             east = int(sec15hd['EastColumnSelectedRectangle']['Value'])
             west = int(sec15hd['WestColumnSelectedRectangle']['Value'])
-            south = int(sec15hd["SouthLineSelectedRectangle"]['Value'])
+            south = int(sec15hd['SouthLineSelectedRectangle']['Value'])
 
             column_step = data15hd['ImageDescription'][
-                "ReferenceGridVIS_IR"]["ColumnDirGridStep"] * 1000.0
+                'ReferenceGridVIS_IR']['ColumnDirGridStep'] * 1000.0
             line_step = data15hd['ImageDescription'][
-                "ReferenceGridVIS_IR"]["LineDirGridStep"] * 1000.0
+                'ReferenceGridVIS_IR']['LineDirGridStep'] * 1000.0
+
             # section 3.1.4.2 of MSG Level 1.5 Image Data Format Description
-            earth_model = data15hd['GeometricProcessing']['EarthModel'][
-                'TypeOfEarthModel']
-            if earth_model == 2:
-                ns_offset = 0  # north +ve
-                we_offset = 0  # west +ve
-            elif earth_model == 1:
+            if earth_model == 1:
                 ns_offset = -0.5  # north +ve
                 we_offset = 0.5  # west +ve
-            else:
-                raise NotImplementedError(
-                    'unrecognised earth model: {}'.format(earth_model)
-                )
 
             # section 3.1.5 of MSG Level 1.5 Image Data Format Description
             ll_c = (center_point - west - 0.5 + we_offset) * column_step
@@ -318,7 +329,41 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
 
         else:
 
-            raise NotImplementedError('HRV not supported!')
+            # section 3.1.4.2 of MSG Level 1.5 Image Data Format Description
+            if earth_model == 1:
+                ns_offset = -1.5  # north +ve
+                we_offset = 1.5  # west +ve
+
+            if self.roi:
+                center_point = 11136/2
+
+                north = int(sec15hd['NorthLineSelectedRectangle']['Value']) * 3
+                east = int(sec15hd['EastColumnSelectedRectangle']['Value']) * 3
+                west = int(sec15hd['WestColumnSelectedRectangle']['Value']) * 3
+                south = int(sec15hd['SouthLineSelectedRectangle']['Value']) * 3
+
+                column_step = data15hd['ImageDescription'][
+                    'ReferenceGridHRV']['ColumnDirGridStep'] * 1000.0
+                line_step = data15hd['ImageDescription'][
+                    'ReferenceGridHRV']['LineDirGridStep'] * 1000.0
+
+                # section 3.1.4.2 of MSG Level 1.5 Image Data Format Description
+                if earth_model == 1:
+                    ns_offset = -1.5  # north +ve
+                    we_offset = 1.5  # west +ve
+
+                # section 3.1.5 of MSG Level 1.5 Image Data Format Description
+                ll_c = (center_point - west - 0.5 + we_offset) * column_step
+                ll_l = (south - center_point - 0.5 + ns_offset) * line_step
+                ur_c = (center_point - east + 0.5 + we_offset) * column_step
+                ur_l = (north - center_point + 0.5 + ns_offset) * line_step
+
+                area_extent = (ll_c, ll_l, ur_c, ur_l)
+
+            else:
+                raise NotImplementedError('HRV not supported!')
+
+
 
         return area_extent
 


### PR DESCRIPTION
Add HRV area extent definition for a ROI (area of interest) files. StackedAreaDefinition is still missing for full disk files.

 - [x ] Tests passed <!-- for all non-documentation changes -->
 - [x ] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 
