### PR TITLE
MITIFF writer: Need to clip enhanced data before scaling to 8 bit values

### DIFF
--- a/satpy/tests/writer_tests/test_mitiff.py
+++ b/satpy/tests/writer_tests/test_mitiff.py
@@ -105,6 +105,40 @@ class TestMITIFFWriter(unittest.TestCase):
         )
         return ds1
 
+    def _get_test_dataset_with_bad_values(self, bands=3):
+        """Helper function to create a single test dataset."""
+        import xarray as xr
+        import numpy as np
+        from datetime import datetime
+        from pyresample.geometry import AreaDefinition
+        from pyresample.utils import proj4_str_to_dict
+        area_def = AreaDefinition(
+            'test',
+            'test',
+            'test',
+            proj4_str_to_dict('+proj=stere +datum=WGS84 +ellps=WGS84 '
+                              '+lon_0=0. +lat_0=90 +lat_ts=60 +units=km'),
+            100,
+            200,
+            (-1000., -1500., 1000., 1500.),
+        )
+
+        data = np.arange(-210, 790, 100).reshape((2, 5)) * 0.95
+        data /= 5.605
+        data[0, 0] = np.nan  # need a nan value
+        data[0, 1] = 0.  # Need a 0 value
+
+        rgb_data = np.stack([data, data, data])
+        ds1 = xr.DataArray(rgb_data,
+                           dims=('bands', 'y', 'x'),
+                           attrs={'name': 'test',
+                                  'start_time': datetime.utcnow(),
+                                  'platform_name': "TEST_PLATFORM_NAME",
+                                  'sensor': 'TEST_SENSOR_NAME',
+                                  'area': area_def,
+                                  'prerequisites': ['1', '2', '3']})
+        return ds1
+
     def _get_test_dataset_calibration(self, bands=6):
         """Helper function to create a single test dataset."""
         import xarray as xr
@@ -240,6 +274,25 @@ class TestMITIFFWriter(unittest.TestCase):
         dataset = self._get_test_dataset_calibration()
         w = MITIFFWriter(filename=dataset.attrs['metadata_requirements']['file_pattern'], base_dir=self.base_dir)
         w.save_dataset(dataset)
+
+    def test_save_dataset_with_bad_value(self):
+        """Test basic writer operation."""
+        import os
+        import numpy as np
+        from libtiff import TIFF
+        from satpy.writers.mitiff import MITIFFWriter
+
+        expected = np.array([[0, 4, 1, 37, 73],
+                             [110, 146, 183, 219, 255]])
+
+        dataset = self._get_test_dataset_with_bad_values()
+        w = MITIFFWriter(base_dir=self.base_dir)
+        w.save_dataset(dataset)
+        filename = "{:s}_{:%Y%m%d_%H%M%S}.mitiff".format(dataset.attrs['name'],
+                                                         dataset.attrs['start_time'])
+        tif = TIFF.open(os.path.join(self.base_dir, filename))
+        for image in tif.iter_images():
+            np.testing.assert_allclose(image, expected, atol=1.e-6, rtol=0)
 
 
 def suite():

--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -608,7 +608,7 @@ class MITIFFWriter(ImageWriter):
             img = get_enhanced_image(datasets.squeeze(), enhance=self.enhancer)
             for i, band in enumerate(img.data['bands']):
                 chn = img.data.sel(bands=band)
-                data = chn.values * 254. + 1
+                data = chn.values.clip(0, 1) * 254. + 1
                 data = data.clip(0, 255)
                 tif.write_image(data.astype(np.uint8), compression='deflate')
 


### PR DESCRIPTION
After enhancement some data points may have values lower than 0.

Clip this to 0 before scaling to 8bit values.

This is needed in the mitiff writer as the 0 value is treated as nodata.
