### PR TITLE
Fix NullHandler not allowing warning/error logs to be printed to console

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -17,6 +17,7 @@ The following people have made contributions to this project:
 - [JohannesSMHI (JohannesSMHI)](https://github.com/JohannesSMHI)
 - [Panu Lahtinen (pnuu)](https://github.com/pnuu)
 - [Thomas Leppelt (m4sth0)](https://github.com/m4sth0)
+- [Esben S. Nielsen (storpipfugl)](https://github.com/storpipfugl)
 - [Tom Parker (tparker-usgs)](https://github.com/tparker-usgs)
 - [Lars Ørum Rasmussen (loerum)](https://github.com/loerum)
 - [Martin Raspaud (mraspaud)](https://github.com/mraspaud)

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -1,13 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2009-2018 PyTroll developers
-#
-# Author(s):
-#
-#   Martin Raspaud <martin.raspaud@smhi.se>
-#   Adam Dybbroe <adam.dybbroe@smhi.se>
-#   Esben S. Nielsen <esn@dmi.dk>
-#   Panu Lahtinen <pnuu+git@iki.fi>
+# Copyright (c) 2009-2019 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -23,12 +16,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with satpy.  If not, see <http://www.gnu.org/licenses/>.
-
 """Module defining various utilities.
 """
 
 import logging
 import os
+import sys
 import re
 
 import numpy as np
@@ -136,7 +129,7 @@ def get_logger(name):
         logging.Logger.trace = trace
 
     log = logging.getLogger(name)
-    if not log.handlers:
+    if not log.handlers and sys.version_info[0] < 3:
         log.addHandler(logging.NullHandler())
     return log
 


### PR DESCRIPTION
See #777 for details. This now results in python 3 printing the raw string of any warning or error messages from the logger and prints nothing with python 2 as the NullHandler is still added.

 - [x] Closes #777 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
