### PR TITLE
Deprecate old reader names so that they are no longer recognized

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -42,34 +42,6 @@ except ImportError:
 LOG = logging.getLogger(__name__)
 
 
-# Old Name -> New Name
-OLD_READER_NAMES = {
-    'avhrr_aapp_l1b': 'avhrr_l1b_aapp',
-    'avhrr_eps_l1b': 'avhrr_l1b_eps',
-    'avhrr_hrpt_l1b': 'avhrr_l1b_hrpt',
-    'gac_lac_l1': 'avhrr_l1b_gaclac',
-    'hdf4_caliopv3': 'caliop_l2_cloud',
-    'hdfeos_l1b': 'modis_l1b',
-    'hrit_electrol': 'electrol_hrit',
-    'hrit_jma': 'ahi_hrit',
-    'fci_fdhsi': 'fci_l1c_fdhsi',
-    'ghrsst_osisaf': 'ghrsst_l3c_sst',
-    'hrit_goes': 'goes-imager_hrit',
-    'hrit_msg': 'seviri_l1b_hrit',
-    'native_msg': 'seviri_l1b_native',
-    'nc_goes': 'goes-imager_nc',
-    'nc_nwcsaf_msg': 'nwcsaf-geo',
-    'nc_nwcsaf_pps': 'nwcsaf-pps_nc',
-    'nc_olci_l1b': 'olci_l1b',
-    'nc_olci_l2': 'olci_l2',
-    'nc_seviri_l1b': 'seviri_l1b_nc',
-    'nc_slstr': 'slstr_l1b',
-    'safe_msi': 'msi_safe',
-    'safe_sar_c': 'sar-c_safe',
-    'scmi_abi_l1b': 'abi_l1b_scmi',
-}
-
-
 class TooManyResults(KeyError):
     pass
 
@@ -451,20 +423,6 @@ def configs_for_reader(reader=None, ppp_config_dir=None):
     if reader is not None:
         if not isinstance(reader, (list, tuple)):
             reader = [reader]
-        # check for old reader names
-        new_readers = []
-        for reader_name in reader:
-            if reader_name.endswith('.yaml') or reader_name not in OLD_READER_NAMES:
-                new_readers.append(reader_name)
-                continue
-
-            new_name = OLD_READER_NAMES[reader_name]
-            # SatPy 0.11 only displays a warning
-            # SatPy 0.13 will raise an exception
-            raise ValueError("Reader name '{}' has been deprecated, use '{}' instead.".format(reader_name, new_name))
-            # SatPy 0.15 or 1.0, remove exception and mapping
-
-        reader = new_readers
         # given a config filename or reader name
         config_files = [r if r.endswith('.yaml') else r + '.yaml' for r in reader]
     else:

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -461,11 +461,9 @@ def configs_for_reader(reader=None, ppp_config_dir=None):
 
             new_name = OLD_READER_NAMES[reader_name]
             # SatPy 0.11 only displays a warning
-            warnings.warn("Reader name '{}' has been deprecated, use '{}' instead.".format(reader_name, new_name),
-                          DeprecationWarning)
-            # SatPy 0.12 will raise an exception
-            # raise ValueError("Reader name '{}' has been deprecated, use '{}' instead.".format(reader_name, new_name))
-            # SatPy 0.13 or 1.0, remove exception and mapping
+            # SatPy 0.13 will raise an exception
+            raise ValueError("Reader name '{}' has been deprecated, use '{}' instead.".format(reader_name, new_name))
+            # SatPy 0.15 or 1.0, remove exception and mapping
 
             new_readers.append(new_name)
 

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -25,7 +25,6 @@
 import logging
 import numbers
 import os
-import warnings
 
 import six
 import yaml

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -465,8 +465,6 @@ def configs_for_reader(reader=None, ppp_config_dir=None):
             raise ValueError("Reader name '{}' has been deprecated, use '{}' instead.".format(reader_name, new_name))
             # SatPy 0.15 or 1.0, remove exception and mapping
 
-            new_readers.append(new_name)
-
         reader = new_readers
         # given a config filename or reader name
         config_files = [r if r.endswith('.yaml') else r + '.yaml' for r in reader]

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -526,11 +526,6 @@ class TestFindFilesAndReaders(unittest.TestCase):
             self.assertRaises(yaml.YAMLError, find_files_and_readers,
                               reader='viirs_sdr')
 
-    def test_old_reader_name_mapping(self):
-        """Test that requesting old reader names raises a warning."""
-        from satpy.readers import configs_for_reader
-        self.assertRaises(ValueError, list, configs_for_reader('hrit_jma'))
-
 
 class TestYAMLFiles(unittest.TestCase):
     """Test and analyze the reader configuration files."""

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -532,15 +532,8 @@ class TestFindFilesAndReaders(unittest.TestCase):
 
     def test_old_reader_name_mapping(self):
         """Test that requesting old reader names raises a warning."""
-        import warnings
         from satpy.readers import configs_for_reader
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always')
-            configs = list(configs_for_reader('hrit_jma'))[0]
-        self.assertIn('ahi_hrit', configs[0])
-        self.assertNotIn('hrit_jma', configs[0])
-        self.assertEqual(len(w), 1)
-        self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+        self.assertRaises(ValueError, list, configs_for_reader('hrit_jma'))
 
 
 class TestYAMLFiles(unittest.TestCase):

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -287,9 +287,7 @@ class TestReaderLoader(unittest.TestCase):
         epi_miss = epi_pro_miss + ['H-000-MSG4__-MSG4________-_________-PRO______-201809050900-__']
         pro_miss = epi_pro_miss + ['H-000-MSG4__-MSG4________-_________-EPI______-201809050900-__']
         for filenames in [epi_miss, pro_miss, epi_pro_miss]:
-            with mock.patch('warnings.warn') as warn_mock:
-                self.assertRaises(ValueError, load_readers, reader='hrit_msg', filenames=filenames)
-                warn_mock.assert_called()
+            self.assertRaises(ValueError, load_readers, reader='seviri_l1b_hrit', filenames=filenames)
 
         # Filenames from multiple scans
         at_least_one_complete = [
@@ -301,9 +299,7 @@ class TestReaderLoader(unittest.TestCase):
             'H-000-MSG4__-MSG4________-IR_108___-000006___-201809051000-__',
         ]
         try:
-            with mock.patch('warnings.warn') as warn_mock:
-                load_readers(filenames=at_least_one_complete, reader='hrit_msg')
-                warn_mock.assert_called()
+            load_readers(filenames=at_least_one_complete, reader='seviri_l1b_hrit')
         except ValueError:
             self.fail('If at least one set of filenames is complete, no '
                       'exception should be raised')


### PR DESCRIPTION
This is meant for version 0.15 of satpy. See #597 for details.