### PR TITLE
Add workaround for datetime64 bug in numpy < 1.15

### DIFF
--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -213,9 +213,9 @@ class HRITMSGPrologueFileHandler(HRITFileHandler):
         # Find index of interval enclosing the nominal timestamp of the scan
         time = np.datetime64(self.prologue['ImageAcquisition']['PlannedAcquisitionTime']['TrueRepeatCycleStart'])
         intervals_tstart = self.prologue['SatelliteStatus']['Orbit']['OrbitPolynomial']['StartTime'][0].astype(
-            'datetime64')
+            'datetime64[us]')
         intervals_tend = self.prologue['SatelliteStatus']['Orbit']['OrbitPolynomial']['EndTime'][0].astype(
-            'datetime64')
+            'datetime64[us]')
         try:
             return np.where(np.logical_and(time >= intervals_tstart, time < intervals_tend))[0][0]
         except IndexError:


### PR DESCRIPTION
array_of_datetimes.astype('datetime64') crops hours and seconds (see https://github.com/numpy/numpy/issues/11106) .Use explicit resolution instead.

 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
