### PR TITLE
Avoid leaking file objects in NetCDF4FileHandler

### DIFF
--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -135,6 +135,16 @@ class NetCDF4FileHandler(BaseFileHandler):
             with xr.open_dataset(self.filename, group=group,
                                  **self._xarray_kwargs) as nc:
                 val = nc[key]
+                # Even though `chunks` is specified in the kwargs, xarray
+                # uses dask.arrays only for data variables that have at least
+                # one dimension; for zero-dimensional data variables (scalar),
+                # it uses its own lazy loading for scalars.  When those are
+                # accessed after file closure, xarray reopens the file without
+                # closing it again.  This will leave potentially many open file
+                # objects (which may in turn trigger a Segmentation Fault:
+                # https://github.com/pydata/xarray/issues/2954#issuecomment-491221266
+                if not val.chunks:
+                    val.load()
         return val
 
     def __contains__(self, item):


### PR DESCRIPTION
Even though `chunks` is specified in the kwargs, xarray uses dask.arrays only for data variables that have at least one dimension; for zero-dimensional data variables (scalar), it uses its own lazy
loading for scalars.  When those are accessed after file closure, xarray reopens the file without closing it again.  This will leave potentially many open file objects (which may in turn trigger a Segmentation Fault: https://github.com/pydata/xarray/issues/2954#issuecomment-491221266

This problem is avoided if the scalar data variables are loaded into memory before the context manager is exited.  This PR implements such a mitigation.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
