### PR TITLE
Fixing start and end times when missing in the CF writer

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -113,6 +113,64 @@ class TestCFWriter(unittest.TestCase):
         finally:
             os.remove(filename)
 
+    def test_bounds_minimum(self):
+        from satpy import Scene
+        import xarray as xr
+        import tempfile
+        scn = Scene()
+        start_timeA = datetime(2018, 5, 30, 10, 0) #expected to be used
+        end_timeA = datetime(2018, 5, 30, 10, 20)
+        start_timeB = datetime(2018, 5, 30, 10, 3)
+        end_timeB = datetime(2018, 5, 30, 10, 15) #expected to be used
+        test_arrayA = np.array([[1, 2], [3, 4]]).reshape(2, 2, 1)
+        test_arrayB = np.array([[1, 2], [3, 5]]).reshape(2, 2, 1)
+        scn['test-arrayA'] = xr.DataArray(test_arrayA,
+                                         dims=['x', 'y', 'time'],
+                                         coords={'time': [np.datetime64('2018-05-30T10:05:00')]},
+                                         attrs=dict(start_time=start_timeA,
+                                                    end_time=end_timeA))
+        scn['test-arrayB'] = xr.DataArray(test_arrayB,
+                                         dims=['x', 'y', 'time'],
+                                         coords={'time': [np.datetime64('2018-05-30T10:05:00')]},
+                                         attrs=dict(start_time=start_timeB,
+                                                    end_time=end_timeB))
+        try:
+            handle, filename = tempfile.mkstemp()
+            os.close(handle)
+            scn.save_datasets(filename=filename, writer='cf')
+            import h5netcdf as nc4
+            with nc4.File(filename) as f:
+                self.assertTrue(all(f['time_bnds'][:] == np.array([-300.,  600.])))
+        finally:
+            os.remove(filename)
+
+    def test_bounds_missing_time_info(self):
+        from satpy import Scene
+        import xarray as xr
+        import tempfile
+        scn = Scene()
+        start_timeA = datetime(2018, 5, 30, 10, 0)
+        end_timeA = datetime(2018, 5, 30, 10, 15)
+        test_arrayA = np.array([[1, 2], [3, 4]]).reshape(2, 2, 1)
+        test_arrayB = np.array([[1, 2], [3, 5]]).reshape(2, 2, 1)
+        scn['test-arrayA'] = xr.DataArray(test_arrayA,
+                                         dims=['x', 'y', 'time'],
+                                         coords={'time': [np.datetime64('2018-05-30T10:05:00')]},
+                                         attrs=dict(start_time=start_timeA,
+                                                    end_time=end_timeA))
+        scn['test-arrayB'] = xr.DataArray(test_arrayB,
+                                          dims=['x', 'y', 'time'],
+                                          coords={'time': [np.datetime64('2018-05-30T10:05:00')]})
+        try:
+            handle, filename = tempfile.mkstemp()
+            os.close(handle)
+            scn.save_datasets(filename=filename, writer='cf')
+            import h5netcdf as nc4
+            with nc4.File(filename) as f:
+                self.assertTrue(all(f['time_bnds'][:] == np.array([-300.,  600.]))) 
+        finally:
+            os.remove(filename)
+
     def test_encoding_kwarg(self):
         from satpy import Scene
         import xarray as xr

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -118,22 +118,22 @@ class TestCFWriter(unittest.TestCase):
         import xarray as xr
         import tempfile
         scn = Scene()
-        start_timeA = datetime(2018, 5, 30, 10, 0) #expected to be used
+        start_timeA = datetime(2018, 5, 30, 10, 0)  # expected to be used
         end_timeA = datetime(2018, 5, 30, 10, 20)
         start_timeB = datetime(2018, 5, 30, 10, 3)
-        end_timeB = datetime(2018, 5, 30, 10, 15) #expected to be used
+        end_timeB = datetime(2018, 5, 30, 10, 15)  # expected to be used
         test_arrayA = np.array([[1, 2], [3, 4]]).reshape(2, 2, 1)
         test_arrayB = np.array([[1, 2], [3, 5]]).reshape(2, 2, 1)
         scn['test-arrayA'] = xr.DataArray(test_arrayA,
-                                         dims=['x', 'y', 'time'],
-                                         coords={'time': [np.datetime64('2018-05-30T10:05:00')]},
-                                         attrs=dict(start_time=start_timeA,
-                                                    end_time=end_timeA))
+                                          dims=['x', 'y', 'time'],
+                                          coords={'time': [np.datetime64('2018-05-30T10:05:00')]},
+                                          attrs=dict(start_time=start_timeA,
+                                                     end_time=end_timeA))
         scn['test-arrayB'] = xr.DataArray(test_arrayB,
-                                         dims=['x', 'y', 'time'],
-                                         coords={'time': [np.datetime64('2018-05-30T10:05:00')]},
-                                         attrs=dict(start_time=start_timeB,
-                                                    end_time=end_timeB))
+                                          dims=['x', 'y', 'time'],
+                                          coords={'time': [np.datetime64('2018-05-30T10:05:00')]},
+                                          attrs=dict(start_time=start_timeB,
+                                                     end_time=end_timeB))
         try:
             handle, filename = tempfile.mkstemp()
             os.close(handle)
@@ -154,10 +154,10 @@ class TestCFWriter(unittest.TestCase):
         test_arrayA = np.array([[1, 2], [3, 4]]).reshape(2, 2, 1)
         test_arrayB = np.array([[1, 2], [3, 5]]).reshape(2, 2, 1)
         scn['test-arrayA'] = xr.DataArray(test_arrayA,
-                                         dims=['x', 'y', 'time'],
-                                         coords={'time': [np.datetime64('2018-05-30T10:05:00')]},
-                                         attrs=dict(start_time=start_timeA,
-                                                    end_time=end_timeA))
+                                          dims=['x', 'y', 'time'],
+                                          coords={'time': [np.datetime64('2018-05-30T10:05:00')]},
+                                          attrs=dict(start_time=start_timeA,
+                                                     end_time=end_timeA))
         scn['test-arrayB'] = xr.DataArray(test_arrayB,
                                           dims=['x', 'y', 'time'],
                                           coords={'time': [np.datetime64('2018-05-30T10:05:00')]})
@@ -167,7 +167,7 @@ class TestCFWriter(unittest.TestCase):
             scn.save_datasets(filename=filename, writer='cf')
             import h5netcdf as nc4
             with nc4.File(filename) as f:
-                self.assertTrue(all(f['time_bnds'][:] == np.array([-300.,  600.]))) 
+                self.assertTrue(all(f['time_bnds'][:] == np.array([-300.,  600.])))
         finally:
             os.remove(filename)
 

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -212,13 +212,13 @@ class CFWriter(Writer):
             ds_collection.update(get_extra_ds(ds))
 
         datas = {}
+        start_times = []
+        end_times = []
         for ds in ds_collection.values():
             try:
                 new_datasets = area2cf(ds)
             except KeyError:
                 new_datasets = [ds.copy(deep=True)]
-            start_times = []
-            end_times = []
             for new_ds in new_datasets:
                 start_times.append(new_ds.attrs.pop("start_time", None))
                 end_times.append(new_ds.attrs.pop("end_time", None))


### PR DESCRIPTION
Signed-off-by: Nina.Hakansson <a001865@c21515.ad.smhi.se>

<!-- Please make the PR against the `master` branch. -->

<!-- Describe what your PR does, and why -->
Fixing problem when start and end times is missing for some datasets in cf_writer.

 
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
