### PR TITLE
Fix multiple filetypes for lon/lats in modis_l1b

### DIFF
--- a/satpy/etc/readers/modis_l1b.yaml
+++ b/satpy/etc/readers/modis_l1b.yaml
@@ -5,15 +5,6 @@ reader:
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader ''
   sensors: [modis]
 
-navigations:
-  hdf_eos_geo:
-      description: MODIS navigation
-      file_type: hdf_eos_geo
-      latitude_key: Latitude
-      longitude_key: Longitude
-      nadir_resolution: [1000]
-      rows_per_scan: 10
-
 datasets:
   '1':
     name: '1'
@@ -406,31 +397,16 @@ datasets:
     - 14.385
 
   longitude1k:
-    file_type: hdf_eos_geo
+    file_type: [hdf_eos_geo, hdf_eos_data_1000m]
     name: longitude
     resolution: [1000, 500, 250]
     standard_name: longitude
     units: degree
 
   latitude1k:
-    file_type: hdf_eos_geo
+    file_type: [hdf_eos_geo, hdf_eos_data_1000m]
     name: latitude
     resolution: [1000, 500, 250]
-    standard_name: latitude
-    units: degree
-
-  # For EUM reduced (thinned) files
-  longitude5k:
-    file_type: hdf_eos_data_1000m
-    name: longitude
-    resolution: [5000, 1000]
-    standard_name: longitude
-    units: degree
-
-  latitude5k:
-    file_type: hdf_eos_data_1000m
-    name: latitude
-    resolution: [5000, 1000]
     standard_name: latitude
     units: degree
 


### PR DESCRIPTION
The longitude and latitude description in the modis_l1b.yaml file was ambiguous from the satpy code perspective and led to an error popping up when not geo file was present. It could even lead to incorrect behaviour of the reader when the geo file was present, by preferring a lower resolution dataset and interpolating it.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
