### PR TITLE
Add TLEs to dataset attributes in avhrr_l1b_gaclac

### DIFF
--- a/doc/source/readers.rst
+++ b/doc/source/readers.rst
@@ -138,6 +138,11 @@ following attributes are standardized across all readers:
     * [DEPRECATED] ``satellite_longitude/latitude/altitude``: Current position of the satellite at the time of observation
       in geodetic coordinates.
 
+  * For *polar orbiting* satellites the readers usually provide coordinates and viewing angles of the swath as
+    ancillary datasets. Additional metadata related to the satellite position include:
+
+      * ``tle``: Two-Line Element (TLE) set used to compute the satellite's orbit
+
 * ``raw_metadata``: Raw, unprocessed metadata from the reader.
 
 Note that the above attributes are not necessarily available for each dataset.

--- a/satpy/readers/avhrr_l1b_gaclac.py
+++ b/satpy/readers/avhrr_l1b_gaclac.py
@@ -105,6 +105,7 @@ class GACLACFile(BaseFileHandler):
         res.attrs['platform_name'] = self.reader.spacecraft_name
         res.attrs['orbit_number'] = self.filename_info['orbit_number']
         res.attrs['sensor'] = self.sensor
+        res.attrs['orbital_parameters'] = {'tle': self.reader.get_tle_lines()}
         res['acq_time'] = ('y', self.reader.get_times())
         res['acq_time'].attrs['long_name'] = 'Mean scanline acquisition time'
         return res

--- a/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
+++ b/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
@@ -97,9 +97,11 @@ class TestGACLACFile(TestCase):
 
             GACPODReader.return_value.get_angles.return_value = (angle_ones, ) * 5
             GACPODReader.return_value.get_times.return_value = acq_ones
+            GACPODReader.return_value.get_tle_lines.return_value = 'tle1', 'tle2'
             res = fh.get_dataset(key, info)
             np.testing.assert_allclose(res.data, angle_ones)
             self.assertIs(res.coords['acq_time'].data, acq_ones)
+            self.assertDictEqual(res.attrs['orbital_parameters'], {'tle': ('tle1', 'tle2')})
 
         key = DatasetID('longitude')
         info = {'name': 'longitude', 'unit': 'degrees_east'}

--- a/satpy/tests/reader_tests/test_electrol_hrit.py
+++ b/satpy/tests/reader_tests/test_electrol_hrit.py
@@ -183,7 +183,6 @@ class TestHRITGOMSFileHandler(unittest.TestCase):
         fh.platform_name = 'Electro'
         fh.mda = {'projection_parameters': {'SSP_longitude': 0.0},
                   'orbital_parameters': {'satellite_nominal_longitude': 0.5}}
-        key = 0
         info = {'units': 'm', 'standard_name': 'electro', 'wavelength': 5.0}
         output = fh.get_dataset(resser(), info)
 


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
This PR adds TLEs to the dataset attributes in `avhrr_l1b_gaclac`. Just to have one example of `orbital_parameters` for polar orbiting satellites.

Depends on https://github.com/pytroll/pygac/pull/28

 - [X] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [X] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
