### PR TITLE
Fix EWA resampling for new versions of pyresample

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -498,10 +498,14 @@ class EWAResampler(BaseResampler):
 
         # SatPy/PyResample don't support dynamic grids out of the box yet
         lons, lats = source_geo_def.get_lonlats()
+        if isinstance(lons, xr.DataArray):
+            # get dask arrays
+            lons = lons.data
+            lats = lats.data
         # we are remapping to a static unchanging grid/area with all of
         # its parameters specified
         chunks = (2,) + lons.chunks
-        res = da.map_blocks(self._call_ll2cr, lons.data, lats.data,
+        res = da.map_blocks(self._call_ll2cr, lons, lats,
                             target_geo_def, swath_usage,
                             dtype=lons.dtype, chunks=chunks, new_axis=[0])
         cols = res[0]


### PR DESCRIPTION
The current pyresample master branch returns dask arrays from
get_lonlats if they were already dask arrays underneath. Previously
this method would return whatever was passed to SwathDefinition.

This was caught by my local tests where I'm using pyresample master branch. This would have been caught by tests in the future once the new pyresample is released, so no tests were added. I'm just fixing this preemptively.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
