### PR TITLE
Update function declarations to make docs reproducible

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -60,7 +60,9 @@ class IncompatibleTimes(Exception):
 class CompositorLoader(object):
     """Read composites using the configuration files on disk."""
 
-    def __init__(self, ppp_config_dir=CONFIG_PATH):
+    def __init__(self, ppp_config_dir=None):
+        if ppp_config_dir is None:
+            ppp_config_dir = CONFIG_PATH
         self.modifiers = {}
         self.compositors = {}
         self.ppp_config_dir = ppp_config_dir

--- a/satpy/config.py
+++ b/satpy/config.py
@@ -40,7 +40,9 @@ BASE_PATH = os.path.dirname(os.path.realpath(__file__))
 PACKAGE_CONFIG_PATH = os.path.join(BASE_PATH, 'etc')
 
 
-def get_environ_config_dir(default=PACKAGE_CONFIG_PATH):
+def get_environ_config_dir(default=None):
+    if default is None:
+        default = PACKAGE_CONFIG_PATH
     return os.environ.get('PPP_CONFIG_DIR', default)
 
 

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -515,7 +515,7 @@ def available_readers(as_dict=False):
 
 
 def find_files_and_readers(start_time=None, end_time=None, base_dir=None,
-                           reader=None, sensor=None, ppp_config_dir=get_environ_config_dir(),
+                           reader=None, sensor=None, ppp_config_dir=None,
                            filter_parameters=None, reader_kwargs=None):
     """Find on-disk files matching the provided parameters.
 
@@ -553,6 +553,8 @@ def find_files_and_readers(start_time=None, end_time=None, base_dir=None,
     Returns: Dictionary mapping reader name string to list of filenames
 
     """
+    if ppp_config_dir is None:
+        ppp_config_dir = get_environ_config_dir()
     reader_files = {}
     reader_kwargs = reader_kwargs or {}
     filter_parameters = filter_parameters or reader_kwargs.get('filter_parameters', {})
@@ -595,7 +597,7 @@ def find_files_and_readers(start_time=None, end_time=None, base_dir=None,
 
 
 def load_readers(filenames=None, reader=None, reader_kwargs=None,
-                 ppp_config_dir=get_environ_config_dir()):
+                 ppp_config_dir=None):
     """Create specified readers and assign files to them.
 
     Args:
@@ -612,6 +614,8 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None,
     """
     reader_instances = {}
     reader_kwargs = reader_kwargs or {}
+    if ppp_config_dir is None:
+        ppp_config_dir = get_environ_config_dir()
 
     if not filenames and not reader:
         # used for an empty Scene

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -72,7 +72,7 @@ class Scene(MetadataObject):
     """
 
     def __init__(self, filenames=None, reader=None, filter_parameters=None, reader_kwargs=None,
-                 ppp_config_dir=get_environ_config_dir(),
+                 ppp_config_dir=None,
                  base_dir=None,
                  sensor=None,
                  start_time=None,
@@ -107,6 +107,8 @@ class Scene(MetadataObject):
 
         """
         super(Scene, self).__init__()
+        if ppp_config_dir is None:
+            ppp_config_dir = get_environ_config_dir()
         # Set the PPP_CONFIG_DIR in the environment in case it's used elsewhere in pytroll
         LOG.debug("Setting 'PPP_CONFIG_DIR' to '%s'", ppp_config_dir)
         os.environ["PPP_CONFIG_DIR"] = self.ppp_config_dir = ppp_config_dir


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort, we noticed that satpy's documentation could not be built reproducibly. This is because it uses the absolute buildpath in the generated docs.

This was first reported in Debian as bug [#919566](https://bugs.debian.org/919566).