### PR TITLE
Change from pygrib to cfgrib

### DIFF
--- a/satpy/readers/grib.py
+++ b/satpy/readers/grib.py
@@ -51,33 +51,12 @@ class GRIBFileHandler(BaseFileHandler):
 
     def __init__(self, filename, filename_info, filetype_info, *req_fh, **fh_kwargs):
         super(GRIBFileHandler, self).__init__(filename, filename_info, filetype_info)
-
-
         self._msg_datasets = {}
         self._start_time = None
         self._end_time = None
 
         try:
             #FIXME add indexpath='' to backend kwargs to disable creation of index file
-           # kwargs = [{'filter_by_keys': {'typeOfLevel': 'maxWind'}},
-                      #{'filter_by_keys': {'typeOfLevel': 'potentialVorticity'}},
-                #      {'filter_by_keys': {'typeOfLevel': 'unknown'}},
-                #    {'filter_by_keys': {'typeOfLevel': 'isobaricInhPa'}},
-                #    {'filter_by_keys':{'typeOfLevel': 'surface'}},
-                #    {'filter_by_keys':{'typeOfLevel': 'depthBelowLandLayer'}},
-                #    {'filter_by_keys':{'typeOfLevel': 'heightAboveGround'}},
-                #    {'filter_by_keys':{'typeOfLevel': 'tropopause'}},
-                #    {'filter_by_keys':{'typeOfLevel': 'maxWind'}},
-                #    {'filter_by_keys':{'typeOfLevel': 'heightAboveSea'}},
-                #    {'filter_by_keys':{'typeOfLevel': 'isothermZero'}},
-                #    {'filter_by_keys':{'typeOfLevel': 'pressureFromGroundLayer'}},
-                #    {'filter_by_keys':{'typeOfLevel': 'sigmaLayer'}},
-            #        {'filter_by_keys':{'typeOfLevel': 'sigma'}},
-                #    {'filter_by_keys':{'typeOfLevel': 'potentialVorticity'}},
-                #    {'filter_by_keys':{'typeOfLevel': 'nominalTop'}},
-                #    {'filter_by_keys':{'typeOfLevel': 'heightAboveGroundLayer'}},
-                #    {'filter_by_keys':{'typeOfLevel': 'meanSea'}}
-             #   ]
 
             fh_kwargs = fh_kwargs.get('backend_kwargs', {})
             grib_file = xr.open_dataset(filename, engine='cfgrib', backend_kwargs=fh_kwargs)
@@ -85,62 +64,12 @@ class GRIBFileHandler(BaseFileHandler):
             self._end_time = self._convert_datetime(grib_file.valid_time.values)
 
             self._analyze_messages(grib_file, fh_kwargs)
-
-
-#            grib_file = xr.open_dataset(filename, engine='cfgrib', backend_kwargs={'filter_by_keys': {'typeOfLevel': 'maxWind'}})
-#            #FIXME starting and ending time
-#            start_time = self._convert_datetime(grib_file.valid_time.values)
-#            end_time = self._convert_datetime(grib_file.valid_time.values)
-#            self._start_time = start_time
-#            self._end_time = end_time
-#
-#            self._analyze_messages(grib_file)
-#            self._idx = None
-#
-#            grib_file = xr.open_dataset(filename, engine='cfgrib', backend_kwargs={'filter_by_keys': {'typeOfLevel': 'potentialVorticity'}})
-#            #FIXME starting and ending time
-#            start_time = self._convert_datetime(grib_file.valid_time.values)
-#            end_time = self._convert_datetime(grib_file.valid_time.values)
-#            self._start_time = start_time
-#            self._end_time = end_time
-#
-#            self._analyze_messages(grib_file)
-#            self._idx = None
-
-      #      with pygrib.open(self.filename) as grib_file:
-      #          first_msg = grib_file.message(1)
-      #          last_msg = grib_file.message(grib_file.messages)
-      #          start_time = self._convert_datetime(
-      #              first_msg, 'validityDate', 'validityTime')
-      #          end_time = self._convert_datetime(
-      #              last_msg, 'validityDate', 'validityTime')
-      #          self._start_time = start_time
-      #          self._end_time = end_time
-      #          if 'keys' not in filetype_info:
-      #              self._analyze_messages(grib_file)
-      #              self._idx = None
-      #          else: #FIXME probably dont need this??
-      #              self._create_dataset_ids(filetype_info['keys'])
-      #              self._idx = pygrib.index(self.filename,
-      #                                       *filetype_info['keys'].keys())
         except KeyError:
             raise KeyError("Unknown argument in backend_kwargs: {}".format(fh_kwargs))
         except RuntimeError:
             raise IOError("Unknown GRIB file format: {}".format(self.filename))
 
     def _analyze_messages(self, grib_file, fh_kwargs):
-        # grib file is the xarray dataset
-
-
-        # go over all of the messages in the dataarray -> can't really iterate over things in the dataarray
-        # FLATTEN THE ARRAY
-        # each of the data variables in the grib file hold the actual messages (with the shortName and the level)
-        # level == typeOfLevel??
-
-        # since everything in cfgrib is already in a array, need to take everything in there and make it into a datasetID thing and store it
-
-        # all files
-        #grib_file = grib_file.stack(flat=tuple(a for a, b in grib_file.data_vars))
         for var in grib_file.data_vars.keys():
                 for val in grib_file[var]:
                     msg_id = DatasetID(name=val.attrs['GRIB_shortName'],
@@ -156,20 +85,6 @@ class GRIBFileHandler(BaseFileHandler):
 
                 self._msg_datasets[msg_id] = ds_info
 
-  #      grib_file.seek(0)
-  #      for idx, msg in enumerate(grib_file):
-  #          msg_id = DatasetID(name=msg['shortName'],
-  #                             level=msg['level'])
-  #          ds_info = {
-  #              # FIXME probably dont need the first one, but the others can stay
-  #              'message': idx + 1,
-  #              'name': msg['shortName'],
-  #              'level': msg['level'],
-  #              'file_type': self.filetype_info['file_type'],
-  #          }
-  #          self._msg_datasets[msg_id] = ds_info
-
-    #FIXME do i need this
     def _create_dataset_ids(self, keys):
         from itertools import product
         ordered_keys = [k for k in keys.keys() if 'id_key' in keys[k]]
@@ -185,17 +100,10 @@ class GRIBFileHandler(BaseFileHandler):
 
     @staticmethod
     def _convert_datetime(msg, format="%Y-%m-%d %H:%M:%S"):
-        #return (datetime.utcfromtimestamp(msg.astype('O')/1e9)).strptime(format)
         u = np.datetime64(0, 's')
         o = np.timedelta64(1, 's')
         s = (msg - u) / o
         return datetime.utcfromtimestamp(s)
-
-
-#    @staticmethod
-#    def _convert_datetime(msg, date_key, time_key, format="%Y%m%d%H%M"):
-#        date_str = "{:d}{:04d}".format(msg[date_key], msg[time_key])
-#        return datetime.strptime(date_str, format)
 
     @property
     def start_time(self):
@@ -219,52 +127,15 @@ class GRIBFileHandler(BaseFileHandler):
         """Automatically determine datasets provided by this file"""
         return self._msg_datasets.items()
 
-    # returns from the message location in the file
     def _get_message(self, ds_info):
-
-        #grib_file = xr.open_dataset(self.filename, engine='cfgrib', backend_kwargs={'filter_by_keys': {'typeOfLevel': 'surface'}})
-
-        # dsinfo has the "index" but probably doesnt matter??
-        # get the "index" from dsinfo
-        # use that info to be able to access the message
-        # use type of level to access
-        # use datavar to access one more level
-
-
-        #FIXME change to not having the typeOfLEvel stuff
-
         grib_file = xr.open_dataset(self.filename, engine='cfgrib', backend_kwargs=ds_info['fh_kwargs'])
         return grib_file[ds_info['name']]
 
-#        if 'message' in ds_info:
-#            msg_num = ds_info['index']
-#            msg = grib_file.message(msg_num)
-
-        #FIXME need this second part??
-       # else:
-       #     msg_keys = self.filetype_info['keys'].keys()
-       #     msg = self._idx(**{k: ds_info[k] for k in msg_keys})[0]
-        #return msg
-
-
-    #    with pygrib.open(self.filename) as grib_file:
-    #        if 'message' in ds_info:
-    #            msg_num = ds_info['message']
-    #            msg = grib_file.message(msg_num)
-    #        else:
-    #            msg_keys = self.filetype_info['keys'].keys()
-    #            msg = self._idx(**{k: ds_info[k] for k in msg_keys})[0]
-    #        return msg
 
     def _area_def_from_msg(self, msg):
-        # TODO find the projparams in the data array
-        # has to do with the radius/shapeOfTheEarth and the proj type can be found from the grid type
-        # update: probably don't need to worry about this?
-
         proj_params = {}
         lats = msg['latitude'].values
         lons = msg['longitude'].values
-        #FIXME need to include other types of grids and projections
         if msg.attrs['GRIB_gridType'] in ['regular_ll', 'regular_gg']:
             proj_params['proj'] = 'eqc'
             proj = Proj(**proj_params)
@@ -324,72 +195,6 @@ class GRIBFileHandler(BaseFileHandler):
         )
 
 
-#        proj_params = msg.projparams.copy()
-#        # correct for longitudes over 180
-#        for lon_param in ['lon_0', 'lon_1', 'lon_2']:
-#            if proj_params.get(lon_param, 0) > 180:
-#                proj_params[lon_param] -= 360
-#
-#        if proj_params['proj'] == 'cyl':
-#            proj_params['proj'] = 'eqc'
-#            proj = Proj(**proj_params)
-#            lons = msg['distinctLongitudes']
-#            lats = msg['distinctLatitudes']
-#            min_lon = lons[0]
-#            max_lon = lons[-1]
-#            min_lat = lats[0]
-#            max_lat = lats[-1]
-#            if min_lat > max_lat:
-#                # lats aren't in the order we thought they were, flip them
-#                # we also need to flip the data in the data loading section
-#                min_lat, max_lat = max_lat, min_lat
-#            shape = (lats.shape[0], lons.shape[0])
-#            min_x, min_y = proj(min_lon, min_lat)
-#            max_x, max_y = proj(max_lon, max_lat)
-#            if max_x < min_x and 'over' not in proj_params:
-#                # wrap around
-#                proj_params['over'] = True
-#                proj = Proj(**proj_params)
-#                max_x, max_y = proj(max_lon, max_lat)
-#            pixel_size_x = (max_x - min_x) / (shape[1] - 1)
-#            pixel_size_y = (max_y - min_y) / (shape[0] - 1)
-#            extents = (
-#                min_x - pixel_size_x / 2.,
-#                min_y - pixel_size_y / 2.,
-#                max_x + pixel_size_x / 2.,
-#                max_y + pixel_size_y / 2.,
-#            )
-#        else:
-#            lats, lons = msg.latlons()
-#            shape = lats.shape
-#            # take the corner points only
-#            lons = lons[([0, 0, -1, -1], [0, -1, 0, -1])]
-#            lats = lats[([0, 0, -1, -1], [0, -1, 0, -1])]
-#            # correct for longitudes over 180
-#            lons[lons > 180] -= 360
-#
-#            proj = Proj(**proj_params)
-#            x, y = proj(lons, lats)
-#            if msg.valid_key('jScansPositively') and msg['jScansPositively'] == 1:
-#                min_x, min_y = x[0], y[0]
-#                max_x, max_y = x[3], y[3]
-#            else:
-#                min_x, min_y = x[2], y[2]
-#                max_x, max_y = x[1], y[1]
-#            half_x = abs((max_x - min_x) / (shape[1] - 1)) / 2.
-#            half_y = abs((max_y - min_y) / (shape[0] - 1)) / 2.
-#            extents = (min_x - half_x, min_y - half_y, max_x + half_x, max_y + half_y)
-#
-#        return geometry.AreaDefinition(
-#            'on-the-fly grib area',
-#            'on-the-fly grib area',
-#            'on-the-fly grib area',
-#            proj_params,
-#            shape[1],
-#            shape[0],
-#            extents,
-#        )
-
     def get_area_def(self, dsid):
         """Get area definition for message.
 
@@ -409,56 +214,18 @@ class GRIBFileHandler(BaseFileHandler):
 
         ds_info.update({
             'filename': self.filename,
+            # FIXME some GRIB files don't have shortname attr
             'shortName': msg.attrs['GRIB_shortName'],
-            #'long_name': msg.attrs['long_name'],
-            #'pressureUnits': msg['pressureUnits'],
             'typeOfLevel': msg.attrs['GRIB_typeOfLevel'],
-            #'standard_name': msg.attrs['GRIB_cfName'],
             'units': msg.attrs['units'],
-           # 'modelName': msg['modelName'],
             'model_time': model_time,
             'valid_min': np.amin(msg.values),
             'valid_max': np.amax(msg.values),
             'start_time': start_time,
             'end_time': end_time,
-           # 'sensor': msg['modelName'],
-            # National Weather Prediction
             'platform_name': 'unknown'
         })
         return ds_info
-
-
-  #      # TIME coord is this
-  #      model_time = self._convert_datetime(msg, 'dataDate',
-  #                                          'dataTime')
-  #      # VALID_TIME coord is this
-  #      start_time = self._convert_datetime(msg, 'validityDate',
-  #                                          'validityTime')
-  #      end_time = start_time
-  #      try:
-  #          center_description = msg['centreDescription']
-  #      except (RuntimeError, KeyError):
-  #          center_description = None
-  #      ds_info.update({
-  #          'filename': self.filename,
-  #          'shortName': msg['shortName'],
-  #          'long_name': msg['name'],
-  #          'pressureUnits': msg['pressureUnits'],
-  #          'typeOfLevel': msg['typeOfLevel'],
-  #          'standard_name': msg['cfName'],
-  #          'units': msg['units'],
-  #          'modelName': msg['modelName'],
-  #          'model_time': model_time,
-  #          'centreDescription': center_description,
-  #          'valid_min': msg['minimum'],
-  #          'valid_max': msg['maximum'],
-  #          'start_time': start_time,
-  #          'end_time': end_time,
-  #          'sensor': msg['modelName'],
-  #          # National Weather Prediction
-  #          'platform_name': 'unknown',
-  #      })
-  #      return ds_info
 
     def get_dataset(self, dataset_id, ds_info):
         """Read a GRIB message into an xarray DataArray."""
@@ -479,19 +246,3 @@ class GRIBFileHandler(BaseFileHandler):
             data = da.from_array(data, chunks=CHUNK_SIZE)
 
         return xr.DataArray(data, attrs=ds_info, dims=('y', 'x'))
-
-  #      msg = self._get_message(ds_info)
-  #      ds_info = self.get_metadata(msg, ds_info)
-  #      fill = msg['missingValue']
-  #      data = msg.values.astype(np.float32)
-  #      if msg.valid_key('jScansPositively') and msg['jScansPositively'] == 1:
-  #          data = data[::-1]
-
-  #      if isinstance(data, np.ma.MaskedArray):
-  #          data = data.filled(np.nan)
-  #          data = da.from_array(data, chunks=CHUNK_SIZE)
-  #      else:
-  #          data[data == fill] = np.nan
-  #          data = da.from_array(data, chunks=CHUNK_SIZE)
-
-  #      return xr.DataArray(data, attrs=ds_info, dims=('y', 'x'))

--- a/satpy/readers/grib.py
+++ b/satpy/readers/grib.py
@@ -37,7 +37,6 @@ from datetime import datetime
 from satpy import DatasetID, CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
 import cfgrib
-#import pygrib
 
 LOG = logging.getLogger(__name__)
 
@@ -183,7 +182,6 @@ class GRIBFileHandler(BaseFileHandler):
             half_y = abs((max_y - min_y) / (shape[0] - 1)) / 2.
             extents = (min_x - half_x, min_y - half_y, max_x + half_x, max_y + half_y)
 
-        print(shape)
         return geometry.AreaDefinition(
             'on-the-fly grib area',
             'on-the-fly grib area',
@@ -233,7 +231,6 @@ class GRIBFileHandler(BaseFileHandler):
         ds_info = self.get_metadata(msg, ds_info)
         fill = msg.attrs['GRIB_missingValue']
         data = msg.values.astype(np.float32)
-        print(data)
         if msg.attrs.get('jScansPositively', -1) == 1:
             data = data[::1]
 

--- a/satpy/tests/reader_tests/test_grib.py
+++ b/satpy/tests/reader_tests/test_grib.py
@@ -29,7 +29,7 @@ class FakeGRIB(object):
 
         vals = np.arange(25.).reshape((5, 5))
         latlon_vals = np.arange(25, 30)
-        
+
         self.grib_file = xr.Dataset({'t': (['latitude', 'longitude'], vals),
                                     'u': (['latitude', 'longitude'], vals),
                                     'v': (['latitude', 'longitude'], vals)},
@@ -62,7 +62,7 @@ class FakeGRIB(object):
 
         vals = np.arange(50.).reshape((2, 5, 5))
         lvl_vals = [1, 2]
-    
+
         self.grib_file_nd = xr.Dataset({'t': (['potentialVorticity', 'latitude', 'longitude'], vals),
                                     'u': (['potentialVorticity', 'latitude', 'longitude'], vals),
                                     'v': (['potentialVorticity', 'latitude', 'longitude'], vals)},
@@ -94,7 +94,7 @@ class FakeGRIB(object):
         return self.grib_file_nd
     def get_data_irr(self):
         return self.grib_file_irr
-    
+
 
 class TestGRIBReader(unittest.TestCase):
     """Test GRIB Reader"""
@@ -128,7 +128,7 @@ class TestGRIBReader(unittest.TestCase):
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)
-        
+
     #@mock.patch('satpy.readers.grib.cfgrib')
     @mock.patch('satpy.readers.grib.xr.open_dataset')
     def test_load_all(self, xar):
@@ -164,7 +164,7 @@ class TestGRIBReader(unittest.TestCase):
             DatasetID(name='v', level=1),
             DatasetID(name='t', level=2),
             DatasetID(name='u', level=2),
-            DatasetID(name='v', level=2), 
+            DatasetID(name='v', level=2),
         ])
         # using 3d dataset, so by default should load by level
         self.assertEqual(len(datasets), 6)

--- a/satpy/tests/reader_tests/test_grib.py
+++ b/satpy/tests/reader_tests/test_grib.py
@@ -19,124 +19,82 @@ except ImportError:
     import mock
 
 
-class FakeMessage(object):
-    """Fake message returned by pygrib.open().message(x)."""
-
-    def __init__(self, values, proj_params=None, latlons=None, **attrs):
-        super(FakeMessage, self).__init__()
-        self.attrs = attrs
-        self.values = values
-        if proj_params is None:
-            proj_params = {'a': 6371229, 'b': 6371229, 'proj': 'cyl'}
-        self.projparams = proj_params
-        self._latlons = latlons
-
-    def latlons(self):
-        return self._latlons
-
-    def __getitem__(self, item):
-        return self.attrs[item]
-
-    def valid_key(self, key):
-        return True
-
-
 class FakeGRIB(object):
-    """Fake GRIB file returned by pygrib.open."""
-
-    def __init__(self, messages=None, proj_params=None, latlons=None):
+    """Fake GRIB file returned from xr.open_dataset."""
+    def __init__(self, messages=None, proj_params=None):
         super(FakeGRIB, self).__init__()
-        if messages is not None:
-            self._messages = messages
-        else:
-            self._messages = [
-                FakeMessage(
-                    values=np.arange(25.).reshape((5, 5)),
-                    name='TEST',
-                    shortName='t',
-                    level=100,
-                    pressureUnits='hPa',
-                    cfName='air_temperature',
-                    units='K',
-                    dataDate=20180504,
-                    dataTime=1200,
-                    validityDate=20180504,
-                    validityTime=1800,
-                    distinctLongitudes=np.arange(5.),
-                    distinctLatitudes=np.arange(5.),
-                    missingValue=9999,
-                    modelName='unknown',
-                    minimum=100.,
-                    maximum=200.,
-                    typeOfLevel='isobaricInhPa',
-                    jScansPositively=0,
-                    proj_params=proj_params,
-                    latlons=latlons,
-                ),
-                FakeMessage(
-                    values=np.arange(25.).reshape((5, 5)),
-                    name='TEST',
-                    shortName='t',
-                    level=200,
-                    pressureUnits='hPa',
-                    cfName='air_temperature',
-                    units='K',
-                    dataDate=20180504,
-                    dataTime=1200,
-                    validityDate=20180504,
-                    validityTime=1800,
-                    distinctLongitudes=np.arange(5.),
-                    distinctLatitudes=np.arange(5.),
-                    missingValue=9999,
-                    modelName='unknown',
-                    minimum=100.,
-                    maximum=200.,
-                    typeOfLevel='isobaricInhPa',
-                    jScansPositively=0,
-                    proj_params=proj_params,
-                    latlons=latlons,
-                ),
-                FakeMessage(
-                    values=np.arange(25.).reshape((5, 5)),
-                    name='TEST',
-                    shortName='t',
-                    level=300,
-                    pressureUnits='hPa',
-                    cfName='air_temperature',
-                    units='K',
-                    dataDate=20180504,
-                    dataTime=1200,
-                    validityDate=20180504,
-                    validityTime=1800,
-                    distinctLongitudes=np.arange(5.),
-                    distinctLatitudes=np.arange(5.),
-                    missingValue=9999,
-                    modelName='unknown',
-                    minimum=100.,
-                    maximum=200.,
-                    typeOfLevel='isobaricInhPa',
-                    jScansPositively=0,
-                    proj_params=proj_params,
-                    latlons=latlons,
-                ),
-            ]
-        self.messages = len(self._messages)
 
-    def message(self, msg_num):
-        return self._messages[msg_num - 1]
+        self.grib_file = None
+        self.grib_file_nd = None
 
-    def seek(self, loc):
-        return
+        vals = np.arange(25.).reshape((5, 5))
+        latlon_vals = np.arange(25, 30)
+        
+        self.grib_file = xr.Dataset({'t': (['latitude', 'longitude'], vals),
+                                    'u': (['latitude', 'longitude'], vals),
+                                    'v': (['latitude', 'longitude'], vals)},
+                                    coords={'latitude': (['latitude'], latlon_vals),
+                                            'longitude': (['longitude'], latlon_vals),
+                                            'time': np.datetime64('2018-07-22T00:00:00'),
+                                            'valid_time': np.datetime64('2018-07-22T06:00:00')},
+                                    attrs={'GRIB_edition': 2, 'GRIB_centre': 'kwbc',
+                                           'Conventions': 'CF-1.7', 'GRIB_centreDescription': 'NCEP'})
 
-    def __iter__(self):
-        return iter(self._messages)
+        self.grib_file_irr = self.grib_file.copy(deep=True)
+
+        for dsvars in self.grib_file.data_vars:
+            dsvar = self.grib_file.data_vars[dsvars]
+            dsvar.attrs['GRIB_shortName'] = dsvars
+            dsvar.attrs['GRIB_typeOfLevel'] = 'maxWind'
+            dsvar.attrs['jScansPositively'] = 0
+            dsvar.attrs['GRIB_gridType'] = 'regular_ll'
+            dsvar.attrs['GRIB_missingValue'] = 9999
+            dsvar.attrs['units'] = 'K'
+
+        for dsvars in self.grib_file_irr.data_vars:
+            dsvar = self.grib_file_irr.data_vars[dsvars]
+            dsvar.attrs['GRIB_shortName'] = dsvars
+            dsvar.attrs['GRIB_typeOfLevel'] = 'maxWind'
+            dsvar.attrs['jScansPositively'] = 0
+            dsvar.attrs['GRIB_gridType'] = 'irregular_ll'
+            dsvar.attrs['GRIB_missingValue'] = 9999
+            dsvar.attrs['units'] = 'K'
+
+        vals = np.arange(50.).reshape((2, 5, 5))
+        lvl_vals = [1, 2]
+    
+        self.grib_file_nd = xr.Dataset({'t': (['potentialVorticity', 'latitude', 'longitude'], vals),
+                                    'u': (['potentialVorticity', 'latitude', 'longitude'], vals),
+                                    'v': (['potentialVorticity', 'latitude', 'longitude'], vals)},
+                                    coords={'latitude': (['latitude'], latlon_vals),
+                                            'longitude': (['longitude'], latlon_vals),
+                                            'potentialVorticity': (['potentialVorticity'], lvl_vals),
+                                            'time': np.datetime64('2018-07-22T00:00:00'),
+                                            'valid_time': np.datetime64('2018-07-22T06:00:00')},
+                                    attrs={'GRIB_edition': 2, 'GRIB_centre': 'kwbc',
+                                           'Conventions': 'CF-1.7', 'GRIB_centreDescription': 'NCEP'})
+
+        for dsvars in self.grib_file_nd.data_vars:
+            dsvar = self.grib_file_nd.data_vars[dsvars]
+            dsvar.attrs['GRIB_shortName'] = dsvars
+            dsvar.attrs['GRIB_typeOfLevel'] = 'potentialVorticity'
+            dsvar.attrs['jScansPositively'] = 0
+            dsvar.attrs['GRIB_gridType'] = 'regular_ll'
+            dsvar.attrs['GRIB_missingValue'] = 9999
+            dsvar.attrs['units'] = 'K'
+
 
     def __enter__(self):
         return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self):
         pass
-
+    def get_data(self):
+        return self.grib_file
+    def get_data_nd(self):
+        return self.grib_file_nd
+    def get_data_irr(self):
+        return self.grib_file_irr
+    
 
 class TestGRIBReader(unittest.TestCase):
     """Test GRIB Reader"""
@@ -146,22 +104,21 @@ class TestGRIBReader(unittest.TestCase):
         """Wrap pygrib to read fake data"""
         from satpy.config import config_search_paths
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
-
         try:
-            import pygrib
+            import cfgrib
         except ImportError:
-            pygrib = None
-        self.orig_pygrib = pygrib
-        sys.modules['pygrib'] = mock.MagicMock()
+            cfgrib = None
+        self.orig_cfgrib = cfgrib
+        sys.modules['cfgrib'] = mock.MagicMock()
 
     def tearDown(self):
-        """Re-enable pygrib import."""
-        sys.modules['pygrib'] = self.orig_pygrib
+        """Re-enable cfgrib import."""
+        sys.modules['cfgrib'] = self.orig_cfgrib
 
-    @mock.patch('satpy.readers.grib.pygrib')
-    def test_init(self, pg):
+    @mock.patch('satpy.readers.grib.cfgrib')
+    def test_init(self, cf):
         """Test basic init with no extra parameters."""
-        pg.open.return_value = FakeGRIB()
+        cf.open_file.return_value = FakeGRIB()
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -171,11 +128,12 @@ class TestGRIBReader(unittest.TestCase):
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)
-
-    @mock.patch('satpy.readers.grib.pygrib')
-    def test_load_all(self, pg):
+        
+    #@mock.patch('satpy.readers.grib.cfgrib')
+    @mock.patch('satpy.readers.grib.xr.open_dataset')
+    def test_load_all(self, xar):
         """Test loading all test datasets"""
-        pg.open.return_value = FakeGRIB()
+        xar.return_value = FakeGRIB().get_data()
         from satpy.readers import load_reader
         from satpy import DatasetID
         r = load_reader(self.reader_configs)
@@ -183,36 +141,16 @@ class TestGRIBReader(unittest.TestCase):
             'gfs.t18z.sfluxgrbf106.grib2',
         ])
         r.create_filehandlers(loadables)
-        datasets = r.load([
-            DatasetID(name='t', level=100),
-            DatasetID(name='t', level=200),
-            DatasetID(name='t', level=300)])
+        datasets = r.load(['t', 'u', 'v'])
         self.assertEqual(len(datasets), 3)
         for v in datasets.values():
             self.assertEqual(v.attrs['units'], 'K')
             self.assertIsInstance(v, xr.DataArray)
 
-    @mock.patch('satpy.readers.grib.pygrib')
-    def test_load_all_lcc(self, pg):
-        """Test loading all test datasets with lcc projections"""
-        lons = np.array([
-            [12.19, 0, 0, 0, 14.34208538],
-            [0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0],
-            [54.56534318, 0, 0, 0, 57.32843565]])
-        lats = np.array([
-            [-133.459, 0, 0, 0, -65.12555139],
-            [0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0],
-            [0, 0, 0, 0, 0],
-            [-152.8786225, 0, 0, 0, -49.41598659]])
-        pg.open.return_value = FakeGRIB(
-            proj_params={
-                'a': 6371229, 'b': 6371229, 'proj': 'lcc',
-                'lon_0': 265.0, 'lat_0': 25.0,
-                'lat_1': 25.0, 'lat_2': 25.0},
-            latlons=(lats, lons))
+    @mock.patch('satpy.readers.grib.xr.open_dataset')
+    def test_load_all_by_level(self, xar):
+        """Test loading all test datasets with a multidimensional grib file"""
+        xar.return_value = FakeGRIB().get_data_nd()
         from satpy.readers import load_reader
         from satpy import DatasetID
         r = load_reader(self.reader_configs)
@@ -221,13 +159,60 @@ class TestGRIBReader(unittest.TestCase):
         ])
         r.create_filehandlers(loadables)
         datasets = r.load([
-            DatasetID(name='t', level=100),
-            DatasetID(name='t', level=200),
-            DatasetID(name='t', level=300)])
+            DatasetID(name='t', level=1),
+            DatasetID(name='u', level=1),
+            DatasetID(name='v', level=1),
+            DatasetID(name='t', level=2),
+            DatasetID(name='u', level=2),
+            DatasetID(name='v', level=2), 
+        ])
+        # using 3d dataset, so by default should load by level
+        self.assertEqual(len(datasets), 6)
+        for v in datasets.values():
+            self.assertEqual(v.attrs['units'], 'K')
+            self.assertIsInstance(v, xr.DataArray)
+
+    @mock.patch('satpy.readers.grib.xr.open_dataset')
+    def test_load_all_nd(self, xar):
+        """Test loading all test datasets with a multidimensional grib file"""
+        xar.return_value = FakeGRIB().get_data_nd()
+        from satpy.readers import load_reader
+        from satpy import DatasetID
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'gfs.t18z.sfluxgrbf106.grib2',
+        ])
+        r.create_filehandlers(loadables, fh_kwargs={'allow_nd': True})
+        datasets = r.load([
+            DatasetID(name='t', level=None),
+            DatasetID(name='u', level=None),
+            DatasetID(name='v', level=None),
+        ])
         self.assertEqual(len(datasets), 3)
         for v in datasets.values():
             self.assertEqual(v.attrs['units'], 'K')
             self.assertIsInstance(v, xr.DataArray)
+            self.assertEqual(len(v.dims), 3)
+
+#    @mock.patch('satpy.readers.grib.xr.open_dataset')
+#    def test_load_all_lcc(self, xar):
+#        """Test loading all test datasets with lcc projections"""
+#        xar.return_value = FakeGRIB().get_data_irr()
+#        from satpy.readers import load_reader
+#        from satpy import DatasetID
+#        r = load_reader(self.reader_configs)
+#        loadables = r.select_files_from_pathnames([
+#            'gfs.t18z.sfluxgrbf106.grib2',
+#        ])
+#        r.create_filehandlers(loadables)
+#        datasets = r.load([
+#            DatasetID(name='t', level=None),
+#            DatasetID(name='u', level=None),
+#            DatasetID(name='v', level=None)])
+#        self.assertEqual(len(datasets), 3)
+#        for v in datasets.values():
+#            self.assertEqual(v.attrs['units'], 'K')
+#            self.assertIsInstance(v, xr.DataArray)
 
 
 def suite():


### PR DESCRIPTION
This changes the grib reader to use cfgrib instead of pygrib.

In order to use it, the user must pass in the type of level they want to load to the reader keyword arguments in the following format:

`{'backend_kwargs': {'filter_by_keys': {'typeOfLevel': <level>}}}`

Currently, it works with simple grib files and partially with heterogenous files. It can load grib messages per level (default) or load it all as a multidimensional array. For the latter, the user must pass the `allow_nd` reader keyword argument as true.

Things that still need to be worked on:
- loading all messages from any generic grib file
- getting proj params (it currently only supports eqc)
- this potentially might not be loading all of the messages in a grib file, but that needs more testing

Related cfgrib issues:
[Programmatically loading all messages](https://github.com/ecmwf/cfgrib/issues/73)
[Not all variables can be extracted w/ filter_by_keys](https://github.com/ecmwf/cfgrib/issues/63)
[Dataset Build Error](https://github.com/ecmwf/cfgrib/issues/66)

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
