### PR TITLE
Fix pyresample import of parse_area_file for new version of pyresample

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -177,7 +177,10 @@ def get_area_def(area_name):
     The file is defined to use is to be placed in the $PPP_CONFIG_DIR
     directory, and its name is defined in satpy's configuration file.
     """
-    from pyresample.utils import parse_area_file
+    try:
+        from pyresample import parse_area_file
+    except ImportError:
+        from pyresample.utils import parse_area_file
     return parse_area_file(get_area_file(), area_name)[0]
 
 


### PR DESCRIPTION
As seen in https://github.com/pytroll/pyresample/pull/158, the `parse_area_file` function has been moved and can not be imported from the global namespace (`from pyresample import parse_area_file`). This PR allows for that import and fallbacks to the old location of `parse_area_file` if needed.

This is *not* needed for things to work, but does remove the deprecation warning.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

