### PR TITLE
Add demo subpackage to simplify test data download

### DIFF
--- a/doc/source/api/satpy.demo.rst
+++ b/doc/source/api/satpy.demo.rst
@@ -1,0 +1,22 @@
+satpy.demo package
+==================
+
+Submodules
+----------
+
+satpy.demo.google\_cloud\_platform module
+-----------------------------------------
+
+.. automodule:: satpy.demo.google_cloud_platform
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+Module contents
+---------------
+
+.. automodule:: satpy.demo
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc/source/api/satpy.rst
+++ b/doc/source/api/satpy.rst
@@ -7,6 +7,7 @@ Subpackages
 .. toctree::
 
     satpy.composites
+    satpy.demo
     satpy.enhancements
     satpy.readers
     satpy.writers

--- a/satpy/demo/__init__.py
+++ b/satpy/demo/__init__.py
@@ -37,28 +37,41 @@ including:
     This is method is mainly meant when tutorials are taught at the SSEC
     using a Jupyter Hub server.
 
+To use these functions, do:
+
+    >>> from satpy import Scene, demo
+    >>> filenames = demo.get_us_midlatitude_cyclone_abi()
+    >>> scn = Scene(reader='abi_l1b', filenames=filenames)
+
 """
 
 import os
 import logging
 
-try:
-    import gcsfs
-except ImportError:
-    gcsfs = None
-
 LOG = logging.getLogger(__name__)
 
 
+def makedirs(directory, exist_ok=False):
+    """Python 2.7 friendly os.makedirs.
+
+    After python 2.7 is dropped, just use `os.makedirs` with `existsok=True`.
+    """
+    try:
+        os.makedirs(directory)
+    except OSError:
+        if not exist_ok:
+            raise
+
+
 def get_us_midlatitude_cyclone_abi(base_dir='.', method=None, force=False):
-    """Get GOES-16 ABI data from March 14th 00:00Z.
+    """Get GOES-16 ABI (CONUS sector) data from March 14th 00:00Z.
 
     Args:
         base_dir (str): Base directory for downloaded files.
         method (str): Force download method for the data if not already cached.
             Allowed options are: 'gcsfs'. Default of ``None`` will
             choose the best method based on environment settings.
-        force (bool): Force re-download of data regardless of its existense on
+        force (bool): Force re-download of data regardless of its existence on
             the local system. Warning: May delete non-demo files stored in
             download directory.
 
@@ -68,16 +81,9 @@ def get_us_midlatitude_cyclone_abi(base_dir='.', method=None, force=False):
     if method not in ['gcsfs']:
         raise NotImplementedError("Demo data download method '{}' not "
                                   "implemented yet.".format(method))
-    fs = gcsfs.GCSFileSystem(token='anon')
-    filenames = []
-    for fn in fs.glob('gs://gcp-public-data-goes-16/ABI-L1b-RadC/2019/073/00/*0002*.nc'):
-        ondisk_fn = os.path.basename(fn)
-        ondisk_pathname = os.path.join(base_dir, ondisk_fn)
-        filenames.append(ondisk_pathname)
-        LOG.info("Downloading: {}".format(ondisk_pathname))
 
-        if force and os.path.isfile(ondisk_pathname):
-            os.remove(ondisk_pathname)
-        elif os.path.isfile(ondisk_pathname):
-            continue
-        fs.get('gs://' + fn, ondisk_pathname)
+    from .google_cloud_platform import get_bucket_files
+    patterns = ['gs://gcp-public-data-goes-16/ABI-L1b-RadC/2019/073/00/*0002*.nc']
+    subdir = os.path.join(base_dir, 'abi_l1b', '20190314_us_midlatitude_cyclone')
+    makedirs(subdir, exist_ok=True)
+    return get_bucket_files(patterns, subdir, force=force)

--- a/satpy/demo/__init__.py
+++ b/satpy/demo/__init__.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 SatPy developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from datetime import datetime, timedelta
+
+DEMO_CASES = {
+    'abi_l1b': {
+        'glob': 'OR_ABI-L1b-RadM1-M3C??_G16_s20182541[3456]?????_e*_c*.nc',
+        'datetime': (
+            datetime(2018, 9, 11, 13, 0, 0),
+            datetime(2018, 9, 11, 16, 0, 0),  # or should it be exclusive
+        ),
+    },
+}
+

--- a/satpy/demo/__init__.py
+++ b/satpy/demo/__init__.py
@@ -15,16 +15,69 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Demo data download helper functions.
 
-from datetime import datetime, timedelta
+Each ``get_*`` function below downloads files to a local directory and returns
+a list of paths to those files. Some (not all) functions have multiple options
+for how the data is downloaded (via the ``method`` keyword argument)
+including:
 
-DEMO_CASES = {
-    'abi_l1b': {
-        'glob': 'OR_ABI-L1b-RadM1-M3C??_G16_s20182541[3456]?????_e*_c*.nc',
-        'datetime': (
-            datetime(2018, 9, 11, 13, 0, 0),
-            datetime(2018, 9, 11, 16, 0, 0),  # or should it be exclusive
-        ),
-    },
-}
+- gcsfs: Download data from a public google cloud storage bucket using the
+    ``gcsfs`` package.
+- unidata_thredds: Access data using OpenDAP or similar method from Unidata's
+    public THREDDS server
+    (https://thredds.unidata.ucar.edu/thredds/catalog.html).
+- uwaos_thredds: Access data using OpenDAP or similar method from the
+    University of Wisconsin - Madison's AOS department's THREDDS server.
+- http: A last resort download method when nothing else is available of a
+    tarball or zip file from one or more servers available to the SatPy
+    project.
+- uw_arcdata: A network mount available on many servers at the Space Science
+    and Engineering Center (SSEC) at the University of Wisconsin - Madison.
+    This is method is mainly meant when tutorials are taught at the SSEC
+    using a Jupyter Hub server.
 
+"""
+
+import os
+import logging
+
+try:
+    import gcsfs
+except ImportError:
+    gcsfs = None
+
+LOG = logging.getLogger(__name__)
+
+
+def get_us_midlatitude_cyclone_abi(base_dir='.', method=None, force=False):
+    """Get GOES-16 ABI data from March 14th 00:00Z.
+
+    Args:
+        base_dir (str): Base directory for downloaded files.
+        method (str): Force download method for the data if not already cached.
+            Allowed options are: 'gcsfs'. Default of ``None`` will
+            choose the best method based on environment settings.
+        force (bool): Force re-download of data regardless of its existense on
+            the local system. Warning: May delete non-demo files stored in
+            download directory.
+
+    """
+    if method is None:
+        method = 'gcsfs'
+    if method not in ['gcsfs']:
+        raise NotImplementedError("Demo data download method '{}' not "
+                                  "implemented yet.".format(method))
+    fs = gcsfs.GCSFileSystem(token='anon')
+    filenames = []
+    for fn in fs.glob('gs://gcp-public-data-goes-16/ABI-L1b-RadC/2019/073/00/*0002*.nc'):
+        ondisk_fn = os.path.basename(fn)
+        ondisk_pathname = os.path.join(base_dir, ondisk_fn)
+        filenames.append(ondisk_pathname)
+        LOG.info("Downloading: {}".format(ondisk_pathname))
+
+        if force and os.path.isfile(ondisk_pathname):
+            os.remove(ondisk_pathname)
+        elif os.path.isfile(ondisk_pathname):
+            continue
+        fs.get('gs://' + fn, ondisk_pathname)

--- a/satpy/demo/__init__.py
+++ b/satpy/demo/__init__.py
@@ -86,4 +86,6 @@ def get_us_midlatitude_cyclone_abi(base_dir='.', method=None, force=False):
     patterns = ['gs://gcp-public-data-goes-16/ABI-L1b-RadC/2019/073/00/*0002*.nc']
     subdir = os.path.join(base_dir, 'abi_l1b', '20190314_us_midlatitude_cyclone')
     makedirs(subdir, exist_ok=True)
-    return get_bucket_files(patterns, subdir, force=force)
+    filenames = get_bucket_files(patterns, subdir, force=force)
+    assert len(filenames) == 16, "Not all ABI files could be downloaded"
+    return filenames

--- a/satpy/demo/google_cloud_platform.py
+++ b/satpy/demo/google_cloud_platform.py
@@ -16,7 +16,54 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
+import logging
+
+LOG = logging.getLogger(__name__)
+
 
 def is_google_cloud_instance():
     from urllib.request import urlopen
     return urlopen('http://metadata.google.internal').headers.get('Metadata-Flavor') == 'Google'
+
+
+def get_bucket_files(glob_pattern, base_dir, force=False):
+    """Helper function to download files from Google Cloud Storage.
+
+    Args:
+        glob_pattern (str or list): Glob pattern string or series of patterns
+            used to search for on Google Cloud Storage. The pattern should
+            include the "gs://" protocol prefix.
+        base_dir (str): Root directory to place downloaded files on the local
+            system.
+        force (bool): Force re-download of data regardless of its existence on
+            the local system. Warning: May delete non-demo files stored in
+            download directory.
+
+    """
+    try:
+        import gcsfs
+    except ImportError:
+        raise RuntimeError("Missing 'gcsfs' dependency for GCS download.")
+
+    if isinstance(glob_pattern, str):
+        glob_pattern = [glob_pattern]
+
+    fs = gcsfs.GCSFileSystem(token='anon')
+    filenames = []
+    for gp in glob_pattern:
+        for fn in fs.glob(gp):
+            ondisk_fn = os.path.basename(fn)
+            ondisk_pathname = os.path.join(base_dir, ondisk_fn)
+            filenames.append(ondisk_pathname)
+            LOG.info("Downloading: {}".format(ondisk_pathname))
+
+            if force and os.path.isfile(ondisk_pathname):
+                os.remove(ondisk_pathname)
+            elif os.path.isfile(ondisk_pathname):
+                continue
+            fs.get('gs://' + fn, ondisk_pathname)
+
+    if not filenames:
+        raise OSError("No files could be found or downloaded.")
+    return filenames

--- a/satpy/demo/google_cloud_platform.py
+++ b/satpy/demo/google_cloud_platform.py
@@ -20,6 +20,13 @@ import os
 import logging
 
 try:
+    from urllib.request import urlopen
+    from urllib.error import URLError
+except ImportError:
+    # python 2
+    from urllib2 import urlopen, URLError
+
+try:
     import gcsfs
 except ImportError:
     gcsfs = None
@@ -28,8 +35,6 @@ LOG = logging.getLogger(__name__)
 
 
 def is_google_cloud_instance():
-    from urllib.request import urlopen
-    from urllib.error import URLError
     try:
         return urlopen('http://metadata.google.internal').headers.get('Metadata-Flavor') == 'Google'
     except URLError:

--- a/satpy/demo/google_cloud_platform.py
+++ b/satpy/demo/google_cloud_platform.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 SatPy developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+def is_google_cloud_instance():
+    from urllib.request import urlopen
+    return urlopen('http://metadata.google.internal').headers.get('Metadata-Flavor') == 'Google'

--- a/satpy/tests/__init__.py
+++ b/satpy/tests/__init__.py
@@ -26,7 +26,7 @@ import logging
 import sys
 
 from satpy.tests import (reader_tests, test_dataset, test_file_handlers,
-                         test_readers, test_resample,
+                         test_readers, test_resample, test_demo,
                          test_scene, test_utils, test_writers,
                          test_yaml_reader, writer_tests,
                          test_enhancements, compositor_tests, test_multiscene)
@@ -49,6 +49,7 @@ def suite():
     mysuite.addTests(test_writers.suite())
     mysuite.addTests(test_readers.suite())
     mysuite.addTests(test_resample.suite())
+    mysuite.addTests(test_demo.suite())
     mysuite.addTests(test_yaml_reader.suite())
     mysuite.addTests(reader_tests.suite())
     mysuite.addTests(writer_tests.suite())

--- a/satpy/tests/test_demo.py
+++ b/satpy/tests/test_demo.py
@@ -33,12 +33,13 @@ except ImportError:
 class TestDemo(unittest.TestCase):
     """Test demo data download functions."""
 
-    @mock.patch('satpy.demo.google_cloud_platform.gcsfs.GCSFileSystem')
-    def test_get_us_midlatitude_cyclone_abi(self, gcsfs_cls):
+    @mock.patch('satpy.demo.google_cloud_platform.gcsfs')
+    def test_get_us_midlatitude_cyclone_abi(self, gcsfs_mod):
         """Test data download function."""
         from satpy.demo import get_us_midlatitude_cyclone_abi
+        gcsfs_mod.GCSFileSystem = mock.MagicMock()
         gcsfs_inst = mock.MagicMock()
-        gcsfs_cls.return_value = gcsfs_inst
+        gcsfs_mod.GCSFileSystem.return_value = gcsfs_inst
         gcsfs_inst.glob.return_value = ['a.nc', 'b.nc']
         self.assertRaises(AssertionError, get_us_midlatitude_cyclone_abi)
         self.assertRaises(NotImplementedError, get_us_midlatitude_cyclone_abi, method='unknown')
@@ -53,9 +54,11 @@ class TestDemo(unittest.TestCase):
 class TestGCPUtils(unittest.TestCase):
     """Test Google Cloud Platform utilities."""
 
-    def test_is_gcp_instance(self):
+    @mock.patch('satpy.demo.google_cloud_platform.urlopen')
+    def test_is_gcp_instance(self, uo):
         """Test is_google_cloud_instance."""
-        from satpy.demo.google_cloud_platform import is_google_cloud_instance
+        from satpy.demo.google_cloud_platform import is_google_cloud_instance, URLError
+        uo.side_effect = URLError("Test Environment")
         self.assertFalse(is_google_cloud_instance())
 
     @mock.patch('satpy.demo.google_cloud_platform.gcsfs.GCSFileSystem')

--- a/satpy/tests/test_demo.py
+++ b/satpy/tests/test_demo.py
@@ -61,12 +61,13 @@ class TestGCPUtils(unittest.TestCase):
         uo.side_effect = URLError("Test Environment")
         self.assertFalse(is_google_cloud_instance())
 
-    @mock.patch('satpy.demo.google_cloud_platform.gcsfs.GCSFileSystem')
-    def test_get_bucket_files(self, gcsfs_cls):
+    @mock.patch('satpy.demo.google_cloud_platform.gcsfs')
+    def test_get_bucket_files(self, gcsfs_mod):
         """Test get_bucket_files basic cases."""
         from satpy.demo.google_cloud_platform import get_bucket_files
+        gcsfs_mod.GCSFileSystem = mock.MagicMock()
         gcsfs_inst = mock.MagicMock()
-        gcsfs_cls.return_value = gcsfs_inst
+        gcsfs_mod.GCSFileSystem.return_value = gcsfs_inst
         gcsfs_inst.glob.return_value = ['a.nc', 'b.nc']
         filenames = get_bucket_files('*.nc', '.')
         expected = [os.path.join('.', 'a.nc'), os.path.join('.', 'b.nc')]

--- a/satpy/tests/test_demo.py
+++ b/satpy/tests/test_demo.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 SatPy developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for the satpy.demo module."""
+
+import os
+import sys
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+class TestDemo(unittest.TestCase):
+    """Test demo data download functions."""
+
+    @mock.patch('satpy.demo.google_cloud_platform.gcsfs.GCSFileSystem')
+    def test_get_us_midlatitude_cyclone_abi(self, gcsfs_cls):
+        """Test data download function."""
+        from satpy.demo import get_us_midlatitude_cyclone_abi
+        gcsfs_inst = mock.MagicMock()
+        gcsfs_cls.return_value = gcsfs_inst
+        gcsfs_inst.glob.return_value = ['a.nc', 'b.nc']
+        self.assertRaises(AssertionError, get_us_midlatitude_cyclone_abi)
+        self.assertRaises(NotImplementedError, get_us_midlatitude_cyclone_abi, method='unknown')
+
+        gcsfs_inst.glob.return_value = ['a.nc'] * 16
+        filenames = get_us_midlatitude_cyclone_abi()
+        expected = os.path.join('.', 'abi_l1b', '20190314_us_midlatitude_cyclone', 'a.nc')
+        for fn in filenames:
+            self.assertEqual(expected, fn)
+
+
+class TestGCPUtils(unittest.TestCase):
+    """Test Google Cloud Platform utilities."""
+
+    def test_is_gcp_instance(self):
+        """Test is_google_cloud_instance."""
+        from satpy.demo.google_cloud_platform import is_google_cloud_instance
+        self.assertFalse(is_google_cloud_instance())
+
+    @mock.patch('satpy.demo.google_cloud_platform.gcsfs.GCSFileSystem')
+    def test_get_bucket_files(self, gcsfs_cls):
+        """Test get_bucket_files basic cases."""
+        from satpy.demo.google_cloud_platform import get_bucket_files
+        gcsfs_inst = mock.MagicMock()
+        gcsfs_cls.return_value = gcsfs_inst
+        gcsfs_inst.glob.return_value = ['a.nc', 'b.nc']
+        filenames = get_bucket_files('*.nc', '.')
+        expected = [os.path.join('.', 'a.nc'), os.path.join('.', 'b.nc')]
+        self.assertEqual(expected, filenames)
+
+        gcsfs_inst.glob.return_value = ['a.nc', 'b.nc']
+        self.assertRaises(OSError, get_bucket_files, '*.nc', 'does_not_exist')
+
+        # touch the file
+        open('a.nc', 'w').close()
+        gcsfs_inst.get.reset_mock()
+        gcsfs_inst.glob.return_value = ['a.nc']
+        filenames = get_bucket_files('*.nc', '.')
+        self.assertEqual(['./a.nc'], filenames)
+        gcsfs_inst.get.assert_not_called()
+
+        # force redownload
+        gcsfs_inst.get.reset_mock()
+        gcsfs_inst.glob.return_value = ['a.nc']
+        filenames = get_bucket_files('*.nc', '.', force=True)
+        self.assertEqual(['./a.nc'], filenames)
+        gcsfs_inst.get.assert_called_once()
+
+        # if we don't get any results then we expect an exception
+        gcsfs_inst.get.reset_mock()
+        gcsfs_inst.glob.return_value = []
+        self.assertRaises(OSError, get_bucket_files, '*.nc', '.')
+
+    @mock.patch('satpy.demo.google_cloud_platform.gcsfs', None)
+    def test_no_gcsfs(self):
+        """Test that 'gcsfs' is required."""
+        from satpy.demo.google_cloud_platform import get_bucket_files
+        self.assertRaises(RuntimeError, get_bucket_files, '*.nc', '.')
+
+
+def suite():
+    """The test suite for test_demo."""
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(TestDemo))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestGCPUtils))
+    return mysuite
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/satpy/tests/test_demo.py
+++ b/satpy/tests/test_demo.py
@@ -81,14 +81,14 @@ class TestGCPUtils(unittest.TestCase):
         gcsfs_inst.get.reset_mock()
         gcsfs_inst.glob.return_value = ['a.nc']
         filenames = get_bucket_files('*.nc', '.')
-        self.assertEqual(['./a.nc'], filenames)
+        self.assertEqual([os.path.join('.', 'a.nc')], filenames)
         gcsfs_inst.get.assert_not_called()
 
         # force redownload
         gcsfs_inst.get.reset_mock()
         gcsfs_inst.glob.return_value = ['a.nc']
         filenames = get_bucket_files('*.nc', '.', force=True)
-        self.assertEqual(['./a.nc'], filenames)
+        self.assertEqual([os.path.join('.', 'a.nc')], filenames)
         gcsfs_inst.get.assert_called_once()
 
         # if we don't get any results then we expect an exception


### PR DESCRIPTION
This PR adds a `satpy.demo` subpackage to make it easier to provide test data to users following notebook tutorials. Right now I have a fairly simple proof of concept with a single GOES-16 ABI test case where I download one time step of CONUS data from Google Cloud Storage. Right now I only have it coded to use the `gcsfs` package to download data from GCS, but have laid out other options in the future. It comes down to this:

```python
from satpy import Scene, demo
filenames = demo.get_us_midlatitude_cyclone_abi()
scn = Scene(reader='abi_l1b', filenames=filenames)
```

As mentioned in #646, I'd like to use `pooch` where possible (downloading tarball/zip files from a server, etc). If that doesn't seem to work then `intake` is another option.

 - [x] Closes #646 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
