### PR TITLE
Remove warning about unused kwargs in YAML reader

### DIFF
--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -259,8 +259,6 @@ class FileYAMLReader(AbstractYAMLReader):
         self.available_ids = {}
         self.filter_filenames = self.info.get('filter_filenames', filter_filenames)
         self.filter_parameters = filter_parameters or {}
-        if kwargs:
-            logger.warning("Unrecognized/unused reader keyword argument(s) '{}'".format(kwargs))
         self.coords_cache = WeakValueDictionary()
 
     @property

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -135,7 +135,7 @@ import dask
 import dask.array as da
 
 from pyresample.ewa import fornav, ll2cr
-from pyresample.geometry import SwathDefinition, AreaDefinition
+from pyresample.geometry import SwathDefinition
 from pyresample.kd_tree import XArrayResamplerNN
 from pyresample.bilinear.xarr import XArrayResamplerBilinear
 from satpy import CHUNK_SIZE


### PR DESCRIPTION
If a scene is created with `reader_kwargs`, the YAML reader logs a warning about unused keyword arguments. For example:
```python
>>> scene = Scene(filenames=[...], reader='seviri_l1b_hrit', reader_kwargs={'calib_mode': 'GSICS'})
[WARNING: 2019-06-17 11:45:14 : satpy.readers.yaml_reader] Unrecognized/unused reader keyword argument(s) '{'calib_mode': 'GSICS'}'
```
This is confusing for the user, because it seems like the reader kwarg has not been recognized.

This PR removes that warning. An alternative would have been to split `reader_kwargs` into separate kwargs for the reader and the file handler. But we agreed that the user shouldn't have to know the difference between a reader and a file handler.

 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
