### PR TITLE
Update 'generic_image' reader to use rasterio for area creation

### DIFF
--- a/satpy/readers/generic_image.py
+++ b/satpy/readers/generic_image.py
@@ -41,6 +41,7 @@ available in the file (eg. geotiff).
 """
 
 import logging
+import rasterio
 
 import xarray as xr
 import dask.array as da
@@ -48,6 +49,7 @@ import numpy as np
 
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy import CHUNK_SIZE
+from pyresample import utils
 
 BANDS = {1: ['L'],
          2: ['L', 'A'],
@@ -74,12 +76,14 @@ class GenericImageFileHandler(BaseFileHandler):
 
     def read(self):
         """Read the image"""
-        data = xr.open_rasterio(self.finfo["filename"],
-                                chunks=(1, CHUNK_SIZE, CHUNK_SIZE))
-        attrs = data.attrs.copy()
+        dataset = rasterio.open(self.finfo['filename'])
+
         # Create area definition
-        if hasattr(data, 'crs'):
-            self.area = self.get_geotiff_area_def(data.crs)
+        if hasattr(dataset, 'crs') and dataset.crs is not None:
+            self.area = utils.get_area_def_from_raster(dataset)
+
+        data = xr.open_rasterio(dataset, chunks=(1, CHUNK_SIZE, CHUNK_SIZE))
+        attrs = data.attrs.copy()
 
         # Rename to Satpy convention
         data = data.rename({'band': 'bands'})
@@ -101,10 +105,6 @@ class GenericImageFileHandler(BaseFileHandler):
             raise NotImplementedError("No CRS information available from image")
         return self.area
 
-    def get_geotiff_area_def(self, crs):
-        """Get extents from GeoTIFF file"""
-        return get_geotiff_area_def(self.finfo['filename'], crs)
-
     @property
     def start_time(self):
         return self.finfo['start_time']
@@ -117,28 +117,6 @@ class GenericImageFileHandler(BaseFileHandler):
         """Get a dataset from the file."""
         logger.debug("Reading %s.", key)
         return self.file_content[key.name]
-
-
-def get_geotiff_area_def(filename, crs):
-    """Read area definition from a geotiff."""
-    from osgeo import gdal
-    from pyresample.geometry import AreaDefinition
-    from pyresample.utils import proj4_str_to_dict
-    fid = gdal.Open(filename)
-    geo_transform = fid.GetGeoTransform()
-    pcs_id = fid.GetProjection().split('"')[1]
-    min_x = geo_transform[0]
-    max_y = geo_transform[3]
-    x_size = fid.RasterXSize
-    y_size = fid.RasterYSize
-    max_x = min_x + geo_transform[1] * x_size
-    min_y = max_y + geo_transform[5] * y_size
-    area_extent = [min_x, min_y, max_x, max_y]
-    area_def = AreaDefinition('geotiff_area', pcs_id, pcs_id,
-                              proj4_str_to_dict(crs),
-                              x_size, y_size, area_extent)
-    return area_def
-
 
 def mask_image_data(data):
     """Mask image data if alpha channel is present."""

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -154,17 +154,6 @@ class TestGenericImage(unittest.TestCase):
         self.assertEqual(scn.attrs['end_time'], None)
         self.assertEqual(scn['image'].area, self.area_def)
 
-    def test_get_geotiff_area_def(self):
-        """Test reading area definition from a geotiff"""
-        from satpy.readers.generic_image import get_geotiff_area_def
-        from satpy import CHUNK_SIZE
-
-        fname = os.path.join(self.base_dir, '20180101_0000_test_rgb.tif')
-        data = xr.open_rasterio(fname,
-                                chunks=(1, CHUNK_SIZE, CHUNK_SIZE))
-        adef = get_geotiff_area_def(fname, data.crs)
-        self.assertEqual(adef, self.area_def)
-
     def test_GenericImageFileHandler(self):
         """Test direct use of the reader."""
         from satpy.readers.generic_image import GenericImageFileHandler


### PR DESCRIPTION
 - use `get_area_def_from_raster` from `pyresample`
 - remove `get_geotiff_area_def` from generic_image.py
 - closes #617 