### PR TITLE
Fix available_composite_ids including inline comp dependencies

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -148,7 +148,7 @@ class CompositorLoader(object):
                     # Handle in-line composites
                     if 'compositor' in item:
                         # Create an unique temporary name for the composite
-                        sub_comp_name = composite_name + '_dep_{}'.format(dep_num)
+                        sub_comp_name = '_' + composite_name + '_dep_{}'.format(dep_num)
                         dep_num += 1
                         # Minimal composite config
                         sub_conf = {composite_type: {sub_comp_name: item}}

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -341,10 +341,9 @@ class Scene(MetadataObject):
             reader_name=reader_name, composites=composites)))
 
     def available_composite_ids(self, available_datasets=None):
-        """Get names of compositors that can be generated from the available
-        datasets.
+        """Get names of compositors that can be generated from the available datasets.
 
-        :return: generator of available compositor's names
+        Returns: generator of available compositor's names
         """
         if available_datasets is None:
             available_datasets = self.available_dataset_ids(composites=False)
@@ -364,13 +363,14 @@ class Scene(MetadataObject):
         return sorted(available_comps & set(all_comps))
 
     def available_composite_names(self, available_datasets=None):
+        """All configured composites known to this Scene."""
         return sorted(set(x.name for x in self.available_composite_ids(
             available_datasets=available_datasets)))
 
     def all_composite_ids(self, sensor_names=None):
         """Get all composite IDs that are configured.
 
-        :return: generator of configured composite names
+        Returns: generator of configured composite names
         """
         if sensor_names is None:
             sensor_names = self.attrs['sensor']
@@ -378,8 +378,9 @@ class Scene(MetadataObject):
         # Note if we get compositors from the dep tree then it will include
         # modified composites which we don't want
         for sensor_name in sensor_names:
-            compositors.extend(
-                self.cpl.compositors.get(sensor_name, {}).keys())
+            sensor_comps = self.cpl.compositors.get(sensor_name, {}).keys()
+            # ignore inline compositor dependencies starting with '_'
+            compositors.extend(c for c in sensor_comps if not c.name.startswith('_'))
         return sorted(set(compositors))
 
     def all_composite_names(self, sensor_names=None):

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -472,8 +472,8 @@ class TestInlineComposites(unittest.TestCase):
         # Check that "fog" product has all its prerequisites defined
         keys = comps['visir'].keys()
         fog = [comps['visir'][dsid] for dsid in keys if "fog" == dsid.name][0]
-        self.assertEqual(fog.attrs['prerequisites'][0], 'fog_dep_0')
-        self.assertEqual(fog.attrs['prerequisites'][1], 'fog_dep_1')
+        self.assertEqual(fog.attrs['prerequisites'][0], '_fog_dep_0')
+        self.assertEqual(fog.attrs['prerequisites'][1], '_fog_dep_1')
         self.assertEqual(fog.attrs['prerequisites'][2], 10.8)
 
         # Check that the sub-composite dependencies use wavelengths


### PR DESCRIPTION
This PR fixes inline composite dependencies being listed in `available_composite_ids/names` and the `all_composite_ids/names`. The point of inline compositors is to not have to put as much work in to "officially" defining new composites and they shouldn't be needed by 99% of users. It can be confusing to see these dependencies (ex. `airmass_dep_0`) in the list coming from `Scene.available_composite_ids`.

This PR prefixes these inline dependencies with a `_` and then ignores composites with that name when listing them in the Scene's methods.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
