### PR TITLE
Add scanline timestamps to seviri_l1b_hrit

### DIFF
--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -217,8 +217,6 @@ def get_cds_time(days, msecs):
     return time
 
 
-
-
 def dec10216(inbuf):
     """Decode 10 bits data into 16 bits words.
 

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -24,7 +24,6 @@
 """Utilities and eventually also base classes for MSG HRIT/Native data reading
 """
 
-from datetime import datetime, timedelta
 import numpy as np
 from numpy.polynomial.chebyshev import Chebyshev
 import dask.array as da
@@ -195,22 +194,24 @@ CALIB[324] = {'HRV': {'F': 79.0035 / np.pi},
 def get_cds_time(days, msecs):
     """Compute timestamp given the days since epoch and milliseconds of the day
 
+    1958-01-01 00:00 is interpreted as fill value and will be replaced by NaT (Not a Time).
+
     Args:
-        days (int or numpy.ndarray):
+        days (int, either scalar or numpy.ndarray):
             Days since 1958-01-01
-        msecs (int or numpy.ndarray):
+        msecs (int, either scalar or numpy.ndarray):
             Milliseconds of the day
 
     Returns:
         numpy.datetime64: Timestamp(s)
-
     """
-    if isinstance(days, (int, float)):
+    if np.isscalar(days):
         days = np.array([days], dtype='int64')
         msecs = np.array([msecs], dtype='int64')
 
     time = np.datetime64('1958-01-01').astype('datetime64[ms]') + \
         days.astype('timedelta64[D]') + msecs.astype('timedelta64[ms]')
+    time[time == np.datetime64('1958-01-01 00:00')] = np.datetime64("NaT")
 
     if len(time) == 1:
         return time[0]

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -193,11 +193,30 @@ CALIB[324] = {'HRV': {'F': 79.0035 / np.pi},
 
 
 def get_cds_time(days, msecs):
-    """Get the datetime object of the time since epoch given in days and
-    milliseconds of day
+    """Compute timestamp given the days since epoch and milliseconds of the day
+
+    Args:
+        days (int or numpy.ndarray):
+            Days since 1958-01-01
+        msecs (int or numpy.ndarray):
+            Milliseconds of the day
+
+    Returns:
+        numpy.datetime64: Timestamp(s)
+
     """
-    return datetime(1958, 1, 1) + timedelta(days=float(days),
-                                            milliseconds=float(msecs))
+    if isinstance(days, (int, float)):
+        days = np.array([days], dtype='int64')
+        msecs = np.array([msecs], dtype='int64')
+
+    time = np.datetime64('1958-01-01').astype('datetime64[ms]') + \
+        days.astype('timedelta64[D]') + msecs.astype('timedelta64[ms]')
+
+    if len(time) == 1:
+        return time[0]
+    return time
+
+
 
 
 def dec10216(inbuf):

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -678,9 +678,7 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
     def _get_timestamps(self):
         """Read scanline timestamps from the segment header"""
         tline = self.mda['image_segment_line_quality']['line_mean_acquisition']
-        tline = get_cds_time(days=tline['days'], msecs=tline['milliseconds'])
-        tline[tline == np.datetime64('1958-01-01 00:00')] = np.datetime64("NaT")
-        return tline
+        return get_cds_time(days=tline['days'], msecs=tline['milliseconds'])
 
 
 def show(data, negate=False):

--- a/satpy/tests/reader_tests/test_seviri_base.py
+++ b/satpy/tests/reader_tests/test_seviri_base.py
@@ -25,7 +25,7 @@
 
 import sys
 import numpy as np
-from satpy.readers.seviri_base import dec10216, chebyshev
+from satpy.readers.seviri_base import dec10216, chebyshev, get_cds_time
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -33,10 +33,16 @@ else:
     import unittest
 
 
-class TestDec10216(unittest.TestCase):
-    """Test the dec10216 function."""
+def chebyshev4(c, x, domain):
+    """Evaluate 4th order Chebyshev polynomial"""
+    start_x, end_x = domain
+    t = (x - 0.5 * (end_x + start_x)) / (0.5 * (end_x - start_x))
+    return c[0] + c[1]*t + c[2]*(2*t**2 - 1) + c[3]*(4*t**3 - 3*t) - 0.5*c[0]
 
+
+class SeviriBaseTest(unittest.TestCase):
     def test_dec10216(self):
+        """Test the dec10216 function."""
         res = dec10216(np.array([255, 255, 255, 255, 255], dtype=np.uint8))
         exp = (np.ones((4, )) * 1023).astype(np.uint16)
         self.assertTrue(np.all(res == exp))
@@ -44,28 +50,32 @@ class TestDec10216(unittest.TestCase):
         exp = np.array([4,  16,  64, 257], dtype=np.uint16)
         self.assertTrue(np.all(res == exp))
 
-
-class TestChebyshev(unittest.TestCase):
-    def chebyshev4(self, c, x, domain):
-        """Evaluate 4th order Chebyshev polynomial"""
-        start_x, end_x = domain
-        t = (x - 0.5 * (end_x + start_x)) / (0.5 * (end_x - start_x))
-        return c[0] + c[1]*t + c[2]*(2*t**2 - 1) + c[3]*(4*t**3 - 3*t) - 0.5*c[0]
-
     def test_chebyshev(self):
         coefs = [1, 2, 3, 4]
         time = 123
         domain = [120, 130]
         res = chebyshev(coefs=[1, 2, 3, 4], time=time, domain=domain)
-        exp = self.chebyshev4(coefs, time, domain)
+        exp = chebyshev4(coefs, time, domain)
         self.assertTrue(np.allclose(res, exp))
+
+    def test_get_cds_time(self):
+        # Scalar
+        self.assertEqual(get_cds_time(days=21246, msecs=12*3600*1000),
+                         np.datetime64('2016-03-03 12:00'))
+
+        # Array
+        days = np.array([21246, 21247, 21248])
+        msecs = np.array([12*3600*1000, 13*3600*1000 + 1, 14*3600*1000 + 2])
+        expected = np.array([np.datetime64('2016-03-03 12:00:00.000'),
+                             np.datetime64('2016-03-04 13:00:00.001'),
+                             np.datetime64('2016-03-05 14:00:00.002')])
+        self.assertTrue(np.all(get_cds_time(days=days, msecs=msecs) == expected))
+
 
 
 def suite():
     """The test suite for test_scene."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
-    tests = [TestDec10216, TestChebyshev]
-    for test in tests:
-        mysuite.addTest(loader.loadTestsFromTestCase(test))
+    mysuite.addTest(loader.loadTestsFromTestCase(SeviriBaseTest))
     return mysuite

--- a/satpy/tests/reader_tests/test_seviri_base.py
+++ b/satpy/tests/reader_tests/test_seviri_base.py
@@ -72,7 +72,6 @@ class SeviriBaseTest(unittest.TestCase):
         self.assertTrue(np.all(get_cds_time(days=days, msecs=msecs) == expected))
 
 
-
 def suite():
     """The test suite for test_scene."""
     loader = unittest.TestLoader()

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -112,6 +112,11 @@ class TestHRITMSGFileHandler(unittest.TestCase):
                     self.reader.mda['navigation_parameters']['satellite_actual_latitude'] = -0.5
                     self.reader.mda['navigation_parameters']['satellite_actual_altitude'] = 35783328
 
+                    tline = np.zeros(nlines, dtype=[('days', '>u2'), ('milliseconds', '>u4')])
+                    tline['days'][1:-1] = 21246 * np.ones(nlines-2)  # 2016-03-03
+                    tline['milliseconds'][1:-1] = np.arange(nlines-2)
+                    self.reader.mda['image_segment_line_quality'] = {'line_mean_acquisition': tline}
+
     def test_get_xy_from_linecol(self):
         """Test get_xy_from_linecol."""
         x__, y__ = self.reader.get_xy_from_linecol(0, 0, (10, 10), (5, 5))
@@ -239,13 +244,17 @@ class TestHRITMSGFileHandler(unittest.TestCase):
         self.assertRaises(ValueError, HRITMSGFileHandler, filename=None, filename_info=None,
                           filetype_info=None, prologue=pro, epilogue=epi, calib_mode='invalid')
 
+    @mock.patch('satpy.readers.seviri_l1b_hrit.HRITMSGFileHandler._get_timestamps')
     @mock.patch('satpy.readers.seviri_l1b_hrit.HRITFileHandler.get_dataset')
     @mock.patch('satpy.readers.seviri_l1b_hrit.HRITMSGFileHandler.calibrate')
-    def test_get_dataset(self, calibrate, parent_get_dataset):
+    def test_get_dataset(self, calibrate, parent_get_dataset, _get_timestamps):
         key = mock.MagicMock(calibration='calibration')
         info = {'units': 'units', 'wavelength': 'wavelength', 'standard_name': 'standard_name'}
+        timestamps = np.array([1, 2, 3], dtype='datetime64[ns]')
+
         parent_get_dataset.return_value = mock.MagicMock()
-        calibrate.return_value = mock.MagicMock(attrs={})
+        calibrate.return_value = xr.DataArray(data=np.zeros((3, 3)), dims=('y', 'x'))
+        _get_timestamps.return_value = timestamps
 
         res = self.reader.get_dataset(key, info)
 
@@ -267,8 +276,28 @@ class TestHRITMSGFileHandler(unittest.TestCase):
             'navigation': self.reader.mda['navigation_parameters'],
             'georef_offset_corrected': self.reader.mda['offset_corrected']
         })
-
         self.assertDictEqual(attrs_exp, res.attrs)
+
+        # Test timestamps
+        self.assertTrue(np.all(res['acq_time'] == timestamps))
+        self.assertEqual(res['acq_time'].attrs['long_name'], 'Mean scanline acquisition time')
+
+    def test_get_timestamps(self):
+        tline = self.reader._get_timestamps()
+
+        # First and last scanline have invalid timestamps (space)
+        self.assertTrue(np.isnat(tline[0]))
+        self.assertTrue(np.isnat(tline[-1]))
+
+        # Test remaining lines
+        year = tline.astype('datetime64[Y]').astype(int) + 1970
+        month = tline.astype('datetime64[M]').astype(int) % 12 + 1
+        day = (tline.astype('datetime64[D]') - tline.astype('datetime64[M]') + 1).astype(int)
+        msec = (tline - tline.astype('datetime64[D]')).astype(int)
+        self.assertTrue(np.all(year[1:-1] == 2016))
+        self.assertTrue(np.all(month[1:-1] == 3))
+        self.assertTrue(np.all(day[1:-1] == 3))
+        self.assertTrue(np.all(msec[1:-1] == np.arange(len(tline) - 2)))
 
 
 class TestHRITMSGPrologueFileHandler(unittest.TestCase):


### PR DESCRIPTION
- Named it `acq_time` because it is a _non-dimension_ coordinate, in contrast to `time` which is expected to be a _dimension_ coordinate in the CF Writer (see also http://xarray.pydata.org/en/stable/data-structures.html?highlight=coordinates#coordinates).
- Resampling drops the acquisition time which I think is correct
- I changed the return value of `satpy.readers.seviri_base.get_cds_time` to datetime64, but it hasn't been used anywhere yet
- Added a basic reader introduction and a recipe to enable `.sel(time=...)` via `MultiIndex` to the docs

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [X] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
