### PR TITLE
Add fusion_args global attribute to ABI L1B data when present

### DIFF
--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -136,6 +136,10 @@ class NC_ABI_L1B(BaseFileHandler):
         # copy global attributes to metadata
         for key in ('scene_id', 'orbital_slot', 'instrument_ID', 'production_site', 'timeline_ID'):
             res.attrs[key] = self.nc.attrs.get(key)
+        # only include these if they are present
+        for key in ('fusion_args',):
+            if key in self.nc.attrs:
+                res.attrs[key] = self.nc.attrs[key]
 
         return res
 


### PR DESCRIPTION
The GOES-17 ABI instrument has some hardware issues and can overheat from time to time. In these cases a "fusion" algorithm has been developed that produces files to "make up for" the missing/bad data in some bands by using "good" bands as a base. Right now the only way to identify these products is by the filename (starts with "FR") and a global attribute called "fusion_args". This is a preliminary product and is not widely distributed (if at all) as of the time of this writing. This PR is in preparation of its release so that users have at least some small way of knowing if they are using this "fusion" product.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
