### PR TITLE
Add cloud_mask as a dataset for olci l2 data

### DIFF
--- a/satpy/etc/readers/olci_l2.yaml
+++ b/satpy/etc/readers/olci_l2.yaml
@@ -355,6 +355,14 @@ datasets:
     file_type: esa_l2_wqsf
     nc_key: WQSF
 
+  cloud_mask:
+    name: cloud_mask
+    sensor: olci
+    resolution: 300
+    coordinates: [longitude, latitude]
+    file_type: esa_l2_wqsf
+    nc_key: WQSF
+
   solar_zenith_angle:
     name: solar_zenith_angle
     sensor: olci

--- a/satpy/readers/olci_nc.py
+++ b/satpy/readers/olci_nc.py
@@ -42,29 +42,26 @@ PLATFORM_NAMES = {'S3A': 'Sentinel-3A',
 
 
 class BitFlags(object):
+    """Manipulate flags stored bitwise."""
 
-    """Manipulate flags stored bitwise.
-    """
-    flag_list = ['INVALID', 'WATER', 'LAND', 'CLOUD', 'SNOW_ICE',
-                 'INLAND_WATER', 'TIDAL', 'COSMETIC', 'SUSPECT',
-                 'HISOLZEN', 'SATURATED', 'MEGLINT', 'HIGHGLINT',
-                 'WHITECAPS', 'ADJAC', 'WV_FAIL', 'PAR_FAIL',
-                 'AC_FAIL', 'OC4ME_FAIL', 'OCNN_FAIL',
-                 'Extra_1',
-                 'KDM_FAIL',
-                 'Extra_2',
-                 'CLOUD_AMBIGUOUS', 'CLOUD_MARGIN', 'BPAC_ON', 'WHITE_SCATT',
-                 'LOWRW', 'HIGHRW']
+    def __init__(self, data, masks, meanings):
 
-    meaning = {f: i for i, f in enumerate(flag_list)}
-
-    def __init__(self, value):
-
-        self._value = value
+        self._data = data
+        self._masks = masks
+        self._meanings = meanings
+        self._map = dict(zip(meanings, masks))
 
     def __getitem__(self, item):
-        pos = self.meaning[item]
-        return ((self._value >> pos) % 2).astype(np.bool)
+        mask = self._map[item]
+        return np.bitwise_and(self._data, mask).astype(np.bool)
+
+    def match_all(self, items):
+        mask = reduce(np.bitwise_or, [self._map[item] for item in items])
+        return np.bitwise_and(self._data, mask) == mask
+
+    def match_any(self, items):
+        mask = reduce(np.bitwise_or, [self._map[item] for item in items])
+        return np.bitwise_and(self._data, mask).astype(np.bool)
 
 
 class NCOLCIBase(BaseFileHandler):
@@ -207,25 +204,24 @@ class NCOLCI2(NCOLCIChannelBase):
             dataset.attrs['_FillValue'] = 1
         elif key.name in ['mask', 'cloud_mask']:
             if key.name == 'cloud_mask':
-                mask = self.getbitmask(dataset.to_masked_array().data, items=["CLOUD"])
+                dataset = self.getbitmask(dataset, items=["CLOUD"])
             else:
-                mask = self.getbitmask(dataset.to_masked_array().data)
-            dataset = dataset * np.nan
-            dataset = dataset.where(~ mask, True)
+                dataset = self.getbitmask(dataset)
 
         dataset.attrs['platform_name'] = self.platform_name
         dataset.attrs['sensor'] = self.sensor
         dataset.attrs.update(key.to_dict())
         return dataset
 
-    def getbitmask(self, wqsf, items=[]):
+    def getbitmask(self, wqsf, items=None):
         """ """
-        if not any(items):
+        if items is None:
             items = ["INVALID", "SNOW_ICE", "INLAND_WATER", "SUSPECT",
                      "AC_FAIL", "CLOUD", "HISOLZEN", "OCNN_FAIL",
                      "CLOUD_MARGIN", "CLOUD_AMBIGUOUS", "LOWRW", "LAND"]
-        bflags = BitFlags(wqsf)
-        return reduce(np.logical_or, [bflags[item] for item in items])
+        bflags = BitFlags(wqsf, wqsf.attrs['flag_masks'],
+                          wqsf.attrs['flag_meanings'].split())
+        return bflags.match_any(items)
 
 
 class NCOLCIAngles(BaseFileHandler):

--- a/satpy/readers/olci_nc.py
+++ b/satpy/readers/olci_nc.py
@@ -205,8 +205,11 @@ class NCOLCI2(NCOLCIChannelBase):
 
         if key.name == 'wqsf':
             dataset.attrs['_FillValue'] = 1
-        elif key.name == 'mask':
-            mask = self.getbitmask(dataset.to_masked_array().data)
+        elif key.name in ['mask', 'cloud_mask']:
+            if key.name == 'cloud_mask':
+                mask = self.getbitmask(dataset.to_masked_array().data, items=["CLOUD"])
+            else:
+                mask = self.getbitmask(dataset.to_masked_array().data)
             dataset = dataset * np.nan
             dataset = dataset.where(~ mask, True)
 
@@ -217,9 +220,10 @@ class NCOLCI2(NCOLCIChannelBase):
 
     def getbitmask(self, wqsf, items=[]):
         """ """
-        items = ["INVALID", "SNOW_ICE", "INLAND_WATER", "SUSPECT",
-                 "AC_FAIL", "CLOUD", "HISOLZEN", "OCNN_FAIL",
-                 "CLOUD_MARGIN", "CLOUD_AMBIGUOUS", "LOWRW", "LAND"]
+        if not any(items):
+            items = ["INVALID", "SNOW_ICE", "INLAND_WATER", "SUSPECT",
+                     "AC_FAIL", "CLOUD", "HISOLZEN", "OCNN_FAIL",
+                     "CLOUD_MARGIN", "CLOUD_AMBIGUOUS", "LOWRW", "LAND"]
         bflags = BitFlags(wqsf)
         return reduce(np.logical_or, [bflags[item] for item in items])
 


### PR DESCRIPTION
This PR modifies the olci_nc reader to allow the extraction of the builtin cloudmask from OLCI level 2 data.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
