### PR TITLE
Fix 'abi_l1b' reader not updating long_name when calibrating

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -35,4 +35,4 @@ The following people have made contributions to this project:
 - Marco Sassi - meteoswiss
 - [Rohan Daruwala (rdaruwala)](https://github.com/rdaruwala)
 - [Simon R. Proud (simonrp84)](https://github.com/simonrp84)
-- [Joleen Feltz (joleenf)] (https://github.com/joleenf)
+- [Joleen Feltz (joleenf)](https://github.com/joleenf)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -35,3 +35,4 @@ The following people have made contributions to this project:
 - Marco Sassi - meteoswiss
 - [Rohan Daruwala (rdaruwala)](https://github.com/rdaruwala)
 - [Simon R. Proud (simonrp84)](https://github.com/simonrp84)
+- [Joleen Feltz (joleenf)] (https://github.com/joleenf)

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -193,6 +193,7 @@ class NC_ABI_L1B(BaseFileHandler):
         res = data * factor
         res.attrs = data.attrs
         res.attrs['units'] = '1'
+        res.attrs['long_name'] = 'Bidirectional Reflectance'
         res.attrs['standard_name'] = 'toa_bidirectional_reflectance'
         return res
 
@@ -206,6 +207,7 @@ class NC_ABI_L1B(BaseFileHandler):
         res = (fk2 / np.log(fk1 / data + 1) - bc1) / bc2
         res.attrs = data.attrs
         res.attrs['units'] = 'K'
+        res.attrs['long_name'] = 'Brightness Temperature'
         res.attrs['standard_name'] = 'toa_brightness_temperature'
         return res
 

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -103,6 +103,7 @@ class Test_NC_ABI_L1B_ir_cal(unittest.TestCase):
         self.assertNotIn('_FillValue', res.attrs)
         self.assertEqual(res.attrs['standard_name'],
                          'toa_brightness_temperature')
+        self.assertEqual(res.attrs['long_name'], 'Brightness Temperature')
 
 
 class Test_NC_ABI_L1B_vis_cal(unittest.TestCase):
@@ -186,6 +187,8 @@ class Test_NC_ABI_L1B_vis_cal(unittest.TestCase):
         self.assertNotIn('_FillValue', res.attrs)
         self.assertEqual(res.attrs['standard_name'],
                          'toa_bidirectional_reflectance')
+        self.assertEqual(res.attrs['long_name'],
+                         'Bidirectional Reflectance')
 
 
 class Test_NC_ABI_L1B_area(unittest.TestCase):


### PR DESCRIPTION
Address issue #774 "ABI Level 1b long_name when reflectances and brightness temperatures are calculated"

Adds long_name to _vis_calibrate and _ir_calibrate within abi l1b reader code to describe the data that has been calculated in these functions.  