### PR TITLE
Fix dask not importing sharedict automatically in dask 1.1+

### DIFF
--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -26,6 +26,7 @@
 import logging
 import numpy as np
 import dask
+import dask.sharedict
 import dask.array as da
 import xarray as xr
 from satpy.scene import Scene


### PR DESCRIPTION
Sharedict will be deprecated in dask in the future. As part of those changes the `sharedict` module is no longer automatically included as part of `import dask` with use `dask.sharedict`. See https://github.com/dask/dask/issues/4417 for migration changes needed in the future.