### PR TITLE
Use HSD blocklengths rather than assumed size

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -34,3 +34,4 @@ The following people have made contributions to this project:
 - Guido della Bruna - meteoswiss
 - Marco Sassi - meteoswiss
 - [Rohan Daruwala (rdaruwala)](https://github.com/rdaruwala)
+- [Simon R. Proud (simonrp84)](https://github.com/simonrp84)

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -8,7 +8,6 @@
 #   Adam.Dybbroe <adam.dybbroe@smhi.se>
 #   Cooke, Michael.C, UK Met Office
 #   Martin Raspaud <martin.raspaud@smhi.se>
-#   Simon R. Proud <simon.proud@physics.ox.ac.uk>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -46,6 +45,7 @@ from datetime import datetime, timedelta
 import numpy as np
 import dask.array as da
 import xarray as xr
+import warnings
 
 from pyresample import geometry
 from satpy import CHUNK_SIZE
@@ -351,15 +351,23 @@ class AHIHSDFileHandler(BaseFileHandler):
         header['block1'] = np.fromfile(
             fp_, dtype=_BASIC_INFO_TYPE, count=1)
         fpos = fpos + int(header['block1']['blocklength'])
+        if (fp_.tell() != fpos):
+            warnings.warn("Actual block1 header size does not match expected")
         fp_.seek(fpos, 0)
         header["block2"] = np.fromfile(fp_, dtype=_DATA_INFO_TYPE, count=1)
         fpos = fpos + int(header['block2']['blocklength'])
+        if (fp_.tell() != fpos):
+            warnings.warn("Actual block2 header size does not match expected")
         fp_.seek(fpos, 0)
         header["block3"] = np.fromfile(fp_, dtype=_PROJ_INFO_TYPE, count=1)
         fpos = fpos + int(header['block3']['blocklength'])
+        if (fp_.tell() != fpos):
+            warnings.warn("Actual block3 header size does not match expected")
         fp_.seek(fpos, 0)
         header["block4"] = np.fromfile(fp_, dtype=_NAV_INFO_TYPE, count=1)
         fpos = fpos + int(header['block4']['blocklength'])
+        if (fp_.tell() != fpos):
+            warnings.warn("Actual block4 header size does not match expected")
         fp_.seek(fpos, 0)
         header["block5"] = np.fromfile(fp_, dtype=_CAL_INFO_TYPE, count=1)
         logger.debug("Band number = " +
@@ -372,6 +380,8 @@ class AHIHSDFileHandler(BaseFileHandler):
         else:
             cal = np.fromfile(fp_, dtype=_IRCAL_INFO_TYPE, count=1)
         fpos = fpos + int(header['block5']['blocklength'])
+        if (fp_.tell() != fpos):
+            warnings.warn("Actual block5 header size does not match expected")
         fp_.seek(fpos, 0)
 
         header['calibration'] = cal
@@ -379,10 +389,14 @@ class AHIHSDFileHandler(BaseFileHandler):
         header["block6"] = np.fromfile(
             fp_, dtype=_INTER_CALIBRATION_INFO_TYPE, count=1)
         fpos = fpos + int(header['block6']['blocklength'])
+        if (fp_.tell() != fpos):
+            warnings.warn("Actual block6 header size does not match expected")
         fp_.seek(fpos, 0)
         header["block7"] = np.fromfile(
             fp_, dtype=_SEGMENT_INFO_TYPE, count=1)
         fpos = fpos + int(header['block7']['blocklength'])
+        if (fp_.tell() != fpos):
+            warnings.warn("Actual block7 header size does not match expected")
         fp_.seek(fpos, 0)
         header["block8"] = np.fromfile(
             fp_, dtype=_NAVIGATION_CORRECTION_INFO_TYPE, count=1)
@@ -397,6 +411,8 @@ class AHIHSDFileHandler(BaseFileHandler):
         for i in range(ncorrs):
             corrections.append(np.fromfile(fp_, dtype=dtype, count=1))
         fpos = fpos + int(header['block8']['blocklength'])
+        if (fp_.tell() + 40 != fpos):
+            warnings.warn("Actual block8 header size does not match expected")
         fp_.seek(fpos, 0)
         header['navigation_corrections'] = corrections
         header["block9"] = np.fromfile(fp_,
@@ -415,6 +431,8 @@ class AHIHSDFileHandler(BaseFileHandler):
                                                count=1))
         header['observation_time_information'] = lines_and_times
         fpos = fpos + int(header['block9']['blocklength'])
+        if (fp_.tell() + 40 != fpos):
+            warnings.warn("Actual block9 header size does not match expected")
         fp_.seek(fpos, 0)
 
         header["block10"] = np.fromfile(fp_,
@@ -431,10 +449,14 @@ class AHIHSDFileHandler(BaseFileHandler):
             err_info_data.append(np.fromfile(fp_, dtype=dtype, count=1))
         header['error_information_data'] = err_info_data
         fpos = fpos + int(header['block10']['blocklength'])
+        if (fp_.tell() + 40 != fpos):
+            warnings.warn("Actual block10 header size does not match expected")
         fp_.seek(fpos, 0)
 
         header["block11"] = np.fromfile(fp_, dtype=_SPARE_TYPE, count=1)
         fpos = fpos + int(header['block11']['blocklength'])
+        if (fp_.tell() != fpos):
+            warnings.warn("Actual block11 header size does not match expected")
         fp_.seek(fpos, 0)
 
         return header

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2014-2018 PyTroll developers
+# Copyright (c) 2014-2019 PyTroll developers
 #
 # Author(s):
 #
 #   Adam.Dybbroe <adam.dybbroe@smhi.se>
 #   Cooke, Michael.C, UK Met Office
 #   Martin Raspaud <martin.raspaud@smhi.se>
+#   Simon R. Proud <simon.proud@physics.ox.ac.uk>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -346,11 +347,20 @@ class AHIHSDFileHandler(BaseFileHandler):
         """Read header"""
         header = {}
 
+        fpos = 0
         header['block1'] = np.fromfile(
             fp_, dtype=_BASIC_INFO_TYPE, count=1)
+        fpos = fpos + int(header['block1']['blocklength'])
+        fp_.seek(fpos, 0)
         header["block2"] = np.fromfile(fp_, dtype=_DATA_INFO_TYPE, count=1)
+        fpos = fpos + int(header['block2']['blocklength'])
+        fp_.seek(fpos, 0)
         header["block3"] = np.fromfile(fp_, dtype=_PROJ_INFO_TYPE, count=1)
+        fpos = fpos + int(header['block3']['blocklength'])
+        fp_.seek(fpos, 0)
         header["block4"] = np.fromfile(fp_, dtype=_NAV_INFO_TYPE, count=1)
+        fpos = fpos + int(header['block4']['blocklength'])
+        fp_.seek(fpos, 0)
         header["block5"] = np.fromfile(fp_, dtype=_CAL_INFO_TYPE, count=1)
         logger.debug("Band number = " +
                      str(header["block5"]['band_number'][0]))
@@ -361,13 +371,19 @@ class AHIHSDFileHandler(BaseFileHandler):
             cal = np.fromfile(fp_, dtype=_VISCAL_INFO_TYPE, count=1)
         else:
             cal = np.fromfile(fp_, dtype=_IRCAL_INFO_TYPE, count=1)
+        fpos = fpos + int(header['block5']['blocklength'])
+        fp_.seek(fpos, 0)
 
         header['calibration'] = cal
 
         header["block6"] = np.fromfile(
             fp_, dtype=_INTER_CALIBRATION_INFO_TYPE, count=1)
+        fpos = fpos + int(header['block6']['blocklength'])
+        fp_.seek(fpos, 0)
         header["block7"] = np.fromfile(
             fp_, dtype=_SEGMENT_INFO_TYPE, count=1)
+        fpos = fpos + int(header['block7']['blocklength'])
+        fp_.seek(fpos, 0)
         header["block8"] = np.fromfile(
             fp_, dtype=_NAVIGATION_CORRECTION_INFO_TYPE, count=1)
         # 8 The navigation corrections:
@@ -380,7 +396,8 @@ class AHIHSDFileHandler(BaseFileHandler):
         corrections = []
         for i in range(ncorrs):
             corrections.append(np.fromfile(fp_, dtype=dtype, count=1))
-        fp_.seek(40, 1)
+        fpos = fpos + int(header['block8']['blocklength'])
+        fp_.seek(fpos, 0)
         header['navigation_corrections'] = corrections
         header["block9"] = np.fromfile(fp_,
                                        dtype=_OBS_TIME_INFO_TYPE,
@@ -397,7 +414,8 @@ class AHIHSDFileHandler(BaseFileHandler):
                                                dtype=dtype,
                                                count=1))
         header['observation_time_information'] = lines_and_times
-        fp_.seek(40, 1)
+        fpos = fpos + int(header['block9']['blocklength'])
+        fp_.seek(fpos, 0)
 
         header["block10"] = np.fromfile(fp_,
                                         dtype=_ERROR_INFO_TYPE,
@@ -412,9 +430,12 @@ class AHIHSDFileHandler(BaseFileHandler):
         for i in range(num_err_info_data):
             err_info_data.append(np.fromfile(fp_, dtype=dtype, count=1))
         header['error_information_data'] = err_info_data
-        fp_.seek(40, 1)
+        fpos = fpos + int(header['block10']['blocklength'])
+        fp_.seek(fpos, 0)
 
-        np.fromfile(fp_, dtype=_SPARE_TYPE, count=1)
+        header["block11"] = np.fromfile(fp_, dtype=_SPARE_TYPE, count=1)
+        fpos = fpos + int(header['block11']['blocklength'])
+        fp_.seek(fpos, 0)
 
         return header
 

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -3,12 +3,6 @@
 #
 # Copyright (c) 2014-2019 PyTroll developers
 #
-# Author(s):
-#
-#   Adam.Dybbroe <adam.dybbroe@smhi.se>
-#   Cooke, Michael.C, UK Met Office
-#   Martin Raspaud <martin.raspaud@smhi.se>
-#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -27,6 +27,7 @@ try:
 except ImportError:
     import mock
 
+import warnings
 import numpy as np
 import dask.array as da
 from datetime import datetime
@@ -175,10 +176,15 @@ class TestAHIHSDFileHandler(unittest.TestCase):
                 return_value=None)
     def test_calibrate(self, *mocks):
         """Test calibration"""
+        def_cali = [-0.0037, 15.20]
+        upd_cali = [-0.0074, 30.40]
+        bad_cali = [0.0, 0.0]
         fh = AHIHSDFileHandler()
+        fh.calib_mode = 'NOMINAL'
         fh._header = {
-            'block5': {'gain_count2rad_conversion': [-0.0037],
-                       'offset_count2rad_conversion': [15.20],
+            'block5': {'band_number': [5],
+                       'gain_count2rad_conversion': [def_cali[0]],
+                       'offset_count2rad_conversion': [def_cali[1]],
                        'central_wave_length': [10.4073], },
             'calibration': {'coeff_rad2albedo_conversion': [0.0019255],
                             'speed_of_light': [299792458.0],
@@ -186,7 +192,9 @@ class TestAHIHSDFileHandler(unittest.TestCase):
                             'boltzmann_constant': [1.3806488e-23],
                             'c0_rad2tb_conversion': [-0.116127314574],
                             'c1_rad2tb_conversion': [1.00099153832],
-                            'c2_rad2tb_conversion': [-1.76961091571e-06]},
+                            'c2_rad2tb_conversion': [-1.76961091571e-06],
+                            'cali_gain_count2rad_conversion': [upd_cali[0]],
+                            'cali_offset_count2rad_conversion': [upd_cali[1]]},
         }
 
         # Counts
@@ -212,6 +220,35 @@ class TestAHIHSDFileHandler(unittest.TestCase):
                              [1.50189, 0.]])
         refl = fh.calibrate(data=counts, calibration='reflectance')
         self.assertTrue(np.allclose(refl, refl_exp))
+
+        # Updated calibration
+        # Standard operation
+        fh.calib_mode = 'UPDATE'
+        rad_exp = np.array([[30.4, 23.0],
+                            [15.6, 0.]])
+        rad = fh.calibrate(data=counts, calibration='radiance')
+        self.assertTrue(np.allclose(rad, rad_exp))
+
+        # Case for no updated calibration available (older data)
+        fh._header = {
+            'block5': {'band_number': [5],
+                       'gain_count2rad_conversion': [def_cali[0]],
+                       'offset_count2rad_conversion': [def_cali[1]],
+                       'central_wave_length': [10.4073], },
+            'calibration': {'coeff_rad2albedo_conversion': [0.0019255],
+                            'speed_of_light': [299792458.0],
+                            'planck_constant': [6.62606957e-34],
+                            'boltzmann_constant': [1.3806488e-23],
+                            'c0_rad2tb_conversion': [-0.116127314574],
+                            'c1_rad2tb_conversion': [1.00099153832],
+                            'c2_rad2tb_conversion': [-1.76961091571e-06],
+                            'cali_gain_count2rad_conversion': [bad_cali[0]],
+                            'cali_offset_count2rad_conversion': [bad_cali[1]]},
+        }
+        rad = fh.calibrate(data=counts, calibration='radiance')
+        rad_exp = np.array([[15.2, 11.5],
+                            [7.8, 0]])
+        self.assertTrue(np.allclose(rad, rad_exp))
 
     @mock.patch('satpy.readers.ahi_hsd.AHIHSDFileHandler._read_header')
     @mock.patch('satpy.readers.ahi_hsd.AHIHSDFileHandler._read_data')
@@ -241,6 +278,25 @@ class TestAHIHSDFileHandler(unittest.TestCase):
             with mock.patch('satpy.readers.ahi_hsd.AHIHSDFileHandler._mask_space') as mask_space:
                 self.fh.read_band(info=mock.MagicMock(), key=mock.MagicMock())
                 mask_space.assert_not_called()
+
+    def test_blocklen_error(self, *mocks):
+        m = mock.mock_open()
+        with mock.patch('__main__.open', m, create=True):
+            fpos = 50
+            with open('/tmp/ahitmp', 'r') as fp_:
+                # Expected and actual blocklength match
+                fp_.tell.return_value = 50
+                with warnings.catch_warnings(record=True) as w:
+                    self.fh._check_fpos(fp_, fpos, 0, 'header 1')
+                    print(w)
+                    self.assertTrue(len(w) == 0)
+
+                # Expected and actual blocklength do not match
+                fp_.tell.return_value = 100
+                with warnings.catch_warnings(record=True) as w:
+                    self.fh._check_fpos(fp_, fpos, 0, 'header 1')
+                    print(w)
+                    self.assertTrue(len(w) > 0)
 
 
 def suite():

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -26,7 +26,7 @@ try:
     from unittest import mock
 except ImportError:
     import mock
-    
+
 try:
     import builtins
 except ImportError:
@@ -288,7 +288,7 @@ class TestAHIHSDFileHandler(unittest.TestCase):
         m = mock.mock_open()
         fpos = 50
         with mock.patch('builtins.open', m, create=True):
-            with open(mock.MagicMock(), 'r') as fp_:
+            with builtins.open(mock.MagicMock(), 'r') as fp_:
                 # Expected and actual blocklength match
                 fp_.tell.return_value = 50
                 with warnings.catch_warnings(record=True) as w:

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -283,7 +283,7 @@ class TestAHIHSDFileHandler(unittest.TestCase):
         m = mock.mock_open()
         with mock.patch('__main__.open', m, create=True):
             fpos = 50
-            with open('fakefile', 'r') as fp_:
+            with open(mock.MagicMock(), 'r') as fp_:
                 # Expected and actual blocklength match
                 fp_.tell.return_value = 50
                 with warnings.catch_warnings(record=True) as w:

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -26,6 +26,11 @@ try:
     from unittest import mock
 except ImportError:
     import mock
+    
+try:
+    import builtins
+except ImportError:
+    import __builtin__ as builtins
 
 import warnings
 import numpy as np

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -281,8 +281,8 @@ class TestAHIHSDFileHandler(unittest.TestCase):
 
     def test_blocklen_error(self, *mocks):
         m = mock.mock_open()
-        with mock.patch('__main__.open', m, create=True):
-            fpos = 50
+        fpos = 50
+        with mock.patch('builtins.open', m, create=True):
             with open(mock.MagicMock(), 'r') as fp_:
                 # Expected and actual blocklength match
                 fp_.tell.return_value = 50

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -285,22 +285,20 @@ class TestAHIHSDFileHandler(unittest.TestCase):
                 mask_space.assert_not_called()
 
     def test_blocklen_error(self, *mocks):
-        m = mock.mock_open()
+        open_name = '%s.open' % __name__
         fpos = 50
-        with mock.patch('builtins.open', m, create=True):
-            with builtins.open(mock.MagicMock(), 'r') as fp_:
+        with mock.patch(open_name, create=True) as mock_open:
+            with open(mock.MagicMock(), 'r') as fp_:
                 # Expected and actual blocklength match
                 fp_.tell.return_value = 50
                 with warnings.catch_warnings(record=True) as w:
                     self.fh._check_fpos(fp_, fpos, 0, 'header 1')
-                    print(w)
                     self.assertTrue(len(w) == 0)
 
                 # Expected and actual blocklength do not match
                 fp_.tell.return_value = 100
                 with warnings.catch_warnings(record=True) as w:
                     self.fh._check_fpos(fp_, fpos, 0, 'header 1')
-                    print(w)
                     self.assertTrue(len(w) > 0)
 
 

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -283,7 +283,7 @@ class TestAHIHSDFileHandler(unittest.TestCase):
         m = mock.mock_open()
         with mock.patch('__main__.open', m, create=True):
             fpos = 50
-            with open('/tmp/ahitmp', 'r') as fp_:
+            with open('fakefile', 'r') as fp_:
                 # Expected and actual blocklength match
                 fp_.tell.return_value = 50
                 with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
Previously, the AHI HSD reader navigated through a data file by using assumed-length headers. However, these headers contain descriptors that give the actual length of the header. This PR uses these descriptors to ensure that we always navigate to the correct position in the file (using file.seek) rather than just assuming that each header is always of a certain size.

 - [x] Tests added
 - [x] Tests passed
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff``
