### PR TITLE
Add flag_meanings and flag_values to 'viirs_edr_active_fires' categories

### DIFF
--- a/satpy/etc/readers/mersi2_l1b.yaml
+++ b/satpy/etc/readers/mersi2_l1b.yaml
@@ -560,7 +560,7 @@ datasets:
 
   longitude:
     name: longitude
-    units: degree_east
+    units: degrees_east
     standard_name: longitude
     resolution:
       1000:
@@ -571,7 +571,7 @@ datasets:
         file_key: Longitude
   latitude:
     name: latitude
-    units: degree_north
+    units: degrees_north
     standard_name: latitude
     resolution:
       1000:

--- a/satpy/etc/readers/viirs_edr_active_fires.yaml
+++ b/satpy/etc/readers/viirs_edr_active_fires.yaml
@@ -18,10 +18,14 @@ file_types:
             - 'AFMOD_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
     fires_text_img:
         file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresTextFileHandler
+        skip_rows: 15
+        columns: ["latitude", "longitude", "T4", "Along-scan", "Along-track", "confidence_cat", "power"]
         file_patterns:
             - 'AFIMG_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
     fires_text:
         file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresTextFileHandler
+        skip_rows: 15
+        columns: ["latitude", "longitude", "T13", "Along-scan", "Along-track", "confidence_pct", "power"]
         file_patterns:
             - 'AFMOD_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
             - 'AFEDR_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.txt'
@@ -32,7 +36,10 @@ datasets:
         file_type: [fires_netcdf_img, fires_text_img]
         file_key: "{variable_prefix}FP_confidence"
         coordinates: [longitude, latitude]
-        units: '[7,8,9]->[lo,med,hi]'
+        units: '1'
+        flag_meanings: ['low', 'medium', 'high']
+        flag_values: [7, 8, 9]
+        _FillValue: 0
     confidence_pct:
         name: confidence_pct
         file_type: [fires_netcdf, fires_text]
@@ -44,13 +51,13 @@ datasets:
         standard_name: longitude
         file_type: [fires_netcdf_img, fires_netcdf, fires_text_img, fires_text]
         file_key: "{variable_prefix}FP_longitude"
-        units: 'degrees'
+        units: 'degrees_east'
     latitude:
         name: latitude
         standard_name: latitude
         file_type: [fires_netcdf_img, fires_netcdf, fires_text_img, fires_text]
         file_key: "{variable_prefix}FP_latitude"
-        units: 'degrees'
+        units: 'degrees_north'
     power:
         name: power
         file_type: [fires_netcdf_img, fires_netcdf, fires_text_img, fires_text]

--- a/satpy/readers/viirs_edr_active_fires.py
+++ b/satpy/readers/viirs_edr_active_fires.py
@@ -26,19 +26,26 @@ from satpy.readers.file_handlers import BaseFileHandler
 import dask.dataframe as dd
 import xarray as xr
 
+# map platform attributes to Oscar standard name
+PLATFORM_MAP = {
+    "NPP": "Suomi-NPP",
+    "J01": "NOAA-20",
+    "J02": "NOAA-21"
+}
+
 
 class VIIRSActiveFiresFileHandler(NetCDF4FileHandler):
-    """NetCDF4 reader for VIIRS Active Fires
-    """
+    """NetCDF4 reader for VIIRS Active Fires."""
 
     def __init__(self, filename, filename_info, filetype_info,
                  auto_maskandscale=False, xarray_kwargs=None):
         super(VIIRSActiveFiresFileHandler, self).__init__(
-            filename, filename_info, filetype_info)
+            filename, filename_info, filetype_info,
+            auto_maskandscale=auto_maskandscale, xarray_kwargs=xarray_kwargs)
         self.prefix = filetype_info.get('variable_prefix')
 
     def get_dataset(self, dsid, dsinfo):
-        """Get dataset function
+        """Get requested data as DataArray.
 
         Args:
             dsid: Dataset ID
@@ -51,11 +58,18 @@ class VIIRSActiveFiresFileHandler(NetCDF4FileHandler):
 
         key = dsinfo.get('file_key', dsid.name).format(variable_prefix=self.prefix)
         data = self[key]
-        data.attrs.update(dsinfo)
+        # rename "phoney dims"
+        data = data.rename(dict(zip(data.dims, ['y', 'x'])))
 
-        platform_key = {"NPP": "Suomi-NPP", "J01": "NOAA-20", "J02": "NOAA-21"}
+        # handle attributes from YAML
+        for key in ('units', 'standard_name', 'flag_meanings', 'flag_values', '_FillValue'):
+            # we only want to add information that isn't present already
+            if key in dsinfo and key not in data.attrs:
+                data.attrs[key] = dsinfo[key]
+        if isinstance(data.attrs.get('flag_meanings'), str):
+            data.attrs['flag_meanings'] = data.attrs['flag_meanings'].split(' ')
 
-        data.attrs["platform_name"] = platform_key.get(self.filename_info['satellite_name'].upper(), "unknown")
+        data.attrs["platform_name"] = PLATFORM_MAP.get(self.filename_info['satellite_name'].upper(), "unknown")
         data.attrs["sensor"] = "VIIRS"
 
         return data
@@ -78,8 +92,8 @@ class VIIRSActiveFiresFileHandler(NetCDF4FileHandler):
 
 
 class VIIRSActiveFiresTextFileHandler(BaseFileHandler):
-    """ASCII reader for VIIRS Active Fires
-    """
+    """ASCII reader for VIIRS Active Fires."""
+
     def __init__(self, filename, filename_info, filetype_info):
         """Makes sure filepath is valid and then reads data into a Dask DataFrame
 
@@ -89,28 +103,23 @@ class VIIRSActiveFiresTextFileHandler(BaseFileHandler):
             filetype_info: Filetype information
         """
 
-        if filetype_info.get('file_type') == 'fires_text_img':
-            self.file_content = dd.read_csv(filename, skiprows=15, header=None,
-                                            names=["latitude", "longitude",
-                                                   "T4", "Along-scan", "Along-track", "confidence_cat",
-                                                   "power"])
-        else:
-            self.file_content = dd.read_csv(filename, skiprows=15, header=None,
-                                            names=["latitude", "longitude",
-                                                   "T13", "Along-scan", "Along-track", "confidence_pct",
-                                                   "power"])
-
+        skip_rows = filetype_info.get('skip_rows', 15)
+        columns = filetype_info['columns']
+        self.file_content = dd.read_csv(filename, skiprows=skip_rows, header=None, names=columns)
         super(VIIRSActiveFiresTextFileHandler, self).__init__(filename, filename_info, filetype_info)
-
-        platform_key = {"NPP": "Suomi-NPP", "J01": "NOAA-20", "J02": "NOAA-21"}
-
-        self.platform_name = platform_key.get(self.filename_info['satellite_name'].upper(), "unknown")
+        self.platform_name = PLATFORM_MAP.get(self.filename_info['satellite_name'].upper(), "unknown")
 
     def get_dataset(self, dsid, dsinfo):
+        """Get requested data as DataArray."""
         ds = self[dsid.name].to_dask_array(lengths=True)
-        data_array = xr.DataArray(ds, dims=("y",), attrs={"platform_name": self.platform_name, "sensor": "VIIRS"})
-        data_array.attrs.update(dsinfo)
-        return data_array
+        data = xr.DataArray(ds, dims=("y",), attrs={"platform_name": self.platform_name, "sensor": "VIIRS"})
+        for key in ('units', 'standard_name', 'flag_meanings', 'flag_values', '_FillValue'):
+            # we only want to add information that isn't present already
+            if key in dsinfo and key not in data.attrs:
+                data.attrs[key] = dsinfo[key]
+        if isinstance(data.attrs.get('flag_meanings'), str):
+            data.attrs['flag_meanings'] = data.attrs['flag_meanings'].split(' ')
+        return data
 
     @property
     def start_time(self):

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -260,7 +260,9 @@ class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
         datasets = r.load(['confidence_cat'])
         self.assertEqual(len(datasets), 1)
         for v in datasets.values():
-            self.assertEqual(v.attrs['units'], '[7,8,9]->[lo,med,hi]')
+            self.assertEqual(v.attrs['units'], '1')
+            self.assertEqual(v.attrs['flag_meanings'], ['low', 'medium', 'high'])
+            self.assertEqual(v.attrs['flag_values'], [7, 8, 9])
 
         datasets = r.load(['T4'])
         self.assertEqual(len(datasets), 1)
@@ -370,7 +372,9 @@ class TestImgVIIRSActiveFiresText(unittest.TestCase):
         datasets = r.load(['confidence_cat'])
         self.assertEqual(len(datasets), 1)
         for v in datasets.values():
-            self.assertEqual(v.attrs['units'], '[7,8,9]->[lo,med,hi]')
+            self.assertEqual(v.attrs['units'], '1')
+            self.assertEqual(v.attrs['flag_meanings'], ['low', 'medium', 'high'])
+            self.assertEqual(v.attrs['flag_values'], [7, 8, 9])
 
         datasets = r.load(['T4'])
         self.assertEqual(len(datasets), 1)


### PR DESCRIPTION
I noticed that the "confidence_cat" dataset for VIIRS EDR Active Fires didn't have flag meanings and values defined. This PR adds them and makes the DataArray more CF compliant and hopefully easier to use.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
