### PR TITLE
Fix offset correction in seviri_l1b_hrit

### DIFF
--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -396,7 +396,16 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
         return x__, y__
 
     def get_area_extent(self, size, offsets, factors, platform_height):
-        """Get the area extent of the file."""
+        """Get the area extent of the file.
+
+        Until December 2017, the data is shifted by 1.5km SSP North and West against the nominal GEOS projection. Since
+        December 2017 this offset has been corrected. A flag in the data indicates if the correction has been applied.
+        If no correction was applied, adjust the area extent to match the shifted data.
+
+        For more information see Section 3.1.4.2 in the MSG Level 1.5 Image Data Format Description. The correction
+        of the area extent is documented in a `developer's memo <https://github.com/pytroll/pytroll-examples/
+        blob/master/satpy/dev_memos/seviri_l1b_hrit_georef_offset.ipynb>`_.
+        """
         nlines, ncols = size
         h = platform_height
 
@@ -416,8 +425,14 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
                np.deg2rad(ur_x) * h, np.deg2rad(ur_y) * h)
 
         if not self.mda['offset_corrected']:
+            # Geo-referencing offset present. Adjust area extent to match the shifted data. Note that we have to adjust
+            # the corners in the *opposite* direction, i.e. S-E. Think of it as if the coastlines were fixed and you
+            # dragged the image to S-E until coastlines and data area aligned correctly.
+            #
+            # Although the image is flipped upside-down and left-right, the projection coordinates retain their
+            # properties, i.e. positive x/y is East/North, respectively.
             xadj = 1500
-            yadj = 1500
+            yadj = -1500
             aex = (aex[0] + xadj, aex[1] + yadj,
                    aex[2] + xadj, aex[3] + yadj)
 

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -403,8 +403,8 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
         If no correction was applied, adjust the area extent to match the shifted data.
 
         For more information see Section 3.1.4.2 in the MSG Level 1.5 Image Data Format Description. The correction
-        of the area extent is documented in a `developer's memo <https://github.com/pytroll/pytroll-examples/
-        blob/master/satpy/dev_memos/seviri_l1b_hrit_georef_offset.ipynb>`_.
+        of the area extent is documented in a `developer's memo <https://github.com/pytroll/satpy/wiki/
+        SEVIRI-georeferencing-offset-correction>`_.
         """
         nlines, ncols = size
         h = platform_height

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -142,6 +142,13 @@ class TestHRITMSGFileHandler(unittest.TestCase):
                          (-77771774058.38356, -3720765401003.719,
                           30310525626438.438, 77771774058.38356))
 
+        # Data shifted by 1.5km to N-W
+        self.reader.mda['offset_corrected'] = False
+        area = self.reader.get_area_def(DatasetID('VIS006'))
+        self.assertEqual(area.area_extent,
+                         (-77771772558.38356, -3720765402503.719,
+                          30310525627938.438, 77771772558.38356))
+
     @mock.patch('satpy.readers.hrit_base.np.memmap')
     def test_read_band(self, memmap):
         nbits = self.reader.mda['number_of_bits_per_pixel']


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

<!-- Describe what your PR does, and why -->
Fix the geo-reference offset correction in ``seviri_l1b_hrit``: Area extent must be shifted in S-E direction (currently N-E). See https://github.com/pytroll/satpy/wiki/SEVIRI-georeferencing-offset-correction  for details.

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [X] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
