### PR TITLE
In LI reader, decode NC attribute time as ASCII

### DIFF
--- a/satpy/readers/li_l2.py
+++ b/satpy/readers/li_l2.py
@@ -62,11 +62,15 @@ class LIFileHandler(BaseFileHandler):
 
     @property
     def start_time(self):
-        return datetime.strptime(self.nc.attrs['sensing_start'], '%Y%m%d%H%M%S')
+        return datetime.strptime(
+                self.nc.attrs['sensing_start'].item().decode("ascii"),
+                '%Y%m%d%H%M%S')
 
     @property
     def end_time(self):
-        return datetime.strptime(self.nc.attrs['end_time'], '%Y%m%d%H%M%S')
+        return datetime.strptime(
+                self.nc.attrs['end_time'].item().decode("ascii"),
+                '%Y%m%d%H%M%S')
 
     def get_dataset(self, key, info=None, out=None, xslice=None, yslice=None):
         """Load a dataset


### PR DESCRIPTION
In the Lightning Imager (LI) L2 reader, decode the NetCDF attributes containing the starting and ending times as ASCII, so that it can be read in using Python 3.

There are no tests yet for the LI reader, I will add relevant tests to PR #656.
