### PR TITLE
Fix DifferenceCompositor when areas are incompatible

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -677,8 +677,8 @@ class DifferenceCompositor(CompositeBase):
 
     def __call__(self, projectables, nonprojectables=None, **info):
         if len(projectables) != 2:
-            raise ValueError("Expected 2 datasets, got %d" %
-                             (len(projectables), ))
+            raise ValueError("Expected 2 datasets, got %d" % (len(projectables),))
+        projectables = self.check_areas(projectables)
         info = combine_metadata(*projectables)
         info['name'] = self.attrs['name']
 


### PR DESCRIPTION
Fix #552

The `DifferenceCompositor` composite class does not do `check_areas` which causes issues in certain situations if the resolutions are different. The numpy operations would fail because the arrays were different shapes which would be seen by satpy as "this composite can't be made" rather than "we should try to make this composite after resampling".

 - [x] Closes #552 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

