### PR TITLE
Add CIMSS True Color (Natural Color) RGB recipes

### DIFF
--- a/satpy/composites/abi.py
+++ b/satpy/composites/abi.py
@@ -29,18 +29,37 @@ LOG = logging.getLogger(__name__)
 
 
 class SimulatedGreen(GenericCompositor):
+    """A single-band dataset resembling a Green (0.55 µm) band.
 
-    """A single-band dataset resembles a Green (0.55 µm)."""
+    This compositor creates a single band product by combining three
+    other bands in various amounts. The general formula with
+    dependencies (d) and fractions (f) is::
+
+        result = d1 * f1 + d2 * f2 + d3 * f3
+
+    See the `fractions` keyword argument for more information.
+    Common used fractions for ABI data with C01, C02, and C03 inputs include:
+
+    - SatPy default (historical): (0.465, 0.465, 0.07)
+    - `CIMSS (Kaba) <https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2018EA000379>`_: (0.45, 0.45, 0.01)
+    - `EDC <http://edc.occ-data.org/goes16/python/>`_: (0.45706946, 0.48358168, 0.06038137)
+
+    """
+
+    def __init__(self, name, fractions=(0.465, 0.465, 0.07), **kwargs):
+        """Initialize fractions for input channels.
+
+        Args:
+            name (str): Name of this composite
+            fractions (iterable): Fractions of each input band to include in the result.
+
+        """
+        self.fractions = fractions
+        super(SimulatedGreen, self).__init__(name, **kwargs)
 
     def __call__(self, projectables, optional_datasets=None, **attrs):
+        """Generate the single band composite."""
         c01, c02, c03 = self.check_areas(projectables)
-
-        # Kaba:
-        # res = (c01 + c02) * 0.45 + 0.1 * c03
-        # EDC:
-        # res = c01 * 0.45706946 + c02 * 0.48358168 + 0.06038137 * c03
-        # Original attempt:
-        res = (c01 + c02) / 2 * 0.93 + 0.07 * c03
+        res = c01 * self.fractions[0] + c02 * self.fractions[1] + c03 * self.fractions[2]
         res.attrs = c03.attrs.copy()
-
         return super(SimulatedGreen, self).__call__((res,), **attrs)

--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -52,6 +52,32 @@ composites:
       modifiers: [sunz_corrected]
     standard_name: toa_bidirection_reflectance
 
+  cimss_green:
+    compositor: !!python/name:satpy.composites.abi.SimulatedGreen
+    fractions: [0.45, 0.45, 0.01]
+    prerequisites:
+      # should we be using the most corrected or least corrected inputs?
+      - name: C01
+        modifiers: [sunz_corrected, rayleigh_corrected]
+      - name: C02
+        modifiers: [sunz_corrected, rayleigh_corrected]
+      - name: C03
+        modifiers: [sunz_corrected]
+    standard_name: toa_bidirection_reflectance
+
+  cimss_green_raw:
+    compositor: !!python/name:satpy.composites.abi.SimulatedGreen
+    fractions: [0.45, 0.45, 0.01]
+    prerequisites:
+      # should we be using the most corrected or least corrected inputs?
+      - name: C01
+        modifiers: [sunz_corrected]
+      - name: C02
+        modifiers: [sunz_corrected]
+      - name: C03
+        modifiers: [sunz_corrected]
+    standard_name: toa_bidirection_reflectance
+
   green:
     compositor: !!python/name:satpy.composites.abi.SimulatedGreen
     # FUTURE: Set a wavelength...see what happens. Dependency finding
@@ -84,6 +110,30 @@ composites:
     - name: green_raw
     - name: C01
       modifiers: [sunz_corrected]
+    standard_name: true_color
+
+  cimss_true_color:
+    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
+    description: CIMSS Enhanced Natural Color RGB
+    references:
+      - https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2018EA000379
+    prerequisites:
+      - name: C02
+        modifiers: [sunz_corrected, rayleigh_corrected]
+      - name: cimss_green
+      - name: C01
+        modifiers: [sunz_corrected, rayleigh_corrected]
+    standard_name: true_color
+
+  cimss_true_color_raw:
+    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
+    description: CIMSS Natural Color RGB (no rayleigh)
+    prerequisites:
+      - name: C02
+        modifiers: [sunz_corrected]
+      - name: cimss_green_raw
+      - name: C01
+        modifiers: [sunz_corrected]
     standard_name: true_color
 
   true_color:

--- a/satpy/etc/enhancements/abi.yaml
+++ b/satpy/etc/enhancements/abi.yaml
@@ -1,0 +1,23 @@
+enhancements:
+  cimss_true_color:
+    name: cimss_true_color
+    standard_name: true_color
+    sensor: abi
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0.0, max_stretch: 100.}
+      - name: gamma
+        method: !!python/name:satpy.enhancements.gamma
+        kwargs: {gamma: 2.0}
+  cimss_true_color_raw:
+    name: cimss_true_color_raw
+    standard_name: true_color
+    sensor: abi
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0.0, max_stretch: 100.}
+      - name: gamma
+        method: !!python/name:satpy.enhancements.gamma
+        kwargs: {gamma: 2.0}


### PR DESCRIPTION
I talked with the NOAA/CIMSS GOES Imagery team about adding this composite to SatPy so that it could be included in CSPP Geo2Grid. This PR adds the necessary steps to add it. Although this is complete I want to wait for some feedback from the Imagery team because the produced output makes the output's green colors look very grey.

This recipe is described here: https://agupubs.onlinelibrary.wiley.com/doi/10.1029/2018EA000379

It is important to note that the Imagery team (as described in the above paper) consider composites to fall in to two categories: true color and false color. I have always considered true color one specific composite (with optional modifications like rayleigh correction and any number of enhancement differences). The Imagery team see it as the true color category where the various modifications/enhancements make separate composites in that category. They also use the name "natural color" for their true color because it is the way the earth looks "naturally". Although this name makes more sense for this RGB compared to what EUMETSAT's "natural color" is, most people know the EUTMETSAT version by this name. Therefore, I've named this composite "cimss_true_color".

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
