### PR TITLE
Add processing-mode and disposition-mode to the avhrr-l1b-eps file name

### DIFF
--- a/satpy/etc/readers/avhrr_l1b_eps.yaml
+++ b/satpy/etc/readers/avhrr_l1b_eps.yaml
@@ -131,5 +131,5 @@ file_types:
     avhrr_eps:
         file_reader: !!python/name:satpy.readers.eps_l1b.EPSAVHRRFile ''
         file_patterns: [
-                       'AVHR_xxx_1B_{platform_short_name}_{start_time:%Y%m%d%H%M%SZ}_{end_time:%Y%m%d%H%M%SZ}_N_O_{creation_time:%Y%m%d%H%M%SZ}',
-                       'AVHR_xxx_1B_{platform_short_name}_{start_time:%Y%m%d%H%M%SZ}_{end_time:%Y%m%d%H%M%SZ}_N_O_{creation_time:%Y%m%d%H%M%SZ}.nat']
+                       'AVHR_xxx_1B_{platform_short_name}_{start_time:%Y%m%d%H%M%SZ}_{end_time:%Y%m%d%H%M%SZ}_{processing_mode}_{disposition_mode}_{creation_time:%Y%m%d%H%M%SZ}',
+                       'AVHR_xxx_1B_{platform_short_name}_{start_time:%Y%m%d%H%M%SZ}_{end_time:%Y%m%d%H%M%SZ}_{processing_mode}_{disposition_mode}_{creation_time:%Y%m%d%H%M%SZ}.nat']


### PR DESCRIPTION
The avhrr-l1b-eps file name is hardcoded with processing-mode to _N_ and disposition-mode to _O_

During the commisioning of Metop-C at least the disposition-mode needs to added.

According to documentation: http://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_AVHRR_L1B_PRODUCT_GUIDE&RevisionSelectionMethod=LatestReleased&Rendition=Web

Enumeration DISPOSITION_MODE
Value    Name
T          Testing
O          Operational
C          Commissioning 

Enumeration PROCESSING_MODE
Value    Name                                     Description
N           Nominal                                 NRT processing
B           Backlog Processing
R          Reprocessing
V          Validation
