### PR TITLE
Fix Scene.crop with RGBs and multidimensional data

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -607,7 +607,7 @@ class Scene(MetadataObject):
                 x_slice = slice(min_x_slice.start * x_factor,
                                 min_x_slice.stop * x_factor)
                 new_area = src_area[y_slice, x_slice]
-                slice_key = (y_slice, x_slice)
+                slice_key = {'y': y_slice, 'x': x_slice}
                 new_scn._slice_datasets(dataset_ids, slice_key, new_area)
             else:
                 new_target_areas[src_area] = self._slice_area_from_bbox(

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -404,6 +404,50 @@ class TestScene(unittest.TestCase):
         self.assertTupleEqual(new_scn1['3'].shape, (36, 70))
         self.assertTupleEqual(new_scn1['4'].shape, (18, 35))
 
+    def test_crop_rgb(self):
+        """Test the crop method on multi-dimensional data."""
+        from satpy import Scene
+        from xarray import DataArray
+        from pyresample.geometry import AreaDefinition
+        import numpy as np
+        scene1 = Scene()
+        area_extent = (-5570248.477339745, -5561247.267842293, 5567248.074173927,
+                       5570248.477339745)
+        proj_dict = {'a': 6378169.0, 'b': 6356583.8, 'h': 35785831.0,
+                     'lon_0': 0.0, 'proj': 'geos', 'units': 'm'}
+        x_size = 3712
+        y_size = 3712
+        area_def = AreaDefinition(
+            'test',
+            'test',
+            'test',
+            proj_dict,
+            x_size,
+            y_size,
+            area_extent,
+        )
+        area_def2 = AreaDefinition(
+            'test2',
+            'test2',
+            'test2',
+            proj_dict,
+            x_size // 2,
+            y_size // 2,
+            area_extent,
+            )
+        scene1["1"] = DataArray(np.zeros((3, y_size, x_size)), dims=('bands', 'y', 'x'), attrs={'area': area_def})
+        scene1["2"] = DataArray(np.zeros((y_size // 2, 3, x_size // 2)), dims=('y', 'bands', 'x'),
+                                attrs={'area': area_def2})
+
+        # by lon/lat bbox
+        new_scn1 = scene1.crop(ll_bbox=(-20., -5., 0, 0))
+        self.assertIn('1', new_scn1)
+        self.assertIn('2', new_scn1)
+        self.assertIn('bands', new_scn1['1'].dims)
+        self.assertIn('bands', new_scn1['2'].dims)
+        self.assertTupleEqual(new_scn1['1'].shape, (3, 184, 714))
+        self.assertTupleEqual(new_scn1['2'].shape, (92, 3, 357))
+
     def test_contains(self):
         from satpy import Scene
         from xarray import DataArray


### PR DESCRIPTION
Geo2Grid user noticed an odd behavior when making AHI RGBs and cropping to a lat/lon bbox. After investigating I discovered that `Scene.crop` is broken for any DataArrays with multiple dimensions where `y` and `x` are not the first dimensions.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

