### PR TITLE
Fix composites not being recorded with desired resolution in deptree

### DIFF
--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -15,8 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Dataset objects.
-"""
+"""Dataset objects."""
 
 import sys
 import logging
@@ -171,6 +170,7 @@ class DatasetID(DatasetID):
     """
 
     def __new__(cls, *args, **kwargs):
+        """Create new DatasetID."""
         ret = super(DatasetID, cls).__new__(cls, *args, **kwargs)
         if ret.modifiers is not None and not isinstance(ret.modifiers, tuple):
             raise TypeError("'DatasetID' modifiers must be a tuple or None, "
@@ -267,6 +267,20 @@ class DatasetID(DatasetID):
     def _to_trimmed_dict(self):
         return {key: getattr(self, key) for key in DATASET_KEYS
                 if getattr(self, key) is not None}
+
+
+def create_filtered_dsid(dataset_key, **dfilter):
+    """Create a DatasetID matching *dataset_key* and *dfilter*."""
+    try:
+        ds_dict = dataset_key.to_dict()
+    except AttributeError:
+        if isinstance(dataset_key, str):
+            ds_dict = {'name': dataset_key}
+        elif isinstance(dataset_key, float):
+            ds_dict = {'wavelength': dataset_key}
+    clean_filter = {key: value for key, value in dfilter.items() if value is not None}
+    ds_dict.update(clean_filter)
+    return DatasetID.from_dict(ds_dict)
 
 
 def dataset_walker(datasets):

--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -283,10 +283,10 @@ def create_filtered_dsid(dataset_key, **dfilter):
             ds_dict = {'name': dataset_key}
         elif isinstance(dataset_key, numbers.Number):
             ds_dict = {'wavelength': dataset_key}
-    clean_filter = {key: value for key, value in dfilter.items() if value is not None}
-    clean_dict = {key: value for key, value in ds_dict.items() if value is not None}
-    clean_filter.update(clean_dict)
-    return DatasetID.from_dict(clean_filter)
+    for key, value in dfilter.items():
+        if value is not None:
+            ds_dict.setdefault(key, value)
+    return DatasetID.from_dict(ds_dict)
 
 
 def dataset_walker(datasets):

--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -281,7 +281,7 @@ def create_filtered_dsid(dataset_key, **dfilter):
     except AttributeError:
         if isinstance(dataset_key, str):
             ds_dict = {'name': dataset_key}
-        elif isinstance(dataset_key, float):
+        elif isinstance(dataset_key, numbers.Number):
             ds_dict = {'wavelength': dataset_key}
     clean_filter = {key: value for key, value in dfilter.items() if value is not None}
     clean_dict = {key: value for key, value in ds_dict.items() if value is not None}

--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -270,7 +270,12 @@ class DatasetID(DatasetID):
 
 
 def create_filtered_dsid(dataset_key, **dfilter):
-    """Create a DatasetID matching *dataset_key* and *dfilter*."""
+    """Create a DatasetID matching *dataset_key* and *dfilter*.
+
+    If a proprety is specified in both *dataset_key* and *dfilter*, the former
+    has priority.
+
+    """
     try:
         ds_dict = dataset_key.to_dict()
     except AttributeError:
@@ -279,8 +284,9 @@ def create_filtered_dsid(dataset_key, **dfilter):
         elif isinstance(dataset_key, float):
             ds_dict = {'wavelength': dataset_key}
     clean_filter = {key: value for key, value in dfilter.items() if value is not None}
-    ds_dict.update(clean_filter)
-    return DatasetID.from_dict(ds_dict)
+    clean_dict = {key: value for key, value in ds_dict.items() if value is not None}
+    clean_filter.update(clean_dict)
+    return DatasetID.from_dict(clean_filter)
 
 
 def dataset_walker(datasets):

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -455,7 +455,8 @@ class DependencyTree(Node):
 
         # 0 check if the *exact* dataset is already loaded
         try:
-            node = self.get_filtered_item(dataset_key, **dfilter)
+            dsid = create_filtered_dsid(dataset_key, **dfilter)
+            node = self.getitem(dsid)
             LOG.trace("Found exact dataset already loaded: {}".format(node.name))
             return node, set()
         except KeyError:


### PR DESCRIPTION
When a given resolution is requested for loading some composites, the resolution wasn't included in the DatasetIDs recorded in the dependency tree for these composites.

This PR fixes this through making sure the fully filtered dataset ID is created and recorded in the dependency tree.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

