### PR TITLE
Add configurable parameters to solar zenith correctors

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -313,14 +313,14 @@ class SunZenithCorrectorBase(CompositeBase):
 
     coszen = WeakValueDictionary()
 
-    def __init__(self, min_sza=0.0, max_sza=90.0, **kwargs):
+    def __init__(self, min_sza=0.0, max_sza=95.0, **kwargs):
         """Collect custom configuration values.
 
         Args:
             min_sza (float): Minimum solar zenith angle in degrees that is
                 considered valid and correctable. Default 0.0.
             max_sza (float): Maximum solar zenith angle in degrees that is
-                considered valid and correctable. Default 90.0.
+                considered valid and correctable. Default 95.0.
 
         """
         self.min_sza = np.cos(np.deg2rad(min_sza)) if min_sza is not None else None
@@ -370,7 +370,13 @@ class SunZenithCorrectorBase(CompositeBase):
 
 
 class SunZenithCorrector(SunZenithCorrectorBase):
-    """Standard sun zenith correction, 1/cos(sunz)."""
+    """Standard sun zenith correction using ``1 / cos(sunz)``.
+
+    In addition to adjusting the provided reflectances by the cosine of the
+    solar zenith angle, this modifier also forces all reflectances beyond a
+    solar zenith angle of `max_sza` to 0.
+
+    """
 
     def __init__(self, correction_limit=88., **kwargs):
         """Collect custom configuration values.
@@ -382,7 +388,7 @@ class SunZenithCorrector(SunZenithCorrectorBase):
             min_sza (float): Minimum solar zenith angle in degrees that is
                 considered valid and correctable. Default 0.0.
             max_sza (float): Maximum solar zenith angle in degrees that is
-                considered valid and correctable. Default 90.0.
+                considered valid and correctable. Default 95.0.
 
         """
         self.correction_limit = correction_limit
@@ -398,6 +404,10 @@ class EffectiveSolarPathLengthCorrector(SunZenithCorrectorBase):
 
     (2006): https://doi.org/10.1175/JAS3682.1
 
+    In addition to adjusting the provided reflectances by the cosine of the
+    solar zenith angle, this modifier also forces all reflectances beyond a
+    solar zenith angle of `max_sza` to 0 to reduce noise in the final data.
+
     """
 
     def __init__(self, correction_limit=88., **kwargs):
@@ -410,7 +420,7 @@ class EffectiveSolarPathLengthCorrector(SunZenithCorrectorBase):
             min_sza (float): Minimum solar zenith angle in degrees that is
                 considered valid and correctable. Default 0.0.
             max_sza (float): Maximum solar zenith angle in degrees that is
-                considered valid and correctable. Default 90.0.
+                considered valid and correctable. Default 95.0.
 
         """
         self.correction_limit = correction_limit

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -334,10 +334,7 @@ class SunZenithCorrectorBase(CompositeBase):
             LOG.debug("Sun zen correction already applied")
             return vis
 
-        if hasattr(vis.attrs["area"], 'area_id'):
-            area_name = vis.attrs["area"].area_id
-        else:
-            area_name = 'swath' + str(vis.shape)
+        area_name = hash(vis.attrs['area'])
         key = (vis.attrs["start_time"], area_name)
         tic = time.time()
         LOG.debug("Applying sun zen correction")
@@ -364,7 +361,6 @@ class SunZenithCorrectorBase(CompositeBase):
 
         proj = self._apply_correction(vis, coszen)
         proj.attrs = vis.attrs.copy()
-        proj.attrs.update(info)
         self.apply_modifier_info(vis, proj)
         LOG.debug("Sun-zenith correction applied. Computation time: %5.1f (sec)", time.time() - tic)
         return proj

--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -160,7 +160,7 @@ class ReflectanceCorrector(CompositeBase):
         lons, lats = vis.attrs['area'].get_lonlats_dask(
             chunks=vis.data.chunks)
         suna = get_alt_az(vis.attrs['start_time'], lons, lats)[1]
-        suna = xu.rad2deg(suna)
+        suna = np.rad2deg(suna)
         sunz = sun_zenith_angle(vis.attrs['start_time'], lons, lats)
         sata, satel = get_observer_look(
             vis.attrs['satellite_longitude'],

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -4,10 +4,12 @@ modifiers:
   sunz_corrected:
     compositor: !!python/name:satpy.composites.SunZenithCorrector
     optional_prerequisites:
-    - satellite_zenith_angle
+    - solar_zenith_angle
 
   effective_solar_pathlength_corrected:
     compositor: !!python/name:satpy.composites.EffectiveSolarPathLengthCorrector
+    optional_prerequisites:
+      - solar_zenith_angle
 
   co2_corrected:
     compositor: !!python/name:satpy.composites.CO2Corrector

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -75,7 +75,6 @@ enhancements:
     operations:
     - name: stretch
       method: *stretchfun
-      #      kwargs: {stretch: crude, min_stretch: 0.0, max_stretch: 1.0}
       kwargs: {stretch: crude, min_stretch: 0, max_stretch: 120}
     - name: gamma
       method: *gammafun

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -66,6 +66,7 @@ enhancements:
     operations:
     - name: stretch
       method: *stretchfun
+      #      kwargs: {stretch: crude, min_stretch: 0.0, max_stretch: 1.0}
       kwargs: {stretch: crude, min_stretch: 0, max_stretch: 120}
     - name: gamma
       method: *gammafun

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -143,7 +143,7 @@ class TestSunZenithCorrector(unittest.TestCase):
         from satpy.composites import SunZenithCorrector
         comp = SunZenithCorrector(name='sza_test', modifiers=tuple())
         res = comp((self.ds1,), test_attr='test')
-        np.testing.assert_allclose(res.values, np.array([[28.653708, 28.653708], [28.653708, 28.653708]]))
+        np.testing.assert_allclose(res.values, np.array([[22.401667, 22.31777 ], [22.437503, 22.353533]]))
 
     def test_basic_lims_not_provided(self):
         """Test custom limits when SZA isn't provided."""
@@ -157,7 +157,7 @@ class TestSunZenithCorrector(unittest.TestCase):
         from satpy.composites import SunZenithCorrector
         comp = SunZenithCorrector(name='sza_test', modifiers=tuple())
         res = comp((self.ds1, self.sza), test_attr='test')
-        np.testing.assert_allclose(res.values, np.array([[28.653708, 28.653708], [28.653708, 28.653708]]))
+        np.testing.assert_allclose(res.values, np.array([[22.401667, 22.31777 ], [22.437503, 22.353533]]))
 
     def test_basic_lims_provided(self):
         """Test custom limits when SZA is provided."""

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -121,7 +121,6 @@ class TestSunZenithCorrector(unittest.TestCase):
     def setUp(self):
         """Create test data."""
         from pyresample.geometry import AreaDefinition
-        from pyorbital.astronomy import cos_zen
         area = AreaDefinition('test', 'test', 'test',
                               {'proj': 'merc'}, 2, 2,
                               (-2000, -2000, 2000, 2000))
@@ -144,7 +143,6 @@ class TestSunZenithCorrector(unittest.TestCase):
         from satpy.composites import SunZenithCorrector
         comp = SunZenithCorrector(name='sza_test', modifiers=tuple())
         res = comp((self.ds1,), test_attr='test')
-        self.assertIn('test_attr', res.attrs)
         np.testing.assert_allclose(res.values, np.array([[28.653708, 28.653708], [28.653708, 28.653708]]))
 
     def test_basic_lims_not_provided(self):
@@ -152,7 +150,6 @@ class TestSunZenithCorrector(unittest.TestCase):
         from satpy.composites import SunZenithCorrector
         comp = SunZenithCorrector(name='sza_test', modifiers=tuple(), correction_limit=90)
         res = comp((self.ds1,), test_attr='test')
-        self.assertIn('test_attr', res.attrs)
         np.testing.assert_allclose(res.values, np.array([[66.853262, 68.168939], [66.30742, 67.601493]]))
 
     def test_basic_default_provided(self):
@@ -160,7 +157,6 @@ class TestSunZenithCorrector(unittest.TestCase):
         from satpy.composites import SunZenithCorrector
         comp = SunZenithCorrector(name='sza_test', modifiers=tuple())
         res = comp((self.ds1, self.sza), test_attr='test')
-        self.assertIn('test_attr', res.attrs)
         np.testing.assert_allclose(res.values, np.array([[28.653708, 28.653708], [28.653708, 28.653708]]))
 
     def test_basic_lims_provided(self):
@@ -168,7 +164,6 @@ class TestSunZenithCorrector(unittest.TestCase):
         from satpy.composites import SunZenithCorrector
         comp = SunZenithCorrector(name='sza_test', modifiers=tuple(), correction_limit=90)
         res = comp((self.ds1, self.sza), test_attr='test')
-        self.assertIn('test_attr', res.attrs)
         np.testing.assert_allclose(res.values, np.array([[66.853262, 68.168939], [66.30742, 67.601493]]))
 
 

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -39,8 +39,6 @@ class TestCheckArea(unittest.TestCase):
 
     def _get_test_ds(self, shape=(50, 100), dims=('y', 'x')):
         """Helper method to get a fake DataArray."""
-        import xarray as xr
-        import dask.array as da
         from pyresample.geometry import AreaDefinition
         data = da.random.random(shape, chunks=25)
         area = AreaDefinition(
@@ -172,10 +170,6 @@ class TestDayNightCompositor(unittest.TestCase):
 
     def setUp(self):
         """Create test data."""
-        import xarray as xr
-        import dask.array as da
-        import numpy as np
-        from datetime import datetime
         bands = ['R', 'G', 'B']
         start_time = datetime(2018, 1, 1, 18, 0, 0)
 
@@ -215,7 +209,6 @@ class TestDayNightCompositor(unittest.TestCase):
 
     def test_basic_sza(self):
         """Test compositor when SZA data is included"""
-        import numpy as np
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test')
         res = comp((self.data_a, self.data_b, self.sza))
@@ -225,7 +218,6 @@ class TestDayNightCompositor(unittest.TestCase):
 
     def test_basic_area(self):
         """Test compositor when SZA data is not provided."""
-        import numpy as np
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test')
         res = comp((self.data_a, self.data_b))
@@ -237,8 +229,6 @@ class TestDayNightCompositor(unittest.TestCase):
 class TestFillingCompositor(unittest.TestCase):
 
     def test_fill(self):
-        import numpy as np
-        import xarray as xr
         from satpy.composites import FillingCompositor
         comp = FillingCompositor(name='fill_test')
         filler = xr.DataArray(np.array([1, 2, 3, 4, 3, 2, 1]))
@@ -256,8 +246,6 @@ class TestLuminanceSharpeningCompositor(unittest.TestCase):
 
     def test_compositor(self):
         """Test luminance sharpening compositor."""
-        import numpy as np
-        import xarray as xr
         from satpy.composites import LuminanceSharpeningCompositor
         comp = LuminanceSharpeningCompositor(name='test')
         # Three shades of grey
@@ -292,8 +280,6 @@ class TestSandwichCompositor(unittest.TestCase):
     @mock.patch('satpy.composites.enhance2dataset')
     def test_compositor(self, e2d):
         """Test luminance sharpening compositor."""
-        import numpy as np
-        import xarray as xr
         from satpy.composites import SandwichCompositor
 
         rgb_arr = np.random.random((3, 2, 2))

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -143,7 +143,7 @@ class TestSunZenithCorrector(unittest.TestCase):
         from satpy.composites import SunZenithCorrector
         comp = SunZenithCorrector(name='sza_test', modifiers=tuple())
         res = comp((self.ds1,), test_attr='test')
-        np.testing.assert_allclose(res.values, np.array([[22.401667, 22.31777 ], [22.437503, 22.353533]]))
+        np.testing.assert_allclose(res.values, np.array([[22.401667, 22.31777], [22.437503, 22.353533]]))
 
     def test_basic_lims_not_provided(self):
         """Test custom limits when SZA isn't provided."""
@@ -157,7 +157,7 @@ class TestSunZenithCorrector(unittest.TestCase):
         from satpy.composites import SunZenithCorrector
         comp = SunZenithCorrector(name='sza_test', modifiers=tuple())
         res = comp((self.ds1, self.sza), test_attr='test')
-        np.testing.assert_allclose(res.values, np.array([[22.401667, 22.31777 ], [22.437503, 22.353533]]))
+        np.testing.assert_allclose(res.values, np.array([[22.401667, 22.31777], [22.437503, 22.353533]]))
 
     def test_basic_lims_provided(self):
         """Test custom limits when SZA is provided."""

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -134,7 +134,9 @@ class TestSunZenithCorrector(unittest.TestCase):
             np.rad2deg(np.arccos(da.from_array([[0.0149581333, 0.0146694376], [0.0150812684, 0.0147925727]],
                                                chunks=2))),
             attrs={'area': area},
-            dims=('y', 'x'))
+            dims=('y', 'x'),
+            coords={'y': [0, 1], 'x': [0, 1]},
+        )
 
     def test_basic_default_not_provided(self):
         """Test default limits when SZA isn't provided."""

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -212,27 +212,39 @@ def _get_sunz_corr_li_and_shibata(cos_zen):
     return 24.35 / (2. * cos_zen + xu.sqrt(498.5225 * cos_zen**2 + 1))
 
 
-def sunzen_corr_cos(data, cos_zen, limit=88.):
+def sunzen_corr_cos(data, cos_zen, limit=88., max_sza=95.):
     """Perform Sun zenith angle correction.
 
     The correction is based on the provided cosine of the zenith
-    angle (*cos_zen*).  The correction is limited
-    to *limit* degrees (default: 88.0 degrees).  For larger zenith
-    angles, the correction is the same as at the *limit*.  Both *data*
-    and *cos_zen* are given as 2-dimensional Numpy arrays or Numpy
-    MaskedArrays, and they should have equal shapes.
+    angle (``cos_zen``).  The correction is limited
+    to ``limit`` degrees (default: 88.0 degrees).  For larger zenith
+    angles, the correction is the same as at the ``limit`` if ``max_sza``
+    is `None`. The default behavior is to gradually reduce the correction
+    past ``limit`` degrees up to ``max_sza`` where the correction becomes
+    0. Both ``data`` and ``cos_zen`` should be 2D arrays of the same shape.
 
     """
 
     # Convert the zenith angle limit to cosine of zenith angle
-    limit = np.cos(np.deg2rad(limit))
+    limit_rad = np.deg2rad(limit)
+    limit_cos = np.cos(limit_rad)
+    max_sza_rad = np.deg2rad(max_sza) if max_sza is not None else max_sza
 
     # Cosine correction
     corr = 1. / cos_zen
-    # Use constant value (the limit) for larger zenith angles
-    corr = corr.where(cos_zen > limit, 1 / limit)
+    if max_sza is not None:
+        # gradually fall off for larger zenith angle
+        grad_factor = (np.arccos(cos_zen) - limit_rad) / (max_sza_rad - limit_rad)
+        # invert the factor so maximum correction is done at `limit` and falls off later
+        grad_factor = 1. - np.log(grad_factor + 1) / np.log(2)
+        # make sure we don't make anything negative
+        grad_factor = grad_factor.clip(0.)
+    else:
+        # Use constant value (the limit) for larger zenith angles
+        grad_factor = 1.
+    corr = corr.where(cos_zen > limit_cos, grad_factor / limit_cos)
     # Force "night" pixels to 0 (where SZA is invalid)
-    data = data.where(cos_zen.notnull(), 0)
+    corr = corr.where(cos_zen.notnull(), 0)
 
     return data * corr
 

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -230,7 +230,9 @@ def sunzen_corr_cos(data, cos_zen, limit=88.):
     # Cosine correction
     corr = 1. / cos_zen
     # Use constant value (the limit) for larger zenith angles
-    corr = corr.where((cos_zen > limit) | cos_zen.isnull(), 1 / limit)
+    corr = corr.where(cos_zen > limit, 1 / limit)
+    # Force "night" pixels to 0 (where SZA is invalid)
+    data = data.where(cos_zen.notnull(), 0)
 
     return data * corr
 
@@ -255,6 +257,8 @@ def atmospheric_path_length_correction(data, cos_zen, limit=88.):
     corr = _get_sunz_corr_li_and_shibata(cos_zen)
     # Use constant value (the limit) for larger zenith angles
     corr_lim = _get_sunz_corr_li_and_shibata(limit)
-    corr = corr.where((cos_zen > limit) | cos_zen.isnull(), corr_lim)
+    corr = corr.where(cos_zen > limit, corr_lim)
+    # Force "night" pixels to 0 (where SZA is invalid)
+    data = data.where(cos_zen.notnull(), 0)
 
     return data * corr

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ import versioneer
 
 from setuptools import find_packages, setup
 
-requires = ['numpy >=1.12', 'pillow', 'pyresample >=1.10.3', 'trollsift',
+requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.10.3', 'trollsift',
             'trollimage >=1.5.1', 'pykdtree', 'six', 'pyyaml', 'xarray >=0.10.1',
             'dask[array] >=0.17.1']
 


### PR DESCRIPTION
## Main Purpose

This PR adds YAML-configurable parameters to the two solar-zenith correctors/modifiers. The three parameters that are now available in both are:

* **correction_limit** (float): Maximum solar zenith angle to apply the correction in degrees. Pixels beyond this limit have a constant correction applied. Default 88.
* **min_sza** (float): Minimum solar zenith angle in degrees that is considered valid and correctable. Default 0.0.
* **max_sza** (float): Maximum solar zenith angle in degrees that is considered valid and correctable. Default 90.0.

## Behavior Change

Currently, this PR has changed the default values for these parameters based on some tests I did with ABI natural_color and true_color RGBs. Previously, the equivalent value for `max_sza` was `None` due to some undesired (in my opinion) usage of the fill values in the correction code. The way the corrections were previously set up is that for data past 88 degrees a constant correction is applied to the data regardless of SZA. So for SZA 0 to 88 the correction was applied normally, for 88-90+ a constant correction was being applied, even if SZA was NaN. In this PR I've changed it to be corrected from 0 to 88, constant from 88-90 (`max_sza`), and NaN after that. This allows satpy and the user to say "anything past this SZA isn't useful data". The main reason for this change was due to noticing that ABI natural color RGBs were having night time pixels "corrected", increasing the "useless" data values.

Note that the user can get the same behavior as before by specifying `max_sza: !!null` in the YAML for the `sunz_corrected`.

I am ok not including this behavior change (I'd still like it) because I can have it customized in my own projects (Polar2Grid/Geo2Grid).

## Examples

NOTE: The default True Color enhancement sets all negative reflectances to NaN/transparent.

### GOES-16 ABI True Color - Old

![image](https://user-images.githubusercontent.com/1828519/49879310-5501ea00-fdef-11e8-8aee-28bc4f9225ba.png)

### GOES-16 ABI Natural Color - Old

![image](https://user-images.githubusercontent.com/1828519/49879347-66e38d00-fdef-11e8-85a4-1c9060aea23a.png)

### GOES-16 ABI True Color - 0 to 88 to 90

![image](https://user-images.githubusercontent.com/1828519/49879397-7d89e400-fdef-11e8-94c5-3c589608f14e.png)

### GOES-16 ABI Natural Color - 0 to 88 to 90

![image](https://user-images.githubusercontent.com/1828519/49879426-8e3a5a00-fdef-11e8-8975-bae273179315.png)

### GOES-16 ABI True Color - 0 to 88 to 92

![image](https://user-images.githubusercontent.com/1828519/49879452-a1e5c080-fdef-11e8-8910-8a0e071ff5ed.png)

### GOES-16 ABI Natural Color - 0 to 88 to 92

![image](https://user-images.githubusercontent.com/1828519/49879490-b1650980-fdef-11e8-8c30-4ab8aee14e63.png)

### GOES-16 ABI True Color - 0 to 88 to 95

Same as 0 to 88 to 92 image.

### GOES-16 ABI Natural Color - 0 to 88 to 95

![image](https://user-images.githubusercontent.com/1828519/49879601-ec673d00-fdef-11e8-964c-aea00e7ed980.png)

## Miscellaneous

I originally started working on this because the natural color image shows bright green and red pixels in the night time data. I was able to prove that negative reflectances were part of the problem and were being made worse by the SZA corrector and by the sharpening code. However, it didn't get rid of all of it and cutting off the SZA correction seemed to make more sense.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
