### PR TITLE
Fix resampling of ancillary variables when also first class datasets

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -944,7 +944,9 @@ class Scene(MetadataObject):
             if parent_dataset is not None:
                 pres = new_datasets[DatasetID.from_dict(parent_dataset.attrs)]
             if ds_id in new_datasets:
-                replace_anc(dataset, pres)
+                replace_anc(new_datasets[ds_id], pres)
+                if ds_id in new_scn.datasets:
+                    new_scn.datasets[ds_id] = new_datasets[ds_id]
                 continue
             if dataset.attrs.get('area') is None:
                 if parent_dataset is None:
@@ -978,9 +980,9 @@ class Scene(MetadataObject):
             res = resample_dataset(dataset, destination_area,
                                    **kwargs)
             new_datasets[ds_id] = res
-            if parent_dataset is None:
+            if ds_id in new_scn.datasets:
                 new_scn.datasets[ds_id] = res
-            else:
+            if parent_dataset is not None:
                 replace_anc(res, pres)
 
     def resample(self, destination=None, datasets=None, generate=True,


### PR DESCRIPTION
Sometimes, datasets from a scene are also an ancillary variable to another dataset. When resampling such a scene, only one of the instances of that dataset was actually replaced by the resampled version. This PR fixes this.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

