### PR TITLE
Fix VIIRS SDR reading of visible channels at nighttime

### DIFF
--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -304,10 +304,16 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
         else:
             scan_size = 16
         scans_path = 'All_Data/{dataset_group}_All/NumberOfScans'
-        scans_path = scans_path.format(dataset_group=DATASET_KEYS[dataset_group])
+        number_of_granules_path = 'Data_Products/{dataset_group}/{dataset_group}_Aggr/attr/AggregateNumberGranules'
+        nb_granules_path = number_of_granules_path.format(dataset_group=DATASET_KEYS[dataset_group])
+        scans = []
+        for granule in range(self[nb_granules_path]):
+            scans_path = 'Data_Products/{dataset_group}/{dataset_group}_Gran_{granule}/attr/N_Number_Of_Scans'
+            scans_path = scans_path.format(dataset_group=DATASET_KEYS[dataset_group], granule=granule)
+            scans.append(self[scans_path])
         start_scan = 0
         data_chunks = []
-        scans = self[scans_path]
+        scans = xr.DataArray(scans)
         variable = self[var_path]
         # check if these are single per-granule value
         if variable.size != scans.size:

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -124,7 +124,7 @@ DATASET_KEYS = {'GDNBO': 'VIIRS-DNB-GEO',
 
 class VIIRSSDRFileHandler(HDF5FileHandler):
 
-    """VIIRS HDF5 File Reader
+    """VIIRS HDF5 File Reader.
     """
 
     def __init__(self, filename, filename_info, filetype_info, use_tc=None, **kwargs):
@@ -337,6 +337,14 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
             return data.where(data < fill_min)
 
     def get_dataset(self, dataset_id, ds_info):
+        """Get the dataset corresponding to *dataset_id*.
+
+        The size of the return DataArray will be dependent on the number of
+        scans actually sensed, and not necessarily the regular 768 scanlines
+        that the file contains for each granule. To that end, the number of
+        scans for each granule is read from:
+          `Data_Products/...Gran_x/N_Number_Of_Scans`.
+        """
         dataset_group = [ds_group for ds_group in ds_info['dataset_groups'] if ds_group in self.datasets]
         if not dataset_group:
             return

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -78,6 +78,7 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
             prefix1 = 'Data_Products/{dataset_group}'.format(dataset_group=dataset_group)
             prefix2 = '{prefix}/{dataset_group}_Aggr'.format(prefix=prefix1, dataset_group=dataset_group)
             prefix3 = 'All_Data/{dataset_group}_All'.format(dataset_group=dataset_group)
+            prefix4 = '{prefix}/{dataset_group}_Gran_0'.format(prefix=prefix1, dataset_group=dataset_group)
             begin_date = start_time.strftime('%Y%m%d')
             begin_time = start_time.strftime('%H%M%S.%fZ')
             ending_date = end_time.strftime('%Y%m%d')
@@ -89,7 +90,8 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
             else:
                 geo_prefix = None
             file_content = {
-                "{prefix3}/NumberOfScans": np.array([48]),
+                "{prefix2}/attr/AggregateNumberGranules": 1,
+                "{prefix4}/attr/N_Number_Of_Scans": 48,
                 "{prefix2}/attr/AggregateBeginningDate": begin_date,
                 "{prefix2}/attr/AggregateBeginningTime": begin_time,
                 "{prefix2}/attr/AggregateEndingDate": ending_date,
@@ -104,7 +106,7 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
             if geo_prefix:
                 file_content['/attr/N_GEO_Ref'] = geo_prefix + filename[5:]
             for k, v in list(file_content.items()):
-                file_content[k.format(prefix1=prefix1, prefix2=prefix2, prefix3=prefix3)] = v
+                file_content[k.format(prefix1=prefix1, prefix2=prefix2, prefix3=prefix3, prefix4=prefix4)] = v
 
             if filename[:3] in ['SVM', 'SVI', 'SVD']:
                 if filename[2:5] in ['M{:02d}'.format(x) for x in range(12)] + ['I01', 'I02', 'I03']:


### PR DESCRIPTION
Since #538, we are depending on the number of scans being read from the files to create the datasets at read time. However, the variable read in that PR is set to a no-data value for visible channels at nighttime.

This PR fixes the problem by accessing another metadata attribute providing a reliable number of scans, even at night time.

 - [x] Closes #692  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
