### PR TITLE
Fix start_time type in seviri_l1b_nc reader

### DIFF
--- a/satpy/readers/seviri_l1b_nc.py
+++ b/satpy/readers/seviri_l1b_nc.py
@@ -35,10 +35,6 @@ from pyresample import geometry
 import datetime
 
 
-def _time_format(tval):
-    return datetime.datetime.strftime(tval, '%Y-%m-%d %H:%M:%S.%f')
-
-
 class NCSEVIRIFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
     def __init__(self, filename, filename_info, filetype_info):
         super(NCSEVIRIFileHandler, self).__init__(filename, filename_info, filetype_info)

--- a/satpy/readers/seviri_l1b_nc.py
+++ b/satpy/readers/seviri_l1b_nc.py
@@ -49,11 +49,11 @@ class NCSEVIRIFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
 
     @property
     def start_time(self):
-        return (_time_format(self.deltaSt))
+        return self.deltaSt
 
     @property
     def end_time(self):
-        return (_time_format(self.deltaEnd))
+        return self.deltaEnd
 
     def _read_file(self):
         if self.nc is None:


### PR DESCRIPTION
Trying to write out geotiff files from data loaded with seviri_l1b_nc
reader gives Error because the reader sets start_time and end_time as
string instead of datetime. This commit fixes this error.