### PR TITLE
Fix save_datasets always using geotiff writer regardless of filename

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1243,8 +1243,46 @@ class Scene(MetadataObject):
             if ds_id in self.wishlist:
                 yield projectable.to_image()
 
-    def save_dataset(self, dataset_id, filename=None, writer=None, overlay=None, compute=True, **kwargs):
-        """Save the *dataset_id* to file using *writer* (default: geotiff)."""
+    def save_dataset(self, dataset_id, filename=None, writer=None,
+                     overlay=None, decorate=None, compute=True, **kwargs):
+        """Save the ``dataset_id`` to file using ``writer``.
+
+        Args:
+            dataset_id (str or Number or DatasetID): Identifier for the
+                dataset to save to disk.
+            filename (str): Optionally specify the filename to save this
+                            dataset to. It may include string formatting
+                            patterns that will be filled in by dataset
+                            attributes.
+            writer (str): Name of writer to use when writing data to disk.
+                Default to ``"geotiff"``. If not provided, but ``filename`` is
+                provided then the filename's extension is used to determine
+                the best writer to use. See :meth:`Scene.get_writer_by_ext`
+                for details.
+            overlay (dict): See :func:`satpy.writers.add_overlay`. Only valid
+                for "image" writers like `geotiff` or `simple_image`.
+            decorate (dict): See :func:`satpy.writers.add_decorate`. Only valid
+                for "image" writers like `geotiff` or `simple_image`.
+            compute (bool): If `True` (default), compute all of the saves to
+                disk. If `False` then the return value is either a
+                :doc:`dask:delayed` object or two lists to be passed to
+                a `dask.array.store` call. See return values below for more
+                details.
+            kwargs: Additional writer arguments. See :doc:`../writers` for more
+                information.
+
+        Returns:
+            Value returned depends on `compute`. If `compute` is `True` then
+            the return value is the result of computing a
+            :doc:`dask:delayed` object or running :func:`dask.array.store`.
+            If `compute` is `False` then the returned value is either a
+            :doc:`dask:delayed` object that can be computed using
+            `delayed.compute()` or a tuple of (source, target) that should be
+            passed to :func:`dask.array.store`. If target is provided the the
+            caller is responsible for calling `target.close()` if the target
+            has this method.
+
+        """
         if writer is None and filename is None:
             writer = 'geotiff'
         elif writer is None:
@@ -1255,11 +1293,44 @@ class Scene(MetadataObject):
                                           filename=filename,
                                           **kwargs)
         return writer.save_dataset(self[dataset_id],
-                                   overlay=overlay, compute=compute,
-                                   **save_kwargs)
+                                   overlay=overlay, decorate=decorate,
+                                   compute=compute, **save_kwargs)
 
-    def save_datasets(self, writer="geotiff", datasets=None, compute=True, **kwargs):
-        """Save all the datasets present in a scene to disk using *writer*."""
+    def save_datasets(self, writer=None, filename=None, datasets=None, compute=True,
+                      **kwargs):
+        """Save all the datasets present in a scene to disk using ``writer``.
+
+        Args:
+            writer (str): Name of writer to use when writing data to disk.
+                Default to ``"geotiff"``. If not provided, but ``filename`` is
+                provided then the filename's extension is used to determine
+                the best writer to use. See :meth:`Scene.get_writer_by_ext`
+                for details.
+            filename (str): Optionally specify the filename to save this
+                            dataset to. It may include string formatting
+                            patterns that will be filled in by dataset
+                            attributes.
+            datasets (iterable): Limit written products to these datasets
+            compute (bool): If `True` (default), compute all of the saves to
+                disk. If `False` then the return value is either a
+                :doc:`dask:delayed` object or two lists to be passed to
+                a `dask.array.store` call. See return values below for more
+                details.
+            kwargs: Additional writer arguments. See :doc:`../writers` for more
+                information.
+
+        Returns:
+            Value returned depends on `compute` keyword argument. If
+            `compute` is `True` the value is the result of a either a
+            `dask.array.store` operation or a :doc:`dask:delayed`
+            compute, typically this is `None`. If `compute` is `False` then the
+            result is either a :doc:`dask:delayed` object that can be
+            computed with `delayed.compute()` or a two element tuple of
+            sources and targets to be passed to :func:`dask.array.store`. If
+            `targets` is provided then it is the caller's responsibility to
+            close any objects that have a "close" method.
+
+        """
         if datasets is not None:
             datasets = [self[ds] for ds in datasets]
         else:
@@ -1270,12 +1341,37 @@ class Scene(MetadataObject):
                                "generated or could not be loaded. Requested "
                                "composite inputs may need to have matching "
                                "dimensions (eg. through resampling).")
-        writer, save_kwargs = load_writer(writer, ppp_config_dir=self.ppp_config_dir, **kwargs)
+        if writer is None and filename is None:
+            writer = 'geotiff'
+        elif writer is None:
+            writer = self.get_writer_by_ext(os.path.splitext(filename)[1])
+        writer, save_kwargs = load_writer(writer,
+                                          ppp_config_dir=self.ppp_config_dir,
+                                          filename=filename,
+                                          **kwargs)
         return writer.save_datasets(datasets, compute=compute, **save_kwargs)
 
     @classmethod
     def get_writer_by_ext(cls, extension):
-        """Find the writer matching the *extension*."""
+        """Find the writer matching the ``extension``.
+
+        Defaults to "simple_image".
+
+        Example Mapping:
+
+            - geotiff: .tif, .tiff
+            - cf: .nc
+            - mitiff: .mitiff
+            - simple_image: .png, .jpeg, .jpg, ...
+
+        Args:
+            extension (str): Filename extension starting with
+                "." (ex. ".png").
+
+        Returns:
+            str: The name of the writer to use for this extension.
+
+        """
         mapping = {".tiff": "geotiff", ".tif": "geotiff", ".nc": "cf",
                    ".mitiff": "mitiff"}
         return mapping.get(extension.lower(), 'simple_image')

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1978,6 +1978,30 @@ class TestSceneSaving(unittest.TestCase):
         self.assertTrue(os.path.isfile(
             os.path.join(self.base_dir, 'test_20180101_000000.tif')))
 
+    def test_save_datasets_by_ext(self):
+        """Save a dataset using 'save_datasets' with 'filename'."""
+        from satpy.scene import Scene
+        from satpy.tests.utils import spy_decorator
+        import xarray as xr
+        import dask.array as da
+        from datetime import datetime
+        ds1 = xr.DataArray(
+            da.zeros((100, 200), chunks=50),
+            dims=('y', 'x'),
+            attrs={'name': 'test',
+                   'start_time': datetime(2018, 1, 1, 0, 0, 0)}
+        )
+        scn = Scene()
+        scn['test'] = ds1
+
+        from satpy.writers.simple_image import PillowWriter
+        save_image_mock = spy_decorator(PillowWriter.save_image)
+        with mock.patch.object(PillowWriter, 'save_image', save_image_mock):
+            scn.save_datasets(base_dir=self.base_dir, filename='{name}.png')
+        save_image_mock.mock.assert_called_once()
+        self.assertTrue(os.path.isfile(
+            os.path.join(self.base_dir, 'test.png')))
+
     def test_save_datasets_bad_writer(self):
         """Save a dataset using 'save_datasets' and a bad writer."""
         from satpy.scene import Scene

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -26,6 +26,22 @@ except ImportError:
     import mock
 
 
+def spy_decorator(method_to_decorate):
+    """Fancy decorate to wrap an object while still calling it.
+
+    See https://stackoverflow.com/a/41599695/433202
+
+    """
+    tmp_mock = mock.MagicMock()
+
+    def wrapper(self, *args, **kwargs):
+        tmp_mock(*args, **kwargs)
+        return method_to_decorate(self, *args, **kwargs)
+
+    wrapper.mock = tmp_mock
+    return wrapper
+
+
 def test_datasets():
     """Get list of various test datasets"""
     from satpy import DatasetID

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -658,8 +658,8 @@ class Writer(Plugin):
                                  save using this writer.
             compute (bool): If `True` (default), compute all of the saves to
                             disk. If `False` then the return value is either
-                            a `dask.delayed.Delayed` object or two lists to
-                            be passed to a `dask.array.store` call.
+                            a :doc:`dask:delayed` object or two lists to
+                            be passed to a :func:`dask.array.store` call.
                             See return values below for more details.
             **kwargs: Keyword arguments to pass to `save_dataset`. See that
                       documentation for more details.
@@ -667,11 +667,11 @@ class Writer(Plugin):
         Returns:
             Value returned depends on `compute` keyword argument. If
             `compute` is `True` the value is the result of a either a
-            `dask.array.store` operation or a `dask.delayed.Delayed` compute,
-            typically this is `None`. If `compute` is `False` then the
-            result is either a `dask.delayed.Delayed` object that can be
+            :func:`dask.array.store` operation or a :doc:`dask:delayed`
+            compute, typically this is `None`. If `compute` is `False` then
+            the result is either a :doc:`dask:delayed` object that can be
             computed with `delayed.compute()` or a two element tuple of
-            sources and targets to be passed to `dask.array.store`. If
+            sources and targets to be passed to :func:`dask.array.store`. If
             `targets` is provided then it is the caller's responsibility to
             close any objects that have a "close" method.
 
@@ -707,7 +707,7 @@ class Writer(Plugin):
                                        with this fill value if applicable to
                                        this writer.
             compute (bool): If `True` (default), compute and save the dataset.
-                            If `False` return either a `dask.delayed.Delayed`
+                            If `False` return either a :doc:`dask:delayed`
                             object or tuple of (source, target). See the
                             return values below for more information.
             **kwargs: Other keyword arguments for this particular writer.
@@ -715,13 +715,13 @@ class Writer(Plugin):
         Returns:
             Value returned depends on `compute`. If `compute` is `True` then
             the return value is the result of computing a
-            `dask.delayed.Delayed` object or running `dask.array.store`. If
-            `compute` is `False` then the returned value is either a
-            `dask.delayed.Delayed` object that can be computed using
+            :doc:`dask:delayed` object or running :func:`dask.array.store`.
+            If `compute` is `False` then the returned value is either a
+            :doc:`dask:delayed` object that can be computed using
             `delayed.compute()` or a tuple of (source, target) that should be
-            passed to `dask.array.store`. If target is provided the the caller
-            is responsible for calling `target.close()` if the target has
-            this method.
+            passed to :func:`dask.array.store`. If target is provided the the
+            caller is responsible for calling `target.close()` if the target
+            has this method.
 
         """
         raise NotImplementedError(
@@ -802,9 +802,9 @@ class ImageWriter(Writer):
                      overlay=None, decorate=None, compute=True, **kwargs):
         """Saves the ``dataset`` to a given ``filename``.
 
-        This method creates an enhanced image using `get_enhanced_image`. The
-        image is then passed to `save_image`. See both of these functions for
-        more details on the arguments passed to this method.
+        This method creates an enhanced image using :func:`get_enhanced_image`.
+        The image is then passed to :meth:`save_image`. See both of these
+        functions for more details on the arguments passed to this method.
 
         """
         img = get_enhanced_image(dataset.squeeze(), enhance=self.enhancer, overlay=overlay,
@@ -821,7 +821,7 @@ class ImageWriter(Writer):
                             patterns that will be filled in by dataset
                             attributes.
             compute (bool): If `True` (default), compute and save the dataset.
-                            If `False` return either a `dask.delayed.Delayed`
+                            If `False` return either a :doc:`dask:delayed`
                             object or tuple of (source, target). See the
                             return values below for more information.
             **kwargs: Other keyword arguments to pass to this writer.
@@ -829,13 +829,13 @@ class ImageWriter(Writer):
         Returns:
             Value returned depends on `compute`. If `compute` is `True` then
             the return value is the result of computing a
-            `dask.delayed.Delayed` object or running `dask.array.store`. If
-            `compute` is `False` then the returned value is either a
-            `dask.delayed.Delayed` object that can be computed using
+            :doc:`dask:delayed` object or running :func:`dask.array.store`.
+            If `compute` is `False` then the returned value is either a
+            :doc:`dask:delayed` object that can be computed using
             `delayed.compute()` or a tuple of (source, target) that should be
-            passed to `dask.array.store`. If target is provided the the caller
-            is responsible for calling `target.close()` if the target has
-            this method.
+            passed to :func:`dask.array.store`. If target is provided the the
+            caller is responsible for calling `target.close()` if the target
+            has this method.
 
         """
         raise NotImplementedError("Writer '%s' has not implemented image saving" % (self.name,))


### PR DESCRIPTION
Fix #625.

This PR makes it so that a logical writer is used when only `filename` is provided to `save_datasets`. Also added a lot of documentation for save_dataset/save_datasets.

 - [x] Closes #625 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
