### PR TITLE
Add missing docstring for to_image

### DIFF
--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -440,6 +440,19 @@ def show(dataset, **kwargs):
 
 
 def to_image(dataset):
+    """convert ``dataset`` into a :class:`~trollimage.xrimage.XRImage` instance.
+
+    Convert the ``dataset`` into an instance of the
+    :class:`~trollimage.xrimage.XRImage` class.  This function makes no other
+    changes.  To get an enhanced image, possibly with overlays and decoration,
+    see :func:`~get_enhanced_image`.
+
+    Args:
+        dataset (xarray.DataArray): Data to be converted to an image.
+
+    Returns:
+        Instance of :class:`~trollimage.xrimage.XRImage`.
+    """
     dataset = dataset.squeeze()
     if dataset.ndim < 2:
         raise ValueError("Need at least a 2D array to make an image.")


### PR DESCRIPTION
Add missing docstring for the ``to_image`` function in the ``satpy.writers.__init__`` module.

<!-- Please make the PR against the `master` branch. -->

<!-- Describe what your PR does, and why -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
