### PR TITLE
Add FY-3D MERSI-2 L1B Reader (mersi2_l1b)

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -182,6 +182,9 @@ installation.
     * - VIRR data in HDF5 format
       - `virr_l1b`
       - Beta
+    * - MERSI-2 L1B data in HDF5 format
+      - `mersi2_l1b`
+      - Beta
 
 Indices and tables
 ==================

--- a/satpy/etc/composites/mersi2.yaml
+++ b/satpy/etc/composites/mersi2.yaml
@@ -1,0 +1,71 @@
+sensor_name: visir/mersi2
+
+modifiers:
+  rayleigh_corrected:
+    compositor: !!python/name:satpy.composites.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: rayleigh_only
+    prerequisites:
+    - name: '3'
+      modifiers: [sunz_corrected]
+    optional_prerequisites:
+    - name: satellite_azimuth_angle
+    - name: satellite_zenith_angle
+    - name: solar_azimuth_angle
+    - name: solar_zenith_angle
+  sunz_corrected:
+    compositor: !!python/name:satpy.composites.SunZenithCorrector
+    prerequisites:
+      - solar_zenith_angle
+
+composites:
+
+  airmass:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - wavelength: 6.2
+          - wavelength: 7.3
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - wavelength: 9.7
+          - wavelength: 10.8
+      - wavelength: 6.2
+    standard_name: airmass
+
+  ash:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - 12.0
+          - 10.8
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - 10.8
+          - 8.7
+      - 10.8
+    standard_name: ash
+
+  true_color_raw:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - 0.650
+      - 0.555
+      - 0.443
+    standard_name: true_color
+
+  true_color:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+#      - name: '12'  # 0.67
+      - name: '3'  # 0.65
+        modifiers: [sunz_corrected, rayleigh_corrected]
+#      - name: '11'  # 0.555
+      - name: '2'
+        modifiers: [sunz_corrected, rayleigh_corrected]
+#      - name: '9'  # 0.443
+      - name: '1'  # 0.47
+        modifiers: [sunz_corrected, rayleigh_corrected]
+    standard_name: true_color

--- a/satpy/etc/composites/mersi2.yaml
+++ b/satpy/etc/composites/mersi2.yaml
@@ -51,21 +51,33 @@ composites:
   true_color_raw:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - 0.650
-      - 0.555
-      - 0.443
+      - '3'
+      - '2'
+      - '1'
     standard_name: true_color
 
   true_color:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-#      - name: '12'  # 0.67
       - name: '3'  # 0.65
         modifiers: [sunz_corrected, rayleigh_corrected]
-#      - name: '11'  # 0.555
       - name: '2'
         modifiers: [sunz_corrected, rayleigh_corrected]
-#      - name: '9'  # 0.443
       - name: '1'  # 0.47
         modifiers: [sunz_corrected, rayleigh_corrected]
     standard_name: true_color
+
+  natural_color:
+    compositor: !!python/name:satpy.composites.RatioSharpenedRGB
+    prerequisites:
+      - name: '6'
+        modifiers: [sunz_corrected]
+      - name: '4'
+        modifiers: [sunz_corrected]
+      - name: '3'
+        modifiers: [sunz_corrected]
+    optional_prerequisites:
+      - name: '15'
+        modifiers: [sunz_corrected]
+    standard_name: natural_color
+    high_resolution_band: green

--- a/satpy/etc/readers/mersi2_l1b.yaml
+++ b/satpy/etc/readers/mersi2_l1b.yaml
@@ -30,9 +30,15 @@ file_types:
       # tf2019071182739.FY3D-X_MERSI_GEOQK_L1B.HDF
       - 'tf{start_time:%Y%j%H%M%S}.{platform_shortname}-{trans_band:1s}_MERSI_GEOQK_L1B.{ext}'
 
+# NOTE: OSCAR website currently has bands in wavelength order
+#       https://www.wmo-sat.info/oscar/instruments/view/279
+#       The order below is by the wavelength in the input files
+#       The slides at the below link have band 5 and 19 swapped:
+#       http://www.wmo.int/pages/prog/sat/meetings/documents/IPET-SUP-4_Doc_05-04_FY-3D-ppt.pdf
 datasets:
   '1':
     name: '1'
+    wavelength: [0.445, 0.470, 0.495]
     resolution:
       1000:
         file_type: mersi2_l1b_1000
@@ -45,18 +51,19 @@ datasets:
         file_key: Data/EV_250_RefSB_b1
         calibration_key: Calibration/VIS_Cal_Coeff
         calibration_index: 0
-    wavelength: [0.402, 0.412, 0.422]
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
         units: "%"
         standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '2':
     name: '2'
-    wavelength: [0.433, 0.443, 0.453]
+    wavelength: [0.525, 0.550, 0.575]
     resolution:
       1000:
         file_type: mersi2_l1b_1000
@@ -74,12 +81,14 @@ datasets:
       reflectance:
         units: "%"
         standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '3':
     name: '3'
-    wavelength: [0.445, 0.470, 0.495]
+    wavelength: [0.625, 0.650, 0.675]
     resolution:
       1000:
         file_type: mersi2_l1b_1000
@@ -97,12 +106,14 @@ datasets:
       reflectance:
         units: "%"
         standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '4':
     name: '4'
-    wavelength: [0.480, 0.490, 0.500]
+    wavelength: [0.840, 0.865, 0.890]
     resolution:
       1000:
         file_type: mersi2_l1b_1000
@@ -120,13 +131,15 @@ datasets:
       reflectance:
         units: "%"
         standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
 
   '5':
     name: '5'
-    wavelength: [0.525, 0.550, 0.575]
+    wavelength: [1.37, 1.38, 1.39]  # or 30nm bandwidth?
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -141,11 +154,11 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '6':
     name: '6'
-    wavelength: [0.545, 0.555, 0.565]
+    wavelength: [1.615, 1.640, 1.665]
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -160,11 +173,11 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '7':
     name: '7'
-    wavelength: [0.625, 0.650, 0.675]
+    wavelength: [2.105, 2.130, 2.155]
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -179,11 +192,11 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '8':
     name: '8'
-    wavelength: [0.660, 0.670, 0.680]
+    wavelength: [0.402, 0.412, 0.422]
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -198,11 +211,11 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '9':
     name: '9'
-    wavelength: [0.699, 0.709, 0.719]
+    wavelength: [0.433, 0.443, 0.453]
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -217,11 +230,11 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '10':
     name: '10'
-    wavelength: [0.736, 0.746, 0.756]
+    wavelength: [0.480, 0.490, 0.500]
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -236,11 +249,11 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '11':
     name: '11'
-    wavelength: [0.855, 0.865, 0.875]
+    wavelength: [0.545, 0.555, 0.565]
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -255,11 +268,11 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '12':
     name: '12'
-    wavelength: [0.840, 0.865, 0.890]
+    wavelength: [0.660, 0.670, 0.680]
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -274,11 +287,11 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '13':
     name: '13'
-    wavelength: [0.895, 0.905, 0.915]
+    wavelength: [0.699, 0.709, 0.719]
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -293,11 +306,11 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '14':
     name: '14'
-    wavelength: [0.926, 0.936, 0.946]
+    wavelength: [0.736, 0.746, 0.756]
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -312,11 +325,11 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '15':
     name: '15'
-    wavelength: [0.915, 0.940, 0.965]
+    wavelength: [0.855, 0.865, 0.875]
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -331,11 +344,11 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '16':
     name: '16'
-    wavelength: [1.23, 1.24, 1.25]  # or 1.03um?
+    wavelength: [0.895, 0.905, 0.915]
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -350,11 +363,11 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '17':
     name: '17'
-    wavelength: [1.37, 1.38, 1.39]  # or 30nm bandwidth?
+    wavelength: [0.926, 0.936, 0.946]
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -369,11 +382,11 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '18':
     name: '18'
-    wavelength: [1.615, 1.640, 1.665]
+    wavelength: [0.915, 0.940, 0.965]
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -388,11 +401,11 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '19':
     name: '19'
-    wavelength: [2.105, 2.130, 2.155]
+    wavelength: [1.23, 1.24, 1.25]  # or 1.03um?
     resolution: 1000
     file_type: mersi2_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -407,9 +420,10 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
 
+  # Not sure how to get radiance for BT channels
   '20':
     name: '20'
     wavelength: [3.710, 3.800, 3.890]
@@ -424,10 +438,8 @@ datasets:
       brightness_temperature:
         units: "K"
         standard_name: toa_brightness_temperature
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '21':
     name: '21'
@@ -443,10 +455,8 @@ datasets:
       brightness_temperature:
         units: "K"
         standard_name: toa_brightness_temperature
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '22':
     name: '22'
@@ -462,10 +472,8 @@ datasets:
       brightness_temperature:
         units: "K"
         standard_name: toa_brightness_temperature
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '23':
     name: '23'
@@ -481,10 +489,8 @@ datasets:
       brightness_temperature:
         units: "K"
         standard_name: toa_brightness_temperature
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '24':
     name: '24'
@@ -506,10 +512,8 @@ datasets:
       brightness_temperature:
         units: "K"
         standard_name: toa_brightness_temperature
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
   '25':
     name: '25'
@@ -531,12 +535,9 @@ datasets:
       brightness_temperature:
         units: "K"
         standard_name: toa_brightness_temperature
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
-        units: 1
+        units: "1"
         standard_name: counts
-
 
   longitude:
     name: longitude

--- a/satpy/etc/readers/mersi2_l1b.yaml
+++ b/satpy/etc/readers/mersi2_l1b.yaml
@@ -1,0 +1,565 @@
+reader:
+  description: FY-3D Medium Resolution Spectral Imager 2 (MERSI-2) L1B Reader
+  name: mersi2_l1b
+  sensors: [mersi2]
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
+
+file_types:
+  mersi2_l1b_1000:
+    file_reader: !!python/name:satpy.readers.mersi2_l1b.MERSI2L1B
+    rows_per_scan: 10
+    file_patterns:
+      # tf2019071182739.FY3D-X_MERSI_1000M_L1B.HDF
+      - 'tf{start_time:%Y%j%H%M%S}.{platform_shortname}-{trans_band:1s}_MERSI_1000M_L1B.{ext}'
+  mersi2_l1b_250:
+    file_reader: !!python/name:satpy.readers.mersi2_l1b.MERSI2L1B
+    rows_per_scan: 40
+    file_patterns:
+      # tf2019071182739.FY3D-X_MERSI_0250M_L1B.HDF
+      - 'tf{start_time:%Y%j%H%M%S}.{platform_shortname}-{trans_band:1s}_MERSI_0250M_L1B.{ext}'
+  mersi2_l1b_1000_geo:
+    file_reader: !!python/name:satpy.readers.mersi2_l1b.MERSI2L1B
+    rows_per_scan: 10
+    file_patterns:
+      # tf2019071182739.FY3D-X_MERSI_GEO1K_L1B.HDF
+      - 'tf{start_time:%Y%j%H%M%S}.{platform_shortname}-{trans_band:1s}_MERSI_GEO1K_L1B.{ext}'
+  mersi2_l1b_250_geo:
+    file_reader: !!python/name:satpy.readers.mersi2_l1b.MERSI2L1B
+    rows_per_scan: 40
+    file_patterns:
+      # tf2019071182739.FY3D-X_MERSI_GEOQK_L1B.HDF
+      - 'tf{start_time:%Y%j%H%M%S}.{platform_shortname}-{trans_band:1s}_MERSI_GEOQK_L1B.{ext}'
+
+datasets:
+  '1':
+    name: '1'
+    resolution:
+      1000:
+        file_type: mersi2_l1b_1000
+        file_key: Data/EV_250_Aggr.1KM_RefSB
+        band_index: 0
+        calibration_key: Calibration/VIS_Cal_Coeff
+        calibration_index: 0
+      250:
+        file_type: mersi2_l1b_250
+        file_key: Data/EV_250_RefSB_b1
+        calibration_key: Calibration/VIS_Cal_Coeff
+        calibration_index: 0
+    wavelength: [0.402, 0.412, 0.422]
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      counts:
+        units: 1
+        standard_name: counts
+  '2':
+    name: '2'
+    wavelength: [0.433, 0.443, 0.453]
+    resolution:
+      1000:
+        file_type: mersi2_l1b_1000
+        file_key: Data/EV_250_Aggr.1KM_RefSB
+        band_index: 1
+        calibration_key: Calibration/VIS_Cal_Coeff
+        calibration_index: 1
+      250:
+        file_type: mersi2_l1b_250
+        file_key: Data/EV_250_RefSB_b2
+        calibration_key: Calibration/VIS_Cal_Coeff
+        calibration_index: 1
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      counts:
+        units: 1
+        standard_name: counts
+  '3':
+    name: '3'
+    wavelength: [0.445, 0.470, 0.495]
+    resolution:
+      1000:
+        file_type: mersi2_l1b_1000
+        file_key: Data/EV_250_Aggr.1KM_RefSB
+        band_index: 2
+        calibration_key: Calibration/VIS_Cal_Coeff
+        calibration_index: 2
+      250:
+        file_type: mersi2_l1b_250
+        file_key: Data/EV_250_RefSB_b3
+        calibration_key: Calibration/VIS_Cal_Coeff
+        calibration_index: 2
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      counts:
+        units: 1
+        standard_name: counts
+  '4':
+    name: '4'
+    wavelength: [0.480, 0.490, 0.500]
+    resolution:
+      1000:
+        file_type: mersi2_l1b_1000
+        file_key: Data/EV_250_Aggr.1KM_RefSB
+        band_index: 3
+        calibration_key: Calibration/VIS_Cal_Coeff
+        calibration_index: 3
+      250:
+        file_type: mersi2_l1b_250
+        file_key: Data/EV_250_RefSB_b4
+        calibration_key: Calibration/VIS_Cal_Coeff
+        calibration_index: 3
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      counts:
+        units: 1
+        standard_name: counts
+
+  '5':
+    name: '5'
+    wavelength: [0.525, 0.550, 0.575]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 0
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 0
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '6':
+    name: '6'
+    wavelength: [0.545, 0.555, 0.565]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 1
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 1
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '7':
+    name: '7'
+    wavelength: [0.625, 0.650, 0.675]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 2
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 2
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '8':
+    name: '8'
+    wavelength: [0.660, 0.670, 0.680]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 3
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 3
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '9':
+    name: '9'
+    wavelength: [0.699, 0.709, 0.719]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 4
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 4
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '10':
+    name: '10'
+    wavelength: [0.736, 0.746, 0.756]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 5
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 5
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '11':
+    name: '11'
+    wavelength: [0.855, 0.865, 0.875]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 6
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 6
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '12':
+    name: '12'
+    wavelength: [0.840, 0.865, 0.890]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 7
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 7
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '13':
+    name: '13'
+    wavelength: [0.895, 0.905, 0.915]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 8
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 8
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '14':
+    name: '14'
+    wavelength: [0.926, 0.936, 0.946]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 9
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 9
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '15':
+    name: '15'
+    wavelength: [0.915, 0.940, 0.965]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 10
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 10
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '16':
+    name: '16'
+    wavelength: [1.23, 1.24, 1.25]  # or 1.03um?
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 11
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 11
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '17':
+    name: '17'
+    wavelength: [1.37, 1.38, 1.39]  # or 30nm bandwidth?
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 12
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 12
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '18':
+    name: '18'
+    wavelength: [1.615, 1.640, 1.665]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 13
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 13
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '19':
+    name: '19'
+    wavelength: [2.105, 2.130, 2.155]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_RefSB
+    band_index: 14
+    calibration_key: Calibration/VIS_Cal_Coeff
+    calibration_index: 14
+    coordinates: [longitude, latitude]
+    calibration:
+      reflectance:
+        units: "%"
+        standard_name: toa_bidirection_reflectance
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+
+  '20':
+    name: '20'
+    wavelength: [3.710, 3.800, 3.890]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_Emissive
+    band_index: 0
+    calibration_key: Calibration/IR_Cal_Coeff
+    calibration_index: 0
+    coordinates: [longitude, latitude]
+    calibration:
+      brightness_temperature:
+        units: "K"
+        standard_name: toa_brightness_temperature
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '21':
+    name: '21'
+    wavelength: [3.9725, 4.050, 4.1275]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_Emissive
+    band_index: 1
+    calibration_key: Calibration/IR_Cal_Coeff
+    calibration_index: 1
+    coordinates: [longitude, latitude]
+    calibration:
+      brightness_temperature:
+        units: "K"
+        standard_name: toa_brightness_temperature
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '22':
+    name: '22'
+    wavelength: [6.950, 7.20, 7.450]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_Emissive
+    band_index: 2
+    calibration_key: Calibration/IR_Cal_Coeff
+    calibration_index: 2
+    coordinates: [longitude, latitude]
+    calibration:
+      brightness_temperature:
+        units: "K"
+        standard_name: toa_brightness_temperature
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '23':
+    name: '23'
+    wavelength: [8.400, 8.550, 8.700]
+    resolution: 1000
+    file_type: mersi2_l1b_1000
+    file_key: Data/EV_1KM_Emissive
+    band_index: 3
+    calibration_key: Calibration/IR_Cal_Coeff
+    calibration_index: 3
+    coordinates: [longitude, latitude]
+    calibration:
+      brightness_temperature:
+        units: "K"
+        standard_name: toa_brightness_temperature
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '24':
+    name: '24'
+    wavelength: [10.300, 10.800, 11.300]
+    resolution:
+      1000:
+        file_type: mersi2_l1b_1000
+        file_key: Data/EV_250_Aggr.1KM_Emissive
+        band_index: 0
+        calibration_key: Calibration/IR_Cal_Coeff
+        calibration_index: 4
+      250:
+        file_type: mersi2_l1b_250
+        file_key: Data/EV_250_Emissive_b24
+        calibration_key: Calibration/IR_Cal_Coeff
+        calibration_index: 4
+    coordinates: [longitude, latitude]
+    calibration:
+      brightness_temperature:
+        units: "K"
+        standard_name: toa_brightness_temperature
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+  '25':
+    name: '25'
+    wavelength: [11.500, 12.000, 12.500]
+    resolution:
+      1000:
+        file_type: mersi2_l1b_1000
+        file_key: Data/EV_250_Aggr.1KM_Emissive
+        band_index: 1
+        calibration_key: Calibration/IR_Cal_Coeff
+        calibration_index: 5
+      250:
+        file_type: mersi2_l1b_250
+        file_key: Data/EV_250_Emissive_b25
+        calibration_key: Calibration/IR_Cal_Coeff
+        calibration_index: 5
+    coordinates: [longitude, latitude]
+    calibration:
+      brightness_temperature:
+        units: "K"
+        standard_name: toa_brightness_temperature
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+      counts:
+        units: 1
+        standard_name: counts
+
+
+  longitude:
+    name: longitude
+    units: degree_east
+    standard_name: longitude
+    resolution:
+      1000:
+        file_type: mersi2_l1b_1000_geo
+        file_key: Geolocation/Longitude
+      250:
+        file_type: mersi2_l1b_250_geo
+        file_key: Longitude
+  latitude:
+    name: latitude
+    units: degree_north
+    standard_name: latitude
+    resolution:
+      1000:
+        file_type: mersi2_l1b_1000_geo
+        file_key: Geolocation/Latitude
+      250:
+        file_type: mersi2_l1b_250_geo
+        file_key: Latitude
+
+
+

--- a/satpy/etc/readers/mersi2_l1b.yaml
+++ b/satpy/etc/readers/mersi2_l1b.yaml
@@ -561,6 +561,35 @@ datasets:
       250:
         file_type: mersi2_l1b_250_geo
         file_key: Latitude
-
-
-
+  solar_zenith_angle:
+    name: solar_zenith_angle
+    units: degree
+    standard_name: solar_zenith_angle
+    resolution: 1000
+    coordinates: [longitude, latitude]
+    file_type: mersi2_l1b_1000_geo
+    file_key: Geolocation/SolarZenith
+  solar_azimuth_angle:
+    name: solar_azimuth_angle
+    units: degree
+    standard_name: solar_azimuth_angle
+    resolution: 1000
+    coordinates: [longitude, latitude]
+    file_type: mersi2_l1b_1000_geo
+    file_key: Geolocation/SolarAzimuth
+  satellite_zenith_angle:
+    name: satellite_zenith_angle
+    units: degree
+    standard_name: sensor_zenith_angle
+    resolution: 1000
+    coordinates: [longitude, latitude]
+    file_type: mersi2_l1b_1000_geo
+    file_key: Geolocation/SensorZenith
+  satellite_azimuth_angle:
+    name: satellite_azimuth_angle
+    units: degree
+    standard_name: sensor_azimuth_angle
+    resolution: 1000
+    coordinates: [longitude, latitude]
+    file_type: mersi2_l1b_1000_geo
+    file_key: Geolocation/SensorAzimuth

--- a/satpy/etc/readers/mersi2_l1b.yaml
+++ b/satpy/etc/readers/mersi2_l1b.yaml
@@ -57,6 +57,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -82,6 +83,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -107,6 +109,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -132,6 +135,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -152,6 +156,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -171,6 +176,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -190,6 +196,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -209,6 +216,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -228,6 +236,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -247,6 +256,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -266,6 +276,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -285,6 +296,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -304,6 +316,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -323,6 +336,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -342,6 +356,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -361,6 +376,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -380,6 +396,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -399,6 +416,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
@@ -418,6 +436,7 @@ datasets:
         units: "%"
         standard_name: toa_bidirection_reflectance
       radiance:
+        units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"

--- a/satpy/etc/readers/virr_l1b.yaml
+++ b/satpy/etc/readers/virr_l1b.yaml
@@ -27,7 +27,6 @@ datasets:
     standard_name: toa_bidirectional_reflectance
     coordinates: [longitude, latitude]
     calibration: reflectance
-    level: 1
 
   R2:
     name: R2
@@ -39,7 +38,6 @@ datasets:
     standard_name: toa_bidirectional_reflectance
     coordinates: [longitude, latitude]
     calibration: reflectance
-    level: 1
 
   E1:
     name: E1
@@ -51,7 +49,6 @@ datasets:
     standard_name: toa_brightness_temperature
     coordinates: [longitude, latitude]
     calibration: brightness_temperature
-    level: 1
 
   E2:
     name: E2
@@ -63,7 +60,6 @@ datasets:
     standard_name: toa_brightness_temperature
     coordinates: [longitude, latitude]
     calibration: brightness_temperature
-    level: 1
 
   E3:
     name: E3
@@ -75,7 +71,6 @@ datasets:
     standard_name: toa_brightness_temperature
     coordinates: [longitude, latitude]
     calibration: brightness_temperature
-    level: 1
 
   R3:
     name: R3
@@ -87,7 +82,6 @@ datasets:
     standard_name: toa_bidirectional_reflectance
     coordinates: [longitude, latitude]
     calibration: reflectance
-    level: 1
 
   R4:
     name: R4
@@ -99,7 +93,6 @@ datasets:
     standard_name: toa_bidirectional_reflectance
     coordinates: [longitude, latitude]
     calibration: reflectance
-    level: 1
 
   R5:
     name: R5
@@ -111,7 +104,6 @@ datasets:
     standard_name: toa_bidirectional_reflectance
     coordinates: [longitude, latitude]
     calibration: reflectance
-    level: 1
 
   R6:
     name: R6
@@ -123,7 +115,6 @@ datasets:
     standard_name: toa_bidirectional_reflectance
     coordinates: [longitude, latitude]
     calibration: reflectance
-    level: 1
 
   R7:
     name: R7
@@ -135,7 +126,6 @@ datasets:
     standard_name: toa_bidirectional_reflectance
     coordinates: [longitude, latitude]
     calibration: reflectance
-    level: 1
 
   satellite_azimuth_angle:
     name: satellite_azimuth_angle

--- a/satpy/readers/hdf5_utils.py
+++ b/satpy/readers/hdf5_utils.py
@@ -82,7 +82,7 @@ class HDF5FileHandler(BaseFileHandler):
             dset_data = da.from_array(dset, chunks=CHUNK_SIZE)
             if dset.ndim == 2:
                 return xr.DataArray(dset_data, dims=['y', 'x'], attrs=dset.attrs)
-            return xr.DataArray(dset_data)
+            return xr.DataArray(dset_data, attrs=dset.attrs)
 
         return val
 

--- a/satpy/readers/mersi2_l1b.py
+++ b/satpy/readers/mersi2_l1b.py
@@ -91,13 +91,16 @@ class MERSI2L1B(HDF5FileHandler):
         if 'rows_per_scan' in self.filetype_info:
             attrs.setdefault('rows_per_scan', self.filetype_info['rows_per_scan'])
 
+        fill_value = attrs.pop('FillValue', np.nan)  # covered by valid_range
         valid_range = attrs.pop('valid_range', None)
-        attrs.pop('FillValue', None)  # covered by valid_range
+        if dataset_id.calibration == 'counts':
+            # preserve integer type of counts if possible
+            attrs['_FillValue'] = fill_value
         if valid_range is not None:
             # typically bad_values == 65535, saturated == 65534
             # dead detector == 65533
             data = data.where((data >= valid_range[0]) &
-                              (data <= valid_range[1]))
+                              (data <= valid_range[1]), fill_value)
 
         slope = attrs.pop('Slope', None)
         intercept = attrs.pop('Intercept', None)

--- a/satpy/readers/virr_l1b.py
+++ b/satpy/readers/virr_l1b.py
@@ -44,7 +44,6 @@ from datetime import datetime
 from satpy.readers.hdf5_utils import HDF5FileHandler
 from pyspectral.blackbody import blackbody_wn_rad2temp as rad2temp
 import numpy as np
-import xarray as xr
 import dask.array as da
 import logging
 
@@ -79,10 +78,17 @@ class VIRR_L1B(HDF5FileHandler):
             if 'E' in dataset_id.name:
                 slope = self[self.l1b_prefix + 'Emissive_Radiance_Scales'].data[:, band_index][:, np.newaxis]
                 intercept = self[self.l1b_prefix + 'Emissive_Radiance_Offsets'].data[:, band_index][:, np.newaxis]
-                radiance_data = rad2temp(self['/attr/' + self.wave_number][band_index] * 100,
-                                         (data * slope + intercept) * 1e-5)
-                data = xr.DataArray(da.from_array(radiance_data, data.chunks),
-                                    coords=data.coords, dims=data.dims, name=data.name, attrs=data.attrs)
+                # Converts cm^-1 (wavenumbers) and (mW/m^2)/(str/cm^-1) (radiance data)
+                # to SI units m^-1, mW*m^-3*str^-1.
+                wave_number = self['/attr/' + self.wave_number][band_index] * 100
+                bt_data = rad2temp(wave_number,
+                                   (data.data * slope + intercept) * 1e-5)
+                if isinstance(bt_data, np.ndarray):
+                    # old versions of pyspectral produce numpy arrays
+                    data.data = da.from_array(bt_data, chunks=data.data.chunks)
+                else:
+                    # new versions of pyspectral can do dask arrays
+                    data.data = bt_data
             elif 'R' in dataset_id.name:
                 slope = self['/attr/RefSB_Cal_Coefficients'][0::2]
                 intercept = self['/attr/RefSB_Cal_Coefficients'][1::2]

--- a/satpy/readers/virr_l1b.py
+++ b/satpy/readers/virr_l1b.py
@@ -48,13 +48,15 @@ import xarray as xr
 import dask.array as da
 import logging
 
+LOG = logging.getLogger(__name__)
+
 
 class VIRR_L1B(HDF5FileHandler):
     """VIRR_L1B reader."""
 
     def __init__(self, filename, filename_info, filetype_info):
         super(VIRR_L1B, self).__init__(filename, filename_info, filetype_info)
-        logging.debug('day/night flag for {0}: {1}'.format(filename, self['/attr/Day Or Night Flag']))
+        LOG.debug('day/night flag for {0}: {1}'.format(filename, self['/attr/Day Or Night Flag']))
         self.geolocation_prefix = filetype_info['geolocation_prefix']
         self.platform_id = filename_info['platform_id']
         self.l1b_prefix = 'Data/'
@@ -68,9 +70,7 @@ class VIRR_L1B(HDF5FileHandler):
         file_key = self.geolocation_prefix + ds_info.get('file_key', dataset_id.name)
         if self.platform_id == 'FY3B':
             file_key = file_key.replace('Data/', '')
-        data = self.get(file_key)
-        if data is None:
-            logging.error('File key "{0}" could not be found in file {1}'.format(file_key, self.filename))
+        data = self[file_key]
         band_index = ds_info.get('band_index')
         if band_index is not None:
             data = data[band_index]

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -218,7 +218,7 @@ class Scene(MetadataObject):
         return set(self.wishlist) - set(self.datasets.keys())
 
     def _compare_areas(self, datasets=None, compare_func=max):
-        """Get  for the provided datasets.
+        """Compare areas for the provided datasets.
 
         Args:
             datasets (iterable): Datasets whose areas will be compared. Can

--- a/satpy/tests/reader_tests/__init__.py
+++ b/satpy/tests/reader_tests/__init__.py
@@ -39,7 +39,8 @@ from satpy.tests.reader_tests import (test_abi_l1b, test_hrit_base,
                                       test_viirs_edr_flood, test_nwcsaf_nc,
                                       test_seviri_l1b_hrit, test_sar_c_safe,
                                       test_modis_l1b, test_viirs_edr_active_fires,
-                                      test_safe_sar_l2_ocn, test_electrol_hrit)
+                                      test_safe_sar_l2_ocn, test_electrol_hrit,
+                                      test_mersi2_l1b)
 
 
 if sys.version_info < (2, 7):
@@ -87,5 +88,6 @@ def suite():
     mysuite.addTests(test_viirs_edr_active_fires.suite())
     mysuite.addTests(test_safe_sar_l2_ocn.suite())
     mysuite.addTests(test_electrol_hrit.suite())
+    mysuite.addTests(test_mersi2_l1b.suite())
 
     return mysuite

--- a/satpy/tests/reader_tests/test_mersi2_l1b.py
+++ b/satpy/tests/reader_tests/test_mersi2_l1b.py
@@ -60,9 +60,11 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
         data = {
             'Data/EV_1KM_RefSB':
                 xr.DataArray(
-                    da.ones((15, num_scans * rows_per_scan, num_cols), chunks=1024),
+                    da.ones((15, num_scans * rows_per_scan, num_cols), chunks=1024,
+                            dtype=np.uint16),
                     attrs={
                         'Slope': [1.] * 15, 'Intercept': [0.] * 15,
+                        'FillValue': 65535,
                         'units': 'NO',
                         'valid_range': [0, 4095],
                         'long_name': b'1km Earth View Science Data',
@@ -70,9 +72,11 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
                     dims=('_ref_bands', '_rows', '_cols')),
             'Data/EV_1KM_Emissive':
                 xr.DataArray(
-                    da.ones((4, num_scans * rows_per_scan, num_cols), chunks=1024),
+                    da.ones((4, num_scans * rows_per_scan, num_cols), chunks=1024,
+                            dtype=np.uint16),
                     attrs={
                         'Slope': [1.] * 4, 'Intercept': [0.] * 4,
+                        'FillValue': 65535,
                         'units': 'mW/ (m2 cm-1 sr)',
                         'valid_range': [0, 25000],
                         'long_name': b'1km Emissive Bands Earth View '
@@ -81,9 +85,11 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
                     dims=('_ir_bands', '_rows', '_cols')),
             'Data/EV_250_Aggr.1KM_RefSB':
                 xr.DataArray(
-                    da.ones((4, num_scans * rows_per_scan, num_cols), chunks=1024),
+                    da.ones((4, num_scans * rows_per_scan, num_cols), chunks=1024,
+                            dtype=np.uint16),
                     attrs={
                         'Slope': [1.] * 4, 'Intercept': [0.] * 4,
+                        'FillValue': 65535,
                         'units': 'NO',
                         'valid_range': [0, 4095],
                         'long_name': b'250m Reflective Bands Earth View '
@@ -92,9 +98,11 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
                     dims=('_ref250_bands', '_rows', '_cols')),
             'Data/EV_250_Aggr.1KM_Emissive':
                 xr.DataArray(
-                    da.ones((2, num_scans * rows_per_scan, num_cols), chunks=1024),
+                    da.ones((2, num_scans * rows_per_scan, num_cols), chunks=1024,
+                            dtype=np.uint16),
                     attrs={
                         'Slope': [1.] * 2, 'Intercept': [0.] * 2,
+                        'FillValue': 65535,
                         'units': 'mW/ (m2 cm-1 sr)',
                         'valid_range': [0, 4095],
                         'long_name': b'250m Emissive Bands Earth View '
@@ -108,54 +116,66 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
         data = {
             'Data/EV_250_RefSB_b1':
                 xr.DataArray(
-                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024,
+                            dtype=np.uint16),
                     attrs={
                         'Slope': [1.] * 1, 'Intercept': [0.] * 1,
+                        'FillValue': 65535,
                         'units': 'NO',
                         'valid_range': [0, 4095],
                     },
                     dims=('_rows', '_cols')),
             'Data/EV_250_RefSB_b2':
                 xr.DataArray(
-                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024,
+                            dtype=np.uint16),
                     attrs={
                         'Slope': [1.] * 1, 'Intercept': [0.] * 1,
+                        'FillValue': 65535,
                         'units': 'NO',
                         'valid_range': [0, 4095],
                     },
                     dims=('_rows', '_cols')),
             'Data/EV_250_RefSB_b3':
                 xr.DataArray(
-                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024,
+                            dtype=np.uint16),
                     attrs={
                         'Slope': [1.] * 1, 'Intercept': [0.] * 1,
+                        'FillValue': 65535,
                         'units': 'NO',
                         'valid_range': [0, 4095],
                     },
                     dims=('_rows', '_cols')),
             'Data/EV_250_RefSB_b4':
                 xr.DataArray(
-                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024,
+                            dtype=np.uint16),
                     attrs={
                         'Slope': [1.] * 1, 'Intercept': [0.] * 1,
+                        'FillValue': 65535,
                         'units': 'NO',
                         'valid_range': [0, 4095],
                     },
                     dims=('_rows', '_cols')),
             'Data/EV_250_Emissive_b24':
                 xr.DataArray(
-                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024,
+                            dtype=np.uint16),
                     attrs={
                         'Slope': [1.] * 1, 'Intercept': [0.] * 1,
+                        'FillValue': 65535,
                         'units': 'mW/ (m2 cm-1 sr)',
                         'valid_range': [0, 4095],
                     },
                     dims=('_rows', '_cols')),
             'Data/EV_250_Emissive_b25':
                 xr.DataArray(
-                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024,
+                            dtype=np.uint16),
                     attrs={
                         'Slope': [1.] * 1, 'Intercept': [0.] * 1,
+                        'FillValue': 65535,
                         'units': 'mW/ (m2 cm-1 sr)',
                         'valid_range': [0, 4095],
                     },
@@ -327,27 +347,35 @@ class TestMERSI2L1BReader(unittest.TestCase):
         self.assertEqual(8, len(res))
         self.assertEqual((2 * 40, 2048 * 2), res['1'].shape)
         self.assertEqual('counts', res['1'].attrs['calibration'])
+        self.assertEqual(res['1'].dtype, np.uint16)
         self.assertEqual('1', res['1'].attrs['units'])
         self.assertEqual((2 * 40, 2048 * 2), res['2'].shape)
         self.assertEqual('counts', res['2'].attrs['calibration'])
+        self.assertEqual(res['2'].dtype, np.uint16)
         self.assertEqual('1', res['2'].attrs['units'])
         self.assertEqual((2 * 40, 2048 * 2), res['3'].shape)
         self.assertEqual('counts', res['3'].attrs['calibration'])
+        self.assertEqual(res['3'].dtype, np.uint16)
         self.assertEqual('1', res['3'].attrs['units'])
         self.assertEqual((2 * 40, 2048 * 2), res['4'].shape)
         self.assertEqual('counts', res['4'].attrs['calibration'])
+        self.assertEqual(res['4'].dtype, np.uint16)
         self.assertEqual('1', res['4'].attrs['units'])
         self.assertEqual((2 * 10, 2048), res['5'].shape)
         self.assertEqual('counts', res['5'].attrs['calibration'])
+        self.assertEqual(res['5'].dtype, np.uint16)
         self.assertEqual('1', res['5'].attrs['units'])
         self.assertEqual((2 * 10, 2048), res['20'].shape)
         self.assertEqual('counts', res['20'].attrs['calibration'])
+        self.assertEqual(res['20'].dtype, np.uint16)
         self.assertEqual('1', res['20'].attrs['units'])
         self.assertEqual((2 * 40, 2048 * 2), res['24'].shape)
         self.assertEqual('counts', res['24'].attrs['calibration'])
+        self.assertEqual(res['24'].dtype, np.uint16)
         self.assertEqual('1', res['24'].attrs['units'])
         self.assertEqual((2 * 40, 2048 * 2), res['25'].shape)
         self.assertEqual('counts', res['25'].attrs['calibration'])
+        self.assertEqual(res['25'].dtype, np.uint16)
         self.assertEqual('1', res['25'].attrs['units'])
 
     def test_fy3d_rad_calib(self):

--- a/satpy/tests/reader_tests/test_mersi2_l1b.py
+++ b/satpy/tests/reader_tests/test_mersi2_l1b.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Satpy developers
+#
+# This file is part of the satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# satpy is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for the 'mersi2_l1b' reader."""
+from satpy.tests.reader_tests.test_hdf5_utils import FakeHDF5FileHandler
+import sys
+import numpy as np
+import dask.array as da
+import xarray as xr
+import os
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+class FakeHDF5FileHandler2(FakeHDF5FileHandler):
+    """Swap-in HDF5 File Handler."""
+
+    def make_test_data(self, dims):
+        return xr.DataArray(da.from_array(np.ones([dim for dim in dims], dtype=np.float32) * 10, [dim for dim in dims]))
+
+    def _get_calibration(self, num_scans, rows_per_scan):
+        calibration = {
+            'Calibration/VIS_Cal_Coeff':
+                xr.DataArray(
+                    da.ones((19, 3), chunks=1024),
+                    attrs={'Slope': [1.] * 19, 'Intercept': [0.] * 19},
+                    dims=('_bands', '_coeffs')),
+            'Calibration/IR_Cal_Coeff':
+                xr.DataArray(
+                    da.ones((6, 4, num_scans), chunks=1024),
+                    attrs={'Slope': [1.] * 6, 'Intercept': [0.] * 6},
+                    dims=('_bands', '_coeffs', '_scans')),
+        }
+        return calibration
+
+    def _get_1km_data(self, num_scans, rows_per_scan, num_cols):
+        data = {
+            'Data/EV_1KM_RefSB':
+                xr.DataArray(
+                    da.ones((15, num_scans * rows_per_scan, num_cols), chunks=1024),
+                    attrs={
+                        'Slope': [1.] * 15, 'Intercept': [0.] * 15,
+                        'units': 'NO',
+                        'valid_range': [0, 4095],
+                        'long_name': b'1km Earth View Science Data',
+                    },
+                    dims=('_ref_bands', '_rows', '_cols')),
+            'Data/EV_1KM_Emissive':
+                xr.DataArray(
+                    da.ones((4, num_scans * rows_per_scan, num_cols), chunks=1024),
+                    attrs={
+                        'Slope': [1.] * 4, 'Intercept': [0.] * 4,
+                        'units': 'mW/ (m2 cm-1 sr)',
+                        'valid_range': [0, 25000],
+                        'long_name': b'1km Emissive Bands Earth View '
+                                     b'Science Data',
+                    },
+                    dims=('_ir_bands', '_rows', '_cols')),
+            'Data/EV_250_Aggr.1KM_RefSB':
+                xr.DataArray(
+                    da.ones((4, num_scans * rows_per_scan, num_cols), chunks=1024),
+                    attrs={
+                        'Slope': [1.] * 4, 'Intercept': [0.] * 4,
+                        'units': 'NO',
+                        'valid_range': [0, 4095],
+                        'long_name': b'250m Reflective Bands Earth View '
+                                     b'Science Data Aggregated to 1 km'
+                    },
+                    dims=('_ref250_bands', '_rows', '_cols')),
+            'Data/EV_250_Aggr.1KM_Emissive':
+                xr.DataArray(
+                    da.ones((2, num_scans * rows_per_scan, num_cols), chunks=1024),
+                    attrs={
+                        'Slope': [1.] * 2, 'Intercept': [0.] * 2,
+                        'units': 'mW/ (m2 cm-1 sr)',
+                        'valid_range': [0, 4095],
+                        'long_name': b'250m Emissive Bands Earth View '
+                                     b'Science Data Aggregated to 1 km'
+                    },
+                    dims=('_ir250_bands', '_rows', '_cols')),
+        }
+        return data
+
+    def _get_250m_data(self, num_scans, rows_per_scan, num_cols):
+        data = {
+            'Data/EV_250_RefSB_b1':
+                xr.DataArray(
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    attrs={
+                        'Slope': [1.] * 1, 'Intercept': [0.] * 1,
+                        'units': 'NO',
+                        'valid_range': [0, 4095],
+                    },
+                    dims=('_rows', '_cols')),
+            'Data/EV_250_RefSB_b2':
+                xr.DataArray(
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    attrs={
+                        'Slope': [1.] * 1, 'Intercept': [0.] * 1,
+                        'units': 'NO',
+                        'valid_range': [0, 4095],
+                    },
+                    dims=('_rows', '_cols')),
+            'Data/EV_250_RefSB_b3':
+                xr.DataArray(
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    attrs={
+                        'Slope': [1.] * 1, 'Intercept': [0.] * 1,
+                        'units': 'NO',
+                        'valid_range': [0, 4095],
+                    },
+                    dims=('_rows', '_cols')),
+            'Data/EV_250_RefSB_b4':
+                xr.DataArray(
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    attrs={
+                        'Slope': [1.] * 1, 'Intercept': [0.] * 1,
+                        'units': 'NO',
+                        'valid_range': [0, 4095],
+                    },
+                    dims=('_rows', '_cols')),
+            'Data/EV_250_Emissive_b24':
+                xr.DataArray(
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    attrs={
+                        'Slope': [1.] * 1, 'Intercept': [0.] * 1,
+                        'units': 'mW/ (m2 cm-1 sr)',
+                        'valid_range': [0, 4095],
+                    },
+                    dims=('_rows', '_cols')),
+            'Data/EV_250_Emissive_b25':
+                xr.DataArray(
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    attrs={
+                        'Slope': [1.] * 1, 'Intercept': [0.] * 1,
+                        'units': 'mW/ (m2 cm-1 sr)',
+                        'valid_range': [0, 4095],
+                    },
+                    dims=('_rows', '_cols')),
+        }
+        return data
+
+    def _get_geo_data(self, num_scans, rows_per_scan, num_cols, prefix='Geolocation/'):
+        geo = {
+            prefix + 'Longitude':
+                xr.DataArray(
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    attrs={
+                        'Slope': [1.] * 1, 'Intercept': [0.] * 1,
+                        'units': 'degree',
+                        'valid_range': [-90, 90],
+                    },
+                    dims=('_rows', '_cols')),
+            prefix + 'Latitude':
+                xr.DataArray(
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    attrs={
+                        'Slope': [1.] * 1, 'Intercept': [0.] * 1,
+                        'units': 'degree',
+                        'valid_range': [-180, 180],
+                    },
+                    dims=('_rows', '_cols')),
+        }
+        return geo
+
+    def get_test_content(self, filename, filename_info, filetype_info):
+        """Mimic reader input file content."""
+        rows_per_scan = self.filetype_info.get('rows_per_scan', 10)
+        num_scans = 2
+        num_cols = 2048
+        global_attrs = {
+            '/attr/Observing Beginning Date': '2019-01-01',
+            '/attr/Observing Ending Date': '2019-01-01',
+            '/attr/Observing Beginning Time': '18:27:39.720',
+            '/attr/Observing Ending Time': '18:38:36.728',
+            '/attr/Satellite Name': 'FY-3D',
+            '/attr/Sensor Identification Code': 'MERSI',
+        }
+
+        data = {}
+        if self.filetype_info['file_type'] == 'mersi2_l1b_1000':
+            data = self._get_1km_data(num_scans, rows_per_scan, num_cols)
+            global_attrs['/attr/TBB_Trans_Coefficient_A'] = [1.0] * 6
+            global_attrs['/attr/TBB_Trans_Coefficient_B'] = [0.0] * 6
+        elif self.filetype_info['file_type'] == 'mersi2_l1b_250':
+            data = self._get_250m_data(num_scans, rows_per_scan, num_cols * 2)
+            global_attrs['/attr/TBB_Trans_Coefficient_A'] = [0.0] * 6
+            global_attrs['/attr/TBB_Trans_Coefficient_B'] = [0.0] * 6
+        elif self.filetype_info['file_type'] == 'mersi2_l1b_1000_geo':
+            data = self._get_geo_data(num_scans, rows_per_scan, num_cols)
+        elif self.filetype_info['file_type'] == 'mersi2_l1b_250_geo':
+            data = self._get_geo_data(num_scans, rows_per_scan, num_cols * 2,
+                                      prefix='')
+
+        test_content = {}
+        test_content.update(global_attrs)
+        test_content.update(data)
+        test_content.update(self._get_calibration(num_scans, rows_per_scan))
+        return test_content
+
+
+class TestMERSI2L1BReader(unittest.TestCase):
+    """Test MERSI2 L1B Reader."""
+    yaml_file = "mersi2_l1b.yaml"
+
+    def setUp(self):
+        """Wrap HDF5 file handler with our own fake handler."""
+        from satpy.readers.mersi2_l1b import MERSI2L1B
+        from satpy.config import config_search_paths
+        self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
+        # http://stackoverflow.com/questions/12219967/how-to-mock-a-base-class-with-python-mock-library
+        self.p = mock.patch.object(MERSI2L1B, '__bases__', (FakeHDF5FileHandler2,))
+        self.fake_handler = self.p.start()
+        self.p.is_local = True
+
+    def tearDown(self):
+        """Stop wrapping the HDF5 file handler."""
+        self.p.stop()
+
+    def test_fy3d_all_resolutions(self):
+        """Test loading data when all resolutions are available."""
+        from satpy import DatasetID
+        from satpy.readers import load_reader, get_key
+        filenames = [
+            'tf2019071182739.FY3D-X_MERSI_0250M_L1B.HDF',
+            'tf2019071182739.FY3D-X_MERSI_1000M_L1B.HDF',
+            'tf2019071182739.FY3D-X_MERSI_GEO1K_L1B.HDF',
+            'tf2019071182739.FY3D-X_MERSI_GEOQK_L1B.HDF',
+        ]
+        reader = load_reader(self.reader_configs)
+        files = reader.select_files_from_pathnames(filenames)
+        self.assertTrue(4, len(files))
+        reader.create_filehandlers(files)
+        # Make sure we have some files
+        self.assertTrue(reader.file_handlers)
+
+        # Verify that we have multiple resolutions for:
+        #     - Bands 1-4 (visible)
+        #     - Bands 24-25 (IR)
+        available_datasets = reader.available_dataset_ids
+        for band_name in ('1', '2', '3', '4', '24', '25'):
+            if band_name in ('24', '25'):
+                # don't know how to get radiance for IR bands
+                num_results = 2
+            else:
+                num_results = 3
+            ds_id = DatasetID(name=band_name, resolution=250)
+            res = get_key(ds_id, available_datasets,
+                          num_results=num_results, best=False)
+            self.assertEqual(num_results, len(res))
+            ds_id = DatasetID(name=band_name, resolution=1000)
+            res = get_key(ds_id, available_datasets,
+                          num_results=num_results, best=False)
+            self.assertEqual(num_results, len(res))
+
+        res = reader.load(['1', '2', '3', '4', '5', '20', '24', '25'])
+        self.assertEqual(8, len(res))
+        self.assertEqual((2 * 40, 2048 * 2), res['1'].shape)
+        self.assertEqual('reflectance', res['1'].attrs['calibration'])
+        self.assertEqual('%', res['1'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['2'].shape)
+        self.assertEqual('reflectance', res['2'].attrs['calibration'])
+        self.assertEqual('%', res['2'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['3'].shape)
+        self.assertEqual('reflectance', res['3'].attrs['calibration'])
+        self.assertEqual('%', res['3'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['4'].shape)
+        self.assertEqual('reflectance', res['4'].attrs['calibration'])
+        self.assertEqual('%', res['4'].attrs['units'])
+        self.assertEqual((2 * 10, 2048), res['5'].shape)
+        self.assertEqual('reflectance', res['5'].attrs['calibration'])
+        self.assertEqual('%', res['5'].attrs['units'])
+        self.assertEqual((2 * 10, 2048), res['20'].shape)
+        self.assertEqual('brightness_temperature', res['20'].attrs['calibration'])
+        self.assertEqual('K', res['20'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['24'].shape)
+        self.assertEqual('brightness_temperature', res['24'].attrs['calibration'])
+        self.assertEqual('K', res['24'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['25'].shape)
+        self.assertEqual('brightness_temperature', res['25'].attrs['calibration'])
+        self.assertEqual('K', res['25'].attrs['units'])
+
+    def test_fy3d_counts_calib(self):
+        """Test loading data at counts calibration."""
+        from satpy import DatasetID
+        from satpy.readers import load_reader
+        filenames = [
+            'tf2019071182739.FY3D-X_MERSI_0250M_L1B.HDF',
+            'tf2019071182739.FY3D-X_MERSI_1000M_L1B.HDF',
+            'tf2019071182739.FY3D-X_MERSI_GEO1K_L1B.HDF',
+            'tf2019071182739.FY3D-X_MERSI_GEOQK_L1B.HDF',
+        ]
+        reader = load_reader(self.reader_configs)
+        files = reader.select_files_from_pathnames(filenames)
+        self.assertTrue(4, len(files))
+        reader.create_filehandlers(files)
+        # Make sure we have some files
+        self.assertTrue(reader.file_handlers)
+
+        ds_ids = []
+        for band_name in ['1', '2', '3', '4', '5', '20', '24', '25']:
+            ds_ids.append(DatasetID(name=band_name, calibration='counts'))
+        res = reader.load(ds_ids)
+        self.assertEqual(8, len(res))
+        self.assertEqual((2 * 40, 2048 * 2), res['1'].shape)
+        self.assertEqual('counts', res['1'].attrs['calibration'])
+        self.assertEqual('1', res['1'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['2'].shape)
+        self.assertEqual('counts', res['2'].attrs['calibration'])
+        self.assertEqual('1', res['2'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['3'].shape)
+        self.assertEqual('counts', res['3'].attrs['calibration'])
+        self.assertEqual('1', res['3'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['4'].shape)
+        self.assertEqual('counts', res['4'].attrs['calibration'])
+        self.assertEqual('1', res['4'].attrs['units'])
+        self.assertEqual((2 * 10, 2048), res['5'].shape)
+        self.assertEqual('counts', res['5'].attrs['calibration'])
+        self.assertEqual('1', res['5'].attrs['units'])
+        self.assertEqual((2 * 10, 2048), res['20'].shape)
+        self.assertEqual('counts', res['20'].attrs['calibration'])
+        self.assertEqual('1', res['20'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['24'].shape)
+        self.assertEqual('counts', res['24'].attrs['calibration'])
+        self.assertEqual('1', res['24'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['25'].shape)
+        self.assertEqual('counts', res['25'].attrs['calibration'])
+        self.assertEqual('1', res['25'].attrs['units'])
+
+    def test_fy3d_rad_calib(self):
+        """Test loading data at radiance calibration."""
+        from satpy import DatasetID
+        from satpy.readers import load_reader
+        filenames = [
+            'tf2019071182739.FY3D-X_MERSI_0250M_L1B.HDF',
+            'tf2019071182739.FY3D-X_MERSI_1000M_L1B.HDF',
+            'tf2019071182739.FY3D-X_MERSI_GEO1K_L1B.HDF',
+            'tf2019071182739.FY3D-X_MERSI_GEOQK_L1B.HDF',
+        ]
+        reader = load_reader(self.reader_configs)
+        files = reader.select_files_from_pathnames(filenames)
+        self.assertTrue(4, len(files))
+        reader.create_filehandlers(files)
+        # Make sure we have some files
+        self.assertTrue(reader.file_handlers)
+
+        ds_ids = []
+        for band_name in ['1', '2', '3', '4', '5']:
+            ds_ids.append(DatasetID(name=band_name, calibration='radiance'))
+        res = reader.load(ds_ids)
+        self.assertEqual(5, len(res))
+        self.assertEqual((2 * 40, 2048 * 2), res['1'].shape)
+        self.assertEqual('radiance', res['1'].attrs['calibration'])
+        self.assertEqual('mW/ (m2 cm-1 sr)', res['1'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['2'].shape)
+        self.assertEqual('radiance', res['2'].attrs['calibration'])
+        self.assertEqual('mW/ (m2 cm-1 sr)', res['2'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['3'].shape)
+        self.assertEqual('radiance', res['3'].attrs['calibration'])
+        self.assertEqual('mW/ (m2 cm-1 sr)', res['3'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['4'].shape)
+        self.assertEqual('radiance', res['4'].attrs['calibration'])
+        self.assertEqual('mW/ (m2 cm-1 sr)', res['4'].attrs['units'])
+        self.assertEqual((2 * 10, 2048), res['5'].shape)
+        self.assertEqual('radiance', res['5'].attrs['calibration'])
+        self.assertEqual('mW/ (m2 cm-1 sr)', res['5'].attrs['units'])
+
+    def test_fy3d_1km_resolutions(self):
+        """Test loading data when only 1km resolutions are available."""
+        from satpy import DatasetID
+        from satpy.readers import load_reader, get_key
+        filenames = [
+            'tf2019071182739.FY3D-X_MERSI_1000M_L1B.HDF',
+            'tf2019071182739.FY3D-X_MERSI_GEO1K_L1B.HDF',
+        ]
+        reader = load_reader(self.reader_configs)
+        files = reader.select_files_from_pathnames(filenames)
+        self.assertTrue(4, len(files))
+        reader.create_filehandlers(files)
+        # Make sure we have some files
+        self.assertTrue(reader.file_handlers)
+
+        # Verify that we have multiple resolutions for:
+        #     - Bands 1-4 (visible)
+        #     - Bands 24-25 (IR)
+        available_datasets = reader.available_dataset_ids
+        for band_name in ('1', '2', '3', '4', '24', '25'):
+            if band_name in ('24', '25'):
+                # don't know how to get radiance for IR bands
+                num_results = 2
+            else:
+                num_results = 3
+            ds_id = DatasetID(name=band_name, resolution=250)
+            res = get_key(ds_id, available_datasets,
+                          num_results=num_results, best=False)
+            self.assertEqual(0, len(res))
+            ds_id = DatasetID(name=band_name, resolution=1000)
+            res = get_key(ds_id, available_datasets,
+                          num_results=num_results, best=False)
+            self.assertEqual(num_results, len(res))
+
+        res = reader.load(['1', '2', '3', '4', '5', '20', '24', '25'])
+        self.assertEqual(8, len(res))
+        self.assertEqual((2 * 10, 2048), res['1'].shape)
+        self.assertEqual('reflectance', res['1'].attrs['calibration'])
+        self.assertEqual('%', res['1'].attrs['units'])
+        self.assertEqual((2 * 10, 2048), res['2'].shape)
+        self.assertEqual('reflectance', res['2'].attrs['calibration'])
+        self.assertEqual('%', res['2'].attrs['units'])
+        self.assertEqual((2 * 10, 2048), res['3'].shape)
+        self.assertEqual('reflectance', res['3'].attrs['calibration'])
+        self.assertEqual('%', res['3'].attrs['units'])
+        self.assertEqual((2 * 10, 2048), res['4'].shape)
+        self.assertEqual('reflectance', res['4'].attrs['calibration'])
+        self.assertEqual('%', res['4'].attrs['units'])
+        self.assertEqual((2 * 10, 2048), res['5'].shape)
+        self.assertEqual('reflectance', res['5'].attrs['calibration'])
+        self.assertEqual('%', res['5'].attrs['units'])
+        self.assertEqual((2 * 10, 2048), res['20'].shape)
+        self.assertEqual('brightness_temperature', res['20'].attrs['calibration'])
+        self.assertEqual('K', res['20'].attrs['units'])
+        self.assertEqual((2 * 10, 2048), res['24'].shape)
+        self.assertEqual('brightness_temperature', res['24'].attrs['calibration'])
+        self.assertEqual('K', res['24'].attrs['units'])
+        self.assertEqual((2 * 10, 2048), res['25'].shape)
+        self.assertEqual('brightness_temperature', res['25'].attrs['calibration'])
+        self.assertEqual('K', res['25'].attrs['units'])
+
+    def test_fy3d_250_resolutions(self):
+        """Test loading data when only 250m resolutions are available."""
+        from satpy import DatasetID
+        from satpy.readers import load_reader, get_key
+        filenames = [
+            'tf2019071182739.FY3D-X_MERSI_0250M_L1B.HDF',
+            'tf2019071182739.FY3D-X_MERSI_GEOQK_L1B.HDF',
+        ]
+        reader = load_reader(self.reader_configs)
+        files = reader.select_files_from_pathnames(filenames)
+        self.assertTrue(4, len(files))
+        reader.create_filehandlers(files)
+        # Make sure we have some files
+        self.assertTrue(reader.file_handlers)
+
+        # Verify that we have multiple resolutions for:
+        #     - Bands 1-4 (visible)
+        #     - Bands 24-25 (IR)
+        available_datasets = reader.available_dataset_ids
+        for band_name in ('1', '2', '3', '4', '24', '25'):
+            if band_name in ('24', '25'):
+                # don't know how to get radiance for IR bands
+                num_results = 2
+            else:
+                num_results = 3
+            ds_id = DatasetID(name=band_name, resolution=250)
+            res = get_key(ds_id, available_datasets,
+                          num_results=num_results, best=False)
+            self.assertEqual(num_results, len(res))
+            ds_id = DatasetID(name=band_name, resolution=1000)
+            res = get_key(ds_id, available_datasets,
+                          num_results=num_results, best=False)
+            self.assertEqual(0, len(res))
+
+        res = reader.load(['1', '2', '3', '4', '5', '20', '24', '25'])
+        self.assertEqual(6, len(res))
+        self.assertRaises(KeyError, res.__getitem__, '5')
+        self.assertRaises(KeyError, res.__getitem__, '20')
+        self.assertEqual((2 * 40, 2048 * 2), res['1'].shape)
+        self.assertEqual('reflectance', res['1'].attrs['calibration'])
+        self.assertEqual('%', res['1'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['2'].shape)
+        self.assertEqual('reflectance', res['2'].attrs['calibration'])
+        self.assertEqual('%', res['2'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['3'].shape)
+        self.assertEqual('reflectance', res['3'].attrs['calibration'])
+        self.assertEqual('%', res['3'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['4'].shape)
+        self.assertEqual('reflectance', res['4'].attrs['calibration'])
+        self.assertEqual('%', res['4'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['24'].shape)
+        self.assertEqual('brightness_temperature', res['24'].attrs['calibration'])
+        self.assertEqual('K', res['24'].attrs['units'])
+        self.assertEqual((2 * 40, 2048 * 2), res['25'].shape)
+        self.assertEqual('brightness_temperature', res['25'].attrs['calibration'])
+        self.assertEqual('K', res['25'].attrs['units'])
+
+
+def suite():
+    """The test suite for test_virr_l1b."""
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(TestMERSI2L1BReader))
+    return mysuite

--- a/satpy/tests/reader_tests/test_virr_l1b.py
+++ b/satpy/tests/reader_tests/test_virr_l1b.py
@@ -109,14 +109,13 @@ class TestVIRRL1BReader(unittest.TestCase):
         self.p.stop()
 
     def _band_helper(self, attributes, units, calibration, standard_name,
-                     file_type, band_index_size, resolution, level):
+                     file_type, band_index_size, resolution):
         self.assertEqual(units, attributes['units'])
         self.assertEqual(calibration, attributes['calibration'])
         self.assertEqual(standard_name, attributes['standard_name'])
         self.assertEqual(file_type, attributes['file_type'])
         self.assertTrue(attributes['band_index'] in range(band_index_size))
         self.assertEqual(resolution, attributes['resolution'])
-        self.assertEqual(level, attributes['level'])
         self.assertEqual(('longitude', 'latitude'), attributes['coordinates'])
 
     def _fy3_helper(self, platform_name, reader, Emissive_units):
@@ -136,11 +135,12 @@ class TestVIRRL1BReader(unittest.TestCase):
             self.assertEqual((19, 20), datasets[dataset.name].shape)
             self.assertEqual(('y', 'x'), datasets[dataset.name].dims)
             if 'R' in dataset.name:
-                self._band_helper(attributes, '%', 'reflectance', 'toa_bidirectional_reflectance', 'virr_l1b', 7, 1000,
-                                  1)
+                self._band_helper(attributes, '%', 'reflectance',
+                                  'toa_bidirectional_reflectance', 'virr_l1b',
+                                  7, 1000)
             elif 'E' in dataset.name:
                 self._band_helper(attributes, Emissive_units, 'brightness_temperature',
-                                  'toa_brightness_temperature', 'virr_l1b', 3, 1000, 1)
+                                  'toa_brightness_temperature', 'virr_l1b', 3, 1000)
             elif dataset.name in ['longitude', 'latitude']:
                 self.assertEqual('degrees', attributes['units'])
                 self.assertTrue(attributes['standard_name'] in ['longitude', 'latitude'])


### PR DESCRIPTION
This PR adds a reader for the MERSI-2 L1B data format which are HDF5 files. This PR also includes some clean up of the VIRR reader (removing the "level" from the DatasetID).

## TODO

 - [x] Closes #706 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
