### PR TITLE
Bug mitiff writer when only one channel is to be written with calibration information

### DIFF
--- a/satpy/tests/writer_tests/test_mitiff.py
+++ b/satpy/tests/writer_tests/test_mitiff.py
@@ -405,7 +405,7 @@ class TestMITIFFWriter(unittest.TestCase):
         w.save_dataset(dataset)
         tif = TIFF.open(os.path.join(self.base_dir, os.listdir(self.base_dir)[0]))
         IMAGEDESCRIPTION = 270
-        imgdesc = str(tif.GetField(IMAGEDESCRIPTION)).split('\\n')
+        imgdesc = (tif.GetField(IMAGEDESCRIPTION)).decode('utf-8').split('\n')
         for key in imgdesc:
             if 'In this file' in key:
                 self.assertEqual(key, ' Channels: 1 In this file: 1')

--- a/satpy/tests/writer_tests/test_mitiff.py
+++ b/satpy/tests/writer_tests/test_mitiff.py
@@ -242,6 +242,68 @@ class TestMITIFFWriter(unittest.TestCase):
                            dims=data.dims, coords=data.coords)
         return ds1
 
+    def _get_test_dataset_calibration_one_dataset(self, bands=1):
+        """Helper function to create a single test dataset."""
+        import xarray as xr
+        import dask.array as da
+        from datetime import datetime
+        from pyresample.geometry import AreaDefinition
+        from pyresample.utils import proj4_str_to_dict
+        from satpy import DatasetID
+        from satpy.scene import Scene
+        area_def = AreaDefinition(
+            'test',
+            'test',
+            'test',
+            proj4_str_to_dict('+proj=stere +datum=WGS84 +ellps=WGS84 '
+                              '+lon_0=0. +lat_0=90 +lat_ts=60 +units=km'),
+            100,
+            200,
+            (-1000., -1500., 1000., 1500.),
+        )
+
+        d = [DatasetID(name='4', calibration='brightness_temperature')]
+        scene = Scene()
+        scene["4"] = xr.DataArray(da.zeros((100, 200), chunks=50),
+                                  dims=('y', 'x'),
+                                  attrs={'calibration': 'brightness_temperature'})
+
+        # data = xr.concat(scene, 'bands', coords='minimal')
+        data = xr.concat(scene, 'bands', coords='minimal')
+        #bands = []
+        calibration = []
+        for p in scene:
+            calibration.append(p.attrs['calibration'])
+            #bands.append(p.attrs['name'])
+        #data['bands'] = list(bands)
+        new_attrs = {'name': 'datasets',
+                     'start_time': datetime.utcnow(),
+                     'platform_name': "TEST_PLATFORM_NAME",
+                     'sensor': 'test-sensor',
+                     'area': area_def,
+                     'prerequisites': d,
+                     'metadata_requirements': {
+                         'order': ['4'],
+                         'config': {
+                             '4': {'alias': '4-IR10.8',
+                                   'calibration': 'brightness_temperature',
+                                   'min-val': '-150',
+                                   'max-val': '50'},
+                         },
+                         'translate': {'1': '1',
+                                       '2': '2',
+                                       '3': '3',
+                                       '4': '4',
+                                       '5': '5',
+                                       '6': '6'
+                                       },
+                         'file_pattern': 'test-dataset-{start_time:%Y%m%d%H%M%S}.mitiff'
+                     }
+                     }
+        ds1 = xr.DataArray(data=data.data, attrs=new_attrs,
+                           dims=data.dims, coords=data.coords)
+        return ds1
+
     def test_init(self):
         """Test creating the writer with no arguments."""
         from satpy.writers.mitiff import MITIFFWriter
@@ -272,6 +334,13 @@ class TestMITIFFWriter(unittest.TestCase):
         """Test basic writer operation."""
         from satpy.writers.mitiff import MITIFFWriter
         dataset = self._get_test_dataset_calibration()
+        w = MITIFFWriter(filename=dataset.attrs['metadata_requirements']['file_pattern'], base_dir=self.base_dir)
+        w.save_dataset(dataset)
+
+    def test_save_dataset_with_calibration_one_dataset(self):
+        """Test saving if mitiff as dataset with only one channel."""
+        from satpy.writers.mitiff import MITIFFWriter
+        dataset = self._get_test_dataset_calibration_one_dataset()
         w = MITIFFWriter(filename=dataset.attrs['metadata_requirements']['file_pattern'], base_dir=self.base_dir)
         w.save_dataset(dataset)
 

--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -607,9 +607,9 @@ class MITIFFWriter(ImageWriter):
                             chn = datasets.sel(bands=band)
                             # Need to possible translate channels names from satpy to mitiff
                             # Note the last index is a tuple index.
-                            cn = cns.get(chn.attrs['prerequisites'][i][0],
-                                         chn.attrs['prerequisites'][i][0])
-                            data = self._calibrate_data(chn, chn.attrs['prerequisites'][i][4],
+                            cn = cns.get(chn.attrs['prerequisites'][int(_cn) - 1][0],
+                                         chn.attrs['prerequisites'][int(_cn) - 1][0])
+                            data = self._calibrate_data(chn, chn.attrs['prerequisites'][int(_cn) - 1][4],
                                                         self.mitiff_config[kwargs['sensor']][cn]['min-val'],
                                                         self.mitiff_config[kwargs['sensor']][cn]['max-val'])
 

--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -600,7 +600,7 @@ class MITIFFWriter(ImageWriter):
                                             self.mitiff_config[kwargs['sensor']][cn]['max-val'])
 
                 tif.write_image(data.astype(np.uint8), compression='deflate')
-            elif len(datasets.dims) == 3 and (any('bands' not in i for i in datasets.dims)):
+            else:
                 for _cn in self.channel_order[kwargs['sensor']]:
                     for i, band in enumerate(datasets['bands']):
                         if band == _cn:
@@ -615,9 +615,6 @@ class MITIFFWriter(ImageWriter):
 
                             tif.write_image(data.astype(np.uint8), compression='deflate')
                             break
-            else:
-                LOG.warning("Not 2 dimensions and no 'bands' dimension "
-                            "or not 3 dimensions with 'bands' dimension. Dont know how to handle this.")
         else:
             LOG.debug("Saving datasets as enhanced image")
             img = get_enhanced_image(datasets.squeeze(), enhance=self.enhancer)

--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -618,6 +618,11 @@ class MITIFFWriter(ImageWriter):
         else:
             LOG.debug("Saving datasets as enhanced image")
             img = get_enhanced_image(datasets.squeeze(), enhance=self.enhancer)
+            if 'bands' in img.data.sizes and 'bands' not in datasets.sizes:
+                LOG.debug("Datasets without 'bands' become image with 'bands' due to enhancement.")
+                LOG.debug("Needs to regenerate mitiff image description")
+                image_description = self._make_image_description(img.data, **kwargs)
+                tif.SetField(IMAGEDESCRIPTION, (image_description).encode('utf-8'))
             for i, band in enumerate(img.data['bands']):
                 chn = img.data.sel(bands=band)
                 data = chn.values.clip(0, 1) * 254. + 1


### PR DESCRIPTION
There is a bug in the mitiff writer when saving only one channel with calibration information. The writer assumed datasets to be a list at one point and used the 'bands' dimension when it was not there.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->