### PR TITLE
Fix VIIRS 'histogram_dnb' compositor not returning new data

### DIFF
--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -205,6 +205,10 @@ class HistogramDNB(CompositeBase):
             sza_data (ndarray): Solar Zenith Angle data array
 
         """
+        # convert dask arrays to DataArray objects
+        dnb_data = xr.DataArray(dnb_data, dims=('y', 'x'))
+        sza_data = xr.DataArray(sza_data, dims=('y', 'x'))
+
         good_mask = ~(dnb_data.isnull() | sza_data.isnull())
         output_dataset = dnb_data.where(good_mask)
         # we only need the numpy array
@@ -228,21 +232,17 @@ class HistogramDNB(CompositeBase):
             for mask in mixed_mask:
                 if mask.any():
                     LOG.debug("Histogram equalizing DNB mixed data...")
-                    histogram_equalization(dnb_data,
-                                           mask,
-                                           out=output_dataset)
+                    histogram_equalization(dnb_data, mask, out=output_dataset)
                     did_equalize = True
         if night_mask.any():
             LOG.debug("Histogram equalizing DNB night data...")
-            histogram_equalization(dnb_data,
-                                   night_mask,
-                                   out=output_dataset)
+            histogram_equalization(dnb_data, night_mask, out=output_dataset)
             did_equalize = True
 
         if not did_equalize:
             raise RuntimeError("No valid data found to histogram equalize")
 
-        return dnb_data
+        return output_dataset
 
     def __call__(self, datasets, **info):
         """Create the composite by scaling the DNB data using a histogram equalization method.
@@ -255,7 +255,7 @@ class HistogramDNB(CompositeBase):
 
         dnb_data = datasets[0]
         sza_data = datasets[1]
-        delayed = dask.delayed(self._run_dnb_normalization)(dnb_data, sza_data)
+        delayed = dask.delayed(self._run_dnb_normalization)(dnb_data.data, sza_data.data)
         output_dataset = dnb_data.copy()
         output_data = da.from_delayed(delayed, dnb_data.shape, dnb_data.dtype)
         output_dataset.data = output_data.rechunk(dnb_data.data.chunks)
@@ -309,6 +309,10 @@ class AdaptiveDNB(HistogramDNB):
             sza_data (ndarray): Solar Zenith Angle data array
 
         """
+        # convert dask arrays to DataArray objects
+        dnb_data = xr.DataArray(dnb_data, dims=('y', 'x'))
+        sza_data = xr.DataArray(sza_data, dims=('y', 'x'))
+
         good_mask = ~(dnb_data.isnull() | sza_data.isnull())
         # good_mask = ~(dnb_data.mask | sza_data.mask)
         output_dataset = dnb_data.where(good_mask)
@@ -424,8 +428,7 @@ class ERFDNB(CompositeBase):
         dnb_data = datasets[0]
         sza_data = datasets[1]
         lza_data = datasets[2]
-        output_dataset = dnb_data.where(
-            ~(dnb_data.isnull() | sza_data.isnull()))
+        output_dataset = dnb_data.where(~(dnb_data.isnull() | sza_data.isnull()))
         # this algorithm assumes units of "W cm-2 sr-1" so if there are other
         # units we need to adjust for that
         if dnb_data.attrs.get("units", "W m-2 sr-1") == "W m-2 sr-1":
@@ -471,14 +474,9 @@ class ERFDNB(CompositeBase):
         # Update from Curtis Seaman, increase max radiance curve until less
         # than 0.5% is saturated
         if self.saturation_correction:
-            delayed = dask.delayed(self._saturation_correction)(
-                output_dataset.data, unit_factor,
-                min_val, max_val)
-            output_dataset.data = da.from_delayed(delayed,
-                                                  output_dataset.shape,
-                                                  output_dataset.dtype)
-            output_dataset.data = output_dataset.data.rechunk(
-                dnb_data.data.chunks)
+            delayed = dask.delayed(self._saturation_correction)(output_dataset.data, unit_factor, min_val, max_val)
+            output_dataset.data = da.from_delayed(delayed, output_dataset.shape, output_dataset.dtype)
+            output_dataset.data = output_dataset.data.rechunk(dnb_data.data.chunks)
         else:
             inner_sqrt = (output_dataset - min_val) / (max_val - min_val)
             # clip negative values to 0 before the sqrt
@@ -511,8 +509,7 @@ def make_day_night_masks(solarZenithAngle,
     given, the whole terminator region will be one mask)
     """
     # if the caller passes None, we're only doing one step
-    stepsDegrees = highAngleCutoff - \
-        lowAngleCutoff if stepsDegrees is None else stepsDegrees
+    stepsDegrees = highAngleCutoff - lowAngleCutoff if stepsDegrees is None else stepsDegrees
 
     night_mask = (solarZenithAngle > highAngleCutoff) & good_mask
     day_mask = (solarZenithAngle <= lowAngleCutoff) & good_mask

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -97,7 +97,7 @@ class TestVIIRSComposites(unittest.TestCase):
                          'equalized_radiance')
         data = res.compute()
         unique_values = np.unique(data)
-        np.testing.assert_allclose(unique_values, [0.5994, 0.7992, 0.999], rtol=1e-4)
+        np.testing.assert_allclose(unique_values, [0.5994, 0.7992, 0.999], rtol=1e-3)
 
     def test_adaptive_dnb(self):
         """Test the 'adaptive_dnb' compositor."""

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -97,7 +97,7 @@ class TestVIIRSComposites(unittest.TestCase):
                          'equalized_radiance')
         data = res.compute()
         unique_values = np.unique(data)
-        np.testing.assert_allclose(unique_values, [0.5994, 0.7992, 0.999])
+        np.testing.assert_allclose(unique_values, [0.5994, 0.7992, 0.999], rtol=1e-4)
 
     def test_adaptive_dnb(self):
         """Test the 'adaptive_dnb' compositor."""

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -81,9 +81,10 @@ class TestVIIRSComposites(unittest.TestCase):
         c01 = xr.DataArray(dnb,
                            dims=('y', 'x'),
                            attrs={'name': 'DNB', 'area': area})
+        # data changes by row, sza changes by col for testing
         sza = np.zeros((rows, cols)) + 70.0
-        sza[3, :] += 20.0
-        sza[4:, :] += 45.0
+        sza[:, 3] += 20.0
+        sza[:, 4:] += 45.0
         sza = da.from_array(sza, chunks=25)
         c02 = xr.DataArray(sza,
                            dims=('y', 'x'),
@@ -96,7 +97,7 @@ class TestVIIRSComposites(unittest.TestCase):
                          'equalized_radiance')
         data = res.compute()
         unique_values = np.unique(data)
-        np.testing.assert_allclose(unique_values, [0.25, 0.5, 0.75])
+        np.testing.assert_allclose(unique_values, [0.5994, 0.7992, 0.999])
 
     def test_adaptive_dnb(self):
         """Test the 'adaptive_dnb' compositor."""
@@ -125,8 +126,8 @@ class TestVIIRSComposites(unittest.TestCase):
                            dims=('y', 'x'),
                            attrs={'name': 'DNB', 'area': area})
         sza = np.zeros((rows, cols)) + 70.0
-        sza[3, :] += 20.0
-        sza[4:, :] += 45.0
+        sza[:, 3] += 20.0
+        sza[:, 4:] += 45.0
         sza = da.from_array(sza, chunks=25)
         c02 = xr.DataArray(sza,
                            dims=('y', 'x'),
@@ -167,8 +168,8 @@ class TestVIIRSComposites(unittest.TestCase):
                            dims=('y', 'x'),
                            attrs={'name': 'DNB', 'area': area})
         sza = np.zeros((rows, cols)) + 70.0
-        sza[3, :] += 20.0
-        sza[4:, :] += 45.0
+        sza[:, 3] += 20.0
+        sza[:, 4:] += 45.0
         sza = da.from_array(sza, chunks=25)
         c02 = xr.DataArray(sza,
                            dims=('y', 'x'),
@@ -188,8 +189,8 @@ class TestVIIRSComposites(unittest.TestCase):
                          'equalized_radiance')
         data = res.compute()
         unique = np.unique(data)
-        np.testing.assert_allclose(
-            unique, [0.00000000e+00, 1.64116082e-01, 2.49270516e+02])
+        np.testing.assert_allclose(unique, [0.00000000e+00, 1.00446703e-01, 1.64116082e-01, 2.09233451e-01,
+                                            1.43916324e+02, 2.03528498e+02, 2.49270516e+02])
 
     def test_hncc_dnb(self):
         """Test the 'hncc_dnb' compositor."""
@@ -218,8 +219,8 @@ class TestVIIRSComposites(unittest.TestCase):
                            dims=('y', 'x'),
                            attrs={'name': 'DNB', 'area': area})
         sza = np.zeros((rows, cols)) + 70.0
-        sza[3, :] += 20.0
-        sza[4:, :] += 45.0
+        sza[:, 3] += 20.0
+        sza[:, 4:] += 45.0
         sza = da.from_array(sza, chunks=25)
         c02 = xr.DataArray(sza,
                            dims=('y', 'x'),
@@ -239,8 +240,11 @@ class TestVIIRSComposites(unittest.TestCase):
                          'ncc_radiance')
         data = res.compute()
         unique = np.unique(data)
+        print(repr(unique))
         np.testing.assert_allclose(
-            unique, [3.484797e-04, 9.507845e-03, 4.500016e+03])
+            unique, [3.48479712e-04, 6.96955799e-04, 1.04543189e-03, 4.75394738e-03,
+                     9.50784532e-03, 1.42617433e-02, 1.50001560e+03, 3.00001560e+03,
+                     4.50001560e+03])
 
     def test_reflectance_corrector_abi(self):
         import xarray as xr


### PR DESCRIPTION
Not sure how I missed this. The histogram dnb compositor was returning the original data which at quick glance looks kind of correct for the data case I was testing with. This fixes it.

This also fixes an issue that I'm discovering I made a lot when first converting to xarray/dask: when using delayed functions we really need to be passing the dask array and not the xarray DataArray. This can cause issues in some/most cases.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

