### PR TITLE
Add grouping parameters for the 'viirs_sdr' reader

### DIFF
--- a/satpy/etc/readers/viirs_sdr.yaml
+++ b/satpy/etc/readers/viirs_sdr.yaml
@@ -3,7 +3,9 @@ reader:
   description: VIIRS SDR Reader
   reader: !!python/name:satpy.readers.viirs_sdr.VIIRSSDRReader
   sensors: [viirs]
-  default_channels:
+  # file pattern keys to sort files by with 'satpy.utils.group_files'
+  # by default, don't use start_time group files (only orbit and platform)
+  group_keys: ['orbit', 'platform_shortname']
 
 datasets:
   i_lon:

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -595,6 +595,31 @@ class TestGroupFiles(unittest.TestCase):
         ]
         self.g16_files = input_files
         self.g17_files = [x.replace('G16', 'G17') for x in input_files]
+        self.noaa20_files = [
+            "GITCO_j01_d20180511_t2027292_e2028538_b02476_c20190530192858056873_noac_ops.h5",
+            "GITCO_j01_d20180511_t2028550_e2030195_b02476_c20190530192932937427_noac_ops.h5",
+            "GITCO_j01_d20180511_t2030208_e2031435_b02476_c20190530192932937427_noac_ops.h5",
+            "GITCO_j01_d20180511_t2031447_e2033092_b02476_c20190530192932937427_noac_ops.h5",
+            "GITCO_j01_d20180511_t2033105_e2034350_b02476_c20190530192932937427_noac_ops.h5",
+            "SVI03_j01_d20180511_t2027292_e2028538_b02476_c20190530190950789763_noac_ops.h5",
+            "SVI03_j01_d20180511_t2028550_e2030195_b02476_c20190530192911205765_noac_ops.h5",
+            "SVI03_j01_d20180511_t2030208_e2031435_b02476_c20190530192911205765_noac_ops.h5",
+            "SVI03_j01_d20180511_t2031447_e2033092_b02476_c20190530192911205765_noac_ops.h5",
+            "SVI03_j01_d20180511_t2033105_e2034350_b02476_c20190530192911205765_noac_ops.h5",
+            "SVI04_j01_d20180511_t2027292_e2028538_b02476_c20190530190951848958_noac_ops.h5",
+            "SVI04_j01_d20180511_t2028550_e2030195_b02476_c20190530192903985164_noac_ops.h5",
+            "SVI04_j01_d20180511_t2030208_e2031435_b02476_c20190530192903985164_noac_ops.h5",
+            "SVI04_j01_d20180511_t2031447_e2033092_b02476_c20190530192903985164_noac_ops.h5",
+            "SVI04_j01_d20180511_t2033105_e2034350_b02476_c20190530192903985164_noac_ops.h5"
+        ]
+        self.npp_files = [
+            "GITCO_npp_d20180511_t1939067_e1940309_b33872_c20190612031740518143_noac_ops.h5",
+            "GITCO_npp_d20180511_t1940321_e1941563_b33872_c20190612031740518143_noac_ops.h5",
+            "GITCO_npp_d20180511_t1941575_e1943217_b33872_c20190612031740518143_noac_ops.h5",
+            "SVI03_npp_d20180511_t1939067_e1940309_b33872_c20190612032009230105_noac_ops.h5",
+            "SVI03_npp_d20180511_t1940321_e1941563_b33872_c20190612032009230105_noac_ops.h5",
+            "SVI03_npp_d20180511_t1941575_e1943217_b33872_c20190612032009230105_noac_ops.h5",
+        ]
 
     def test_no_reader(self):
         """Test that reader must be provided."""
@@ -662,6 +687,43 @@ class TestGroupFiles(unittest.TestCase):
         groups = group_files(self.g16_files + self.g17_files, reader='abi_l1b')
         self.assertEqual(12, len(groups))
         self.assertEqual(2, len(groups[0]['abi_l1b']))
+
+    def test_viirs_orbits(self):
+        """Test a reader that doesn't use 'start_time' for default grouping."""
+        from satpy.readers import group_files
+        groups = group_files(self.noaa20_files + self.npp_files, reader='viirs_sdr')
+        self.assertEqual(2, len(groups))
+        # the noaa-20 files will be first because the orbit number is smaller
+        # 5 granules * 3 file types
+        self.assertEqual(5 * 3, len(groups[0]['viirs_sdr']))
+        # 3 granules * 2 file types
+        self.assertEqual(6, len(groups[1]['viirs_sdr']))
+
+    def test_viirs_override_keys(self):
+        """Test overriding a group keys to add 'start_time'."""
+        from satpy.readers import group_files
+        groups = group_files(self.noaa20_files + self.npp_files, reader='viirs_sdr',
+                             group_keys=('start_time', 'orbit', 'platform_shortname'))
+        self.assertEqual(8, len(groups))
+        self.assertEqual(2, len(groups[0]['viirs_sdr']))  # NPP
+        self.assertEqual(2, len(groups[1]['viirs_sdr']))  # NPP
+        self.assertEqual(2, len(groups[2]['viirs_sdr']))  # NPP
+        self.assertEqual(3, len(groups[3]['viirs_sdr']))  # N20
+        self.assertEqual(3, len(groups[4]['viirs_sdr']))  # N20
+        self.assertEqual(3, len(groups[5]['viirs_sdr']))  # N20
+        self.assertEqual(3, len(groups[6]['viirs_sdr']))  # N20
+        self.assertEqual(3, len(groups[7]['viirs_sdr']))  # N20
+
+        # Ask for a larger time span with our groups
+        groups = group_files(self.noaa20_files + self.npp_files, reader='viirs_sdr',
+                             time_threshold=60 * 60 * 2,
+                             group_keys=('start_time', 'orbit', 'platform_shortname'))
+        self.assertEqual(2, len(groups))
+        # NPP is first because it has an earlier time
+        # 3 granules * 2 file types
+        self.assertEqual(6, len(groups[0]['viirs_sdr']))
+        # 5 granules * 3 file types
+        self.assertEqual(5 * 3, len(groups[1]['viirs_sdr']))
 
 
 def suite():


### PR DESCRIPTION
This allows someone to use the `group_files` utility function or `MultiScene.from_files` class method with a series of VIIRS SDR files and have them be sorted by orbit and platform. This differs from what would normally be done where only `start_time` and maybe platform would be used. I made the assumption that most people would want to group orbits together instead of individual granules and I wanted that to work by default. So as an example:

```
groups = group_files(self.noaa20_files + self.npp_files, reader='viirs_sdr')
```

Would give you two groups, one for the NOAA-20 files and one for the NPP files. You could also give it two orbits of either one of these platforms. You could get around this by doing something like:

```
        groups = group_files(self.noaa20_files + self.npp_files, reader='viirs_sdr',
                             time_threshold=60 * 60 * 2,
                             group_keys=('start_time', 'orbit', 'platform_shortname'))
```

I'm open to discussion of making the start_time version the default and requiring people to use `time_threshold` to get "chunks" of data.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

