### PR TITLE
Fix Satpy tests to work with new versions of pyresample

### DIFF
--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -71,10 +71,13 @@ class TestAHIHSDNavigation(unittest.TestCase):
                             'spare': ''}
 
             area_def = fh.get_area_def(None)
-            self.assertEqual(area_def.proj_dict, {'a': 6378137.0, 'b': 6356752.3,
-                                                  'h': 35785863.0, 'lon_0': 140.7,
-                                                  'proj': 'geos', 'units': 'm'})
-
+            proj_dict = area_def.proj_dict
+            self.assertEqual(proj_dict['a'], 6378137.0)
+            self.assertEqual(proj_dict['b'], 6356752.3)
+            self.assertEqual(proj_dict['h'], 35785863.0)
+            self.assertEqual(proj_dict['lon_0'], 140.7)
+            self.assertEqual(proj_dict['proj'], 'geos')
+            self.assertEqual(proj_dict['units'], 'm')
             self.assertEqual(area_def.area_extent, (592000.0038256244, 4132000.026701824,
                                                     1592000.0102878278, 5132000.033164027))
 
@@ -113,10 +116,13 @@ class TestAHIHSDNavigation(unittest.TestCase):
                             'spare': ''}
 
             area_def = fh.get_area_def(None)
-            self.assertEqual(area_def.proj_dict, {'a': 6378137.0, 'b': 6356752.3,
-                                                  'h': 35785863.0, 'lon_0': 140.7,
-                                                  'proj': 'geos', 'units': 'm'})
-
+            proj_dict = area_def.proj_dict
+            self.assertEqual(proj_dict['a'], 6378137.0)
+            self.assertEqual(proj_dict['b'], 6356752.3)
+            self.assertEqual(proj_dict['h'], 35785863.0)
+            self.assertEqual(proj_dict['lon_0'], 140.7)
+            self.assertEqual(proj_dict['proj'], 'geos')
+            self.assertEqual(proj_dict['units'], 'm')
             self.assertEqual(area_def.area_extent, (-5500000.035542117, -3300000.021325271,
                                                     5500000.035542117, -2200000.0142168473))
 

--- a/satpy/tests/reader_tests/test_hrit_base.py
+++ b/satpy/tests/reader_tests/test_hrit_base.py
@@ -142,12 +142,13 @@ class TestHRITFileHandler(unittest.TestCase):
 
     def test_get_area_def(self):
         area = self.reader.get_area_def('VIS06')
-        self.assertEqual(area.proj_dict, {'a': 6378169.0,
-                                          'b': 6356583.8,
-                                          'h': 35785831.0,
-                                          'lon_0': 44.0,
-                                          'proj': 'geos',
-                                          'units': 'm'})
+        proj_dict = area.proj_dict
+        self.assertEqual(proj_dict['a'], 6378169.0)
+        self.assertEqual(proj_dict['b'], 6356583.8)
+        self.assertEqual(proj_dict['h'], 35785831.0)
+        self.assertEqual(proj_dict['lon_0'], 44.0)
+        self.assertEqual(proj_dict['proj'], 'geos')
+        self.assertEqual(proj_dict['units'], 'm')
         self.assertEqual(area.area_extent,
                          (-77771774058.38356, -77771774058.38356,
                           30310525626438.438, 3720765401003.719))

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -134,12 +134,13 @@ class TestHRITMSGFileHandler(unittest.TestCase):
 
     def test_get_area_def(self):
         area = self.reader.get_area_def(DatasetID('VIS006'))
-        self.assertEqual(area.proj_dict, {'a': 6378169.0,
-                                          'b': 6356583.8,
-                                          'h': 35785831.0,
-                                          'lon_0': 44.0,
-                                          'proj': 'geos',
-                                          'units': 'm'})
+        proj_dict = area.proj_dict
+        self.assertEqual(proj_dict['a'], 6378169.0)
+        self.assertEqual(proj_dict['b'], 6356583.8)
+        self.assertEqual(proj_dict['h'], 35785831.0)
+        self.assertEqual(proj_dict['lon_0'], 44.0)
+        self.assertEqual(proj_dict['proj'], 'geos')
+        self.assertEqual(proj_dict['units'], 'm')
         self.assertEqual(area.area_extent,
                          (-77771774058.38356, -3720765401003.719,
                           30310525626438.438, 77771774058.38356))

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -59,13 +59,25 @@ class TestBuiltinAreas(unittest.TestCase):
         """Test all areas have valid projections with pyproj."""
         import pyproj
         from pyresample import parse_area_file
+        from pyresample.geometry import SwathDefinition
         from satpy.resample import get_area_file
+        import numpy as np
+        import xarray as xr
 
+        lons = np.array([[0, 0.1, 0.2], [0.05, 0.15, 0.25]])
+        lats = np.array([[0, 0.1, 0.2], [0.05, 0.15, 0.25]])
+        lons = xr.DataArray(lons)
+        lats = xr.DataArray(lats)
+        swath_def = SwathDefinition(lons, lats)
         all_areas = parse_area_file(get_area_file())
         for area_obj in all_areas:
-            if getattr(area_obj, 'optimize_projection', False):
-                # the PROJ.4 is known to not be valid on this DynamicAreaDef
-                continue
+            if hasattr(area_obj, 'freeze'):
+                try:
+                    area_obj = area_obj.freeze(lonslats=swath_def)
+                except RuntimeError:
+                    # we didn't provide enough info to freeze, hard to guess
+                    # in a generic test so just skip this area
+                    continue
             proj_dict = area_obj.proj_dict
             _ = pyproj.Proj(proj_dict)
 
@@ -79,13 +91,32 @@ class TestBuiltinAreas(unittest.TestCase):
             return unittest.skip("RasterIO 1.0+ required")
 
         from pyresample import parse_area_file
+        from pyresample.geometry import SwathDefinition
         from satpy.resample import get_area_file
+        import numpy as np
+        import xarray as xr
+
+        lons = np.array([[0, 0.1, 0.2], [0.05, 0.15, 0.25]])
+        lats = np.array([[0, 0.1, 0.2], [0.05, 0.15, 0.25]])
+        lons = xr.DataArray(lons)
+        lats = xr.DataArray(lats)
+        swath_def = SwathDefinition(lons, lats)
         all_areas = parse_area_file(get_area_file())
         for area_obj in all_areas:
-            if getattr(area_obj, 'optimize_projection', False):
-                # the PROJ.4 is known to not be valid on this DynamicAreaDef
-                continue
+            if hasattr(area_obj, 'freeze'):
+                try:
+                    area_obj = area_obj.freeze(lonslats=swath_def)
+                except RuntimeError:
+                    # we didn't provide enough info to freeze, hard to guess
+                    # in a generic test so just skip this area
+                    continue
             proj_dict = area_obj.proj_dict
+            if proj_dict['proj'] in ('ob_tran', 'nsper') and \
+                    'wktext' not in proj_dict:
+                # FIXME: rasterio doesn't understand ob_tran unless +wktext
+                # See: https://github.com/pyproj4/pyproj/issues/357
+                # pyproj 2.0+ seems to drop wktext from PROJ dict
+                continue
             _ = CRS.from_dict(proj_dict)
 
 

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -720,8 +720,14 @@ class TestCFWriter(unittest.TestCase):
         with mock.patch('satpy.writers.cf_writer.warnings.warn') as warn:
             res, grid_mapping = area2gridmapping(ds)
             warn.assert_called()
-            self.assertDictEqual(dict(pyresample.geometry.proj4_str_to_dict(res.attrs['grid_proj4'])),
-                                 dict(pyresample.geometry.proj4_str_to_dict(proj_str)))
+            proj_dict = pyresample.geometry.proj4_str_to_dict(res.attrs['grid_proj4'])
+            self.assertEqual(proj_dict['lon_0'], 4.535)
+            self.assertEqual(proj_dict['lat_0'], 46.0)
+            self.assertEqual(proj_dict['o_lon_p'], -5.465)
+            self.assertEqual(proj_dict['o_lat_p'], 90.0)
+            self.assertEqual(proj_dict['proj'], 'ob_tran')
+            self.assertEqual(proj_dict['o_proj'], 'stere')
+            self.assertEqual(proj_dict['ellps'], 'WGS84')
             self.assertEqual(grid_mapping, cosmo_expected)
 
     def test_area2lonlat(self):


### PR DESCRIPTION
See https://github.com/pytroll/pyresample/pull/196

In the above pyresample PR I make changes to pyresample so that pyproj's CRS object is used for intermediate storage of the CRS information used by `AreaDefinition` when pyproj 2.0+ is installed. However, pyproj 2.0+ may add, remove, or change parameter names depending on what is most accurate. This means that a lot of Satpy's tests that do `my_area.proj_dict == expected_proj_dict` won't work because new parameters will be provided. I fixed this by only checking the expected parameters exact values instead of the `dict` as a whole.

One other "gotcha" with this PR is discussed in https://github.com/pyproj4/pyproj/issues/357. Basically pyproj 2.0+ seems to be dropping `+wktext` from the PROJ parameters which from my experience was needed for some projections to be accepted by rasterio's `CRS` object. Since pyproj is removing it, these projections are no longer valid (`+proj=ob_tran` and `+proj=nsper`). I've skipped the checks for these projections in the Satpy tests.

If @TAlonglong has time I'd like his opinion on my changes to the mitiff writer which basically say "Try to get an EPSG code if at all possible before restoring to `area_def.proj_str`". This is to avoid pyproj/pyresample expanding EPSG codes when mitiff wants the original EPSG code to do further conversions. It'd be nice, if mitiff files could support it, if the writer could use pyproj 2.0+ to do the EPSG to PROJ conversion, but it seems the results are different which I think is the visualization clients fault.

Note: Satpy should still work fine with the new pyresample and old pyresample, but the *tests* in this PR are needed to pass with newer pyresample (once my pyresample PR is merged and released).

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

