### PR TITLE
DOC: Fix small typos in documentation

### DIFF
--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -363,7 +363,7 @@ needs to implement a few methods:
    - the filename info (dict) that we get by parsing the filename using the pattern defined in the yaml file
    - the filetype info that we get from the filetype definition in the yaml file
 
-  This method can also recieve other file handler instances as parameter
+  This method can also receive other file handler instances as parameter
   if the filetype at hand has requirements. (See the explanation in the
   YAML file filetype section above)
 
@@ -399,7 +399,7 @@ On top of that, two attributes need to be defined: ``start_time`` and
 
         def get_dataset(self, dataset_id, dataset_info):
             if dataset_id.calibration != 'radiance':
-                # TODO: implement calibration to relfectance or brightness temperature
+                # TODO: implement calibration to reflectance or brightness temperature
                 return
             if self.nc is None:
                 self.nc = xr.open_dataset(self.filename,

--- a/doc/source/dev_guide/xarray_migration.rst
+++ b/doc/source/dev_guide/xarray_migration.rst
@@ -102,6 +102,7 @@ To save metadata, we use the :attr:`~xarray.DataArray.attrs` dictionary.
     my_dataarray.attrs['platform_name'] = 'Sentinel-3A'
 
 Some metadata that should always be present in our dataarrays:
+
 - ``area`` the area of the dataset. This should be handled in the reader.
 - ``start_time``, ``end_time``
 - ``sensor``

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -17,7 +17,7 @@ Scene
 =====
 
 SatPy provides most of its functionality through the
-:class:`~satpy.scene.Scene` class. The acts as a container for the datasets
+:class:`~satpy.scene.Scene` class. This acts as a container for the datasets
 being operated on and provides methods for acting on those datasets. It
 attempts to reduce the amount of low-level knowledge needed by the user while
 still providing a pythonic interface to the functionality underneath.
@@ -64,7 +64,7 @@ Reading
 =======
 
 One of the biggest advantages of using SatPy is the large number of input
-file formats that it can read. It encapsulates this functionality in to
+file formats that it can read. It encapsulates this functionality into
 individual :doc:`readers`. SatPy Readers handle all of the complexity of
 reading whatever format they represent. Meteorological Satellite file formats
 can be extremely complex and formats are rarely reused across satellites

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -38,7 +38,7 @@ Resampling algorithms
     "nearest", "Nearest Neighbor", :class:`~satpy.resample.KDTreeResampler`
     "ewa", "Elliptical Weighted Averaging", :class:`~satpy.resample.EWAResampler`
     "native", "Native", :class:`~satpy.resample.NativeResampler`
-    "bilinear", "Bilinear", :class`~satpy.resample.BilinearResampler`
+    "bilinear", "Bilinear", :class:`~satpy.resample.BilinearResampler`
 
 The resampling algorithm used can be specified with the ``resampler`` keyword
 argument and defaults to ``nearest``:


### PR DESCRIPTION
Fix various small typos in the documentation, both in RST files and in docstrings that are transcluded into the documentation.

 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` 
