### PR TITLE
Fix ABI L1B coordinates to be equivalent at all resolutions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
         - CONDA_CHANNELS='conda-forge'
-        - CONDA_CHANNEL_PRIORITY='True'
+        - CONDA_CHANNEL_PRIORITY='strict'
 matrix:
   include:
   - env: PYTHON_VERSION=2.7


### PR DESCRIPTION
I was recently attempting to make an accurate 10km version of the GOES-16 ABI full disk area. While doing this I realized that the area extents were different depending on which band resolution you used (500m, 1km, or 2km). Outer extents could be anywhere between 0 and 4 meters different between resolutions depending on which extent you looked at. After doing some investigating I discovered this was all caused by floating point precision.

This PR includes changes to the abi_l1b reader to round and cast the various numbers involved in the extent calculations so that all resolutions produce the same extents. I talked with some members of the NOAA GOES Imagery team and it sounds like I should do whatever I have to do to get the numbers to be as accurate as possible since floating point precision can only go so far. We are dealing with very small numbers (radians, scale factors) and very large numbers (offset, height of the satellite) and this causes a lot of drift in the pixel distances.

I'd like if @yufeizhu600 could review this given his work on #767.

 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->