### PR TITLE
Fix typo for mersi2/abi/ahi using bidirection instead of bidirectional

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -36,7 +36,7 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected_crefl]
     - name: C03
       modifiers: [sunz_corrected, rayleigh_corrected_crefl]
-    standard_name: toa_bidirection_reflectance
+    standard_name: toa_bidirectional_reflectance
 
   green_raw:
     compositor: !!python/name:satpy.composites.abi.SimulatedGreen
@@ -50,7 +50,7 @@ composites:
       modifiers: [sunz_corrected]
     - name: C03
       modifiers: [sunz_corrected]
-    standard_name: toa_bidirection_reflectance
+    standard_name: toa_bidirectional_reflectance
 
   green:
     compositor: !!python/name:satpy.composites.abi.SimulatedGreen
@@ -64,7 +64,7 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected]
     - name: C03
       modifiers: [sunz_corrected]
-    standard_name: toa_bidirection_reflectance
+    standard_name: toa_bidirectional_reflectance
 
   true_color_crefl:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -26,7 +26,7 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected]
     - wavelength: 0.85
       modifiers: [sunz_corrected]
-    standard_name: toa_bidirection_reflectance
+    standard_name: toa_bidirectional_reflectance
 
   overview:
     compositor: !!python/name:satpy.composites.GenericCompositor

--- a/satpy/etc/readers/mersi2_l1b.yaml
+++ b/satpy/etc/readers/mersi2_l1b.yaml
@@ -55,7 +55,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -81,7 +81,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -107,7 +107,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -133,7 +133,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -154,7 +154,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -174,7 +174,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -194,7 +194,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -214,7 +214,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -234,7 +234,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -254,7 +254,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -274,7 +274,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -294,7 +294,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -314,7 +314,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -334,7 +334,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -354,7 +354,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -374,7 +374,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -394,7 +394,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -414,7 +414,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -434,7 +434,7 @@ datasets:
     calibration:
       reflectance:
         units: "%"
-        standard_name: toa_bidirection_reflectance
+        standard_name: toa_bidirectional_reflectance
       radiance:
         units: 'mW/ (m2 cm-1 sr)'
         standard_name: toa_outgoing_radiance_per_unit_wavelength


### PR DESCRIPTION
`standard_name` for ABI, AHI, MERSI-2 L1B I had a typo of `toa_bidirection_reflectance` when it should be `toa_bidirectional_reflectance` (note the `al`). This fixes this typo.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

