### PR TITLE
Update MTG FCI FDHSI L1C reader for latest data format

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,6 +11,7 @@ The following people have made contributions to this project:
 - [Adam Dybbroe (adybbroe)](https://github.com/adybbroe)
 - [Ulrik Egede (egede)](https://github.com/egede)
 - [Stephan Finkensieper (sfinkens)](https://github.com/sfinkens)
+- [Gerrit Holl (gerritholl)](https://github.com/gerritholl)
 - [David Hoese (djhoese)](https://github.com/djhoese)
 - [Marc Honnorat (honnorat)](https://github.com/honnorat)
 - [Mikhail Itkin (mitkin)](https://github.com/mitkin)

--- a/satpy/etc/readers/fci_l1c_fdhsi.yaml
+++ b/satpy/etc/readers/fci_l1c_fdhsi.yaml
@@ -357,4 +357,4 @@ datasets:
 file_types:
   fci_l1c_fdhsi:
     file_reader: !!python/name:satpy.readers.fci_l1c_fdhsi.FCIFDHSIFileHandler ''
-    file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_evel}-{type}-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc']
+    file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_level}-{type}-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc']

--- a/satpy/etc/readers/fci_l1c_fdhsi.yaml
+++ b/satpy/etc/readers/fci_l1c_fdhsi.yaml
@@ -352,7 +352,9 @@ datasets:
 
 # Source: FCI L1 Dataset User Guide [FCIL1DUG]
 # ftp://ftp.eumetsat.int/pub/OPS/out/test-data/FCI_L1C_Format_Familiarisation/FCI_L1_Dataset_User_Guide_[FCIL1DUG].pdf
+# and Example Products for Pytroll Workshop Package Description,
+# EUM/MTG/DOC/19/1079228
 file_types:
   fci_l1c_fdhsi:
     file_reader: !!python/name:satpy.readers.fci_l1c_fdhsi.FCIFDHSIFileHandler ''
-    file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_evel}-{type}-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}-{oflag}-{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{accumulation_interval_in_day}.nc']
+    file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_evel}-{type}-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc']

--- a/satpy/etc/readers/fci_l1c_fdhsi.yaml
+++ b/satpy/etc/readers/fci_l1c_fdhsi.yaml
@@ -22,7 +22,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   vis_05:
     name: vis_05
@@ -39,7 +39,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   vis_06:
     name: vis_06
@@ -56,7 +56,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   vis_06_hr:
     name: vis_06_hr
@@ -73,7 +73,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   vis_08:
     name: vis_08
@@ -90,7 +90,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   vis_09:
     name: vis_09
@@ -107,7 +107,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   nir_13:
     name: nir_13
@@ -124,7 +124,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   nir_16:
     name: nir_16
@@ -141,7 +141,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   nir_22:
     name: nir_22
@@ -158,7 +158,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   nir_22_hr:
     name: nir_22_hr
@@ -175,7 +175,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   ir_38:
     name: ir_38
@@ -192,7 +192,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   ir_38_hr:
     name: ir_38_hr
@@ -209,7 +209,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
 
   wv_63:
@@ -227,7 +227,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   wv_73:
     name: wv_73
@@ -244,7 +244,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   ir_87:
     name: ir_87
@@ -261,7 +261,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   ir_97:
     name: ir_97
@@ -278,7 +278,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   ir_105:
     name: ir_105
@@ -295,7 +295,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   ir_105_hr:
     name: ir_105_hr
@@ -312,7 +312,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
 
   ir_123:
@@ -330,7 +330,7 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
   ir_133:
     name: ir_133
@@ -347,12 +347,12 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
-    file_type: fci_fdhsi
+    file_type: fci_l1c_fdhsi
 
 
 # Source: FCI L1 Dataset User Guide [FCIL1DUG]
 # ftp://ftp.eumetsat.int/pub/OPS/out/test-data/FCI_L1C_Format_Familiarisation/FCI_L1_Dataset_User_Guide_[FCIL1DUG].pdf
 file_types:
-  fci_fdhsi:
+  fci_l1c_fdhsi:
     file_reader: !!python/name:satpy.readers.fci_l1c_fdhsi.FCIFDHSIFileHandler ''
     file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_evel}-{type}-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}-{oflag}-{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{accumulation_interval_in_day}.nc']

--- a/satpy/etc/readers/fci_l1c_fdhsi.yaml
+++ b/satpy/etc/readers/fci_l1c_fdhsi.yaml
@@ -357,4 +357,4 @@ datasets:
 file_types:
   fci_l1c_fdhsi:
     file_reader: !!python/name:satpy.readers.fci_l1c_fdhsi.FCIFDHSIFileHandler ''
-    file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_level}-{type}-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc']
+    file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_level}-{type}-{subtype}-{coverage}-{subsetting}-{component1}-BODY-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc']

--- a/satpy/etc/readers/fci_l1c_fdhsi.yaml
+++ b/satpy/etc/readers/fci_l1c_fdhsi.yaml
@@ -58,23 +58,6 @@ datasets:
         units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
-  vis_06_hr:
-    name: vis_06_hr
-    sensor: fci
-    wavelength: [0.590, 0.640, 0.690]
-    resolution: 500
-    calibration:
-      counts:
-        standard_name: counts
-        units: "count"
-      reflectance:
-        standard_name: toa_bidirectional_reflectance
-        units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
-    file_type: fci_l1c_fdhsi
-
   vis_08:
     name: vis_08
     sensor: fci
@@ -160,45 +143,11 @@ datasets:
         units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
-  nir_22_hr:
-    name: nir_22_hr
-    sensor: fci
-    wavelength: [2.200, 2.250, 2.300]
-    resolution: 500
-    calibration:
-      counts:
-        standard_name: counts
-        units: "count"
-      reflectance:
-        standard_name: toa_bidirectional_reflectance
-        units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
-    file_type: fci_l1c_fdhsi
-
   ir_38:
     name: ir_38
     sensor: fci
     wavelength: [3.400, 3.800, 4.200]
     resolution: 2000
-    calibration:
-      counts:
-        standard_name: counts
-        units: "count"
-      brightness_temperature:
-        standard_name: toa_brightness_temperature
-        units: "K"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
-    file_type: fci_l1c_fdhsi
-
-  ir_38_hr:
-    name: ir_38_hr
-    sensor: fci
-    wavelength: [3.400, 3.800, 4.200]
-    resolution: 1000
     calibration:
       counts:
         standard_name: counts
@@ -285,23 +234,6 @@ datasets:
     sensor: fci
     wavelength: [9.800, 10.500, 11.200]
     resolution: 2000
-    calibration:
-      counts:
-        standard_name: counts
-        units: "count"
-      brightness_temperature:
-        standard_name: toa_brightness_temperature
-        units: "K"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
-    file_type: fci_l1c_fdhsi
-
-  ir_105_hr:
-    name: ir_105_hr
-    sensor: fci
-    wavelength: [9.800, 10.500, 11.200]
-    resolution: 1000
     calibration:
       counts:
         standard_name: counts

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -31,7 +31,7 @@ Imager (FCI) Full Disk High Spectral Imagery (FDHSI) data.  FCI will fly
 on the MTG Imager (MTG-I) series of satellites, scheduled to be launched
 in 2021 by the earliest.  For more information about FCI, see `EUMETSAT`_.
 
-.. EUMETSAT: https://www.eumetsat.int/website/home/Satellites/FutureSatellites/MeteosatThirdGeneration/MTGDesign/index.html#fci
+.. _EUMETSAT: https://www.eumetsat.int/website/home/Satellites/FutureSatellites/MeteosatThirdGeneration/MTGDesign/index.html#fci  # noqa: E501
 """
 
 import logging
@@ -52,7 +52,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
     Combined Imager (FCI) Full Disk High Spectral Imagery (FDHSI) reader.
     It is designed to be used through the :class:`~satpy.Scene`
     class using the :mod:`~satpy.Scene.load` method with the reader
-    `"fci_l1c_fdhsi"`.
+    ``"fci_l1c_fdhsi"``.
 
     """
 

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -241,7 +241,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         for v in (coef, wl_c, a, b, c1, c2):
             if v == v.attrs.get("FillValue",
                                 default_fillvals.get(v.dtype.str[1:])):
-                logging.error(
+                logger.error(
                     "{:s} set to fill value, cannot produce "
                     "brightness temperatures for {:s}.".format(
                         v.attrs.get("long_name",
@@ -273,7 +273,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         cesi = self[cesilab]
         if cesi == cesi.attrs.get(
                 "FillValue", default_fillvals.get(cesi.dtype.str[1:])):
-            logging.error(
+            logger.error(
                 "channel effective solar irradiance set to fill value, "
                 "cannot produce reflectance for {:s}.".format(measured))
             return xr.DataArray(

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -7,6 +7,7 @@
 #
 #   Thomas Leppelt <thomas.leppelt@gmail.com>
 #   Sauli Joro <sauli.joro@icloud.com>
+#   Gerrit Holl <gerrit.holl@dwd.de>
 
 # This file is part of satpy.
 
@@ -22,16 +23,17 @@
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Interface to MTG-FCI Retrieval NetCDF files
+"""Interface to MTG-FCI-FDHSI L1C NetCDF files
 
 """
-import xarray.ufuncs as xu
-from pyresample import geometry
-import xarray as xr
 import logging
+import numpy as np
+import xarray as xr
 
-from satpy.readers.file_handlers import BaseFileHandler
-from satpy import CHUNK_SIZE
+from pyresample import geometry
+
+from ..readers.file_handlers import BaseFileHandler
+from .. import CHUNK_SIZE
 
 logger = logging.getLogger(__name__)
 
@@ -200,7 +202,7 @@ class FCIFDHSIFileHandler(BaseFileHandler):
         c1, c2 = measured['radiance_to_bt_conversion_constants']
 
         nom = c2 * vc
-        denom = a * xu.log(1 + (c1 * vc**3) / Lv)
+        denom = a * np.log(1 + (c1 * vc**3) / Lv)
 
         return nom / denom - b / a
 

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2016.
+# Copyright (c) 2016--2019.
 
 # Author(s):
 
@@ -99,8 +99,8 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
             nfv = fv
         else:
             nfv = np.nan
-        data = data.where(data > vr[0], nfv)
-        data = data.where(data < vr[1], nfv)
+        data = data.where(data >= vr[0], nfv)
+        data = data.where(data <= vr[1], nfv)
         if key.calibration == "counts":
             # from package description, this just means not applying add_offset
             # and scale_factor
@@ -186,7 +186,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         lon_0 = float(self["state/processor/projection_origin_longitude"])
         if h == default_fillvals[
                 self["state/processor/reference_altitude"].dtype.str[1:]]:
-            logger.warn(
+            logger.warning(
                     "Reference altitude in {:s} set to "
                     "fill value, using {:d}".format(
                         self.filename,
@@ -224,7 +224,10 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         elif key.calibration == 'reflectance':
             data = self._vis_calibrate(data, measured)
         else:
-            raise RuntimeError("Reached unreachable code!")
+            raise RuntimeError(
+                    "Received unknown calibration key.  Expected "
+                    "'brightness_temperature' or 'reflectance', got "
+                    + key.calibration)
 
         return data
 

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -76,7 +76,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
     def get_dataset(self, key, info=None):
         """Load a dataset."""
 
-        logger.debug('Reading {}'.format(key.name))
+        logger.debug('Reading {} from {}'.format(key.name, self.filename))
         # Get the dataset
         # Get metadata for given dataset
         measured, root = self.get_channel_dataset(key.name)

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -34,6 +34,9 @@ in 2021 by the earliest.  For more information about FCI, see `EUMETSAT`_.
 .. _EUMETSAT: https://www.eumetsat.int/website/home/Satellites/FutureSatellites/MeteosatThirdGeneration/MTGDesign/index.html#fci  # noqa: E501
 """
 
+from __future__ import (division, absolute_import, print_function,
+                        unicode_literals)
+
 import logging
 import numpy as np
 import dask.array as da
@@ -119,10 +122,9 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         attrs.pop("units")
 
         self.nlines, self.ncols = res.shape
-        res.attrs.update({
-                **key.to_dict(),
-                **info,
-                **attrs})
+        res.attrs.update(key.to_dict())
+        res.attrs.update(info)
+        res.attrs.update(attrs)
         return res
 
     def get_channel_dataset(self, channel):

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -86,8 +86,8 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         radiances = self[radlab]
         radiances = radiances.where(radiances > radiances.attrs['valid_range'][0])
         radiances = radiances.where(radiances < radiances.attrs['valid_range'][1])
-        radiances = (radiances * self[radlab + "/scale_factor"] +
-                     self[radlab + "/add_offset"])
+        radiances = (radiances * radiances.attrs["scale_factor"] +
+                     radiances.attrs["add_offset"])
 
         res = self.calibrate(radiances, key, measured, root)
 
@@ -111,13 +111,12 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
 
         # Get metadata for given dataset
         measured, root = self.get_channel_dataset(key.name)
-        variable = self[measured + "/effective_radiance"]
         # Get start/end line and column of loaded swath.
         self.startline = int(self[measured + "/start_position_row"])
         self.endline = int(self[measured + "/end_position_row"])
         self.startcol = int(self[measured + "/start_position_column"])
         self.endcol = int(self[measured + "/end_position_column"])
-        self.nlines, self.ncols = variable.shape
+        self.nlines, self.ncols = self[measured + "/effective_radiance/shape"]
 
         logger.debug('Channel {} resolution: {}'.format(key.name, chkres))
         logger.debug('Row/Cols: {} / {}'.format(self.nlines, self.ncols))

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -105,7 +105,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
             res = data
         else:
             data = (data * attrs.pop("scale_factor", 1) +
-                           attrs.pop("add_offset", 0))
+                    attrs.pop("add_offset", 0))
 
             if key.calibration in ("brightness_temperature", "reflectance"):
                 res = self.calibrate(data, key, measured, root)

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -36,13 +36,11 @@ in 2021 by the earliest.  For more information about FCI, see `EUMETSAT`_.
 
 import logging
 import numpy as np
-import xarray as xr
 
 from pyresample import geometry
 from netCDF4 import default_fillvals
 
 from .netcdf_utils import NetCDF4FileHandler
-from .. import CHUNK_SIZE
 
 logger = logging.getLogger(__name__)
 
@@ -139,8 +137,9 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         return(chk_extent)
 
     _fallback_area_def = {
-            "reference_altitude": 35786400, # metre
+            "reference_altitude": 35786400,  # metre
             }
+
     def get_area_def(self, key, info=None):
         """Calculate on-fly area definition for 0 degree geos-projection for a dataset."""
         # TODO Projection information are hard coded for 0 degree geos projection

--- a/satpy/tests/reader_tests/__init__.py
+++ b/satpy/tests/reader_tests/__init__.py
@@ -41,7 +41,7 @@ from satpy.tests.reader_tests import (test_abi_l1b, test_hrit_base,
                                       test_safe_sar_l2_ocn, test_viirs_edr_active_fires,
                                       test_hdfeos_base, test_modis_l2,
                                       test_electrol_hrit, test_mersi2_l1b,
-                                      test_avhrr_l1b_gaclac)
+                                      test_avhrr_l1b_gaclac, test_fci_l1c_fdhsi)
 
 
 if sys.version_info < (2, 7):
@@ -92,5 +92,6 @@ def suite():
     mysuite.addTests(test_electrol_hrit.suite())
     mysuite.addTests(test_mersi2_l1b.suite())
     mysuite.addTests(test_avhrr_l1b_gaclac.suite())
+    mysuite.addTests(test_fci_l1c_fdhsi.suite())
 
     return mysuite

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Satpy developers
+#
+# This file is part of the satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# satpy is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with satpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the 'fci_l1c_fdhsi' reader."""
+
+import xarray as xr
+import dask.array as da
+
+from .netcdf_utils import NetCDF4FileHandler
+
+try:
+    from unittest import mock # Python 3.3 or newer
+except ImportError:
+    import mock # Python 2.7
+
+class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
+    def _get_test_calib_for_channel_ir(self, chroot, meas):
+        data = {}
+        data[meas + "/radiance_unit_conversion_coefficient"] = 1
+        data[chroot + "/central_wavelength_actual"] = 1
+        for c in "ab":
+            data[meas + "/radiance_to_bt_conversion_coefficient_" + c] = 1
+        for c in "12":
+            data[meas + "/radiance_to_bt_conversion_constant_c" + c] = 1
+        return data
+
+    def _get_test_calib_for_channel_vis(self, chroot, meas):
+        data = {}
+        data[meas + "/channel_effective_solar_irradiance"] = 42
+        return data
+
+    def _get_test_content_for_channel(self, pat, ch):
+        nrows = 596
+        ncols = 11136
+        chroot = "data/{:s}"
+        meas = chroot + "/measured"
+        rad = meas + "/effective_radiance"
+        pos_path = meas + "/{:s}_position_{:s}"
+        data = {}
+        ch_str = pat.format(ch)
+        ch_path = rad.format(ch_str)
+        da = xr.DataArray(
+                da.ones(nrows, ncols),
+                dtype="uint16",
+                chunks=1024,
+                attrs={
+                    "valid_range": [0, 4095],
+                    "scale_factor": 1,
+                    "add_offset": 0,
+                    }
+                )
+        data[ch_path] = da
+        for (st, no) in (("start", 0), ("end", 100)):
+            for rc in ("row", "column"):
+                pos_path = pos.format(meas, st, rc)
+                data[pos_path] = xr.DataArray(no)
+        if "ir" in pat:
+            data.extend(self._get_test_calib_for_channel_ir(self))
+        elif "vis" in pat:
+            data.extend(self._get_test_calib_for_channel_vis(self))
+        return data
+
+    def _get_test_content_all_channels(self):
+        chan_patterns = {
+                "vis_{:>02d}": (4, 5, 6, 8, 9),
+                "nir_{:>02d}": (13, 16, 22),
+                "ir_{:>02d}": (38, 87, 97, 105, 123, 133),
+                "wv_{:>02d}": (63, 73),
+                }
+        data = {}
+        for pat in chan_patterns.keys():
+            for ch_num in chan_patterns[pat].values():
+                data.extend(self._get_test_content_for_channel(ch_num))
+        return data
+
+    def _get_test_content_areadef(self):
+        data = {}
+        proc = "state/processor"
+        for (lb, no) in (
+                ("earth_equatorial_radius", 6378137),
+                ("earth_polar_radius", 6356752),
+                ("reference_altitude", 35786000),
+                ("projection_origin_longitude", 0)):
+            data[proc + "/" + lb] = xr.DataArray(no)
+        return data
+
+    def get_test_content(self, filename, filename_info, filetype_info):
+        # mock global attributes
+        # - root groups global
+        # - other groups global
+        # mock data variables
+        # mock dimensions
+        #
+        # ... but only what satpy is using ...
+
+        return {
+                **self._get_test_content_channels(),
+                **self._get_test_content_areadef(),
+                }
+

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -29,9 +29,10 @@ import unittest
 from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
 
 try:
-    from unittest import mock # Python 3.3 or newer
+    from unittest import mock  # Python 3.3 or newer
 except ImportError:
-    import mock # Python 2.7
+    import mock  # Python 2.7
+
 
 class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
     def _get_test_calib_for_channel_ir(self, chroot, meas):
@@ -77,10 +78,10 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         data[pos.format(ch_str, "end", "column")] = ncols
         if pat.startswith("ir") or pat.startswith("wv"):
             data.update(self._get_test_calib_for_channel_ir(chroot.format(ch_str),
-                meas.format(ch_str)))
+                        meas.format(ch_str)))
         elif pat.startswith("vis") or pat.startswith("nir"):
             data.update(self._get_test_calib_for_channel_vis(chroot.format(ch_str),
-                meas.format(ch_str)))
+                        meas.format(ch_str)))
         data[shp.format(ch_str)] = (nrows, ncols)
         return data
 
@@ -121,6 +122,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
                 **self._get_test_content_all_channels(),
                 **self._get_test_content_areadef(),
                 }
+
 
 class TestFCIL1CFDHSIReader(unittest.TestCase):
     """Test FCI L1C FDHSI reader
@@ -297,6 +299,7 @@ class TestFCIL1CFDHSIReader(unittest.TestCase):
             self.assertEqual(res[ch].attrs["calibration"],
                              "brightness_temperature")
             self.assertEqual(res[ch].attrs["units"], "K")
+
 
 def suite():
     """The test suite

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -21,6 +21,7 @@
 
 import xarray as xr
 import dask.array as da
+import unittest
 
 from .netcdf_utils import NetCDF4FileHandler
 
@@ -114,3 +115,30 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
                 **self._get_test_content_areadef(),
                 }
 
+class TestFCIL1CFDHSIReader(unittest.Testcase):
+    """Test FCI L1C FDHSI reader
+    """
+    yaml_file = "fci_l1c_fdhsi.yaml"
+
+    def setUp(self):
+        """Wrap NetCDF4 FileHandler with our own fake handler
+        """
+
+        # implementation strongly inspired by test_viirs_l1b.py
+        from satpy.config import config_search_paths
+        from satpy.readers.fci_l1c_fdhsi import FCIFDHSIFileHandler
+
+        self.reader_configs = config_search_paths(
+                os.path.join("readers", self.yaml_file))
+        self.p = mock.patch.object(
+                FCIFDHSIFileHandler,
+                "__bases__",
+                (FakeNetCDF4FileHandler2,))
+        self.fake_handler = self.p.start()
+        self.p.is_local = True
+
+    def tearDown(self):
+        """Stop wrapping the NetCDF4 file handler
+        """
+        # implementation strongly inspired by test_viirs_l1b.py
+        self.p.stop()

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -135,6 +135,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         D.update(self._get_test_content_areadef())
         return D
 
+
 class FakeNetCDF4FileHandler3(FakeNetCDF4FileHandler2):
     """Mock bad data
     """
@@ -254,7 +255,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
             self.assertEqual(res[ch].dtype, np.uint16)
             self.assertEqual(res[ch].attrs["calibration"], "counts")
             self.assertEqual(res[ch].attrs["units"], "1")
-        numpy.testing.assert_array_equal(res[ch], 1)
+            numpy.testing.assert_array_equal(res[ch], 1)
 
     def test_load_radiance(self):
         """Test loading with radiance
@@ -280,7 +281,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
             self.assertEqual(res[ch].dtype, np.float64)
             self.assertEqual(res[ch].attrs["calibration"], "radiance")
             self.assertEqual(res[ch].attrs["units"], 'mW.m-2.sr-1.(cm-1)-1')
-        numpy.testing.assert_array_equal(res[ch], 15)
+            numpy.testing.assert_array_equal(res[ch], 15)
 
     def test_load_reflectance(self):
         """Test loading with reflectance
@@ -306,7 +307,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
             self.assertEqual(res[ch].dtype, np.float64)
             self.assertEqual(res[ch].attrs["calibration"], "reflectance")
             self.assertEqual(res[ch].attrs["units"], "%")
-        numpy.testing.assert_array_equal(res[ch], 15 / 50 * 100)
+            numpy.testing.assert_array_equal(res[ch], 15 / 50 * 100)
 
     def test_load_bt(self):
         """Test loading with bt
@@ -333,9 +334,9 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
             self.assertEqual(res[ch].attrs["calibration"],
                              "brightness_temperature")
             self.assertEqual(res[ch].attrs["units"], "K")
-        numpy.testing.assert_array_almost_equal(
-                res[ch],
-                181.917084)
+            numpy.testing.assert_array_almost_equal(
+                    res[ch],
+                    181.917084)
 
 
 class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -131,6 +131,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
                 **self._get_test_content_areadef(),
                 }
 
+
 class FakeNetCDF4FileHandler3(FakeNetCDF4FileHandler2):
     """Mock bad data
     """
@@ -146,10 +147,12 @@ class FakeNetCDF4FileHandler3(FakeNetCDF4FileHandler2):
         data[meas + "/radiance_to_bt_conversion_constant_c2"] = v
         return data
 
+
 class TestFCIL1CFDHSIReader(unittest.TestCase):
     yaml_file = "fci_l1c_fdhsi.yaml"
 
     _alt_handler = FakeNetCDF4FileHandler2
+
     def setUp(self):
         """Wrap NetCDF4 FileHandler with our own fake handler
         """
@@ -173,6 +176,7 @@ class TestFCIL1CFDHSIReader(unittest.TestCase):
         # implementation strongly inspired by test_viirs_l1b.py
         self.p.stop()
 
+
 class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
     """Test FCI L1C FDHSI reader
     """
@@ -182,6 +186,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
     # - test geolocation
 
     _alt_handler = FakeNetCDF4FileHandler2
+
     def test_file_pattern(self):
         """Test file pattern matching
         """
@@ -329,6 +334,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
                 res[ch],
                 181.917084)
 
+
 class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):
     _alt_handler = FakeNetCDF4FileHandler3
 
@@ -350,11 +356,11 @@ class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):
         with self.assertLogs(
                 'satpy.readers.fci_l1c_fdhsi',
                 level="ERROR") as cm:
-            #from nose.tools import set_trace; set_trace()
-            res = reader.load([DatasetID(
+            reader.load([DatasetID(
                     name="ir_123",
                     calibration="brightness_temperature")])
         self.assertRegex(cm.output[0], "cannot produce brightness temperatur")
+
 
 def suite():
     """The test suite

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -19,6 +19,10 @@
 
 """Tests for the 'fci_l1c_fdhsi' reader."""
 
+from __future__ import (division, absolute_import, print_function,
+                        unicode_literals)
+
+import sys
 import os
 
 import numpy as np
@@ -126,11 +130,10 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         #
         # ... but only what satpy is using ...
 
-        return {
-                **self._get_test_content_all_channels(),
-                **self._get_test_content_areadef(),
-                }
-
+        D = {}
+        D.update(self._get_test_content_all_channels())
+        D.update(self._get_test_content_areadef())
+        return D
 
 class FakeNetCDF4FileHandler3(FakeNetCDF4FileHandler2):
     """Mock bad data
@@ -338,6 +341,10 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
 class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):
     _alt_handler = FakeNetCDF4FileHandler3
 
+    @unittest.skipIf(
+            sys.version < (3, 4),
+            "skipping log message testing on old Python version "
+            "that doesn't have TestCase.assertLogs")
     def test_handling_bad_data_ir(self):
         """Test handling of bad data
         """

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -367,5 +367,6 @@ def suite():
     """
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
-    mysuite.addTest(loader.loadTestsFromTestCase(TestFCIL1CFDHSIReader))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestFCIL1CFDHSIReaderGoodData))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestFCIL1CFDHSIReaderBadData))
     return mysuite

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -343,7 +343,7 @@ class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):
     _alt_handler = FakeNetCDF4FileHandler3
 
     @unittest.skipIf(
-            sys.version < (3, 4),
+            sys.version_info < (3, 4),
             "skipping log message testing on old Python version "
             "that doesn't have TestCase.assertLogs")
     def test_handling_bad_data_ir(self):

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -61,11 +61,13 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         ch_str = pat.format(ch)
         ch_path = rad.format(ch_str)
         d = xr.DataArray(
-                da.ones(nrows, ncols, dtype="uint16", chunks=1024),
+                da.ones((nrows, ncols), dtype="uint16", chunks=1024),
+                dims=("y", "x"),
                 attrs={
                     "valid_range": [0, 4095],
                     "scale_factor": 1,
                     "add_offset": 0,
+                    "units": "1",
                     }
                 )
         data[ch_path] = d
@@ -93,7 +95,6 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         for pat in chan_patterns.keys():
             for ch_num in chan_patterns[pat]:
                 data.update(self._get_test_content_for_channel(pat, ch_num))
-        from nose.tools import set_trace; set_trace()
         return data
 
     def _get_test_content_areadef(self):
@@ -209,7 +210,7 @@ class TestFCIL1CFDHSIReader(unittest.TestCase):
                     self._chans["solar"] + self._chans["terran"]])
         self.assertEqual(16, len(res))
         for ch in self._chans["solar"] + self._chans["terran"]:
-            self.assertEqual(res[ch].shape, (11136, 206*2))
+            self.assertEqual(res[ch].shape, (200*2, 11136))
             self.assertEqual(res[ch].dtype, np.uint16)
             self.assertEqual(res[ch].attrs["calibration"], "counts")
             self.assertEqual(res[ch].attrs["units"], "1")
@@ -234,8 +235,8 @@ class TestFCIL1CFDHSIReader(unittest.TestCase):
                     self._chans["solar"] + self._chans["terran"]])
         self.assertEqual(16, len(res))
         for ch in self._chans["solar"] + self._chans["terran"]:
-            self.assertEqual(res[ch].shape, (11136, 206))
-            self.assertEqual(res[ch].dtype, np.float32)
+            self.assertEqual(res[ch].shape, (200, 11136))
+            self.assertEqual(res[ch].dtype, np.float64)
             self.assertEqual(res[ch].attrs["calibration"], "radiance")
             self.assertEqual(res[ch].attrs["units"], "W m-2 um-1 sr-1")
 
@@ -259,8 +260,8 @@ class TestFCIL1CFDHSIReader(unittest.TestCase):
                     self._chans["solar"]])
         self.assertEqual(8, len(res))
         for ch in self._chans["solar"]:
-            self.assertEqual(res[ch].shape, (11136, 206))
-            self.assertEqual(res[ch].dtype, np.float32)
+            self.assertEqual(res[ch].shape, (200, 11136))
+            self.assertEqual(res[ch].dtype, np.float64)
             self.assertEqual(res[ch].attrs["calibration"], "reflectance")
             self.assertEqual(res[ch].attrs["units"], "%")
 
@@ -284,8 +285,8 @@ class TestFCIL1CFDHSIReader(unittest.TestCase):
                     name in self._chans["terran"]])
         self.assertEqual(8, len(res))
         for ch in self._chans["terran"]:
-            self.assertEqual(res[ch].shape, (11136, 206))
-            self.assertEqual(res[ch].dtype, np.float32)
+            self.assertEqual(res[ch].shape, (200, 11136))
+            self.assertEqual(res[ch].dtype, np.float64)
             self.assertEqual(res[ch].attrs["calibration"],
                              "brightness_temperature")
             self.assertEqual(res[ch].attrs["units"], "K")

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -67,7 +67,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
                     "valid_range": [0, 4095],
                     "scale_factor": 1,
                     "add_offset": 0,
-                    "units": "1",
+                    "units": "mW.m-2.sr-1.(cm-1)-1",
                     }
                 )
         data[ch_path] = d
@@ -126,6 +126,13 @@ class TestFCIL1CFDHSIReader(unittest.TestCase):
     """Test FCI L1C FDHSI reader
     """
     yaml_file = "fci_l1c_fdhsi.yaml"
+
+    # TODO:
+    # - test actual return values for radiances
+    # - test actual return values for reflectances
+    # - test actual return values for BTs
+    # - test special case for extended range IR38
+    # - test geolocation
 
     def setUp(self):
         """Wrap NetCDF4 FileHandler with our own fake handler
@@ -238,7 +245,7 @@ class TestFCIL1CFDHSIReader(unittest.TestCase):
             self.assertEqual(res[ch].shape, (200, 11136))
             self.assertEqual(res[ch].dtype, np.float64)
             self.assertEqual(res[ch].attrs["calibration"], "radiance")
-            self.assertEqual(res[ch].attrs["units"], "W m-2 um-1 sr-1")
+            self.assertEqual(res[ch].attrs["units"], 'mW.m-2.sr-1.(cm-1)-1')
 
     def test_load_reflectance(self):
         """Test loading with reflectance


### PR DESCRIPTION
This PR is a continuation of #525.  It updates the FCI L1C FDHSI reader to read the file format for the Pytroll workshop in May 2019 (Release ID MTGTD-168), "Example Products for Pytroll Workshop", and adds a test class for this reader.

 - [x] Closes #649
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
