### PR TITLE
Fix mersi2_l1b reader setting sensor as a set object

### DIFF
--- a/satpy/readers/mersi2_l1b.py
+++ b/satpy/readers/mersi2_l1b.py
@@ -54,13 +54,13 @@ class MERSI2L1B(HDF5FileHandler):
         return self._strptime('/attr/Observing Ending Date', '/attr/Observing Ending Time')
 
     @property
-    def sensor_names(self):
+    def sensor_name(self):
         """Map sensor name to Satpy 'standard' sensor names."""
         file_sensor = self['/attr/Sensor Identification Code']
         sensor = {
             'MERSI': 'mersi2',
         }.get(file_sensor, file_sensor)
-        return {sensor}  # set
+        return sensor
 
     def _get_coefficients(self, cal_key, cal_index):
         coeffs = self[cal_key][cal_index]
@@ -161,7 +161,7 @@ class MERSI2L1B(HDF5FileHandler):
 
         data.attrs.update({
             'platform_name': self['/attr/Satellite Name'],
-            'sensor': self.sensor_names,
+            'sensor': self.sensor_name,
         })
 
         return data


### PR DESCRIPTION
The DataArray 'sensor' attribute should be a single string right now. Rayleigh correction was complaining about not being able to serialize the 'sensor' attribute.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
