### PR TITLE
Replace usage of deprecated get_proj_coords_dask

### DIFF
--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -33,6 +33,8 @@ import numpy as np
 from pyresample.geometry import AreaDefinition
 from pyresample.boundary import AreaDefBoundary, Boundary
 
+from satpy import CHUNK_SIZE
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -96,7 +98,7 @@ def get_geostationary_mask(area):
     ymax *= h
 
     # Compute projection coordinates at the centre of each pixel
-    x, y = area.get_proj_coords_dask()
+    x, y = area.get_proj_coords(chunks=CHUNK_SIZE)
 
     # Compute mask of the earth's elliptical shape
     return ((x / xmax) ** 2 + (y / ymax) ** 2) <= 1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ import versioneer
 
 from setuptools import find_packages, setup
 
-requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.10.3', 'trollsift',
+requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.11.0', 'trollsift',
             'trollimage >=1.5.1', 'pykdtree', 'six', 'pyyaml', 'xarray >=0.10.1',
             'dask[array] >=0.17.1', 'pyproj']
 


### PR DESCRIPTION
`pyresample.AreaDefinition.get_proj_coords_dask` is deprecated. Use `get_proj_coords(chunks=...)` instead.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
