### PR TITLE
seviri_l1b_hrit: Add georef offset correction flag to attributes

### DIFF
--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -527,6 +527,7 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
                                    'satellite_latitude': self.mda['projection_parameters']['SSP_latitude'],
                                    'satellite_altitude': self.mda['projection_parameters']['h']}
         res.attrs['navigation'] = self.mda['navigation_parameters'].copy()
+        res.attrs['georef_offset_corrected'] = self.mda['offset_corrected']
 
         return res
 

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -264,7 +264,8 @@ class TestHRITMSGFileHandler(unittest.TestCase):
             'projection': {'satellite_longitude': self.reader.mda['projection_parameters']['SSP_longitude'],
                            'satellite_latitude': self.reader.mda['projection_parameters']['SSP_latitude'],
                            'satellite_altitude': self.reader.mda['projection_parameters']['h']},
-            'navigation': self.reader.mda['navigation_parameters']
+            'navigation': self.reader.mda['navigation_parameters'],
+            'georef_offset_corrected': self.reader.mda['offset_corrected']
         })
 
         self.assertDictEqual(attrs_exp, res.attrs)


### PR DESCRIPTION
Add a flag `georef_offset_corrected` to the dataset attributes which indicates whether the geo-referencing offset in SEVIRI L1.5 data has been corrected (since Dec 2017).

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
