### PR TITLE
Refactor available datasets logic to be more flexible

### DIFF
--- a/satpy/readers/clavrx.py
+++ b/satpy/readers/clavrx.py
@@ -125,7 +125,7 @@ class CLAVRXFileHandler(HDF4FileHandler):
                 handled_variables.add(var_name)
                 new_info = ds_info.copy()  # don't mess up the above yielded
                 new_info['resolution'] = nadir_resolution
-                if not self.is_geo and this_coords is None:
+                if self._is_polar() and this_coords is None:
                     new_info['coordinates'] = coordinates
                 yield True, new_info
             elif is_avail is None:

--- a/satpy/readers/clavrx.py
+++ b/satpy/readers/clavrx.py
@@ -102,19 +102,48 @@ class CLAVRXFileHandler(HDF4FileHandler):
     def end_time(self):
         return self.filename_info.get('end_time', self.start_time)
 
-    def available_datasets(self):
+    def available_datasets(self, configured_datasets=None):
         """Automatically determine datasets provided by this file"""
         sensor = self.get_sensor(self['/attr/sensor'])
         nadir_resolution = self.get_nadir_resolution(sensor)
+        coordinates = ('longitude', 'latitude')
+        handled_variables = set()
+
+        # update previously configured datasets
+        for is_avail, ds_info in (configured_datasets or []):
+            this_res = ds_info.get('resolution')
+            this_coords = ds_info.get('coordinates')
+            # some other file handler knows how to load this
+            if is_avail is not None:
+                yield is_avail, ds_info
+
+            var_name = ds_info.get('file_key', ds_info['name'])
+            matches = self.file_type_matches(ds_info['file_type'])
+            # we can confidently say that we can provide this dataset and can
+            # provide more info
+            if matches and var_name in self and this_res != nadir_resolution:
+                handled_variables.add(var_name)
+                new_info = ds_info.copy()  # don't mess up the above yielded
+                new_info['resolution'] = nadir_resolution
+                if not self.is_geo and this_coords is None:
+                    new_info['coordinates'] = coordinates
+                yield True, new_info
+            elif is_avail is None:
+                # if we didn't know how to handle this dataset and no one else did
+                # then we should keep it going down the chain
+                yield is_avail, ds_info
+
+        # add new datasets
         for var_name, val in self.file_content.items():
             if isinstance(val, SDS):
                 ds_info = {
                     'file_type': self.filetype_info['file_type'],
                     'resolution': nadir_resolution,
+                    'name': var_name,
                 }
                 if self._is_polar():
                     ds_info['coordinates'] = ['longitude', 'latitude']
-                yield DatasetID(name=var_name, resolution=nadir_resolution), ds_info
+                yield True, ds_info
 
     def get_shape(self, dataset_id, ds_info):
         var_name = ds_info.get('file_key', dataset_id.name)

--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -149,7 +149,7 @@ class BaseFileHandler(six.with_metaclass(ABCMeta, object)):
         of redundant datasets produced.
 
         This method should **not** update values of the dataset information
-        dictionary **unless* this file handler has a matching file type
+        dictionary **unless** this file handler has a matching file type
         (the data could be loaded from this object in the future) and at least
         **one** :class:`satpy.dataset.DatasetID` key is also modified.
         Otherwise, this file type may override the information provided by

--- a/satpy/readers/geocat.py
+++ b/satpy/readers/geocat.py
@@ -129,19 +129,60 @@ class GEOCATFileHandler(NetCDF4FileHandler):
         return self.resolutions.get(sensor, {}).get(int(elem_res),
                                                     elem_res * 1000.)
 
-    def available_datasets(self):
-        """Automatically determine datasets provided by this file"""
+    def available_datasets(self, configured_datasets=None):
+        """Update information for or add datasets provided by this file.
+
+        If this file handler can load a dataset then it will supplement the
+        dataset info with the resolution and possibly coordinate datasets
+        needed to load it. Otherwise it will continue passing the dataset
+        information down the chain.
+
+        See
+        :meth:`satpy.readers.file_handlers.BaseFileHandler.available_datasets`
+        for details.
+
+        """
         res = self.resolution
-        coordinates = ['pixel_longitude', 'pixel_latitude']
+        coordinates = ('pixel_longitude', 'pixel_latitude')
+        handled_variables = set()
+
+        # update previously configured datasets
+        for is_avail, ds_info in (configured_datasets or []):
+            this_res = ds_info.get('resolution')
+            this_coords = ds_info.get('coordinates')
+            # some other file handler knows how to load this
+            if is_avail is not None:
+                yield is_avail, ds_info
+
+            var_name = ds_info.get('file_key', ds_info['name'])
+            matches = self.file_type_matches(ds_info['file_type'])
+            # we can confidently say that we can provide this dataset and can
+            # provide more info
+            if matches and var_name in self and this_res != res:
+                handled_variables.add(var_name)
+                new_info = ds_info.copy()  # don't mess up the above yielded
+                new_info['resolution'] = res
+                if not self.is_geo and this_coords is None:
+                    new_info['coordinates'] = coordinates
+                yield True, new_info
+            elif is_avail is None:
+                # if we didn't know how to handle this dataset and no one else did
+                # then we should keep it going down the chain
+                yield is_avail, ds_info
+
+        # Provide new datasets
         for var_name, val in self.file_content.items():
+            if var_name in handled_variables:
+                continue
             if isinstance(val, netCDF4.Variable):
                 ds_info = {
                     'file_type': self.filetype_info['file_type'],
                     'resolution': res,
+                    'name': var_name,
                 }
                 if not self.is_geo:
                     ds_info['coordinates'] = coordinates
-                yield DatasetID(name=var_name, resolution=res), ds_info
+                yield True, ds_info
 
     def get_shape(self, dataset_id, ds_info):
         var_name = ds_info.get('file_key', dataset_id.name)

--- a/satpy/readers/goes_imager_nc.py
+++ b/satpy/readers/goes_imager_nc.py
@@ -959,6 +959,33 @@ class GOESNCBaseFileHandler(BaseFileHandler):
         except (AttributeError, IOError, OSError):
             pass
 
+    def available_datasets(self, configured_datasets=None):
+        """Update information for or add datasets provided by this file.
+
+        If this file handler can load a dataset then it will supplement the
+        dataset info with the resolution and possibly coordinate datasets
+        needed to load it. Otherwise it will continue passing the dataset
+        information down the chain.
+
+        See
+        :meth:`satpy.readers.file_handlers.BaseFileHandler.available_datasets`
+        for details.
+
+        """
+        res = self.resolution
+        # update previously configured datasets
+        for is_avail, ds_info in (configured_datasets or []):
+            if is_avail is not None:
+                yield is_avail, ds_info
+
+            matches = self.file_type_matches(ds_info['file_type'])
+            if matches and ds_info.get('resolution') is None:
+                new_info = ds_info.copy()
+                new_info['resolution'] = res
+                yield True, new_info
+            elif is_avail is None:
+                yield is_avail, ds_info
+
 
 class GOESNCFileHandler(GOESNCBaseFileHandler):
     """File handler for GOES Imager data in netCDF format"""

--- a/satpy/readers/goes_imager_nc.py
+++ b/satpy/readers/goes_imager_nc.py
@@ -979,7 +979,7 @@ class GOESNCBaseFileHandler(BaseFileHandler):
                 yield is_avail, ds_info
 
             matches = self.file_type_matches(ds_info['file_type'])
-            if matches and ds_info.get('resolution') is None:
+            if matches and ds_info.get('resolution') != res:
                 new_info = ds_info.copy()
                 new_info['resolution'] = res
                 yield True, new_info

--- a/satpy/readers/grib.py
+++ b/satpy/readers/grib.py
@@ -123,9 +123,15 @@ class GRIBFileHandler(BaseFileHandler):
         """
         return self._end_time
 
-    def available_datasets(self):
+    def available_datasets(self, configured_datasets=None):
         """Automatically determine datasets provided by this file"""
-        return self._msg_datasets.items()
+        # previously configured or provided datasets
+        # we can't provide any additional information
+        for is_avail, ds_info in (configured_datasets or []):
+            yield is_avail, ds_info
+        # new datasets
+        for ds_info in self._msg_datasets.values():
+            yield True, ds_info
 
     def _get_message(self, ds_info):
         with pygrib.open(self.filename) as grib_file:

--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -215,8 +215,8 @@ class NUCAPSReader(FileYAMLReader):
         pressure level.
         """
         super(NUCAPSReader, self).load_ds_ids_from_config()
-        for ds_id in list(self.ids.keys()):
-            ds_info = self.ids[ds_id]
+        for ds_id in list(self.all_ids.keys()):
+            ds_info = self.all_ids[ds_id]
             if ds_info.get('pressure_based', False):
                 for idx, lvl_num in enumerate(ALL_PRESSURE_LEVELS):
                     if lvl_num < 5.0:
@@ -231,7 +231,7 @@ class NUCAPSReader(FileYAMLReader):
                     new_info['name'] = ds_id.name + suffix
                     new_ds_id = ds_id._replace(name=new_info['name'])
                     new_info['id'] = new_ds_id
-                    self.ids[new_ds_id] = new_info
+                    self.all_ids[new_ds_id] = new_info
                     self.pressure_dataset_names[ds_id.name].append(new_info['name'])
 
     def load(self, dataset_keys, previous_datasets=None, pressure_levels=None):
@@ -246,7 +246,7 @@ class NUCAPSReader(FileYAMLReader):
         if pressure_levels is not None:
             # Filter out datasets that don't fit in the correct pressure level
             for ds_id in dataset_keys.copy():
-                ds_info = self.ids[ds_id]
+                ds_info = self.all_ids[ds_id]
                 ds_level = ds_info.get("pressure_level")
                 if ds_level is not None:
                     if pressure_levels is True:

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -547,7 +547,7 @@ class VIIRSSDRReader(FileYAMLReader):
 
     def get_right_geo_fhs(self, dsid, fhs):
         """Find the right geographical file handlers for given dataset ID *dsid*."""
-        ds_info = self.ids[dsid]
+        ds_info = self.all_ids[dsid]
         req_geo, rem_geo = self._get_req_rem_geo(ds_info)
         desired, other = split_desired_other(fhs, req_geo, rem_geo)
         if desired:
@@ -561,7 +561,7 @@ class VIIRSSDRReader(FileYAMLReader):
 
     def _get_file_handlers(self, dsid):
         """Get the file handler to load this dataset."""
-        ds_info = self.ids[dsid]
+        ds_info = self.all_ids[dsid]
 
         fhs = [fh for fh in self.file_handlers['generic_file']
                if set(fh.datasets) & set(ds_info['dataset_groups'])]
@@ -581,7 +581,7 @@ class VIIRSSDRReader(FileYAMLReader):
         """
         coords = super(VIIRSSDRReader, self)._get_coordinates_for_dataset_key(dsid)
         for c_id in coords:
-            c_info = self.ids[c_id]  # c_info['dataset_groups'] should be a list of 2 elements
+            c_info = self.all_ids[c_id]  # c_info['dataset_groups'] should be a list of 2 elements
             self._get_file_handlers(c_id)
             if len(c_info['dataset_groups']) == 1:  # filtering already done
                 continue

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -124,9 +124,7 @@ DATASET_KEYS = {'GDNBO': 'VIIRS-DNB-GEO',
 
 
 class VIIRSSDRFileHandler(HDF5FileHandler):
-
-    """VIIRS HDF5 File Reader.
-    """
+    """VIIRS HDF5 File Reader."""
 
     def __init__(self, filename, filename_info, filetype_info, use_tc=None, **kwargs):
         self.datasets = filename_info['datasets'].split('-')
@@ -414,6 +412,24 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
             idx += 1
 
         return lons_ring, lats_ring
+
+    def available_datasets(self, configured_datasets=None):
+        """Generate dataset info and their availablity.
+
+        See
+        :meth:`satpy.readers.file_handlers.BaseFileHandler.available_datasets`
+        for details.
+
+        """
+        for is_avail, ds_info in (configured_datasets or []):
+            if is_avail is not None:
+                yield is_avail, ds_info
+                continue
+            dataset_group = [ds_group for ds_group in ds_info['dataset_groups'] if ds_group in self.datasets]
+            if dataset_group:
+                yield True, ds_info
+            elif is_avail is None:
+                yield is_avail, ds_info
 
 
 def split_desired_other(fhs, req_geo, rem_geo):

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -535,10 +535,11 @@ class FileYAMLReader(AbstractYAMLReader):
             the information.
 
         """
-        first_fhs = (fhs[0] for fhs in self.file_handlers.values())
+        # flatten all file handlers in to one list
+        flat_fhs = (fh for fhs in self.file_handlers.values() for fh in fhs)
         id_values = list(self.ids.values())
         configured_datasets = ((None, ds_info) for ds_info in id_values)
-        for fh in first_fhs:
+        for fh in flat_fhs:
             # chain the 'available_datasets' methods together by calling the
             # current file handler's method with the previous ones result
             configured_datasets = fh.available_datasets(configured_datasets=configured_datasets)

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -799,7 +799,7 @@ class FileYAMLReader(AbstractYAMLReader):
                     new_vars.append(av_id)
             dataset.attrs['ancillary_variables'] = new_vars
 
-    def get_dataset_key(self, key, prefer_available=False, **kwargs):
+    def get_dataset_key(self, key, prefer_available=True, **kwargs):
         """Get the fully qualified `DatasetID` matching `key`.
 
         See `satpy.readers.get_key` for more information about kwargs.
@@ -810,7 +810,6 @@ class FileYAMLReader(AbstractYAMLReader):
                 return get_key(key, self.available_ids.keys(), **kwargs)
             except KeyError:
                 return get_key(key, self.ids.keys(), **kwargs)
-        # FIXME: Only do the try/except above
         return get_key(key, self.ids.keys(), **kwargs)
 
     def load(self, dataset_keys, previous_datasets=None):

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -566,7 +566,8 @@ class FileYAMLReader(AbstractYAMLReader):
 
         """
         first_fhs = (fhs[0] for fhs in self.file_handlers.values())
-        configured_datasets = ((None, ds_info) for ds_info in self.ids.values())
+        id_values = list(self.ids.values())
+        configured_datasets = ((None, ds_info) for ds_info in id_values)
         for fh in first_fhs:
             # chain the 'available_datasets' methods together by calling the
             # current file handler's method with the previous ones result

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -534,6 +534,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
             'GDNBO_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
         ])
         r.create_filehandlers(loadables)
+        self.assertNotIn('I01', [x.name for x in r.available_dataset_ids])
         ds = r.load(['I01'])
         self.assertEqual(len(ds), 0)
 

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -673,10 +673,10 @@ class TestScene(unittest.TestCase):
         scene.cpl.compositors = comps
         scene.cpl.modifiers = mods
         id_list = scene.all_dataset_ids()
-        self.assertEqual(len(id_list), len(r.ids))
+        self.assertEqual(len(id_list), len(r.all_ids))
         id_list = scene.all_dataset_ids(composites=True)
         self.assertEqual(len(id_list),
-                         len(r.ids) + len(scene.cpl.compositors['fake_sensor'].keys()))
+                         len(r.all_ids) + len(scene.cpl.compositors['fake_sensor'].keys()))
 
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -56,10 +56,10 @@ class TestScene(unittest.TestCase):
 
     def test_init_with_sensor(self):
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader
+        from satpy.tests.utils import FakeReader
         with mock.patch('satpy.scene.Scene.create_reader_instances') as cri:
             cri.return_value = {
-                'fake_reader': create_fake_reader('fake_reader', sensor_name='fake_sensor'),
+                'fake_reader': FakeReader('fake_reader', sensor_name='fake_sensor'),
             }
             scene = satpy.scene.Scene(filenames=['bla'],
                                       base_dir='bli',
@@ -72,13 +72,13 @@ class TestScene(unittest.TestCase):
 
     def test_start_end_times(self):
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader
+        from satpy.tests.utils import FakeReader
         from datetime import datetime
         with mock.patch('satpy.scene.Scene.create_reader_instances') as cri:
-            r = create_fake_reader('fake_reader',
-                                   start_time=datetime(2017, 1, 1, 0, 0, 0),
-                                   end_time=datetime(2017, 1, 1, 1, 0, 0),
-                                   )
+            r = FakeReader('fake_reader',
+                           start_time=datetime(2017, 1, 1, 0, 0, 0),
+                           end_time=datetime(2017, 1, 1, 1, 0, 0),
+                           )
             cri.return_value = {'fake_reader': r}
             scene = satpy.scene.Scene(filenames=['bla'],
                                       base_dir='bli',
@@ -88,13 +88,13 @@ class TestScene(unittest.TestCase):
 
     def test_init_preserve_reader_kwargs(self):
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader
+        from satpy.tests.utils import FakeReader
         from datetime import datetime
         with mock.patch('satpy.scene.Scene.create_reader_instances') as cri:
-            r = create_fake_reader('fake_reader',
-                                   start_time=datetime(2017, 1, 1, 0, 0, 0),
-                                   end_time=datetime(2017, 1, 1, 1, 0, 0),
-                                   )
+            r = FakeReader('fake_reader',
+                           start_time=datetime(2017, 1, 1, 0, 0, 0),
+                           end_time=datetime(2017, 1, 1, 1, 0, 0),
+                           )
             cri.return_value = {'fake_reader': r}
             reader_kwargs = {'calibration_type': 'gsics'}
             scene = satpy.scene.Scene(filenames=['bla'],
@@ -190,7 +190,7 @@ class TestScene(unittest.TestCase):
 
     def test_create_reader_instances_with_reader_kwargs(self):
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader
+        from satpy.tests.utils import FakeReader
         from datetime import datetime
         filenames = ["1", "2", "3"]
         reader_kwargs = {'calibration_type': 'gsics'}
@@ -198,12 +198,14 @@ class TestScene(unittest.TestCase):
         reader_kwargs2 = {'calibration_type': 'gsics', 'filter_parameters': filter_parameters}
 
         with mock.patch('satpy.readers.load_reader') as lr_mock:
-            r = create_fake_reader('fake_reader',
-                                   start_time=datetime(2017, 1, 1, 0, 0, 0),
-                                   end_time=datetime(2017, 1, 1, 1, 0, 0),
-                                   )
+            r = FakeReader('fake_reader',
+                           start_time=datetime(2017, 1, 1, 0, 0, 0),
+                           end_time=datetime(2017, 1, 1, 1, 0, 0),
+                           )
             lr_mock.return_value = r
-            r.select_path_from_pathnames.return_value = filenames
+            r.select_files_from_pathnames = mock.MagicMock()
+            r.select_files_from_pathnames.return_value = filenames
+            r.create_filehandlers = mock.MagicMock()
             scene = satpy.scene.Scene(filenames=['bla'],
                                       base_dir='bli',
                                       sensor='fake_sensor',
@@ -659,8 +661,8 @@ class TestScene(unittest.TestCase):
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_all_datasets_one_reader(self, cri, cl):
         from satpy import Scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        r = create_fake_reader('fake_reader', 'fake_sensor')
+        from satpy.tests.utils import FakeReader, test_composites
+        r = FakeReader('fake_reader', 'fake_sensor')
         cri.return_value = {'fake_reader': r}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -671,18 +673,18 @@ class TestScene(unittest.TestCase):
         scene.cpl.compositors = comps
         scene.cpl.modifiers = mods
         id_list = scene.all_dataset_ids()
-        self.assertEqual(len(id_list), len(r.datasets))
+        self.assertEqual(len(id_list), len(r.ids))
         id_list = scene.all_dataset_ids(composites=True)
         self.assertEqual(len(id_list),
-                         len(r.datasets) + len(scene.cpl.compositors['fake_sensor'].keys()))
+                         len(r.ids) + len(scene.cpl.compositors['fake_sensor'].keys()))
 
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_all_datasets_multiple_reader(self, cri, cl):
         from satpy import Scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        r = create_fake_reader('fake_reader', 'fake_sensor', datasets=['ds1'])
-        r2 = create_fake_reader(
+        from satpy.tests.utils import FakeReader, test_composites
+        r = FakeReader('fake_reader', 'fake_sensor', datasets=['ds1'])
+        r2 = FakeReader(
             'fake_reader2', 'fake_sensor2', datasets=['ds2'])
         cri.return_value = {'fake_reader': r, 'fake_reader2': r2}
         comps, mods = test_composites('fake_sensor')
@@ -703,8 +705,8 @@ class TestScene(unittest.TestCase):
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_available_datasets_one_reader(self, cri, cl):
         from satpy import Scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        r = create_fake_reader('fake_reader', 'fake_sensor', datasets=['ds1'])
+        from satpy.tests.utils import FakeReader, test_composites
+        r = FakeReader('fake_reader', 'fake_sensor', datasets=['ds1'])
         cri.return_value = {'fake_reader': r}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -741,8 +743,8 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_no_exist(self, cri, cl):
         """Test loading a dataset that doesn't exist"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        cri.return_value = {'fake_reader': create_fake_reader(
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -756,9 +758,9 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_no_exist2(self, cri, cl):
         """Test loading a dataset that doesn't exist then another load"""
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID, Scene
-        r = create_fake_reader('fake_reader', 'fake_sensor')
+        r = FakeReader('fake_reader', 'fake_sensor')
         cri.return_value = {'fake_reader': r}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -782,9 +784,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_ds1_no_comps(self, cri):
         """Test loading one dataset with no loaded compositors"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader
+        from satpy.tests.utils import FakeReader
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         scene = satpy.scene.Scene(filenames=['bla'],
                                   base_dir='bli',
@@ -799,9 +801,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_ds1_load_twice(self, cri):
         """Test loading one dataset with no loaded compositors"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader
+        from satpy.tests.utils import FakeReader
         from satpy import DatasetID
-        r = create_fake_reader('fake_reader', 'fake_sensor')
+        r = FakeReader('fake_reader', 'fake_sensor')
         cri.return_value = {'fake_reader': r}
         scene = satpy.scene.Scene(filenames=['bla'],
                                   base_dir='bli',
@@ -826,9 +828,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_ds1_unknown_modifier(self, cri, cl):
         """Test loading one dataset with no loaded compositors"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -843,8 +845,8 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_ds4_cal(self, cri, cl):
         """Test loading a dataset that has two calibration variations"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        cri.return_value = {'fake_reader': create_fake_reader(
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -858,11 +860,56 @@ class TestSceneLoading(unittest.TestCase):
 
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_ds5_best_resolution(self, cri, cl):
+        """Test loading a dataset has multiple resolutions available."""
+        import satpy.scene
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
+            'fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames=['bla'],
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load(['ds5'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEqual(len(loaded_ids), 1)
+        self.assertEqual(loaded_ids[0].name, 'ds5')
+        self.assertEqual(loaded_ids[0].resolution, 250)
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_ds5_missing_best_resolution(self, cri, cl):
+        """Test loading a dataset that has multiple resolutions but the best isn't available."""
+        import satpy.scene
+        from satpy import DatasetID
+        from satpy.tests.utils import FakeReader, test_composites
+
+        # only the 500m is available
+        available_datasets = [DatasetID('ds5', resolution=500)]
+        cri.return_value = {
+            'fake_reader': FakeReader(
+                'fake_reader', 'fake_sensor', datasets=['ds5'],
+                available_datasets=available_datasets),
+        }
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames=['bla'],
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load(['ds5'])
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEqual(len(loaded_ids), 1)
+        self.assertEqual(loaded_ids[0].name, 'ds5')
+        self.assertEqual(loaded_ids[0].resolution, 500)
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_ds6_wl(self, cri, cl):
         """Test loading a dataset by wavelength"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        cri.return_value = {'fake_reader': create_fake_reader(
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -879,8 +926,8 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_ds9_fail_load(self, cri, cl):
         """Test loading a dataset that will fail during load"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        cri.return_value = {'fake_reader': create_fake_reader(
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -896,9 +943,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp1(self, cri, cl):
         """Test loading a composite with one required prereq"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -916,9 +963,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp4(self, cri, cl):
         """Test loading a composite that depends on a composite"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -936,9 +983,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp5(self, cri, cl):
         """Test loading a composite that has an optional prerequisite"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -956,9 +1003,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp6(self, cri, cl):
         """Test loading a composite that has an optional composite prerequisite"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -976,8 +1023,8 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp8(self, cri, cl):
         """Test loading a composite that has a non-existent prereq"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        cri.return_value = {'fake_reader': create_fake_reader(
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -991,9 +1038,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp9(self, cri, cl):
         """Test loading a composite that has a non-existent optional prereq"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1012,9 +1059,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp10(self, cri, cl):
         """Test loading a composite that depends on a modified dataset"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1033,9 +1080,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp11(self, cri, cl):
         """Test loading a composite that depends all wavelengths"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1054,9 +1101,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp12(self, cri, cl):
         """Test loading a composite that depends all wavelengths that get modified"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1075,9 +1122,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp13(self, cri, cl):
         """Test loading a composite that depends on a modified dataset where the resolution changes"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1096,8 +1143,8 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp14(self, cri, cl):
         """Test loading a composite that updates the DatasetID during generation"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        cri.return_value = {'fake_reader': create_fake_reader(
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1118,8 +1165,8 @@ class TestSceneLoading(unittest.TestCase):
         Note that the prereq exists in the reader, but fails in loading.
         """
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        cri.return_value = {'fake_reader': create_fake_reader(
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1139,8 +1186,8 @@ class TestSceneLoading(unittest.TestCase):
         Note that the prereq exists in the reader, but fails in loading
         """
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        cri.return_value = {'fake_reader': create_fake_reader(
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1159,8 +1206,8 @@ class TestSceneLoading(unittest.TestCase):
         """Test loading a composite that depends on a composite that won't load
         """
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        cri.return_value = {'fake_reader': create_fake_reader(
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1178,9 +1225,9 @@ class TestSceneLoading(unittest.TestCase):
         """Test loading a composite that depends on a incompatible area modified dataset
         """
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1217,9 +1264,9 @@ class TestSceneLoading(unittest.TestCase):
 
         """
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1253,8 +1300,8 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_multiple_comps(self, cri, cl):
         """Test loading multiple composites"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        cri.return_value = {'fake_reader': create_fake_reader(
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1271,8 +1318,8 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_multiple_comps_separate(self, cri, cl):
         """Test loading multiple composites, one at a time"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        cri.return_value = {'fake_reader': create_fake_reader(
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1296,9 +1343,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_modified(self, cri, cl):
         """Test loading a modified dataset"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1315,9 +1362,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_multiple_modified(self, cri, cl):
         """Test loading multiple modified datasets"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1342,8 +1389,8 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_dataset_after_composite(self, cri, cl):
         """Test load composite followed by other datasets"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        r = create_fake_reader('fake_reader', 'fake_sensor')
+        from satpy.tests.utils import FakeReader, test_composites
+        r = FakeReader('fake_reader', 'fake_sensor')
         cri.return_value = {'fake_reader': r}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1368,9 +1415,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_dataset_after_composite2(self, cri, cl):
         """Test load complex composite followed by other datasets"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        r = create_fake_reader('fake_reader', 'fake_sensor')
+        r = FakeReader('fake_reader', 'fake_sensor')
         cri.return_value = {'fake_reader': r}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1412,9 +1459,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp20(self, cri, cl):
         """Test loading composite with optional modifier dependencies"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1433,9 +1480,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp21(self, cri, cl):
         """Test loading composite with bad optional modifier dependencies"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1454,9 +1501,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp22(self, cri, cl):
         """Test loading composite with only optional modifier dependencies"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1475,8 +1522,8 @@ class TestSceneLoading(unittest.TestCase):
     def test_no_generate_comp10(self, cri, cl):
         """Test generating a composite after loading"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
-        cri.return_value = {'fake_reader': create_fake_reader(
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1507,9 +1554,9 @@ class TestSceneLoading(unittest.TestCase):
 
         """
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1549,9 +1596,9 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_comp11_and_23(self, cri, cl):
         """Test loading two composites that depend on similar wavelengths."""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID, DatasetDict
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
 
@@ -1591,12 +1638,11 @@ class TestSceneLoading(unittest.TestCase):
     def test_load_too_many(self, cri, cl):
         """Test dependency tree if too many reader keys match."""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
         datasets = [DatasetID(name='duplicate1', wavelength=(0.1, 0.2, 0.3)),
                     DatasetID(name='duplicate2', wavelength=(0.1, 0.2, 0.3))]
-        reader = create_fake_reader('fake_reader', 'fake_sensor', datasets=datasets)
-        reader.datasets = reader.available_dataset_ids = reader.all_dataset_ids = datasets
+        reader = FakeReader('fake_reader', 'fake_sensor', datasets=datasets)
         cri.return_value = {'fake_reader': reader}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1625,11 +1671,11 @@ class TestSceneResampling(unittest.TestCase):
 
         """
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
         from pyresample.geometry import AreaDefinition
         from pyresample.utils import proj4_str_to_dict
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1675,13 +1721,13 @@ class TestSceneResampling(unittest.TestCase):
     def test_resample_reduce_data_toggle(self, cri, cl, rs):
         """Test that the Scene can be reduced or not reduced during resampling."""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
         from pyresample.geometry import AreaDefinition
         from pyresample.utils import proj4_str_to_dict
         import dask.array as da
         import xarray as xr
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1739,10 +1785,10 @@ class TestSceneResampling(unittest.TestCase):
     def test_resample_ancillary(self, cri, cl):
         """Test that the Scene reducing data does not affect final output."""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from pyresample.geometry import AreaDefinition
         from pyresample.utils import proj4_str_to_dict
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1771,10 +1817,10 @@ class TestSceneResampling(unittest.TestCase):
     def test_resample_reduce_data(self, cri, cl):
         """Test that the Scene reducing data does not affect final output."""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from pyresample.geometry import AreaDefinition
         from pyresample.utils import proj4_str_to_dict
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1805,10 +1851,10 @@ class TestSceneResampling(unittest.TestCase):
     def test_no_generate_comp10(self, cri, cl, rs):
         """Test generating a composite after loading"""
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from pyresample.geometry import AreaDefinition
         from pyresample.utils import proj4_str_to_dict
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)
@@ -1826,7 +1872,7 @@ class TestSceneResampling(unittest.TestCase):
             400,
             (-1000., -1500., 1000., 1500.),
         )
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1262,9 +1262,9 @@ class TestSceneLoading(unittest.TestCase):
 
         """
         import satpy.scene
-        from satpy.tests.utils import create_fake_reader, test_composites
+        from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
-        cri.return_value = {'fake_reader': create_fake_reader(
+        cri.return_value = {'fake_reader': FakeReader(
             'fake_reader', 'fake_sensor')}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -543,7 +543,7 @@ class TestFileFileYAMLReaderMultipleFileTypes(unittest.TestCase):
     def test_update_ds_ids_from_file_handlers(self):
         """Test updating existing dataset IDs with information from the file"""
         from functools import partial
-        orig_ids = self.reader.ids
+        orig_ids = self.reader.all_ids
 
         def available_datasets(self, configured_datasets=None):
             res = self.resolution
@@ -570,7 +570,7 @@ class TestFileFileYAMLReaderMultipleFileTypes(unittest.TestCase):
         for ftype, resol in zip(('ftype1', 'ftype2'), (1, 2)):
             # need to copy this because the dataset infos will be modified
             _orig_ids = {key: val.copy() for key, val in orig_ids.items()}
-            with patch.dict(self.reader.ids, _orig_ids, clear=True), \
+            with patch.dict(self.reader.all_ids, _orig_ids, clear=True), \
                     patch.dict(self.reader.available_ids, {}, clear=True):
                 # Add a file handler with resolution property
                 fh = MagicMock(filetype_info={'file_type': ftype},
@@ -586,7 +586,7 @@ class TestFileFileYAMLReaderMultipleFileTypes(unittest.TestCase):
 
                 # Make sure the resolution property has been transferred
                 # correctly from the file handler to the dataset ID
-                for ds_id, ds_info in self.reader.ids.items():
+                for ds_id, ds_info in self.reader.all_ids.items():
                     file_types = ds_info['file_type']
                     if not isinstance(file_types, list):
                         file_types = [file_types]

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -196,6 +196,7 @@ class TestFileFileYAMLReader(unittest.TestCase):
         res_dict = {'reader': {'name': 'fake',
                                'sensors': ['canon']},
                     'file_types': {'ftype1': {'name': 'ft1',
+                                              'file_reader': BaseFileHandler,
                                               'file_patterns': patterns}},
                     'datasets': {'ch1': {'name': 'ch01',
                                          'wavelength': [0.5, 0.6, 0.7],
@@ -255,7 +256,8 @@ class TestFileFileYAMLReader(unittest.TestCase):
 
     def test_available_dataset_ids(self):
         """Get ids of the available datasets."""
-        self.reader.file_handlers = ['ftype1']
+        loadables = self.reader.select_files_from_pathnames(['a001.bla'])
+        self.reader.create_filehandlers(loadables)
         self.assertSetEqual(set(self.reader.available_dataset_ids),
                             {DatasetID(name='ch02',
                                        wavelength=(0.7, 0.75, 0.8),
@@ -272,7 +274,8 @@ class TestFileFileYAMLReader(unittest.TestCase):
 
     def test_available_dataset_names(self):
         """Get ids of the available datasets."""
-        self.reader.file_handlers = ['ftype1']
+        loadables = self.reader.select_files_from_pathnames(['a001.bla'])
+        self.reader.create_filehandlers(loadables)
         self.assertSetEqual(set(self.reader.available_dataset_names),
                             set(["ch01", "ch02"]))
 

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -1,28 +1,24 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017.
-
-# Author(s):
-
-#   Martin Raspaud <martin.raspaud@smhi.se>
-#   David Hoese <david.hoese@ssec.wisc.edu>
-
+# Copyright (c) 2017-2019 Satpy developers
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
-
+#
 # This program is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU General Public License for more details.
-
+#
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Utilities for various satpy tests.
 """
 
 from datetime import datetime
+from satpy.readers.yaml_reader import FileYAMLReader
 
 try:
     from unittest import mock
@@ -179,46 +175,75 @@ def test_composites(sensor_name):
     return comps, mods
 
 
-def _get_dataset_key(self, key, **kwargs):
-    from satpy.readers import get_key
-    return get_key(key, self.datasets, **kwargs)
+def _filter_datasets(all_ds, names_or_ids):
+    """Helper function for filtering DatasetIDs by name or DatasetID."""
+    # DatasetID will match a str to the name
+    # need to separate them out
+    str_filter = [ds_name for ds_name in names_or_ids if isinstance(ds_name, str)]
+    id_filter = [ds_id for ds_id in names_or_ids if not isinstance(ds_id, str)]
+    for ds_id in all_ds:
+        if ds_id in id_filter or ds_id.name in str_filter:
+            yield ds_id
 
 
-def _reader_load(self, dataset_keys):
-    from satpy import DatasetDict
-    from xarray import DataArray
-    import numpy as np
-    dataset_ids = self.datasets
-    loaded_datasets = DatasetDict()
-    for k in dataset_keys:
-        if k == 'ds9_fail_load':
-            continue
-        for ds in dataset_ids:
-            if ds == k:
-                loaded_datasets[ds] = DataArray(data=np.arange(25).reshape(5, 5),
-                                                attrs=ds.to_dict(),
-                                                dims=['y', 'x'])
-    return loaded_datasets
+class FakeReader(FileYAMLReader):
+    """Fake reader to make testing basic Scene/reader functionality easier."""
 
+    def __init__(self, name, sensor_name='fake_sensor', datasets=None,
+                 available_datasets=None, start_time=None, end_time=None):
+        """Initialize reader and mock necessary properties and methods."""
+        with mock.patch('satpy.readers.yaml_reader.recursive_dict_update') as rdu, \
+                mock.patch('satpy.readers.yaml_reader.open'), \
+                mock.patch('satpy.readers.yaml_reader.yaml.load'):
+            rdu.return_value = {'reader': {'name': name}, 'file_types': {}}
+            super(FakeReader, self).__init__(['fake.yaml'])
 
-def create_fake_reader(reader_name, sensor_name='fake_sensor', datasets=None,
-                       start_time=None, end_time=None):
-    from functools import partial
-    if start_time is None:
-        start_time = datetime.utcnow()
-    if end_time is None:
-        end_time = start_time
-    r = mock.MagicMock()
-    ds = test_datasets()
-    if datasets is not None:
-        ds = [d for d in ds if d.name in datasets]
+        if start_time is None:
+            start_time = datetime.utcnow()
+        self._start_time = start_time
+        if end_time is None:
+            end_time = start_time
+        self._end_time = end_time
+        self._sensor_name = set([sensor_name])
 
-    r.datasets = ds
-    r.start_time = start_time
-    r.end_time = end_time
-    r.sensor_names = set([sensor_name])
-    r.get_dataset_key = partial(_get_dataset_key, r)
-    r.all_dataset_ids = r.datasets
-    r.available_dataset_ids = r.datasets
-    r.load.side_effect = partial(_reader_load, r)
-    return r
+        all_ds = test_datasets()
+        if datasets is not None:
+            all_ds = list(_filter_datasets(all_ds, datasets))
+        if available_datasets is not None:
+            available_datasets = list(_filter_datasets(all_ds, available_datasets))
+        else:
+            available_datasets = all_ds
+
+        self.ids = {ds_id: {} for ds_id in all_ds}
+        self.available_ids = {ds_id: {} for ds_id in available_datasets}
+
+        # Wrap load method in mock object so we can record call information
+        self.load = mock.patch.object(self, 'load', wraps=self.load).start()
+
+    @property
+    def start_time(self):
+        return self._start_time
+
+    @property
+    def end_time(self):
+        return self._end_time
+
+    @property
+    def sensor_names(self):
+        return self._sensor_name
+
+    def load(self, dataset_keys):
+        from satpy import DatasetDict
+        from xarray import DataArray
+        import numpy as np
+        dataset_ids = self.ids.keys()
+        loaded_datasets = DatasetDict()
+        for k in dataset_keys:
+            if k == 'ds9_fail_load':
+                continue
+            for ds in dataset_ids:
+                if ds == k:
+                    loaded_datasets[ds] = DataArray(data=np.arange(25).reshape(5, 5),
+                                                    attrs=ds.to_dict(),
+                                                    dims=['y', 'x'])
+        return loaded_datasets

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -214,7 +214,7 @@ class FakeReader(FileYAMLReader):
         else:
             available_datasets = all_ds
 
-        self.ids = {ds_id: {} for ds_id in all_ds}
+        self.all_ids = {ds_id: {} for ds_id in all_ds}
         self.available_ids = {ds_id: {} for ds_id in available_datasets}
 
         # Wrap load method in mock object so we can record call information
@@ -236,7 +236,7 @@ class FakeReader(FileYAMLReader):
         from satpy import DatasetDict
         from xarray import DataArray
         import numpy as np
-        dataset_ids = self.ids.keys()
+        dataset_ids = self.all_ids.keys()
         loaded_datasets = DatasetDict()
         for k in dataset_keys:
             if k == 'ds9_fail_load':

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -195,13 +195,18 @@ def add_overlay(orig, area, coast_dir, color=(0, 0, 0), width=0.5, resolution=No
 
         This function currently loses the data mask (alpha band).
 
-    ``resolution`` is chosen automatically if None (default), otherwise it should be one of:
+    ``resolution`` is chosen automatically if None (default),
+    otherwise it should be one of:
 
     +-----+-------------------------+---------+
     | 'f' | Full resolution         | 0.04 km |
+    +-----+-------------------------+---------+
     | 'h' | High resolution         | 0.2 km  |
+    +-----+-------------------------+---------+
     | 'i' | Intermediate resolution | 1.0 km  |
+    +-----+-------------------------+---------+
     | 'l' | Low resolution          | 5.0 km  |
+    +-----+-------------------------+---------+
     | 'c' | Crude resolution        | 25  km  |
     +-----+-------------------------+---------+
 
@@ -216,9 +221,12 @@ def add_overlay(orig, area, coast_dir, color=(0, 0, 0), width=0.5, resolution=No
     no labels for the grid lines are plotted, the color used for the grid lines
     is light gray, and the width of the gratucules is 0.5 pixels.
 
-    For grid if aggdraw is used, font option is mandatory, if not write_text is set to False
-    eg. font = aggdraw.Font('black', '/usr/share/fonts/truetype/msttcorefonts/Arial.ttf',
+    For grid if aggdraw is used, font option is mandatory, if not
+    ``write_text`` is set to False::
+
+        font = aggdraw.Font('black', '/usr/share/fonts/truetype/msttcorefonts/Arial.ttf',
                             opacity=127, size=16)
+
     """
 
     if area is None:


### PR DESCRIPTION
This is an attempt at resolving the discussion brought up in #434.

# Problem Summary

Currently in Satpy we have a couple difficult-to-code use cases with readers:

1. Some readers don't have their datasets pre-configured, like generic readers or readers that parse the output of algorithm software (clavrx, geocat, etc). So far we've gotten by with an `available_datasets` method on file handlers that provides the dataset info for new "dynamic" datasets that the file reader knows about but the YAML didn't.
2. Certain datasets have information that is only knowable by the file contents, like resolution. Since it can't be configured in YAML we get around this by file handlers having a `resolution` property that the base yaml class is checking for and using to update DatasetIDs configured in the YAML.
3. Some datasets are configured in YAML but may or may not be in the input file depending on how it was created. There is therefore no way to know if it is "available" or not until it is actually requested by the user.
4. If a dataset is available in multiple resolutions but the highest ("best") resolution is not available due to some files not being provided, we see that the dataset is not available via `available_dataset_ids` but even asking for the generic "name" of the dataset will still try to load the highest resolution version and fail (see MODIS L1B reader).

# Solution Summary

I've updated the `available_datasets` method of the file handlers to take a series of `(is_available, dataset_info)` pairs via a generator. I chain these calls together for the first file handler of each loaded file type. The `is_available` "boolean" can be:

1. `True`: There is a file handler and it has this dataset and can load it
2. `False`: There is a file handler and it knows it should be able to load this, but doesn't have it.
3. `None`: There isn't a file handler that knows how to load this dataset.

This method can do three things:

1. Yield the dataset info provided it, as is.
2. Update the dataset info with new identifying information (resolution, etc) and possibly other metadata that would effect loading (coordinates, etc). Then yield the dataset info.
3. Generate new dataset info for dynamic datasets that haven't been configured in the YAML, but that the file handler knows about.

I've changed the base class to have an idea of "all datasets" and "available datasets", but there are some flaws. Right now, as of this first commit, this only reproduces the current behaviors (maybe with a little extra flair).

# Doubts and Questions

1. I used the "chaining" idea when calling `available_datasets` because it seemed the most flexible, ended up being kind of elegant, should be performant because of the way the generators are used, and allows for file handlers to "communicate" between themselves with what is available. However, it may make the actual use of the generator inside `available_datasets` overly complex and hard to use. The simple cases are still relatively simple, but the semi-complex ones become very hard to walk through.
2. The dependency tree used by the Scene and `.load` of the readers have a strange way of handling a "known" versus "available" dataset. It is very obvious now that I've been able to take a step back and work on this.

   The dependency tree needs to know what's possible regardless of whether or not a dataset exists. If we **know** that it exists then we know what is possible. However, we also use the dependency tree when we actually load datasets to get the `DatasetID` that we need to load. The "best" dataset to load (highest resolution) may not be the "best available", we currently only load "best". We would probably be ok building the dependency tree with only available datasets, but I'm a little nervous about the lack of future-proofing this would cause. Maybe building two dependency trees would be best/most flexible; one of all known and one of available.

   The main thing to decide is what should the base reader's `get_dataset_key` return. Should we split it in to two or more methods that do similar things? Is a keyword argument as I've laid out in this PR so far good enough? This is compounded by the problem in the previous paragraph, which components need "known" datasets and which ones need "available"? Right now I have it possible to do "prefer available but give me known if it isn't available".

I'm not sure what's best here and wouldn't mind some opinions. I've been thinking about this too much so I'm taking a break for a little while.

# TODO

1. Move the "resolution" property logic to `available_datasets` functionality.
2. Determine best way to handle all/available differences in current dependency tree creation and use.

 - [x] Closes #434 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
