### PR TITLE
Drop x and y indexes before zeroing data in DayNightCompositor

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -988,6 +988,16 @@ def add_bands(data, bands):
 
 def zero_missing_data(data1, data2):
     """Replace NaN values with zeros in data1 if the data is valid in data2."""
+    def _drop_xy_idxs(data):
+        # Remove x and y indexes
+        try:
+            return data.drop(['x', 'y'])
+        except ValueError:
+            return data
+
+    data1 = _drop_xy_idxs(data1)
+    data2 = _drop_xy_idxs(data2)
+
     nans = xu.logical_and(xu.isnan(data1), xu.logical_not(xu.isnan(data2)))
     return data1.where(~nans, 0)
 

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -387,6 +387,28 @@ class TestDayNightCompositor(unittest.TestCase):
         expected = np.array([[0., 0.33164983], [0.66835017, 1.]])
         np.testing.assert_allclose(res.values[0], expected)
 
+    def test_zero_missing_data(self):
+        """Test that missing values are zeroed."""
+        from satpy.composites import zero_missing_data
+        res = zero_missing_data(self.data_b, self.data_a)
+        res = res.compute()
+        self.assertFalse(np.any(np.isnan(res)))
+        # Add coordinates (and indexes)
+        data_a = self.data_a.copy()
+        data_a.coords['x'] = [0, 1]
+        data_a.coords['y'] = [0, 1]
+        data_b = self.data_b.copy()
+        data_b.coords['x'] = [0, 1]
+        data_b.coords['y'] = [0, 1]
+        res = zero_missing_data(data_a, data_b)
+        self.assertTrue('x' not in res.indexes)
+        self.assertTrue('y' not in res.indexes)
+        self.assertFalse(np.any(np.isnan(res)))
+        res = zero_missing_data(data_b, data_a)
+        self.assertTrue('x' not in res.indexes)
+        self.assertTrue('y' not in res.indexes)
+        self.assertFalse(np.any(np.isnan(res)))
+
 
 class TestFillingCompositor(unittest.TestCase):
 


### PR DESCRIPTION
This PR removes extra indexes from the data arrays before zeroing the data for DayNightCompositor.

 - [x] Closes #584  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
