### PR TITLE
Corrected nc_key for channels WV_062, WV_073, IR_087

### DIFF
--- a/satpy/etc/readers/seviri_l1b_nc.yaml
+++ b/satpy/etc/readers/seviri_l1b_nc.yaml
@@ -76,7 +76,7 @@ datasets:
         standard_name: counts
         units: count
     file_type: seviri_l1b_nc
-    nc_key: 'ch5'
+    nc_key: 'ch7'
 
   IR_097:
     name: IR_097
@@ -196,7 +196,7 @@ datasets:
         standard_name: counts
         units: count
     file_type: seviri_l1b_nc
-    nc_key: 'ch6'
+    nc_key: 'ch5'
 
   WV_073:
     name: WV_073
@@ -213,6 +213,6 @@ datasets:
         standard_name: counts
         units: count
     file_type: seviri_l1b_nc
-    nc_key: 'ch7'
+    nc_key: 'ch6'
 
 


### PR DESCRIPTION
Corrects nc_key for channels WV_062, WV_073, IR_087 in seviri_l1b_nc.yaml, fixing problem with loading the wrong channels.

closes #826 

