### PR TITLE
Fix geotiff writer being unimportable if gdal isn't installed

### DIFF
--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -27,26 +27,23 @@ import logging
 
 import dask
 import numpy as np
-from osgeo import gdal, osr
 
 from satpy.utils import ensure_dir
 from satpy.writers import ImageWriter
 
+try:
+    import rasterio
+    gdal = osr = None
+except ImportError as r_exc:
+    try:
+        # fallback to legacy gdal writer
+        from osgeo import gdal, osr
+        rasterio = None
+    except ImportError:
+        # raise the original rasterio exception
+        raise r_exc
+
 LOG = logging.getLogger(__name__)
-
-
-# Map numpy data types to GDAL data types
-NP2GDAL = {
-    np.float32: gdal.GDT_Float32,
-    np.float64: gdal.GDT_Float64,
-    np.uint8: gdal.GDT_Byte,
-    np.uint16: gdal.GDT_UInt16,
-    np.uint32: gdal.GDT_UInt32,
-    np.int16: gdal.GDT_Int16,
-    np.int32: gdal.GDT_Int32,
-    np.complex64: gdal.GDT_CFloat32,
-    np.complex128: gdal.GDT_CFloat64,
-}
 
 
 class GeoTIFFWriter(ImageWriter):
@@ -256,6 +253,20 @@ class GeoTIFFWriter(ImageWriter):
                           "This will be deprecated in the future. Install "
                           "'rasterio' for faster saving and future "
                           "compatibility.", PendingDeprecationWarning)
+
+            # Map numpy data types to GDAL data types
+            NP2GDAL = {
+                np.float32: gdal.GDT_Float32,
+                np.float64: gdal.GDT_Float64,
+                np.uint8: gdal.GDT_Byte,
+                np.uint16: gdal.GDT_UInt16,
+                np.uint32: gdal.GDT_UInt32,
+                np.int16: gdal.GDT_Int16,
+                np.int32: gdal.GDT_Int32,
+                np.complex64: gdal.GDT_CFloat32,
+                np.complex128: gdal.GDT_CFloat64,
+            }
+
             # force to numpy dtype object
             dtype = np.dtype(dtype)
             gformat = NP2GDAL[dtype.type]


### PR DESCRIPTION
The geotiff writer is deprecating its use of the 'gdal' python library. It is recommended (and has been for a long time) that `trollimage` is used with `rasterio`. The `rasterio` library only uses the C `gdal` library and not the python library. On some environments (conda) it is possible to have `rasterio` and not python gdal. The geotiff writer currently imports gdal regardless of rasterio existing so in this case you would be unable to use the geotiff writer at all even though you had all the necessary dependencies. This PR fixes that and raises an error if neither rasterio or gdal is importable.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
