### PR TITLE
Fix dask deprecation warning for sharedict in multiscene

### DIFF
--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -26,12 +26,17 @@
 import logging
 import numpy as np
 import dask
-import dask.sharedict
 import dask.array as da
 import xarray as xr
 from satpy.scene import Scene
 from satpy.writers import get_enhanced_image
-from itertools import chain
+
+try:
+    # new API
+    from dask.highlevelgraph import HighLevelGraph
+except ImportError:
+    # old API
+    import dask.sharedict as HighLevelGraph
 
 try:
     from itertools import zip_longest
@@ -78,7 +83,7 @@ def cascaded_compute(callback, arrays, batch_size=None, optimize=True):
             # optimize Dask graph over all objects
             dsk = da.Array.__dask_optimize__(
                 # combine all Dask Array graphs
-                dask.sharedict.merge(*[e.__dask_graph__() for e in batch_arrs]),
+                HighLevelGraph.merge(*[e.__dask_graph__() for e in batch_arrs]),
                 # get Dask Array keys in result
                 list(dask.core.flatten([e.__dask_keys__() for e in batch_arrs]))
             )

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -30,6 +30,7 @@ import dask.array as da
 import xarray as xr
 from satpy.scene import Scene
 from satpy.writers import get_enhanced_image
+from itertools import chain
 
 try:
     # new API


### PR DESCRIPTION
See #589 for more details. The dask `sharedict` module/object is now deprecated in favor of `HighLevelGraph`. The module and object can be used in similar ways so this PR does an try/except to try to use the `HighLevelGraph` and avoids the deprecation warning.

Closes https://github.com/dask/dask/issues/4417