### PR TITLE
Fix copy/paste error in readers table for viirs_l1b

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -141,7 +141,7 @@ installation.
       - `viirs_sdr`
       - Nominal
     * - SNPP VIIRS data in netCDF4 L1B format
-      - `viirs_sdr`
+      - `viirs_l1b`
       - Nominal
     * - SNPP VIIRS data in hdf5 Compact format
       - `viirs_compact`


### PR DESCRIPTION
I accidentally reused `viirs_sdr` in the documentation's reader table when it should be `viirs_l1b`.