### PR TITLE
Add image 'mode' as identifying attribute to enhancements

### DIFF
--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -30,6 +30,15 @@ def noop(img, **kwargs):
     return img
 
 
+def unconfigured_noop(img, **kwargs):
+    """Do nothing and warn that no enhancement was configured."""
+    import warnings
+    name = img.data.attrs.get('name', '<unknown>')
+    warnings.warn("No enhancement configured for '{}'. Will not stretch and "
+                  "assuming already 0-1 normalized.".format(name))
+    return noop(img, **kwargs)
+
+
 def stretch(img, **kwargs):
     """Perform stretch."""
     return img.stretch(**kwargs)

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -25,6 +25,11 @@ import logging
 LOG = logging.getLogger(__name__)
 
 
+def noop(img, **kwargs):
+    """Do nothing and return the original image."""
+    return img
+
+
 def stretch(img, **kwargs):
     """Perform stretch."""
     return img.stretch(**kwargs)

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -6,6 +6,12 @@ enhancements:
     - name: stretch
       method: &stretchfun !!python/name:satpy.enhancements.stretch
       kwargs: {stretch: linear}
+  rgb_default:
+    mode: RGB
+    operations:
+      - name: stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: crude, min_stretch: [0.0, 0.0, 0.0], max_stretch: [1.0, 1.0, 1.0]}
   reflectance_default:
     standard_name: toa_bidirectional_reflectance
     operations:

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -9,9 +9,8 @@ enhancements:
   rgb_default:
     mode: RGB
     operations:
-      - name: stretch
-        method: !!python/name:satpy.enhancements.stretch
-        kwargs: {stretch: crude, min_stretch: [0.0, 0.0, 0.0], max_stretch: [1.0, 1.0, 1.0]}
+      - name: passive
+        method: !!python/name:satpy.enhancements.noop
   reflectance_default:
     standard_name: toa_bidirectional_reflectance
     operations:

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -10,7 +10,7 @@ enhancements:
     mode: RGB
     operations:
       - name: passive
-        method: !!python/name:satpy.enhancements.noop
+        method: !!python/name:satpy.enhancements.unconfigured_noop
   reflectance_default:
     standard_name: toa_bidirectional_reflectance
     operations:

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -382,7 +382,7 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test')
         res = comp((self.data_a, self.data_b, self.sza))
         res = res.compute()
-        expected = np.array([[0., 0.2985455], [0.51680423, 1.]])
+        expected = np.array([[0.1, 0.20499086], [0.48003658, 0.75]])
         np.testing.assert_allclose(res.values[0], expected)
 
     def test_basic_area(self):
@@ -391,7 +391,7 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test')
         res = comp((self.data_a, self.data_b))
         res = res.compute()
-        expected = np.array([[0., 0.33164983], [0.66835017, 1.]])
+        expected = np.array([[0.1, 0.2], [0.3, 0.4]])
         np.testing.assert_allclose(res.values[0], expected)
 
 

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -323,6 +323,27 @@ sensor_name: visir/test_sensor2
                              os.path.abspath(self.ENH_ENH_FN)})
         np.testing.assert_almost_equal(img.data.isel(bands=0).max().values, 0.5)
 
+    def test_builtin_enhancements_default_rgb(self):
+        """Test what happens to RGBs with builtin enhancements."""
+        from satpy.writers import Enhancer, get_enhanced_image
+        from xarray import DataArray
+        ds = DataArray(
+            np.linspace(-0.1, 1.2, 75).reshape((3, 5, 5)),
+            attrs=dict(name='arbitrary', units='kelvin', sensor='test_sensor'),
+            dims=('bands', 'y', 'x'), coords={'bands': ['R', 'G', 'B']})
+        e = Enhancer()
+        self.assertIsNotNone(e.enhancement_tree)
+        img = get_enhanced_image(ds, enhance=e)
+        # make sure data on the output is same as input
+        np.testing.assert_almost_equal(img.data.min().values, -0.1)
+        np.testing.assert_almost_equal(img.data.max().values, 1.2)
+
+        # make sure a configured dataset doesn't use mode enhancement
+        # and actually gets stretched
+        ds.attrs['name'] = 'test1'
+        img = get_enhanced_image(ds, enhance=e)
+        np.testing.assert_almost_equal(img.data.values[0, 0, 0], -0.005)
+
 
 class TestYAMLFiles(unittest.TestCase):
     """Test and analyze the writer configuration files."""

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -383,6 +383,24 @@ def add_decorate(orig, fill_value=None, **decorate):
     return img
 
 
+def _bands_to_mode(data_arr):
+    """Convert a 'bands' coordinate variable to a string."""
+    # turn DataArray of characters in to string
+    bands = data_arr.coords.get('bands')
+    if bands is not None:
+        if bands.ndim == 0:
+            bands = [bands.item()]
+        else:
+            bands = list(bands.values)
+        if not isinstance(bands[0], str):
+            # we don't understand what these bands are
+            # probably integers or not set
+            bands = []
+    else:
+        bands = []
+    return "".join(bands) or None
+
+
 def get_enhanced_image(dataset, ppp_config_dir=None, enhance=None, enhancement_config_file=None,
                        overlay=None, decorate=None, fill_value=None):
     """Get an enhanced version of `dataset` as an :class:`~trollimage.xrimage.XRImage` instance.
@@ -445,11 +463,8 @@ def get_enhanced_image(dataset, ppp_config_dir=None, enhance=None, enhancement_c
             enhancer.add_sensor_enhancements(dataset.attrs["sensor"])
 
         attrs = dataset.attrs.copy()
-        # turn DataArray of characters in to string
-        default_mode = "".join(str(band.values) for band in
-                               dataset.coords.get('bands', []))
-        attrs.setdefault('mode', default_mode or None)
-        enhancer.apply(img, **dataset.attrs)
+        attrs.setdefault('mode', _bands_to_mode(dataset))
+        enhancer.apply(img, **attrs)
 
     if overlay is not None:
         img = add_overlay(img, dataset.attrs['area'], fill_value=fill_value, **overlay)

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -444,6 +444,11 @@ def get_enhanced_image(dataset, ppp_config_dir=None, enhance=None, enhancement_c
         if dataset.attrs.get("sensor", None):
             enhancer.add_sensor_enhancements(dataset.attrs["sensor"])
 
+        attrs = dataset.attrs.copy()
+        # turn DataArray of characters in to string
+        default_mode = "".join(str(band.values) for band in
+                               dataset.coords.get('bands', []))
+        attrs.setdefault('mode', default_mode or None)
         enhancer.apply(img, **dataset.attrs)
 
     if overlay is not None:
@@ -914,7 +919,8 @@ class EnhancementDecisionTree(DecisionTree):
                                      "platform_name",
                                      "sensor",
                                      "standard_name",
-                                     "units",))
+                                     "units",
+                                     "mode",))
         self.prefix = kwargs.pop("config_section", "enhancements")
         super(EnhancementDecisionTree, self).__init__(
             decision_dicts, attrs, **kwargs)


### PR DESCRIPTION
Similar to how we have `name` and `standard_name` as identifying factors that someone can use in the enhancement configs, this PR adds `mode`. This is used in the new RGB default enhancement which does a crude linear stretch between 0 and 1. This is a nice thing to have when creating new RGBs and experimenting with them because we don't have to configure a new enhancement every time. This is also useful for DayNightCompositor composites which are already enhanced and on a 0 to 1 scale. This way you could make any number of DayNight composites and wouldn't need to make a new 0 to 1 enhancement for each one.

I should really add documentation for this and it needs tests but I wanted to have people look at this as soon as possible since I'd like this for my scipy tutorial.

The other thing that is *not* implemented here but has been talked about is the shortcut of allowing certain attributes to "shortcut" the enhancement process. So if an RGB is detected (via the enhancement mode) then a special RGB-friendly enhancement would be used which would default to color limits of 0 and 1 for each band but could also use a `color_limits` attribute or `vmin` and `vmax` attributes if they existed to override the 0 and 1. I'm not sure this is the right time to implement this functionality since it seems like a work around for the general problem of "creating enhancements is more annoying than it should be for simple composites".

 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
