### PR TITLE
Make masking of Himawari space pixels optional

### DIFF
--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -243,7 +243,7 @@ class AHIHSDFileHandler(BaseFileHandler):
 
     """
 
-    def __init__(self, filename, filename_info, filetype_info,mask_space=True):
+    def __init__(self, filename, filename_info, filetype_info, mask_space=True):
         """Initialize the reader."""
         super(AHIHSDFileHandler, self).__init__(filename, filename_info,
                                                 filetype_info)

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -219,8 +219,29 @@ _SPARE_TYPE = np.dtype([
     ("spare", "S256")
 ])
 
+
 class AHIHSDFileHandler(BaseFileHandler):
-    """AHI standard format reader."""
+    """AHI standard format reader.
+    The AHI sensor produces data for some pixels outside the Earth disk (i,e: 
+    atmospheric limb or deep space pixels).
+    By default, these pixels are masked out as they contain data of limited
+    or no value, but some applications do require these pixels.
+    It is therefore possible to override the default behaviour and perform no
+    masking of non-Earth pixels.
+
+    In order to change the default behaviour, use the 'mask_space' variable
+    as part of ``reader_kwargs`` upon Scene creation::
+
+        import satpy
+        import glob
+
+        filenames = glob.glob('*FLDK*.dat')
+        scene = satpy.Scene(filenames,
+                            reader='ahi_hsd',
+                            reader_kwargs={'mask_space': False})
+        scene.load([0.6])
+
+    """
 
     def __init__(self, filename, filename_info, filetype_info,mask_space=True):
         """Initialize the reader."""

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -445,7 +445,7 @@ class AHIHSDFileHandler(BaseFileHandler):
 
         # Mask space pixels
         if (self.mask_space):
-           res = self._mask_space(res)
+            res = self._mask_space(res)
 
         return res
 

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -465,7 +465,7 @@ class AHIHSDFileHandler(BaseFileHandler):
         res = xr.DataArray(res, attrs=new_info, dims=['y', 'x'])
 
         # Mask space pixels
-        if (self.mask_space):
+        if self.mask_space:
             res = self._mask_space(res)
 
         return res

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -222,7 +222,7 @@ _SPARE_TYPE = np.dtype([
 
 class AHIHSDFileHandler(BaseFileHandler):
     """AHI standard format reader.
-    The AHI sensor produces data for some pixels outside the Earth disk (i,e: 
+    The AHI sensor produces data for some pixels outside the Earth disk (i,e:
     atmospheric limb or deep space pixels).
     By default, these pixels are masked out as they contain data of limited
     or no value, but some applications do require these pixels.

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -219,11 +219,10 @@ _SPARE_TYPE = np.dtype([
     ("spare", "S256")
 ])
 
-
 class AHIHSDFileHandler(BaseFileHandler):
     """AHI standard format reader."""
 
-    def __init__(self, filename, filename_info, filetype_info):
+    def __init__(self, filename, filename_info, filetype_info,mask_space=True):
         """Initialize the reader."""
         super(AHIHSDFileHandler, self).__init__(filename, filename_info,
                                                 filetype_info)
@@ -254,6 +253,7 @@ class AHIHSDFileHandler(BaseFileHandler):
         self.platform_name = np2str(self.basic_info['satellite'])
         self.observation_area = np2str(self.basic_info['observation_area'])
         self.sensor = 'ahi'
+        self.mask_space = mask_space
 
     @property
     def start_time(self):
@@ -444,7 +444,8 @@ class AHIHSDFileHandler(BaseFileHandler):
         res = xr.DataArray(res, attrs=new_info, dims=['y', 'x'])
 
         # Mask space pixels
-        res = self._mask_space(res)
+        if (self.mask_space):
+           res = self._mask_space(res)
 
         return res
 

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -222,6 +222,7 @@ _SPARE_TYPE = np.dtype([
 
 class AHIHSDFileHandler(BaseFileHandler):
     """AHI standard format reader.
+
     The AHI sensor produces data for some pixels outside the Earth disk (i,e:
     atmospheric limb or deep space pixels).
     By default, these pixels are masked out as they contain data of limited

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -229,22 +229,18 @@ class TestAHIHSDFileHandler(unittest.TestCase):
         calibrate.return_value = np.ones((nrows, ncols))
         m = mock.mock_open()
         with mock.patch('satpy.readers.ahi_hsd.open', m, create=True):
-            # Default behaviour, mask space pixels
             im = self.fh.read_band(info=mock.MagicMock(), key=mock.MagicMock())
             # Note: Within the earth's shape get_geostationary_mask() is True but the numpy.ma mask
             # is False
             mask = im.to_masked_array().mask
             ref_mask = np.logical_not(get_geostationary_mask(self.fh.area).compute())
-            self.assertTrue(np.all(mask == ref_mask))
-
-            # Modified behaviour, do not mask space pixels
-            self.fh.mask_space = False
-            im = self.fh.read_band(info=mock.MagicMock(), key=mock.MagicMock())
-            # Note: Within the earth's shape get_geostationary_mask() is True but the numpy.ma mask
-            # is False
-            mask = im.to_masked_array().mask
-            ref_mask = np.logical_not(get_geostationary_mask(self.fh.area).compute())
-            self.assertFalse(np.all(mask == ref_mask))
+            self.assertTrue(np.all(mask == ref_mask))    
+            
+        # Test if masking space pixels disables with appropriate flag
+        self.fh.mask_space = False
+        with mock.patch('satpy.readers.ahi_hsd.AHIHSDFileHandler._mask_space') as mask_space:
+            self.fh.read_band(info=mock.MagicMock(), key=mock.MagicMock())
+            mask_space.assert_not_called()
 
 
 def suite():

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -236,11 +236,11 @@ class TestAHIHSDFileHandler(unittest.TestCase):
             ref_mask = np.logical_not(get_geostationary_mask(self.fh.area).compute())
             self.assertTrue(np.all(mask == ref_mask))
 
-        # Test if masking space pixels disables with appropriate flag
-        self.fh.mask_space = False
-        with mock.patch('satpy.readers.ahi_hsd.AHIHSDFileHandler._mask_space') as mask_space:
-            self.fh.read_band(info=mock.MagicMock(), key=mock.MagicMock())
-            mask_space.assert_not_called()
+            # Test if masking space pixels disables with appropriate flag
+            self.fh.mask_space = False
+            with mock.patch('satpy.readers.ahi_hsd.AHIHSDFileHandler._mask_space') as mask_space:
+                self.fh.read_band(info=mock.MagicMock(), key=mock.MagicMock())
+                mask_space.assert_not_called()
 
 
 def suite():

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -229,12 +229,22 @@ class TestAHIHSDFileHandler(unittest.TestCase):
         calibrate.return_value = np.ones((nrows, ncols))
         m = mock.mock_open()
         with mock.patch('satpy.readers.ahi_hsd.open', m, create=True):
+            # Default behaviour, mask space pixels
             im = self.fh.read_band(info=mock.MagicMock(), key=mock.MagicMock())
             # Note: Within the earth's shape get_geostationary_mask() is True but the numpy.ma mask
             # is False
             mask = im.to_masked_array().mask
             ref_mask = np.logical_not(get_geostationary_mask(self.fh.area).compute())
             self.assertTrue(np.all(mask == ref_mask))
+
+            # Modified behaviour, do not mask space pixels
+            self.fh.mask_space = False
+            im = self.fh.read_band(info=mock.MagicMock(), key=mock.MagicMock())
+            # Note: Within the earth's shape get_geostationary_mask() is True but the numpy.ma mask
+            # is False
+            mask = im.to_masked_array().mask
+            ref_mask = np.logical_not(get_geostationary_mask(self.fh.area).compute())
+            self.assertFalse(np.all(mask == ref_mask))
 
 
 def suite():

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -235,7 +235,7 @@ class TestAHIHSDFileHandler(unittest.TestCase):
             mask = im.to_masked_array().mask
             ref_mask = np.logical_not(get_geostationary_mask(self.fh.area).compute())
             self.assertTrue(np.all(mask == ref_mask))
-            
+
         # Test if masking space pixels disables with appropriate flag
         self.fh.mask_space = False
         with mock.patch('satpy.readers.ahi_hsd.AHIHSDFileHandler._mask_space') as mask_space:

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -234,7 +234,7 @@ class TestAHIHSDFileHandler(unittest.TestCase):
             # is False
             mask = im.to_masked_array().mask
             ref_mask = np.logical_not(get_geostationary_mask(self.fh.area).compute())
-            self.assertTrue(np.all(mask == ref_mask))    
+            self.assertTrue(np.all(mask == ref_mask))
             
         # Test if masking space pixels disables with appropriate flag
         self.fh.mask_space = False


### PR DESCRIPTION
Currently, when processing Himawari data SatPy will mask all pixels outside the Earth disk. This is not always the desired behaviour (for example, studying noctilucent clouds in AHI data requires the 'space' pixels to be preserved).
This PR makes the space pixel masking optional by setting up a new kwarg - `mask_space` - that can be set to either True or False. The default value is True, which mirrors the current behaviour of SatPy and means that users must explicitly disable masking.
This can be done by passing `reader_kwargs={'mask_space': False}` to a new Scene object.

An example of usage is included in the docstring for AHIHSDFileHandler and is copied below:
```
        import satpy
        import glob

        filenames = glob.glob('*FLDK*.dat')
        scene = satpy.Scene(filenames,
                            reader='ahi_hsd',
                            reader_kwargs={'mask_space': False})
        scene.load([0.6])
```



 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented
