### PR TITLE
Add 'crop' and 'save_datasets' to MultiScene

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -245,6 +245,7 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'xarray': ('https://xarray.pydata.org/en/stable', None),
     'dask': ('https://docs.dask.org/en/latest', None),
+    'jobqueue': ('https://jobqueue.dask.org/en/latest', None),
     'pyresample': ('https://pyresample.readthedocs.io/en/stable', None),
     'trollsift': ('https://trollsift.readthedocs.io/en/stable', None),
     'trollimage': ('https://trollimage.readthedocs.io/en/stable', None),

--- a/doc/source/dev_guide/xarray_migration.rst
+++ b/doc/source/dev_guide/xarray_migration.rst
@@ -297,12 +297,13 @@ than creating a delayed function. Similar to delayed functions the inputs to
 the function are fully computed DataArrays or numpy arrays, but only the
 individual chunks of the dask array at a time. Note that ``map_blocks`` must
 be provided dask arrays and won't function properly on XArray DataArrays.
+It is recommended that the function object passed to ``map_blocks`` **not**
+be an internal function (a function defined inside another function) or it
+may be unserializable and can cause issues in some environments.
 
 .. code-block:: python
 
     my_new_arr = da.map_blocks(_complex_operation, my_dask_arr1, my_dask_arr2, dtype=my_dask_arr1.dtype)
-
-http://dask.pydata.org/en/latest/array-api.html#dask.array.core.map_blocks
 
 Helpful functions
 *****************

--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -74,7 +74,7 @@ Saving frames of an animation
 -----------------------------
 
 The MultiScene can take "frames" of data and join them together in a single
-animation movie file. Saving animations required the `imageio` python library
+animation movie file. Saving animations requires the `imageio` python library
 and for most available formats the ``ffmpeg`` command line tool suite should
 also be installed. The below example saves a series of GOES-EAST ABI channel
 1 and channel 2 frames to MP4 movie files. We can use the
@@ -96,9 +96,12 @@ time.
 
 This will compute one video frame (image) at a time and write it to the MPEG-4
 video file. For users with more powerful systems it is possible to use
-the ``batch_size`` keyword argument and if the
-dask ``distributed`` library is installed, multiple frames can be computed
-in parallel.
+the ``client`` and ``batch_size`` keyword arguments to compute multiple frames
+in parallel using the dask ``distributed`` library (if installed).
+See the :doc:`dask distributed <dask:setup/single-distributed>` documentation
+for information on creating a ``Client`` object. If working on a cluster
+you may want to use :doc:`dask jobqueue <jobqueue:index>` to take advantage
+of multiple nodes at a time.
 
 For older versions of SatPy we can manually create the `Scene` objects used.
 The :func:`~glob.glob` function and for loops are used to group files into

--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -124,3 +124,22 @@ code below is equivalent to the ``from_files`` code above:
 
     GIF images, although supported, are not recommended due to the large file
     sizes that can be produced from only a few frames.
+
+Saving multiple scenes
+----------------------
+
+The ``MultiScene`` object includes a
+:meth:`~satpy.multiscene.MultiScene.save_datasets` method for saving the
+data from multiple Scenes to disk. By default this will operate on one Scene
+at a time, but similar to the ``save_animation`` method above this method can
+accept a dask distributed ``Client`` object via the ``client`` keyword
+argument to compute scenes in parallel (see documentation above). Note however
+that some writers, like the ``geotiff`` writer, do not support multi-process
+operations at this time and will fail when used with dask distributed. To save
+multiple Scenes use:
+
+    >>> from satpy import Scene, MultiScene
+    >>> from glob import glob
+    >>> mscn = MultiScene.from_files(glob('/data/abi/day_1/*C0[12]*.nc'), reader='abi_l1b')
+    >>> mscn.load(['C01', 'C02'])
+    >>> mscn.save_datasets(base_dir='/path/for/output')

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1269,6 +1269,33 @@ class RatioSharpenedRGB(GenericCompositor):
         return super(RatioSharpenedRGB, self).__call__((r, g, b), **info)
 
 
+def _mean4(data, offset=(0, 0), block_id=None):
+    rows, cols = data.shape
+    # we assume that the chunks except the first ones are aligned
+    if block_id[0] == 0:
+        row_offset = offset[0] % 2
+    else:
+        row_offset = 0
+    if block_id[1] == 0:
+        col_offset = offset[1] % 2
+    else:
+        col_offset = 0
+    row_after = (row_offset + rows) % 2
+    col_after = (col_offset + cols) % 2
+    pad = ((row_offset, row_after), (col_offset, col_after))
+
+    rows2 = rows + row_offset + row_after
+    cols2 = cols + col_offset + col_after
+
+    av_data = np.pad(data, pad, 'edge')
+    new_shape = (int(rows2 / 2.), 2, int(cols2 / 2.), 2)
+    data_mean = np.nanmean(av_data.reshape(new_shape), axis=(1, 3))
+    data_mean = np.repeat(np.repeat(data_mean, 2, axis=0), 2, axis=1)
+    data_mean = data_mean[row_offset:row_offset + rows,
+                col_offset:col_offset + cols]
+    return data_mean
+
+
 class SelfSharpenedRGB(RatioSharpenedRGB):
     """Sharpen RGB with ratio of a band with a strided-version of itself.
 
@@ -1289,32 +1316,6 @@ class SelfSharpenedRGB(RatioSharpenedRGB):
     @staticmethod
     def four_element_average_dask(d):
         """Average every 4 elements (2x2) in a 2D array"""
-        def _mean4(data, offset=(0, 0), block_id=None):
-            rows, cols = data.shape
-            # we assume that the chunks except the first ones are aligned
-            if block_id[0] == 0:
-                row_offset = offset[0] % 2
-            else:
-                row_offset = 0
-            if block_id[1] == 0:
-                col_offset = offset[1] % 2
-            else:
-                col_offset = 0
-            row_after = (row_offset + rows) % 2
-            col_after = (col_offset + cols) % 2
-            pad = ((row_offset, row_after), (col_offset, col_after))
-
-            rows2 = rows + row_offset + row_after
-            cols2 = cols + col_offset + col_after
-
-            av_data = np.pad(data, pad, 'edge')
-            new_shape = (int(rows2 / 2.), 2, int(cols2 / 2.), 2)
-            data_mean = np.nanmean(av_data.reshape(new_shape), axis=(1, 3))
-            data_mean = np.repeat(np.repeat(data_mean, 2, axis=0), 2, axis=1)
-            data_mean = data_mean[row_offset:row_offset + rows,
-                                  col_offset:col_offset + cols]
-            return data_mean
-
         try:
             offset = d.attrs['area'].crop_offset
         except (KeyError, AttributeError):

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1291,8 +1291,7 @@ def _mean4(data, offset=(0, 0), block_id=None):
     new_shape = (int(rows2 / 2.), 2, int(cols2 / 2.), 2)
     data_mean = np.nanmean(av_data.reshape(new_shape), axis=(1, 3))
     data_mean = np.repeat(np.repeat(data_mean, 2, axis=0), 2, axis=1)
-    data_mean = data_mean[row_offset:row_offset + rows,
-                col_offset:col_offset + cols]
+    data_mean = data_mean[row_offset:row_offset + rows, col_offset:col_offset + cols]
     return data_mean
 
 

--- a/satpy/composites/crefl_utils.py
+++ b/satpy/composites/crefl_utils.py
@@ -327,6 +327,11 @@ def chand(phi, muv, mus, taur):
     return rhoray, trdown, trup
 
 
+def _sphalb_index(index_arr, sphalb0):
+    # FIXME: if/when dask can support lazy index arrays then remove this
+    return sphalb0[index_arr]
+
+
 def atm_variables_finder(mus, muv, phi, height, tau, tO3, tH2O, taustep4sphalb, tO2=1.0):
     tau_step = da.linspace(taustep4sphalb, MAXNUMSPHALBVALUES * taustep4sphalb, MAXNUMSPHALBVALUES,
                            chunks=int(MAXNUMSPHALBVALUES / 2))
@@ -334,9 +339,6 @@ def atm_variables_finder(mus, muv, phi, height, tau, tO3, tH2O, taustep4sphalb, 
     taur = tau * da.exp(-height / SCALEHEIGHT)
     rhoray, trdown, trup = chand(phi, muv, mus, taur)
     if isinstance(height, xr.DataArray):
-        def _sphalb_index(index_arr, sphalb0):
-            # FIXME: if/when dask can support lazy index arrays then remove this
-            return sphalb0[index_arr]
         sphalb = da.map_blocks(_sphalb_index, (taur / taustep4sphalb + 0.5).astype(np.int32).data, sphalb0.compute(),
                                dtype=sphalb0.dtype)
     else:
@@ -378,6 +380,10 @@ def get_atm_variables_abi(mus, muv, phi, height, G_O3, G_H2O, G_O2, ah2o, ao2, a
 
 def G_calc(zenith, a_coeff):
     return (da.cos(da.deg2rad(zenith))+(a_coeff[0]*(zenith**a_coeff[1])*(a_coeff[2]-zenith)**a_coeff[3]))**-1
+
+
+def _avg_elevation_index(avg_elevation, row, col):
+    return avg_elevation[row, col]
 
 
 def run_crefl(refl, coeffs,
@@ -423,8 +429,6 @@ def run_crefl(refl, coeffs,
         row[space_mask] = 0
         col[space_mask] = 0
 
-        def _avg_elevation_index(avg_elevation, row, col):
-            return avg_elevation[row, col]
         height = da.map_blocks(_avg_elevation_index, avg_elevation, row, col, dtype=avg_elevation.dtype)
         height = xr.DataArray(height, dims=['y', 'x'])
         # negative heights aren't allowed, clip to 0

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -316,11 +316,7 @@ class MultiScene(object):
 
         log.debug("Waiting for child thread to get saved results...")
         load_thread.join()
-        if load_thread.is_alive():
-            import warnings
-            warnings.warn("Background thread still alive after failing to die gracefully")
-        else:
-            log.debug("Child thread died successfully")
+        log.debug("Child thread died successfully")
 
     def _simple_save_datasets(self, scenes_iter, **kwargs):
         """Helper to simple run save_datasets on each Scene."""

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -25,14 +25,12 @@
 
 import logging
 import numpy as np
-import dask
 import dask.array as da
 import xarray as xr
 import pandas as pd
 from satpy.scene import Scene
 from satpy.writers import get_enhanced_image
 from satpy.dataset import combine_metadata, DatasetID
-from itertools import chain
 from threading import Thread
 
 try:
@@ -41,13 +39,6 @@ try:
 except ImportError:
     # python 2
     from Queue import Queue
-
-try:
-    # new API
-    from dask.highlevelgraph import HighLevelGraph
-except ImportError:
-    # old API
-    import dask.sharedict as HighLevelGraph
 
 try:
     from itertools import zip_longest

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -285,10 +285,8 @@ class MultiScene(object):
     def _distribute_save_datasets(self, scenes_iter, client, batch_size=1, **kwargs):
         """Distribute save_datasets across a cluster."""
         def load_data(scene_gen, q):
-            from satpy.writers import compute_writer_results
             for scene in scene_gen:
-                delayed_save = [scene.save_datasets(compute=False, **kwargs)]
-                future = client.submit(compute_writer_results, delayed_save)
+                future = client.submit(scene.save_datasets, **kwargs)
                 q.put(future)
             q.put(None)
 

--- a/satpy/readers/electrol_hrit.py
+++ b/satpy/readers/electrol_hrit.py
@@ -305,6 +305,10 @@ class HRITGOMSFileHandler(HRITFileHandler):
         logger.debug("Calibration time " + str(datetime.now() - tic))
         return res
 
+    @staticmethod
+    def _getitem(block, lut):
+        return lut[block]
+
     def _calibrate(self, data):
         """Visible/IR channel calibration."""
         lut = self.prologue['ImageCalibration'][self.chid]
@@ -315,7 +319,7 @@ class HRITGOMSFileHandler(HRITFileHandler):
         lut /= 1000
         lut[0] = np.nan
         # Dask/XArray don't support indexing in 2D (yet).
-        res = data.data.map_blocks(lambda block: lut[block], dtype=lut.dtype)
+        res = data.data.map_blocks(self._getitem, dtype=lut.dtype)
         res = xr.DataArray(res, dims=data.dims,
                            attrs=data.attrs, coords=data.coords)
         res = res.where(data > 0)

--- a/satpy/readers/goes_imager_hrit.py
+++ b/satpy/readers/goes_imager_hrit.py
@@ -432,7 +432,7 @@ class HRITGOESFileHandler(HRITFileHandler):
         idx = self.mda['calibration_parameters']['indices']
         val = self.mda['calibration_parameters']['values']
         data.data = da.where(data.data == 0, np.nan, data.data)
-        ddata = data.data.map_blocks(lambda block: np.interp(block, idx, val), dtype=val.dtype)
+        ddata = data.data.map_blocks(np.interp, idx, val, dtype=val.dtype)
         res = xr.DataArray(ddata,
                            dims=data.dims, attrs=data.attrs,
                            coords=data.coords)

--- a/satpy/readers/msi_safe.py
+++ b/satpy/readers/msi_safe.py
@@ -143,6 +143,12 @@ class SAFEMSIMDXML(BaseFileHandler):
                     area_extent=area_extent)
         return area
 
+    @staticmethod
+    def _do_interp(minterp, xcoord, ycoord):
+        interp_points2 = np.vstack((xcoord.ravel(), ycoord.ravel()))
+        res = minterp(interp_points2)
+        return res.reshape(xcoord.shape)
+
     def interpolate_angles(self, angles, resolution):
         # FIXME: interpolate in cartesian coordinates if the lons or lats are
         # problematic
@@ -158,17 +164,10 @@ class SAFEMSIMDXML(BaseFileHandler):
         minterp = MultilinearInterpolator(smin, smax, orders)
         minterp.set_values(da.atleast_2d(angles.ravel()))
 
-        def _do_interp(minterp, xcoord, ycoord):
-            interp_points2 = np.vstack((xcoord.ravel(),
-                                        ycoord.ravel()))
-            res = minterp(interp_points2)
-            return res.reshape(xcoord.shape)
-
         x = da.arange(rows, dtype=angles.dtype, chunks=CHUNK_SIZE) / (rows-1) * (angles.shape[0] - 1)
         y = da.arange(cols, dtype=angles.dtype, chunks=CHUNK_SIZE) / (cols-1) * (angles.shape[1] - 1)
         xcoord, ycoord = da.meshgrid(x, y)
-        return da.map_blocks(_do_interp, minterp, xcoord, ycoord, dtype=angles.dtype,
-                             chunks=xcoord.chunks)
+        return da.map_blocks(self._do_interp, minterp, xcoord, ycoord, dtype=angles.dtype, chunks=xcoord.chunks)
 
     def _get_coarse_dataset(self, key, info):
         """Get the coarse dataset refered to by `key` from the XML data."""

--- a/satpy/readers/olci_nc.py
+++ b/satpy/readers/olci_nc.py
@@ -158,16 +158,16 @@ class NCOLCI1B(NCOLCIChannelBase):
                        dtype=solar_flux.dtype)
         return res
 
+    @staticmethod
+    def _get_items(idx, solar_flux):
+        return solar_flux[idx]
+
     def _get_solar_flux(self, band):
         """Get the solar flux for the band."""
         solar_flux = self.cal['solar_flux'].isel(bands=band).values
         d_index = self.cal['detector_index'].fillna(0).astype(int)
 
-        def get_items(idx, solar_flux):
-            return solar_flux[idx]
-
-        return da.map_blocks(get_items, d_index.data, solar_flux=solar_flux,
-                             dtype=solar_flux.dtype)
+        return da.map_blocks(self._get_items, d_index.data, solar_flux=solar_flux, dtype=solar_flux.dtype)
 
     def get_dataset(self, key, info):
         """Load a dataset."""

--- a/satpy/readers/sar_c_safe.py
+++ b/satpy/readers/sar_c_safe.py
@@ -185,6 +185,10 @@ def interpolate_xarray(xpoints, ypoints, values, shape, kind='cubic',
     return DataArray(res, dims=('y', 'x'))
 
 
+def intp(grid_x, grid_y, interpolator):
+    return interpolator((grid_y, grid_x))
+
+
 def interpolate_xarray_linear(xpoints, ypoints, values, shape):
     """Interpolate linearly, generating a dask array."""
     from scipy.interpolate.interpnd import (LinearNDInterpolator,
@@ -193,10 +197,6 @@ def interpolate_xarray_linear(xpoints, ypoints, values, shape):
                                                  np.asarray(xpoints))).T)
 
     interpolator = LinearNDInterpolator(points, values)
-
-    def intp(grid_x, grid_y, interpolator):
-        return interpolator((grid_y, grid_x))
-
     grid_x, grid_y = da.meshgrid(da.arange(shape[1], chunks=CHUNK_SIZE),
                                  da.arange(shape[0], chunks=CHUNK_SIZE))
     # workaround for non-thread-safe first call of the interpolator:

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -673,6 +673,14 @@ class BilinearResampler(BaseResampler):
         return res
 
 
+def _mean(data, y_size, x_size):
+    rows, cols = data.shape
+    new_shape = (int(rows / y_size), int(y_size),
+                 int(cols / x_size), int(x_size))
+    data_mean = np.nanmean(data.reshape(new_shape), axis=(1, 3))
+    return data_mean
+
+
 class NativeResampler(BaseResampler):
     """Expand or reduce input datasets to be the same shape.
 
@@ -720,7 +728,7 @@ class NativeResampler(BaseResampler):
 
         new_chunks = (tuple(int(x / y_size) for x in d.chunks[0]),
                       tuple(int(x / x_size) for x in d.chunks[1]))
-        return da.core.map_blocks(_mean, d, dtype=d.dtype, chunks=new_chunks)
+        return da.core.map_blocks(_mean, d, y_size, x_size, dtype=d.dtype, chunks=new_chunks)
 
     @classmethod
     def expand_reduce(cls, d_arr, repeats):

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -705,13 +705,6 @@ class NativeResampler(BaseResampler):
     @staticmethod
     def aggregate(d, y_size, x_size):
         """Average every 4 elements (2x2) in a 2D array"""
-        def _mean(data):
-            rows, cols = data.shape
-            new_shape = (int(rows / y_size), int(y_size),
-                         int(cols / x_size), int(x_size))
-            data_mean = np.nanmean(data.reshape(new_shape), axis=(1, 3))
-            return data_mean
-
         if d.ndim != 2:
             # we can't guarantee what blocks we are getting and how
             # it should be reshaped to do the averaging.

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -25,7 +25,6 @@ import os
 import sys
 import tempfile
 import shutil
-from glob import glob
 from datetime import datetime
 
 if sys.version_info < (2, 7):

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -355,18 +355,6 @@ class TestMultiSceneSave(unittest.TestCase):
                                 attrs={'area': area_def2})
         mscn = MultiScene([scene1])
 
-        # by area
-        crop_area = AreaDefinition(
-            'test',
-            'test',
-            'test',
-            proj_dict,
-            x_size,
-            y_size,
-            (area_extent[0] + 10000., area_extent[1] + 500000.,
-             area_extent[2] - 10000., area_extent[3] - 500000.)
-        )
-
         # by lon/lat bbox
         new_mscn = mscn.crop(ll_bbox=(-20., -5., 0, 0))
         new_scn1 = list(new_mscn.scenes)[0]

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -25,6 +25,7 @@ import os
 import sys
 import tempfile
 import shutil
+from glob import glob
 from datetime import datetime
 
 if sys.version_info < (2, 7):
@@ -256,6 +257,126 @@ class TestMultiSceneSave(unittest.TestCase):
         self.assertEqual(filenames[0], 'test_save_mp4_ds1_20180101_00_20180102_12.mp4')
         self.assertEqual(filenames[1], 'test_save_mp4_ds2_20180101_00_20180102_12.mp4')
         self.assertEqual(filenames[2], 'test_save_mp4_ds3_20180102_00_20180102_12.mp4')
+
+    @mock.patch('satpy.multiscene.get_enhanced_image', _fake_get_enhanced_image)
+    def test_save_datasets_simple(self):
+        """Save a series of fake scenes to an PNG images."""
+        from satpy import MultiScene
+        area = _create_test_area()
+        scenes = _create_test_scenes(area=area)
+
+        # Add a dataset to only one of the Scenes
+        scenes[1]['ds3'] = _create_test_dataset('ds3')
+        # Add a start and end time
+        for ds_id in ['ds1', 'ds2', 'ds3']:
+            scenes[1][ds_id].attrs['start_time'] = datetime(2018, 1, 2)
+            scenes[1][ds_id].attrs['end_time'] = datetime(2018, 1, 2, 12)
+            if ds_id == 'ds3':
+                continue
+            scenes[0][ds_id].attrs['start_time'] = datetime(2018, 1, 1)
+            scenes[0][ds_id].attrs['end_time'] = datetime(2018, 1, 1, 12)
+
+        mscn = MultiScene(scenes)
+        client_mock = mock.MagicMock()
+        client_mock.compute.side_effect = lambda x: tuple(v for v in x)
+        client_mock.gather.side_effect = lambda x: x
+        with mock.patch('satpy.multiscene.Scene.save_datasets') as save_datasets:
+            save_datasets.return_value = [True]  # some arbitrary return value
+            # force order of datasets by specifying them
+            mscn.save_datasets(base_dir=self.base_dir, client=False, datasets=['ds1', 'ds2', 'ds3'],
+                               writer='simple_image')
+
+        # 2 for each scene
+        self.assertEqual(save_datasets.call_count, 2)
+
+    @mock.patch('satpy.multiscene.get_enhanced_image', _fake_get_enhanced_image)
+    def test_save_datasets_distributed(self):
+        """Save a series of fake scenes to an PNG images using dask distributed."""
+        from satpy import MultiScene
+        area = _create_test_area()
+        scenes = _create_test_scenes(area=area)
+
+        # Add a dataset to only one of the Scenes
+        scenes[1]['ds3'] = _create_test_dataset('ds3')
+        # Add a start and end time
+        for ds_id in ['ds1', 'ds2', 'ds3']:
+            scenes[1][ds_id].attrs['start_time'] = datetime(2018, 1, 2)
+            scenes[1][ds_id].attrs['end_time'] = datetime(2018, 1, 2, 12)
+            if ds_id == 'ds3':
+                continue
+            scenes[0][ds_id].attrs['start_time'] = datetime(2018, 1, 1)
+            scenes[0][ds_id].attrs['end_time'] = datetime(2018, 1, 1, 12)
+
+        mscn = MultiScene(scenes)
+        client_mock = mock.MagicMock()
+        client_mock.compute.side_effect = lambda x: tuple(v for v in x)
+        client_mock.gather.side_effect = lambda x: x
+        future_mock = mock.MagicMock()
+        with mock.patch('satpy.multiscene.Scene.save_datasets') as save_datasets:
+            save_datasets.return_value = [future_mock]  # some arbitrary return value
+            # force order of datasets by specifying them
+            mscn.save_datasets(base_dir=self.base_dir, client=client_mock, datasets=['ds1', 'ds2', 'ds3'],
+                               writer='simple_image')
+
+        # 2 for each scene
+        self.assertEqual(save_datasets.call_count, 2)
+
+    def test_crop(self):
+        """Test the crop method."""
+        from satpy import Scene, MultiScene
+        from xarray import DataArray
+        from pyresample.geometry import AreaDefinition
+        import numpy as np
+        scene1 = Scene()
+        area_extent = (-5570248.477339745, -5561247.267842293, 5567248.074173927,
+                       5570248.477339745)
+        proj_dict = {'a': 6378169.0, 'b': 6356583.8, 'h': 35785831.0,
+                     'lon_0': 0.0, 'proj': 'geos', 'units': 'm'}
+        x_size = 3712
+        y_size = 3712
+        area_def = AreaDefinition(
+            'test', 'test', 'test',
+            proj_dict,
+            x_size,
+            y_size,
+            area_extent,
+        )
+        area_def2 = AreaDefinition(
+            'test2', 'test2', 'test2', proj_dict,
+            x_size // 2,
+            y_size // 2,
+            area_extent,
+            )
+        scene1["1"] = DataArray(np.zeros((y_size, x_size)))
+        scene1["2"] = DataArray(np.zeros((y_size, x_size)), dims=('y', 'x'))
+        scene1["3"] = DataArray(np.zeros((y_size, x_size)), dims=('y', 'x'),
+                                attrs={'area': area_def})
+        scene1["4"] = DataArray(np.zeros((y_size // 2, x_size // 2)), dims=('y', 'x'),
+                                attrs={'area': area_def2})
+        mscn = MultiScene([scene1])
+
+        # by area
+        crop_area = AreaDefinition(
+            'test',
+            'test',
+            'test',
+            proj_dict,
+            x_size,
+            y_size,
+            (area_extent[0] + 10000., area_extent[1] + 500000.,
+             area_extent[2] - 10000., area_extent[3] - 500000.)
+        )
+
+        # by lon/lat bbox
+        new_mscn = mscn.crop(ll_bbox=(-20., -5., 0, 0))
+        new_scn1 = list(new_mscn.scenes)[0]
+        self.assertIn('1', new_scn1)
+        self.assertIn('2', new_scn1)
+        self.assertIn('3', new_scn1)
+        self.assertTupleEqual(new_scn1['1'].shape, (y_size, x_size))
+        self.assertTupleEqual(new_scn1['2'].shape, (y_size, x_size))
+        self.assertTupleEqual(new_scn1['3'].shape, (184, 714))
+        self.assertTupleEqual(new_scn1['4'].shape, (92, 357))
 
 
 class TestBlendFuncs(unittest.TestCase):


### PR DESCRIPTION
This PR adds the 'crop' and 'save_datasets' method to the `MultiScene` object. It also cleans up some of the dask distributed usage from a previous PR. This adds the functionality to use dask distributed in save_datasets for the MultiScene as well which can improve processing time.

The biggest possible cause of issues from this PR is the work I had to do is to fix the serialization of multiple readers and other parts of satpy. Dask distributed does not like `map_blocks` or `delayed` functions to be internal functions because they can't be serialized. This should be fixed in all of satpy now.

I still need to write tests.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

