### PR TITLE
Fix bug in Scene.resample causing AssertionError

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -962,7 +962,7 @@ class Scene(MetadataObject):
                 if reduce_data:
                     key = source_area
                     try:
-                        slices, source_area = reductions[key]
+                        (slice_x, slice_y), source_area = reductions[key]
                     except KeyError:
                         slice_x, slice_y = source_area.get_area_slices(destination_area)
                         source_area = source_area[slice_y, slice_x]
@@ -979,8 +979,7 @@ class Scene(MetadataObject):
                 self.resamplers[key] = resampler
             kwargs = resample_kwargs.copy()
             kwargs['resampler'] = resamplers[source_area]
-            res = resample_dataset(dataset, destination_area,
-                                   **kwargs)
+            res = resample_dataset(dataset, destination_area, **kwargs)
             new_datasets[ds_id] = res
             if ds_id in new_scn.datasets:
                 new_scn.datasets[ds_id] = res


### PR DESCRIPTION
This has been a bug that I've run in to randomly and have had a hard time reproducing it. The following error is sometimes seen when resampling a Scene:

```
/srv/conda/lib/python3.7/site-packages/satpy/scene.py in _slice_data(self, source_area, slices, dataset)
    913         slice_x, slice_y = slices
    914         dataset = dataset.isel(x=slice_x, y=slice_y)
--> 915         assert ('x', source_area.x_size) in dataset.sizes.items()
    916         assert ('y', source_area.y_size) in dataset.sizes.items()
    917         dataset.attrs['area'] = source_area

AssertionError: 
```

This is caused by the slices used during area reduction (just before resampling) being mixed up. So although the new area of a sliced dataset is correct, the slices used to resample the actual data are from the previous iteration of the loop. The order the loop is executed is technically random based on dictionary/set order. This is generally what happens when things go wrong:

1. Reduce ds1 at 500m resolution (slice_x, slice_y, and source_area correspond to ds1)
2. Reduce ds2 at 1km resolution (slice_x, slice_y, and source_area correspond to ds2)
3. Reduce ds3 at 500m resolution. We see that we've reduced this area before so the code *was* (before this PR) setting the slices to use to a `slices` variable but then never using it! Instead falling back to using the previous iterations `slice_x` and `slice_y`.

Technically this is just a typo, but the tests added to test this were...not fun.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

