### PR TITLE
Rename SatPy to Satpy throughout documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -26,7 +26,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Environment Info:**
  - OS: [e.g. OSX, Windows, Linux]
- - SatPy Version: [e.g. 0.9.0]
+ - Satpy Version: [e.g. 0.9.0]
  - PyResample Version:
  - Readers and writers dependencies (when relevant): [run `from satpy.config import check_satpy; check_satpy()`]
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -2,15 +2,15 @@
 How to contribute
 =================
 
-Thank you for considering contributing to SatPy! SatPy's development team
+Thank you for considering contributing to Satpy! Satpy's development team
 is made up of volunteers so any help we can get is very appreciated.
 
 Contributions from users are what keep this community going. We welcome
 any contributions including bug reports, documentation fixes or updates,
-bug fixes, and feature requests. By contributing to SatPy you are providing
+bug fixes, and feature requests. By contributing to Satpy you are providing
 code that everyone can use and benefit from.
 
-The following guidelines will describe how the SatPy project structures
+The following guidelines will describe how the Satpy project structures
 its code contributions from discussion to code to package release.
 
 For more information on contributing to open source projects see
@@ -39,7 +39,7 @@ What can I do?
 - Read the :doc:`index` for more details on contributing code.
 - `Fork <https://help.github.com/articles/fork-a-repo/>`_ the repository on
   GitHub and install the package in development mode.
-- Update the SatPy documentation to make it clearer and more detailed.
+- Update the Satpy documentation to make it clearer and more detailed.
 - Contribute code to either fix a bug or add functionality and submit a
   `Pull Request <https://help.github.com/articles/creating-a-pull-request/>`_.
 - Make an example Jupyter Notebook and add it to the
@@ -53,25 +53,25 @@ fault. When you submit your changes to be merged as a GitHub
 `Pull Request <https://help.github.com/articles/creating-a-pull-request/>`_
 they will be automatically tested and checked against coding style rules.
 Before they are merged they are reviewed by at least one maintainer of the
-SatPy project. If anything needs updating, we'll let you know.
+Satpy project. If anything needs updating, we'll let you know.
 
 What is expected?
 =================
 
-You can expect the SatPy maintainers to help you. We are all volunteers,
+You can expect the Satpy maintainers to help you. We are all volunteers,
 have jobs, and occasionally go on vacations. We will try our best to answer
 your questions as soon as possible. We will try our best to understand your
 use case and add the features you need. Although we strive to make
-SatPy useful for everyone there may be some feature requests that we can't
+Satpy useful for everyone there may be some feature requests that we can't
 allow if they would require breaking existing features. Other features may
 be best for a different package, PyTroll or otherwise. Regardless, we will
 help you find the best place for your feature and to make it possible to do
 what you want.
 
-We, the SatPy maintainers, expect you to be patient, understanding, and
-respectful of both developers and users. SatPy can only be successful if
+We, the Satpy maintainers, expect you to be patient, understanding, and
+respectful of both developers and users. Satpy can only be successful if
 everyone in the community feels welcome. We also expect you to put in as
-much work as you expect out of us. There is no dedicated PyTroll or SatPy
+much work as you expect out of us. There is no dedicated PyTroll or Satpy
 support team, so there may be times when you need to do most of the work
 to solve your problem (trying different test cases, environments, etc).
 
@@ -79,7 +79,7 @@ Being respectful includes following the style of the existing code for any
 code submissions. Please follow
 `PEP8 <https://www.python.org/dev/peps/pep-0008/>`_ style guidelines and
 limit lines of code to 80 characters whenever possible and when it doesn't
-hurt readability. SatPy follows
+hurt readability. Satpy follows
 `Google Style Docstrings <http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html>`_
 for all code API documentation. When in doubt use the existing code as a
 guide for how coding should be done.
@@ -89,7 +89,7 @@ guide for how coding should be done.
 How do I get help?
 ==================
 
-The SatPy developers (and all other PyTroll package developers) monitor the:
+The Satpy developers (and all other PyTroll package developers) monitor the:
 
 - `Mailing List <https://groups.google.com/group/pytroll>`_
 - `Slack chat <https://pytroll.slack.com/>`_ (get an `invitation <https://pytrollslackin.herokuapp.com/>`_)
@@ -99,17 +99,17 @@ How do I submit my changes?
 ===========================
 
 Any contributions should start with some form of communication (see above) to
-let the SatPy maintainers know how you plan to help. The larger the
+let the Satpy maintainers know how you plan to help. The larger the
 contribution the more important direct communication is so everyone can avoid
 duplicate code and wasted time.
-After talking to the SatPy developers any additional work like code or
+After talking to the Satpy developers any additional work like code or
 documentation changes can be provided as a GitHub
 `Pull Request <https://help.github.com/articles/creating-a-pull-request/>`_.
 
 Code of Conduct
 ===============
 
-SatPy follows the same code of conduct as the PyTroll project. For reference
+Satpy follows the same code of conduct as the PyTroll project. For reference
 it is copied to this repository in
 `CODE_OF_CONDUCT.md <https://github.com/pytroll/satpy/blob/master/CODE_OF_CONDUCT.md>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -14,9 +14,9 @@ Satpy
     :target: https://badge.fury.io/py/satpy
 
 
-The SatPy package is a python library for reading and manipulating
+The Satpy package is a python library for reading and manipulating
 meteorological remote sensing data and writing it to various image and
-data file formats. SatPy comes with the ability to make various RGB
+data file formats. Satpy comes with the ability to make various RGB
 composites directly from satellite instrument channel data or higher level
 processing output. The
 `pyresample <http://pyresample.readthedocs.io/en/latest/>`_ package is used
@@ -28,7 +28,7 @@ http://satpy.readthedocs.org/.
 Installation
 ------------
 
-SatPy can be installed from PyPI with pip:
+Satpy can be installed from PyPI with pip:
 
 .. code-block:: bash
 
@@ -44,7 +44,7 @@ It is also available from `conda-forge` for conda installations:
 Code of Conduct
 ---------------
 
-SatPy follows the same code of conduct as the PyTroll project. For reference
+Satpy follows the same code of conduct as the PyTroll project. For reference
 it is copied to this repository in CODE_OF_CONDUCT.md_.
 
 As stated in the PyTroll home page, this code of conduct applies to the

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,4 +1,4 @@
-# Releasing SatPy
+# Releasing Satpy
 
 1. checkout master
 2. pull from repo

--- a/doc/README
+++ b/doc/README
@@ -4,7 +4,7 @@ by running:
     make html
 
 The generated HTML documentation pages are available in `build/html`. If
-SatPy's API has changed (new functions, modules, classes, etc) then the
+Satpy's API has changed (new functions, modules, classes, etc) then the
 API documentation should be regenerated before running the above make
 command.
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -75,7 +75,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'SatPy'
+project = u'Satpy'
 copyright = u'2009-{}, The PyTroll Team'.format(datetime.utcnow().strftime("%Y"))
 
 # The version info for the project you're documenting, acts as replacement for

--- a/doc/source/data_download.rst
+++ b/doc/source/data_download.rst
@@ -1,9 +1,9 @@
 Downloading Data
 ================
 
-One of the main features of SatPy is its ability to read various satellite
+One of the main features of Satpy is its ability to read various satellite
 data formats. However, it does not currently provide any functionality for
-downloading data from any remote sources. SatPy assumes all data is available
+downloading data from any remote sources. Satpy assumes all data is available
 through the local system, either as a local directory or network
 mounted file systems. Certain readers that use ``xarray`` to open data files
 may be able to load files from remote systems by using OpenDAP or similar
@@ -22,7 +22,7 @@ satellite mission organization (NOAA, NASA, EUMETSAT, etc). In these cases
 data is usually available as a mounted network file system and can be accessed
 like a normal local path (with the added latency of network communications).
 
-Below are some data sources that provide data that can be read by SatPy. If
+Below are some data sources that provide data that can be read by Satpy. If
 you know of others please let us know by either creating a GitHub issue or
 pull request.
 

--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -1,5 +1,5 @@
 =================================
- Adding a Custom Reader to SatPy
+ Adding a Custom Reader to Satpy
 =================================
 
 In order to add a reader to satpy, you will need to create two files:
@@ -14,7 +14,7 @@ format for SEVIRI data
 Naming your reader
 ------------------
 
-SatPy tries to follow a standard scheme for naming its readers. These names
+Satpy tries to follow a standard scheme for naming its readers. These names
 are used in filenames, but are also used by users so it is important that
 the name be recognizable and clear. Although some
 special cases exist, most fit in to the following naming scheme:
@@ -57,7 +57,7 @@ if needed (ex. goes-imager).
 
 The existing :ref:`reader's table <reader_table>` can be used for reference.
 When in doubt, reader names can be discussed in the github pull
-request when this reader is added to SatPy or a github issue.
+request when this reader is added to Satpy or a github issue.
 
 The YAML file
 -------------

--- a/doc/source/dev_guide/index.rst
+++ b/doc/source/dev_guide/index.rst
@@ -18,19 +18,19 @@ at the pages listed below.
 Coding guidelines
 =================
 
-SatPy is part of `PyTroll <http://pytroll.github.io/>`_,
+Satpy is part of `PyTroll <http://pytroll.github.io/>`_,
 and all code should follow the
 `PyTroll coding guidelines and best
 practices <http://pytroll.github.io/guidelines.html>`_.
 
-SatPy currently supports Python 2.7 and 3.4+. All code should be written to
+Satpy currently supports Python 2.7 and 3.4+. All code should be written to
 be compatible with these versions.
 
 Development installation
 ========================
 
 See the :doc:`../install` section for basic installation instructions. When
-it comes time to install SatPy it should be installed from a clone of the git
+it comes time to install Satpy it should be installed from a clone of the git
 repository and in development mode so that local file changes are
 automatically reflected in the python environment. We highly recommend making
 a separate conda environment or virtualenv for development.
@@ -44,7 +44,7 @@ clone your fork. The package can then be installed in development by doing::
 Running tests
 =============
 
-SatPy tests are written using the python :mod:`unittest` module and the tests
+Satpy tests are written using the python :mod:`unittest` module and the tests
 can be executed by running::
 
     python setup.py test
@@ -52,7 +52,7 @@ can be executed by running::
 Documentation
 =============
 
-SatPy's documentation is built using Sphinx. All documentation lives in the
+Satpy's documentation is built using Sphinx. All documentation lives in the
 ``doc/`` directory of the project repository. After editing the source files
 there the documentation can be generated locally::
 

--- a/doc/source/dev_guide/xarray_migration.rst
+++ b/doc/source/dev_guide/xarray_migration.rst
@@ -5,16 +5,16 @@ Migrating to xarray and dask
 Many python developers dealing with meteorologic satellite data begin with
 using NumPy arrays directly. This work usually involves masked arrays,
 boolean masks, index arrays, and reshaping. Due to the libraries used by
-SatPy these operations can't always be done in the same way. This guide acts
-as a starting point for new SatPy developers in transitioning from NumPy's
-array operations to SatPy's operations, although they are very similar.
+Satpy these operations can't always be done in the same way. This guide acts
+as a starting point for new Satpy developers in transitioning from NumPy's
+array operations to Satpy's operations, although they are very similar.
 
 To provide the most functionality for users,
-SatPy uses the `xarray <http://xarray.pydata.org/en/stable/>`_ library's
+Satpy uses the `xarray <http://xarray.pydata.org/en/stable/>`_ library's
 :class:`~xarray.DataArray` object as the main representation for its data.
 DataArray objects can also benefit from the
 `dask <https://dask.pydata.org/en/latest/>`_ library. The combination of
-these libraries allow SatPy to easily distribute operations over multiple
+these libraries allow Satpy to easily distribute operations over multiple
 workers, lazy evaluate operations, and keep track additional metadata and
 coordinate information.
 
@@ -38,7 +38,7 @@ To create such an array, you can do for example
                                 attrs={'sensor': 'olci'})
 
 where ``my_data`` can be a regular numpy array, a numpy memmap, or, if you
-want to keep things lazy, a dask array (more on dask later). SatPy uses dask
+want to keep things lazy, a dask array (more on dask later). Satpy uses dask
 arrays with all of its DataArrays.
 
 Dimensions
@@ -235,7 +235,7 @@ Regular arithmetic operations are provided, and generate another dask array.
 
 In order to compute the actual data during testing, use the
 :func:`~dask.compute` method.
-In normal SatPy operations you will want the data to be evaluated as late as
+In normal Satpy operations you will want the data to be evaluated as late as
 possible to improve performance so `compute` should only be used when needed.
 
     >>> (arr1 + arr2).compute()

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -1,7 +1,7 @@
 Examples
 ========
 
-SatPy examples are available as Jupyter Notebooks on the
+Satpy examples are available as Jupyter Notebooks on the
 `pytroll-examples <https://github.com/pytroll/pytroll-examples/tree/master/satpy>`_
 git repository. They include python code, PNG images, and descriptions of
 what the example is doing. Below is a list of some of the examples and a brief
@@ -22,7 +22,7 @@ as explanations in the various sections of this documentation.
     * - `Sentinel-3 OLCI True Color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/OLCI%20L1B.ipynb>`_
       - Reading OLCI data from Sentinel 3 with Pytroll/Satpy
     * - `Sentinel 2 MSI true color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/Sentinel%202%20MSI%20true%20color.ipynb>`_
-      - Reading MSI data from Sentinel 2 with Pytroll/SatPy
+      - Reading MSI data from Sentinel 2 with Pytroll/Satpy
     * - `Suomi-NPP VIIRS SDR True Color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/satpy_rayleigh_iband_enhanced.ipynb>`_
       - Generate a rayleigh corrected true color RGB from VIIRS I- and M-bands
     * - `Aqua/Terra MODIS True Color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/satpy_rayleigh_modis.ipynb>`_

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -2,7 +2,7 @@ FAQ
 ===
 
 Below you'll find frequently asked questions, performance tips, and other
-topics that don't really fit in to the rest of the SatPy documentation.
+topics that don't really fit in to the rest of the Satpy documentation.
 
 If you have any other questions that aren't answered here feel free to make
 an issue on GitHub or talk to us on the Slack team or mailing list. See the
@@ -12,16 +12,16 @@ an issue on GitHub or talk to us on the Slack team or mailing list. See the
     :depth: 1
     :local:
 
-Why is SatPy slow on my powerful machine?
+Why is Satpy slow on my powerful machine?
 -----------------------------------------
 
-SatPy depends heavily on the dask library for its performance. However,
+Satpy depends heavily on the dask library for its performance. However,
 on some systems dask's default settings can actually hurt performance.
 By default dask will create a "worker" for each logical core on your
 system. In most systems you have twice as many logical cores
 (also known as threaded cores) as physical cores. Managing and communicating
 with all of these workers can slow down dask, especially when they aren't all
-being used by most SatPy calculations. One option is to limit the number of
+being used by most Satpy calculations. One option is to limit the number of
 workers by doing the following at the **top** of your python code:
 
 .. code-block:: python
@@ -29,7 +29,7 @@ workers by doing the following at the **top** of your python code:
     import dask
     from multiprocessing.pool import ThreadPool
     dask.config.set(pool=ThreadPool(8))
-    # all other SatPy imports and code
+    # all other Satpy imports and code
 
 This will limit dask to using 8 workers. Typically numbers between 4 and 8
 are good starting points. Number of workers can also be set from an
@@ -43,7 +43,7 @@ isn't necessary:
 Similarly, if you have many workers processing large chunks of data you may
 be using much more memory than you expect. If you limit the number of workers
 *and* the size of the data chunks being processed by each worker you can
-reduce the overall memory usage. Default chunk size can be configured in SatPy
+reduce the overall memory usage. Default chunk size can be configured in Satpy
 by setting the following environment variable:
 
 .. code-block:: bash
@@ -51,7 +51,7 @@ by setting the following environment variable:
     export PYTROLL_CHUNK_SIZE=2048
 
 This could also be set inside python using ``os.environ``, but must be set
-**before** SatPy is imported. This value defaults to 4096, meaning each
+**before** Satpy is imported. This value defaults to 4096, meaning each
 chunk of data will be 4096 rows by 4096 columns. In the future setting this
 value will change to be easier to set in python.
 
@@ -93,8 +93,8 @@ How do I avoid memory errors?
 -----------------------------
 
 If your environment is using many dask workers, it may be using more memory
-than it needs to be using. See the "Why is SatPy slow on my powerful machine?"
-question above for more information on changing SatPy's memory usage.
+than it needs to be using. See the "Why is Satpy slow on my powerful machine?"
+question above for more information on changing Satpy's memory usage.
 
 Reducing GDAL output size?
 --------------------------

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,16 +1,16 @@
 =====================
-SatPy's Documentation
+Satpy's Documentation
 =====================
 
-SatPy is a python library for reading and manipulating
+Satpy is a python library for reading and manipulating
 meteorological remote sensing data and writing it to various image and
-data file formats. SatPy comes with the ability to make various RGB
+data file formats. Satpy comes with the ability to make various RGB
 composites directly from satellite instrument channel data or higher level
 processing output. The
 `pyresample <http://pyresample.readthedocs.io/en/latest/>`_ package is used
 to resample data to different uniform areas or grids. Various atmospheric
 corrections and visual enhancements are also provided, either directly in
-SatPy or from those in the
+Satpy or from those in the
 `PySpectral <https://pyspectral.readthedocs.io/en/develop/>`_ and
 `TrollImage <http://trollimage.readthedocs.io/en/latest/>`_ packages.
 
@@ -18,12 +18,12 @@ Go to the project_ page for source code and downloads.
 
 It is designed to be easily extendable to support any meteorological satellite
 by the creation of plugins (readers, compositors, writers, etc). The table at
-the bottom of this page shows the input formats supported by the base SatPy
+the bottom of this page shows the input formats supported by the base Satpy
 installation.
 
 .. note::
 
-    SatPy's interfaces are not guaranteed stable and may change until version
+    Satpy's interfaces are not guaranteed stable and may change until version
     1.0 when backwards compatibility will be a main focus.
 
 .. _project: http://github.com/pytroll/satpy
@@ -46,12 +46,12 @@ installation.
 .. toctree::
     :maxdepth: 1
 
-    SatPy API <api/satpy>
+    Satpy API <api/satpy>
     faq
 
 .. _reader_table:
 
-.. list-table:: SatPy Readers
+.. list-table:: Satpy Readers
     :header-rows: 1
     :widths: 45 25 30
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -5,7 +5,7 @@ Installation Instructions
 Pip-based Installation
 ======================
 
-SatPy is available from the Python Packaging Index (PyPI). A sandbox
+Satpy is available from the Python Packaging Index (PyPI). A sandbox
 environment for `satpy` can be created using
 `Virtualenv <http://pypi.python.org/pypi/virtualenv>`_.
 
@@ -34,7 +34,7 @@ dependencies:
 Conda-based Installation
 ========================
 
-Starting with version 0.9, SatPy is available from the conda-forge channel. If
+Starting with version 0.9, Satpy is available from the conda-forge channel. If
 you have not configured your conda environment to search conda-forge already
 then do:
 
@@ -42,7 +42,7 @@ then do:
 
     $ conda config --add channels conda-forge
 
-Then to install SatPy in to your current environment run:
+Then to install Satpy in to your current environment run:
 
 .. code-block:: bash
 
@@ -50,18 +50,18 @@ Then to install SatPy in to your current environment run:
 
 .. note::
 
-    SatPy only automatically installs the dependencies needed to process the
+    Satpy only automatically installs the dependencies needed to process the
     most common use cases. Additional dependencies may need to be installed
     with conda or pip if import errors are encountered.
 
 Ubuntu System Python Installation
 =================================
 
-To install SatPy on an Ubuntu system we recommend using virtual environments
-to separate SatPy and its dependencies from the rest of the system. Note that
+To install Satpy on an Ubuntu system we recommend using virtual environments
+to separate Satpy and its dependencies from the rest of the system. Note that
 these instructions require using "sudo" privileges which may not be available
 to all users and can be very dangerous. The following instructions attempt
-to install some SatPy dependencies using the Ubuntu `apt` package manager to
+to install some Satpy dependencies using the Ubuntu `apt` package manager to
 ease installation. Replace `/path/to/pytroll-env` with the environment to be
 created.
 

--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -1,11 +1,11 @@
 MultiScene (Experimental)
 =========================
 
-Scene objects in SatPy are meant to represent a single geographic region at
+Scene objects in Satpy are meant to represent a single geographic region at
 a specific single instant in time or range of time. This means they are not
 suited for handling multiple orbits of polar-orbiting satellite data,
 multiple time steps of geostationary satellite data, or other special data
-cases. To handle these cases SatPy provides the `MultiScene` class. The below
+cases. To handle these cases Satpy provides the `MultiScene` class. The below
 examples will walk through some basic use cases of the MultiScene.
 
 .. warning::
@@ -91,7 +91,7 @@ time.
 
 .. versionadded:: 0.12
 
-    The ``from_files`` and ``group_files`` functions were added in SatPy 0.12.
+    The ``from_files`` and ``group_files`` functions were added in Satpy 0.12.
     See below for an alternative solution.
 
 This will compute one video frame (image) at a time and write it to the MPEG-4
@@ -103,7 +103,7 @@ for information on creating a ``Client`` object. If working on a cluster
 you may want to use :doc:`dask jobqueue <jobqueue:index>` to take advantage
 of multiple nodes at a time.
 
-For older versions of SatPy we can manually create the `Scene` objects used.
+For older versions of Satpy we can manually create the `Scene` objects used.
 The :func:`~glob.glob` function and for loops are used to group files into
 Scene objects that, if used individually, could load the data we want. The
 code below is equivalent to the ``from_files`` code above:

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -2,21 +2,21 @@
 Overview
 ========
 
-SatPy is designed to provide easy access to common operations for processing
+Satpy is designed to provide easy access to common operations for processing
 meteorological remote sensing data. Any details needed to perform these
-operations are configured internally to SatPy meaning users should not have to
+operations are configured internally to Satpy meaning users should not have to
 worry about *how* something is done, only ask for what they want. Most of the
-features provided by SatPy can be configured by keyword arguments (see the
+features provided by Satpy can be configured by keyword arguments (see the
 :doc:`API Documentation <api/satpy>` or other specific section for more details).
-For more complex customizations or added features SatPy uses a set of
+For more complex customizations or added features Satpy uses a set of
 configuration files that can be modified by the user. The various components
-and concepts of SatPy are described below. The :doc:`quickstart` guide also
-provides simple example code for the available features of SatPy.
+and concepts of Satpy are described below. The :doc:`quickstart` guide also
+provides simple example code for the available features of Satpy.
 
 Scene
 =====
 
-SatPy provides most of its functionality through the
+Satpy provides most of its functionality through the
 :class:`~satpy.scene.Scene` class. This acts as a container for the datasets
 being operated on and provides methods for acting on those datasets. It
 attempts to reduce the amount of low-level knowledge needed by the user while
@@ -30,9 +30,9 @@ it is not guaranteed that all functionality works in these situations.
 DataArrays
 ==========
 
-SatPy's lower-level container for data is the
+Satpy's lower-level container for data is the
 :class:`xarray.DataArray`. For historical reasons DataArrays are often
-referred to as "Datasets" in SatPy. These objects act similar to normal
+referred to as "Datasets" in Satpy. These objects act similar to normal
 numpy arrays, but add additional metadata and attributes for describing the
 data. Metadata is stored in a ``.attrs`` dictionary and named dimensions can
 be accessed in a ``.dims`` attribute, along with other attributes.
@@ -41,14 +41,14 @@ with special care taken to make sure the metadata dictionary contains
 expected values. See the XArray documentation for more info on handling
 :class:`xarray.DataArray` objects.
 
-Additionally, SatPy uses a special form of DataArrays where data is stored
-in :class:`dask.array.Array` objects which allows SatPy to perform
+Additionally, Satpy uses a special form of DataArrays where data is stored
+in :class:`dask.array.Array` objects which allows Satpy to perform
 multi-threaded lazy operations vastly improving the performance of processing.
 For help on developing with dask and xarray see
 :doc:`dev_guide/xarray_migration` or the documentation for the specific
 project.
 
-To uniquely identify ``DataArray`` objects SatPy uses `DatasetID`. A
+To uniquely identify ``DataArray`` objects Satpy uses `DatasetID`. A
 ``DatasetID`` consists of various pieces of available metadata. This usually
 includes `name` and `wavelength` as identifying metadata, but also includes
 `resolution`, `calibration`, `polarization`, and additional `modifiers`
@@ -57,18 +57,18 @@ to further distinguish one dataset from another.
 .. warning::
 
     XArray includes other object types called "Datasets". These are different
-    from the "Datasets" mentioned in SatPy.
+    from the "Datasets" mentioned in Satpy.
 
 
 Reading
 =======
 
-One of the biggest advantages of using SatPy is the large number of input
+One of the biggest advantages of using Satpy is the large number of input
 file formats that it can read. It encapsulates this functionality into
-individual :doc:`readers`. SatPy Readers handle all of the complexity of
+individual :doc:`readers`. Satpy Readers handle all of the complexity of
 reading whatever format they represent. Meteorological Satellite file formats
 can be extremely complex and formats are rarely reused across satellites
-or instruments. No matter the format, SatPy's Reader interface is meant to
+or instruments. No matter the format, Satpy's Reader interface is meant to
 provide a consistent data loading interface while still providing flexibility
 to add new complex file formats.
 
@@ -78,10 +78,10 @@ Compositing
 Many users of satellite imagery combine multiple sensor channels to bring
 out certain features of the data. This includes using one dataset to enhance
 another, combining 3 or more datasets in to an RGB image, or any other
-combination of datasets. SatPy comes with a lot of common composite
+combination of datasets. Satpy comes with a lot of common composite
 combinations built-in and allows the user to request them like any other
-dataset. SatPy also makes it possible to create your own custom composites
-and have SatPy treat them like any other dataset. See :doc:`composites`
+dataset. Satpy also makes it possible to create your own custom composites
+and have Satpy treat them like any other dataset. See :doc:`composites`
 for more information.
 
 Resampling
@@ -93,9 +93,9 @@ coordinates. It is also common to see the channels from a single sensor
 in multiple resolutions, making it complicated to combine or compare the
 datasets. Many use cases of satellite data require the data to
 be in a certain projection other than the native projection or to have
-output imagery cover a specific area of interest. SatPy makes it easy to
+output imagery cover a specific area of interest. Satpy makes it easy to
 resample datasets to allow for users to combine them or grid them to these
-projections or areas of interest. SatPy uses the PyTroll `pyresample` package
+projections or areas of interest. Satpy uses the PyTroll `pyresample` package
 to provide nearest neighbor, bilinear, or elliptical weighted averaging
 resampling methods. See :doc:`resample` for more information.
 
@@ -104,13 +104,13 @@ Enhancements
 
 When making images from satellite data the data has to be manipulated to be
 compatible with the output image format and still look good to the human eye.
-SatPy calls this functionality "enhancing" the data, also commonly called
+Satpy calls this functionality "enhancing" the data, also commonly called
 scaling or stretching the data. This process can become complicated not just
 because of how subjective the quality of an image can be, but also because
 of historical expectations of forecasters and other users for how the data
-should look. SatPy tries to hide the complexity of all the possible
+should look. Satpy tries to hide the complexity of all the possible
 enhancement methods from the user and just provide the best looking image
-by default. SatPy still makes it possible to customize these procedures, but
+by default. Satpy still makes it possible to customize these procedures, but
 in most cases it shouldn't be necessary. See the documentation on
 :doc:`writers` for more information on what's possible for output formats
 and enhancing images.
@@ -118,9 +118,9 @@ and enhancing images.
 Writing
 =======
 
-SatPy is designed to make data loading, manipulating, and analysis easy.
+Satpy is designed to make data loading, manipulating, and analysis easy.
 However, the best way to get satellite imagery data out to as many users
-as possible is to make it easy to save it in multiple formats. SatPy allows
+as possible is to make it easy to save it in multiple formats. Satpy allows
 users to save data in image formats like PNG or GeoTIFF as well as data file
 formats like NetCDF. Each format's complexity is hidden behind the interface
 of individual Writer objects and includes keyword arguments for accessing

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -11,11 +11,11 @@ Loading and accessing data
     >>> sys.setdefaultencoding('utf8')
 
 To work with weather satellite data you must create a
-:class:`~satpy.scene.Scene` object. SatPy does not currently provide an
+:class:`~satpy.scene.Scene` object. Satpy does not currently provide an
 interface to download satellite data, it assumes that the data is on a
-local hard disk already. In order for SatPy to get access to the data the
+local hard disk already. In order for Satpy to get access to the data the
 Scene must be told what files to read and what
-:ref:`SatPy Reader <reader_table>` should read them:
+:ref:`Satpy Reader <reader_table>` should read them:
 
     >>> from satpy import Scene
     >>> from glob import glob
@@ -101,7 +101,7 @@ method. Printing the Scene object will list each of the
         modifiers:            ()
         ancillary_variables:  []
 
-SatPy allows loading file data by wavelengths in micrometers (shown above) or by channel name::
+Satpy allows loading file data by wavelengths in micrometers (shown above) or by channel name::
 
     >>> global_scene.load(["VIS006", "VIS008", "IR_108"])
 
@@ -163,7 +163,7 @@ advanced loading methods see the :doc:`readers` documentation.
 Generating composites
 =====================
 
-SatPy comes with many composite recipes built-in and makes them loadable like any other dataset:
+Satpy comes with many composite recipes built-in and makes them loadable like any other dataset:
 
     >>> global_scene.load(['overview'])
 
@@ -204,7 +204,7 @@ to a uniform grid, limiting input data to an area of interest, changing from
 one projection to another, or for preparing datasets to be combined in a
 composite (see above). For more details on resampling, different resampling
 algorithms, and creating your own area of interest see the
-:doc:`resample` documentation. To resample a SatPy Scene:
+:doc:`resample` documentation. To resample a Satpy Scene:
 
     >>> local_scene = global_scene.resample("eurol")
 
@@ -250,10 +250,10 @@ function called `check_satpy` can be used:
   >>> from satpy.config import check_satpy
   >>> check_satpy()
 
-Due to the way SatPy works, producing as many datasets as possible, there are
+Due to the way Satpy works, producing as many datasets as possible, there are
 times that behavior can be unexpected but with no exceptions raised. To help
 troubleshoot these situations log messages can be turned on. To do this run
-the following code before running any other SatPy code:
+the following code before running any other Satpy code:
 
     >>> from satpy.utils import debug_on
     >>> debug_on()

--- a/doc/source/readers.rst
+++ b/doc/source/readers.rst
@@ -6,7 +6,7 @@ Readers
 
     How to read cloud products from NWCSAF software. (separate document?)
 
-SatPy supports reading and loading data from many input file formats and
+Satpy supports reading and loading data from many input file formats and
 schemes. The :class:`~satpy.scene.Scene` object provides a simple interface
 around all the complexity of these various formats through its ``load``
 method. The following sections describe the different way data can be loaded,
@@ -28,7 +28,7 @@ Coming soon...
 Load data
 =========
 
-Datasets in SatPy are identified by certain pieces of metadata set during
+Datasets in Satpy are identified by certain pieces of metadata set during
 data loading. These include `name`, `wavelength`, `calibration`,
 `resolution`, `polarization`, and `modifiers`. Normally, once a ``Scene``
 is created requesting datasets by `name` or `wavelength` is all that is
@@ -43,7 +43,7 @@ However, in many cases datasets are available in multiple spatial resolutions,
 multiple calibrations (``brightness_temperature``, ``reflectance``,
 ``radiance``, etc),
 multiple polarizations, or have corrections or other modifiers already applied
-to them. By default SatPy will provide the version of the dataset with the
+to them. By default Satpy will provide the version of the dataset with the
 highest resolution and the highest level of calibration (brightness
 temperature or reflectance over radiance). It is also possible to request one
 of these exact versions of a dataset by using the
@@ -63,7 +63,7 @@ Or multiple calibrations::
 
     >>> scn.load([0.6, 10.8], calibrations=['brightness_temperature', 'radiance'])
 
-In the above case SatPy will load whatever dataset is available and matches
+In the above case Satpy will load whatever dataset is available and matches
 the specified parameters. So the above ``load`` call would load the ``0.6``
 (a visible/reflectance band) radiance data and ``10.8`` (an IR band)
 brightness temperature data.
@@ -89,7 +89,7 @@ names of Datasets::
 Search for local files
 ======================
 
-SatPy provides a utility
+Satpy provides a utility
 :func:`~satpy.readers.find_files_and_readers` for searching for files in
 a base directory matching various search parameters. This function discovers
 files based on filename patterns. It returns a dictionary mapping reader name
@@ -109,7 +109,7 @@ the :class:`~satpy.scene.Scene` initialization.
 See the :func:`~satpy.readers.find_files_and_readers` documentation for
 more information on the possible parameters.
 
-Adding a Reader to SatPy
+Adding a Reader to Satpy
 ========================
 
 This is described in the developer guide, see :doc:`dev_guide/custom_reader`.

--- a/doc/source/writers.rst
+++ b/doc/source/writers.rst
@@ -2,7 +2,7 @@
 Writers
 =======
 
-SatPy makes it possible to save datasets in multiple formats. For details
+Satpy makes it possible to save datasets in multiple formats. For details
 on additional arguments and features available for a specific Writer see
 the table below. Most use cases will want to save datasets using the
 :meth:`~satpy.scene.Scene.save_datasets` method::
@@ -24,7 +24,7 @@ One common parameter across almost all Writers is ``filename`` and
 
 .. _writer_table:
 
-.. list-table:: SatPy Writers
+.. list-table:: Satpy Writers
     :header-rows: 1
 
     * - Description

--- a/satpy/__init__.py
+++ b/satpy/__init__.py
@@ -26,7 +26,7 @@
 
 # You should have received a copy of the GNU General Public License
 # along with satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""SatPy Package initializer.
+"""Satpy Package initializer.
 """
 
 import os

--- a/satpy/config.py
+++ b/satpy/config.py
@@ -23,7 +23,7 @@
 # You should have received a copy of the GNU General Public License
 # along with satpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""SatPy Configuration directory and file handling
+"""Satpy Configuration directory and file handling
 """
 import glob
 import logging

--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -145,7 +145,7 @@ class DatasetID(DatasetID):
     and "reflectance". If an element is `None` then it is considered not
     applicable.
 
-    A DatasetID can also be used in SatPy to query for a Dataset. This way
+    A DatasetID can also be used in Satpy to query for a Dataset. This way
     a fully qualified DatasetID can be found even if some of the DatasetID
     elements are unknown. In this case a `None` signifies something that is
     unknown or not applicable to the requested Dataset.

--- a/satpy/demo/__init__.py
+++ b/satpy/demo/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019 SatPy developers
+# Copyright (c) 2019 Satpy developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -30,7 +30,7 @@ including:
 - uwaos_thredds: Access data using OpenDAP or similar method from the
     University of Wisconsin - Madison's AOS department's THREDDS server.
 - http: A last resort download method when nothing else is available of a
-    tarball or zip file from one or more servers available to the SatPy
+    tarball or zip file from one or more servers available to the Satpy
     project.
 - uw_arcdata: A network mount available on many servers at the Space Science
     and Engineering Center (SSEC) at the University of Wisconsin - Madison.

--- a/satpy/demo/google_cloud_platform.py
+++ b/satpy/demo/google_cloud_platform.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019 SatPy developers
+# Copyright (c) 2019 Satpy developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/satpy/etc/writers/scmi.yaml
+++ b/satpy/etc/writers/scmi.yaml
@@ -1,6 +1,6 @@
 # Originally converted from the CSPP Polar2Grid SCMI Writer
 # Some datasets are named differently and have not been converted to
-# SatPy-style naming yet. These config entries are commented out.
+# Satpy-style naming yet. These config entries are commented out.
 writer:
   name: scmi
   description: AWIPS-compatible Tiled NetCDF4 Writer

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -440,9 +440,9 @@ def group_files(files_to_sort, reader=None, time_threshold=10,
             that files will not be grouped properly (datetimes being barely
             unequal). Defaults to a reader's ``group_keys`` configuration (set
             in YAML), otherwise ``('start_time',)``.
-        ppp_config_dir (str): Root usser configuration directory for SatPy.
+        ppp_config_dir (str): Root usser configuration directory for Satpy.
             This will be deprecated in the future, but is here for consistency
-            with other SatPy features.
+            with other Satpy features.
         reader_kwargs (dict): Additional keyword arguments to pass to reader
             creation.
 
@@ -559,10 +559,10 @@ def configs_for_reader(reader=None, ppp_config_dir=None):
                 continue
 
             new_name = OLD_READER_NAMES[reader_name]
-            # SatPy 0.11 only displays a warning
-            # SatPy 0.13 will raise an exception
+            # Satpy 0.11 only displays a warning
+            # Satpy 0.13 will raise an exception
             raise ValueError("Reader name '{}' has been deprecated, use '{}' instead.".format(reader_name, new_name))
-            # SatPy 0.15 or 1.0, remove exception and mapping
+            # Satpy 0.15 or 1.0, remove exception and mapping
 
         reader = new_readers
         # given a config filename or reader name
@@ -638,7 +638,7 @@ def find_files_and_readers(start_time=None, end_time=None, base_dir=None,
         reader (str or list): The name of the reader to use for loading the data or a list of names.
         sensor (str or list): Limit used files by provided sensors.
         ppp_config_dir (str): The directory containing the configuration
-                              files for SatPy.
+                              files for Satpy.
         filter_parameters (dict): Filename pattern metadata to filter on. `start_time` and `end_time` are
                                   automatically added to this dictionary. Shortcut for
                                   `reader_kwargs['filter_parameters']`.

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2016-2018 SatPy developers
+# Copyright (c) 2016-2018 Satpy developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/satpy/readers/generic_image.py
+++ b/satpy/readers/generic_image.py
@@ -64,7 +64,7 @@ class GenericImageFileHandler(BaseFileHandler):
         if hasattr(data, 'crs'):
             self.area = self.get_geotiff_area_def(data.crs)
 
-        # Rename to SatPy convention
+        # Rename to Satpy convention
         data = data.rename({'band': 'bands'})
 
         # Rename bands to [R, G, B, A], or a subset of those

--- a/satpy/readers/scmi.py
+++ b/satpy/readers/scmi.py
@@ -30,10 +30,10 @@ There are two forms of these files that this reader supports:
 1. Official SCMI format: NetCDF4 files where the main data variable is stored
     in a variable called "Sectorized_CMI". This variable name can be
     configured in the YAML configuration file.
-2. SatPy/Polar2Grid SCMI format: NetCDF4 files based on the official SCMI
+2. Satpy/Polar2Grid SCMI format: NetCDF4 files based on the official SCMI
     format created for the Polar2Grid project. This format was migrated to
-    SatPy as part of Polar2Grid's adoption of SatPy for the majority of its
-    features. This format is what is produced by SatPy's `scmi` writer.
+    Satpy as part of Polar2Grid's adoption of Satpy for the majority of its
+    features. This format is what is produced by Satpy's `scmi` writer.
     This format can be identified by a single variable named "data" and a
     global attribute named ``"awips_id"`` that is set to a string starting with
     ``"AWIPS_"``.

--- a/satpy/readers/viirs_edr_active_fires.py
+++ b/satpy/readers/viirs_edr_active_fires.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 SatPy Developers
+# Copyright (c) 2019 Satpy Developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/satpy/readers/virr_l1b.py
+++ b/satpy/readers/virr_l1b.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2016-2018 SatPy developers
+# Copyright (c) 2016-2018 Satpy developers
 #
 # This file is part of satpy.
 #

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -19,12 +19,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""SatPy provides multiple resampling algorithms for resampling geolocated
+"""Satpy provides multiple resampling algorithms for resampling geolocated
 data to uniform projected grids. The easiest way to perform resampling in
-SatPy is through the :class:`~satpy.scene.Scene` object's
+Satpy is through the :class:`~satpy.scene.Scene` object's
 :meth:`~satpy.scene.Scene.resample` method. Additional utility functions are
 also available to assist in resampling data. Below is more information on
-resampling with SatPy as well as links to the relevant API documentation for
+resampling with Satpy as well as links to the relevant API documentation for
 available keyword arguments.
 
 Resampling algorithms
@@ -82,7 +82,7 @@ may work, but behavior is currently undefined.
 Caching for geostationary data
 ------------------------------
 
-SatPy will do its best to reuse calculations performed to resample datasets,
+Satpy will do its best to reuse calculations performed to resample datasets,
 but it can only do this for the current processing and will lose this
 information when the process/script ends. Some resampling algorithms, like
 ``nearest`` and ``bilinear``, can benefit by caching intermediate data on disk in the directory
@@ -503,7 +503,7 @@ class EWAResampler(BaseResampler):
         if cache_dir:
             LOG.warning("'cache_dir' is not used by EWA resampling")
 
-        # SatPy/PyResample don't support dynamic grids out of the box yet
+        # Satpy/PyResample don't support dynamic grids out of the box yet
         lons, lats = source_geo_def.get_lonlats()
         if isinstance(lons, xr.DataArray):
             # get dask arrays

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 SatPy Developers
+# Copyright (c) 2019 Satpy Developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/satpy/tests/reader_tests/test_virr_l1b.py
+++ b/satpy/tests/reader_tests/test_virr_l1b.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2016-2018 SatPy developers
+# Copyright (c) 2016-2018 Satpy developers
 #
 # This file is part of satpy.
 #

--- a/satpy/tests/test_dataset.py
+++ b/satpy/tests/test_dataset.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2015-2018 SatPy Developers
+# Copyright (c) 2015-2018 Satpy Developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/satpy/tests/test_demo.py
+++ b/satpy/tests/test_demo.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2019 SatPy developers
+# Copyright (c) 2019 Satpy developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/satpy/tests/writer_tests/test_scmi.py
+++ b/satpy/tests/writer_tests/test_scmi.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2017-2018 SatPy Developers
+# Copyright (c) 2017-2018 Satpy Developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/satpy/writers/scmi.py
+++ b/satpy/writers/scmi.py
@@ -672,7 +672,7 @@ class NetCDFWriter(object):
         self.nc.Conventions = "CF-1.7"
         if creator is None:
             from satpy import __version__
-            self.nc.creator = "SatPy Version {} - SCMI Writer".format(__version__)
+            self.nc.creator = "Satpy Version {} - SCMI Writer".format(__version__)
         else:
             self.nc.creator = creator
         self.nc.creation_time = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S')


### PR DESCRIPTION
As discussed on slack, from now on we will try to standardize Pytroll package names in text by capitalizing the first letter and no other letters unless there is an acronym. This means Pyresample, Trollimage, Pytroll (the organization), and Satpy.

Muscle memory is going to be a problem...