### PR TITLE
Fix yaml load to be compatible with pyyaml 5.1

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -30,12 +30,17 @@ import time
 import warnings
 from weakref import WeakValueDictionary
 
+import dask.array as da
 import numpy as np
 import six
 import xarray as xr
 import xarray.ufuncs as xu
-import dask.array as da
 import yaml
+
+try:
+    from yaml import UnsafeLoader
+except ImportError:
+    from yaml import Loader as UnsafeLoader
 
 from satpy.config import CONFIG_PATH, config_search_paths, recursive_dict_update
 from satpy.dataset import DATASET_KEYS, DatasetID, MetadataObject, combine_metadata
@@ -183,7 +188,7 @@ class CompositorLoader(object):
         conf = {}
         for composite_config in composite_configs:
             with open(composite_config) as conf_file:
-                conf = recursive_dict_update(conf, yaml.load(conf_file))
+                conf = recursive_dict_update(conf, yaml.load(conf_file, Loader=UnsafeLoader))
         try:
             sensor_name = conf['sensor_name']
         except KeyError:

--- a/satpy/config.py
+++ b/satpy/config.py
@@ -30,8 +30,13 @@ import logging
 import os
 from collections import Mapping, OrderedDict
 
-from six.moves import configparser
 import yaml
+from six.moves import configparser
+
+try:
+    from yaml import UnsafeLoader
+except ImportError:
+    from yaml import Loader as UnsafeLoader
 
 LOG = logging.getLogger(__name__)
 
@@ -146,7 +151,7 @@ def check_yaml_configs(configs, key, hdr_len):
         for fname in i:
             with open(fname) as stream:
                 try:
-                    res = yaml.load(stream)
+                    res = yaml.load(stream, Loader=UnsafeLoader)
                     try:
                         diagnostic[res[key]['name']] = 'ok'
                     except Exception:
@@ -154,7 +159,7 @@ def check_yaml_configs(configs, key, hdr_len):
                 except yaml.YAMLError as err:
                     stream.seek(0)
                     lines = ''.join(stream.readline() for line in range(hdr_len))
-                    res = yaml.load(lines)
+                    res = yaml.load(lines, Loader=UnsafeLoader)
                     if err.context == 'while constructing a Python object':
                         problem = err.problem
                     else:

--- a/satpy/plugin_base.py
+++ b/satpy/plugin_base.py
@@ -23,7 +23,13 @@
 """
 
 import logging
+
 import yaml
+
+try:
+    from yaml import UnsafeLoader
+except ImportError:
+    from yaml import Loader as UnsafeLoader
 
 from satpy.config import config_search_paths, get_environ_config_dir, recursive_dict_update
 
@@ -67,4 +73,4 @@ class Plugin(object):
     def load_yaml_config(self, conf):
         """Load a YAML configuration file and recursively update the overall configuration."""
         with open(conf) as fd:
-            self.config = recursive_dict_update(self.config, yaml.load(fd))
+            self.config = recursive_dict_update(self.config, yaml.load(fd, Loader=UnsafeLoader))

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -25,11 +25,15 @@
 import logging
 import numbers
 import os
-import warnings
 from datetime import datetime, timedelta
 
 import six
 import yaml
+
+try:
+    from yaml import UnsafeLoader
+except ImportError:
+    from yaml import Loader as UnsafeLoader
 
 from satpy.config import (config_search_paths, get_environ_config_dir,
                           glob_config)
@@ -506,14 +510,14 @@ def group_files(files_to_sort, reader=None, time_threshold=10,
     return [{reader: file_groups[group_key]} for group_key in sorted_group_keys]
 
 
-def read_reader_config(config_files, loader=yaml.Loader):
+def read_reader_config(config_files, loader=UnsafeLoader):
     """Read the reader `config_files` and return the info extracted."""
 
     conf = {}
     LOG.debug('Reading %s', str(config_files))
     for config_file in config_files:
         with open(config_file) as fd:
-            conf.update(yaml.load(fd.read(), loader))
+            conf.update(yaml.load(fd.read(), Loader=loader))
 
     try:
         reader_info = conf['reader']

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -26,15 +26,20 @@ import glob
 import itertools
 import logging
 import os
+import warnings
 from abc import ABCMeta, abstractmethod, abstractproperty
 from collections import deque, OrderedDict
 from fnmatch import fnmatch
-import warnings
+from weakref import WeakValueDictionary
 
 import six
 import xarray as xr
 import yaml
-from weakref import WeakValueDictionary
+
+try:
+    from yaml import UnsafeLoader
+except ImportError:
+    from yaml import Loader as UnsafeLoader
 
 from pyresample.geometry import StackedAreaDefinition, SwathDefinition
 from pyresample.boundary import AreaDefBoundary, Boundary
@@ -89,7 +94,7 @@ class AbstractYAMLReader(six.with_metaclass(ABCMeta, object)):
         self.config_files = config_files
         for config_file in config_files:
             with open(config_file) as fd:
-                self.config = recursive_dict_update(self.config, yaml.load(fd))
+                self.config = recursive_dict_update(self.config, yaml.load(fd, Loader=UnsafeLoader))
 
         self.info = self.config['reader']
         self.name = self.info['name']

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -27,12 +27,17 @@ For now, this includes enhancement configuration utilities.
 
 import logging
 import os
-
-import numpy as np
-import yaml
-import dask.array as da
-import xarray as xr
 import warnings
+
+import dask.array as da
+import numpy as np
+import xarray as xr
+import yaml
+
+try:
+    from yaml import UnsafeLoader
+except ImportError:
+    from yaml import Loader as UnsafeLoader
 
 from satpy.config import (config_search_paths, glob_config,
                           get_environ_config_dir, recursive_dict_update)
@@ -47,14 +52,14 @@ from trollimage.xrimage import XRImage
 LOG = logging.getLogger(__name__)
 
 
-def read_writer_config(config_files, loader=yaml.Loader):
+def read_writer_config(config_files, loader=UnsafeLoader):
     """Read the writer `config_files` and return the info extracted."""
 
     conf = {}
     LOG.debug('Reading %s', str(config_files))
     for config_file in config_files:
         with open(config_file) as fd:
-            conf.update(yaml.load(fd.read(), loader))
+            conf.update(yaml.load(fd.read(), Loader=loader))
 
     try:
         writer_info = conf['writer']
@@ -882,7 +887,7 @@ class EnhancementDecisionTree(DecisionTree):
         for config_file in decision_dict:
             if os.path.isfile(config_file):
                 with open(config_file) as fd:
-                    enhancement_config = yaml.load(fd)
+                    enhancement_config = yaml.load(fd, Loader=UnsafeLoader)
                     if enhancement_config is None:
                         # empty file
                         continue
@@ -896,7 +901,7 @@ class EnhancementDecisionTree(DecisionTree):
                 conf = recursive_dict_update(conf, config_file)
             else:
                 LOG.debug("Loading enhancement config string")
-                d = yaml.load(config_file)
+                d = yaml.load(config_file, Loader=UnsafeLoader)
                 if not isinstance(d, dict):
                     raise ValueError(
                         "YAML file doesn't exist or string is not YAML dict: {}".format(config_file))

--- a/utils/convert_to_ninjotiff.py
+++ b/utils/convert_to_ninjotiff.py
@@ -14,17 +14,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
-
-
-import os, sys
-from satpy.utils import debug_on
-import pyninjotiff
-debug_on()
-from satpy import Scene
-from mpop.projector import get_area_def
-import argparse
-import yaml
-
 """
 First version of a simple command line too that converts an
 image into a NinJo Tiff file.
@@ -38,25 +27,45 @@ areas configuration file (located in $PPP_CONFIG_DIR).
 
 """
 
+import os
+
+from satpy.utils import debug_on
+
+from satpy import Scene
+from mpop.projector import get_area_def
+import argparse
+import yaml
+try:
+    from yaml import UnsafeLoader
+except ImportError:
+    from yaml import Loader as UnsafeLoader
+
+
+debug_on()
 
 parser = argparse.ArgumentParser(description='Turn an image into a NinjoTiff.')
-parser.add_argument('--cfg', dest='cfg', action="store", help="YAML configuration as an alternative to the command line input for NinJo metadata.")
-parser.add_argument('--input_dir', dest='input_dir', action="store", help="Directory with input data, that must contain a timestamp in the filename.")
+parser.add_argument('--cfg', dest='cfg', action="store",
+                    help="YAML configuration as an alternative to the command line input for NinJo metadata.")
+parser.add_argument('--input_dir', dest='input_dir', action="store",
+                    help="Directory with input data, that must contain a timestamp in the filename.")
 parser.add_argument('--chan_id', dest='chan_id', action="store", help="Channel ID", default="9999")
 parser.add_argument('--sat_id', dest='sat_id', action="store", help="Satellite ID", default="8888")
-parser.add_argument('--data_cat', dest='data_cat', action="store", help="Category of data (one of GORN, GPRN, PORN)", default="GORN")
-parser.add_argument('--area', dest='areadef', action="store", help="Area name, the definition must exist in your areas configuration file", default="nrEURO1km_NPOL_COALeqc")
+parser.add_argument('--data_cat', dest='data_cat', action="store",
+                    help="Category of data (one of GORN, GPRN, PORN)", default="GORN")
+parser.add_argument('--area', dest='areadef', action="store",
+                    help="Area name, the definition must exist in your areas configuration file",
+                    default="nrEURO1km_NPOL_COALeqc")
 parser.add_argument('--ph_unit', dest='ph_unit', action="store", help="Physical unit", default="CELSIUS")
 parser.add_argument('--data_src', dest='data_src', action="store", help="Data source", default="EUMETCAST")
 args = parser.parse_args()
 
-if (args.input_dir != None):
+if (args.input_dir is not None):
     os.chdir(args.input_dir)
 
 cfg = vars(args)
-if (args.cfg != None):
+if (args.cfg is not None):
     with open(args.cfg, 'r') as ymlfile:
-        cfg = yaml.load(ymlfile)
+        cfg = yaml.load(ymlfile, Loader=UnsafeLoader)
 
 narea = get_area_def(args.areadef)
 global_data = Scene(sensor="images", reader="generic_image", area=narea)
@@ -66,10 +75,10 @@ global_data['image'].info['area'] = narea
 fname = global_data['image'].info['filename']
 ofname = fname[:-3] + "tif"
 
-#global_data.save_dataset('image', filename="out.png", writer="simple_image")
+# global_data.save_dataset('image', filename="out.png", writer="simple_image")
 global_data.save_dataset('image', filename=ofname, writer="ninjotiff",
-                      sat_id=cfg['sat_id'],
-                      chan_id=cfg['chan_id'],
-                      data_cat=cfg['data_cat'],
-                      data_source=cfg['data_src'],
-                      physic_unit=cfg['ph_unit'])
+                         sat_id=cfg['sat_id'],
+                         chan_id=cfg['chan_id'],
+                         data_cat=cfg['data_cat'],
+                         data_source=cfg['data_src'],
+                         physic_unit=cfg['ph_unit'])


### PR DESCRIPTION
Pyyaml 5.1 deprecated the use of unsafe loading as default, making satpy config loading shaky. This PR restores the expected behaviour in satpy

Here are some explanations about the pyyaml change:
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

