### PR TITLE
Fix standard_name and units for T4/T13 in viirs_edr_active_fires reader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
         - EVENT_TYPE='push pull_request'
         - SETUP_CMD='test'
         - CONDA_CHANNELS='conda-forge'
-        - CONDA_CHANNEL_PRIORITY='True'
+        - CONDA_CHANNEL_PRIORITY='strict'
 matrix:
   include:
   - env: PYTHON_VERSION=2.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
         - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio<1.0.14 imageio pyhdf mock libtiff pycoast pydecorate geoviews'
+        - CONDA_DEPENDENCIES='xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff pycoast pydecorate geoviews'
         - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital libtiff'
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ matrix:
     os: osx
     language: generic
 install:
-    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+#    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
+    - git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
 script:
 - coverage run --source=satpy setup.py test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,6 @@ install:
 #    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
     - "git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
-    - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
     - "conda activate test"
 
 build: false  # Not a C# project, build stuff at the test step instead.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ environment:
     PYTHON: "C:\\conda"
     MINICONDA_VERSION: "latest"
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-    CONDA_DEPENDENCIES: "xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coverage netcdf4 h5py h5netcdf gdal 'rasterio<1.0.14' imageio pyhdf mock libtiff pycoast pydecorate"
+    CONDA_DEPENDENCIES: "xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coverage netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff pycoast pydecorate"
     PIP_DEPENDENCIES: "trollsift trollimage pyspectral pyorbital libtiff"
     CONDA_CHANNELS: "conda-forge"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,14 +14,11 @@ environment:
       NUMPY_VERSION: "stable"
 
 install:
-    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
+#    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
+    - "git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-    - "activate test"
-    # HACK: Copy tiff.dll to libtiff.dll
-    - "cd %PYTHON%\\envs\\test\\Library\\bin"
-    - "copy tiff.dll libtiff.dll"
-    - "cd C:\\projects\\satpy"
+    - "conda activate test"
 
 build: false  # Not a C# project, build stuff at the test step instead.
 

--- a/satpy/etc/readers/viirs_edr_active_fires.yaml
+++ b/satpy/etc/readers/viirs_edr_active_fires.yaml
@@ -69,10 +69,12 @@ datasets:
         file_type: [fires_netcdf, fires_text]
         file_key: "{variable_prefix}FP_T13"
         coordinates: [longitude, latitude]
+        standard_name: toa_brightness_temperature
         units: 'K'
     T4:
         name: T4
         file_type: [fires_netcdf_img, fires_text_img]
         file_key: "{variable_prefix}FP_T4"
         coordinates: [longitude, latitude]
+        standard_name: toa_brightness_temperature
         units: 'K'

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -15,10 +15,11 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""VIIRS Active Fires Tests
-*********************
+"""VIIRS Active Fires Tests.
+
 This module implements tests for VIIRS Active Fires NetCDF and ASCII file
 readers.
+
 """
 
 import sys
@@ -62,9 +63,10 @@ DEFAULT_POWER_FILE_DATA = np.arange(start=1, stop=25, step=0.24,
 
 
 class FakeModFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
-    """Swap in CDF4 file handler"""
+    """Swap in CDF4 file handler."""
+
     def get_test_content(self, filename, filename_info, filename_type):
-        """Mimic reader input file content"""
+        """Mimic reader input file content."""
         file_content = {}
         file_content['/attr/data_id'] = "AFMOD"
         file_content['satellite_name'] = "npp"
@@ -74,6 +76,7 @@ class FakeModFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
         file_content['Fire Pixels/FP_longitude'] = DEFAULT_LATLON_FILE_DATA
         file_content['Fire Pixels/FP_power'] = DEFAULT_POWER_FILE_DATA
         file_content['Fire Pixels/FP_T13'] = DEFAULT_M13_FILE_DATA
+        file_content['Fire Pixels/FP_T13/attr/units'] = 'kelvins'
         file_content['Fire Pixels/FP_confidence'] = DEFAULT_DETECTION_FILE_DATA
         file_content['Fire Pixels/attr/units'] = 'none'
         file_content['Fire Pixels/shape'] = DEFAULT_FILE_SHAPE
@@ -86,9 +89,10 @@ class FakeModFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
 
 
 class FakeImgFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
-    """Swap in CDF4 file handler"""
+    """Swap in CDF4 file handler."""
+
     def get_test_content(self, filename, filename_info, filename_type):
-        """Mimic reader input file content"""
+        """Mimic reader input file content."""
         file_content = {}
         file_content['/attr/data_id'] = "AFIMG"
         file_content['satellite_name'] = "npp"
@@ -98,6 +102,7 @@ class FakeImgFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
         file_content['FP_longitude'] = DEFAULT_LATLON_FILE_DATA
         file_content['FP_power'] = DEFAULT_POWER_FILE_DATA
         file_content['FP_T4'] = DEFAULT_M13_FILE_DATA
+        file_content['FP_T4/attr/units'] = 'kelvins'
         file_content['FP_confidence'] = DEFAULT_DETECTION_FILE_DATA
 
         attrs = ('FP_latitude', 'FP_longitude',  'FP_T13', 'FP_confidence')
@@ -108,8 +113,10 @@ class FakeImgFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
 
 
 class FakeModFiresTextFileHandler(BaseFileHandler):
+    """Fake file handler for text files at moderate resolution."""
+
     def __init__(self, filename, filename_info, filetype_info, **kwargs):
-        """Get fake file content from 'get_test_content'"""
+        """Get fake file content from 'get_test_content'."""
         super(FakeModFiresTextFileHandler, self).__init__(filename, filename_info, filetype_info)
         self.file_content = self.get_test_content()
 
@@ -118,6 +125,7 @@ class FakeModFiresTextFileHandler(BaseFileHandler):
         self.platform_name = platform_key.get(self.filename_info['satellite_name'].upper(), "unknown")
 
     def get_test_content(self):
+        """Create fake test file content."""
         fake_file = io.StringIO(u'''\n\n\n\n\n\n\n\n\n\n\n\n\n\n
         24.64015007, -107.57017517,  317.38290405,   0.75,   0.75,   40,    4.28618050
         25.90660477, -100.06127167,  331.17962646,   0.75,   0.75,   81,   20.61096764''')
@@ -130,12 +138,15 @@ class FakeModFiresTextFileHandler(BaseFileHandler):
 
 
 class FakeImgFiresTextFileHandler(BaseFileHandler):
+    """Fake file handler for text files at image resolution."""
+
     def __init__(self, filename, filename_info, filetype_info, **kwargs):
-        """Get fake file content from 'get_test_content'"""
+        """Get fake file content from 'get_test_content'."""
         super(FakeImgFiresTextFileHandler, self).__init__(filename, filename_info, filetype_info)
         self.file_content = self.get_test_content()
 
     def get_test_content(self):
+        """Create fake test file content."""
         fake_file = io.StringIO(u'''\n\n\n\n\n\n\n\n\n\n\n\n\n\n
         24.64015007, -107.57017517,  317.38290405,   0.75,   0.75,   40,    4.28618050
         25.90660477, -100.06127167,  331.17962646,   0.75,   0.75,   81,   20.61096764''')
@@ -152,11 +163,12 @@ class FakeImgFiresTextFileHandler(BaseFileHandler):
 
 
 class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
-    """Test VIIRS Fires Reader"""
+    """Test VIIRS Fires Reader."""
+
     yaml_file = 'viirs_edr_active_fires.yaml'
 
     def setUp(self):
-        """Wrap CDF4 file handler with own fake file handler"""
+        """Wrap CDF4 file handler with own fake file handler."""
         from satpy.config import config_search_paths
         from satpy.readers.viirs_edr_active_fires import VIIRSActiveFiresFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
@@ -165,11 +177,11 @@ class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
         self.p.is_local = True
 
     def tearDown(self):
-        """Stop wrapping the CDF4 file handler"""
+        """Stop wrapping the CDF4 file handler."""
         self.p.stop()
 
     def test_init(self):
-        """Test basic init with no extra parameters"""
+        """Test basic init with no extra parameters."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -180,7 +192,7 @@ class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
         self.assertTrue(r.file_handlers)
 
     def test_load_dataset(self):
-        """Test loading all datasets"""
+        """Test loading all datasets."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -206,11 +218,12 @@ class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
 
 
 class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
-    """Test VIIRS Fires Reader"""
+    """Test VIIRS Fires Reader."""
+
     yaml_file = 'viirs_edr_active_fires.yaml'
 
     def setUp(self):
-        """Wrap CDF4 file handler with own fake file handler"""
+        """Wrap CDF4 file handler with own fake file handler."""
         from satpy.config import config_search_paths
         from satpy.readers.viirs_edr_active_fires import VIIRSActiveFiresFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
@@ -219,11 +232,11 @@ class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
         self.p.is_local = True
 
     def tearDown(self):
-        """Stop wrapping the CDF4 file handler"""
+        """Stop wrapping the CDF4 file handler."""
         self.p.stop()
 
     def test_init(self):
-        """Test basic init with no extra parameters"""
+        """Test basic init with no extra parameters."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -234,7 +247,7 @@ class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
         self.assertTrue(r.file_handlers)
 
     def test_load_dataset(self):
-        """Test loading all datasets"""
+        """Test loading all datasets."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -263,11 +276,12 @@ class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
 
 @mock.patch('satpy.readers.viirs_edr_active_fires.dd.read_csv')
 class TestModVIIRSActiveFiresText(unittest.TestCase):
-    """Test VIIRS Fires Reader"""
+    """Test VIIRS Fires Reader."""
+
     yaml_file = 'viirs_edr_active_fires.yaml'
 
     def setUp(self):
-        """Wrap file handler with own fake file handler"""
+        """Wrap file handler with own fake file handler."""
         from satpy.config import config_search_paths
         from satpy.readers.viirs_edr_active_fires import VIIRSActiveFiresTextFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
@@ -276,11 +290,11 @@ class TestModVIIRSActiveFiresText(unittest.TestCase):
         self.p.is_local = True
 
     def tearDown(self):
-        """Stop wrapping the text file handler"""
+        """Stop wrapping the text file handler."""
         self.p.stop()
 
     def test_init(self, mock_obj):
-        """Test basic init with no extra parameters"""
+        """Test basic init with no extra parameters."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -291,7 +305,7 @@ class TestModVIIRSActiveFiresText(unittest.TestCase):
         self.assertTrue(r.file_handlers)
 
     def test_load_dataset(self, csv_mock):
-        """Test loading all datasets"""
+        """Test loading all datasets."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -318,11 +332,12 @@ class TestModVIIRSActiveFiresText(unittest.TestCase):
 
 @mock.patch('satpy.readers.viirs_edr_active_fires.dd.read_csv')
 class TestImgVIIRSActiveFiresText(unittest.TestCase):
-    """Test VIIRS Fires Reader"""
+    """Test VIIRS Fires Reader."""
+
     yaml_file = 'viirs_edr_active_fires.yaml'
 
     def setUp(self):
-        """Wrap file handler with own fake file handler"""
+        """Wrap file handler with own fake file handler."""
         from satpy.config import config_search_paths
         from satpy.readers.viirs_edr_active_fires import VIIRSActiveFiresTextFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
@@ -331,11 +346,11 @@ class TestImgVIIRSActiveFiresText(unittest.TestCase):
         self.p.is_local = True
 
     def tearDown(self):
-        """Stop wrapping the text file handler"""
+        """Stop wrapping the text file handler."""
         self.p.stop()
 
     def test_init(self, mock_obj):
-        """Test basic init with no extra parameters"""
+        """Test basic init with no extra parameters."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -346,7 +361,7 @@ class TestImgVIIRSActiveFiresText(unittest.TestCase):
         self.assertTrue(r.file_handlers)
 
     def test_load_dataset(self, mock_obj):
-        """Test loading all datasets"""
+        """Test loading all datasets."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -374,8 +389,7 @@ class TestImgVIIRSActiveFiresText(unittest.TestCase):
 
 
 def suite():
-    """The test suite for testing viirs active fires
-    """
+    """Create test suite for testing viirs active fires."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestModVIIRSActiveFiresNetCDF4))


### PR DESCRIPTION
Noticed this when working with fire data more. The units in the files are `"kelvins"` which, although accepted by udunits, is not the most common way of describing a temperature variable's units.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
