### PR TITLE
Fix builtin areas to be compatible with rasterio

### DIFF
--- a/satpy/etc/areas.yaml
+++ b/satpy/etc/areas.yaml
@@ -285,6 +285,7 @@ afghanistan:
     proj: merc
     lat_ts: 35.0
     a: 6370997.0
+    b: 6370997.0
     lon_0: 67.5
     lat_0: 35.0
   shape:
@@ -584,6 +585,8 @@ mesanX:
     o_lon_p: 10.0
     lon_0: -10.0
     a: 6371000.0
+    b: 6371000.0
+    wktext: True
   shape:
     height: 1608
     width: 1476
@@ -599,6 +602,8 @@ mesanE:
     o_lon_p: 10.0
     lon_0: -10.0
     a: 6371000.0
+    b: 6371000.0
+    wktext: True
   shape:
     height: 6294
     width: 5093
@@ -831,6 +836,7 @@ baltrad_lambert:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lon_0: 20.0
     lat_0: 60.0
   shape:
@@ -914,6 +920,7 @@ npp_sample_m:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lat_0: 60.0
     lon_0: -120.0
   shape:
@@ -927,6 +934,7 @@ arctic_europe_1km:
   projection:
     proj: laea
     a: 6371228.0
+    b: 6371228.0
     lon_0: 0.0
     lat_0: 90.0
   shape:
@@ -940,6 +948,7 @@ arctic_europe_9km:
   projection:
     proj: laea
     a: 6371228.0
+    b: 6371228.0
     lon_0: 0.0
     lat_0: 90.0
   shape:
@@ -1001,6 +1010,7 @@ ease_sh:
     lat_0: -90.0
     lon_0: 0.0
     a: 6371228.0
+    b: 6371228.0
   shape:
     height: 425
     width: 425
@@ -1015,6 +1025,7 @@ ease_nh:
     lat_0: 90.0
     lon_0: 0.0
     a: 6371228.0
+    b: 6371228.0
   shape:
     height: 425
     width: 425
@@ -1041,6 +1052,7 @@ antarctica:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lon_0: 0.0
     lat_0: -90.0
   shape:
@@ -1054,6 +1066,7 @@ arctica:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lon_0: 0.0
     lat_0: 90.0
   shape:
@@ -1067,6 +1080,7 @@ euroasia:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lat_0: 55.0
     lon_0: 20.0
   shape:
@@ -1080,6 +1094,7 @@ euroasia_10km:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lat_0: 55.0
     lon_0: 20.0
   shape:
@@ -1093,6 +1108,7 @@ euroasia_asia:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lat_0: 45.0
     lon_0: 100.0
   shape:
@@ -1106,6 +1122,7 @@ euroasia_asia_10km:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lat_0: 45.0
     lon_0: 100.0
   shape:
@@ -1119,6 +1136,7 @@ australia_pacific:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lat_0: -15.0
     lon_0: 135.0
   shape:
@@ -1132,6 +1150,7 @@ australia_pacific_10km:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lat_0: -15.0
     lon_0: 135.0
   shape:
@@ -1145,6 +1164,7 @@ africa:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lat_0: 5.0
     lon_0: 20.0
   shape:
@@ -1158,6 +1178,7 @@ africa_10km:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lat_0: 5.0
     lon_0: 20.0
   shape:
@@ -1171,6 +1192,7 @@ southamerica:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lat_0: -15.0
     lon_0: -60.0
   shape:
@@ -1184,6 +1206,7 @@ southamerica_10km:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lat_0: -15.0
     lon_0: -60.0
   shape:
@@ -1197,6 +1220,7 @@ northamerica:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lat_0: 50.0
     lon_0: -100.0
   shape:
@@ -1210,6 +1234,7 @@ northamerica_10km:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lat_0: 50.0
     lon_0: -100.0
   shape:
@@ -1263,6 +1288,7 @@ nsper_swe:
     lon_0: 16.0
     lat_0: 58.0
     h: 360000000.0
+    wktext: True
   shape:
     height: 1024
     width: 1024
@@ -1287,6 +1313,7 @@ scanice:
   projection:
     proj: laea
     a: 6370997.0
+    b: 6370997.0
     lon_0: 0.0
     lat_0: 64.0
   shape:

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -52,9 +52,43 @@ class TestCheckSatpy(unittest.TestCase):
                                           "mentioned in checks")
 
 
+class TestBuiltinAreas(unittest.TestCase):
+    """Test that the builtin areas are all valid."""
+
+    def test_areas_pyproj(self):
+        """Test all areas have valid projections with pyproj."""
+        import pyproj
+        from pyresample import parse_area_file
+        from satpy.resample import get_area_file
+        all_areas = parse_area_file(get_area_file())
+
+        for area_obj in all_areas:
+            if getattr(area_obj, 'optimize_projection', False):
+                # the PROJ.4 is known to not be valid on this DynamicAreaDef
+                continue
+            proj_dict = area_obj.proj_dict
+            _ = pyproj.Proj(proj_dict)
+
+    def test_areas_rasterio(self):
+        """Test all areas have valid projections with rasterio."""
+        try:
+            from rasterio.crs import CRS
+        except ImportError:
+            return unittest.skip("Missing rasterio dependency")
+        from pyresample import parse_area_file
+        from satpy.resample import get_area_file
+        all_areas = parse_area_file(get_area_file())
+
+        for area_obj in all_areas:
+            if getattr(area_obj, 'optimize_projection', False):
+                # the PROJ.4 is known to not be valid on this DynamicAreaDef
+                continue
+            proj_dict = area_obj.proj_dict
+            _ = CRS.from_dict(proj_dict)
+
+
 def suite():
-    """The test suite for test_projector.
-    """
+    """The test suite for test_config."""
     loader = unittest.TestLoader()
     my_suite = unittest.TestSuite()
     my_suite.addTest(loader.loadTestsFromTestCase(TestCheckSatpy))

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -60,8 +60,8 @@ class TestBuiltinAreas(unittest.TestCase):
         import pyproj
         from pyresample import parse_area_file
         from satpy.resample import get_area_file
-        all_areas = parse_area_file(get_area_file())
 
+        all_areas = parse_area_file(get_area_file())
         for area_obj in all_areas:
             if getattr(area_obj, 'optimize_projection', False):
                 # the PROJ.4 is known to not be valid on this DynamicAreaDef
@@ -75,10 +75,12 @@ class TestBuiltinAreas(unittest.TestCase):
             from rasterio.crs import CRS
         except ImportError:
             return unittest.skip("Missing rasterio dependency")
+        if not hasattr(CRS, 'from_dict'):
+            return unittest.skip("RasterIO 1.0+ required")
+
         from pyresample import parse_area_file
         from satpy.resample import get_area_file
         all_areas = parse_area_file(get_area_file())
-
         for area_obj in all_areas:
             if getattr(area_obj, 'optimize_projection', False):
                 # the PROJ.4 is known to not be valid on this DynamicAreaDef

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -92,5 +92,6 @@ def suite():
     loader = unittest.TestLoader()
     my_suite = unittest.TestSuite()
     my_suite.addTest(loader.loadTestsFromTestCase(TestCheckSatpy))
+    my_suite.addTest(loader.loadTestsFromTestCase(TestBuiltinAreas))
 
     return my_suite


### PR DESCRIPTION
As mentioned in #776 some of the builtin areas can be loaded by pyproj but not rasterio. This means any data on these areas (resampled to) can not be saved to geotiff (the default writer). This was pointed out by @gerritholl.

I added some tests that check all areas with pyproj and with rasterio and fixed the problem areas.

References that helped me determine how to fix some of these:

- https://github.com/mapbox/rasterio/issues/1292
- http://northstar-www.dartmouth.edu/doc/idl/html_6.2/MAP_PROJ_INIT.html

And I tested by making to `Proj` objects with and without the `b` arguments to verify that Proj defaults to spherical projections when `b` is not specified.

 - [x] Closes #776 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``git diff origin/master -- "*py" | flake8 --diff`` <!-- remove if you did not edit any Python files -->

