### PR TITLE
Fix mitiff writer handling negative values

### DIFF
--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -608,11 +608,8 @@ class MITIFFWriter(ImageWriter):
             img = get_enhanced_image(datasets.squeeze(), enhance=self.enhancer)
             for i, band in enumerate(img.data['bands']):
                 chn = img.data.sel(bands=band)
-                if (chn < 0).any():
-                    LOG.warning("Band has negative values. Set these to 0.")
-                    chn = chn.where(chn > 0, 0)
+                data = data.clip(0, 1)
                 data = chn.values * 254. + 1
-                data = data.clip(0, 255)
                 tif.write_image(data.astype(np.uint8), compression='deflate')
 
         del tif

--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -608,6 +608,9 @@ class MITIFFWriter(ImageWriter):
             img = get_enhanced_image(datasets.squeeze(), enhance=self.enhancer)
             for i, band in enumerate(img.data['bands']):
                 chn = img.data.sel(bands=band)
+                if (chn < 0).any():
+                    LOG.warning("Band has negative values. Set these to 0.")
+                    chn = chn.where(chn > 0, 0)
                 data = chn.values * 254. + 1
                 data = data.clip(0, 255)
                 tif.write_image(data.astype(np.uint8), compression='deflate')


### PR DESCRIPTION
… set to 0. Else these negative values will be showed as no data in mitiff makeing holes in the images

 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
