### PR TITLE
Add missing warnings import to geotiff writer

### DIFF
--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -252,6 +252,7 @@ class GeoTIFFWriter(ImageWriter):
         except ImportError:
             LOG.warning("Using legacy/slower geotiff save method, install "
                         "'rasterio' for faster saving.")
+            import warnings
             warnings.warn("Using legacy/slower geotiff save method with 'gdal'."
                           "This will be deprecated in the future. Install "
                           "'rasterio' for faster saving and future "


### PR DESCRIPTION
This PR adds a missing `warnings` import. Otherwise when rasterio isn't available you will get: UnboundLocalError: local variable 'warnings' referenced before assignment