### PR TITLE
Add satellite position to dataset attributes (seviri_l1b_hrit)

### DIFF
--- a/satpy/readers/hrit_base.py
+++ b/satpy/readers/hrit_base.py
@@ -229,6 +229,7 @@ class HRITFileHandler(BaseFileHandler):
                                              'h': 35785831.00,
                                              # FIXME: find a reasonable SSP
                                              'SSP_longitude': 0.0}
+        self.mda['navigation_parameters'] = {}
 
     def get_shape(self, dsid, ds_info):
         return int(self.mda['number_of_lines']), int(self.mda['number_of_columns'])

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -26,6 +26,7 @@
 
 from datetime import datetime, timedelta
 import numpy as np
+from numpy.polynomial.chebyshev import Chebyshev
 import dask.array as da
 import xarray.ufuncs as xu
 
@@ -288,3 +289,16 @@ class SEVIRICalibrationHandler(object):
         """Calibrate to reflectance."""
 
         return data * 100.0 / solar_irradiance
+
+
+def chebyshev(coefs, time, domain):
+    """Evaluate a Chebyshev Polynomial
+
+    Args:
+        coefs (list, np.array): Coefficients defining the polynomial
+        time (int, float): Time where to evaluate the polynomial
+        domain (list, tuple): Domain (or time interval) for which the polynomial is defined: [left, right]
+
+    Reference: Appendix A in the MSG Level 1.5 Image Data Format Description.
+    """
+    return Chebyshev(coefs, domain=domain)(time) - 0.5 * coefs[0]

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -212,9 +212,11 @@ class HRITMSGPrologueFileHandler(HRITFileHandler):
         Returns: Corresponding index in the coefficient list.
         """
         # Find index of interval enclosing the nominal timestamp of the scan
-        time = self.prologue['ImageAcquisition']['PlannedAcquisitionTime']['TrueRepeatCycleStart']
-        intervals_tstart = self.prologue['SatelliteStatus']['Orbit']['OrbitPolynomial']['StartTime'][0]
-        intervals_tend = self.prologue['SatelliteStatus']['Orbit']['OrbitPolynomial']['EndTime'][0]
+        time = np.datetime64(self.prologue['ImageAcquisition']['PlannedAcquisitionTime']['TrueRepeatCycleStart'])
+        intervals_tstart = self.prologue['SatelliteStatus']['Orbit']['OrbitPolynomial']['StartTime'][0].astype(
+            'datetime64')
+        intervals_tend = self.prologue['SatelliteStatus']['Orbit']['OrbitPolynomial']['EndTime'][0].astype(
+            'datetime64')
         try:
             return np.where(np.logical_and(time >= intervals_tstart, time < intervals_tend))[0][0]
         except IndexError:

--- a/satpy/tests/reader_tests/test_seviri_base.py
+++ b/satpy/tests/reader_tests/test_seviri_base.py
@@ -65,5 +65,7 @@ def suite():
     """The test suite for test_scene."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
-    mysuite.addTest(loader.loadTestsFromTestCase(TestDec10216))
+    tests = [TestDec10216, TestChebyshev]
+    for test in tests:
+        mysuite.addTest(loader.loadTestsFromTestCase(test))
     return mysuite

--- a/satpy/tests/reader_tests/test_seviri_base.py
+++ b/satpy/tests/reader_tests/test_seviri_base.py
@@ -25,7 +25,7 @@
 
 import sys
 import numpy as np
-from satpy.readers.seviri_base import dec10216
+from satpy.readers.seviri_base import dec10216, chebyshev
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -43,6 +43,22 @@ class TestDec10216(unittest.TestCase):
         res = dec10216(np.array([1, 1, 1, 1, 1], dtype=np.uint8))
         exp = np.array([4,  16,  64, 257], dtype=np.uint16)
         self.assertTrue(np.all(res == exp))
+
+
+class TestChebyshev(unittest.TestCase):
+    def chebyshev4(self, c, x, domain):
+        """Evaluate 4th order Chebyshev polynomial"""
+        start_x, end_x = domain
+        t = (x - 0.5 * (end_x + start_x)) / (0.5 * (end_x - start_x))
+        return c[0] + c[1]*t + c[2]*(2*t**2 - 1) + c[3]*(4*t**3 - 3*t) - 0.5*c[0]
+
+    def test_chebyshev(self):
+        coefs = [1, 2, 3, 4]
+        time = 123
+        domain = [120, 130]
+        res = chebyshev(coefs=[1, 2, 3, 4], time=time, domain=domain)
+        exp = self.chebyshev4(coefs, time, domain)
+        self.assertTrue(np.allclose(res, exp))
 
 
 def suite():

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -109,7 +109,7 @@ class TestHRITMSGFileHandler(unittest.TestCase):
                     self.reader.mda['navigation_parameters']['satellite_nominal_latitude'] = 0.0
                     self.reader.mda['navigation_parameters']['satellite_actual_longitude'] = 47.5
                     self.reader.mda['navigation_parameters']['satellite_actual_latitude'] = -0.5
-                    self.reader.mda['navigation_parameters']['satellite_actual_distance'] = 42161463.0
+                    self.reader.mda['navigation_parameters']['satellite_actual_altitude'] = 35783328
 
     def test_get_xy_from_linecol(self):
         """Test get_xy_from_linecol."""
@@ -335,7 +335,7 @@ class TestHRITMSGPrologueFileHandler(unittest.TestCase):
         """Test satellite position in spherical coordinates"""
         get_satpos_cart.return_value = [42078421.37095518, -2611352.744615312, -419828.9699940758]
         lon, lat, dist = self.reader.get_satpos()
-        self.assertTrue(np.allclose(lon, lat, dist), [-3.5511754060136873, -0.5705405726211026, 42161463.02732821])
+        self.assertTrue(np.allclose(lon, lat, dist), [-3.5511754052132387, -0.5711189258438045, 35783328.146167256])
 
         # Test cache
         self.reader.get_satpos()

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -356,6 +356,16 @@ class TestHRITMSGPrologueFileHandler(unittest.TestCase):
             'TrueRepeatCycleStart'] = datetime(2000, 1, 1)
         self.assertTupleEqual(self.reader.get_satpos(), (None, None, None))
 
+    def test_get_earth_radii(self):
+        """Test readout of earth radii"""
+        earth_model = self.reader.prologue['GeometricProcessing']['EarthModel']
+        earth_model['EquatorialRadius'] = 2
+        earth_model['NorthPolarRadius'] = 1
+        earth_model['SouthPolarRadius'] = 2
+        a, b = self.reader.get_earth_radii()
+        self.assertEqual(a, 2000)
+        self.assertEqual(b, 1500)
+
 
 class TestHRITMSGEpilogueFileHandler(unittest.TestCase):
     """Test the HRIT epilogue file handler."""

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -78,6 +78,7 @@ class TestHRITMSGFileHandler(unittest.TestCase):
                                                                                 'EquatorialRadius': 10}},
                                          'ImageDescription': {'ProjectionDescription': {'LongitudeOfSSP': 0.0}}}
                     prologue.get_satpos.return_value = None, None, None
+                    prologue.get_earth_radii.return_value = None, None
 
                     self.reader = HRITMSGFileHandler(
                         'filename',
@@ -270,6 +271,13 @@ class TestHRITMSGPrologueFileHandler(unittest.TestCase):
         self.reader = HRITMSGPrologueFileHandler()
         self.reader.satpos = None
         self.reader.prologue = {
+            'GeometricProcessing': {
+                'EarthModel': {
+                    'EquatorialRadius': 6378.169,
+                    'NorthPolarRadius': 6356.5838,
+                    'SouthPolarRadius': 6356.5838
+                }
+            },
             'ImageAcquisition': {
                 'PlannedAcquisitionTime': {
                     'TrueRepeatCycleStart': datetime(2006, 1, 1, 12, 15, 9, 304888)
@@ -335,7 +343,7 @@ class TestHRITMSGPrologueFileHandler(unittest.TestCase):
         """Test satellite position in spherical coordinates"""
         get_satpos_cart.return_value = [42078421.37095518, -2611352.744615312, -419828.9699940758]
         lon, lat, dist = self.reader.get_satpos()
-        self.assertTrue(np.allclose(lon, lat, dist), [-3.5511754052132387, -0.5711189258438045, 35783328.146167256])
+        self.assertTrue(np.allclose(lon, lat, dist), [-3.5511754052132387, -0.5711189258409902, 35783328.146167226])
 
         # Test cache
         self.reader.get_satpos()

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -27,8 +27,8 @@ from datetime import datetime
 import numpy as np
 import xarray as xr
 
-from satpy.readers.seviri_l1b_hrit import (HRITMSGFileHandler, HRITMSGPrologueFileHandler,
-                                           HRITMSGEpilogueFileHandler)
+from satpy.readers.seviri_l1b_hrit import (HRITMSGFileHandler, HRITMSGPrologueFileHandler, HRITMSGEpilogueFileHandler,
+                                           NoValidNavigationCoefs)
 from satpy.readers.seviri_base import CHANNEL_NAMES, VIS_CHANNELS
 from satpy.dataset import DatasetID
 
@@ -51,6 +51,7 @@ def new_get_hd(instance, hdr_info):
                                              'b': 6356583.80,
                                              'h': 35785831.00,
                                              'SSP_longitude': 0.0}
+    instance.mda['navigation_parameters'] = {}
     instance.mda['total_header_length'] = 12
 
 
@@ -69,12 +70,15 @@ class TestHRITMSGFileHandler(unittest.TestCase):
                 with mock.patch.object(HRITMSGFileHandler, '_get_hd', new=new_get_hd):
                     newopen.return_value.__enter__.return_value.tell.return_value = 1
                     prologue = mock.MagicMock()
-                    prologue.prologue = {"SatelliteStatus": {"SatelliteDefinition": {"SatelliteId": 324}},
+                    prologue.prologue = {"SatelliteStatus": {"SatelliteDefinition": {"SatelliteId": 324,
+                                                                                     "NominalLongitude": 47}},
                                          'GeometricProcessing': {'EarthModel': {'TypeOfEarthModel': 2,
                                                                                 'NorthPolarRadius': 10,
                                                                                 'SouthPolarRadius': 10,
                                                                                 'EquatorialRadius': 10}},
                                          'ImageDescription': {'ProjectionDescription': {'LongitudeOfSSP': 0.0}}}
+                    prologue.get_satpos.return_value = None, None, None
+
                     self.reader = HRITMSGFileHandler(
                         'filename',
                         {'platform_shortname': 'MSG3',
@@ -99,6 +103,13 @@ class TestHRITMSGFileHandler(unittest.TestCase):
                     self.reader.mda['projection_parameters']['b'] = 6356583.8
                     self.reader.mda['projection_parameters']['h'] = 35785831.0
                     self.reader.mda['projection_parameters']['SSP_longitude'] = 44
+                    self.reader.mda['projection_parameters']['SSP_latitude'] = 0.0
+                    self.reader.mda['navigation_parameters'] = {}
+                    self.reader.mda['navigation_parameters']['satellite_nominal_longitude'] = 47
+                    self.reader.mda['navigation_parameters']['satellite_nominal_latitude'] = 0.0
+                    self.reader.mda['navigation_parameters']['satellite_actual_longitude'] = 47.5
+                    self.reader.mda['navigation_parameters']['satellite_actual_latitude'] = -0.5
+                    self.reader.mda['navigation_parameters']['satellite_actual_distance'] = 42161463.0
 
     def test_get_xy_from_linecol(self):
         """Test get_xy_from_linecol."""
@@ -220,9 +231,73 @@ class TestHRITMSGFileHandler(unittest.TestCase):
         self.assertRaises(ValueError, HRITMSGFileHandler, filename=None, filename_info=None,
                           filetype_info=None, prologue=pro, epilogue=epi, calib_mode='invalid')
 
+    @mock.patch('satpy.readers.seviri_l1b_hrit.HRITFileHandler.get_dataset')
+    @mock.patch('satpy.readers.seviri_l1b_hrit.HRITMSGFileHandler.calibrate')
+    def test_get_dataset(self, calibrate, parent_get_dataset):
+        key = mock.MagicMock(calibration='calibration')
+        info = {'units': 'units', 'wavelength': 'wavelength', 'standard_name': 'standard_name'}
+        parent_get_dataset.return_value = mock.MagicMock()
+        calibrate.return_value = mock.MagicMock(attrs={})
+
+        res = self.reader.get_dataset(key, info)
+
+        # Test method calls
+        parent_get_dataset.assert_called_with(key, info)
+        calibrate.assert_called_with(parent_get_dataset(), key.calibration)
+
+        # Test attributes
+        attrs_exp = info.copy()
+        attrs_exp.update({
+            'platform_name': self.reader.platform_name,
+            'sensor': 'seviri',
+            'satellite_longitude': self.reader.mda['projection_parameters']['SSP_longitude'],
+            'satellite_latitude': self.reader.mda['projection_parameters']['SSP_latitude'],
+            'satellite_altitude': self.reader.mda['projection_parameters']['h'],
+            'projection': {'satellite_longitude': self.reader.mda['projection_parameters']['SSP_longitude'],
+                           'satellite_latitude': self.reader.mda['projection_parameters']['SSP_latitude'],
+                           'satellite_altitude': self.reader.mda['projection_parameters']['h']},
+            'navigation': self.reader.mda['navigation_parameters']
+        })
+
+        self.assertDictEqual(attrs_exp, res.attrs)
+
 
 class TestHRITMSGPrologueFileHandler(unittest.TestCase):
     """Test the HRIT prologue file handler."""
+
+    @mock.patch('satpy.readers.seviri_l1b_hrit.HRITMSGPrologueFileHandler.__init__', return_value=None)
+    def setUp(self, *mocks):
+        self.reader = HRITMSGPrologueFileHandler()
+        self.reader.satpos = None
+        self.reader.prologue = {
+            'ImageAcquisition': {
+                'PlannedAcquisitionTime': {
+                    'TrueRepeatCycleStart': datetime(2006, 1, 1, 12, 15, 9, 304888)
+                }
+            },
+            'SatelliteStatus': {
+                'Orbit': {
+                    'OrbitPolynomial': {
+                        'StartTime': np.array([
+                            [datetime(2006, 1, 1, 6), datetime(2006, 1, 1, 12), datetime(2006, 1, 1, 18)]]),
+                        'EndTime': np.array([
+                            [datetime(2006, 1, 1, 12), datetime(2006, 1, 1, 18), datetime(2006, 1, 2, 0)]]),
+                        'X': [np.zeros(8),
+                              [8.41607082e+04, 2.94319260e+00, 9.86748617e-01, -2.70135453e-01,
+                               -3.84364650e-02, 8.48718433e-03, 7.70548174e-04, -1.44262718e-04],
+                              np.zeros(8)],
+                        'Y': [np.zeros(8),
+                              [-5.21170255e+03, 5.12998948e+00, -1.33370453e+00, -3.09634144e-01,
+                               6.18232793e-02, 7.50505681e-03, -1.35131011e-03, -1.12054405e-04],
+                              np.zeros(8)],
+                        'Z': [np.zeros(8),
+                              [-6.51293855e+02, 1.45830459e+02, 5.61379400e+01, -3.90970565e+00,
+                               -7.38137565e-01, 3.06131644e-02, 3.82892428e-03, -1.12739309e-04],
+                              np.zeros(8)],
+                    }
+                }
+            }
+        }
 
     @mock.patch('satpy.readers.seviri_l1b_hrit.HRITMSGPrologueFileHandler.read_prologue')
     @mock.patch('satpy.readers.hrit_base.HRITFileHandler.__init__', autospec=True)
@@ -237,6 +312,41 @@ class TestHRITMSGPrologueFileHandler(unittest.TestCase):
                                    filetype_info=None,
                                    ext_calib_coefs={},
                                    calib_mode='nominal')
+
+    def test_find_navigation_coefs(self):
+        """Test identification of navigation coefficients"""
+
+        self.assertEqual(self.reader._find_navigation_coefs(), 1)
+
+        # No interval enclosing the given timestamp
+        self.reader.prologue['ImageAcquisition']['PlannedAcquisitionTime'][
+            'TrueRepeatCycleStart'] = datetime(2000, 1, 1)
+        self.assertRaises(NoValidNavigationCoefs, self.reader._find_navigation_coefs)
+
+    @mock.patch('satpy.readers.seviri_l1b_hrit.HRITMSGPrologueFileHandler._find_navigation_coefs')
+    def test_get_satpos_cart(self, find_navigation_coefs):
+        """Test satellite position in cartesian coordinates"""
+        find_navigation_coefs.return_value = 1
+        x, y, z = self.reader._get_satpos_cart()
+        self.assertTrue(np.allclose([x, y, z], [42078421.37095518, -2611352.744615312, -419828.9699940758]))
+
+    @mock.patch('satpy.readers.seviri_l1b_hrit.HRITMSGPrologueFileHandler._get_satpos_cart')
+    def test_get_satpos(self, get_satpos_cart):
+        """Test satellite position in spherical coordinates"""
+        get_satpos_cart.return_value = [42078421.37095518, -2611352.744615312, -419828.9699940758]
+        lon, lat, dist = self.reader.get_satpos()
+        self.assertTrue(np.allclose(lon, lat, dist), [-3.5511754060136873, -0.5705405726211026, 42161463.02732821])
+
+        # Test cache
+        self.reader.get_satpos()
+        self.assertEqual(get_satpos_cart.call_count, 1)
+
+        # No valid coefficients
+        self.reader.satpos = None  # reset cache
+        get_satpos_cart.side_effect = NoValidNavigationCoefs
+        self.reader.prologue['ImageAcquisition']['PlannedAcquisitionTime'][
+            'TrueRepeatCycleStart'] = datetime(2000, 1, 1)
+        self.assertTupleEqual(self.reader.get_satpos(), (None, None, None))
 
 
 class TestHRITMSGEpilogueFileHandler(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ from setuptools import find_packages, setup
 
 requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.10.3', 'trollsift',
             'trollimage >=1.5.1', 'pykdtree', 'six', 'pyyaml', 'xarray >=0.10.1',
-            'dask[array] >=0.17.1']
+            'dask[array] >=0.17.1', 'pyproj']
 
 test_requires = ['behave', 'h5py', 'netCDF4', 'pyhdf', 'imageio', 'libtiff',
                  'rasterio', 'geoviews']


### PR DESCRIPTION
The `seviri_l1b_hrit` reader currenlty only provides the longitude and latitude of the projection centre. However, the projection centre does not necessarily represent the actual position of the satellite. For some applications the actual position is required. From the MSG Level 1.5 Image Data Format Description:


> In practise, if the user needs (e.g.) to find a location of a pixel on the Earth ellipsoid, he/she needs to refer to the image projection. If one needs to refer to (e.g) the satellite viewing angles, one needs to refer to the satellite position.


This PR adds the nominal and actual satellite position to the dataset attributes:

- Nominal & actual satellite position can be found under ``navigation``.
- Projection centre and altitude can be found under ``projection``.
- Existing keys ``satellite_longitude/latitude/altitude`` remain
  unchanged for the moment

Example:
```python
from satpy import Scene
import glob

filenames = glob.glob('data/*200601011215*')
scene = Scene(filenames, reader='seviri_l1b_hrit')
scene.load(['IR_108'])

print(scene['IR_108'].attrs['projection'])
print(scene['IR_108'].attrs['navigation'])
```

Output:
```
{'satellite_longitude': 0.0, 'satellite_latitude': 0.0, 'satellite_altitude': 35785831.0}
{'satellite_nominal_longitude': -3.4, 'satellite_nominal_latitude': 0.0, 'satellite_actual_longitude': -3.55117540521326, 'satellite_actual_latitude': -0.5705405815406472, 'satellite_actual_altitude': 35783328.146167256}
```


<!-- Please make the PR against the `master` branch. -->

<!-- Describe what your PR does, and why -->

 - [X] Addresses #670
 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
