### PR TITLE
Hardcoding of mersi2 l1b reader valid_range for channel 24 and 25 as these are wrong in the HDF data

### DIFF
--- a/satpy/readers/mersi2_l1b.py
+++ b/satpy/readers/mersi2_l1b.py
@@ -102,7 +102,7 @@ class MERSI2L1B(HDF5FileHandler):
         if valid_range is not None:
             # Due to a bug in the valid_range upper limit in the 10.8(24) and 12.0(25)
             # in the HDF data, this is hardcoded here.
-            if(dataset_id.name in ['24', '25'] and valid_range[1] == 4095):
+            if dataset_id.name in ['24', '25'] and valid_range[1] == 4095:
                 valid_range[1] = 25000
             # typically bad_values == 65535, saturated == 65534
             # dead detector == 65533

--- a/satpy/readers/mersi2_l1b.py
+++ b/satpy/readers/mersi2_l1b.py
@@ -100,6 +100,10 @@ class MERSI2L1B(HDF5FileHandler):
         else:
             new_fill = np.nan
         if valid_range is not None:
+            # Due to a bug in the valid_range upper limit in the 10.8(24) and 12.0(25)
+            # in the HDF data, this is hardcoded here.
+            if(dataset_id.name in ['24', '25'] and valid_range[1] == 4095):
+                valid_range[1] = 25000
             # typically bad_values == 65535, saturated == 65534
             # dead detector == 65533
             data = data.where((data >= valid_range[0]) &


### PR DESCRIPTION
Add harcoding of mersi2 l1b reader valid_range for channel 24(10.8) and 25(12.0) as these have wrong values in the HDF data