### PR TITLE
Remove legacy GDAL-based geotiff writer support

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,7 +18,7 @@ The following people have made contributions to this project:
 - [Ulrik Egede (egede)](https://github.com/egede)
 - [Joleen Feltz (joleenf)](https://github.com/joleenf)
 - [Stephan Finkensieper (sfinkens)](https://github.com/sfinkens)
-- [Nina Håkansson](https://github.com/)
+- [Nina Håkansson (ninahakansson)](https://github.com/ninahakansson)
 - [Ulrich Hamann](https://github.com/)
 - [Gerrit Holl (gerritholl)](https://github.com/gerritholl)
 - [David Hoese (djhoese)](https://github.com/djhoese)

--- a/satpy/tests/writer_tests/test_geotiff.py
+++ b/satpy/tests/writer_tests/test_geotiff.py
@@ -130,6 +130,18 @@ class TestGeoTIFFWriter(unittest.TestCase):
             w.save_datasets(datasets, compute=False)
             self.assertEqual(save_method.call_args[1]['fill_value'], 128)
 
+    def test_tags(self):
+        """Test tags being added."""
+        from satpy.writers.geotiff import GeoTIFFWriter
+        datasets = self._get_test_datasets()
+        w = GeoTIFFWriter(tags={'test1': 1}, base_dir=self.base_dir)
+        w.info['fill_value'] = 128
+        with mock.patch('satpy.writers.XRImage.save') as save_method:
+            save_method.return_value = None
+            w.save_datasets(datasets, tags={'test2': 2}, compute=False)
+            called_tags = save_method.call_args[1]['tags']
+            self.assertDictEqual(called_tags, {'test1': 1, 'test2': 2})
+
 
 def suite():
     """The test suite for this writer's tests."""

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -34,11 +34,16 @@ class GeoTIFFWriter(ImageWriter):
 
     Basic example from Scene:
 
-        scn.save_datasets(writer='geotiff')
+        >>> scn.save_datasets(writer='geotiff')
 
     Un-enhanced float geotiff with NaN for fill values:
 
-        scn.save_datasets(writer='geotiff', dtype=np.float32, enhance=False)
+        >>> scn.save_datasets(writer='geotiff', dtype=np.float32, enhance=False)
+
+    To add custom metadata use `tags`:
+
+        >>> scn.save_dataset(dataset_name, writer='geotiff',
+        ...                  tags={'offset': 291.8, 'scale': -0.35})
 
     For performance tips on creating geotiffs quickly and making them smaller
     see the :doc:`faq`.
@@ -139,6 +144,7 @@ class GeoTIFFWriter(ImageWriter):
                 ``img`` object. The colormap's range should be set to match
                 the index range of the palette
                 (ex. `cmap.set_range(0, len(colors))`).
+            tags (dict): Extra metadata to store in geotiff.
 
         .. _geotiff: http://trac.osgeo.org/geotiff/
 

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -20,24 +20,11 @@
 """
 
 import logging
-
-import dask
 import numpy as np
-
-from satpy.utils import ensure_dir
 from satpy.writers import ImageWriter
-
-try:
-    import rasterio
-    gdal = osr = None
-except ImportError as r_exc:
-    try:
-        # fallback to legacy gdal writer
-        from osgeo import gdal, osr
-        rasterio = None
-    except ImportError:
-        # raise the original rasterio exception
-        raise r_exc
+# make sure we have rasterio even though we don't use it until trollimage
+# saves the image
+import rasterio  # noqa
 
 LOG = logging.getLogger(__name__)
 
@@ -108,72 +95,8 @@ class GeoTIFFWriter(ImageWriter):
 
         return init_kwargs, kwargs
 
-    def _gdal_write_datasets(self, dst_ds, datasets):
-        """Write datasets in a gdal raster structure dts_ds"""
-        for i, band in enumerate(datasets['bands']):
-            chn = datasets.sel(bands=band)
-            bnd = dst_ds.GetRasterBand(i + 1)
-            bnd.SetNoDataValue(0)
-            bnd.WriteArray(chn.values)
-
-    def _gdal_write_geo(self, dst_ds, area):
-        try:
-            geotransform = [area.area_extent[0], area.pixel_size_x, 0,
-                            area.area_extent[3], 0, -area.pixel_size_y]
-            dst_ds.SetGeoTransform(geotransform)
-            srs = osr.SpatialReference()
-
-            srs.ImportFromProj4(area.proj_str)
-            srs.SetProjCS(area.proj_id)
-            try:
-                srs.SetWellKnownGeogCS(area.proj_dict['ellps'])
-            except KeyError:
-                pass
-            try:
-                # Check for epsg code.
-                srs.ImportFromEPSG(int(
-                    area.proj_dict['init'].lower().split('epsg:')[1]))
-            except (KeyError, IndexError):
-                pass
-            srs = srs.ExportToWkt()
-            dst_ds.SetProjection(srs)
-        except AttributeError:
-            LOG.warning(
-                "Can't save geographic information to geotiff, unsupported area type")
-
-    def _create_file(self, filename, img, gformat, g_opts, datasets, mode):
-        num_bands = len(mode)
-        if mode[-1] == 'A':
-            g_opts.append("ALPHA=YES")
-
-        def _delayed_create(create_opts, datasets, area, start_time, tags):
-            raster = gdal.GetDriverByName("GTiff")
-            dst_ds = raster.Create(*create_opts)
-            self._gdal_write_datasets(dst_ds, datasets)
-
-            # Create raster GeoTransform based on upper left corner and pixel
-            # resolution ... if not overwritten by argument geotransform.
-            if area is None:
-                LOG.warning("No 'area' metadata found in image")
-            else:
-                self._gdal_write_geo(dst_ds, area)
-
-            if start_time is not None:
-                tags.update({'TIFFTAG_DATETIME': start_time.strftime(
-                    "%Y:%m:%d %H:%M:%S")})
-
-            dst_ds.SetMetadata(tags, '')
-
-        create_opts = (filename, img.width, img.height, num_bands, gformat, g_opts)
-        delayed = dask.delayed(_delayed_create)(
-            create_opts, datasets, img.data.attrs.get('area'),
-            img.data.attrs.get('start_time'),
-            self.tags.copy())
-        return delayed
-
     def save_image(self, img, filename=None, dtype=None, fill_value=None,
-                   floating_point=None, compute=True, keep_palette=False,
-                   cmap=None, **kwargs):
+                   compute=True, keep_palette=False, cmap=None, **kwargs):
         """Save the image to the given ``filename`` in geotiff_ format.
 
         Note for faster output and reduced memory usage the ``rasterio``
@@ -193,8 +116,6 @@ class GeoTIFFWriter(ImageWriter):
             fill_value (int or float): Value to use where data values are
                 NaN/null. If this is specified in the writer configuration
                 file that value will be used as the default.
-            floating_point (bool): Deprecated. Use ``dtype=np.float64``
-                instead.
             compute (bool): Compute dask arrays and save the image
                 immediately. If ``False`` then the return value can be passed
                 to :func:`~satpy.writers.compute_writer_results` to do the
@@ -233,12 +154,6 @@ class GeoTIFFWriter(ImageWriter):
             # fall back to fill_value from configuration file
             fill_value = self.info.get('fill_value')
 
-        if floating_point is not None:
-            import warnings
-            warnings.warn("'floating_point' is deprecated, use"
-                          "'dtype=np.float64' instead.",
-                          DeprecationWarning)
-            dtype = np.float64
         dtype = dtype if dtype is not None else self.dtype
         if dtype is None:
             dtype = np.uint8
@@ -260,49 +175,7 @@ class GeoTIFFWriter(ImageWriter):
             cmap = create_colormap({'colors': img.palette})
             cmap.set_range(0, len(img.palette) - 1)
 
-        try:
-            import rasterio  # noqa
-            # we can use the faster rasterio-based save
-            return img.save(filename, fformat='tif', fill_value=fill_value,
-                            dtype=dtype, compute=compute,
-                            keep_palette=keep_palette, cmap=cmap,
-                            **gdal_options)
-        except ImportError:
-            LOG.warning("Using legacy/slower geotiff save method, install "
-                        "'rasterio' for faster saving.")
-            import warnings
-            warnings.warn("Using legacy/slower geotiff save method with 'gdal'."
-                          "This will be deprecated in the future. Install "
-                          "'rasterio' for faster saving and future "
-                          "compatibility.", PendingDeprecationWarning)
-
-            # Map numpy data types to GDAL data types
-            NP2GDAL = {
-                np.float32: gdal.GDT_Float32,
-                np.float64: gdal.GDT_Float64,
-                np.uint8: gdal.GDT_Byte,
-                np.uint16: gdal.GDT_UInt16,
-                np.uint32: gdal.GDT_UInt32,
-                np.int16: gdal.GDT_Int16,
-                np.int32: gdal.GDT_Int32,
-                np.complex64: gdal.GDT_CFloat32,
-                np.complex128: gdal.GDT_CFloat64,
-            }
-
-            # force to numpy dtype object
-            dtype = np.dtype(dtype)
-            gformat = NP2GDAL[dtype.type]
-
-            gdal_options['nbits'] = int(gdal_options.get('nbits',
-                                                         dtype.itemsize * 8))
-            datasets, mode = img._finalize(fill_value=fill_value, dtype=dtype)
-            LOG.debug("Saving to GeoTiff: %s", filename)
-            g_opts = ["{0}={1}".format(k.upper(), str(v))
-                      for k, v in gdal_options.items()]
-
-            ensure_dir(filename)
-            delayed = self._create_file(filename, img, gformat, g_opts,
-                                        datasets, mode)
-            if compute:
-                return delayed.compute()
-            return delayed
+        return img.save(filename, fformat='tif', fill_value=fill_value,
+                        dtype=dtype, compute=compute,
+                        keep_palette=keep_palette, cmap=cmap,
+                        **gdal_options)

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -175,7 +175,10 @@ class GeoTIFFWriter(ImageWriter):
             cmap = create_colormap({'colors': img.palette})
             cmap.set_range(0, len(img.palette) - 1)
 
+        tags = kwargs.get('tags', {})
+        tags.update(self.tags)
         return img.save(filename, fformat='tif', fill_value=fill_value,
                         dtype=dtype, compute=compute,
                         keep_palette=keep_palette, cmap=cmap,
+                        tags=tags,
                         **gdal_options)

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ extras_require = {
     # Writers:
     'cf': ['h5netcdf >= 0.7.3'],
     'scmi': ['netCDF4 >= 1.1.8'],
-    'geotiff': ['gdal', 'trollimage[geotiff]'],
+    'geotiff': ['rasterio', 'trollimage[geotiff]'],
     'mitiff': ['libtiff'],
     # MultiScene:
     'animations': ['imageio'],


### PR DESCRIPTION
The original geotiff writing support in Satpy used the plain `gdal` python wrappers. When we switched to using `rasterio` for more flexibility we left the `gdal` based version in for backwards compatibility. Enough features/performance/functionality has been added to `trollimage's` geotiff writing that I think the `gdal` reader is ready to be deprecated.

Additionally, I've removed the `floating_point` keyword argument which has been deprecated for some time.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
