### PR TITLE
Fix sunz_corrected modifier adding unnecessary x and y coordinates

### DIFF
--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -34,7 +34,6 @@ import unittest
 
 
 class TestCheckArea(unittest.TestCase):
-
     """Test the utility method 'check_areas'."""
 
     def _get_test_ds(self, shape=(50, 100), dims=('y', 'x')):
@@ -252,6 +251,15 @@ class TestSunZenithCorrector(unittest.TestCase):
         comp = SunZenithCorrector(name='sza_test', modifiers=tuple())
         res = comp((self.ds1,), test_attr='test')
         np.testing.assert_allclose(res.values, np.array([[22.401667, 22.31777], [22.437503, 22.353533]]))
+        self.assertIn('y', res.coords)
+        self.assertIn('x', res.coords)
+        ds1 = self.ds1.copy()
+        del ds1.coords['y']
+        del ds1.coords['x']
+        res = comp((ds1,), test_attr='test')
+        np.testing.assert_allclose(res.values, np.array([[22.401667, 22.31777], [22.437503, 22.353533]]))
+        self.assertNotIn('y', res.coords)
+        self.assertNotIn('x', res.coords)
 
     def test_basic_lims_not_provided(self):
         """Test custom limits when SZA isn't provided."""


### PR DESCRIPTION
See #587 for details. This is a replacement for that PR.

In summary, the sunz_corrected modifier was adding new x and y coordinates to the SZA data it was creating. This happened because `my_data_arr['y']` will create a new data array even if the `'y'` coordinate doesn't exist. The value would be a range representing the indexes of the array. The way this was being used was adding y/x coordinates to the dataset when the original array didn't have them. This would then add these coordinates to the input data and pass it on to the DayNightCompositor. The DayNightCompositor would then get confused if it had y/x for one dataset and no coordinates for the other. This PR makes it so those coordinates are only added if they already existed in the input data to the sunz_corrected modifier.

 - [ ] Closes #587, fixes #584  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
