### PR TITLE
Fix turning off enhancements in writers for float data

### DIFF
--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -272,7 +272,7 @@ sensor_name: visir/test_sensor2
 
     def test_writer_custom_enhance(self):
         """Test using custom enhancements with writer."""
-        from satpy.writers import ImageWriter, Enhancer
+        from satpy.writers import Enhancer
         from xarray import DataArray
         ds = DataArray(np.arange(1, 11.).reshape((2, 5)),
                        attrs=dict(name='test1', sensor='test_sensor', mode='L'),

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -372,10 +372,13 @@ def get_enhanced_image(dataset, ppp_config_dir=None, enhance=None, enhancement_c
                       "'Enhancer' class to the 'enhance' keyword argument instead.", DeprecationWarning)
 
     if enhance is False:
+        # no enhancement
         enhancer = None
-    elif enhance is None:
+    elif enhance is None or enhance is True:
+        # default enhancement
         enhancer = Enhancer(ppp_config_dir, enhancement_config_file)
     else:
+        # custom enhancer
         enhancer = enhance
 
     # Create an image for enhancement
@@ -500,7 +503,7 @@ class Writer(Plugin):
             """
         # Load the config
         Plugin.__init__(self, **kwargs)
-        self.info = self.config['writer']
+        self.info = self.config.get('writer', {})
 
         if 'file_pattern' in self.info:
             warnings.warn("Writer YAML config is using 'file_pattern' which "
@@ -705,17 +708,20 @@ class ImageWriter(Writer):
             enhancement_config = self.info.get("enhancement_config", None)
 
         if enhance is False:
-            self.enhancer = None
-        elif enhance is None:
+            # No enhancement
+            self.enhancer = False
+        elif enhance is None or enhance is True:
+            # default enhancement
             self.enhancer = Enhancer(ppp_config_dir=self.ppp_config_dir, enhancement_config_file=enhancement_config)
         else:
-            self.enhancer = None
+            # custom enhancer
+            self.enhancer = enhance
 
     @classmethod
     def separate_init_kwargs(cls, kwargs):
         # FUTURE: Don't pass Scene.save_datasets kwargs to init and here
         init_kwargs, kwargs = super(ImageWriter, cls).separate_init_kwargs(kwargs)
-        for kw in ['enhancement_config']:
+        for kw in ['enhancement_config', 'enhance']:
             if kw in kwargs:
                 init_kwargs[kw] = kwargs.pop(kw)
         return init_kwargs, kwargs

--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -43,17 +43,9 @@ KELVIN_TO_CELSIUS = -273.15
 
 class MITIFFWriter(ImageWriter):
 
-    def __init__(self, name=None, filename=None, enhancement_config=None, base_dir=None, tags=None, **kwargs):
-        ImageWriter.__init__(self,
-                             name,
-                             filename,
-                             enhancement_config,
-                             base_dir,
-                             default_config_filename="writers/mitiff.yaml",
-                             **kwargs)
-
-        self.tags = self.info.get("tags",
-                                  None) if tags is None else tags
+    def __init__(self, name=None, tags=None, **kwargs):
+        ImageWriter.__init__(self, name=name, default_config_filename="writers/mitiff.yaml", **kwargs)
+        self.tags = self.info.get("tags", None) if tags is None else tags
         if self.tags is None:
             self.tags = {}
         elif not isinstance(self.tags, dict):


### PR DESCRIPTION
A user pointed out that doing `enhance=False` doesn't actually work. This PR fixes that.

NOTE: This does *not* fix turning off enhancements for integer data. That will be tackled in a separate PR for trollimage and likely released with trollimage 1.6.1.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
