### PR TITLE
Fix MODIS L1B and L2 readers not reading geolocation properly

### DIFF
--- a/satpy/etc/readers/modis_l1b.yaml
+++ b/satpy/etc/readers/modis_l1b.yaml
@@ -405,32 +405,33 @@ datasets:
     - 14.235
     - 14.385
 
-  longitude1k:
-    file_type: hdf_eos_geo
+  longitude:
     name: longitude
-    resolution: [1000, 500, 250]
+    resolution:
+      5000:
+        # For EUM reduced (thinned) files
+        file_type: hdf_eos_data_1000m
+      1000:
+        file_type: [hdf_eos_geo, hdf_eos_data_1000m]
+      500:
+        file_type: hdf_eos_geo
+      250:
+        file_type: hdf_eos_geo
     standard_name: longitude
     units: degree
 
-  latitude1k:
-    file_type: hdf_eos_geo
+  latitude:
     name: latitude
-    resolution: [1000, 500, 250]
-    standard_name: latitude
-    units: degree
-
-  # For EUM reduced (thinned) files
-  longitude5k:
-    file_type: hdf_eos_data_1000m
-    name: longitude
-    resolution: [5000, 1000]
-    standard_name: longitude
-    units: degree
-
-  latitude5k:
-    file_type: hdf_eos_data_1000m
-    name: latitude
-    resolution: [5000, 1000]
+    resolution:
+      5000:
+        # For EUM reduced (thinned) files
+        file_type: hdf_eos_data_1000m
+      1000:
+        file_type: [hdf_eos_geo, hdf_eos_data_1000m]
+      500:
+        file_type: hdf_eos_geo
+      250:
+        file_type: hdf_eos_geo
     standard_name: latitude
     units: degree
 
@@ -497,4 +498,4 @@ file_types:
     - 'M{platform_indicator:1s}D03.A{start_time:%Y%j.%H%M}.{collection:03d}{suffix}.hdf'
     - 'M{platform_indicator:1s}D03.{start_time:%y%j%H%M%S}.hdf'
     - '{platform_indicator:1s}1.{start_time:%y%j.%H%M}.geo.hdf'
-    file_reader: !!python/name:satpy.readers.modis_l1b.HDFEOSGeoReader ''
+    file_reader: !!python/name:satpy.readers.modis_l1b.HDFEOSGeoReader

--- a/satpy/etc/readers/modis_l2.yaml
+++ b/satpy/etc/readers/modis_l2.yaml
@@ -6,10 +6,18 @@ reader:
   sensors: [modis]
 
 file_types:
-  hdf:
+  mod35_hdf:
     file_patterns:
     - 'M{platform_indicator:1s}D35_L2.A{acquisition_time:%Y%j.%H%M}.{collection:03d}.{production_time:%Y%j%H%M%S}.hdf'
     file_reader: !!python/name:satpy.readers.modis_l2.ModisL2HDFFileHandler
+  hdf_eos_geo:
+    file_patterns:
+      - 'M{platform_indicator:1s}D03_A{start_time:%y%j_%H%M%S}_{processing_time:%Y%j%H%M%S}.hdf'
+      - 'M{platform_indicator:1s}D03.A{start_time:%Y%j.%H%M}.{collection:03d}.{processing_time:%Y%j%H%M%S}.hdf'
+      - 'M{platform_indicator:1s}D03.A{start_time:%Y%j.%H%M}.{collection:03d}{suffix}.hdf'
+      - 'M{platform_indicator:1s}D03.{start_time:%y%j%H%M%S}.hdf'
+      - '{platform_indicator:1s}1.{start_time:%y%j.%H%M}.geo.hdf'
+    file_reader: !!python/name:satpy.readers.modis_l1b.HDFEOSGeoReader
 
 datasets:
   cloud_mask:
@@ -32,21 +40,37 @@ datasets:
     quality_assurance:
       - 250: True
     file_key: Cloud_Mask
-    file_type: hdf
+    file_type: mod35_hdf
+    coordinates: [longitude, latitude]
 
   longitude:
     name: longitude
+    resolution:
+      5000:
+        file_type: mod35_hdf
+      1000:
+        file_type: [hdf_eos_geo, mod35_hdf]
+      500:
+        file_type: hdf_eos_geo
+      250:
+        file_type: hdf_eos_geo
+    standard_name: longitude
     units: degree
-    resolution: [1000, 5000]
-    file_key: Longitude
-    file_type: hdf
 
   latitude:
     name: latitude
+    resolution:
+      5000:
+        # For EUM reduced (thinned) files
+        file_type: mod35_hdf
+      1000:
+        file_type: [hdf_eos_geo, mod35_hdf]
+      500:
+        file_type: hdf_eos_geo
+      250:
+        file_type: hdf_eos_geo
+    standard_name: latitude
     units: degree
-    resolution: [1000, 5000]
-    file_key: Latitude
-    file_type: hdf
 
   quality_assurance:
     # byte Quality_Assurance(Cell_Along_Swath_1km, Cell_Across_Swath_1km, QA_Dimension)
@@ -59,5 +83,6 @@ datasets:
     bit_start: 0
     bit_count: 1
     file_key: Quality_Assurance
-    file_type: hdf
+    file_type: mod35_hdf
+    coordinates: [longitude, latitude]
 

--- a/satpy/readers/hdfeos_base.py
+++ b/satpy/readers/hdfeos_base.py
@@ -234,15 +234,16 @@ class HDFEOSGeoReader(HDFEOSBaseFileReader):
         dataset_name = dataset_keys.name
         # Resolution asked
         resolution = dataset_keys.resolution
-        # Default variable name
         if in_file_dataset_name is not None:
+            # if the YAML was configured with a specific name use that
             data = self.load_dataset(in_file_dataset_name)
         else:
+            # otherwise use the default name for this variable
             data = self._load_ds_by_name(dataset_name)
         if resolution != self.geo_resolution:
             if in_file_dataset_name is not None:
-                # they specified a custom variable name but we don't know
-                # how to interpolate this yet
+                # they specified a custom variable name but
+                # we don't know how to interpolate this yet
                 raise NotImplementedError(
                     "Interpolation for variable '{}' is not "
                     "configured".format(dataset_name))

--- a/satpy/readers/hdfeos_base.py
+++ b/satpy/readers/hdfeos_base.py
@@ -15,6 +15,7 @@
 
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
+import re
 import logging
 
 from datetime import datetime
@@ -28,6 +29,27 @@ from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
 
 logger = logging.getLogger(__name__)
+
+
+def interpolate(clons, clats, csatz, src_resolution, dst_resolution):
+    from geotiepoints.modisinterpolator import modis_1km_to_250m, modis_1km_to_500m, modis_5km_to_1km
+
+    interpolation_functions = {
+        (5000, 1000): modis_5km_to_1km,
+        (1000, 500): modis_1km_to_500m,
+        (1000, 250): modis_1km_to_250m
+    }
+
+    try:
+        interpolation_function = interpolation_functions[(src_resolution, dst_resolution)]
+    except KeyError:
+        error_message = "Interpolation from {}m to {}m not implemented".format(
+            src_resolution, dst_resolution)
+        raise NotImplementedError(error_message)
+
+    logger.debug("Interpolating from {} to {}".format(src_resolution, dst_resolution))
+
+    return interpolation_function(clons, clats, csatz)
 
 
 class HDFEOSBaseFileReader(BaseFileHandler):
@@ -120,11 +142,24 @@ class HDFEOSBaseFileReader(BaseFileHandler):
 
         dataset = self._read_dataset_in_file(dataset_name)
         fill_value = dataset._FillValue
-        scale_factor = np.float32(dataset.scale_factor)
-        data = xr.DataArray(from_sds(dataset, chunks=CHUNK_SIZE),
-                            dims=['y', 'x']).astype(np.float32)
-        data_mask = data.where(data != fill_value)
-        data = data_mask * scale_factor
+        dask_arr = from_sds(dataset, chunks=CHUNK_SIZE)
+        dims = ('y', 'x') if dask_arr.ndim == 2 else None
+        data = xr.DataArray(dask_arr, dims=dims,
+                            attrs=dataset.attributes())
+
+        # preserve integer data types if possible
+        if np.issubdtype(data.dtype, np.integer):
+            new_fill = fill_value
+        else:
+            new_fill = np.nan
+            data.attrs.pop('_FillValue', None)
+        good_mask = data != fill_value
+
+        scale_factor = data.attrs.get('scale_factor')
+        if scale_factor is not None:
+            data = data * scale_factor
+
+        data = data.where(good_mask, new_fill)
         return data
 
 
@@ -132,115 +167,123 @@ class HDFEOSGeoReader(HDFEOSBaseFileReader):
     """Handler for the geographical datasets. """
 
     # list of geographical datasets handled by the georeader
-    DATASET_NAMES = ['longitude', 'latitude',
-                     'satellite_azimuth_angle', 'satellite_zenith_angle',
-                     'solar_azimuth_angle', 'solar_zenith_angle']
+    # mapping to the default variable name if not specified in YAML
+    DATASET_NAMES = {
+        'longitude': 'Longitude',
+        'latitude': 'Latitude',
+        'satellite_azimuth_angle': ('SensorAzimuth', 'Sensor_Azimuth'),
+        'satellite_zenith_angle': ('SensorZenith', 'Sensor_Zenith'),
+        'solar_azimuth_angle': ('SolarAzimuth', 'SolarAzimuth'),
+        'solar_zenith_angle': ('SolarZenith', 'Solar_Zenith'),
+    }
 
     def __init__(self, filename, filename_info, filetype_info):
         HDFEOSBaseFileReader.__init__(self, filename, filename_info, filetype_info)
 
     @staticmethod
     def read_geo_resolution(metadata):
-        """Parses metada to find the geolocation resolution.
+        """Parses metadata to find the geolocation resolution.
+
         It is implemented as a staticmethod to match read_mda pattern.
 
         """
-        import re
+        # level 1 files
+        try:
+            ds = metadata['INVENTORYMETADATA']['COLLECTIONDESCRIPTIONCLASS']['SHORTNAME']['VALUE']
+            if ds.endswith('D03'):
+                return 1000
+            else:
+                # 1km files have 5km geolocation usually
+                return 5000
+        except KeyError:
+            pass
+
+        # data files probably have this level 2 files
+        # this does not work for L1B 1KM data files because they are listed
+        # as 1KM data but the geo data inside is at 5km
         try:
             latitude_dim = metadata['SwathStructure']['SWATH_1']['DimensionMap']['DimensionMap_2']['GeoDimension']
-        except KeyError as e:
-            logger.debug("Resolution not found in metadata: {}".format(e))
-            return None
-        resolution_regex = re.compile(r'(?P<resolution>\d+)(km|KM)')
-        resolution_match = resolution_regex.search(latitude_dim)
-        return int(resolution_match.group('resolution')) * 1000
+            resolution_regex = re.compile(r'(?P<resolution>\d+)(km|KM)')
+            resolution_match = resolution_regex.search(latitude_dim)
+            return int(resolution_match.group('resolution')) * 1000
+        except (AttributeError, KeyError):
+            pass
+
+        raise RuntimeError("Could not determine resolution from file metadata")
 
     @property
     def geo_resolution(self):
-        """Resolution of the geographical data retrieved in the metada. """
+        """Resolution of the geographical data retrieved in the metadata."""
         return self.read_geo_resolution(self.metadata)
+
+    def _load_ds_by_name(self, ds_name):
+        """Helper to attempt loading using multiple common names."""
+        var_names = self.DATASET_NAMES[ds_name]
+        if isinstance(var_names, (list, tuple)):
+            try:
+                return self.load_dataset(var_names[0])
+            except KeyError:
+                return self.load_dataset(var_names[1])
+        return self.load_dataset(var_names)
 
     def get_dataset(self, dataset_keys, dataset_info):
         """Get the geolocation dataset."""
         # Name of the dataset as it appears in the HDF EOS file
-        in_file_dataset_name = dataset_info['file_key']
+        in_file_dataset_name = dataset_info.get('file_key')
         # Name of the dataset in the YAML file
         dataset_name = dataset_keys.name
         # Resolution asked
         resolution = dataset_keys.resolution
-
-        data = self.load_dataset(in_file_dataset_name)
-
+        # Default variable name
+        if in_file_dataset_name is not None:
+            data = self.load_dataset(in_file_dataset_name)
+        else:
+            data = self._load_ds_by_name(dataset_name)
         if resolution != self.geo_resolution:
+            if in_file_dataset_name is not None:
+                # they specified a custom variable name but we don't know
+                # how to interpolate this yet
+                raise NotImplementedError(
+                    "Interpolation for variable '{}' is not "
+                    "configured".format(dataset_name))
 
             # The data must be interpolated
             interpolated_dataset = {}
-
-            def interpolate(clons, clats, csatz):
-                from geotiepoints.modisinterpolator import modis_1km_to_250m, modis_1km_to_500m, modis_5km_to_1km
-
-                interpolation_functions = {
-                    (5000, 1000): modis_5km_to_1km,
-                    (1000, 500): modis_1km_to_500m,
-                    (1000, 250): modis_1km_to_250m
-                }
-
-                try:
-                    interpolation_function = interpolation_functions[(self.geo_resolution, resolution)]
-                except KeyError:
-                    error_message = "Interpolation from {}m to {}m not implemented".format(
-                        self.geo_resolution, resolution)
-                    raise NotImplementedError(error_message)
-
-                logger.debug("Interpolating from {} to {}".format(self.geo_resolution, resolution))
-
-                return interpolation_function(clons, clats, csatz)
-
-            # Sensor zenith dataset name differs between L1b and L2 products
-            sensor_zentih = None
-            try:
-                sensor_zenith = self.load_dataset('SensorZenith')
-            except KeyError:
-                sensor_zenith = self.load_dataset('Sensor_Zenith')
-
+            sensor_zenith = self._load_ds_by_name(dataset_name)
             if dataset_name in ['longitude', 'latitude']:
-                latitude = self.load_dataset('Longitude')
-                longitude = self.load_dataset('Latitude')
+                latitude = self._load_ds_by_name('longitude')
+                longitude = self._load_ds_by_name('latitude')
                 longitude, latitude = interpolate(
-                    longitude, latitude, sensor_zenith
+                    longitude, latitude, sensor_zenith,
+                    self.geo_resolution, resolution
                 )
                 interpolated_dataset['longitude'] = longitude
                 interpolated_dataset['latitude'] = latitude
-
-            else:
-                if dataset_name in ['satellite_azimuth_angle', 'satellite_zenith_angle']:
-                    # Sensor dataset names differs between L1b and L2 products
-                    try:
-                        sensor_azimuth_a = self.load_dataset('SensorAzimuth')
-                        sensor_azimuth_b = self.load_dataset('SensorZenith') - 90
-                    except KeyError:
-                        sensor_azimuth_a = self.load_dataset('Sensor_Azimuth')
-                        sensor_azimuth_b = self.load_dataset('Sensor_Zenith') - 90
-                    sensor_azimuth_a, sensor_azimuth_b = interpolate(
-                        sensor_azimuth_a, sensor_azimuth_b, sensor_zenith
-                    )
-                    interpolated_dataset['satellite_azimuth_angle'] = sensor_azimuth_a
-                    interpolated_dataset['satellite_zentih_angle'] = sensor_azimuth_b + 90
-
-                elif dataset_name in ['solar_azimuth_angle', 'solar_zenith_angle']:
-                    # Sensor dataset names differs between L1b and L2 products
-                    try:
-                        solar_azimuth_a = self.load_dataset('SolarAzimuth')
-                        solar_azimuth_b = self.load_dataset('SolarZenith') - 90
-                    except KeyError:
-                        solar_azimuth_a = self.load_dataset('Solar_Azimuth')
-                        solar_azimuth_b = self.load_dataset('Solar_Zenith') - 90
-                    solar_azimuth_a, solar_azimuth_b = interpolate(
-                        solar_azimuth_a, solar_azimuth_b, sensor_zentih
-                    )
-                    interpolated_dataset['solar_azimuth_angle'] = solar_azimuth_a
-                    interpolated_dataset['solar_zentih_angle'] = solar_azimuth_b + 90
+            elif dataset_name in ['satellite_azimuth_angle', 'satellite_zenith_angle']:
+                # Sensor dataset names differs between L1b and L2 products
+                sensor_azimuth_a = self._load_ds_by_name('satellite_azimuth_angle')
+                sensor_azimuth_b = self._load_ds_by_name('satellite_zenith_angle') - 90
+                sensor_azimuth_a, sensor_azimuth_b = interpolate(
+                    sensor_azimuth_a, sensor_azimuth_b, sensor_zenith,
+                    self.geo_resolution, resolution
+                )
+                interpolated_dataset['satellite_azimuth_angle'] = sensor_azimuth_a
+                interpolated_dataset['satellite_zenith_angle'] = sensor_azimuth_b + 90
+            elif dataset_name in ['solar_azimuth_angle', 'solar_zenith_angle']:
+                # Sensor dataset names differs between L1b and L2 products
+                solar_azimuth_a = self._load_ds_by_name('solar_azimuth_angle')
+                solar_azimuth_b = self._load_ds_by_name('solar_zenith_angle') - 90
+                solar_azimuth_a, solar_azimuth_b = interpolate(
+                    solar_azimuth_a, solar_azimuth_b, sensor_zenith,
+                    self.geo_resolution, resolution
+                )
+                interpolated_dataset['solar_azimuth_angle'] = solar_azimuth_a
+                interpolated_dataset['solar_zenith_angle'] = solar_azimuth_b + 90
 
             data = interpolated_dataset[dataset_name]
+
+        for key in ('standard_name', 'units'):
+            if key in dataset_info:
+                data.attrs[key] = dataset_info[key]
 
         return data

--- a/satpy/readers/mersi2_l1b.py
+++ b/satpy/readers/mersi2_l1b.py
@@ -96,11 +96,14 @@ class MERSI2L1B(HDF5FileHandler):
         if dataset_id.calibration == 'counts':
             # preserve integer type of counts if possible
             attrs['_FillValue'] = fill_value
+            new_fill = fill_value
+        else:
+            new_fill = np.nan
         if valid_range is not None:
             # typically bad_values == 65535, saturated == 65534
             # dead detector == 65533
             data = data.where((data >= valid_range[0]) &
-                              (data <= valid_range[1]), fill_value)
+                              (data <= valid_range[1]), new_fill)
 
         slope = attrs.pop('Slope', None)
         intercept = attrs.pop('Intercept', None)


### PR DESCRIPTION
This PR has a couple fixes resulting from some missed things in #611. It kind of helps with #744. If you try to load true_color from only 500m + geo files then you will still need to resample because Satpy isn't smart enough to realize that the data is 500m and it needs SZA at 500m to do some of the modifiers; so Satpy will load SZA at 250m.

This also adds necessary coordinate information for the L2 reader so that cloud mask will always have a SwathDefinition (geolocation) associated with it.

This PR will also include a small fix for the MERSI-2 L1B reader that I noticed after working on MODIS in a similar way.

@LTMeyer If you see anything suspicious in this, let me know.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
