### PR TITLE
seviri_l1b_hrit: Make satpos computation pyproj 2 compatible

### DIFF
--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -162,7 +162,7 @@ class HRITMSGPrologueFileHandler(HRITFileHandler):
                 # Transform to geodetic coordinates
                 geocent = pyproj.Proj(proj='geocent')
                 a, b = self.get_earth_radii()
-                latlong = pyproj.Proj(proj='latlong', a=a, b=b, units='meters')
+                latlong = pyproj.Proj(proj='latlong', a=a, b=b, units='m')
                 lon, lat, alt = pyproj.transform(geocent, latlong, x, y, z)
             except NoValidNavigationCoefs as err:
                 logger.warning(err)


### PR DESCRIPTION
`Proj(..., units='meters')` is not accepted by pyproj 2, use `units='m'` instead

<!-- Describe what your PR does, and why -->

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
