### PR TITLE
Allow selection of Himawari VIS calibration coefficients for HSD data

### DIFF
--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -524,7 +524,7 @@ class AHIHSDFileHandler(BaseFileHandler):
             offset = self._header['calibration']["cali_offset_count2rad_conversion"][0]
             if (gain == 0 and offset == 0):
                 logger.info(
-                    "No valid updated coefficients, fall back to pre-launch")
+                    "No valid updated coefficients, fall back to default values.")
                 gain = self._header["block5"]["gain_count2rad_conversion"][0]
                 offset = self._header["block5"]["offset_count2rad_conversion"][0]
         else:

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -224,7 +224,7 @@ _SPARE_TYPE = np.dtype([
 
 
 class AHIHSDFileHandler(BaseFileHandler):
-    """AHI standard format reader.
+    """AHI standard format reader
 
     The AHI sensor produces data for some pixels outside the Earth disk (i,e:
     atmospheric limb or deep space pixels).
@@ -234,7 +234,7 @@ class AHIHSDFileHandler(BaseFileHandler):
     masking of non-Earth pixels.
 
     In order to change the default behaviour, use the 'mask_space' variable
-    as part of ``reader_kwargs`` upon Scene creation:
+    as part of ``reader_kwargs`` upon Scene creation::
 
         import satpy
         import glob
@@ -242,13 +242,13 @@ class AHIHSDFileHandler(BaseFileHandler):
         filenames = glob.glob('*FLDK*.dat')
         scene = satpy.Scene(filenames,
                             reader='ahi_hsd',
-                            reader_kwargs={'mask_space': False})
+                            reader_kwargs={'mask_space':: False})
         scene.load([0.6])
 
     The AHI HSD data files contain multiple VIS channel calibration
     coefficients. By default, the standard coefficients in header block 5
     are used. If the user prefers the updated calibration coefficients then
-    they can pass calib_mode='update' when creating a scene:
+    they can pass calib_mode='update' when creating a scene::
 
         import satpy
         import glob
@@ -256,7 +256,7 @@ class AHIHSDFileHandler(BaseFileHandler):
         filenames = glob.glob('*FLDK*.dat')
         scene = satpy.Scene(filenames,
                             reader='ahi_hsd',
-                            reader_kwargs={'calib_mode': 'update'})
+                            reader_kwargs={'calib_mode':: 'update'})
         scene.load([0.6])
 
     By default these updated coefficients are not used.
@@ -519,10 +519,10 @@ class AHIHSDFileHandler(BaseFileHandler):
 
         bnum = self._header["block5"]['band_number'][0]
         # Check calibration mode and select corresponding coefficients
-        if (self.calib_mode == "UPDATE" and bnum < 7):
+        if self.calib_mode == "UPDATE" and bnum < 7:
             gain = self._header['calibration']["cali_gain_count2rad_conversion"][0]
             offset = self._header['calibration']["cali_offset_count2rad_conversion"][0]
-            if (gain == 0 and offset == 0):
+            if gain == 0 and offset == 0:
                 logger.info(
                     "No valid updated coefficients, fall back to default values.")
                 gain = self._header["block5"]["gain_count2rad_conversion"][0]

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -234,7 +234,7 @@ class AHIHSDFileHandler(BaseFileHandler):
     masking of non-Earth pixels.
 
     In order to change the default behaviour, use the 'mask_space' variable
-    as part of ``reader_kwargs`` upon Scene creation::
+    as part of ``reader_kwargs`` upon Scene creation:
 
         import satpy
         import glob
@@ -247,12 +247,24 @@ class AHIHSDFileHandler(BaseFileHandler):
 
     The AHI HSD data files contain multiple VIS channel calibration
     coefficients. By default, the standard coefficients in header block 5
-    are used.
+    are used. If the user prefers the updated calibration coefficients then
+    they can pass calib_mode='update' when creating a scene:
+
+        import satpy
+        import glob
+
+        filenames = glob.glob('*FLDK*.dat')
+        scene = satpy.Scene(filenames,
+                            reader='ahi_hsd',
+                            reader_kwargs={'calib_mode': 'update'})
+        scene.load([0.6])
+
+    By default these updated coefficients are not used.
 
     """
 
     def __init__(self, filename, filename_info, filetype_info,
-                 mask_space=True, calib_mode='update'):
+                 mask_space=True, calib_mode='nominal'):
         """Initialize the reader."""
         super(AHIHSDFileHandler, self).__init__(filename, filename_info,
                                                 filetype_info)

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -175,10 +175,14 @@ class TestAHIHSDFileHandler(unittest.TestCase):
                 return_value=None)
     def test_calibrate(self, *mocks):
         """Test calibration"""
+        def_cali = [-0.0037, 15.20]
+        upd_cali = [-0.0074, 30.40]
         fh = AHIHSDFileHandler()
+        fh.calib_mode = 'NOMINAL'
         fh._header = {
-            'block5': {'gain_count2rad_conversion': [-0.0037],
-                       'offset_count2rad_conversion': [15.20],
+            'block5': {'band_number': [5],
+                       'gain_count2rad_conversion': [def_cali[0]],
+                       'offset_count2rad_conversion': [def_cali[1]],
                        'central_wave_length': [10.4073], },
             'calibration': {'coeff_rad2albedo_conversion': [0.0019255],
                             'speed_of_light': [299792458.0],
@@ -186,7 +190,9 @@ class TestAHIHSDFileHandler(unittest.TestCase):
                             'boltzmann_constant': [1.3806488e-23],
                             'c0_rad2tb_conversion': [-0.116127314574],
                             'c1_rad2tb_conversion': [1.00099153832],
-                            'c2_rad2tb_conversion': [-1.76961091571e-06]},
+                            'c2_rad2tb_conversion': [-1.76961091571e-06],
+                            'cali_gain_count2rad_conversion': [upd_cali[0]],
+                            'cali_offset_count2rad_conversion': [upd_cali[1]]},
         }
 
         # Counts
@@ -212,6 +218,13 @@ class TestAHIHSDFileHandler(unittest.TestCase):
                              [1.50189, 0.]])
         refl = fh.calibrate(data=counts, calibration='reflectance')
         self.assertTrue(np.allclose(refl, refl_exp))
+
+        # Updated calibration
+        fh.calib_mode = 'UPDATE'
+        rad_exp = np.array([[30.4, 23.0],
+                            [15.6, 0.]])
+        rad = fh.calibrate(data=counts, calibration='radiance')
+        self.assertTrue(np.allclose(rad, rad_exp))
 
     @mock.patch('satpy.readers.ahi_hsd.AHIHSDFileHandler._read_header')
     @mock.patch('satpy.readers.ahi_hsd.AHIHSDFileHandler._read_data')


### PR DESCRIPTION
Starting with version 1.3 of the Himawari HSD format specification there exists two sets of VIS channel calibration coefficients.
There is a default set, which is what SatPy uses at the moment, and there is an updated sat, which are currently ignored. This PR allows the user to switch between calibration coefficients with a kwarg passed to Scene: calib_mode: "update" or "nominal".
The default value is "nominal", which will retain the same functionality as the old reader.

Older HSD data (pre-1.3) does not contain these updated coefficients. If they are not present but the user selects 'update' then the reader will log a warning message and fall back to the default coefficients.

I have also updated the HSD calibration test scripts, which will now test both calibration modes.

 - [x] Tests added
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff``
 - [x] Fully documented
