### PR TITLE
Fix EWA resampling tests not properly testing caching

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1170,13 +1170,8 @@ class Scene(MetadataObject):
               to be passed to geoviews
 
         """
-        try:
-            import geoviews as gv
-            from cartopy import crs  # noqa
-        except ImportError:
-            import warnings
-            warnings.warn("This method needs the geoviews package installed.")
-
+        import geoviews as gv
+        from cartopy import crs  # noqa
         if gvtype is None:
             gvtype = gv.Image
 


### PR DESCRIPTION
This was first noticed by @zxdawn in #751. Starting with dask 2.0+ these tests failed. The main reason is that this test was not testing what it was supposed to be testing after changes a long time ago to `resample.py`. The other reason is that in dask 2.0+, any `map_blocks` function is called with fake/empty input data to check what array type object is going to be returned. This meant multiple calls to `ll2cr` when previously there were only calls for actual data calculations.

So this PR fixes:

1. The EWA tests so that they actually make sure things were cached.
2. Resampler caching so that hashing of `resample_kwargs` results in proper equality checks, meaning resampler's that should be re-used **are** reused.
3. Fix geoviews conversion methods only issuing a warning if geoviews was not imported (FYI @BENR0) even though nothing could be done if it failed to import.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
