### PR TITLE
Fix confusing error in abi_l1b reader when file fails to open

### DIFF
--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -45,8 +45,7 @@ PLATFORM_NAMES = {
 class NC_ABI_L1B(BaseFileHandler):
 
     def __init__(self, filename, filename_info, filetype_info):
-        super(NC_ABI_L1B, self).__init__(filename, filename_info,
-                                         filetype_info)
+        super(NC_ABI_L1B, self).__init__(filename, filename_info, filetype_info)
         # xarray's default netcdf4 engine
         self.nc = xr.open_dataset(self.filename,
                                   decode_cf=True,
@@ -218,5 +217,5 @@ class NC_ABI_L1B(BaseFileHandler):
     def __del__(self):
         try:
             self.nc.close()
-        except (IOError, OSError):
+        except (IOError, OSError, AttributeError):
             pass


### PR DESCRIPTION
Sometimes there are cases where the ABI L1B reader can't open a file and it never creates `self.nc`. In these cases the `__del__` method was trying to access `self.nc.close()` and failing with an `AttributeError`. This AttributeError was getting through to the user and making the overall issue with their use of the reader confusing. This PR catches the AttributeError and stops it from being shown to the user. The rest of the reader should still properly report what went wrong with opening the file (not found, etc).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
