### PR TITLE
Fix CTTH composite not to mark invalid data as cloud-free

### DIFF
--- a/satpy/composites/cloud_products.py
+++ b/satpy/composites/cloud_products.py
@@ -71,7 +71,7 @@ class CloudTopHeightCompositor(ColormapCompositor):
                                 dims=data.dims, coords=data.coords,
                                 attrs=data.attrs).where(mask_nan)
             # Set cloud-free pixels as black
-            chans.append(chan.where(mask_cloud_free, 0))
+            chans.append(chan.where(mask_cloud_free, 0).where(status != status.attrs['_FillValue']))
 
         res = super(CloudTopHeightCompositor, self).__call__(chans, **data.attrs)
         res.attrs['_FillValue'] = np.nan

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -555,16 +555,18 @@ class TestCloudTopHeightCompositor(unittest.TestCase):
         palette = xr.DataArray(np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]]),
                                dims=['value', 'band'])
         palette.attrs['palette_meanings'] = [2, 3, 4]
-        status = np.array([1, 0, 1])
-        data = xr.DataArray(np.array([[4, 3, 2], [2, 3, 4]], dtype=np.uint8), dims=['y', 'x'])
+        status = xr.DataArray(np.array([[1, 0, 1], [1, 0, 65535]]), dims=['y', 'x'],
+                              attrs={'_FillValue': 65535})
+        data = xr.DataArray(np.array([[4, 3, 2], [2, 3, 4]], dtype=np.uint8),
+                            dims=['y', 'x'])
         res = cmap_comp([data, palette, status])
-        exp = np.array([[[0., 0.498039, 0.],
-                         [0., 0.498039, 0.]],
-                        [[0., 0.498039, 0.],
-                         [0., 0.498039, 0.]],
-                        [[0., 0.498039, 0.],
-                         [0., 0.498039, 0.]]])
-        self.assertTrue(np.allclose(res, exp))
+        exp = np.array([[[0., 0.49803922, 0.],
+                         [0., 0.49803922, np.nan]],
+                        [[0., 0.49803922, 0.],
+                         [0., 0.49803922, np.nan]],
+                        [[0., 0.49803922, 0.],
+                         [0., 0.49803922, np.nan]]])
+        np.testing.assert_allclose(res, exp)
 
 
 class TestGenericCompositor(unittest.TestCase):


### PR DESCRIPTION
This PR fixes a bug that appears when the cloud height product is generated after resampling.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

