### PR TITLE
Fix the modis overview not to sun normalize the IR channel

### DIFF
--- a/satpy/etc/composites/modis.yaml
+++ b/satpy/etc/composites/modis.yaml
@@ -64,7 +64,6 @@ composites:
     - name: '2'
       modifiers: [sunz_corrected]
     - name: '31'
-      modifiers: [sunz_corrected]
     standard_name: overview
 
   airmass:


### PR DESCRIPTION
The overview recipe for modis was wrong, this fixes it.


 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
