### PR TITLE
Fix palette application for pps 2018 products

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -718,23 +718,28 @@ class ColormapCompositor(GenericCompositor):
     def build_colormap(palette, dtype, info):
         """Create the colormap from the `raw_palette` and the valid_range."""
         from trollimage.colormap import Colormap
+        sqpalette = np.asanyarray(palette).squeeze() / 255.0
+        if 'palette_meanings' in palette.attrs:
+            meanings = [int(val) for val in palette.attrs['palette_meanings'].split()]
+            iterator = zip(meanings, sqpalette)
+        else:
+            iterator = enumerate(sqpalette[:-1])
 
-        palette = np.asanyarray(palette).squeeze()
         if dtype == np.dtype('uint8'):
             tups = [(val, tuple(tup))
-                    for (val, tup) in enumerate(palette[:-1])]
+                    for (val, tup) in iterator]
             colormap = Colormap(*tups)
 
         elif 'valid_range' in info:
             tups = [(val, tuple(tup))
-                    for (val, tup) in enumerate(palette[:-1])]
+                    for (val, tup) in iterator]
             colormap = Colormap(*tups)
 
             sf = info.get('scale_factor', np.array(1))
             colormap.set_range(
                 *info['valid_range'] * sf + info.get('add_offset', 0))
 
-        return colormap
+        return colormap, sqpalette
 
 
 class ColorizeCompositor(ColormapCompositor):
@@ -749,8 +754,7 @@ class ColorizeCompositor(ColormapCompositor):
         # writer.
 
         data, palette = projectables
-        palette = np.asanyarray(palette).squeeze()
-        colormap = self.build_colormap(palette / 255.0, data.dtype, data.attrs)
+        colormap, palette = self.build_colormap(palette, data.dtype, data.attrs)
 
         r, g, b = colormap.colorize(np.asanyarray(data))
         r[data.mask] = palette[-1][0]
@@ -776,8 +780,7 @@ class PaletteCompositor(ColormapCompositor):
         # writer.
 
         data, palette = projectables
-        palette = np.asanyarray(palette).squeeze() / 255.0
-        colormap = self.build_colormap(palette, data.dtype, data.attrs)
+        colormap, palette = self.build_colormap(palette, data.dtype, data.attrs)
 
         channels, colors = colormap.palettize(np.asanyarray(data.squeeze()))
         channels = palette[channels]

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -719,8 +719,8 @@ class ColormapCompositor(GenericCompositor):
         """Create the colormap from the `raw_palette` and the valid_range."""
         from trollimage.colormap import Colormap
         sqpalette = np.asanyarray(palette).squeeze() / 255.0
-        if 'palette_meanings' in palette.attrs:
-            meanings = [int(val) for val in palette.attrs['palette_meanings'].split()]
+        if hasattr(palette, 'attrs') and 'palette_meanings' in palette.attrs:
+            meanings = palette.attrs['palette_meanings']
             iterator = zip(meanings, sqpalette)
         else:
             iterator = enumerate(sqpalette[:-1])

--- a/satpy/composites/cloud_products.py
+++ b/satpy/composites/cloud_products.py
@@ -39,7 +39,7 @@ class CloudTopHeightCompositor(ColormapCompositor):
 
         from trollimage.colormap import Colormap
         if 'palette_meanings' in palette.attrs:
-            palette_indices = [int(val) for val in palette.attrs['palette_meanings'].split()]
+            palette_indices = palette.attrs['palette_meanings']
         else:
             palette_indices = range(len(palette))
 

--- a/satpy/composites/cloud_products.py
+++ b/satpy/composites/cloud_products.py
@@ -43,16 +43,16 @@ class CloudTopHeightCompositor(ColormapCompositor):
         else:
             palette_indices = range(len(palette))
 
-        palette = np.asanyarray(palette).squeeze() / 255.0
+        sqpalette = np.asanyarray(palette).squeeze() / 255.0
         tups = [(val, tuple(tup))
-                for (val, tup) in zip(palette_indices, palette)]
+                for (val, tup) in zip(palette_indices, sqpalette)]
         colormap = Colormap(*tups)
+        if 'palette_meanings' not in palette.attrs:
+            sf = info.get('scale_factor', np.array(1))
+            colormap.set_range(
+                *(np.array(info['valid_range']) * sf + info.get('add_offset', 0)))
 
-        sf = info.get('scale_factor', np.array(1))
-        colormap.set_range(
-            *(np.array(info['valid_range']) * sf + info.get('add_offset', 0)))
-
-        return colormap, palette
+        return colormap, sqpalette
 
     def __call__(self, projectables, **info):
         """Create the composite."""

--- a/satpy/readers/nc_nwcsaf.py
+++ b/satpy/readers/nc_nwcsaf.py
@@ -162,6 +162,10 @@ class NcNWCSAF(BaseFileHandler):
         except AttributeError:
             pass
 
+        if 'palette_meanings' in variable.attrs:
+            variable.attrs['palette_meanings'] = [int(val)
+                                                  for val in variable.attrs['palette_meanings'].split()]
+
         if 'standard_name' in info:
             variable.attrs.setdefault('standard_name', info['standard_name'])
         if self.sw_version == 'NWC/PPS version v2014' and dsid.name == 'ctth_alti':

--- a/satpy/readers/nc_nwcsaf.py
+++ b/satpy/readers/nc_nwcsaf.py
@@ -76,6 +76,7 @@ class NcNWCSAF(BaseFileHandler):
                                   chunks=CHUNK_SIZE)
 
         self.nc = self.nc.rename({'nx': 'x', 'ny': 'y'})
+        self.sw_version = self.nc.attrs['source']
         self.pps = False
 
         try:
@@ -108,7 +109,6 @@ class NcNWCSAF(BaseFileHandler):
         if dsid_name in self.cache:
             logger.debug('Get the data set from cache: %s.', dsid_name)
             return self.cache[dsid_name]
-
         if dsid_name in ['lon', 'lat'] and dsid_name not in self.nc:
             dsid_name = dsid_name + '_reduced'
 
@@ -131,7 +131,7 @@ class NcNWCSAF(BaseFileHandler):
         variable = remove_empties(variable)
         scale = variable.attrs.get('scale_factor', np.array(1))
         offset = variable.attrs.get('add_offset', np.array(0))
-        if np.issubdtype((scale + offset).dtype, np.floating):
+        if np.issubdtype((scale + offset).dtype, np.floating) or np.issubdtype(variable.dtype, np.floating):
             if '_FillValue' in variable.attrs:
                 variable = variable.where(
                     variable != variable.attrs['_FillValue'])
@@ -164,12 +164,11 @@ class NcNWCSAF(BaseFileHandler):
 
         if 'standard_name' in info:
             variable.attrs.setdefault('standard_name', info['standard_name'])
-
-        if self.pps and dsid.name == 'ctth_alti':
-            # pps valid range and palette don't match
+        if self.sw_version == 'NWC/PPS version v2014' and dsid.name == 'ctth_alti':
+            # pps 2014 valid range and palette don't match
             variable.attrs['valid_range'] = (0., 9000.)
-        if self.pps and dsid.name == 'ctth_alti_pal':
-            # pps palette has the nodata color (black) first
+        if self.sw_version == 'NWC/PPS version v2014' and dsid.name == 'ctth_alti_pal':
+            # pps 2014 palette has the nodata color (black) first
             variable = variable[1:, :]
 
         return variable

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -378,6 +378,7 @@ def suite():
     mysuite.addTest(loader.loadTestsFromTestCase(TestInlineComposites))
     mysuite.addTest(loader.loadTestsFromTestCase(TestColormapCompositor))
     mysuite.addTest(loader.loadTestsFromTestCase(TestPaletteCompositor))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestCloudTopHeightCompositor))
 
     return mysuite
 

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -340,6 +340,29 @@ class TestPaletteCompositor(unittest.TestCase):
         self.assertTrue(np.allclose(res, exp))
 
 
+class TestCloudTopHeightCompositor(unittest.TestCase):
+    """Test the CloudTopHeightCompositor."""
+
+    def test_call(self):
+        from satpy.composites.cloud_products import CloudTopHeightCompositor
+        import numpy as np
+        import xarray as xr
+        cmap_comp = CloudTopHeightCompositor('test_cmap_compositor')
+        palette = xr.DataArray(np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]]),
+                               dims=['value', 'band'])
+        palette.attrs['palette_meanings'] = [2, 3, 4]
+        status = np.array([1, 0, 1])
+        data = xr.DataArray(np.array([[4, 3, 2], [2, 3, 4]], dtype=np.uint8), dims=['y', 'x'])
+        res = cmap_comp([data, palette, status])
+        exp = np.array([[[0., 0.498039, 0.],
+                         [0., 0.498039, 0.]],
+                        [[0., 0.498039, 0.],
+                         [0., 0.498039, 0.]],
+                        [[0., 0.498039, 0.],
+                         [0., 0.498039, 0.]]])
+        self.assertTrue(np.allclose(res, exp))
+
+
 def suite():
     """Test suite for all reader tests"""
     loader = unittest.TestLoader()

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -296,6 +296,50 @@ class TestInlineComposites(unittest.TestCase):
                          ['IR_108', 'IR_087'])
 
 
+class TestColormapCompositor(unittest.TestCase):
+    """Test the ColormapCompositor."""
+
+    def test_build_colormap(self):
+        from satpy.composites import ColormapCompositor
+        import numpy as np
+        import xarray as xr
+        cmap_comp = ColormapCompositor('test_cmap_compositor')
+        palette = np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]])
+        cmap, sqpal = cmap_comp.build_colormap(palette, np.uint8, {})
+        self.assertTrue(np.allclose(cmap.values, [0, 1]))
+        self.assertTrue(np.allclose(sqpal, palette / 255.0))
+
+        palette = xr.DataArray(np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]]),
+                               dims=['value', 'band'])
+        palette.attrs['palette_meanings'] = [2, 3, 4]
+        cmap, sqpal = cmap_comp.build_colormap(palette, np.uint8, {})
+        self.assertTrue(np.allclose(cmap.values, [2, 3, 4]))
+        self.assertTrue(np.allclose(sqpal, palette / 255.0))
+
+
+class TestPaletteCompositor(unittest.TestCase):
+    """Test the PaletteCompositor."""
+
+    def test_call(self):
+        from satpy.composites import PaletteCompositor
+        import numpy as np
+        import xarray as xr
+        cmap_comp = PaletteCompositor('test_cmap_compositor')
+        palette = xr.DataArray(np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]]),
+                               dims=['value', 'band'])
+        palette.attrs['palette_meanings'] = [2, 3, 4]
+
+        data = xr.DataArray(np.array([[4, 3, 2], [2, 3, 4]], dtype=np.uint8), dims=['y', 'x'])
+        res = cmap_comp([data, palette])
+        exp = np.array([[[1., 0.498039, 0.],
+                         [0., 0.498039, 1.]],
+                        [[1., 0.498039, 0.],
+                         [0., 0.498039, 1.]],
+                        [[1., 0.498039, 0.],
+                         [0., 0.498039, 1.]]])
+        self.assertTrue(np.allclose(res, exp))
+
+
 def suite():
     """Test suite for all reader tests"""
     loader = unittest.TestLoader()
@@ -309,6 +353,8 @@ def suite():
     mysuite.addTest(loader.loadTestsFromTestCase(TestSandwichCompositor))
     mysuite.addTest(loader.loadTestsFromTestCase(TestLuminanceSharpeningCompositor))
     mysuite.addTest(loader.loadTestsFromTestCase(TestInlineComposites))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestColormapCompositor))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestPaletteCompositor))
 
     return mysuite
 


### PR DESCRIPTION
This PR fixes the palette handling for PPS 2018 products. It allows the use of the `palette_meanings` attribute when available (palette indices).

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
