### PR TITLE
Add local caching of slicing for data reduction

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -920,7 +920,10 @@ class Scene(MetadataObject):
 
     def _resampled_scene(self, new_scn, destination_area, reduce_data=True,
                          **resample_kwargs):
-        """Resample `datasets` to the `destination` area."""
+        """Resample `datasets` to the `destination` area.
+
+        If data reduction is enabled, some local caching is perfomed in order to
+        avoid recomputation of area intersections."""
         new_datasets = {}
         datasets = list(new_scn.datasets.values())
         if isinstance(destination_area, (str, six.text_type)):
@@ -953,7 +956,7 @@ class Scene(MetadataObject):
             source_area = dataset.attrs['area']
             try:
                 if reduce_data:
-                    key = (source_area, destination_area)
+                    key = source_area
                     try:
                         slices, source_area = reductions[key]
                     except KeyError:

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -918,12 +918,6 @@ class Scene(MetadataObject):
 
         return dataset
 
-    def _reduce_data(self, source_area, destination_area, dataset):
-        """Reduce data by slicing it."""
-        slice_x, slice_y = source_area.get_area_slices(destination_area)
-        source_area = source_area[slice_y, slice_x]
-        return self._slice_data(self, source_area, (slice_x, slice_y), dataset)
-
     def _resampled_scene(self, new_scn, destination_area, reduce_data=True,
                          **resample_kwargs):
         """Resample `datasets` to the `destination` area."""

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -908,16 +908,21 @@ class Scene(MetadataObject):
         if unload:
             self.unload(keepables=keepables)
 
-    def _reduce_data(self, source_area, destination_area, dataset):
-        """Reduce data by slicing it."""
-        slice_x, slice_y = source_area.get_area_slices(destination_area)
-        source_area = source_area[slice_y, slice_x]
+    def _slice_data(self, source_area, slices, dataset):
+        """Slice the data to reduce it."""
+        slice_x, slice_y = slices
         dataset = dataset.isel(x=slice_x, y=slice_y)
         assert ('x', source_area.x_size) in dataset.sizes.items()
         assert ('y', source_area.y_size) in dataset.sizes.items()
         dataset.attrs['area'] = source_area
 
         return dataset
+
+    def _reduce_data(self, source_area, destination_area, dataset):
+        """Reduce data by slicing it."""
+        slice_x, slice_y = source_area.get_area_slices(destination_area)
+        source_area = source_area[slice_y, slice_x]
+        return self._slice_data(self, source_area, (slice_x, slice_y), dataset)
 
     def _resampled_scene(self, new_scn, destination_area, reduce_data=True,
                          **resample_kwargs):
@@ -935,6 +940,7 @@ class Scene(MetadataObject):
                                  "DynamicAreaDefinition.")
 
         resamplers = {}
+        reductions = {}
         for dataset, parent_dataset in dataset_walker(datasets):
             ds_id = DatasetID.from_dict(dataset.attrs)
             pres = None
@@ -953,8 +959,14 @@ class Scene(MetadataObject):
             source_area = dataset.attrs['area']
             try:
                 if reduce_data:
-                    dataset = self._reduce_data(source_area, destination_area, dataset)
-                    source_area = dataset.attrs['area']
+                    key = (source_area, destination_area)
+                    try:
+                        slices, source_area = reductions[key]
+                    except KeyError:
+                        slice_x, slice_y = source_area.get_area_slices(destination_area)
+                        source_area = source_area[slice_y, slice_x]
+                        reductions[key] = (slice_x, slice_y), source_area
+                    dataset = self._slice_data(source_area, (slice_x, slice_y), dataset)
                 else:
                     LOG.debug("Data reduction disabled by the user")
             except NotImplementedError:

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1483,12 +1483,12 @@ class TestSceneResampling(unittest.TestCase):
         """Return copy of dataset pretending it was resampled."""
         return dataset.copy()
 
-    @mock.patch('satpy.scene.Scene._reduce_data')
+    @mock.patch('satpy.scene.Scene._slice_data')
     @mock.patch('satpy.scene.resample_dataset')
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
-    def test_resample_scene_copy(self, cri, cl, rs, reduce_data):
-        """Test that the Scene is properly copied during resampled.
+    def test_resample_scene_copy(self, cri, cl, rs, slice_data):
+        """Test that the Scene is properly copied during resampling.
 
         The Scene that is created as a copy of the original Scene should not
         be able to affect the original Scene object.
@@ -1508,7 +1508,7 @@ class TestSceneResampling(unittest.TestCase):
         proj_dict = proj4_str_to_dict('+proj=lcc +datum=WGS84 +ellps=WGS84 '
                                       '+lon_0=-95. +lat_0=25 +lat_1=25 '
                                       '+units=m +no_defs')
-        area_def = AreaDefinition('test', 'test', 'test', proj_dict, 200, 400, (-1000., -1500., 1000., 1500.))
+        area_def = AreaDefinition('test', 'test', 'test', proj_dict, 5, 5, (-1000., -1500., 1000., 1500.))
 
         scene = satpy.scene.Scene(filenames=['bla'],
                                   base_dir='bli',
@@ -1545,11 +1545,11 @@ class TestSceneResampling(unittest.TestCase):
         scene.load(['comp19'])
         scene['comp19'].attrs['area'] = area_def
         scene.resample(area_def, reduce_data=False)
-        self.assertFalse(reduce_data.called)
+        self.assertFalse(slice_data.called)
         scene.resample(area_def)
-        self.assertTrue(reduce_data.called_once)
+        self.assertTrue(slice_data.called_once)
         scene.resample(area_def, reduce_data=True)
-        self.assertEqual(reduce_data.call_count, 2)
+        self.assertEqual(slice_data.call_count, 2)
 
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')


### PR DESCRIPTION
This PR avoids computing the slices for data reduction repeatedly when a bunch of datasets are resampled from the same area to the same area at the same time

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
