### PR TITLE
Mask out invalid values in the precipitation probability product

### DIFF
--- a/satpy/composites/cloud_products.py
+++ b/satpy/composites/cloud_products.py
@@ -106,12 +106,15 @@ class PrecipCloudsRGB(GenericCompositor):
         scalef1 = 1.0 / maxs1 - 1 / 255.0
 
         p1data = (light*scalef1).where(light != 0)
+        p1data = p1data.where(light != light.attrs['_FillValue'])
         p1data.attrs = light.attrs
         data = moderate*scalef2
         p2data = data.where(moderate != 0)
+        p2data = p2data.where(moderate != moderate.attrs['_FillValue'])
         p2data.attrs = moderate.attrs
         data = intense*scalef3
         p3data = data.where(intense != 0)
+        p3data = p3data.where(intense != intense.attrs['_FillValue'])
         p3data.attrs = intense.attrs
 
         res = super(PrecipCloudsRGB, self).__call__((p3data, p2data, p1data),

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -550,6 +550,7 @@ class TestCloudTopHeightCompositor(unittest.TestCase):
     """Test the CloudTopHeightCompositor."""
 
     def test_call(self):
+        """Test the CloudTopHeight composite generation."""
         from satpy.composites.cloud_products import CloudTopHeightCompositor
         cmap_comp = CloudTopHeightCompositor('test_cmap_compositor')
         palette = xr.DataArray(np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]]),
@@ -566,6 +567,34 @@ class TestCloudTopHeightCompositor(unittest.TestCase):
                          [0., 0.49803922, np.nan]],
                         [[0., 0.49803922, 0.],
                          [0., 0.49803922, np.nan]]])
+        np.testing.assert_allclose(res, exp)
+
+
+class TestPrecipCloudsCompositor(unittest.TestCase):
+    """Test the PrecipClouds compositor."""
+
+    def test_call(self):
+        """Test the precip composite generation."""
+        from satpy.composites.cloud_products import PrecipCloudsRGB
+        cmap_comp = PrecipCloudsRGB('test_precip_compositor')
+
+        data_light = xr.DataArray(np.array([[80, 70, 60, 0], [20, 30, 40, 255]], dtype=np.uint8),
+                                  dims=['y', 'x'], attrs={'_FillValue': 255})
+        data_moderate = xr.DataArray(np.array([[60, 50, 40, 0], [20, 30, 40, 255]], dtype=np.uint8),
+                                     dims=['y', 'x'], attrs={'_FillValue': 255})
+        data_intense = xr.DataArray(np.array([[40, 30, 20, 0], [20, 30, 40, 255]], dtype=np.uint8),
+                                    dims=['y', 'x'], attrs={'_FillValue': 255})
+        data_flags = xr.DataArray(np.array([[0, 0, 4, 0], [0, 0, 0, 0]], dtype=np.uint8),
+                                  dims=['y', 'x'])
+        res = cmap_comp([data_light, data_moderate, data_intense, data_flags])
+
+        exp = np.array([[[0.24313725, 0.18235294, 0.12156863, np.nan],
+                         [0.12156863, 0.18235294, 0.24313725, np.nan]],
+                        [[0.62184874, 0.51820728, 0.41456583, np.nan],
+                         [0.20728291, 0.31092437, 0.41456583, np.nan]],
+                        [[0.82913165, 0.7254902, 0.62184874, np.nan],
+                         [0.20728291, 0.31092437, 0.41456583, np.nan]]])
+
         np.testing.assert_allclose(res, exp)
 
 

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -738,6 +738,7 @@ def suite():
     mysuite.addTest(loader.loadTestsFromTestCase(TestPaletteCompositor))
     mysuite.addTest(loader.loadTestsFromTestCase(TestCloudTopHeightCompositor))
     mysuite.addTest(loader.loadTestsFromTestCase(TestGenericCompositor))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestPrecipCloudsCompositor))
 
     return mysuite
 


### PR DESCRIPTION
 This PR masks out invalid values in the precipitation probability product that were being rendered as white before.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

