### PR TITLE
Fix viirs sdr reader to allow ivcdb files in the sdr directory

### DIFF
--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2011-2017.
+# Copyright (c) 2011-2019 Pytroll
 
 # Author(s):
 
@@ -119,6 +119,7 @@ DATASET_KEYS = {'GDNBO': 'VIIRS-DNB-GEO',
                 'SVM14': 'VIIRS-M14-SDR',
                 'SVM15': 'VIIRS-M15-SDR',
                 'SVM16': 'VIIRS-M16-SDR',
+                'IVCDB': 'VIIRS-DualGain-Cal-IP'
                 }
 
 


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

CSPP (and IPOPP) may output Dual Gain calibration files with the prefix IVCDB. As of now, when having these files in the directory together with the other SDR files, satpy fails with a `KeyError`

CSPP version 3.2 will output these files on default.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
