### PR TITLE
Consistent platform id attribute across NAT + HRIT SEVIRI readers

### DIFF
--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -172,9 +172,9 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
         self.mda['channel_list'] = [i for i in CHANNEL_NAMES.values()
                                     if self.mda['available_channels'][i]]
 
-        self.mda['platform_id'] = data15hd[
+        self.platform_id = data15hd[
             'SatelliteStatus']['SatelliteDefinition']['SatelliteId']
-        self.mda['platform_name'] = "Meteosat-" + SATNUM[self.mda['platform_id']]
+        self.mda['platform_name'] = "Meteosat-" + SATNUM[self.platform_id]
 
         equator_radius = data15hd['GeometricProcessing'][
             'EarthModel']['EquatorialRadius'] * 1000.
@@ -453,7 +453,7 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
             res = self._convert_to_radiance(data, gain, offset)
 
         if calibration == 'reflectance':
-            solar_irradiance = CALIB[self.mda['platform_id']][channel]["F"]
+            solar_irradiance = CALIB[self.platform_id][channel]["F"]
             res = self._vis_calibrate(res, solar_irradiance)
 
         elif calibration == 'brightness_temperature':


### PR DESCRIPTION
**Bugfix**
Currently, the SEVIRI L1B Native reader will crash, as it is unable to calibrate IR channels:
`AttributeError: 'NativeMSGFileHandler' object has no attribute 'platform_id'`
This is because the Native reader stores `platform_id` inside `self.mda` whereas the calibration routine expects it as `self.platform_id`. The HRIT reader stores this attribute as `self.platform_id`.

This PR updates the Native reader to store the attribute as `self.platform_id`, thus making both SEVIRI readers consistent and preventing the `AttributeError` from occurring.

[edit] The method described in issue #722 is a better solution to this.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff``
