### PR TITLE
Add 'reduce_data' keyword argument to disable cropping before resampling

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -900,7 +900,8 @@ class Scene(MetadataObject):
         if unload:
             self.unload(keepables=keepables)
 
-    def _resampled_scene(self, new_scn, destination_area, **resample_kwargs):
+    def _resampled_scene(self, new_scn, destination_area, reduce_data=True,
+                         **resample_kwargs):
         """Resample `datasets` to the `destination` area."""
         new_datasets = {}
         datasets = list(new_scn.datasets.values())
@@ -933,7 +934,7 @@ class Scene(MetadataObject):
             LOG.debug("Resampling %s", ds_id)
             source_area = dataset.attrs['area']
             try:
-                if resample_kwargs.get('reduce_data', True):
+                if reduce_data:
                     slice_x, slice_y = source_area.get_area_slices(
                         destination_area)
                     source_area = source_area[slice_y, slice_x]

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -968,7 +968,8 @@ class Scene(MetadataObject):
                 replace_anc(res, pres)
 
     def resample(self, destination=None, datasets=None, generate=True,
-                 unload=True, resampler=None, **resample_kwargs):
+                 unload=True, resampler=None, reduce_data=True,
+                 **resample_kwargs):
         """Resample datasets and return a new scene.
 
         Args:
@@ -987,6 +988,8 @@ class Scene(MetadataObject):
                 ('nearest'). Other possible values include 'native', 'ewa',
                 etc. See the :mod:`~satpy.resample` documentation for more
                 information.
+            reduce_data (bool): Reduce data by matching the input and output
+                areas and slicing the data arrays (default: True)
             resample_kwargs: Remaining keyword arguments to pass to individual
                 resampler classes. See the individual resampler class
                 documentation :mod:`here <satpy.resample>` for available
@@ -1002,7 +1005,7 @@ class Scene(MetadataObject):
         # we may have some datasets we asked for but don't exist yet
         new_scn.wishlist = self.wishlist.copy()
         self._resampled_scene(new_scn, destination, resampler=resampler,
-                              **resample_kwargs)
+                              reduce_data=reduce_data, **resample_kwargs)
 
         # regenerate anything from the wishlist that needs it (combining
         # multiple resolutions, etc.)

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -933,13 +933,16 @@ class Scene(MetadataObject):
             LOG.debug("Resampling %s", ds_id)
             source_area = dataset.attrs['area']
             try:
-                slice_x, slice_y = source_area.get_area_slices(
-                    destination_area)
-                source_area = source_area[slice_y, slice_x]
-                dataset = dataset.isel(x=slice_x, y=slice_y)
-                assert ('x', source_area.x_size) in dataset.sizes.items()
-                assert ('y', source_area.y_size) in dataset.sizes.items()
-                dataset.attrs['area'] = source_area
+                if resample_kwargs.get('reduce_data', True):
+                    slice_x, slice_y = source_area.get_area_slices(
+                        destination_area)
+                    source_area = source_area[slice_y, slice_x]
+                    dataset = dataset.isel(x=slice_x, y=slice_y)
+                    assert ('x', source_area.x_size) in dataset.sizes.items()
+                    assert ('y', source_area.y_size) in dataset.sizes.items()
+                    dataset.attrs['area'] = source_area
+                else:
+                    LOG.info("Data reduction disabled by the user")
             except NotImplementedError:
                 LOG.info("Not reducing data before resampling.")
             if source_area not in resamplers:

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -943,7 +943,7 @@ class Scene(MetadataObject):
                     assert ('y', source_area.y_size) in dataset.sizes.items()
                     dataset.attrs['area'] = source_area
                 else:
-                    LOG.info("Data reduction disabled by the user")
+                    LOG.debug("Data reduction disabled by the user")
             except NotImplementedError:
                 LOG.info("Not reducing data before resampling.")
             if source_area not in resamplers:

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1488,10 +1488,11 @@ class TestSceneResampling(unittest.TestCase):
         """Return copy of dataset pretending it was resampled."""
         return dataset.copy()
 
+    @mock.patch('satpy.scene.Scene._reduce_data')
     @mock.patch('satpy.scene.resample_dataset')
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
-    def test_resample_scene_copy(self, cri, cl, rs):
+    def test_resample_scene_copy(self, cri, cl, rs, reduce_data):
         """Test that the Scene is properly copied during resampled.
 
         The Scene that is created as a copy of the original Scene should not
@@ -1554,6 +1555,20 @@ class TestSceneResampling(unittest.TestCase):
             tuple(loaded_ids[0]), tuple(DatasetID(name='comp19')))
         self.assertTupleEqual(
             tuple(loaded_ids[1]), tuple(DatasetID(name='new_ds')))
+
+        # Test that data reduction can be disabled
+        scene = satpy.scene.Scene(filenames=['bla'],
+                                  base_dir='bli',
+                                  reader='fake_reader')
+
+        scene.load(['comp19'])
+        scene['comp19'].attrs['area'] = area_def
+        new_scene = scene.resample(area_def, reduce_data=False)
+        self.assertFalse(reduce_data.called)
+        new_scene = scene.resample(area_def)
+        self.assertTrue(reduce_data.called_once)
+        new_scene = scene.resample(area_def, reduce_data=True)
+        self.assertEqual(reduce_data.call_count, 2)
 
     @mock.patch('satpy.scene.resample_dataset')
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')


### PR DESCRIPTION
This PR adds a way to disable data reduction before resampling. This is a work-around for #383 that might be useful even after fixing pyresample.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

Usage when calling resampling:
```python
lcl = glbl.resample(..., reduce_data=False)
```
The default is to apply data reduction.

Not sure where to document this, as resampling documentation is coming direct from resample.py docstrings, and this fix happens in scene.py. Suggestions?