### PR TITLE
Add ability to use dask distributed when generating animation videos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
         - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio<1.0.14 imageio pyhdf mock libtiff pycoast pydecorate geoviews'
+        - CONDA_DEPENDENCIES='xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio<1.0.14 imageio pyhdf mock libtiff pycoast pydecorate geoviews'
         - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital libtiff'
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ environment:
     PYTHON: "C:\\conda"
     MINICONDA_VERSION: "latest"
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-    CONDA_DEPENDENCIES: "xarray dask toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coverage netcdf4 h5py h5netcdf gdal 'rasterio<1.0.14' imageio pyhdf mock libtiff pycoast pydecorate"
+    CONDA_DEPENDENCIES: "xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coverage netcdf4 h5py h5netcdf gdal 'rasterio<1.0.14' imageio pyhdf mock libtiff pycoast pydecorate"
     PIP_DEPENDENCIES: "trollsift trollimage pyspectral pyorbital libtiff"
     CONDA_CHANNELS: "conda-forge"
 

--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -94,6 +94,12 @@ time.
     The ``from_files`` and ``group_files`` functions were added in SatPy 0.12.
     See below for an alternative solution.
 
+This will compute one video frame (image) at a time and write it to the MPEG-4
+video file. For users with more powerful systems it is possible to use
+the ``batch_size`` keyword argument and if the
+dask ``distributed`` library is installed, multiple frames can be computed
+in parallel.
+
 For older versions of SatPy we can manually create the `Scene` objects used.
 The :func:`~glob.glob` function and for loops are used to group files into
 Scene objects that, if used individually, could load the data we want. The

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -457,7 +457,7 @@ class MultiScene(object):
             except ValueError:
                 # create new client
                 from dask.distributed import Client
-                client = Client()
+                client = Client(diagnostics_port=None)
                 close_client = True
 
         # get an ordered list of frames

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -457,7 +457,7 @@ class MultiScene(object):
             except ValueError:
                 # create new client
                 from dask.distributed import Client
-                client = Client(diagnostics_port=None)
+                client = Client()
                 close_client = True
 
         # get an ordered list of frames

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -312,7 +312,12 @@ class MultiScene(object):
 
     def _distribute_frame_compute(self, writers, frame_keys, frames_to_write, client, batch_size=1):
         """Use ``dask.distributed`` to compute multiple frames at a time."""
-        from queue import Queue
+        try:
+            # python 3
+            from queue import Queue
+        except ImportError:
+            # python 2
+            from Queue import Queue
         from threading import Thread
 
         def load_data(frame_gen, q):

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -241,10 +241,13 @@ class TestMultiSceneSave(unittest.TestCase):
             self.base_dir,
             'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
         writer_mock = mock.MagicMock()
+        client_mock = mock.MagicMock()
+        client_mock.compute.side_effect = lambda x: tuple(v.compute() for v in x)
+        client_mock.gather.side_effect = lambda x: x
         with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
             get_writer.return_value = writer_mock
             # force order of datasets by specifying them
-            mscn.save_animation(fn, datasets=['ds1', 'ds2', 'ds3'])
+            mscn.save_animation(fn, client=client_mock, datasets=['ds1', 'ds2', 'ds3'])
 
         # 2 saves for the first scene + 1 black frame
         # 3 for the second scene
@@ -253,22 +256,6 @@ class TestMultiSceneSave(unittest.TestCase):
         self.assertEqual(filenames[0], 'test_save_mp4_ds1_20180101_00_20180102_12.mp4')
         self.assertEqual(filenames[1], 'test_save_mp4_ds2_20180101_00_20180102_12.mp4')
         self.assertEqual(filenames[2], 'test_save_mp4_ds3_20180102_00_20180102_12.mp4')
-
-        # make sure that not specifying datasets still saves all of them
-        fn = os.path.join(
-            self.base_dir,
-            'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
-        writer_mock = mock.MagicMock()
-        with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
-            get_writer.return_value = writer_mock
-            # force order of datasets by specifying them
-            mscn.save_animation(fn)
-        # the 'ds3' dataset isn't known to the first scene so it doesn't get saved
-        # 2 for first scene, 2 for second scene
-        self.assertEqual(writer_mock.append_data.call_count, 2 + 2)
-        self.assertIn('test_save_mp4_ds1_20180101_00_20180102_12.mp4', filenames)
-        self.assertIn('test_save_mp4_ds2_20180101_00_20180102_12.mp4', filenames)
-        self.assertIn('test_save_mp4_ds3_20180102_00_20180102_12.mp4', filenames)
 
 
 class TestBlendFuncs(unittest.TestCase):

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -218,57 +218,57 @@ class TestMultiSceneSave(unittest.TestCase):
         self.assertIn('test_save_mp4_ds2_20180101_00_20180102_12.mp4', filenames)
         self.assertIn('test_save_mp4_ds3_20180102_00_20180102_12.mp4', filenames)
 
-    @mock.patch('satpy.multiscene.get_enhanced_image', _fake_get_enhanced_image)
-    def test_save_mp4_distributed(self):
-        """Save a series of fake scenes to an mp4 video."""
-        from satpy import MultiScene
-        area = _create_test_area()
-        scenes = _create_test_scenes(area=area)
-
-        # Add a dataset to only one of the Scenes
-        scenes[1]['ds3'] = _create_test_dataset('ds3')
-        # Add a start and end time
-        for ds_id in ['ds1', 'ds2', 'ds3']:
-            scenes[1][ds_id].attrs['start_time'] = datetime(2018, 1, 2)
-            scenes[1][ds_id].attrs['end_time'] = datetime(2018, 1, 2, 12)
-            if ds_id == 'ds3':
-                continue
-            scenes[0][ds_id].attrs['start_time'] = datetime(2018, 1, 1)
-            scenes[0][ds_id].attrs['end_time'] = datetime(2018, 1, 1, 12)
-
-        mscn = MultiScene(scenes)
-        fn = os.path.join(
-            self.base_dir,
-            'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
-        writer_mock = mock.MagicMock()
-        with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
-            get_writer.return_value = writer_mock
-            # force order of datasets by specifying them
-            mscn.save_animation(fn, datasets=['ds1', 'ds2', 'ds3'])
-
-        # 2 saves for the first scene + 1 black frame
-        # 3 for the second scene
-        self.assertEqual(writer_mock.append_data.call_count, 3 + 3)
-        filenames = [os.path.basename(args[0][0]) for args in get_writer.call_args_list]
-        self.assertEqual(filenames[0], 'test_save_mp4_ds1_20180101_00_20180102_12.mp4')
-        self.assertEqual(filenames[1], 'test_save_mp4_ds2_20180101_00_20180102_12.mp4')
-        self.assertEqual(filenames[2], 'test_save_mp4_ds3_20180102_00_20180102_12.mp4')
-
-        # make sure that not specifying datasets still saves all of them
-        fn = os.path.join(
-            self.base_dir,
-            'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
-        writer_mock = mock.MagicMock()
-        with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
-            get_writer.return_value = writer_mock
-            # force order of datasets by specifying them
-            mscn.save_animation(fn)
-        # the 'ds3' dataset isn't known to the first scene so it doesn't get saved
-        # 2 for first scene, 2 for second scene
-        self.assertEqual(writer_mock.append_data.call_count, 2 + 2)
-        self.assertIn('test_save_mp4_ds1_20180101_00_20180102_12.mp4', filenames)
-        self.assertIn('test_save_mp4_ds2_20180101_00_20180102_12.mp4', filenames)
-        self.assertIn('test_save_mp4_ds3_20180102_00_20180102_12.mp4', filenames)
+    # @mock.patch('satpy.multiscene.get_enhanced_image', _fake_get_enhanced_image)
+    # def test_save_mp4_distributed(self):
+    #     """Save a series of fake scenes to an mp4 video."""
+    #     from satpy import MultiScene
+    #     area = _create_test_area()
+    #     scenes = _create_test_scenes(area=area)
+    #
+    #     # Add a dataset to only one of the Scenes
+    #     scenes[1]['ds3'] = _create_test_dataset('ds3')
+    #     # Add a start and end time
+    #     for ds_id in ['ds1', 'ds2', 'ds3']:
+    #         scenes[1][ds_id].attrs['start_time'] = datetime(2018, 1, 2)
+    #         scenes[1][ds_id].attrs['end_time'] = datetime(2018, 1, 2, 12)
+    #         if ds_id == 'ds3':
+    #             continue
+    #         scenes[0][ds_id].attrs['start_time'] = datetime(2018, 1, 1)
+    #         scenes[0][ds_id].attrs['end_time'] = datetime(2018, 1, 1, 12)
+    #
+    #     mscn = MultiScene(scenes)
+    #     fn = os.path.join(
+    #         self.base_dir,
+    #         'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
+    #     writer_mock = mock.MagicMock()
+    #     with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
+    #         get_writer.return_value = writer_mock
+    #         # force order of datasets by specifying them
+    #         mscn.save_animation(fn, datasets=['ds1', 'ds2', 'ds3'])
+    #
+    #     # 2 saves for the first scene + 1 black frame
+    #     # 3 for the second scene
+    #     self.assertEqual(writer_mock.append_data.call_count, 3 + 3)
+    #     filenames = [os.path.basename(args[0][0]) for args in get_writer.call_args_list]
+    #     self.assertEqual(filenames[0], 'test_save_mp4_ds1_20180101_00_20180102_12.mp4')
+    #     self.assertEqual(filenames[1], 'test_save_mp4_ds2_20180101_00_20180102_12.mp4')
+    #     self.assertEqual(filenames[2], 'test_save_mp4_ds3_20180102_00_20180102_12.mp4')
+    #
+    #     # make sure that not specifying datasets still saves all of them
+    #     fn = os.path.join(
+    #         self.base_dir,
+    #         'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
+    #     writer_mock = mock.MagicMock()
+    #     with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
+    #         get_writer.return_value = writer_mock
+    #         # force order of datasets by specifying them
+    #         mscn.save_animation(fn)
+    #     # the 'ds3' dataset isn't known to the first scene so it doesn't get saved
+    #     # 2 for first scene, 2 for second scene
+    #     self.assertEqual(writer_mock.append_data.call_count, 2 + 2)
+    #     self.assertIn('test_save_mp4_ds1_20180101_00_20180102_12.mp4', filenames)
+    #     self.assertIn('test_save_mp4_ds2_20180101_00_20180102_12.mp4', filenames)
+    #     self.assertIn('test_save_mp4_ds3_20180102_00_20180102_12.mp4', filenames)
 
 
 class TestBlendFuncs(unittest.TestCase):

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -192,6 +192,58 @@ class TestMultiSceneSave(unittest.TestCase):
         with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
             get_writer.return_value = writer_mock
             # force order of datasets by specifying them
+            mscn.save_animation(fn, datasets=['ds1', 'ds2', 'ds3'], client=False)
+
+        # 2 saves for the first scene + 1 black frame
+        # 3 for the second scene
+        self.assertEqual(writer_mock.append_data.call_count, 3 + 3)
+        filenames = [os.path.basename(args[0][0]) for args in get_writer.call_args_list]
+        self.assertEqual(filenames[0], 'test_save_mp4_ds1_20180101_00_20180102_12.mp4')
+        self.assertEqual(filenames[1], 'test_save_mp4_ds2_20180101_00_20180102_12.mp4')
+        self.assertEqual(filenames[2], 'test_save_mp4_ds3_20180102_00_20180102_12.mp4')
+
+        # make sure that not specifying datasets still saves all of them
+        fn = os.path.join(
+            self.base_dir,
+            'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
+        writer_mock = mock.MagicMock()
+        with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
+            get_writer.return_value = writer_mock
+            # force order of datasets by specifying them
+            mscn.save_animation(fn, client=False)
+        # the 'ds3' dataset isn't known to the first scene so it doesn't get saved
+        # 2 for first scene, 2 for second scene
+        self.assertEqual(writer_mock.append_data.call_count, 2 + 2)
+        self.assertIn('test_save_mp4_ds1_20180101_00_20180102_12.mp4', filenames)
+        self.assertIn('test_save_mp4_ds2_20180101_00_20180102_12.mp4', filenames)
+        self.assertIn('test_save_mp4_ds3_20180102_00_20180102_12.mp4', filenames)
+
+    @mock.patch('satpy.multiscene.get_enhanced_image', _fake_get_enhanced_image)
+    def test_save_mp4_distributed(self):
+        """Save a series of fake scenes to an mp4 video."""
+        from satpy import MultiScene
+        area = _create_test_area()
+        scenes = _create_test_scenes(area=area)
+
+        # Add a dataset to only one of the Scenes
+        scenes[1]['ds3'] = _create_test_dataset('ds3')
+        # Add a start and end time
+        for ds_id in ['ds1', 'ds2', 'ds3']:
+            scenes[1][ds_id].attrs['start_time'] = datetime(2018, 1, 2)
+            scenes[1][ds_id].attrs['end_time'] = datetime(2018, 1, 2, 12)
+            if ds_id == 'ds3':
+                continue
+            scenes[0][ds_id].attrs['start_time'] = datetime(2018, 1, 1)
+            scenes[0][ds_id].attrs['end_time'] = datetime(2018, 1, 1, 12)
+
+        mscn = MultiScene(scenes)
+        fn = os.path.join(
+            self.base_dir,
+            'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
+        writer_mock = mock.MagicMock()
+        with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
+            get_writer.return_value = writer_mock
+            # force order of datasets by specifying them
             mscn.save_animation(fn, datasets=['ds1', 'ds2', 'ds3'])
 
         # 2 saves for the first scene + 1 black frame

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -218,57 +218,57 @@ class TestMultiSceneSave(unittest.TestCase):
         self.assertIn('test_save_mp4_ds2_20180101_00_20180102_12.mp4', filenames)
         self.assertIn('test_save_mp4_ds3_20180102_00_20180102_12.mp4', filenames)
 
-    # @mock.patch('satpy.multiscene.get_enhanced_image', _fake_get_enhanced_image)
-    # def test_save_mp4_distributed(self):
-    #     """Save a series of fake scenes to an mp4 video."""
-    #     from satpy import MultiScene
-    #     area = _create_test_area()
-    #     scenes = _create_test_scenes(area=area)
-    #
-    #     # Add a dataset to only one of the Scenes
-    #     scenes[1]['ds3'] = _create_test_dataset('ds3')
-    #     # Add a start and end time
-    #     for ds_id in ['ds1', 'ds2', 'ds3']:
-    #         scenes[1][ds_id].attrs['start_time'] = datetime(2018, 1, 2)
-    #         scenes[1][ds_id].attrs['end_time'] = datetime(2018, 1, 2, 12)
-    #         if ds_id == 'ds3':
-    #             continue
-    #         scenes[0][ds_id].attrs['start_time'] = datetime(2018, 1, 1)
-    #         scenes[0][ds_id].attrs['end_time'] = datetime(2018, 1, 1, 12)
-    #
-    #     mscn = MultiScene(scenes)
-    #     fn = os.path.join(
-    #         self.base_dir,
-    #         'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
-    #     writer_mock = mock.MagicMock()
-    #     with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
-    #         get_writer.return_value = writer_mock
-    #         # force order of datasets by specifying them
-    #         mscn.save_animation(fn, datasets=['ds1', 'ds2', 'ds3'])
-    #
-    #     # 2 saves for the first scene + 1 black frame
-    #     # 3 for the second scene
-    #     self.assertEqual(writer_mock.append_data.call_count, 3 + 3)
-    #     filenames = [os.path.basename(args[0][0]) for args in get_writer.call_args_list]
-    #     self.assertEqual(filenames[0], 'test_save_mp4_ds1_20180101_00_20180102_12.mp4')
-    #     self.assertEqual(filenames[1], 'test_save_mp4_ds2_20180101_00_20180102_12.mp4')
-    #     self.assertEqual(filenames[2], 'test_save_mp4_ds3_20180102_00_20180102_12.mp4')
-    #
-    #     # make sure that not specifying datasets still saves all of them
-    #     fn = os.path.join(
-    #         self.base_dir,
-    #         'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
-    #     writer_mock = mock.MagicMock()
-    #     with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
-    #         get_writer.return_value = writer_mock
-    #         # force order of datasets by specifying them
-    #         mscn.save_animation(fn)
-    #     # the 'ds3' dataset isn't known to the first scene so it doesn't get saved
-    #     # 2 for first scene, 2 for second scene
-    #     self.assertEqual(writer_mock.append_data.call_count, 2 + 2)
-    #     self.assertIn('test_save_mp4_ds1_20180101_00_20180102_12.mp4', filenames)
-    #     self.assertIn('test_save_mp4_ds2_20180101_00_20180102_12.mp4', filenames)
-    #     self.assertIn('test_save_mp4_ds3_20180102_00_20180102_12.mp4', filenames)
+    @mock.patch('satpy.multiscene.get_enhanced_image', _fake_get_enhanced_image)
+    def test_save_mp4_distributed(self):
+        """Save a series of fake scenes to an mp4 video."""
+        from satpy import MultiScene
+        area = _create_test_area()
+        scenes = _create_test_scenes(area=area)
+
+        # Add a dataset to only one of the Scenes
+        scenes[1]['ds3'] = _create_test_dataset('ds3')
+        # Add a start and end time
+        for ds_id in ['ds1', 'ds2', 'ds3']:
+            scenes[1][ds_id].attrs['start_time'] = datetime(2018, 1, 2)
+            scenes[1][ds_id].attrs['end_time'] = datetime(2018, 1, 2, 12)
+            if ds_id == 'ds3':
+                continue
+            scenes[0][ds_id].attrs['start_time'] = datetime(2018, 1, 1)
+            scenes[0][ds_id].attrs['end_time'] = datetime(2018, 1, 1, 12)
+
+        mscn = MultiScene(scenes)
+        fn = os.path.join(
+            self.base_dir,
+            'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
+        writer_mock = mock.MagicMock()
+        with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
+            get_writer.return_value = writer_mock
+            # force order of datasets by specifying them
+            mscn.save_animation(fn, datasets=['ds1', 'ds2', 'ds3'])
+
+        # 2 saves for the first scene + 1 black frame
+        # 3 for the second scene
+        self.assertEqual(writer_mock.append_data.call_count, 3 + 3)
+        filenames = [os.path.basename(args[0][0]) for args in get_writer.call_args_list]
+        self.assertEqual(filenames[0], 'test_save_mp4_ds1_20180101_00_20180102_12.mp4')
+        self.assertEqual(filenames[1], 'test_save_mp4_ds2_20180101_00_20180102_12.mp4')
+        self.assertEqual(filenames[2], 'test_save_mp4_ds3_20180102_00_20180102_12.mp4')
+
+        # make sure that not specifying datasets still saves all of them
+        fn = os.path.join(
+            self.base_dir,
+            'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
+        writer_mock = mock.MagicMock()
+        with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
+            get_writer.return_value = writer_mock
+            # force order of datasets by specifying them
+            mscn.save_animation(fn)
+        # the 'ds3' dataset isn't known to the first scene so it doesn't get saved
+        # 2 for first scene, 2 for second scene
+        self.assertEqual(writer_mock.append_data.call_count, 2 + 2)
+        self.assertIn('test_save_mp4_ds1_20180101_00_20180102_12.mp4', filenames)
+        self.assertIn('test_save_mp4_ds2_20180101_00_20180102_12.mp4', filenames)
+        self.assertIn('test_save_mp4_ds3_20180102_00_20180102_12.mp4', filenames)
 
 
 class TestBlendFuncs(unittest.TestCase):


### PR DESCRIPTION
This PR is a rewrite of the animation saving logic in the MultiScene. It removes the "cascaded" dask graph that I was using before because I discovered this was not multiprocess safe (opening a new ffmpeg connection on every process/node). I now give the option to use distributed to upload frames to be computed and write them as they complete. My hope is that some users with higher performance systems (or clusters) can take advantage of their systems specs by specifying `batch_size` and computing multiple frames at a time.

If a user does not have distributed installed then a basic one-frame-at-a-time computation will be done using normal dask computations.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

I should note that this is documented in the function but not emphasized in the sphinx docs. I'll consider adding that soon.
