### PR TITLE
Fix delayed generation of composites and composite resolution

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -823,7 +823,10 @@ class GenericCompositor(CompositeBase):
         new_attrs.update({key: val
                           for (key, val) in attrs.items()
                           if val is not None})
+        resolution = new_attrs.get('resolution', None)
         new_attrs.update(self.attrs)
+        if resolution is not None:
+            new_attrs['resolution'] = resolution
         new_attrs["sensor"] = self._get_sensors(projectables)
         new_attrs["mode"] = mode
 
@@ -847,8 +850,8 @@ class Filler(GenericCompositor):
 
     def __call__(self, projectables, nonprojectables=None, **info):
         """Generate the composite."""
-        projectables[0] = projectables[0].fillna(projectables[1])
-        return super(Filler, self).__call__([projectables[0]], **info)
+        filled_projectable = projectables[0].fillna(projectables[1])
+        return super(Filler, self).__call__([filled_projectable], **info)
 
 
 class RGBCompositor(GenericCompositor):
@@ -1403,6 +1406,7 @@ class StaticImageCompositor(GenericCompositor):
         super(StaticImageCompositor, self).__init__(name, **kwargs)
 
     def __call__(self, *args, **kwargs):
+        """Call the compositor."""
         from satpy import Scene
         scn = Scene(reader='generic_image', filenames=[self.filename])
         scn.load(['image'])
@@ -1435,6 +1439,7 @@ class BackgroundCompositor(GenericCompositor):
     """A compositor that overlays one composite on top of another."""
 
     def __call__(self, projectables, *args, **kwargs):
+        """Call the compositor."""
         projectables = self.check_areas(projectables)
 
         # Get enhanced datasets

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -65,6 +65,9 @@ class Node(object):
         if node_cache and self.name in node_cache:
             return node_cache[self.name]
 
+        if self.name == EMPTY_LEAF_NAME:
+            return self
+
         s = Node(self.name, self.data)
         for c in self.children:
             c = c.copy(node_cache=node_cache)

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -432,6 +432,20 @@ class DependencyTree(Node):
 
         return root, set()
 
+    def get_filtered_item(self, dataset_key, **dfilter):
+        """Get the item matching *dataset_key* and *dfilter*."""
+        try:
+            ds_dict = dataset_key.to_dict()
+        except AttributeError:
+            if isinstance(dataset_key, str):
+                ds_dict = {'name': dataset_key}
+            elif isinstance(dataset_key, float):
+                ds_dict = {'wavelength': dataset_key}
+        clean_filter = {key: value for key, value in dfilter.items() if value is not None}
+        ds_dict.update(clean_filter)
+        dsid = DatasetID.from_dict(ds_dict)
+        return self[dsid]
+
     def _find_dependencies(self, dataset_key, **dfilter):
         """Find the dependencies for *dataset_key*.
 
@@ -472,7 +486,7 @@ class DependencyTree(Node):
             # assume that there is no such thing as a "better" composite
             # version so if we find any DatasetIDs already loaded then
             # we want to use them
-            node = self[dataset_key]
+            node = self.get_filtered_item(dataset_key, **dfilter)
             LOG.trace("Composite already loaded:\n\tRequested: {}\n\tFound: {}".format(dataset_key, node.name))
             return node, set()
         except KeyError:

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -65,7 +65,7 @@ class Node(object):
         if node_cache and self.name in node_cache:
             return node_cache[self.name]
 
-        if self.name == EMPTY_LEAF_NAME:
+        if self.name is EMPTY_LEAF_NAME:
             return self
 
         s = Node(self.name, self.data)

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -38,11 +38,11 @@ class Node(object):
 
     @property
     def is_leaf(self):
+        """Check if the node is a leaf."""
         return not self.children
 
     def flatten(self, d=None):
         """Flatten tree structure to a one level dictionary.
-
 
         Args:
             d (dict, optional): output dictionary to update
@@ -50,6 +50,7 @@ class Node(object):
         Returns:
             dict: Node.name -> Node. The returned dictionary includes the
                   current Node and all its children.
+
         """
         if d is None:
             d = {}
@@ -60,6 +61,7 @@ class Node(object):
         return d
 
     def copy(self, node_cache=None):
+        """Make a copy of the node."""
         if node_cache and self.name in node_cache:
             return node_cache[self.name]
 
@@ -79,12 +81,15 @@ class Node(object):
         return self.display()
 
     def __repr__(self):
+        """Generate a representation of the node."""
         return "<Node ({})>".format(repr(self.name))
 
     def __eq__(self, other):
+        """Check equality."""
         return self.name == other.name
 
     def __hash__(self):
+        """Generate the hash of the node."""
         return hash(self.name)
 
     def display(self, previous=0, include_data=False):
@@ -124,13 +129,17 @@ class Node(object):
 
 
 class DependencyTree(Node):
-    """Structure to discover and store `Dataset` dependencies
+    """Structure to discover and store `Dataset` dependencies.
 
     Used primarily by the `Scene` object to organize dependency finding.
     Dependencies are stored used a series of `Node` objects which this
     class is a subclass of.
 
     """
+
+    # simplify future logic by only having one "sentinel" empty node
+    # making it a class attribute ensures it is the same across instances
+    empty_node = Node(EMPTY_LEAF_NAME)
 
     def __init__(self, readers, compositors, modifiers):
         """Collect Dataset generating information.
@@ -154,8 +163,6 @@ class DependencyTree(Node):
         # keep a flat dictionary of nodes contained in the tree for better
         # __contains__
         self._all_nodes = DatasetDict()
-        # simplify future logic by only having one "sentinel" empty node
-        self.empty_node = Node(EMPTY_LEAF_NAME)
 
     def leaves(self, nodes=None, unique=True):
         """Get the leaves of the tree starting at this root.
@@ -201,6 +208,7 @@ class DependencyTree(Node):
         return res
 
     def add_child(self, parent, child):
+        """Add a child to the tree."""
         Node.add_child(parent, child)
         # Sanity check: Node objects should be unique. They can be added
         #               multiple times if more than one Node depends on them
@@ -213,6 +221,7 @@ class DependencyTree(Node):
         self._all_nodes[child.name] = child
 
     def add_leaf(self, ds_id, parent=None):
+        """Add a leaf to the tree."""
         if parent is None:
             parent = self
         try:
@@ -222,7 +231,7 @@ class DependencyTree(Node):
         self.add_child(parent, node)
 
     def copy(self):
-        """Copy the this node tree
+        """Copy this node tree.
 
         Note all references to readers are removed. This is meant to avoid
         tree copies accessing readers that would return incompatible (Area)
@@ -237,9 +246,11 @@ class DependencyTree(Node):
         return new_tree
 
     def __contains__(self, item):
+        """Check if a item is in the tree."""
         return item in self._all_nodes
 
     def __getitem__(self, item):
+        """Get an item of the tree."""
         return self._all_nodes[item]
 
     def contains(self, item):
@@ -251,6 +262,7 @@ class DependencyTree(Node):
         return super(DatasetDict, self._all_nodes).__getitem__(item)
 
     def get_compositor(self, key):
+        """Get a compositor."""
         for sensor_name in self.compositors.keys():
             try:
                 return self.compositors[sensor_name][key]
@@ -264,6 +276,7 @@ class DependencyTree(Node):
         raise KeyError("Could not find compositor '{}'".format(key))
 
     def get_modifier(self, comp_id):
+        """Get a modifer."""
         # create a DatasetID for the compositor we are generating
         modifier = comp_id.modifiers[-1]
         for sensor_name in self.modifiers.keys():

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -15,8 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Tests for compositors.
-"""
+"""Tests for compositors."""
 
 import xarray as xr
 import dask.array as da
@@ -36,7 +35,7 @@ class TestMatchDataArrays(unittest.TestCase):
     """Test the utility method 'match_data_arrays'."""
 
     def _get_test_ds(self, shape=(50, 100), dims=('y', 'x')):
-        """Helper method to get a fake DataArray."""
+        """Get a fake DataArray."""
         from pyresample.geometry import AreaDefinition
         data = da.random.random(shape, chunks=25)
         area = AreaDefinition(
@@ -113,6 +112,7 @@ class TestMatchDataArrays(unittest.TestCase):
         self.assertRaises(IncompatibleAreas, comp.match_data_arrays, (ds1, ds2))
 
     def test_nondimensional_coords(self):
+        """Test the removal of non-dimensional coordinates when compositing."""
         from satpy.composites import CompositeBase
         ds = self._get_test_ds(shape=(2, 2))
         ds['acq_time'] = ('y', [0, 1])
@@ -230,6 +230,8 @@ class TestRatioSharpenedCompositors(unittest.TestCase):
 
 
 class TestSunZenithCorrector(unittest.TestCase):
+    """Test case for the zenith corrector."""
+
     def setUp(self):
         """Create test data."""
         from pyresample.geometry import AreaDefinition
@@ -291,6 +293,7 @@ class TestSunZenithCorrector(unittest.TestCase):
 
 
 class TestDifferenceCompositor(unittest.TestCase):
+    """Test case for the difference compositor."""
 
     def setUp(self):
         """Create test data."""
@@ -385,7 +388,7 @@ class TestDayNightCompositor(unittest.TestCase):
         self.sza.attrs['area'] = my_area
 
     def test_basic_sza(self):
-        """Test compositor when SZA data is included"""
+        """Test compositor when SZA data is included."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test')
         res = comp((self.data_a, self.data_b, self.sza))
@@ -404,8 +407,10 @@ class TestDayNightCompositor(unittest.TestCase):
 
 
 class TestFillingCompositor(unittest.TestCase):
+    """Test case for the filling compositor."""
 
     def test_fill(self):
+        """Test filling."""
         from satpy.composites import FillingCompositor
         comp = FillingCompositor(name='fill_test')
         filler = xr.DataArray(np.array([1, 2, 3, 4, 3, 2, 1]))
@@ -586,6 +591,7 @@ class TestColormapCompositor(unittest.TestCase):
     """Test the ColormapCompositor."""
 
     def test_build_colormap(self):
+        """Test colormap building."""
         from satpy.composites import ColormapCompositor
         cmap_comp = ColormapCompositor('test_cmap_compositor')
         palette = np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]])
@@ -605,6 +611,7 @@ class TestPaletteCompositor(unittest.TestCase):
     """Test the PaletteCompositor."""
 
     def test_call(self):
+        """Test palette compositing."""
         from satpy.composites import PaletteCompositor
         cmap_comp = PaletteCompositor('test_cmap_compositor')
         palette = xr.DataArray(np.array([[0, 0, 0], [127, 127, 127], [255, 255, 255]]),
@@ -748,7 +755,7 @@ class TestGenericCompositor(unittest.TestCase):
     @mock.patch('satpy.composites.check_times')
     @mock.patch('satpy.composites.GenericCompositor.match_data_arrays')
     def test_call_with_mock(self, match_data_arrays, check_times, combine_metadata, get_sensors):
-        """Test calling generic compositor"""
+        """Test calling generic compositor."""
         from satpy.composites import IncompatibleAreas
         combine_metadata.return_value = dict()
         get_sensors.return_value = 'foo'
@@ -777,11 +784,12 @@ class TestGenericCompositor(unittest.TestCase):
         match_data_arrays.assert_called_once()
 
     def test_call(self):
-        """Test calling generic compositor"""
+        """Test calling generic compositor."""
         # Multiple datasets with extra attributes
         all_valid = self.all_valid
         all_valid.attrs['sensor'] = 'foo'
-        attrs = {'foo': 'bar'}
+        attrs = {'foo': 'bar', 'resolution': 333}
+        self.comp.attrs['resolution'] = None
         res = self.comp([self.all_valid, self.first_invalid], **attrs)
         # Verify attributes
         self.assertEqual(res.attrs.get('sensor'), 'foo')
@@ -792,11 +800,14 @@ class TestGenericCompositor(unittest.TestCase):
         self.assertTrue('modifiers' not in res.attrs)
         self.assertIsNone(res.attrs['wavelength'])
         self.assertEqual(res.attrs['mode'], 'LA')
+        self.assertEquals(res.attrs['resolution'], 333)
 
 
 class TestAddBands(unittest.TestCase):
+    """Test case for the `add_bands` function."""
 
     def test_add_bands(self):
+        """Test adding bands."""
         from satpy.composites import add_bands
         import dask.array as da
         import numpy as np
@@ -849,9 +860,11 @@ class TestAddBands(unittest.TestCase):
 
 
 class TestStaticImageCompositor(unittest.TestCase):
+    """Test case for the static compositor."""
 
     @mock.patch('satpy.resample.get_area_def')
     def test_init(self, get_area_def):
+        """Test the initializiation of static compositor."""
         from satpy.composites import StaticImageCompositor
 
         # No filename given raises ValueError
@@ -872,6 +885,7 @@ class TestStaticImageCompositor(unittest.TestCase):
 
     @mock.patch('satpy.Scene')
     def test_call(self, Scene):
+        """Test the static compositing."""
         from satpy.composites import StaticImageCompositor
 
         class mock_scene(dict):
@@ -905,12 +919,14 @@ class TestStaticImageCompositor(unittest.TestCase):
 
 
 class TestBackgroundCompositor(unittest.TestCase):
+    """Test case for the background compositor."""
 
     @mock.patch('satpy.composites.combine_metadata')
     @mock.patch('satpy.composites.add_bands')
     @mock.patch('satpy.composites.enhance2dataset')
     @mock.patch('satpy.composites.BackgroundCompositor.check_areas')
     def test_call(self, check_areas, e2d, add_bands, combine_metadata):
+        """Test the background compositing."""
         from satpy.composites import BackgroundCompositor
         import numpy as np
 

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -15,8 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for scene.py.
-"""
+"""Unit tests for scene.py."""
 
 import os
 import sys
@@ -39,6 +38,7 @@ class TestScene(unittest.TestCase):
     """Test the scene class."""
 
     def test_init(self):
+        """Test scene initialization."""
         import satpy.scene
         with mock.patch('satpy.scene.Scene.create_reader_instances') as cri:
             cri.return_value = {}
@@ -47,10 +47,12 @@ class TestScene(unittest.TestCase):
                                         reader_kwargs=None)
 
     def test_init_str_filename(self):
+        """Test initializing with a single string as filenames."""
         import satpy.scene
         self.assertRaises(ValueError, satpy.scene.Scene, reader='blo', filenames='test.nc')
 
     def test_init_with_sensor(self):
+        """Test initializing with a sensor."""
         import satpy.scene
         from satpy.tests.utils import FakeReader
         with mock.patch('satpy.scene.Scene.create_reader_instances') as cri:
@@ -67,6 +69,7 @@ class TestScene(unittest.TestCase):
             self.assertIsInstance(scene.attrs['sensor'], set)
 
     def test_start_end_times(self):
+        """Test start and end times for a scene."""
         import satpy.scene
         from satpy.tests.utils import FakeReader
         from datetime import datetime
@@ -83,6 +86,7 @@ class TestScene(unittest.TestCase):
             self.assertEqual(scene.end_time, r.end_time)
 
     def test_init_preserve_reader_kwargs(self):
+        """Test that the initialization preserves the kwargs."""
         import satpy.scene
         from satpy.tests.utils import FakeReader
         from datetime import datetime
@@ -103,6 +107,7 @@ class TestScene(unittest.TestCase):
             self.assertEqual(scene.end_time, r.end_time)
 
     def test_init_alone(self):
+        """Test simple initialization."""
         from satpy.scene import Scene
         from satpy.config import PACKAGE_CONFIG_PATH
         scn = Scene()
@@ -115,11 +120,13 @@ class TestScene(unittest.TestCase):
         self.assertRaises(ValueError, Scene, reader='viirs_sdr', filenames=[])
 
     def test_init_with_ppp_config_dir(self):
+        """Test initializing with a ppp_config_dir."""
         from satpy.scene import Scene
         scn = Scene(ppp_config_dir="foo")
         self.assertEqual(scn.ppp_config_dir, 'foo')
 
     def test_create_reader_instances_with_filenames(self):
+        """Test creating a reader providing filenames."""
         import satpy.scene
         filenames = ["bla", "foo", "bar"]
         reader_name = None
@@ -135,6 +142,7 @@ class TestScene(unittest.TestCase):
                 )
 
     def test_init_with_empty_filenames(self):
+        """Test initialization with empty filename list."""
         from satpy.scene import Scene
         filenames = []
         Scene(filenames=filenames)
@@ -172,6 +180,7 @@ class TestScene(unittest.TestCase):
     #             )
 
     def test_create_reader_instances_with_reader(self):
+        """Test createring a reader instance providing the reader name."""
         from satpy.scene import Scene
         reader = "foo"
         filenames = ["1", "2", "3"]
@@ -185,6 +194,7 @@ class TestScene(unittest.TestCase):
                                                )
 
     def test_create_reader_instances_with_reader_kwargs(self):
+        """Test creating a reader instance with reader kwargs."""
         import satpy.scene
         from satpy.tests.utils import FakeReader
         from datetime import datetime
@@ -217,6 +227,7 @@ class TestScene(unittest.TestCase):
             del scene
 
     def test_iter(self):
+        """Test iteration over the scene."""
         from satpy import Scene
         from xarray import DataArray
         import numpy as np
@@ -228,6 +239,7 @@ class TestScene(unittest.TestCase):
             self.assertIsInstance(x, DataArray)
 
     def test_iter_by_area_swath(self):
+        """Test iterating by area on a swath."""
         from satpy import Scene
         from xarray import DataArray
         from pyresample.geometry import SwathDefinition
@@ -246,12 +258,14 @@ class TestScene(unittest.TestCase):
                 self.assertSetEqual(ds_list_names, {'3'})
 
     def test_bad_setitem(self):
+        """Test setting an item wrongly."""
         from satpy import Scene
         import numpy as np
         scene = Scene()
         self.assertRaises(ValueError, scene.__setitem__, '1', np.arange(5))
 
     def test_setitem(self):
+        """Test setting an item."""
         from satpy import Scene, DatasetID
         import numpy as np
         import xarray as xr
@@ -262,7 +276,7 @@ class TestScene(unittest.TestCase):
         self.assertSetEqual(set(scene.wishlist), {expected_id})
 
     def test_getitem(self):
-        """Test __getitem__ with names only"""
+        """Test __getitem__ with names only."""
         from satpy import Scene
         from xarray import DataArray
         import numpy as np
@@ -278,7 +292,7 @@ class TestScene(unittest.TestCase):
         self.assertIs(scene.get('4'), None)
 
     def test_getitem_modifiers(self):
-        """Test __getitem__ with names and modifiers"""
+        """Test __getitem__ with names and modifiers."""
         from satpy import Scene, DatasetID
         from xarray import DataArray
         import numpy as np
@@ -312,7 +326,7 @@ class TestScene(unittest.TestCase):
         self.assertEqual(len(list(scene.keys())), 2)
 
     def test_getitem_slices(self):
-        """Test __getitem__ with slices"""
+        """Test __getitem__ with slices."""
         from satpy import Scene
         from xarray import DataArray
         from pyresample.geometry import AreaDefinition, SwathDefinition
@@ -535,6 +549,7 @@ class TestScene(unittest.TestCase):
         self.assertTupleEqual(scene2['3'].shape, (y_size / 2, x_size / 2))
 
     def test_contains(self):
+        """Test contains."""
         from satpy import Scene
         from xarray import DataArray
         import numpy as np
@@ -546,6 +561,7 @@ class TestScene(unittest.TestCase):
         self.assertFalse(0.31 in scene)
 
     def test_delitem(self):
+        """Test deleting an item."""
         from satpy import Scene
         from xarray import DataArray
         import numpy as np
@@ -603,6 +619,7 @@ class TestScene(unittest.TestCase):
         self.assertIs(scene.min_area(['2', '3']), area_def2)
 
     def test_all_datasets_no_readers(self):
+        """Test all datasets with no reader."""
         from satpy import Scene
         scene = Scene()
         self.assertRaises(KeyError, scene.all_dataset_ids, reader_name='fake')
@@ -613,6 +630,7 @@ class TestScene(unittest.TestCase):
         self.assertListEqual(id_list, [])
 
     def test_all_dataset_names_no_readers(self):
+        """Test all dataset names with no reader."""
         from satpy import Scene
         scene = Scene()
         self.assertRaises(KeyError, scene.all_dataset_names, reader_name='fake')
@@ -623,6 +641,7 @@ class TestScene(unittest.TestCase):
         self.assertListEqual(name_list, [])
 
     def test_available_dataset_no_readers(self):
+        """Test the available datasets without a reader."""
         from satpy import Scene
         scene = Scene()
         self.assertRaises(
@@ -634,6 +653,7 @@ class TestScene(unittest.TestCase):
         self.assertListEqual(name_list, [])
 
     def test_available_dataset_names_no_readers(self):
+        """Test the available dataset names without a reader."""
         from satpy import Scene
         scene = Scene()
         self.assertRaises(
@@ -645,6 +665,7 @@ class TestScene(unittest.TestCase):
         self.assertListEqual(name_list, [])
 
     def test_available_composites_no_datasets(self):
+        """Test the available composites with no datasets."""
         from satpy import Scene
         scene = Scene()
         id_list = scene.available_composite_ids(available_datasets=[])
@@ -656,6 +677,7 @@ class TestScene(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_all_datasets_one_reader(self, cri, cl):
+        """Test all datasets for one reader."""
         from satpy import Scene
         from satpy.tests.utils import FakeReader, test_composites
         r = FakeReader('fake_reader', 'fake_sensor')
@@ -677,6 +699,7 @@ class TestScene(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_all_datasets_multiple_reader(self, cri, cl):
+        """Test all datasets for multiple readers."""
         from satpy import Scene
         from satpy.tests.utils import FakeReader, test_composites
         r = FakeReader('fake_reader', 'fake_sensor', datasets=['ds1'])
@@ -700,6 +723,7 @@ class TestScene(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_available_datasets_one_reader(self, cri, cl):
+        """Test the available datasets for one reader."""
         from satpy import Scene
         from satpy.tests.utils import FakeReader, test_composites
         r = FakeReader('fake_reader', 'fake_sensor', datasets=['ds1'])
@@ -719,12 +743,14 @@ class TestScene(unittest.TestCase):
         self.assertEqual(len(id_list), 5)
 
     def test_available_composite_ids_bad_available(self):
+        """Test the available composite ids."""
         from satpy import Scene
         scn = Scene()
         self.assertRaises(ValueError, scn.available_composite_ids,
                           available_datasets=['bad'])
 
     def test_available_composite_names_bad_available(self):
+        """Test the available composite names."""
         from satpy import Scene
         scn = Scene()
         self.assertRaises(
@@ -732,12 +758,12 @@ class TestScene(unittest.TestCase):
 
 
 class TestSceneLoading(unittest.TestCase):
-    """Test the Scene objects `.load` method
-    """
+    """Test the Scene objects `.load` method."""
+
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_no_exist(self, cri, cl):
-        """Test loading a dataset that doesn't exist"""
+        """Test loading a dataset that doesn't exist."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         cri.return_value = {'fake_reader': FakeReader(
@@ -753,7 +779,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_no_exist2(self, cri, cl):
-        """Test loading a dataset that doesn't exist then another load"""
+        """Test loading a dataset that doesn't exist then another load."""
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID, Scene
         r = FakeReader('fake_reader', 'fake_sensor')
@@ -778,7 +804,7 @@ class TestSceneLoading(unittest.TestCase):
 
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_ds1_no_comps(self, cri):
-        """Test loading one dataset with no loaded compositors"""
+        """Test loading one dataset with no loaded compositors."""
         import satpy.scene
         from satpy.tests.utils import FakeReader
         from satpy import DatasetID
@@ -795,7 +821,7 @@ class TestSceneLoading(unittest.TestCase):
 
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_ds1_load_twice(self, cri):
-        """Test loading one dataset with no loaded compositors"""
+        """Test loading one dataset with no loaded compositors."""
         import satpy.scene
         from satpy.tests.utils import FakeReader
         from satpy import DatasetID
@@ -822,7 +848,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_ds1_unknown_modifier(self, cri, cl):
-        """Test loading one dataset with no loaded compositors"""
+        """Test loading one dataset with no loaded compositors."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -839,7 +865,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_ds4_cal(self, cri, cl):
-        """Test loading a dataset that has two calibration variations"""
+        """Test loading a dataset that has two calibration variations."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         cri.return_value = {'fake_reader': FakeReader(
@@ -902,7 +928,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_ds6_wl(self, cri, cl):
-        """Test loading a dataset by wavelength"""
+        """Test loading a dataset by wavelength."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         cri.return_value = {'fake_reader': FakeReader(
@@ -920,7 +946,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_ds9_fail_load(self, cri, cl):
-        """Test loading a dataset that will fail during load"""
+        """Test loading a dataset that will fail during load."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         cri.return_value = {'fake_reader': FakeReader(
@@ -937,7 +963,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp1(self, cri, cl):
-        """Test loading a composite with one required prereq"""
+        """Test loading a composite with one required prereq."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -957,7 +983,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp4(self, cri, cl):
-        """Test loading a composite that depends on a composite"""
+        """Test loading a composite that depends on a composite."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -977,7 +1003,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp5(self, cri, cl):
-        """Test loading a composite that has an optional prerequisite"""
+        """Test loading a composite that has an optional prerequisite."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -997,7 +1023,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp6(self, cri, cl):
-        """Test loading a composite that has an optional composite prerequisite"""
+        """Test loading a composite that has an optional composite prerequisite."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -1017,7 +1043,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp8(self, cri, cl):
-        """Test loading a composite that has a non-existent prereq"""
+        """Test loading a composite that has a non-existent prereq."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         cri.return_value = {'fake_reader': FakeReader(
@@ -1032,7 +1058,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp9(self, cri, cl):
-        """Test loading a composite that has a non-existent optional prereq"""
+        """Test loading a composite that has a non-existent optional prereq."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -1053,7 +1079,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp10(self, cri, cl):
-        """Test loading a composite that depends on a modified dataset"""
+        """Test loading a composite that depends on a modified dataset."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -1074,7 +1100,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp11(self, cri, cl):
-        """Test loading a composite that depends all wavelengths"""
+        """Test loading a composite that depends all wavelengths."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -1095,7 +1121,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp12(self, cri, cl):
-        """Test loading a composite that depends all wavelengths that get modified"""
+        """Test loading a composite that depends all wavelengths that get modified."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -1116,7 +1142,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp13(self, cri, cl):
-        """Test loading a composite that depends on a modified dataset where the resolution changes"""
+        """Test loading a composite that depends on a modified dataset where the resolution changes."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -1137,7 +1163,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp14(self, cri, cl):
-        """Test loading a composite that updates the DatasetID during generation"""
+        """Test loading a composite that updates the DatasetID during generation."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         cri.return_value = {'fake_reader': FakeReader(
@@ -1156,9 +1182,10 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp15(self, cri, cl):
-        """Test loading a composite whose prerequisites can't be loaded
+        """Test loading a composite whose prerequisites can't be loaded.
 
         Note that the prereq exists in the reader, but fails in loading.
+
         """
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
@@ -1177,9 +1204,10 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp16(self, cri, cl):
-        """Test loading a composite whose opt prereq can't be loaded
+        """Test loading a composite whose opt prereq can't be loaded.
 
         Note that the prereq exists in the reader, but fails in loading
+
         """
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
@@ -1199,8 +1227,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp17(self, cri, cl):
-        """Test loading a composite that depends on a composite that won't load
-        """
+        """Test loading a composite that depends on a composite that won't load."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         cri.return_value = {'fake_reader': FakeReader(
@@ -1218,8 +1245,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp18(self, cri, cl):
-        """Test loading a composite that depends on a incompatible area modified dataset
-        """
+        """Test loading a composite that depends on a incompatible area modified dataset."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -1332,7 +1358,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_multiple_comps(self, cri, cl):
-        """Test loading multiple composites"""
+        """Test loading multiple composites."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         cri.return_value = {'fake_reader': FakeReader(
@@ -1350,7 +1376,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_multiple_comps_separate(self, cri, cl):
-        """Test loading multiple composites, one at a time"""
+        """Test loading multiple composites, one at a time."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         cri.return_value = {'fake_reader': FakeReader(
@@ -1375,7 +1401,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_modified(self, cri, cl):
-        """Test loading a modified dataset"""
+        """Test loading a modified dataset."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -1394,7 +1420,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_multiple_modified(self, cri, cl):
-        """Test loading multiple modified datasets"""
+        """Test loading multiple modified datasets."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -1421,7 +1447,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_dataset_after_composite(self, cri, cl):
-        """Test load composite followed by other datasets"""
+        """Test load composite followed by other datasets."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         r = FakeReader('fake_reader', 'fake_sensor')
@@ -1447,7 +1473,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_dataset_after_composite2(self, cri, cl):
-        """Test load complex composite followed by other datasets"""
+        """Test load complex composite followed by other datasets."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -1491,7 +1517,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp20(self, cri, cl):
-        """Test loading composite with optional modifier dependencies"""
+        """Test loading composite with optional modifier dependencies."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -1512,7 +1538,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp21(self, cri, cl):
-        """Test loading composite with bad optional modifier dependencies"""
+        """Test loading composite with bad optional modifier dependencies."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -1533,7 +1559,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_comp22(self, cri, cl):
-        """Test loading composite with only optional modifier dependencies"""
+        """Test loading composite with only optional modifier dependencies."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID
@@ -1554,7 +1580,7 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_no_generate_comp10(self, cri, cl):
-        """Test generating a composite after loading"""
+        """Test generating a composite after loading."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         cri.return_value = {'fake_reader': FakeReader(
@@ -1719,6 +1745,29 @@ class TestSceneLoading(unittest.TestCase):
         self.assertIn(DatasetID(name='static_image'), all_comp_ids)
         available_comp_ids = scene.available_composite_ids()
         self.assertIn(DatasetID(name='static_image'), available_comp_ids)
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_empty_node_copy(self, cri, cl):
+        """Test copying a dependency tree while preserving the empty node identical."""
+        import satpy.scene
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
+            'fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames=['bla'],
+                                  base_dir='bli',
+                                  reader='fake_reader')
+
+        # Check dependency tree nodes
+        # initialize the dep tree without loading the data
+        scene.dep_tree.find_dependencies({'comp19'})
+        sc2 = scene.copy()
+        self.assertIs(scene.dep_tree.children[0].children[0].children[1], scene.dep_tree.empty_node)
+        self.assertIs(scene.dep_tree.children[0].children[0].children[1], sc2.dep_tree.empty_node)
+        self.assertIs(sc2.dep_tree.children[0].children[0].children[1], scene.dep_tree.empty_node)
+        self.assertIs(sc2.dep_tree.children[0].children[0].children[1], sc2.dep_tree.empty_node)
 
 
 class TestSceneResampling(unittest.TestCase):
@@ -1917,7 +1966,7 @@ class TestSceneResampling(unittest.TestCase):
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_no_generate_comp10(self, cri, cl, rs):
-        """Test generating a composite after loading"""
+        """Test generating a composite after loading."""
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from pyresample.geometry import AreaDefinition
@@ -1978,12 +2027,12 @@ class TestSceneSaving(unittest.TestCase):
     """Test the Scene's saving method."""
 
     def setUp(self):
-        """Create temporary directory to save files to"""
+        """Create temporary directory to save files to."""
         import tempfile
         self.base_dir = tempfile.mkdtemp()
 
     def tearDown(self):
-        """Remove the temporary directory created for a test"""
+        """Remove the temporary directory created for a test."""
         try:
             import shutil
             shutil.rmtree(self.base_dir, ignore_errors=True)
@@ -2124,7 +2173,7 @@ class TestSceneConversions(unittest.TestCase):
 
 
 def suite():
-    """The test suite for test_scene."""
+    """Test suite for test_scene."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestScene))

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -901,6 +901,28 @@ class TestSceneLoading(unittest.TestCase):
 
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_ds5_multiple_resolution(self, cri, cl):
+        """Test loading a dataset has multiple resolutions available with different resolutions."""
+        import satpy.scene
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
+            'fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames=['bla'],
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        scene.load(['ds5'], resolution=1000)
+        scene.load(['ds5'], resolution=500)
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEqual(len(loaded_ids), 2)
+        self.assertEqual(loaded_ids[0].name, 'ds5')
+        self.assertEqual(loaded_ids[0].resolution, 500)
+        self.assertEqual(loaded_ids[1].name, 'ds5')
+        self.assertEqual(loaded_ids[1].resolution, 1000)
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_ds5_missing_best_resolution(self, cri, cl):
         """Test loading a dataset that has multiple resolutions but the best isn't available."""
         import satpy.scene
@@ -999,6 +1021,41 @@ class TestSceneLoading(unittest.TestCase):
         self.assertEqual(len(loaded_ids), 1)
         self.assertTupleEqual(
             tuple(loaded_ids[0]), tuple(DatasetID(name='comp4')))
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_multiple_resolutions(self, cri, cl):
+        """Test loading a dataset has multiple resolutions available with different resolutions."""
+        # import satpy.scene
+        # from satpy.tests.utils import FakeReader, test_composites
+        # cri.return_value = {'fake_reader': FakeReader(
+        #     'fake_reader', 'fake_sensor')}
+        # comps, mods = test_composites('fake_sensor')
+        # cl.return_value = (comps, mods)
+        # scene = satpy.scene.Scene(filenames=['bla'],
+        #                           base_dir='bli',
+        #                           reader='fake_reader')
+        # scene.load(['comp4'], resolution=1000)
+        import satpy.scene
+        from satpy.tests.utils import FakeReader, test_composites
+        from satpy import DatasetID
+        cri.return_value = {'fake_reader': FakeReader(
+            'fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames=['bla'],
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        comp25 = DatasetID(name='comp25', resolution=1000)
+        scene[comp25] = 'bla'
+        scene.load(['comp25'], resolution=500)
+
+        loaded_ids = list(scene.datasets.keys())
+        self.assertEqual(len(loaded_ids), 2)
+        self.assertEqual(loaded_ids[0].name, 'comp25')
+        self.assertEqual(loaded_ids[0].resolution, 500)
+        self.assertEqual(loaded_ids[1].name, 'comp25')
+        self.assertEqual(loaded_ids[1].resolution, 1000)
 
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1026,16 +1026,6 @@ class TestSceneLoading(unittest.TestCase):
     @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_multiple_resolutions(self, cri, cl):
         """Test loading a dataset has multiple resolutions available with different resolutions."""
-        # import satpy.scene
-        # from satpy.tests.utils import FakeReader, test_composites
-        # cri.return_value = {'fake_reader': FakeReader(
-        #     'fake_reader', 'fake_sensor')}
-        # comps, mods = test_composites('fake_sensor')
-        # cl.return_value = (comps, mods)
-        # scene = satpy.scene.Scene(filenames=['bla'],
-        #                           base_dir='bli',
-        #                           reader='fake_reader')
-        # scene.load(['comp4'], resolution=1000)
         import satpy.scene
         from satpy.tests.utils import FakeReader, test_composites
         from satpy import DatasetID

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -14,8 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Utilities for various satpy tests.
-"""
+"""Utilities for various satpy tests."""
 
 from datetime import datetime
 from satpy.readers.yaml_reader import FileYAMLReader
@@ -44,7 +43,7 @@ def spy_decorator(method_to_decorate):
 
 def convert_file_content_to_data_array(file_content, attrs=tuple(),
                                        dims=('z', 'y', 'x')):
-    """Helper for old reader tests that still use numpy arrays.
+    """Help old reader tests that still use numpy arrays.
 
     A lot of old reader tests still use numpy arrays and depend on the
     "var_name/attr/attr_name" convention established before Satpy used xarray
@@ -91,7 +90,7 @@ def convert_file_content_to_data_array(file_content, attrs=tuple(),
 
 
 def test_datasets():
-    """Get list of various test datasets"""
+    """Get list of various test datasets."""
     from satpy import DatasetID
     d = [
         DatasetID(name='ds1'),
@@ -107,6 +106,12 @@ def test_datasets():
         DatasetID(name='ds8', wavelength=(0.7, 0.8, 0.9)),
         DatasetID(name='ds9_fail_load', wavelength=(1.0, 1.1, 1.2)),
         DatasetID(name='ds10', wavelength=(0.75, 0.85, 0.95)),
+        DatasetID(name='ds11', resolution=500),
+        DatasetID(name='ds11', resolution=1000),
+        DatasetID(name='ds12', resolution=500),
+        DatasetID(name='ds12', resolution=1000),
+
+
     ]
     return d
 
@@ -189,6 +194,7 @@ def _create_fake_modifiers(name, prereqs, opt_prereqs):
 
 
 def test_composites(sensor_name):
+    """Create some test composites."""
     from satpy import DatasetID, DatasetDict
     # Composite ID -> (prereqs, optional_prereqs)
     comps = {
@@ -223,6 +229,14 @@ def test_composites(sensor_name):
         DatasetID(name='comp22'): ([DatasetID(name='ds5', modifiers=('mod_opt_only',))], []),
         DatasetID(name='comp23'): ([0.8], []),
         DatasetID(name='static_image'): ([], []),
+        DatasetID(name='comp24', resolution=500): ([DatasetID(name='ds11', resolution=500),
+                                                    DatasetID(name='ds12', resolution=500)], []),
+        DatasetID(name='comp24', resolution=1000): ([DatasetID(name='ds11', resolution=1000),
+                                                     DatasetID(name='ds12', resolution=1000)], []),
+        DatasetID(name='comp25', resolution=500): ([DatasetID(name='comp24', resolution=500),
+                                                    DatasetID(name='ds5', resolution=500)], []),
+        DatasetID(name='comp25', resolution=1000): ([DatasetID(name='comp24', resolution=1000),
+                                                     DatasetID(name='ds5', resolution=1000)], []),
     }
     # Modifier name -> (prereqs (not including to-be-modified), opt_prereqs)
     mods = {
@@ -245,7 +259,7 @@ def test_composites(sensor_name):
 
 
 def _filter_datasets(all_ds, names_or_ids):
-    """Helper function for filtering DatasetIDs by name or DatasetID."""
+    """Help filtering DatasetIDs by name or DatasetID."""
     # DatasetID will match a str to the name
     # need to separate them out
     str_filter = [ds_name for ds_name in names_or_ids if isinstance(ds_name, str)]
@@ -300,17 +314,21 @@ class FakeReader(FileYAMLReader):
 
     @property
     def start_time(self):
+        """Get the start time."""
         return self._start_time
 
     @property
     def end_time(self):
+        """Get the end time."""
         return self._end_time
 
     @property
     def sensor_names(self):
+        """Get the sensor names."""
         return self._sensor_name
 
     def load(self, dataset_keys):
+        """Load some data."""
         from satpy import DatasetDict
         from xarray import DataArray
         import numpy as np

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -110,8 +110,6 @@ def test_datasets():
         DatasetID(name='ds11', resolution=1000),
         DatasetID(name='ds12', resolution=500),
         DatasetID(name='ds12', resolution=1000),
-
-
     ]
     return d
 


### PR DESCRIPTION
This PR fixes three bugs in the composite generation part of satpy.
 1. The `empty_node` is now a class attribute to make sure it is the same across multiple instances of the dependency tree. This fixes a bug appearing when the composite generation is delayed, which causes the dependency tree to be copied and previously a net `empty_node` to be created.
 2. The resolution of a composite made of datasets with the same resolution is now set (it was None).
 3. Two composites with the same dependencies, loaded one after the other with different resolutions are now loaded with the proper respective resolution

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
