### PR TITLE
[Obsolete] Cache bilinear resampling LUTs in-memory

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -267,12 +267,13 @@ class BaseResampler(object):
         cache_id = self.precompute(cache_dir=cache_dir, **kwargs)
         return self.compute(data, cache_id=cache_id, **kwargs)
 
-    def _create_cache_filename(self, cache_dir=None, **kwargs):
+    def _create_cache_filename(self, cache_dir=None, prefix='resample_lut-',
+                               **kwargs):
         """Create filename for the cached resampling parameters"""
         cache_dir = cache_dir or '.'
         hash_str = self.get_hash(**kwargs)
 
-        return os.path.join(cache_dir, 'resample_lut-' + hash_str + '.npz')
+        return os.path.join(cache_dir, prefix + hash_str + '.npz')
 
 
 class KDTreeResampler(BaseResampler):
@@ -650,7 +651,7 @@ class BilinearResampler(BaseResampler):
         mask_name = getattr(mask, 'name', None)
         filename = self._create_cache_filename(cache_dir,
                                                mask=mask_name,
-                                               prefix='resample_lut_bil_',
+                                               prefix='resample_lut_bil-',
                                                **kwargs)
         if kwargs.get('mask') in self._index_caches:
             self._apply_cached_indexes(self._index_caches[kwargs.get('mask')])
@@ -669,7 +670,7 @@ class BilinearResampler(BaseResampler):
         if cache_dir:
             filename = self._create_cache_filename(cache_dir,
                                                    mask=mask,
-                                                   prefix='resample_lut_bil_',
+                                                   prefix='resample_lut_bil-',
                                                    **kwargs)
             LOG.info('Saving kd_tree neighbour info to %s', filename)
             cache = {'bilinear_s': self.resampler.bilinear_s,

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -365,7 +365,6 @@ class KDTreeResampler(BaseResampler):
                                                mask=mask_name, **kwargs)
         if kwargs.get('mask') in self._index_caches:
             self._apply_cached_indexes(self._index_caches[kwargs.get('mask')])
-            LOG.debug("Pre-computed kd-tree parameters were re-used from memory")
         elif cache_dir:
             cache = np.load(filename, mmap_mode='r')
             # copy the dict so we can modify it's keys

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -339,7 +339,6 @@ class KDTreeResampler(BaseResampler):
 
         try:
             self.load_neighbour_info(cache_dir, mask=mask, **kwargs)
-            LOG.debug("Read pre-computed kd-tree parameters")
         except IOError:
             LOG.debug("Computing kd-tree parameters")
             self.resampler.get_neighbour_info(mask=mask)
@@ -366,6 +365,7 @@ class KDTreeResampler(BaseResampler):
                                                mask=mask_name, **kwargs)
         if kwargs.get('mask') in self._index_caches:
             self._apply_cached_indexes(self._index_caches[kwargs.get('mask')])
+            LOG.debug("Pre-computed kd-tree parameters were re-used from memory")
         elif cache_dir:
             cache = np.load(filename, mmap_mode='r')
             # copy the dict so we can modify it's keys
@@ -373,6 +373,7 @@ class KDTreeResampler(BaseResampler):
             cache.close()
             self._apply_cached_indexes(new_cache)  # modifies cache dict in-place
             self._index_caches[mask_name] = new_cache
+            LOG.debug("Pre-computed kd-tree parameters were read from disk")
         else:
             raise IOError
 

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -460,7 +460,7 @@ class TestBilinearResampler(unittest.TestCase):
             # we already have things cached in-memory, no need to save again
             self.assertEqual(len(savez.mock_calls), 1)
             # we already have things cached in-memory, don't need to load
-            # self.assertEqual(len(load.mock_calls), 1)
+            self.assertEqual(len(load.mock_calls), 1)
             self.assertEqual(len(resampler.resampler.get_bil_info.mock_calls), nbcalls)
 
             # test loading saved resampler
@@ -469,7 +469,7 @@ class TestBilinearResampler(unittest.TestCase):
             self.assertEqual(len(load.mock_calls), 2)
             self.assertEqual(len(resampler.resampler.get_bil_info.mock_calls), nbcalls)
             # we should have cached things in-memory now
-            # self.assertEqual(len(resampler._index_caches), 1)
+            self.assertEqual(len(resampler._index_caches), 1)
         finally:
             shutil.rmtree(the_dir)
 


### PR DESCRIPTION
This PR adds in-memory caching of bilinear resampling parameters in the same way as nearest neighbour resampling is doing. Before this the parameters were always re-read from disk.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
