### PR TITLE
Add DNB satellite angles (DNB_SENZ, DNB_SENA) to VIIRS SDR reader

### DIFF
--- a/satpy/etc/readers/viirs_sdr.yaml
+++ b/satpy/etc/readers/viirs_sdr.yaml
@@ -425,10 +425,26 @@ datasets:
     coordinates: [dnb_longitude, dnb_latitude]
     file_type: gdnbo
     file_key: 'All_Data/{file_group}_All/LunarZenithAngle'
+  DNB_SENZ:
+    name: dnb_satellite_zenith_angle
+    standard_name: sensor_zenith_angle
+    resolution: 743
+    coordinates: [dnb_longitude, dnb_latitude]
+    units: degrees
+    file_type: gdnbo
+    file_key: 'All_Data/{file_group}_All/SatelliteZenithAngle'
+  DNB_SENA:
+    name: dnb_satellite_azimuth_angle
+    standard_name: sensor_azimuth_angle
+    resolution: 743
+    coordinates: [dnb_longitude, dnb_latitude]
+    units: degrees
+    file_type: gdnbo
+    file_key: 'All_Data/{file_group}_All/SatelliteAzimuthAngle'
   dnb_moon_illumination_fraction:
     name: dnb_moon_illumination_fraction
     file_type: gdnbo
-    file_key: All_Data/{file_group}_All/MoonIllumFraction
+    file_key: 'All_Data/{file_group}_All/MoonIllumFraction'
 
 file_types:
   gitco:


### PR DESCRIPTION
Currently, the VIIRS SDR reader does not load the satellite zenith and azimuth angles from the geolocation file. This PR allows those datasets to be read if required (as is already done for I and M band data).
