### PR TITLE
Fix masking of AHI HSD space pixels

### DIFF
--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -399,7 +399,7 @@ class AHIHSDFileHandler(BaseFileHandler):
         ncols = int(header["block2"]['number_of_columns'][0])
         return da.from_array(np.memmap(self.filename, offset=fp_.tell(),
                                        dtype='<u2', shape=(nlines, ncols), mode='r'),
-                            chunks=CHUNK_SIZE)
+                             chunks=CHUNK_SIZE)
 
     def _mask_invalid(self, data, header):
         """Mask invalid data"""

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -213,7 +213,6 @@ class TestAHIHSDFileHandler(unittest.TestCase):
         refl = fh.calibrate(data=counts, calibration='reflectance')
         self.assertTrue(np.allclose(refl, refl_exp))
 
-
     @mock.patch('satpy.readers.ahi_hsd.AHIHSDFileHandler._read_header')
     @mock.patch('satpy.readers.ahi_hsd.AHIHSDFileHandler._read_data')
     @mock.patch('satpy.readers.ahi_hsd.AHIHSDFileHandler._mask_invalid')


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Replace usage of ``satpy.readers.ahi_hsd.AHIHSDFileHandler.geo_mask`` with ``satpy.readers.utils.get_geostationary_mask`` because they do the same thing.

A closer analysis revealed that the masks computed by the two methods are shifted vertically by one pixel. The reason for that are incorrect line indices in ``geo_mask`` (shifted by one). If applying the following modification, both methods compute exactly the same masks. Therefore it should be safe to replace ``geo_mask`` with ``get_geostationary_mask``.

```
diff --git a/satpy/readers/ahi_hsd.py b/satpy/readers/ahi_hsd.py
index 538b6af9..43fb70e9 100644
--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -341,8 +341,8 @@ class AHIHSDFileHandler(BaseFileHandler):
         cols_idx = da.arange(-(coff - local_coff),
                              ncols - (coff - local_coff),
                              dtype=np.float, chunks=CHUNK_SIZE)
-        lines_idx = da.arange(nlines - (loff - local_loff),
-                              -(loff - local_loff),
+        lines_idx = da.arange(nlines - 1 - (loff - local_loff),
+                              -(loff - local_loff) - 1,
                               -1,
                               dtype=np.float, chunks=CHUNK_SIZE)
         return ellipse(lines_idx[:, None], cols_idx[None, :])
```

 - [x] Closes #531  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
