### PR TITLE
Add AHI HRIT B07 files for high resolution night data

### DIFF
--- a/satpy/etc/readers/ahi_hrit.yaml
+++ b/satpy/etc/readers/ahi_hrit.yaml
@@ -47,13 +47,17 @@ file_types:
         - 'IMG_DK{area:02d}B06_{start_time:%Y%m%d%H%M}'
 
     hrit_b07:
-        file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
+      file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
         # B07 are high resolution versions of IR4 at night
         # See section 1.3 of
-        # https://www.data.jma.go.jp/mscweb/en/himawari89/himawari_cast/note/HimawariCast_dataset_20150624_en.pdf
-        file_patterns:
+      # https://www.data.jma.go.jp/mscweb/en/himawari89/himawari_cast/note/HimawariCast_dataset_20150624_en.pdf
+      file_patterns:
         - 'IMG_DK{area:02d}B07_{start_time:%Y%m%d%H%M}_{segment:03d}'
         - 'IMG_DK{area:02d}B07_{start_time:%Y%m%d%H%M}'
+
+    hrit_b07_ir4:
+        file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
+        file_patterns:
         - 'IMG_DK{area:02d}IR4_{start_time:%Y%m%d%H%M}_{segment:03d}'
         - 'IMG_DK{area:02d}IR4_{start_time:%Y%m%d%H%M}'
 
@@ -144,7 +148,7 @@ datasets:
     name: B03
     sensor: ahi
     wavelength: [0.62,0.64,0.66]
-    resolution: 500
+    resolution: 1000
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -158,7 +162,7 @@ datasets:
     name: B04
     sensor: ahi
     wavelength: [0.83, 0.85, 0.87]
-    resolution: 1000
+    resolution: 4000
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -172,7 +176,7 @@ datasets:
     name: B05
     sensor: ahi
     wavelength: [1.5, 1.6, 1.7]
-    resolution: 2000
+    resolution: 4000
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -186,7 +190,7 @@ datasets:
     name: B06
     sensor: ahi
     wavelength: [2.2, 2.3, 2.4]
-    resolution: 2000
+    resolution: 4000
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -196,11 +200,25 @@ datasets:
         units: 1
     file_type: hrit_b06
 
-  B07:
+  B07_low_res:
     name: B07
+    resolution: 4000
     sensor: ahi
     wavelength: [3.7, 3.9, 4.1]
+    calibration:
+      brightness_temperature:
+        standard_name: toa_brightness_temperature
+        units: "K"
+      counts:
+        standard_name: counts
+        units: 1
+    file_type: hrit_b07_ir4
+
+  B07_high_res:
+    name: B07
     resolution: 2000
+    sensor: ahi
+    wavelength: [3.7, 3.9, 4.1]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -214,7 +232,7 @@ datasets:
     name: B08
     sensor: ahi
     wavelength: [6.0, 6.2, 6.4]
-    resolution: 2000
+    resolution: 4000
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -228,7 +246,7 @@ datasets:
     name: B09
     sensor: ahi
     wavelength: [6.7, 6.9, 7.1]
-    resolution: 2000
+    resolution: 4000
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -242,7 +260,7 @@ datasets:
     name: B10
     sensor: ahi
     wavelength: [7.1, 7.3, 7.5]
-    resolution: 2000
+    resolution: 4000
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -256,7 +274,7 @@ datasets:
     name: B11
     sensor: ahi
     wavelength: [8.4, 8.6, 8.8]
-    resolution: 2000
+    resolution: 4000
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -270,7 +288,7 @@ datasets:
     name: B12
     sensor: ahi
     wavelength: [9.4, 9.6, 9.8]
-    resolution: 2000
+    resolution: 4000
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -284,7 +302,7 @@ datasets:
     name: B13
     sensor: ahi
     wavelength: [10.2, 10.4, 10.6]
-    resolution: 2000
+    resolution: 4000
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -298,7 +316,7 @@ datasets:
     name: B14
     sensor: ahi
     wavelength: [11.0, 11.2, 11.4]
-    resolution: 2000
+    resolution: 4000
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -312,7 +330,7 @@ datasets:
     name: B15
     sensor: ahi
     wavelength: [12.2, 12.4, 12.6]
-    resolution: 2000
+    resolution: 4000
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -326,7 +344,7 @@ datasets:
     name: B16
     sensor: ahi
     wavelength: [13.1, 13.3, 13.5]
-    resolution: 2000
+    resolution: 4000
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature

--- a/satpy/etc/readers/ahi_hrit.yaml
+++ b/satpy/etc/readers/ahi_hrit.yaml
@@ -203,6 +203,7 @@ datasets:
   B07_low_res:
     name: B07
     resolution: 4000
+#    resolution: 2000
     sensor: ahi
     wavelength: [3.7, 3.9, 4.1]
     calibration:
@@ -212,21 +213,22 @@ datasets:
       counts:
         standard_name: counts
         units: 1
-    file_type: hrit_b07_ir4
+    # FUTURE: Split this in to multiple resolutions so each can be loaded
+    file_type: [hrit_b07, hrit_b07_ir4]
 
-  B07_high_res:
-    name: B07
-    resolution: 2000
-    sensor: ahi
-    wavelength: [3.7, 3.9, 4.1]
-    calibration:
-      brightness_temperature:
-        standard_name: toa_brightness_temperature
-        units: "K"
-      counts:
-        standard_name: counts
-        units: 1
-    file_type: hrit_b07
+#  B07_high_res:
+#    name: B07
+#    resolution: 2000
+#    sensor: ahi
+#    wavelength: [3.7, 3.9, 4.1]
+#    calibration:
+#      brightness_temperature:
+#        standard_name: toa_brightness_temperature
+#        units: "K"
+#      counts:
+#        standard_name: counts
+#        units: 1
+#    file_type: hrit_b07
 
   B08:
     name: B08

--- a/satpy/etc/readers/ahi_hrit.yaml
+++ b/satpy/etc/readers/ahi_hrit.yaml
@@ -48,7 +48,12 @@ file_types:
 
     hrit_b07:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
+        # B07 are high resolution versions of IR4 at night
+        # See section 1.3 of
+        # https://www.data.jma.go.jp/mscweb/en/himawari89/himawari_cast/note/HimawariCast_dataset_20150624_en.pdf
         file_patterns:
+        - 'IMG_DK{area:02d}B07_{start_time:%Y%m%d%H%M}_{segment:03d}'
+        - 'IMG_DK{area:02d}B07_{start_time:%Y%m%d%H%M}'
         - 'IMG_DK{area:02d}IR4_{start_time:%Y%m%d%H%M}_{segment:03d}'
         - 'IMG_DK{area:02d}IR4_{start_time:%Y%m%d%H%M}'
 


### PR DESCRIPTION
See section 1.3 of https://www.data.jma.go.jp/mscweb/en/himawari89/himawari_cast/note/HimawariCast_dataset_20150624_en.pdf

At night the B07 file is provided as a high resolution version of B07 (IR4) in addition to the original IR4 file. I think the PDF above shows us that our resolutions for `ahi_hrit` are wrong and should be 4km for all bands except VIS/B03 at 1km and B07 at 2km. This can be updated in a future PR though if it doesn't cause any issues now.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
