### PR TITLE
Fix error in hncc_dnb composite test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
+        - MINICONDA_VERSION="4.6.14"
         - CONDA_VERSION="4.6"
         - CONDA_CHANNELS='conda-forge'
         - CONDA_CHANNEL_PRIORITY='strict'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
+        - CONDA_VERSION="4.6"
         - CONDA_CHANNELS='conda-forge'
         - CONDA_CHANNEL_PRIORITY='strict'
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
-        - MINICONDA_VERSION="4.6.14"
-        - CONDA_VERSION="4.6"
         - CONDA_CHANNELS='conda-forge'
         - CONDA_CHANNEL_PRIORITY='strict'
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,13 @@ env:
         - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio<1.0.14 imageio pyhdf mock libtiff pycoast pydecorate geoviews'
+        - CONDA_DEPENDENCIES='xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff pycoast pydecorate geoviews'
         - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital libtiff'
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
         - CONDA_CHANNELS='conda-forge'
-        - CONDA_CHANNEL_PRIORITY='True'
+        - CONDA_CHANNEL_PRIORITY='strict'
 matrix:
   include:
   - env: PYTHON_VERSION=2.7

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -173,7 +173,10 @@ class TestVIIRSComposites(unittest.TestCase):
         c02 = xr.DataArray(sza,
                            dims=('y', 'x'),
                            attrs={'name': 'solar_zenith_angle', 'area': area})
-        lza = da.from_array(sza, chunks=25)
+        lza = np.zeros((rows, cols)) + 70.0
+        lza[:, 3] += 20.0
+        lza[:, 4:] += 45.0
+        lza = da.from_array(lza, chunks=25)
         c03 = xr.DataArray(lza,
                            dims=('y', 'x'),
                            attrs={'name': 'lunar_zenith_angle', 'area': area})

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -15,8 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Tests for VIIRS compositors.
-"""
+"""Tests for VIIRS compositors."""
 
 import sys
 
@@ -30,6 +29,7 @@ class TestVIIRSComposites(unittest.TestCase):
     """Test VIIRS-specific composites."""
 
     def data_area_ref_corrector(self):
+        """Create test area definition and data."""
         import dask.array as da
         import numpy as np
         from pyresample.geometry import AreaDefinition
@@ -224,7 +224,10 @@ class TestVIIRSComposites(unittest.TestCase):
         c02 = xr.DataArray(sza,
                            dims=('y', 'x'),
                            attrs={'name': 'solar_zenith_angle', 'area': area})
-        lza = da.from_array(sza, chunks=25)
+        lza = np.zeros((rows, cols)) + 70.0
+        lza[:, 3] += 20.0
+        lza[:, 4:] += 45.0
+        lza = da.from_array(lza, chunks=25)
         c03 = xr.DataArray(lza,
                            dims=('y', 'x'),
                            attrs={'name': 'lunar_zenith_angle', 'area': area})
@@ -245,6 +248,7 @@ class TestVIIRSComposites(unittest.TestCase):
                      4.50001560e+03])
 
     def test_reflectance_corrector_abi(self):
+        """Test ReflectanceCorrector modifier with ABI data."""
         import xarray as xr
         import dask.array as da
         import numpy as np
@@ -317,6 +321,7 @@ class TestVIIRSComposites(unittest.TestCase):
                                             71.10179768327806, 71.33161009169649, 78.81291424983952])
 
     def test_reflectance_corrector_viirs(self):
+        """Test ReflectanceCorrector modifier with VIIRS data."""
         import xarray as xr
         import dask.array as da
         import numpy as np
@@ -349,7 +354,7 @@ class TestVIIRSComposites(unittest.TestCase):
         area, dnb = self.data_area_ref_corrector()
 
         def make_xarray(self, file_key, name, standard_name, wavelength=None, units='degrees', calibration=None,
-                        file_type=['gitco', 'gimgo']):
+                        file_type=('gitco', 'gimgo')):
             return xr.DataArray(dnb, dims=('y', 'x'),
                                 attrs={'start_orbit': 1708, 'end_orbit': 1708, 'wavelength': wavelength, 'level': None,
                                        'modifiers': None, 'calibration': calibration, 'file_key': file_key,
@@ -394,6 +399,7 @@ class TestVIIRSComposites(unittest.TestCase):
         np.testing.assert_allclose(unique, [25.20341702519979, 52.38819447051263, 75.79089653845898])
 
     def test_reflectance_corrector_modis(self):
+        """Test ReflectanceCorrector modifier with MODIS data."""
         import xarray as xr
         import dask.array as da
         import numpy as np
@@ -466,8 +472,7 @@ class TestVIIRSComposites(unittest.TestCase):
 
 
 def suite():
-    """The test suite for test_ahi.
-    """
+    """Create test suite for test_ahi."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestVIIRSComposites))


### PR DESCRIPTION
Pull requests started failing on travis with the following error:

```
 File "/home/travis/build/pytroll/satpy/satpy/composites/viirs.py", line 1069, in _gain_factor
    gain[mask] = (58 + 4 / np.cos(np.deg2rad(theta[mask]))) / 5
IndexError: too many indices for array
```

This PR should fix this, although on my machine I got a different error for the same line of code.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
