### PR TITLE
Update VIIRS EDR Active Fires

### DIFF
--- a/satpy/etc/readers/viirs_edr_active_fires.yaml
+++ b/satpy/etc/readers/viirs_edr_active_fires.yaml
@@ -15,7 +15,6 @@ file_types:
         variable_prefix: "Fire Pixels/"
         file_patterns:
         - 'AFEDR_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
-        - 'AF_v1r1_npp_s{start_time:%Y%m%d%H%M%S%f}_e{end_time:%Y%m%d%H%M%S%f}_c{creation_time:%Y%m%d%H%M%S%f}.nc'
         - 'AFMOD_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
     fires_text:
         file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresTextFileHandler

--- a/satpy/etc/readers/viirs_edr_active_fires.yaml
+++ b/satpy/etc/readers/viirs_edr_active_fires.yaml
@@ -68,4 +68,4 @@ datasets:
         file_type: [fires_text, fires_netcdf_img]
         file_key: "{variable_prefix}T4"
         coordinates: [longitude, latitude]
-        units: 'K'1
+        units: 'K'

--- a/satpy/etc/readers/viirs_edr_active_fires.yaml
+++ b/satpy/etc/readers/viirs_edr_active_fires.yaml
@@ -59,7 +59,13 @@ datasets:
         units: 'MW'
     T13:
         name: T13
-        file_type: [fires_netcdf, fires_text, fires_netcdf_img]
+        file_type: [fires_netcdf, fires_text]
         file_key: "{variable_prefix}FP_T13"
         coordinates: [longitude, latitude]
         units: 'K'
+    T4:
+        name: T4
+        file_type: [fires_text, fires_netcdf_img]
+        file_key: "{variable_prefix}T4"
+        coordinates: [longitude, latitude]
+        units: 'K'1

--- a/satpy/etc/readers/viirs_edr_active_fires.yaml
+++ b/satpy/etc/readers/viirs_edr_active_fires.yaml
@@ -21,8 +21,6 @@ file_types:
         file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresTextFileHandler
         file_patterns:
             - '{data_id}_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
-#            - 'AFIMG_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
-#            - 'AFMOD_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
 
 datasets:
     confidence_cat:

--- a/satpy/etc/readers/viirs_edr_active_fires.yaml
+++ b/satpy/etc/readers/viirs_edr_active_fires.yaml
@@ -14,17 +14,22 @@ file_types:
         file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresFileHandler
         variable_prefix: "Fire Pixels/"
         file_patterns:
-        - 'AFEDR_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
-        - 'AFMOD_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
+            - 'AFEDR_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
+            - 'AFMOD_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
+    fires_text_img:
+        file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresTextFileHandler
+        file_patterns:
+            - 'AFIMG_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
     fires_text:
         file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresTextFileHandler
         file_patterns:
-            - '{data_id}_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
+            - 'AFMOD_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
+            - 'AFEDR_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
 
 datasets:
     confidence_cat:
         name: confidence_cat
-        file_type: [fires_netcdf_img, fires_text]
+        file_type: [fires_netcdf_img, fires_text_img]
         file_key: "{variable_prefix}FP_confidence"
         coordinates: [longitude, latitude]
         units: '[7,8,9]->[lo,med,hi]'
@@ -37,18 +42,18 @@ datasets:
     longitude:
         name: longitude
         standard_name: longitude
-        file_type: [fires_netcdf_img, fires_netcdf, fires_text]
+        file_type: [fires_netcdf_img, fires_netcdf, fires_text_img, fires_text]
         file_key: "{variable_prefix}FP_longitude"
         units: 'degrees'
     latitude:
         name: latitude
         standard_name: latitude
-        file_type: [fires_netcdf_img, fires_netcdf, fires_text]
+        file_type: [fires_netcdf_img, fires_netcdf, fires_text_img, fires_text]
         file_key: "{variable_prefix}FP_latitude"
         units: 'degrees'
     power:
         name: power
-        file_type: [fires_netcdf_img, fires_netcdf, fires_text]
+        file_type: [fires_netcdf_img, fires_netcdf, fires_text_img, fires_text]
         file_key: "{variable_prefix:s}FP_power"
         coordinates: [longitude, latitude]
         units: 'MW'
@@ -60,7 +65,7 @@ datasets:
         units: 'K'
     T4:
         name: T4
-        file_type: [fires_netcdf_img, fires_text]
+        file_type: [fires_netcdf_img, fires_text_img]
         file_key: "{variable_prefix}FP_T4"
         coordinates: [longitude, latitude]
         units: 'K'

--- a/satpy/etc/readers/viirs_edr_active_fires.yaml
+++ b/satpy/etc/readers/viirs_edr_active_fires.yaml
@@ -20,7 +20,7 @@ file_types:
     fires_text:
         file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresTextFileHandler
         file_patterns:
-            - '{data_id}_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
+            - '{satellite_name}_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
 
 datasets:
     confidence_cat:
@@ -64,6 +64,6 @@ datasets:
     T4:
         name: T4
         file_type: [fires_text, fires_netcdf_img]
-        file_key: "{variable_prefix}T4"
+        file_key: "{variable_prefix}FP_T4"
         coordinates: [longitude, latitude]
         units: 'K'

--- a/satpy/etc/readers/viirs_edr_active_fires.yaml
+++ b/satpy/etc/readers/viirs_edr_active_fires.yaml
@@ -9,29 +9,27 @@ file_types:
         file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresFileHandler
         variable_prefix: ""
         file_patterns:
-            - 'AFIMG_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
+            - 'AFIMG_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
     fires_netcdf:
         file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresFileHandler
         variable_prefix: "Fire Pixels/"
         file_patterns:
-        - 'AFEDR_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
-        - 'AFMOD_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
+        - 'AFEDR_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
+        - 'AFMOD_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
     fires_text:
         file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresTextFileHandler
         file_patterns:
-            - '{satellite_name}_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
+            - '{data_id}_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
 
 datasets:
     confidence_cat:
         name: confidence_cat
-        standard_name: confidence_cat
-        file_type: [fires_text, fires_netcdf_img]
+        file_type: [fires_netcdf_img, fires_text]
         file_key: "{variable_prefix}FP_confidence"
         coordinates: [longitude, latitude]
         units: '[7,8,9]->[lo,med,hi]'
     confidence_pct:
         name: confidence_pct
-        standard_name: confidence_pct
         file_type: [fires_netcdf, fires_text]
         file_key: "{variable_prefix}FP_confidence"
         coordinates: [longitude, latitude]
@@ -39,18 +37,18 @@ datasets:
     longitude:
         name: longitude
         standard_name: longitude
-        file_type: [fires_netcdf, fires_text, fires_netcdf_img]
+        file_type: [fires_netcdf_img, fires_netcdf, fires_text]
         file_key: "{variable_prefix}FP_longitude"
         units: 'degrees'
     latitude:
         name: latitude
         standard_name: latitude
-        file_type: [fires_netcdf, fires_text, fires_netcdf_img]
+        file_type: [fires_netcdf_img, fires_netcdf, fires_text]
         file_key: "{variable_prefix}FP_latitude"
         units: 'degrees'
     power:
         name: power
-        file_type: [fires_netcdf, fires_text, fires_netcdf_img]
+        file_type: [fires_netcdf_img, fires_netcdf, fires_text]
         file_key: "{variable_prefix:s}FP_power"
         coordinates: [longitude, latitude]
         units: 'MW'
@@ -62,7 +60,7 @@ datasets:
         units: 'K'
     T4:
         name: T4
-        file_type: [fires_text, fires_netcdf_img]
+        file_type: [fires_netcdf_img, fires_text]
         file_key: "{variable_prefix}FP_T4"
         coordinates: [longitude, latitude]
         units: 'K'

--- a/satpy/etc/readers/viirs_edr_active_fires.yaml
+++ b/satpy/etc/readers/viirs_edr_active_fires.yaml
@@ -5,44 +5,61 @@ reader:
     sensors: [viirs]
 
 file_types:
+    fires_netcdf_img:
+        file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresFileHandler
+        variable_prefix: ""
+        file_patterns:
+            - 'AFIMG_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
     fires_netcdf:
         file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresFileHandler
+        variable_prefix: "Fire Pixels/"
         file_patterns:
-            - 'AFEDR_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
+        - 'AFEDR_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
+        - 'AF_v1r1_npp_s{start_time:%Y%m%d%H%M%S%f}_e{end_time:%Y%m%d%H%M%S%f}_c{creation_time:%Y%m%d%H%M%S%f}.nc'
+        - 'AFMOD_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
     fires_text:
         file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresTextFileHandler
         file_patterns:
-            - 'AFEDR_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
+            - '{data_id}_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
+#            - 'AFIMG_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
+#            - 'AFMOD_npp_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
 
 datasets:
-    detection_confidence:
-        name: detection_confidence
-        standard_name: fire_confidence
+    confidence_cat:
+        name: confidence_cat
+        standard_name: confidence_cat
+        file_type: [fires_text, fires_netcdf_img]
+        file_key: "{variable_prefix}FP_confidence"
+        coordinates: [longitude, latitude]
+        units: '[7,8,9]->[lo,med,hi]'
+    confidence_pct:
+        name: confidence_pct
+        standard_name: confidence_pct
         file_type: [fires_netcdf, fires_text]
-        file_key: "Fire Pixels/FP_confidence"
+        file_key: "{variable_prefix}FP_confidence"
         coordinates: [longitude, latitude]
         units: '%'
     longitude:
         name: longitude
         standard_name: longitude
-        file_type: [fires_netcdf, fires_text]
-        file_key: "Fire Pixels/FP_longitude"
+        file_type: [fires_netcdf, fires_text, fires_netcdf_img]
+        file_key: "{variable_prefix}FP_longitude"
         units: 'degrees'
     latitude:
         name: latitude
         standard_name: latitude
-        file_type: [fires_netcdf, fires_text]
-        file_key: "Fire Pixels/FP_latitude"
+        file_type: [fires_netcdf, fires_text, fires_netcdf_img]
+        file_key: "{variable_prefix}FP_latitude"
         units: 'degrees'
     power:
         name: power
-        file_type: [fires_netcdf, fires_text]
-        file_key: "Fire Pixels/FP_power"
+        file_type: [fires_netcdf, fires_text, fires_netcdf_img]
+        file_key: "{variable_prefix:s}FP_power"
         coordinates: [longitude, latitude]
         units: 'MW'
     T13:
         name: T13
-        file_type: [fires_netcdf, fires_text]
-        file_key: "Fire Pixels/FP_T13"
+        file_type: [fires_netcdf, fires_text, fires_netcdf_img]
+        file_key: "{variable_prefix}FP_T13"
         coordinates: [longitude, latitude]
         units: 'K'

--- a/satpy/readers/viirs_edr_active_fires.py
+++ b/satpy/readers/viirs_edr_active_fires.py
@@ -110,7 +110,6 @@ class VIIRSActiveFiresTextFileHandler(BaseFileHandler):
                                                    "power"])
 
     def get_dataset(self, dsid, dsinfo):
-        print(self.platform_name)
         ds = self[dsid.name].to_dask_array(lengths=True)
         data_array = xr.DataArray(ds, dims=("y",), attrs={"platform_name": self.platform_name, "sensor": "VIIRS"})
         data_array.attrs.update(dsinfo)

--- a/satpy/readers/viirs_edr_active_fires.py
+++ b/satpy/readers/viirs_edr_active_fires.py
@@ -89,14 +89,6 @@ class VIIRSActiveFiresTextFileHandler(BaseFileHandler):
             filename_info: Filename information
             filetype_info: Filetype information
         """
-        super(VIIRSActiveFiresTextFileHandler, self).__init__(filename, filename_info, filetype_info)
-
-        if not os.path.isfile(filename):
-            return
-
-        platform_key = {"NPP": "Suomi-NPP", "J01": "NOAA-20", "J02": "NOAA-21"}
-
-        self.platform_name = platform_key.get(self.filename_info['satellite_name'].upper(), "unknown")
 
         if filetype_info.get('file_type') == 'fires_text_img':
             self.file_content = dd.read_csv(filename, skiprows=15, header=None,
@@ -108,6 +100,12 @@ class VIIRSActiveFiresTextFileHandler(BaseFileHandler):
                                             names=["latitude", "longitude",
                                                    "T13", "Along-scan", "Along-track", "confidence_pct",
                                                    "power"])
+
+        super(VIIRSActiveFiresTextFileHandler, self).__init__(filename, filename_info, filetype_info)
+
+        platform_key = {"NPP": "Suomi-NPP", "J01": "NOAA-20", "J02": "NOAA-21"}
+
+        self.platform_name = platform_key.get(self.filename_info['satellite_name'].upper(), "unknown")
 
     def get_dataset(self, dsid, dsinfo):
         ds = self[dsid.name].to_dask_array(lengths=True)

--- a/satpy/readers/viirs_edr_active_fires.py
+++ b/satpy/readers/viirs_edr_active_fires.py
@@ -53,9 +53,9 @@ class VIIRSActiveFiresFileHandler(NetCDF4FileHandler):
         key = dsinfo.get('file_key', dsid.name).format(variable_prefix=self.prefix)
         data = self[key]
         data.attrs.update(dsinfo)
-
-        data.attrs["platform_name"] = self.get('/attr/satellite_name')
-        data.attrs["sensor"] = self.get('/attr/instrument_name')
+        print(self.filename_info)
+        data.attrs["platform_name"] = self.filename_info.get('satellite_name')
+        data.attrs["sensor"] = "VIIRS"
 
         return data
 
@@ -92,7 +92,7 @@ class VIIRSActiveFiresTextFileHandler(BaseFileHandler):
         if not os.path.isfile(filename):
             return
 
-        if filename_info.get('satellite_name') == 'AFIMG':
+        if filename_info.get('data_id') == 'AFIMG':
             self.file_content = dd.read_csv(filename, skiprows=15, header=None,
                                             names=["latitude", "longitude",
                                                    "T4", "Along-scan", "Along-track", "confidence_cat",

--- a/satpy/readers/viirs_edr_active_fires.py
+++ b/satpy/readers/viirs_edr_active_fires.py
@@ -53,8 +53,17 @@ class VIIRSActiveFiresFileHandler(NetCDF4FileHandler):
         key = dsinfo.get('file_key', dsid.name).format(variable_prefix=self.prefix)
         data = self[key]
         data.attrs.update(dsinfo)
-        print(self.filename_info)
-        data.attrs["platform_name"] = self.filename_info['satellite_name']
+
+        if self.filename_info['satellite_name'].upper() == "NPP":
+            data.attrs["platform_name"] = "Suomi-NP"
+        elif self.filename_info['satellite_name'].upper() == "J01":
+            data.attrs["platform_name"] = "NOAA-20"
+        elif self.filename_info['satellite_name'].upper() == "J02":
+            data.attrs["platform_name"] = "NOAA-21"
+        else:
+            print("ERROR - Invalid platform")
+            data.attrs["platform_name"] = "unknown"
+
         data.attrs["sensor"] = "VIIRS"
 
         return data
@@ -92,6 +101,16 @@ class VIIRSActiveFiresTextFileHandler(BaseFileHandler):
         if not os.path.isfile(filename):
             return
 
+        if filename_info['satellite_name'].upper() == "NPP":
+            self.platform_name = "Suomi-NP"
+        elif filename_info['satellite_name'].upper() == "J01":
+            self.platform_name = "NOAA-20"
+        elif filename_info['satellite_name'].upper() == "J02":
+            self.platform_name = "NOAA-21"
+        else:
+            print("ERROR - Invalid platform")
+            self.platform_name = "unknown"
+
         if filetype_info.get('file_type') == 'fires_text_img':
             self.file_content = dd.read_csv(filename, skiprows=15, header=None,
                                             names=["latitude", "longitude",
@@ -105,7 +124,7 @@ class VIIRSActiveFiresTextFileHandler(BaseFileHandler):
 
     def get_dataset(self, dsid, dsinfo):
         ds = self[dsid.name].to_dask_array(lengths=True)
-        data_array = xr.DataArray(ds, dims=("y",), attrs={"platform_name": "NPP", "sensor": "VIIRS"})
+        data_array = xr.DataArray(ds, dims=("y",), attrs={"platform_name": self.platform_name, "sensor": "VIIRS"})
         data_array.attrs.update(dsinfo)
         return data_array
 

--- a/satpy/readers/viirs_edr_active_fires.py
+++ b/satpy/readers/viirs_edr_active_fires.py
@@ -49,13 +49,8 @@ class VIIRSActiveFiresFileHandler(NetCDF4FileHandler):
             Dask DataArray: Data
 
         """
-        print(str(dsid))
-        print("Prefix: " + str(dsinfo.get('variable_prefix')))
-       # print(dsinfo.get('file_key').format(variable_prefix=self.prefix))
 
         key = dsinfo.get('file_key', dsid.name).format(variable_prefix=self.prefix)
-
-        print(key)
         data = self[key]
         data.attrs.update(dsinfo)
 

--- a/satpy/readers/viirs_edr_active_fires.py
+++ b/satpy/readers/viirs_edr_active_fires.py
@@ -54,16 +54,9 @@ class VIIRSActiveFiresFileHandler(NetCDF4FileHandler):
         data = self[key]
         data.attrs.update(dsinfo)
 
-        if self.filename_info['satellite_name'].upper() == "NPP":
-            data.attrs["platform_name"] = "Suomi-NP"
-        elif self.filename_info['satellite_name'].upper() == "J01":
-            data.attrs["platform_name"] = "NOAA-20"
-        elif self.filename_info['satellite_name'].upper() == "J02":
-            data.attrs["platform_name"] = "NOAA-21"
-        else:
-            print("ERROR - Invalid platform")
-            data.attrs["platform_name"] = "unknown"
+        platform_key = {"NPP": "Suomi-NPP", "J01": "NOAA-20", "J02": "NOAA-21"}
 
+        data.attrs["platform_name"] = platform_key.get(self.filename_info['satellite_name'].upper(), "unknown")
         data.attrs["sensor"] = "VIIRS"
 
         return data
@@ -101,15 +94,9 @@ class VIIRSActiveFiresTextFileHandler(BaseFileHandler):
         if not os.path.isfile(filename):
             return
 
-        if filename_info['satellite_name'].upper() == "NPP":
-            self.platform_name = "Suomi-NP"
-        elif filename_info['satellite_name'].upper() == "J01":
-            self.platform_name = "NOAA-20"
-        elif filename_info['satellite_name'].upper() == "J02":
-            self.platform_name = "NOAA-21"
-        else:
-            print("ERROR - Invalid platform")
-            self.platform_name = "unknown"
+        platform_key = {"NPP": "Suomi-NPP", "J01": "NOAA-20", "J02": "NOAA-21"}
+
+        self.platform_name = platform_key.get(self.filename_info['satellite_name'].upper(), "unknown")
 
         if filetype_info.get('file_type') == 'fires_text_img':
             self.file_content = dd.read_csv(filename, skiprows=15, header=None,
@@ -123,6 +110,7 @@ class VIIRSActiveFiresTextFileHandler(BaseFileHandler):
                                                    "power"])
 
     def get_dataset(self, dsid, dsinfo):
+        print(self.platform_name)
         ds = self[dsid.name].to_dask_array(lengths=True)
         data_array = xr.DataArray(ds, dims=("y",), attrs={"platform_name": self.platform_name, "sensor": "VIIRS"})
         data_array.attrs.update(dsinfo)

--- a/satpy/readers/viirs_edr_active_fires.py
+++ b/satpy/readers/viirs_edr_active_fires.py
@@ -97,7 +97,7 @@ class VIIRSActiveFiresTextFileHandler(BaseFileHandler):
         if not os.path.isfile(filename):
             return
 
-        if filename_info.get('data_id') == 'AFIMG':
+        if filename_info.get('satellite_name') == 'AFIMG':
             self.file_content = dd.read_csv(filename, skiprows=15, header=None,
                                             names=["latitude", "longitude",
                                                    "T4", "Along-scan", "Along-track", "confidence_cat",

--- a/satpy/readers/viirs_edr_active_fires.py
+++ b/satpy/readers/viirs_edr_active_fires.py
@@ -54,7 +54,7 @@ class VIIRSActiveFiresFileHandler(NetCDF4FileHandler):
         data = self[key]
         data.attrs.update(dsinfo)
         print(self.filename_info)
-        data.attrs["platform_name"] = self.filename_info.get('satellite_name')
+        data.attrs["platform_name"] = self.filename_info['satellite_name']
         data.attrs["sensor"] = "VIIRS"
 
         return data
@@ -92,7 +92,7 @@ class VIIRSActiveFiresTextFileHandler(BaseFileHandler):
         if not os.path.isfile(filename):
             return
 
-        if filename_info.get('data_id') == 'AFIMG':
+        if filetype_info.get('file_type') == 'fires_text_img':
             self.file_content = dd.read_csv(filename, skiprows=15, header=None,
                                             names=["latitude", "longitude",
                                                    "T4", "Along-scan", "Along-track", "confidence_cat",
@@ -105,9 +105,8 @@ class VIIRSActiveFiresTextFileHandler(BaseFileHandler):
 
     def get_dataset(self, dsid, dsinfo):
         ds = self[dsid.name].to_dask_array(lengths=True)
-        data_array = xr.DataArray(ds, dims=("y",), attrs={"platform_name": "unknown", "sensor": "viirs"})
+        data_array = xr.DataArray(ds, dims=("y",), attrs={"platform_name": "NPP", "sensor": "VIIRS"})
         data_array.attrs.update(dsinfo)
-
         return data_array
 
     @property

--- a/satpy/readers/viirs_edr_active_fires.py
+++ b/satpy/readers/viirs_edr_active_fires.py
@@ -97,15 +97,16 @@ class VIIRSActiveFiresTextFileHandler(BaseFileHandler):
         if not os.path.isfile(filename):
             return
 
-        if filename_info.get('data_id') == 'AFMOD':
-            confidence = 'confidence_pct'
+        if filename_info.get('data_id') == 'AFIMG':
+            self.file_content = dd.read_csv(filename, skiprows=15, header=None,
+                                            names=["latitude", "longitude",
+                                                   "T4", "Along-scan", "Along-track", "confidence_cat",
+                                                   "power"])
         else:
-            confidence = 'confidence_cat'
-
-        self.file_content = dd.read_csv(filename, skiprows=15, header=None,
-                                        names=["latitude", "longitude",
-                                               "T13", "Along-scan", "Along-track", confidence,
-                                               "power"])
+            self.file_content = dd.read_csv(filename, skiprows=15, header=None,
+                                            names=["latitude", "longitude",
+                                                   "T13", "Along-scan", "Along-track", "confidence_pct",
+                                                   "power"])
 
     def get_dataset(self, dsid, dsinfo):
         ds = self[dsid.name].to_dask_array(lengths=True)

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -128,6 +128,10 @@ class FakeModFiresTextFileHandler(BaseFileHandler):
         super(FakeModFiresTextFileHandler, self).__init__(filename, filename_info, filetype_info)
         self.file_content = self.get_test_content()
 
+        platform_key = {"NPP": "Suomi-NPP", "J01": "NOAA-20", "J02": "NOAA-21"}
+
+        self.platform_name = platform_key.get(self.filename_info['satellite_name'].upper(), "unknown")
+
     def get_test_content(self):
         fake_file = io.StringIO(u'''\n\n\n\n\n\n\n\n\n\n\n\n\n\n
         24.64015007, -107.57017517,  317.38290405,   0.75,   0.75,   40,    4.28618050
@@ -150,6 +154,10 @@ class FakeImgFiresTextFileHandler(BaseFileHandler):
         fake_file = io.StringIO(u'''\n\n\n\n\n\n\n\n\n\n\n\n\n\n
         24.64015007, -107.57017517,  317.38290405,   0.75,   0.75,   40,    4.28618050
         25.90660477, -100.06127167,  331.17962646,   0.75,   0.75,   81,   20.61096764''')
+
+        platform_key = {"NPP": "Suomi-NPP", "J01": "NOAA-20", "J02": "NOAA-21"}
+
+        self.platform_name = platform_key.get(self.filename_info['satellite_name'].upper(), "unknown")
 
         return dd.from_pandas(pd.read_csv(fake_file, skiprows=15, header=None,
                                           names=["latitude", "longitude",

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -148,7 +148,6 @@ class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
-            'AFEDR_npp_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.nc',
             'AFMOD_npp_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.nc'
         ])
         self.assertTrue(len(loadables), 1)
@@ -160,7 +159,6 @@ class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
-            'AFEDR_npp_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.nc',
             'AFMOD_npp_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.nc'
         ])
         r.create_filehandlers(loadables)

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -63,7 +63,8 @@ class FakeModFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
     def get_test_content(self, filename, filename_info, filename_type):
         """Mimic reader input file content"""
         file_content = {}
-        file_content['/attr/satellite_name'] = "AFMOD"
+        file_content['/attr/data_id'] = "AFMOD"
+        file_content['/attr/satellite_name'] = "npp"
         file_content['/attr/instrument_name'] = 'VIIRS'
 
         file_content['Fire Pixels/FP_latitude'] = DEFAULT_LATLON_FILE_DATA
@@ -95,7 +96,8 @@ class FakeImgFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
     def get_test_content(self, filename, filename_info, filename_type):
         """Mimic reader input file content"""
         file_content = {}
-        file_content['/attr/satellite_name'] = "AFIMG"
+        file_content['/attr/data_id'] = "AFIMG"
+        file_content['/attr/satellite_name'] = "npp"
         file_content['/attr/instrument_name'] = 'VIIRS'
 
         file_content['FP_latitude'] = DEFAULT_LATLON_FILE_DATA

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -90,10 +90,10 @@ class FakeFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
         return file_content
 
 
-class FakeFiresTextFileHandler(BaseFileHandler):
+class FakeModFiresTextFileHandler(BaseFileHandler):
     def __init__(self, filename, filename_info, filetype_info, **kwargs):
         """Get fake file content from 'get_test_content'"""
-        super(FakeFiresTextFileHandler, self).__init__(filename, filename_info, filetype_info)
+        super(FakeModFiresTextFileHandler, self).__init__(filename, filename_info, filetype_info)
         self.file_content = self.get_test_content()
 
     def get_test_content(self):
@@ -105,6 +105,24 @@ class FakeFiresTextFileHandler(BaseFileHandler):
                                           names=["latitude", "longitude",
                                                  "T13", "Along-scan", "Along-track",
                                                  "confidence_pct",
+                                                 "power"]), chunksize=1)
+
+
+class FakeImgFiresTextFileHandler(BaseFileHandler):
+    def __init__(self, filename, filename_info, filetype_info, **kwargs):
+        """Get fake file content from 'get_test_content'"""
+        super(FakeImgFiresTextFileHandler, self).__init__(filename, filename_info, filetype_info)
+        self.file_content = self.get_test_content()
+
+    def get_test_content(self):
+        fake_file = io.StringIO(u'''\n\n\n\n\n\n\n\n\n\n\n\n\n\n
+        24.64015007, -107.57017517,  317.38290405,   0.75,   0.75,   40,    4.28618050
+        25.90660477, -100.06127167,  331.17962646,   0.75,   0.75,   81,   20.61096764''')
+
+        return dd.from_pandas(pd.read_csv(fake_file, skiprows=15, header=None,
+                                          names=["latitude", "longitude",
+                                                 "T4", "Along-scan", "Along-track",
+                                                 "confidence_cat",
                                                  "power"]), chunksize=1)
 
 
@@ -222,7 +240,7 @@ class TestModVIIRSActiveFiresText(unittest.TestCase):
         from satpy.config import config_search_paths
         from satpy.readers.viirs_edr_active_fires import VIIRSActiveFiresTextFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
-        self.p = mock.patch.object(VIIRSActiveFiresTextFileHandler, '__bases__', (FakeFiresTextFileHandler,))
+        self.p = mock.patch.object(VIIRSActiveFiresTextFileHandler, '__bases__', (FakeModFiresTextFileHandler,))
         self.fake_handler = self.p.start()
         self.p.is_local = True
 
@@ -275,7 +293,7 @@ class TestImgVIIRSActiveFiresText(unittest.TestCase):
         from satpy.config import config_search_paths
         from satpy.readers.viirs_edr_active_fires import VIIRSActiveFiresTextFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
-        self.p = mock.patch.object(VIIRSActiveFiresTextFileHandler, '__bases__', (FakeFiresTextFileHandler,))
+        self.p = mock.patch.object(VIIRSActiveFiresTextFileHandler, '__bases__', (FakeImgFiresTextFileHandler,))
         self.fake_handler = self.p.start()
         self.p.is_local = True
 

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -89,6 +89,7 @@ class FakeModFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
 
         return file_content
 
+
 class FakeImgFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
     """Swap in CDF4 file handler"""
     def get_test_content(self, filename, filename_info, filename_type):
@@ -117,6 +118,7 @@ class FakeImgFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
                     file_content[key] = DataArray(val, attrs=attrs)
 
         return file_content
+
 
 class FakeModFiresTextFileHandler(BaseFileHandler):
     def __init__(self, filename, filename_info, filetype_info, **kwargs):
@@ -204,6 +206,7 @@ class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
         self.assertEqual(len(datasets), 1)
         for v in datasets.values():
             self.assertEqual(v.attrs['units'], 'MW')
+
 
 class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
     """Test VIIRS Fires Reader"""
@@ -309,6 +312,7 @@ class TestModVIIRSActiveFiresText(unittest.TestCase):
         self.assertEqual(len(datasets), 1)
         for v in datasets.values():
             self.assertEqual(v.attrs['units'], 'MW')
+
 
 class TestImgVIIRSActiveFiresText(unittest.TestCase):
     """Test VIIRS Fires Reader"""

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -28,7 +28,6 @@ import dask.dataframe as dd
 import pandas as pd
 from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
 from satpy.readers.file_handlers import BaseFileHandler
-from unittest.mock import patch
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -276,7 +275,7 @@ class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
             self.assertEqual(v.attrs['sensor'], 'VIIRS')
 
 
-@patch('satpy.readers.viirs_edr_active_fires.dd.read_csv')
+@mock.patch('satpy.readers.viirs_edr_active_fires.dd.read_csv')
 class TestModVIIRSActiveFiresText(unittest.TestCase):
     """Test VIIRS Fires Reader"""
     yaml_file = 'viirs_edr_active_fires.yaml'
@@ -331,7 +330,7 @@ class TestModVIIRSActiveFiresText(unittest.TestCase):
             self.assertEqual(v.attrs['sensor'], 'VIIRS')
 
 
-@patch('satpy.readers.viirs_edr_active_fires.dd.read_csv')
+@mock.patch('satpy.readers.viirs_edr_active_fires.dd.read_csv')
 class TestImgVIIRSActiveFiresText(unittest.TestCase):
     """Test VIIRS Fires Reader"""
     yaml_file = 'viirs_edr_active_fires.yaml'

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -104,7 +104,7 @@ class FakeFiresTextFileHandler(BaseFileHandler):
         return dd.from_pandas(pd.read_csv(fake_file, skiprows=15, header=None,
                                           names=["latitude", "longitude",
                                                  "T13", "Along-scan", "Along-track",
-                                                 "detection_confidence",
+                                                 "confidence_pct",
                                                  "power"]), chunksize=1)
 
 
@@ -144,7 +144,7 @@ class TestVIIRSActiveFiresNetCDF4(unittest.TestCase):
             'AFEDR_npp_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.nc'
         ])
         r.create_filehandlers(loadables)
-        datasets = r.load(['detection_confidence'])
+        datasets = r.load(['confidence_pct'])
         self.assertEqual(len(datasets), 1)
         for v in datasets.values():
             self.assertEqual(v.attrs['units'], '%')

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -212,7 +212,6 @@ class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
             self.assertEqual(v.attrs['sensor'], 'VIIRS')
 
 
-
 class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
     """Test VIIRS Fires Reader"""
     yaml_file = 'viirs_edr_active_fires.yaml'

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -180,7 +180,7 @@ class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
-            'AFMOD_npp_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.nc'
+            'AFMOD_j02_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.nc'
         ])
         self.assertTrue(len(loadables), 1)
         r.create_filehandlers(loadables)
@@ -191,7 +191,7 @@ class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
-            'AFMOD_npp_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.nc'
+            'AFMOD_j02_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.nc'
         ])
         r.create_filehandlers(loadables)
         datasets = r.load(['confidence_pct'])
@@ -208,6 +208,9 @@ class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
         self.assertEqual(len(datasets), 1)
         for v in datasets.values():
             self.assertEqual(v.attrs['units'], 'MW')
+            self.assertEqual(v.attrs['platform_name'], 'NOAA-21')
+            self.assertEqual(v.attrs['sensor'], 'VIIRS')
+
 
 
 class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
@@ -260,6 +263,8 @@ class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
         self.assertEqual(len(datasets), 1)
         for v in datasets.values():
             self.assertEqual(v.attrs['units'], 'MW')
+            self.assertEqual(v.attrs['platform_name'], 'Suomi-NPP')
+            self.assertEqual(v.attrs['sensor'], 'VIIRS')
 
 
 class TestModVIIRSActiveFiresText(unittest.TestCase):
@@ -284,8 +289,7 @@ class TestModVIIRSActiveFiresText(unittest.TestCase):
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
-            'AFEDR_npp_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.txt',
-            'AFMOD_npp_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.txt'
+            'AFEDR_j01_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.txt'
         ])
         self.assertTrue(len(loadables), 1)
         r.create_filehandlers(loadables)
@@ -296,8 +300,7 @@ class TestModVIIRSActiveFiresText(unittest.TestCase):
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
-            'AFEDR_npp_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.txt',
-            'AFMOD_npp_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.txt'
+            'AFEDR_j01_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.txt'
         ])
         r.create_filehandlers(loadables)
         datasets = r.load(['confidence_pct'])
@@ -314,6 +317,8 @@ class TestModVIIRSActiveFiresText(unittest.TestCase):
         self.assertEqual(len(datasets), 1)
         for v in datasets.values():
             self.assertEqual(v.attrs['units'], 'MW')
+            self.assertEqual(v.attrs['platform_name'], 'NOAA-20')
+            self.assertEqual(v.attrs['sensor'], 'VIIRS')
 
 
 class TestImgVIIRSActiveFiresText(unittest.TestCase):
@@ -366,6 +371,8 @@ class TestImgVIIRSActiveFiresText(unittest.TestCase):
         self.assertEqual(len(datasets), 1)
         for v in datasets.values():
             self.assertEqual(v.attrs['units'], 'MW')
+            self.assertEqual(v.attrs['platform_name'], 'Suomi-NPP')
+            self.assertEqual(v.attrs['sensor'], 'VIIRS')
 
 
 def suite():

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -64,8 +64,8 @@ class FakeModFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
         """Mimic reader input file content"""
         file_content = {}
         file_content['/attr/data_id'] = "AFMOD"
-        file_content['/attr/satellite_name'] = "npp"
-        file_content['/attr/instrument_name'] = 'VIIRS'
+        file_content['satellite_name'] = "npp"
+        file_content['sensor'] = 'VIIRS'
 
         file_content['Fire Pixels/FP_latitude'] = DEFAULT_LATLON_FILE_DATA
         file_content['Fire Pixels/FP_longitude'] = DEFAULT_LATLON_FILE_DATA
@@ -97,8 +97,8 @@ class FakeImgFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
         """Mimic reader input file content"""
         file_content = {}
         file_content['/attr/data_id'] = "AFIMG"
-        file_content['/attr/satellite_name'] = "npp"
-        file_content['/attr/instrument_name'] = 'VIIRS'
+        file_content['satellite_name'] = "npp"
+        file_content['sensor'] = 'VIIRS'
 
         file_content['FP_latitude'] = DEFAULT_LATLON_FILE_DATA
         file_content['FP_longitude'] = DEFAULT_LATLON_FILE_DATA

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -28,6 +28,8 @@ import dask.dataframe as dd
 import pandas as pd
 from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
 from satpy.readers.file_handlers import BaseFileHandler
+from unittest.mock import patch
+
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -274,6 +276,7 @@ class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
             self.assertEqual(v.attrs['sensor'], 'VIIRS')
 
 
+@patch('satpy.readers.viirs_edr_active_fires.dd.read_csv')
 class TestModVIIRSActiveFiresText(unittest.TestCase):
     """Test VIIRS Fires Reader"""
     yaml_file = 'viirs_edr_active_fires.yaml'
@@ -291,7 +294,7 @@ class TestModVIIRSActiveFiresText(unittest.TestCase):
         """Stop wrapping the text file handler"""
         self.p.stop()
 
-    def test_init(self):
+    def test_init(self, mock_obj):
         """Test basic init with no extra parameters"""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
@@ -302,7 +305,7 @@ class TestModVIIRSActiveFiresText(unittest.TestCase):
         r.create_filehandlers(loadables)
         self.assertTrue(r.file_handlers)
 
-    def test_load_dataset(self):
+    def test_load_dataset(self, csv_mock):
         """Test loading all datasets"""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
@@ -328,6 +331,7 @@ class TestModVIIRSActiveFiresText(unittest.TestCase):
             self.assertEqual(v.attrs['sensor'], 'VIIRS')
 
 
+@patch('satpy.readers.viirs_edr_active_fires.dd.read_csv')
 class TestImgVIIRSActiveFiresText(unittest.TestCase):
     """Test VIIRS Fires Reader"""
     yaml_file = 'viirs_edr_active_fires.yaml'
@@ -345,7 +349,7 @@ class TestImgVIIRSActiveFiresText(unittest.TestCase):
         """Stop wrapping the text file handler"""
         self.p.stop()
 
-    def test_init(self):
+    def test_init(self, mock_obj):
         """Test basic init with no extra parameters"""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
@@ -356,7 +360,7 @@ class TestImgVIIRSActiveFiresText(unittest.TestCase):
         r.create_filehandlers(loadables)
         self.assertTrue(r.file_handlers)
 
-    def test_load_dataset(self):
+    def test_load_dataset(self, mock_obj):
         """Test loading all datasets"""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -163,7 +163,7 @@ class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
         from satpy.config import config_search_paths
         from satpy.readers.viirs_edr_active_fires import VIIRSActiveFiresFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
-        self.p = mock.patch.object(VIIRSActiveFiresFileHandler, '__bases__', (FakeFiresNetCDF4FileHandler,))
+        self.p = mock.patch.object(VIIRSActiveFiresFileHandler, '__bases__', (FakeModFiresNetCDF4FileHandler,))
         self.fake_handler = self.p.start()
         self.p.is_local = True
 
@@ -214,7 +214,7 @@ class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
         from satpy.config import config_search_paths
         from satpy.readers.viirs_edr_active_fires import VIIRSActiveFiresFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
-        self.p = mock.patch.object(VIIRSActiveFiresFileHandler, '__bases__', (FakeFiresNetCDF4FileHandler,))
+        self.p = mock.patch.object(VIIRSActiveFiresFileHandler, '__bases__', (FakeImgFiresNetCDF4FileHandler,))
         self.fake_handler = self.p.start()
         self.p.is_local = True
 


### PR DESCRIPTION
Updates the VIIRS EDR Active Fires reader to read `AFEDR`, `AFIMG`, and `AFMOD` NetCDF and CSV files.

For `AFEDR` and `AFMOD`, the following parameters can be accessed:
- confidence_pct
- power
- T13
- latitude & longitude

For `AFIMG`, the following parameters can be accessed:
- confidence_cat
- power
- T4
- latitude & longitude

 - [x] Closes #725
 - [x] Tests added
 - [x] Tests passed
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff``
