### PR TITLE
Add links to source from API documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -60,7 +60,8 @@ autoclass_content = 'both'  # append class __init__ docstring to the class docst
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx.ext.coverage',
-              'sphinx.ext.doctest', 'sphinx.ext.napoleon', 'sphinx.ext.autosummary', 'doi_role']
+              'sphinx.ext.doctest', 'sphinx.ext.napoleon', 'sphinx.ext.autosummary', 'doi_role',
+              'sphinx.ext.viewcode']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
From the API documentation, add links the source for each class, method,
and function.  In a perfect world, each of those would have perfect
documentation such that a developer will not need to refer to the
source.  I believe that some parts of satpy are not quite there yet, and
therefore such links to the source could be useful in the interim.


 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

