### PR TITLE
Fix VIIRS L1B reader not using standard 'y' and 'x' dimension names

### DIFF
--- a/satpy/readers/viirs_l1b.py
+++ b/satpy/readers/viirs_l1b.py
@@ -233,4 +233,7 @@ class VIIRSL1BFileHandler(NetCDF4FileHandler):
         if factors[0] != 1 or factors[1] != 0:
             data *= factors[0]
             data += factors[1]
+        # rename dimensions to correspond to satpy's 'y' and 'x' standard
+        if 'number_of_lines' in data.dims:
+            data = data.rename({'number_of_lines': 'y', 'number_of_pixels': 'x'})
         return data


### PR DESCRIPTION
To be completely compatible with all parts of satpy and trollimage right now, data returned by readers have to have 'y' and 'x' dimensions. The VIIRS L1B reader uses `number_of_lines` and `number_of_pixels` which will fail if provided to trollimage's XRImage inside an RGB. This renames those dimensions 'y' and 'x'. This was noticed at the same time as #593.

I'm not really sure how to add a test for this given that #593 is the real solution/problem.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
