### PR TITLE
Improve Scene.show documentation

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1124,7 +1124,25 @@ class Scene(MetadataObject):
         return new_scn
 
     def show(self, dataset_id, overlay=None):
-        """Show the *dataset* on screen as an image."""
+        """Show the *dataset* on screen as an image.
+
+        Show dataset on screen as an image, possibly with an overlay.
+
+        Args:
+            dataset_id (DatasetID or str):
+                Either a DatasetID or a string representing a DatasetID, that
+                has been previously loaded using Scene.load.
+            overlay (dict, optional):
+                Add an overlay before showing the image.  The keys/values for
+                this dictionary are as the arguments for
+                :meth:`~satpy.writers.add_overlay`.  The dictionary should
+                contain at least the key ``"coast_dir"``, which should refer
+                to a top-level directory containing shapefiles.  See the
+                pycoast_ package documentation for coastline shapefile
+                installation instructions.
+
+        .. _pycoast: https://pycoast.readthedocs.io/
+        """
         from satpy.writers import get_enhanced_image
         from satpy.utils import in_ipynb
         img = get_enhanced_image(self[dataset_id].squeeze(), overlay=overlay)


### PR DESCRIPTION
Improve the docstring for Scene.show, linking to documentation on what can be passed as an overlay and where is described how to get shapefiles.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
