### PR TITLE
Fix geotiff writer not using fill_value from writer YAML config

### DIFF
--- a/satpy/tests/writer_tests/test_geotiff.py
+++ b/satpy/tests/writer_tests/test_geotiff.py
@@ -29,6 +29,11 @@ if sys.version_info < (2, 7):
 else:
     import unittest
 
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 
 class TestGeoTIFFWriter(unittest.TestCase):
     """Test the GeoTIFF Writer class."""
@@ -104,6 +109,17 @@ class TestGeoTIFFWriter(unittest.TestCase):
                           enhancement_config=False,
                           dtype=np.float32)
         w.save_datasets(datasets)
+
+    def test_fill_value_from_config(self):
+        """Test fill_value coming from the writer config."""
+        from satpy.writers.geotiff import GeoTIFFWriter
+        datasets = self._get_test_datasets()
+        w = GeoTIFFWriter(base_dir=self.base_dir)
+        w.info['fill_value'] = 128
+        with mock.patch('satpy.writers.XRImage.save') as save_method:
+            save_method.return_value = None
+            w.save_datasets(datasets, compute=False)
+            self.assertEqual(save_method.call_args[1]['fill_value'], 128)
 
 
 def suite():


### PR DESCRIPTION
This was brought up on slack by "memamm". In a past change I had made to writers in general I removed the functionality to have the geotiff writer's `fill_value` specified in a configuration file. This PR fixes that to use the config value as a fallback.

This should probably be fixed in a better way in the future, but I'm not sure the best way. Basically the "save_dataset/s" method on the `Scene` passes all keyword arguments and the Writer's have a special classmethod for splitting these in to init/save keyword argument dicts. Additionally, the config is loaded in the `__init__` method but most arguments are used in the `save` method so special handling has to be added to each writer to say "the user didn't specify this kwarg specifically so use the config in `self.info`".

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
