### PR TITLE
Fix 'abi_l1b' reader keeping _Unsigned attribute

### DIFF
--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -144,6 +144,7 @@ class NC_ABI_L1B(BaseFileHandler):
         res.attrs.pop('_FillValue', None)
         res.attrs.pop('scale_factor', None)
         res.attrs.pop('add_offset', None)
+        res.attrs.pop('_Unsigned', None)
         res.attrs.pop('ancillary_variables', None)  # Can't currently load DQF
         # add in information from the filename that may be useful to the user
         for key in ('observation_type', 'scene_abbr', 'scan_mode', 'platform_shortname'):


### PR DESCRIPTION
The `'abi_l1b'` reader currently keeps the `_Unsigned` attribute that can be present in ABI L1B files. This attribute has special meaning in NetCDF files and should not be included in the metadata shown to the user. This can/could also be an issue when saving to NetCDF files with the `cf` writer.

 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
