### PR TITLE
Add Scene.aggregate method (python 3 only)

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -324,11 +324,18 @@ class KDTreeResampler(BaseResampler):
                         "resampler. Cached parameters are affected by "
                         "masked pixels. Will not cache results.")
             cache_dir = None
-
+        # TODO: move this to pyresample
         if radius_of_influence is None:
             try:
                 radius_of_influence = source_geo_def.lons.resolution * 3
-            except (AttributeError, TypeError):
+            except AttributeError:
+                try:
+                    radius_of_influence = max(abs(source_geo_def.pixel_size_x),
+                                              abs(source_geo_def.pixel_size_y)) * 3
+                except AttributeError:
+                    radius_of_influence = 1000
+
+            except TypeError:
                 radius_of_influence = 10000
 
         kwargs = dict(source_geo_def=source_geo_def,

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -646,9 +646,9 @@ class Scene(MetadataObject):
         """
         new_scn = self.copy(datasets=dataset_ids)
 
-        for src_area, dataset_ids in new_scn.iter_by_area():
+        for src_area, ds_ids in new_scn.iter_by_area():
             if src_area is None:
-                for ds_id in dataset_ids:
+                for ds_id in ds_ids:
                     new_scn.datasets[ds_id] = self[ds_id]
                 continue
 

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -656,7 +656,7 @@ class Scene(MetadataObject):
                 raise NotImplementedError("boundary modes appart from 'exact' are not implemented yet.")
             target_area = src_area.aggregate(**dim_kwargs)
             resolution = max(target_area.pixel_size_x, target_area.pixel_size_y)
-            for ds_id in dataset_ids:
+            for ds_id in ds_ids:
                 res = self[ds_id].coarsen(boundary=boundary, side=side, func=func, **dim_kwargs)
 
                 new_scn.datasets[ds_id] = getattr(res, func)()

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -588,6 +588,8 @@ class Scene(MetadataObject):
         # get the lowest resolution area, use it as the base of the slice
         # this makes sure that the other areas *should* be a consistent factor
         min_area = new_scn.min_area()
+        if isinstance(area, str):
+            area = get_area_def(area)
         new_min_area, min_y_slice, min_x_slice = self._slice_area_from_bbox(
             min_area, area, ll_bbox, xy_bbox)
         new_target_areas = {}

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -500,6 +500,8 @@ class TestScene(unittest.TestCase):
 
     def test_aggregate(self):
         """Test the aggregate method."""
+        if (sys.version_info < (3, 0)):
+            self.skipTest("Not implemented in python 2 (xarray).")
         from satpy import Scene
         from xarray import DataArray
         from pyresample.geometry import AreaDefinition

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -498,6 +498,42 @@ class TestScene(unittest.TestCase):
         self.assertTupleEqual(new_scn1['1'].shape, (3, 184, 714))
         self.assertTupleEqual(new_scn1['2'].shape, (92, 3, 357))
 
+    def test_aggregate(self):
+        """Test the aggregate method."""
+        from satpy import Scene
+        from xarray import DataArray
+        from pyresample.geometry import AreaDefinition
+        import numpy as np
+        scene1 = Scene()
+        area_extent = (-5570248.477339745, -5561247.267842293, 5567248.074173927,
+                       5570248.477339745)
+        proj_dict = {'a': 6378169.0, 'b': 6356583.8, 'h': 35785831.0,
+                     'lon_0': 0.0, 'proj': 'geos', 'units': 'm'}
+        x_size = 3712
+        y_size = 3712
+        area_def = AreaDefinition(
+            'test',
+            'test',
+            'test',
+            proj_dict,
+            x_size,
+            y_size,
+            area_extent,
+        )
+
+        scene1["1"] = DataArray(np.ones((y_size, x_size)))
+        scene1["2"] = DataArray(np.ones((y_size, x_size)), dims=('y', 'x'))
+        scene1["3"] = DataArray(np.ones((y_size, x_size)), dims=('y', 'x'),
+                                attrs={'area': area_def})
+
+        scene2 = scene1.aggregate(func='sum', x=2, y=2)
+        self.assertIs(scene1['1'], scene2['1'])
+        self.assertIs(scene1['2'], scene2['2'])
+        np.testing.assert_allclose(scene2['3'].data, 4)
+        self.assertTupleEqual(scene2['1'].shape, (y_size, x_size))
+        self.assertTupleEqual(scene2['2'].shape, (y_size, x_size))
+        self.assertTupleEqual(scene2['3'].shape, (y_size / 2, x_size / 2))
+
     def test_contains(self):
         from satpy import Scene
         from xarray import DataArray


### PR DESCRIPTION
This PR implements aggregation for scenes.

For example, one can call:
```python
    newscn = scn.aggregate(x=4, y=4, func='mean')
```

The result is a scene with datasets 4 times smaller in both x and y axis, with values averaged over 4x4 windows.

This feature depends on pytroll/pyresample#182

Two small fixes were also added here: crop can now take a string as area, and the radius of influence, if not specified, is guestimated for area definitions too.

 - [x] Closes #683
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

Example results of an aggregated scene that has been resampled:

![eurolagg](https://user-images.githubusercontent.com/167802/55439099-dbf7ef80-55a3-11e9-879b-e7bfd7849db2.jpg)

Reference image (not aggregated before resampling):

![eurol](https://user-images.githubusercontent.com/167802/55439116-e2866700-55a3-11e9-8772-3fc729b5b9b5.jpg)
