### PR TITLE
Add "extras" checks to check_satpy utility function

### DIFF
--- a/satpy/config.py
+++ b/satpy/config.py
@@ -37,6 +37,7 @@ try:
     from yaml import UnsafeLoader
 except ImportError:
     from yaml import Loader as UnsafeLoader
+from yaml import BaseLoader
 
 LOG = logging.getLogger(__name__)
 
@@ -139,12 +140,10 @@ def recursive_dict_update(d, u):
     return d
 
 
-def check_yaml_configs(configs, key, hdr_len):
+def check_yaml_configs(configs, key):
     """Get a diagnostic for the yaml *configs*.
 
     *key* is the section to look for to get a name for the config at hand.
-    *hdr_len* is the number of lines that can be safely read from the config to
-    get a name.
     """
     diagnostic = {}
     for i in configs:
@@ -158,8 +157,7 @@ def check_yaml_configs(configs, key, hdr_len):
                         continue
                 except yaml.YAMLError as err:
                     stream.seek(0)
-                    lines = ''.join(stream.readline() for line in range(hdr_len))
-                    res = yaml.load(lines, Loader=UnsafeLoader)
+                    res = yaml.load(stream, Loader=BaseLoader)
                     if err.context == 'while constructing a Python object':
                         problem = err.problem
                     else:
@@ -177,12 +175,12 @@ def check_satpy():
     from satpy.writers import configs_for_writer
     print('Readers')
     print('=======')
-    for reader, res in sorted(check_yaml_configs(configs_for_reader(), 'reader', 5).items()):
+    for reader, res in sorted(check_yaml_configs(configs_for_reader(), 'reader').items()):
         print(reader + ': ' + res)
     print()
     print('Writers')
     print('=======')
-    for writer, res in sorted(check_yaml_configs(configs_for_writer(), 'writer', 3).items()):
+    for writer, res in sorted(check_yaml_configs(configs_for_writer(), 'writer').items()):
         print(writer + ': ' + res)
     print()
     print('Extras')

--- a/satpy/config.py
+++ b/satpy/config.py
@@ -184,3 +184,13 @@ def check_satpy():
     print('=======')
     for writer, res in sorted(check_yaml_configs(configs_for_writer(), 'writer', 3).items()):
         print(writer + ': ' + res)
+    print()
+    print('Extras')
+    print('======')
+    for module_name in sorted(('cartopy', 'geoviews')):
+        try:
+            __import__(module_name)
+            res = 'ok'
+        except ImportError as err:
+            res = str(err)
+        print(module_name + ': ' + res)

--- a/satpy/tests/__init__.py
+++ b/satpy/tests/__init__.py
@@ -29,7 +29,8 @@ from satpy.tests import (reader_tests, test_dataset, test_file_handlers,
                          test_readers, test_resample, test_demo,
                          test_scene, test_utils, test_writers,
                          test_yaml_reader, writer_tests,
-                         test_enhancements, compositor_tests, test_multiscene)
+                         test_enhancements, compositor_tests, test_multiscene,
+                         test_crefl_utils, test_config)
 
 
 if sys.version_info < (2, 7):
@@ -58,6 +59,8 @@ def suite():
     mysuite.addTests(test_enhancements.suite())
     mysuite.addTests(compositor_tests.suite())
     mysuite.addTests(test_multiscene.suite())
+    mysuite.addTests(test_crefl_utils.suite())
+    mysuite.addTests(test_config.suite())
 
     return mysuite
 

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -19,7 +19,6 @@
 """
 
 import sys
-from io import StringIO
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 Satpy Developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Test objects and functions in the satpy.config module.
+"""
+
+import sys
+from io import StringIO
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+class TestCheckSatpy(unittest.TestCase):
+    """Test the 'check_satpy' function."""
+
+    def test_basic_check_satpy(self):
+        """Test 'check_satpy' basic functionality."""
+        from satpy.config import check_satpy
+        check_satpy()
+
+    def test_specific_check_satpy(self):
+        """Test 'check_satpy' with specific features provided."""
+        from satpy.config import check_satpy
+        with mock.patch('satpy.config.print') as print_mock:
+            check_satpy(readers=['viirs_sdr'], extras=('cartopy', '__fake'))
+            checked_fake = False
+            for call in print_mock.mock_calls:
+                if len(call[1]) > 0 and '__fake' in call[1][0]:
+                    self.assertNotIn('ok', call[1][1])
+                    checked_fake = True
+            self.assertTrue(checked_fake, "Did not find __fake module "
+                                          "mentioned in checks")
+
+
+def suite():
+    """The test suite for test_projector.
+    """
+    loader = unittest.TestLoader()
+    my_suite = unittest.TestSuite()
+    my_suite.addTest(loader.loadTestsFromTestCase(TestCheckSatpy))
+
+    return my_suite

--- a/satpy/tests/test_crefl_utils.py
+++ b/satpy/tests/test_crefl_utils.py
@@ -1,4 +1,28 @@
-import unittest
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2019 Satpy Developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""Test CREFL rayleigh correction functions.
+"""
+import sys
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
 
 
 class TestCreflUtils(unittest.TestCase):


### PR DESCRIPTION
I'm working on my scipy tutorial about Satpy and realized I could use `check_satpy` as a quick way to verify the installation of the attendees. Since I plan on including parts about `geoviews` and `cartopy` in my tutorial I wanted to make the checks for these part of `check_satpy`. This adds an "Extras" section with these checks to the output of that function:

```plaintext
Readers
=======
abi_l1b: ok
...
viirs_sdr: ok

Writers
=======
cf: ok
geotiff: ok
...
simple_image: ok

Extras
======
cartopy: ok
geoviews: ok
```

@mraspaud What do you think about arguments to `check_satpy` to "assert" that certain features are available? Like `check_satpy(readers=['abi_l1b', 'viirs_sdr'], extras=['cartopy'])`? Maybe it doesn't print anything out except for these features?

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
