### PR TITLE
Temporarily remove longitude/latitude 2D xarray coordinates

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -839,6 +839,7 @@ class FillingCompositor(GenericCompositor):
 
     def __call__(self, projectables, nonprojectables=None, **info):
         """Generate the composite."""
+        projectables = self.check_areas(projectables)
         projectables[1] = projectables[1].fillna(projectables[0])
         projectables[2] = projectables[2].fillna(projectables[0])
         projectables[3] = projectables[3].fillna(projectables[0])
@@ -850,6 +851,7 @@ class Filler(GenericCompositor):
 
     def __call__(self, projectables, nonprojectables=None, **info):
         """Generate the composite."""
+        projectables = self.check_areas(projectables)
         filled_projectable = projectables[0].fillna(projectables[1])
         return super(Filler, self).__call__([filled_projectable], **info)
 

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -679,13 +679,13 @@ class FileYAMLReader(AbstractYAMLReader):
                     sdef = None
                 if sdef is None:
                     sdef = SwathDefinition(*coords)
+                    sensor_str = '_'.join(self.info['sensors'])
+                    shape_str = '_'.join(map(str, coords[0].shape))
+                    sdef.name = "{}_{}_{}_{}".format(sensor_str, shape_str,
+                                                     coords[0].attrs['name'],
+                                                     coords[1].attrs['name'])
                     if key is not None:
                         self.coords_cache[key] = sdef
-                sensor_str = '_'.join(self.info['sensors'])
-                shape_str = '_'.join(map(str, coords[0].shape))
-                sdef.name = "{}_{}_{}_{}".format(sensor_str, shape_str,
-                                                 coords[0].attrs['name'],
-                                                 coords[1].attrs['name'])
                 return sdef
             else:
                 raise ValueError(

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -271,7 +271,8 @@ def add_crs_xy_coords(data_arr, area):
         lats.attrs.setdefault('standard_name', 'latitude')
         lats.attrs.setdefault('long_name', 'latitude')
         lats.attrs.setdefault('units', 'degrees_north')
-        data_arr = data_arr.assign_coords(longitude=lons, latitude=lats)
+        # See https://github.com/pydata/xarray/issues/3068
+        # data_arr = data_arr.assign_coords(longitude=lons, latitude=lats)
     else:
         # Gridded data (AreaDefinition/StackedAreaDefinition)
         data_arr = add_xy_coords(data_arr, area, crs=crs)

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -596,16 +596,17 @@ class TestCoordinateHelpers(unittest.TestCase):
             dims=('y', 'x'),
         )
         new_data_arr = add_crs_xy_coords(data_arr, area_def)
-        self.assertIn('longitude', new_data_arr.coords)
-        self.assertIn('units', new_data_arr.coords['longitude'].attrs)
-        self.assertEqual(
-            new_data_arr.coords['longitude'].attrs['units'], 'degrees_east')
-        self.assertIsInstance(new_data_arr.coords['longitude'].data, da.Array)
-        self.assertIn('latitude', new_data_arr.coords)
-        self.assertIn('units', new_data_arr.coords['latitude'].attrs)
-        self.assertEqual(
-            new_data_arr.coords['latitude'].attrs['units'], 'degrees_north')
-        self.assertIsInstance(new_data_arr.coords['latitude'].data, da.Array)
+        # See https://github.com/pydata/xarray/issues/3068
+        # self.assertIn('longitude', new_data_arr.coords)
+        # self.assertIn('units', new_data_arr.coords['longitude'].attrs)
+        # self.assertEqual(
+        #     new_data_arr.coords['longitude'].attrs['units'], 'degrees_east')
+        # self.assertIsInstance(new_data_arr.coords['longitude'].data, da.Array)
+        # self.assertIn('latitude', new_data_arr.coords)
+        # self.assertIn('units', new_data_arr.coords['latitude'].attrs)
+        # self.assertEqual(
+        #     new_data_arr.coords['latitude'].attrs['units'], 'degrees_north')
+        # self.assertIsInstance(new_data_arr.coords['latitude'].data, da.Array)
 
         if CRS is not None:
             self.assertIn('crs', new_data_arr.coords)


### PR DESCRIPTION
 This was discovered while testing #836. Xarray currently has a bug (of sorts) where any dask array coordinates are computed whenever two xarray DataArrays are combined. See the [related xarray issue](https://github.com/pydata/xarray/issues/3068). Until this is resolved better on the xarray/dask side we need to stop adding these coordinates.

As is, this requires a lot of computation to load/compute these geolocation arrays.

 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

