### PR TITLE
Make counts available in ahi_hsd

### DIFF
--- a/satpy/etc/readers/ahi_hsd.yaml
+++ b/satpy/etc/readers/ahi_hsd.yaml
@@ -21,6 +21,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b01
 
   B02:
@@ -35,6 +38,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b02
 
   B03:
@@ -49,6 +55,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b03
 
   B04:
@@ -63,6 +72,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b04
 
   B05:
@@ -77,6 +89,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b05
 
   B06:
@@ -91,6 +106,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b06
 
   B07:
@@ -105,6 +123,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b07
 
   B08:
@@ -119,6 +140,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b08
 
   B09:
@@ -133,6 +157,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b09
 
   B10:
@@ -147,6 +174,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b10
 
   B11:
@@ -161,6 +191,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b11
 
   B12:
@@ -175,6 +208,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b12
 
   B13:
@@ -189,6 +225,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b13
 
   B14:
@@ -203,6 +242,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b14
 
   B15:
@@ -217,6 +259,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b15
 
   B16:
@@ -231,6 +276,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: 1
     file_type: hsd_b16
 
 

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -460,7 +460,7 @@ class AHIHSDFileHandler(BaseFileHandler):
         tic = datetime.now()
 
         if calibration == 'counts':
-            return
+            return data
 
         if calibration in ['radiance', 'reflectance', 'brightness_temperature']:
             data = self.convert_to_radiance(data)


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

<!-- Describe what your PR does, and why -->
Make counts available in ``ahi_hsd``:
- Add datasets to YAML
- Fix ``AHIHSDFileHandler.calibrate`` to return counts instead of ``None``

While adding some calibration tests I discovered the following minor problems:
- Not only 65535 but also 65534 occurs as space fill value. Solution: Mask 65534 as well.
- Negative radiances can occur. Solution: Clip to zero
- If radiance is zero, the corresponding BT is negative and then clipped to zero. Solution: Set zero radiance to nan before division in ``_ir_calibrate`` -> corresponding BT is nan.

However these problems only affect space pixels. As long as the earth mask is applied, they are not visible.




 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
