### PR TITLE
Fix masked resampling when dataset dtype is integer

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -263,7 +263,11 @@ class BaseResampler(object):
                 geo_dims = ('y', 'x')
             flat_dims = [dim for dim in data.dims if dim not in geo_dims]
             # xarray <= 0.10.1 computes dask arrays during isnull
-            kwargs['mask'] = data.isnull().all(dim=flat_dims)
+            if np.issubdtype(data.dtype, np.integer):
+                kwargs['mask'] = data == data.attrs.get('_FillValue', np.iinfo(data.dtype.type).max)
+            else:
+                kwargs['mask'] = data.isnull()
+            kwargs['mask'] = kwargs['mask'].all(dim=flat_dims)
         cache_id = self.precompute(cache_dir=cache_dir, **kwargs)
         return self.compute(data, cache_id=cache_id, **kwargs)
 

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -47,13 +47,18 @@ class TestHLResample(unittest.TestCase):
                                       xr.DataArray(da.arange(4, chunks=5).reshape((2, 2)), dims=['y', 'x']))
         dest_area = SwathDefinition(xr.DataArray(da.arange(4, chunks=5).reshape((2, 2)) + .0001, dims=['y', 'x']),
                                     xr.DataArray(da.arange(4, chunks=5).reshape((2, 2)) + .0001, dims=['y', 'x']))
-        expected = np.array([[1, 2], [3, 255]])
-        data = xr.DataArray(da.from_array(expected, chunks=5), dims=['y', 'x'])
+        expected_gap = np.array([[1, 2], [3, 255]])
+        data = xr.DataArray(da.from_array(expected_gap, chunks=5), dims=['y', 'x'])
         data.attrs['_FillValue'] = 255
         data.attrs['area'] = source_area
         res = resample_dataset(data, dest_area)
         self.assertEqual(res.dtype, data.dtype)
-        self.assertTrue(np.all(res.values == expected))
+        self.assertTrue(np.all(res.values == expected_gap))
+
+        expected_filled = np.array([[1, 2], [3, 3]])
+        res = resample_dataset(data, dest_area, radius_of_influence=1000000)
+        self.assertEqual(res.dtype, data.dtype)
+        self.assertTrue(np.all(res.values == expected_filled))
 
 
 class TestKDTreeResampler(unittest.TestCase):


### PR DESCRIPTION
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

