### PR TITLE
Improve compatibility with Python 3.7

### DIFF
--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -122,7 +122,10 @@ class _SceneGenerator(object):
         self._dataset_idx[ds_id] = idx = 0
         while True:
             if idx >= len(self._scene_cache):
-                scn = next(self._self_iter)
+                try:
+                    scn = next(self._self_iter)
+                except StopIteration:
+                    return
             else:
                 scn = self._scene_cache[idx]
             yield scn.get(ds_id)


### PR DESCRIPTION
This PR improves the compatibility with Python 3.7.
In particular the change ensures compatibility with PEP 479 "Change StopIteration handling inside generators" [1]

[1] https://www.python.org/dev/peps/pep-0479/

Without this fix running tests with Python 3.7 gives the following error:

```
======================================================================
ERROR: test_save_mp4 (satpy.tests.test_multiscene.TestMultiSceneSave)
Save a series of fake scenes to an mp4 video.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/antonio/debian/git/satpy/satpy/multiscene.py", line 125, in __getitem__
    scn = next(self._self_iter)
StopIteration

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.7/unittest/mock.py", line 1195, in patched
    return func(*args, **keywargs)
  File "/home/antonio/debian/git/satpy/satpy/tests/test_multiscene.py", line 179, in test_save_mp4
    mscn.save_animation(fn, datasets=['ds1', 'ds2', 'ds3'])
  File "/home/antonio/debian/git/satpy/satpy/multiscene.py", line 356, in save_animation
    for delayed_batch in zip_longest(*iter_delayeds):
  File "/home/antonio/debian/git/satpy/satpy/multiscene.py", line 75, in cascaded_compute
    batch_arrs = [x for x in batch_arrs if x is not None]
  File "/home/antonio/debian/git/satpy/satpy/multiscene.py", line 75, in <listcomp>
    batch_arrs = [x for x in batch_arrs if x is not None]
  File "/home/antonio/debian/git/satpy/satpy/multiscene.py", line 271, in _get_animation_frames
    for idx, ds in enumerate(all_datasets):
RuntimeError: generator raised StopIteration
```