### PR TITLE
Deprecate old reader names so that they are no longer recognized

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -45,29 +45,6 @@ LOG = logging.getLogger(__name__)
 
 # Old Name -> New Name
 OLD_READER_NAMES = {
-    'avhrr_aapp_l1b': 'avhrr_l1b_aapp',
-    'avhrr_eps_l1b': 'avhrr_l1b_eps',
-    'avhrr_hrpt_l1b': 'avhrr_l1b_hrpt',
-    'gac_lac_l1': 'avhrr_l1b_gaclac',
-    'hdf4_caliopv3': 'caliop_l2_cloud',
-    'hdfeos_l1b': 'modis_l1b',
-    'hrit_electrol': 'electrol_hrit',
-    'hrit_jma': 'ahi_hrit',
-    'fci_fdhsi': 'fci_l1c_fdhsi',
-    'ghrsst_osisaf': 'ghrsst_l3c_sst',
-    'hrit_goes': 'goes-imager_hrit',
-    'hrit_msg': 'seviri_l1b_hrit',
-    'native_msg': 'seviri_l1b_native',
-    'nc_goes': 'goes-imager_nc',
-    'nc_nwcsaf_msg': 'nwcsaf-geo',
-    'nc_nwcsaf_pps': 'nwcsaf-pps_nc',
-    'nc_olci_l1b': 'olci_l1b',
-    'nc_olci_l2': 'olci_l2',
-    'nc_seviri_l1b': 'seviri_l1b_nc',
-    'nc_slstr': 'slstr_l1b',
-    'safe_msi': 'msi_safe',
-    'safe_sar_c': 'sar-c_safe',
-    'scmi_abi_l1b': 'abi_l1b_scmi',
 }
 
 

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -531,8 +531,12 @@ class TestFindFilesAndReaders(unittest.TestCase):
 
     def test_old_reader_name_mapping(self):
         """Test that requesting old reader names raises a warning."""
-        from satpy.readers import configs_for_reader
-        self.assertRaises(ValueError, list, configs_for_reader('hrit_jma'))
+        from satpy.readers import configs_for_reader, OLD_READER_NAMES
+        if not OLD_READER_NAMES:
+            return unittest.skip("Skipping deprecated reader tests because "
+                                 "no deprecated readers.")
+        test_reader = sorted(OLD_READER_NAMES.keys())[0]
+        self.assertRaises(ValueError, list, configs_for_reader(test_reader))
 
 
 class TestYAMLFiles(unittest.TestCase):


### PR DESCRIPTION
Replace #598. This removes the available/known reader names that can be mapped to the new preferred reader names. In #598 I completely removed the functionality and tests, but in this PR I left the logic there, just removed the names that can be mapped.

 - [x] Closes #598 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
