### PR TITLE
Change default CF writer engine to follow xarray defaults

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -251,6 +251,6 @@ intersphinx_mapping = {
     'trollsift': ('https://trollsift.readthedocs.io/en/stable', None),
     'trollimage': ('https://trollimage.readthedocs.io/en/stable', None),
     'pydecorate': ('https://pydecorate.readthedocs.io/en/stable', None),
-    'geoviews': ('http://geo.holoviews.org', None),
+    'geoviews': ('http://geoviews.org', None),
     'pyproj': ('https://pyproj4.github.io/pyproj/dev', None)
 }

--- a/satpy/readers/modis_l2.py
+++ b/satpy/readers/modis_l2.py
@@ -35,7 +35,7 @@ To get a list of the available datasets for a given file refer to the "Load data
 Geolocation files
 -----------------
 
-Similar to the ``modis_l1b` reader the geolocation files (mod03) for the 1km data are optional and if not
+Similar to the ``modis_l1b`` reader the geolocation files (mod03) for the 1km data are optional and if not
 given 1km geolocations will be interpolated from the 5km geolocation contained within the file.
 
 For the 500m and 250m data geolocation files are needed.

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -83,13 +83,12 @@ class TestCFWriter(unittest.TestCase):
                                                     prerequisites=[DatasetID('hej')]))
         with TempFile() as filename:
             scn.save_datasets(filename=filename, writer='cf')
-            import h5netcdf as nc4
-            with nc4.File(filename) as f:
+            with xr.open_dataset(filename) as f:
                 self.assertTrue(np.all(f['test-array'][:] == [1, 2, 3]))
                 expected_prereq = ("DatasetID(name='hej', wavelength=None, "
                                    "resolution=None, polarization=None, "
                                    "calibration=None, level=None, modifiers=())")
-                self.assertEqual(f['test-array'].attrs['prerequisites'][0],
+                self.assertEqual(f['test-array'].attrs['prerequisites'],
                                  expected_prereq)
 
     def test_save_with_compression(self):
@@ -136,8 +135,7 @@ class TestCFWriter(unittest.TestCase):
                                                     prerequisites=[DatasetID('hej')]))
         with TempFile() as filename:
             scn.save_datasets(filename=filename, writer='cf')
-            import h5netcdf as nc4
-            with nc4.File(filename) as f:
+            with xr.open_dataset(filename) as f:
                 self.assertTrue(np.all(f['test-array'][:] == [1, 2, 3]))
                 self.assertTrue(np.all(f['x'][:] == [0, 1, 2]))
                 self.assertTrue(np.all(f['y'][:] == [0]))
@@ -147,7 +145,7 @@ class TestCFWriter(unittest.TestCase):
                 expected_prereq = ("DatasetID(name='hej', wavelength=None, "
                                    "resolution=None, polarization=None, "
                                    "calibration=None, level=None, modifiers=())")
-                self.assertEqual(f['test-array'].attrs['prerequisites'][0],
+                self.assertEqual(f['test-array'].attrs['prerequisites'],
                                  expected_prereq)
 
     def test_groups(self):
@@ -222,8 +220,7 @@ class TestCFWriter(unittest.TestCase):
                                                     end_time=end_time))
         with TempFile() as filename:
             scn.save_datasets(filename=filename, writer='cf')
-            import h5netcdf as nc4
-            with nc4.File(filename) as f:
+            with xr.open_dataset(filename, decode_cf=False) as f:
                 self.assertTrue(np.all(f['time_bnds'][:] == np.array([-300.,  600.])))
 
     def test_bounds(self):
@@ -241,8 +238,7 @@ class TestCFWriter(unittest.TestCase):
                                                     end_time=end_time))
         with TempFile() as filename:
             scn.save_datasets(filename=filename, writer='cf')
-            import h5netcdf as nc4
-            with nc4.File(filename) as f:
+            with xr.open_dataset(filename, decode_cf=False) as f:
                 self.assertTrue(np.all(f['time_bnds'][:] == np.array([-300.,  600.])))
 
     def test_bounds_minimum(self):
@@ -268,8 +264,7 @@ class TestCFWriter(unittest.TestCase):
                                                      end_time=end_timeB))
         with TempFile() as filename:
             scn.save_datasets(filename=filename, writer='cf')
-            import h5netcdf as nc4
-            with nc4.File(filename) as f:
+            with xr.open_dataset(filename, decode_cf=False) as f:
                 self.assertTrue(np.all(f['time_bnds'][:] == np.array([-300.,  600.])))
 
     def test_bounds_missing_time_info(self):
@@ -291,8 +286,7 @@ class TestCFWriter(unittest.TestCase):
                                           coords={'time': [np.datetime64('2018-05-30T10:05:00')]})
         with TempFile() as filename:
             scn.save_datasets(filename=filename, writer='cf')
-            import h5netcdf as nc4
-            with nc4.File(filename) as f:
+            with xr.open_dataset(filename, decode_cf=False) as f:
                 self.assertTrue(np.all(f['time_bnds'][:] == np.array([-300.,  600.])))
 
     def test_encoding_kwarg(self):
@@ -311,8 +305,7 @@ class TestCFWriter(unittest.TestCase):
                                        'add_offset': 0.0,
                                        '_FillValue': 3}}
             scn.save_datasets(filename=filename, encoding=encoding, writer='cf')
-            import h5netcdf as nc4
-            with nc4.File(filename) as f:
+            with xr.open_dataset(filename, mask_and_scale=False) as f:
                 self.assertTrue(np.all(f['test-array'][:] == [10, 20, 30]))
                 self.assertTrue(f['test-array'].attrs['scale_factor'] == 0.1)
                 self.assertTrue(f['test-array'].attrs['_FillValue'] == 3)
@@ -335,8 +328,8 @@ class TestCFWriter(unittest.TestCase):
             scn.save_datasets(filename=filename,
                               header_attrs=header_attrs,
                               writer='cf')
-            import h5netcdf as nc4
-            with nc4.File(filename) as f:
+            import netCDF4 as nc4
+            with xr.open_dataset(filename) as f:
                 self.assertTrue(f.attrs['sensor'] == 'SEVIRI')
                 self.assertTrue('sensor' in f.attrs.keys())
                 self.assertTrue('orbit' not in f.attrs.keys())

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -328,7 +328,6 @@ class TestCFWriter(unittest.TestCase):
             scn.save_datasets(filename=filename,
                               header_attrs=header_attrs,
                               writer='cf')
-            import netCDF4 as nc4
             with xr.open_dataset(filename) as f:
                 self.assertTrue(f.attrs['sensor'] == 'SEVIRI')
                 self.assertTrue('sensor' in f.attrs.keys())

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -123,7 +123,7 @@ NC4_DTYPES = [np.dtype('int8'), np.dtype('uint8'),
               np.dtype('int64'), np.dtype('uint64'),
               np.dtype('float32'), np.dtype('float64'),
               np.string_]
-"""Numpy datatypes compatible with all netCDF4 backends. np.unicode_ is excluded because h5py (and thus h5netcdf)
+"""Numpy datatypes compatible with all netCDF4 backends. ``np.unicode_`` is excluded because h5py (and thus h5netcdf)
 has problems with unicode, see https://github.com/h5py/h5py/issues/624."""
 
 
@@ -570,7 +570,7 @@ class CFWriter(Writer):
 
         return encoding, other_to_netcdf_kwargs
 
-    def save_datasets(self, datasets, filename=None, groups=None, header_attrs=None, engine='h5netcdf', epoch=EPOCH,
+    def save_datasets(self, datasets, filename=None, groups=None, header_attrs=None, engine=None, epoch=EPOCH,
                       flatten_attrs=False, exclude_attrs=None, include_lonlats=True, pretty=False,
                       compression=None, **to_netcdf_kwargs):
         """Save the given datasets in one netCDF file.
@@ -589,7 +589,9 @@ class CFWriter(Writer):
             header_attrs:
                 Global attributes to be included
             engine (str):
-                Module to be used for writing netCDF files
+                Module to be used for writing netCDF files. Follows xarray's
+                :meth:`~xarray.Dataset.to_netcdf` engine choices with a
+                preference for 'netcdf4'.
             epoch (str):
                 Reference time for encoding of time coordinates
             flatten_attrs (bool):


### PR DESCRIPTION
Xarray has default engine choices based on what is available in the current environment. It prefers to use netcdf4-python if available, otherwise `scipy`. It is also possible to tell xarray to use `h5netcdf`. Right now Satpy defaults to `h5netcdf` regardless of what is installed. This has caused unexpected results for some users (at least me) where they're able to read NetCDF files with the `abi_l1b` reader, but can't write NetCDF files with the `cf` writer because they don't have `h5netcdf` installed.

This PR changes the default to `None` which means "let xarray choose". The biggest issue with doing this is that it seems xarray doesn't use `h5netcdf` unless it is explicitly asked for. So if someone only had `h5netcdf` installed or was using an h5netcdf-only feature they would have to explicitly specify the engine. The other better option would be to make our own "try importing these backends and use that backend if successful" where we include h5netcdf as one of the options. Or we could make a PR to xarray to add `h5netcdf` as one of the options.

The only other thing I considered adding to this PR, similar to the above point, is importing one of the netcdf backends in the module level so that things like `available_writers` and `check_satpy` would "know" if one of the dependencies was installed. Thoughts? I'm not sure whether to mark this as a "bug" or "backwards-incompatibility".

This PR also includes some sphinx docs clean up.

 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
