### PR TITLE
Add compositor for adding an image as a background

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist
 build
 doc/build
 eggs
+*.eggs
 parts
 bin
 var
@@ -27,6 +28,7 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+htmlcov
 
 #Translations
 *.mo

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -392,7 +392,7 @@ To ensure that the images aren't auto-stretched and possibly altered,
 the following should be added to enhancement config (assuming 8-bit
 image) for both of the static images::
 
-      static_day:
+    static_day:
       standard_name: static_day
       operations:
       - name: stretch

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -189,6 +189,33 @@ reflectance.
     >>> colorized_ir_clouds = local_scene['colorized_ir_clouds']
     >>> composite = compositor([vis_data, colorized_ir_clouds])
 
+StaticImageCompositor
+---------------------
+
+    :class:`StaticImageCompositor` can be used to read an image from disk
+    and used just like satellite data, including resampling and using as a
+    part of other composites.
+
+    >>> from satpy.composites import StaticImageCompositor
+    >>> compositor = StaticImageCompositor("static_image", filename="image.tif")
+    >>> composite = compositor()
+
+BackgroundCompositor
+--------------------
+
+    :class:`BackgroundCompositor` can be used to stack two composites
+    together.  If the composites don't have `alpha` channels, the
+    `background` is used where `foreground` has no data.  If `foreground`
+    has alpha channel, the `alpha` values are used to weight when blending
+    the two composites.
+
+    >>> from satpy import Scene
+    >>> from satpy.composites import BackgroundCompositor
+    >>> compositor = BackgroundCompositor()
+    >>> clouds = local_scene['ir_cloud_day']
+    >>> background = local_scene['overview']
+    >>> composite = compositor([clouds, background])
+
 Creating composite configuration files
 ======================================
 
@@ -319,6 +346,61 @@ the built-in airmass composite::
           - wavelength: 10.8
       - wavelength: 6.2
       standard_name: airmass
+
+Using a pre-made image as a background
+--------------------------------------
+
+Below is an example composite config using
+:class:`StaticImageCompositor`, :class:`DayNightCompositor`,
+:class:`CloudCompositor` and :class:`BackgroundCompositor` to show how
+to create a composite with a blended day/night imagery as background
+for clouds.  As the images are in PNG format, and thus not
+georeferenced, the name of the area definition for the background
+images are given.  When using GeoTIFF images the `area` parameter can
+be left out.
+
+.. note::
+
+    The background blending uses the current time if there is no
+    timestamps in the image filenames.
+
+::
+
+    clouds_with_background:
+      compositor: !!python/name:satpy.composites.BackgroundCompositor
+      standard_name: clouds_with_background
+      prerequisites:
+        - ir_cloud_day
+        - compositor: !!python/name:satpy.composites.DayNightCompositor
+          prerequisites:
+            - static_day
+            - static_night
+
+    static_day:
+      compositor: !!python/name:satpy.composites.StaticImageCompositor
+      standard_name: static_day
+      filename: /path/to/day_image.png
+      area: euro4
+
+    static_night:
+      compositor: !!python/name:satpy.composites.StaticImageCompositor
+      standard_name: static_night
+      filename: /path/to/night_image.png
+      area: euro4
+
+To ensure that the images aren't auto-stretched and possibly altered,
+the following should be added to enhancement config (assuming 8-bit
+image) for both of the static images::
+
+      static_day:
+      standard_name: static_day
+      operations:
+      - name: stretch
+        method: *stretchfun
+        kwargs:
+          stretch: crude
+          min_stretch: [0, 0, 0]
+          max_stretch: [255, 255, 255]
 
 Enhancing the images
 ====================

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1421,6 +1421,9 @@ class StaticImageCompositor(GenericCompositor):
         scn = Scene(reader='generic_image', filenames=[self.fname])
         scn.load(['image'])
         img = scn['image']
+        # use compositor parameters as extra metadata
+        # most important: set 'name' of the image
+        img.attrs.update(self.attrs)
         # Check for proper area definition.  Non-georeferenced images
         # will raise IndexError
         try:

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1494,4 +1494,7 @@ class BackgroundCompositor(GenericCompositor):
             # Split to separate bands so the mode is correct
             data = [data.sel(bands=b) for b in data['bands']]
 
-        return super(BackgroundCompositor, self).__call__(data, **kwargs)
+        res = super(BackgroundCompositor, self).__call__(data, **kwargs)
+        res.attrs['area'] = attrs['area']
+
+        return res

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1415,7 +1415,7 @@ class StaticImageCompositor(GenericCompositor):
 
         super(StaticImageCompositor, self).__init__(name, **kwargs)
 
-    def __call__(self, projectables, **kwargs):
+    def __call__(self, *args, **kwargs):
         from satpy import Scene
         scn = Scene(reader='generic_image', filenames=[self.fname])
         scn.load('image')

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1409,17 +1409,17 @@ class SandwichCompositor(GenericCompositor):
 class StaticImageCompositor(GenericCompositor):
     """A compositor that loads a static image from disk."""
 
-    def __init__(self, name, fname=None, area=None, **kwargs):
+    def __init__(self, name, filename=None, area=None, **kwargs):
         """Collect custom configuration values.
 
         Args:
-            fname (str): Filename of the image to load
+            filename (str): Filename of the image to load
             area (str): Name of area definition for the image.  Optional
                         for images with built-in area definitions (geotiff)
         """
-        if fname is None:
+        if filename is None:
             raise ValueError("No image configured for static image compositor")
-        self.fname = fname
+        self.filename = filename
         self.area = None
         if area is not None:
             from satpy.resample import get_area_def
@@ -1429,7 +1429,7 @@ class StaticImageCompositor(GenericCompositor):
 
     def __call__(self, *args, **kwargs):
         from satpy import Scene
-        scn = Scene(reader='generic_image', filenames=[self.fname])
+        scn = Scene(reader='generic_image', filenames=[self.filename])
         scn.load(['image'])
         img = scn['image']
         # use compositor parameters as extra metadata

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1418,7 +1418,7 @@ class StaticImageCompositor(GenericCompositor):
     def __call__(self, *args, **kwargs):
         from satpy import Scene
         scn = Scene(reader='generic_image', filenames=[self.fname])
-        scn.load('image')
+        scn.load(['image'])
         img = scn['image']
         # Check for proper area definition.  Non-georeferenced images
         # will raise IndexError

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1409,6 +1409,7 @@ class StaticImageCompositor(GenericCompositor):
         if fname is None:
             raise ValueError("No image configured for static image compositor")
         self.fname = fname
+        self.area = None
         if area is not None:
             from satpy.resample import get_area_def
             self.area = get_area_def(area)
@@ -1427,7 +1428,7 @@ class StaticImageCompositor(GenericCompositor):
         except IndexError:
             if self.area is None:
                 raise AttributeError("Area definition needs to be configured")
-            img.area = self.area
+            img.attrs['area'] = self.area
         img.attrs['sensor'] = None
         img.attrs['mode'] = ''.join(img.bands.data)
         img.attrs.pop('modifiers', None)

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1433,5 +1433,9 @@ class StaticImageCompositor(GenericCompositor):
         img.attrs['mode'] = ''.join(img.bands.data)
         img.attrs.pop('modifiers', None)
         img.attrs.pop('calibration', None)
+        # Add start time if not present in the filename
+        if 'start_time' not in img.attrs or not img.attrs['start_time']:
+            import datetime as dt
+            img.attrs['start_time'] = dt.datetime.utcnow()
 
         return img

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1447,9 +1447,9 @@ class BackgroundCompositor(GenericCompositor):
     def __call__(self, projectables, *args, **kwargs):
         projectables = self.check_areas(projectables)
 
-        # Get enhanced images out of the composites
-        foreground = get_enhanced_image(projectables[0])
-        background = get_enhanced_image(projectables[1])
+        # Get enhanced datasets
+        foreground = enhance2dataset(projectables[0])
+        background = enhance2dataset(projectables[1])
 
         # Adjust bands so that they match
         # L/RGB -> RGB/RGB
@@ -1459,13 +1459,14 @@ class BackgroundCompositor(GenericCompositor):
         background = add_bands(background, foreground['bands'])
 
         # Stack the images
-        background.stack(foreground)
+        #data = xr.where(foreground.isnull(), background, foreground)
+        data = xr.where(foreground.isnull(), background, foreground)
 
         # Get merged metadata
-        attrs = combine_metadata
-        background.attrs = attrs
+        attrs = combine_metadata(foreground, background)
+        data.attrs = attrs
 
         # Split to separate bands so the mode is correct
-        data = [background.sel(bands=b) for b in background['bands']]
+        data = [data.sel(bands=b) for b in data['bands']]
 
         return super(BackgroundCompositor, self).__call__(data, **kwargs)

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1463,6 +1463,7 @@ class BackgroundCompositor(GenericCompositor):
 
         # Get merged metadata
         attrs = combine_metadata
+        background.attrs = attrs
 
         # Split to separate bands so the mode is correct
         data = [background.sel(bands=b) for b in background['bands']]

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1449,7 +1449,7 @@ class BackgroundCompositor(GenericCompositor):
 
         # Get enhanced images out of the composites
         foreground = get_enhanced_image(projectables[0])
-        background = get_enhance_image(projectables[1])
+        background = get_enhanced_image(projectables[1])
 
         # Adjust bands so that they match
         # L/RGB -> RGB/RGB

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1451,6 +1451,9 @@ class StaticImageCompositor(GenericCompositor):
         if 'start_time' not in img.attrs or not img.attrs['start_time']:
             import datetime as dt
             img.attrs['start_time'] = dt.datetime.utcnow()
+        if 'end_time' not in img.attrs or not img.attrs['end_time']:
+            import datetime as dt
+            img.attrs['end_time'] = dt.datetime.utcnow()
 
         return img
 

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1459,7 +1459,6 @@ class BackgroundCompositor(GenericCompositor):
         background = add_bands(background, foreground['bands'])
 
         # Stack the images
-        #data = xr.where(foreground.isnull(), background, foreground)
         data = xr.where(foreground.isnull(), background, foreground)
 
         # Get merged metadata

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1436,10 +1436,8 @@ class StaticImageCompositor(GenericCompositor):
         # most important: set 'name' of the image
         img.attrs.update(self.attrs)
         # Check for proper area definition.  Non-georeferenced images
-        # will raise IndexError
-        try:
-            _ = img.area.size
-        except IndexError:
+        # have None as .ndim
+        if img.area.ndim is None:
             if self.area is None:
                 raise AttributeError("Area definition needs to be configured")
             img.attrs['area'] = self.area

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1483,6 +1483,8 @@ class BackgroundCompositor(GenericCompositor):
             # Use alpha channel as weight and blend the two composites
             alpha = foreground.sel(bands='A')
             data = []
+            # NOTE: there's no alpha band in the output image, it will
+            # be added by the data writer
             for band in foreground.mode[:-1]:
                 fg_band = foreground.sel(bands=band)
                 bg_band = background.sel(bands=band)

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -26,6 +26,8 @@ from satpy.readers import TooManyResults
 from satpy.utils import get_logger
 
 LOG = get_logger(__name__)
+# Empty leaf used for marking composites with no prerequisites
+EMPTY_LEAF_NAME = "__EMPTY_LEAF_SENTINEL__"
 
 
 class Node(object):
@@ -98,7 +100,9 @@ class Node(object):
 
     def leaves(self, unique=True):
         """Get the leaves of the tree starting at this root."""
-        if not self.children:
+        if self.name is EMPTY_LEAF_NAME:
+            return []
+        elif not self.children:
             return [self]
         else:
             res = list()
@@ -113,7 +117,7 @@ class Node(object):
         # uniqueness is not correct in `trunk` yet
         unique = False
         res = []
-        if self.children:
+        if self.children and self.name is not EMPTY_LEAF_NAME:
             if self.name is not None:
                 res.append(self)
             for child in self.children:
@@ -154,6 +158,8 @@ class DependencyTree(Node):
         # keep a flat dictionary of nodes contained in the tree for better
         # __contains__
         self._all_nodes = DatasetDict()
+        # simplify future logic by only having one "sentinel" empty node
+        self.empty_node = Node(EMPTY_LEAF_NAME)
 
     def leaves(self, nodes=None, unique=True):
         """Get the leaves of the tree starting at this root.
@@ -205,6 +211,9 @@ class DependencyTree(Node):
         #               but they should all map to the same Node object.
         if self.contains(child.name):
             assert self._all_nodes[child.name] is child
+        if child is self.empty_node:
+            # No need to store "empty" nodes
+            return
         self._all_nodes[child.name] = child
 
     def add_leaf(self, ds_id, parent=None):
@@ -330,6 +339,10 @@ class DependencyTree(Node):
         """
         prereq_ids = []
         unknowns = set()
+        if not prereq_names and not skip:
+            # this composite has no required prerequisites
+            prereq_names = [None]
+
         for prereq in prereq_names:
             n, u = self._find_dependencies(prereq, **dfilter)
             if u:
@@ -418,6 +431,10 @@ class DependencyTree(Node):
                               `satpy.readers.get_key` for more details.
 
         """
+        # Special case: No required dependencies for this composite
+        if dataset_key is None:
+            return self.empty_node, set()
+
         # 0 check if the *exact* dataset is already loaded
         try:
             node = self.getitem(dataset_key)

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -104,13 +104,13 @@ class Node(object):
             return []
         elif not self.children:
             return [self]
-        else:
-            res = list()
-            for child in self.children:
-                for sub_child in child.leaves(unique=unique):
-                    if not unique or sub_child not in res:
-                        res.append(sub_child)
-            return res
+
+        res = list()
+        for child in self.children:
+            for sub_child in child.leaves(unique=unique):
+                if not unique or sub_child not in res:
+                    res.append(sub_child)
+        return res
 
     def trunk(self, unique=True):
         """Get the trunk of the tree starting at this root."""

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -752,7 +752,10 @@ class Scene(MetadataObject):
                     and not prereq_node.is_leaf:
                 self._generate_composite(prereq_node, keepables)
 
-            if prereq_id in self.datasets:
+            if prereq_node is self.dep_tree.empty_node:
+                # empty sentinel node - no need to load it
+                continue
+            elif prereq_id in self.datasets:
                 prereq_datasets.append(self.datasets[prereq_id])
             elif not prereq_node.is_leaf and prereq_id in keepables:
                 delayed_gen = True

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -863,6 +863,7 @@ def suite():
     mysuite.addTest(loader.loadTestsFromTestCase(TestGenericCompositor))
     mysuite.addTest(loader.loadTestsFromTestCase(TestNIRReflectance))
     mysuite.addTest(loader.loadTestsFromTestCase(TestPrecipCloudsCompositor))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestAddBands))
 
     return mysuite
 

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -843,6 +843,16 @@ class TestAddBands(unittest.TestCase):
 
 class TestStaticImageCompositor(unittest.TestCase):
 
+    composite = """
+        sensor_name: visir/seviri
+          composites:
+            background_day:
+              compositor: !!python/name:satpy.composites.StaticImageCompositor
+              standard_name: background_day
+              fname: /path/to/image.tif
+              area: euro4
+    """
+
     @mock.patch('satpy.resample.get_area_def')
     def test_init(self, get_area_def):
         from satpy.composites import StaticImageCompositor
@@ -887,6 +897,22 @@ class TestStaticImageCompositor(unittest.TestCase):
         # `area` kwarg is None
         # TODO: mock a case when img.area.size raises IndexError and
         # `area` kwarg is given
+
+    @mock.patch('satpy.scene.Scene._compute_metadata_from_readers')
+    @mock.patch('satpy.scene.load_readers')
+    def test_scene(self, load_readers, compute_metadata_from_readers):
+        """Test usage through satpy.Scene()"""
+        from satpy import Scene
+        import os.path
+
+        # load_readers.return_value =
+        path = os.path.dirname(os.path.realpath(__file__))
+        compute_metadata_from_readers.return_value = {'sensor': ['seviri']}
+        scn = Scene(reader='seviri_l1b_hrit', filenames=['filename'],
+                    ppp_config_dir=path)
+
+        # TODO: figure out what to mock to get real results from
+        # scn.available_*() without real files
 
 
 class TestBackgroundCompositor(unittest.TestCase):

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -882,11 +882,19 @@ class TestStaticImageCompositor(unittest.TestCase):
                                       filenames=[comp.fname])
         self.assertTrue("start_time" in res.attrs)
         self.assertTrue("end_time" in res.attrs)
+        self.assertIsNone(res.attrs['sensor'])
+        self.assertTrue('modifiers' not in res.attrs)
+        self.assertTrue('calibration' not in res.attrs)
 
-        # TODO: mock a case when img.area.size raises IndexError and
-        # `area` kwarg is None
-        # TODO: mock a case when img.area.size raises IndexError and
-        # `area` kwarg is given
+        # Non-georeferenced image, no area given
+        img.area.ndim = None
+        with self.assertRaises(AttributeError):
+            res = comp()
+
+        # Non-georeferenced image, area given
+        comp = StaticImageCompositor("name", fname="foo.tif", area='euro4')
+        res = comp()
+        self.assertEqual(res.attrs['area'].area_id, 'euro4')
 
 
 class TestBackgroundCompositor(unittest.TestCase):

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -787,6 +787,60 @@ class TestGenericCompositor(unittest.TestCase):
         self.assertEqual(res.attrs['mode'], 'LA')
 
 
+class TestAddBands(unittest.TestCase):
+
+    def test_add_bands(self):
+        from satpy.composites import add_bands
+        import dask.array as da
+        import numpy as np
+        import xarray as xr
+
+        # L + RGB -> RGB
+        data = xr.DataArray(da.ones((1, 3, 3)), dims=('bands', 'y', 'x'),
+                            coords={'bands': ['L']})
+        new_bands = xr.DataArray(da.array(['R', 'G', 'B']), dims=('bands'),
+                                 coords={'bands': ['R', 'G', 'B']})
+        res = add_bands(data, new_bands)
+        res_bands = ['R', 'G', 'B']
+        self.assertEqual(res.mode, ''.join(res_bands))
+        np.testing.assert_array_equal(res.bands, res_bands)
+        np.testing.assert_array_equal(res.coords['bands'], res_bands)
+
+        # L + RGBA -> RGBA
+        data = xr.DataArray(da.ones((1, 3, 3)), dims=('bands', 'y', 'x'),
+                            coords={'bands': ['L']}, attrs={'mode': 'L'})
+        new_bands = xr.DataArray(da.array(['R', 'G', 'B', 'A']), dims=('bands'),
+                                 coords={'bands': ['R', 'G', 'B', 'A']})
+        res = add_bands(data, new_bands)
+        res_bands = ['R', 'G', 'B', 'A']
+        self.assertEqual(res.mode, ''.join(res_bands))
+        np.testing.assert_array_equal(res.bands, res_bands)
+        np.testing.assert_array_equal(res.coords['bands'], res_bands)
+
+        # LA + RGB -> RGBA
+        data = xr.DataArray(da.ones((2, 3, 3)), dims=('bands', 'y', 'x'),
+                            coords={'bands': ['L', 'A']}, attrs={'mode': 'LA'})
+        new_bands = xr.DataArray(da.array(['R', 'G', 'B']), dims=('bands'),
+                                 coords={'bands': ['R', 'G', 'B']})
+        res = add_bands(data, new_bands)
+        res_bands = ['R', 'G', 'B', 'A']
+        self.assertEqual(res.mode, ''.join(res_bands))
+        np.testing.assert_array_equal(res.bands, res_bands)
+        np.testing.assert_array_equal(res.coords['bands'], res_bands)
+
+        # RGB + RGBA -> RGBA
+        data = xr.DataArray(da.ones((3, 3, 3)), dims=('bands', 'y', 'x'),
+                            coords={'bands': ['R', 'G', 'B']},
+                            attrs={'mode': 'RGB'})
+        new_bands = xr.DataArray(da.array(['R', 'G', 'B', 'A']), dims=('bands'),
+                                 coords={'bands': ['R', 'G', 'B', 'A']})
+        res = add_bands(data, new_bands)
+        res_bands = ['R', 'G', 'B', 'A']
+        self.assertEqual(res.mode, ''.join(res_bands))
+        np.testing.assert_array_equal(res.bands, res_bands)
+        np.testing.assert_array_equal(res.coords['bands'], res_bands)
+
+
 def suite():
     """Test suite for all reader tests."""
     loader = unittest.TestLoader()

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -852,14 +852,14 @@ class TestStaticImageCompositor(unittest.TestCase):
             comp = StaticImageCompositor("name")
 
         # No area defined
-        comp = StaticImageCompositor("name", fname="foo.tif")
-        self.assertEqual(comp.fname, "foo.tif")
+        comp = StaticImageCompositor("name", filename="foo.tif")
+        self.assertEqual(comp.filename, "foo.tif")
         self.assertIsNone(comp.area)
 
         # Area defined
         get_area_def.return_value = "bar"
-        comp = StaticImageCompositor("name", fname="foo.tif", area="euro4")
-        self.assertEqual(comp.fname, "foo.tif")
+        comp = StaticImageCompositor("name", filename="foo.tif", area="euro4")
+        self.assertEqual(comp.filename, "foo.tif")
         self.assertEqual(comp.area, "bar")
         get_area_def.assert_called_once_with("euro4")
 
@@ -876,10 +876,10 @@ class TestStaticImageCompositor(unittest.TestCase):
         scn = mock_scene()
         scn['image'] = img
         Scene.return_value = scn
-        comp = StaticImageCompositor("name", fname="foo.tif")
+        comp = StaticImageCompositor("name", filename="foo.tif")
         res = comp()
         Scene.assert_called_once_with(reader='generic_image',
-                                      filenames=[comp.fname])
+                                      filenames=[comp.filename])
         self.assertTrue("start_time" in res.attrs)
         self.assertTrue("end_time" in res.attrs)
         self.assertIsNone(res.attrs['sensor'])
@@ -892,7 +892,7 @@ class TestStaticImageCompositor(unittest.TestCase):
             res = comp()
 
         # Non-georeferenced image, area given
-        comp = StaticImageCompositor("name", fname="foo.tif", area='euro4')
+        comp = StaticImageCompositor("name", filename="foo.tif", area='euro4')
         res = comp()
         self.assertEqual(res.attrs['area'].area_id, 'euro4')
 

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -843,16 +843,6 @@ class TestAddBands(unittest.TestCase):
 
 class TestStaticImageCompositor(unittest.TestCase):
 
-    composite = """
-        sensor_name: visir/seviri
-          composites:
-            background_day:
-              compositor: !!python/name:satpy.composites.StaticImageCompositor
-              standard_name: background_day
-              fname: /path/to/image.tif
-              area: euro4
-    """
-
     @mock.patch('satpy.resample.get_area_def')
     def test_init(self, get_area_def):
         from satpy.composites import StaticImageCompositor
@@ -897,22 +887,6 @@ class TestStaticImageCompositor(unittest.TestCase):
         # `area` kwarg is None
         # TODO: mock a case when img.area.size raises IndexError and
         # `area` kwarg is given
-
-    @mock.patch('satpy.scene.Scene._compute_metadata_from_readers')
-    @mock.patch('satpy.scene.load_readers')
-    def test_scene(self, load_readers, compute_metadata_from_readers):
-        """Test usage through satpy.Scene()"""
-        from satpy import Scene
-        import os.path
-
-        # load_readers.return_value =
-        path = os.path.dirname(os.path.realpath(__file__))
-        compute_metadata_from_readers.return_value = {'sensor': ['seviri']}
-        scn = Scene(reader='seviri_l1b_hrit', filenames=['filename'],
-                    ppp_config_dir=path)
-
-        # TODO: figure out what to mock to get real results from
-        # scn.available_*() without real files
 
 
 class TestBackgroundCompositor(unittest.TestCase):
@@ -1042,6 +1016,8 @@ def suite():
     mysuite.addTest(loader.loadTestsFromTestCase(TestNIRReflectance))
     mysuite.addTest(loader.loadTestsFromTestCase(TestPrecipCloudsCompositor))
     mysuite.addTest(loader.loadTestsFromTestCase(TestAddBands))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestBackgroundCompositor))
+    mysuite.addTest(loader.loadTestsFromTestCase(TestStaticImageCompositor))
 
     return mysuite
 

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1680,7 +1680,8 @@ class TestSceneLoading(unittest.TestCase):
         from satpy import DatasetID
         datasets = [DatasetID(name='duplicate1', wavelength=(0.1, 0.2, 0.3)),
                     DatasetID(name='duplicate2', wavelength=(0.1, 0.2, 0.3))]
-        reader = FakeReader('fake_reader', 'fake_sensor', datasets=datasets)
+        reader = FakeReader('fake_reader', 'fake_sensor', datasets=datasets,
+                            filter_datasets=False)
         cri.return_value = {'fake_reader': reader}
         comps, mods = test_composites('fake_sensor')
         cl.return_value = (comps, mods)

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -719,8 +719,8 @@ class TestScene(unittest.TestCase):
         id_list = scene.available_dataset_ids()
         self.assertEqual(len(id_list), 1)
         id_list = scene.available_dataset_ids(composites=True)
-        # ds1, comp1, comp14, comp16
-        self.assertEqual(len(id_list), 4)
+        # ds1, comp1, comp14, comp16, static_image
+        self.assertEqual(len(id_list), 5)
 
     def test_available_composite_ids_bad_available(self):
         from satpy import Scene
@@ -1689,6 +1689,39 @@ class TestSceneLoading(unittest.TestCase):
         avail_comps = scene.available_composite_ids()
         self.assertEqual(len(avail_comps), 0)
         self.assertRaises(KeyError, scene.load, [0.21])
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors', autospec=True)
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_available_comps_no_deps(self, cri, cl):
+        """Test Scene available composites when composites don't have a dependency."""
+        from satpy.tests.utils import FakeReader, test_composites
+        import satpy.scene
+        from satpy.readers import DatasetDict
+        from satpy import DatasetID
+
+        def _test(self, sensor_names):
+            if not self.compositors:
+                self.compositors = comps
+                self.modifiers = mods
+            new_comps = {}
+            new_mods = {}
+            for sn in sensor_names:
+                new_comps[sn] = DatasetDict(
+                    self.compositors[sn].copy())
+                new_mods[sn] = self.modifiers[sn].copy()
+            return new_comps, new_mods
+
+        # fancy magic to make sure the CompositorLoader thinks it has comps
+        cl.side_effect = _test
+
+        reader = FakeReader('fake_reader', 'fake_sensor')
+        cri.return_value = {'fake_reader': reader}
+        comps, mods = test_composites('fake_sensor')
+        scene = satpy.scene.Scene(filenames=['bla'], base_dir='bli', reader='fake_reader')
+        all_comp_ids = scene.available_composite_ids()
+        self.assertIn(DatasetID(name='static_image'), all_comp_ids)
+        available_comp_ids = scene.available_composite_ids()
+        self.assertIn(DatasetID(name='static_image'), available_comp_ids)
 
 
 class TestSceneResampling(unittest.TestCase):

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -158,6 +158,7 @@ def test_composites(sensor_name):
         DatasetID(name='comp21'): ([DatasetID(name='ds5', modifiers=('mod_bad_opt',))], []),
         DatasetID(name='comp22'): ([DatasetID(name='ds5', modifiers=('mod_opt_only',))], []),
         DatasetID(name='comp23'): ([0.8], []),
+        DatasetID(name='static_image'): ([], []),
     }
     # Modifier name -> (prereqs (not including to-be-modified), opt_prereqs)
     mods = {

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -195,8 +195,15 @@ class FakeReader(FileYAMLReader):
     """Fake reader to make testing basic Scene/reader functionality easier."""
 
     def __init__(self, name, sensor_name='fake_sensor', datasets=None,
-                 available_datasets=None, start_time=None, end_time=None):
-        """Initialize reader and mock necessary properties and methods."""
+                 available_datasets=None, start_time=None, end_time=None,
+                 filter_datasets=True):
+        """Initialize reader and mock necessary properties and methods.
+
+        By default any 'datasets' provided will be filtered by what datasets
+        are configured at the top of this module in 'test_datasets'. This can
+        be disabled by specifying `filter_datasets=False`.
+
+        """
         with mock.patch('satpy.readers.yaml_reader.recursive_dict_update') as rdu, \
                 mock.patch('satpy.readers.yaml_reader.open'), \
                 mock.patch('satpy.readers.yaml_reader.yaml.load'):
@@ -212,8 +219,10 @@ class FakeReader(FileYAMLReader):
         self._sensor_name = set([sensor_name])
 
         all_ds = test_datasets()
-        if datasets is not None:
+        if datasets is not None and filter_datasets:
             all_ds = list(_filter_datasets(all_ds, datasets))
+        elif datasets:
+            all_ds = datasets
         if available_datasets is not None:
             available_datasets = list(_filter_datasets(all_ds, available_datasets))
         else:


### PR DESCRIPTION
This PR adds two compositors that makes it possible to use pre-made images as a part of other composites:

- `StaticImageCompositor` - load image and use it as a part of other composites
- `BackgroundCompositor` - use a composite as a background for other composites

Add compositor for loading pre-made images as part of a composite.

 - [x] Closes #734
 - [x] Closes #460 
 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
