### PR TITLE
Fix longitude/latitude being swapped in modis readers

### DIFF
--- a/satpy/readers/hdfeos_base.py
+++ b/satpy/readers/hdfeos_base.py
@@ -252,8 +252,8 @@ class HDFEOSGeoReader(HDFEOSBaseFileReader):
             interpolated_dataset = {}
             sensor_zenith = self._load_ds_by_name(dataset_name)
             if dataset_name in ['longitude', 'latitude']:
-                latitude = self._load_ds_by_name('longitude')
-                longitude = self._load_ds_by_name('latitude')
+                longitude = self._load_ds_by_name('longitude')
+                latitude = self._load_ds_by_name('latitude')
                 longitude, latitude = interpolate(
                     longitude, latitude, sensor_zenith,
                     self.geo_resolution, resolution

--- a/satpy/tests/reader_tests/test_modis_l2.py
+++ b/satpy/tests/reader_tests/test_modis_l2.py
@@ -34,12 +34,16 @@ from satpy import available_readers, Scene
 SCAN_WIDTH = 406
 SCAN_LEN = 270
 SCALE_FACTOR = 1
+TEST_LAT = np.repeat(np.linspace(35., 45., SCAN_WIDTH)[:, None], SCAN_LEN, 1)
+TEST_LAT *= np.linspace(0.9, 1.1, SCAN_LEN)
+TEST_LON = np.repeat(np.linspace(-45., -35., SCAN_LEN)[None, :], SCAN_WIDTH, 0)
+TEST_LON *= np.linspace(0.9, 1.1, SCAN_WIDTH)[:, None]
 TEST_DATA = {
-    'Latitude': {'data': np.random.rand(SCAN_WIDTH, SCAN_LEN).astype(np.float32) * 5.0 + 25.0,
+    'Latitude': {'data': TEST_LAT.astype(np.float32),
                  'type': SDC.FLOAT32,
                  'fill_value': -999,
                  'attrs': {'dim_labels': ['Cell_Along_Swath_5km:mod35', 'Cell_Across_Swath_5km:mod35']}},
-    'Longitude': {'data': np.random.rand(SCAN_WIDTH, SCAN_LEN).astype(np.float32) * -5.0 - 25.0,
+    'Longitude': {'data': TEST_LON.astype(np.float32),
                   'type': SDC.FLOAT32,
                   'fill_value': -999,
                   'attrs': {'dim_labels': ['Cell_Along_Swath_5km:mod35', 'Cell_Across_Swath_5km:mod35']}},

--- a/satpy/tests/reader_tests/test_modis_l2.py
+++ b/satpy/tests/reader_tests/test_modis_l2.py
@@ -35,7 +35,7 @@ SCAN_WIDTH = 406
 SCAN_LEN = 270
 SCALE_FACTOR = 1
 TEST_DATA = {
-    'Latitude': {'data': np.zeros((SCAN_WIDTH, SCAN_LEN), dtype=np.float32),
+    'Latitude': {'data': np.ones((SCAN_WIDTH, SCAN_LEN), dtype=np.float32),
                  'type': SDC.FLOAT32,
                  'fill_value': -999,
                  'attrs': {'dim_labels': ['Cell_Along_Swath_5km:mod35', 'Cell_Across_Swath_5km:mod35']}},
@@ -162,16 +162,19 @@ class TestModisL2(unittest.TestCase):
         from satpy import DatasetID
         scene = Scene(reader='modis_l2', filenames=[self.file_name])
         for dataset_name in ['longitude', 'latitude']:
+            expected_val = 0 if dataset_name == 'longitude' else 1
             # Default resolution should be the interpolated 1km
             scene.load([dataset_name])
             longitude_1km_id = DatasetID(name=dataset_name, resolution=1000)
             longitude_1km = scene[longitude_1km_id]
             self.assertEqual(longitude_1km.shape, (5*SCAN_WIDTH, 5*SCAN_LEN+4))
+            np.testing.assert_allclose(longitude_1km, expected_val)
             # Specify original 5km scale
-            longitude_5km = scene.load([dataset_name], resolution=5000)
+            scene.load([dataset_name], resolution=5000)
             longitude_5km_id = DatasetID(name=dataset_name, resolution=5000)
             longitude_5km = scene[longitude_5km_id]
             self.assertEqual(longitude_5km.shape, TEST_DATA[dataset_name.capitalize()]['data'].shape)
+            np.testing.assert_allclose(longitude_5km, expected_val)
 
     def test_load_quality_assurance(self):
         from satpy import DatasetID


### PR DESCRIPTION
See #766. These MODIS L1B reader doesn't have tests yet. I'll see if I can add a small check for this in one of the existing tests.

 - [x] Closes #766 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
