### PR TITLE
Fix VIIRS SDR masking and distracting colors in composites

### DIFF
--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -253,6 +253,10 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
             fill_min = int(ds_info.pop("fill_min_int", 65528))
             data = data.where(data < fill_min)
 
+        # Mask values less than or equal to zero.  These seem to
+        # happen on the night-side of the reflective channels
+        data = data.where(data > 0)
+
         factors = self.get(factor_var_path)
         if factors is None:
             LOG.debug("No scaling factors found for %s", dataset_id)


### PR DESCRIPTION
The VIIRS SDR data has leftover unmasked pixels on the night side, which results in distracting black areas in image composites in the middle of otherwise masked areas. The are also differences in the masking of different channels, which causes distracting coloring in the composites. The image below shows both of these features.

![20190108085721_npp_nat_na_740m](https://user-images.githubusercontent.com/3170788/50881506-78b65100-13ea-11e9-9f50-c7645ce172a3.png)

This PR adds a masking for the zero values in the VIIRS SDR data, and in composites using `GenericCompositor` masks the locations where even one of the channels is invalid. The resulting image is shown below. This behavior is equal to what was available in SatPy 0.7.x.

![natural_i_20190108_085721_fixed](https://user-images.githubusercontent.com/3170788/50881784-5ffa6b00-13eb-11e9-84c7-1c86c318d84e.png)

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
