### PR TITLE
Make composites available to FCI FDHSI L1C 

### DIFF
--- a/satpy/etc/composites/fci.yaml
+++ b/satpy/etc/composites/fci.yaml
@@ -1,0 +1,1 @@
+sensor_name: visir/fci

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -336,6 +336,20 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
                     res[ch],
                     181.917084)
 
+    def test_load_composite(self):
+        """Test that composites are loadable
+        """
+
+        # when dedicated composites for FCI FDHSI are implemented in satpy,
+        # this method should probably move to a dedicated class and module
+        # in the tests.compositor_tests package
+
+        from satpy.composites import CompositorLoader
+        cl = CompositorLoader()
+        (comps, mods) = cl.load_compositors(["fci"])
+        self.assertGreater(len(comps["fci"]), 0)
+        self.assertGreater(len(mods["fci"]), 0)
+
 
 class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):
     _alt_handler = FakeNetCDF4FileHandler3


### PR DESCRIPTION
This PR makes composites available for use with the FCI FDHSI L1C reader, and adds a unit test to make sure that they are indeed.

 - [x] Closes #848  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
