### PR TITLE
Fix resample reduce_data bug introduced in #582

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -924,7 +924,6 @@ class Scene(MetadataObject):
         """Resample `datasets` to the `destination` area."""
         new_datasets = {}
         datasets = list(new_scn.datasets.values())
-        max_area = None
         if isinstance(destination_area, (str, six.text_type)):
             destination_area = get_area_def(destination_area)
         if hasattr(destination_area, 'freeze'):
@@ -954,8 +953,8 @@ class Scene(MetadataObject):
             source_area = dataset.attrs['area']
             try:
                 if reduce_data:
-                    dataset = self._reduce_data(source_area, destination_area,
-                                                dataset)
+                    dataset = self._reduce_data(source_area, destination_area, dataset)
+                    source_area = dataset.attrs['area']
                 else:
                     LOG.debug("Data reduction disabled by the user")
             except NotImplementedError:


### PR DESCRIPTION
On slack @adybbroe pointed out that resampling was broken in current master. This was caused by some changes in #582 by @pnuu as part of refactoring the code. Bottom line, the `source_area` variable needs to represent the "reduced" area after reducing has been done.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

