### PR TITLE
Fix CF epoch for xarray compat

### DIFF
--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -33,7 +33,7 @@ from satpy.writers import Writer
 
 logger = logging.getLogger(__name__)
 
-EPOCH = u"seconds since 1970-01-01 00:00:00 +00:00"
+EPOCH = u"seconds since 1970-01-01 00:00:00"
 
 
 def omerc2cf(area):


### PR DESCRIPTION
This PR fixes CF epoch for xarray > 0.11.0 compatibility

<!-- Describe what your PR does, and why -->

 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

