### PR TITLE
Fix AVHRR tests importing external mock on Python 3

### DIFF
--- a/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
+++ b/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
@@ -18,7 +18,10 @@
 
 from unittest import TestCase, main, TestLoader, TestSuite
 import numpy as np
-import mock
+try:
+    from unittest import mock
+except ImportError: # python 2
+    import mock
 
 GAC_PATTERN = 'NSS.GHRR.{platform_id:2s}.D{start_time:%y%j.S%H%M}.E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}'  # noqa
 

--- a/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
+++ b/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
@@ -20,7 +20,7 @@ from unittest import TestCase, main, TestLoader, TestSuite
 import numpy as np
 try:
     from unittest import mock
-except ImportError: # python 2
+except ImportError:  # python 2
     import mock
 
 GAC_PATTERN = 'NSS.GHRR.{platform_id:2s}.D{start_time:%y%j.S%H%M}.E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}'  # noqa


### PR DESCRIPTION
In the AVHRR L1B GACLAC testing routine, do not import mock from
external package when it can be successfully imported from the unittest
module.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
