### PR TITLE
Fix VIIRS HNCC composite passing xarray objects to dask

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ deploy:
     user: dhoese
     password:
       secure: frK+0k1STeTM7SizRseP0qdTfOVz9ZMIra+3qEytPdxCLceXAH8LxPU16zj5rdNQxasF1hZ6rAd952fly+ypw2TEf5r2WnStrt7G5QlyE7VB6XGSDpIUxKF1FYccLvYs0/R6Y35MTEPqdM51PM5yEBjoY5b4tA3RF3fDq11cqc/SiWr6DgSLB1WJZULOdtCzBbfGbm5LyJ7yeNbISASSAwVvZTGWw7kJDgi0W5zxwEX82N5tBGbfKIu59qmxyj8FxmcrUwKZ4P3rQNg1kN1utzAB+PSf3GAVvbZfWJQuAKwMqpZgaV9lX0V7eUd/AxPobzEk9WyoNBMIdrSPej5BKWTDiYvaeRTOsggoUCSQJJA/SITEvkJgLWXoKKX2OWrM8RBUO4MoZJpPGXN42PRtMJkV2sx6ZigkpJlHdn39SsIRZX31zsfv8bBhclb70bt1Ts0fDd0rVdZAI6gMI+sgUePwEUn+XbWrvI0sMfDX3QsXDMV393RHgaIPxd+lRqUlYsNOxjsWpsbsvX55ePLxYHsNrv11KKyL/iGjGotVeVUO5D78qvfd4JrsUnMalQyZfW8NTEKa5Ebcs7gYJTwYEOTCQU12BkHOv1zFkjZG5RdGwkEvG3pykLhx+qDyYEd7pKB3TvhzLPqZPSrPxirwcoc0UzCc6ocYdzpqVuViFuk=
-    distributions: sdist bdist_wheel
+    distributions: sdist
     skip_existing: true
     on:
       tags: true

--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -1039,7 +1039,7 @@ class NCCZinke(CompositeBase):
         dnb_data = dnb_data.copy() / unit_factor
 
         # convert to decimal instead of %
-        moon_illum_fraction = da.mean(datasets[3]) * 0.01
+        moon_illum_fraction = da.mean(datasets[3].data) * 0.01
 
         phi = da.rad2deg(da.arccos(2. * moon_illum_fraction - 1))
 

--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -30,7 +30,6 @@ import numpy as np
 import dask
 import dask.array as da
 import xarray as xr
-import xarray.ufuncs as xu
 
 from satpy.composites import CompositeBase, GenericCompositor
 from satpy.config import get_environ_ancpath
@@ -481,7 +480,7 @@ class ERFDNB(CompositeBase):
             inner_sqrt = (output_dataset - min_val) / (max_val - min_val)
             # clip negative values to 0 before the sqrt
             inner_sqrt = inner_sqrt.where(inner_sqrt > 0, 0)
-            output_dataset.data = xu.sqrt(inner_sqrt).data
+            output_dataset.data = np.sqrt(inner_sqrt).data
 
         info = dnb_data.attrs.copy()
         info.update(self.attrs)

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -240,7 +240,6 @@ class TestVIIRSComposites(unittest.TestCase):
                          'ncc_radiance')
         data = res.compute()
         unique = np.unique(data)
-        print(repr(unique))
         np.testing.assert_allclose(
             unique, [3.48479712e-04, 6.96955799e-04, 1.04543189e-03, 4.75394738e-03,
                      9.50784532e-03, 1.42617433e-02, 1.50001560e+03, 3.00001560e+03,


### PR DESCRIPTION
See https://github.com/dask/dask/issues/4532 for details. This fixes the poor usage of dask by passing xarray objects to it.

I'm also using this PR to remove the `bdist_wheel` creation in travis CI given the recent issues discovered with versioneer and wheel creation (see https://github.com/warner/python-versioneer/issues/170).

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

