### PR TITLE
Align SEVIRI area defs from YAML and readers

### DIFF
--- a/satpy/etc/areas.yaml
+++ b/satpy/etc/areas.yaml
@@ -399,8 +399,8 @@ seviri_0deg:
     height: 3712
     width: 3712
   area_extent:
-    lower_left_xy: [-5570248.477339261, -5567248.074173444]
-    upper_right_xy: [5567248.074173444, 5570248.477339261]
+    lower_left_xy: [-5570248.686685662, -5567248.28340708]
+    upper_right_xy: [5567248.28340708, 5570248.686685662]
 seviri_iodc:
   description: Full globe MSG image 41.5 degrees
   projection:
@@ -413,8 +413,8 @@ seviri_iodc:
     height: 3712
     width: 3712
   area_extent:
-    lower_left_xy: [-5570248.477339261, -5567248.074173444]
-    upper_right_xy: [5567248.074173444, 5570248.477339261]
+    lower_left_xy: [-5570248.686685662, -5567248.28340708]
+    upper_right_xy: [5567248.28340708, 5570248.686685662]
 msg_resample_area:
   description: Full globe MSG image 20.75 degrees
   projection:


### PR DESCRIPTION
Make sure the extents of the `seviri*` area defs in `areas.yaml` are consistent with the extent of the area def returned by the `seviri_l1b_hrit` reader.

 - [ ] Tests passed <!-- for all non-documentation changes -->