### PR TITLE
Fix Himawari HSD reader's incorrect header information

### DIFF
--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -157,7 +157,10 @@ _IRCAL_INFO_TYPE = np.dtype([("c0_rad2tb_conversion", "f8"),
 # Visible, near-infrared band (Band No. 1 – 6)
 # (Band No. 1: backup operation (See Table 4 bb))
 _VISCAL_INFO_TYPE = np.dtype([("coeff_rad2albedo_conversion", "f8"),
-                              ("spare", "S104"),
+                              ("coeff_update_time", "f8"),
+                              ("cali_gain_count2rad_conversion", "f8"),
+                              ("cali_offset_count2rad_conversion", "f8"),
+                              ("spare", "S80"),
                               ])
 
 # 6 Inter-calibration information block
@@ -165,16 +168,17 @@ _INTER_CALIBRATION_INFO_TYPE = np.dtype([
     ("hblock_number", "u1"),
     ("blocklength", "<u2"),
     ("gsics_calibration_intercept", "f8"),
-    ("gsics_calibration_intercept_stderr", "f8"),
     ("gsics_calibration_slope", "f8"),
-    ("gsics_calibration_slope_stderr", "f8"),
     ("gsics_calibration_coeff_quadratic_term", "f8"),
-    ("gsics_calibration_coeff_quadratic_term_stderr",
-     "f8"),
+    ("gsics_std_scn_radiance_bias", "f8"),
+    ("gsics_std_scn_radiance_bias_uncertainty", "f8"),
+    ("gsics_std_scn_radiance", "f8"),
     ("gsics_correction_starttime", "f8"),
     ("gsics_correction_endtime", "f8"),
-    ("ancillary_text", "S64"),
-    ("spare", "S128"),
+    ("gsics_radiance_validity_upper_lim", "f4"),
+    ("gsics_radiance_validity_lower_lim", "f4"),
+    ("gsics_filename", "S128"),
+    ("spare", "S56"),
 ])
 
 
@@ -205,10 +209,11 @@ _OBS_TIME_INFO_TYPE = np.dtype([
     ("number_of_observation_times", "<u2"),
 ])
 
+
 # 10 Error information block
 _ERROR_INFO_TYPE = np.dtype([
     ("hblock_number", "u1"),
-    ("blocklength", "<u2"),
+    ("blocklength", "<u4"),
     ("number_of_error_info_data", "<u2"),
 ])
 

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -181,7 +181,6 @@ _INTER_CALIBRATION_INFO_TYPE = np.dtype([
     ("spare", "S56"),
 ])
 
-
 # 7 Segment information block
 _SEGMENT_INFO_TYPE = np.dtype([
     ("hblock_number", "u1"),
@@ -208,7 +207,6 @@ _OBS_TIME_INFO_TYPE = np.dtype([
     ("blocklength", "<u2"),
     ("number_of_observation_times", "<u2"),
 ])
-
 
 # 10 Error information block
 _ERROR_INFO_TYPE = np.dtype([


### PR DESCRIPTION
This PR addresses the issue raised in #681. The error info block in the header now has the correct number of bytes for the blocklength (4 instead of 2). We are now reading the correct data from the file and there is no longer a 1 pixel offset in the x-axis.

Furthermore, I have updated the header info to meet the latest version of the documentation (v1.3) that includes a few new calibration variables.
These two types have been updated:
_VISCAL_INFO_TYPE
_INTER_CALIBRATION_INFO_TYPE

As far as I can see from test data these new fields do not, yet, contain any useful information - so this update will have no effect on the quality of data supplied to the user through SatPy.

 - [x] Closes #681
 - [x] Tests passed
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff``
