### PR TITLE
Fix coord2area_def.py utillity script for python 3

### DIFF
--- a/utils/coord2area_def.py
+++ b/utils/coord2area_def.py
@@ -105,19 +105,7 @@ if __name__ == '__main__':
                    ",lon_0=" + str(lon_0) + ",ellps=WGS84").split(","))
 
     print(proj4_string)
-
-    print("REGION:", name, "{")
-    print("\tNAME:\t", name)
-    print("\tPCS_ID:\t", proj + "_" + str(lon_0) + "_" + str(lat_0))
-    print("\tPCS_DEF:\tproj=" + proj +
-          ",lat_0=" + str(lat_0) +
-          ",lon_0=" + str(lon_0) +
-          ",ellps=WGS84")
-    print("\tXSIZE:\t", xsize)
-    print("\tYSIZE:\t", ysize)
-    print("\tAREA_EXTENT:\t", area_extent)
-    print("};")
-
+    print()
     print(name + ":")
     print("  description: " + name)
     print("  projection:")

--- a/utils/coord2area_def.py
+++ b/utils/coord2area_def.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2012, 2015
+# Copyright (c) 2012, 2015, 2019
 #
 
 # Author(s):
@@ -104,19 +104,33 @@ if __name__ == '__main__':
         " +".join(("proj=" + proj + ",lat_0=" + str(lat_0) +
                    ",lon_0=" + str(lon_0) + ",ellps=WGS84").split(","))
 
-    print proj4_string
+    print(proj4_string)
 
-    print "REGION:", name, "{"
-    print "\tNAME:\t", name
-    print "\tPCS_ID:\t", proj + "_" + str(lon_0) + "_" + str(lat_0)
-    print ("\tPCS_DEF:\tproj=" + proj +
-           ",lat_0=" + str(lat_0) +
-           ",lon_0=" + str(lon_0) +
-           ",ellps=WGS84")
-    print "\tXSIZE:\t", xsize
-    print "\tYSIZE:\t", ysize
-    print "\tAREA_EXTENT:\t", area_extent
-    print "};"
+    print("REGION:", name, "{")
+    print("\tNAME:\t", name)
+    print("\tPCS_ID:\t", proj + "_" + str(lon_0) + "_" + str(lat_0))
+    print("\tPCS_DEF:\tproj=" + proj +
+          ",lat_0=" + str(lat_0) +
+          ",lon_0=" + str(lon_0) +
+          ",ellps=WGS84")
+    print("\tXSIZE:\t", xsize)
+    print("\tYSIZE:\t", ysize)
+    print("\tAREA_EXTENT:\t", area_extent)
+    print("};")
+
+    print(name + ":")
+    print("  description: " + name)
+    print("  projection:")
+    print("    proj: " + proj)
+    print("    ellps: WGS84")
+    print("    lat_0: " + str(lat_0))
+    print("    lon_0: " + str(lon_0))
+    print("  shape:")
+    print("    height: " + str(ysize))
+    print("    width: " + str(xsize))
+    print("  area_extent:")
+    print("    lower_left_xy: [%f, %f]" % (area_extent[0], area_extent[1]))
+    print("    upper_right_xy: [%f, %f]" % (area_extent[2], area_extent[3]))
 
     if args.shapes is None:
         sys.exit(0)


### PR DESCRIPTION
<!-- Please make the PR against the `master` branch. -->

Fixing the utility script used to help users define a new area. Now it should be Python 3 compatible and it outputs the "new" area definition format for the areas.yaml file.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
