### PR TITLE
 Replace Numpy files with zarr for resampling LUT caching

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -399,7 +399,7 @@ class BaseResampler(object):
         cache_dir = cache_dir or '.'
         hash_str = self.get_hash(**kwargs)
 
-        return os.path.join(cache_dir, 'resample_lut-' + hash_str + '.npz')
+        return os.path.join(cache_dir, 'resample_lut-' + hash_str + '.zarr')
 
 
 class KDTreeResampler(BaseResampler):

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -133,7 +133,6 @@ import numpy as np
 import xarray as xr
 import dask
 import dask.array as da
-import zarr
 
 from pyresample.ewa import fornav, ll2cr
 from pyresample.geometry import SwathDefinition
@@ -493,8 +492,6 @@ class KDTreeResampler(BaseResampler):
         """Reassign resampler index attributes."""
         if isinstance(val, np.ndarray):
             val = da.from_array(val, chunks=CHUNK_SIZE)
-        elif isinstance(val, zarr.core.Array):
-            val = da.from_zarr(val)
         elif persist and isinstance(val, da.Array):
             val = val.persist()
         setattr(self.resampler, idx_name, val)
@@ -512,7 +509,7 @@ class KDTreeResampler(BaseResampler):
                     self._index_caches[mask][idx_name], idx_name)
             elif cache_dir:
                 try:
-                    cache = zarr.open(filename, 'r')
+                    cache = da.from_zarr(filename)
                 except ValueError:
                     raise IOError
                 cache = self._apply_cached_index(cache, idx_name)
@@ -793,10 +790,10 @@ class BilinearResampler(BaseResampler):
                                                        prefix=key,
                                                        **kwargs)
                 try:
-                    fid = zarr.open(filename, 'r')
+                    cache = da.from_zarr(filename)
                 except ValueError:
                     raise IOError
-                setattr(self.resampler, val, da.from_zarr(fid))
+                setattr(self.resampler, val, cache)
 
         else:
             raise IOError

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -796,7 +796,7 @@ class BilinearResampler(BaseResampler):
                     fid = zarr.open(filename, 'r')
                 except ValueError:
                     raise IOError
-                setattr(self.resampler, val, fid)
+                setattr(self.resampler, val, da.from_zarr(fid))
 
         else:
             raise IOError
@@ -808,7 +808,10 @@ class BilinearResampler(BaseResampler):
                                                        prefix=key,
                                                        **kwargs)
                 LOG.info('Saving BIL neighbour info to %s', filename)
-                zarr.save(filename, getattr(self.resampler, val))
+                var = getattr(self.resampler, val)
+                if isinstance(var, np.ndarray):
+                    var = da.from_array(var, chunks=CHUNK_SIZE)
+                var.to_zarr(filename)
 
     def compute(self, data, fill_value=None, **kwargs):
         """Resample the given data using bilinear interpolation"""

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -506,9 +506,9 @@ class KDTreeResampler(BaseResampler):
         filename = self._create_cache_filename(cache_dir, prefix='nn_lut-',
                                                mask=mask_name, **kwargs)
         for idx_name in NN_COORDINATES.keys():
-            if mask in self._index_caches:
+            if mask_name in self._index_caches:
                 cached[idx_name] = self._apply_cached_index(
-                    self._index_caches[mask][idx_name], idx_name)
+                    self._index_caches[mask_name][idx_name], idx_name)
             elif cache_dir:
                 try:
                     cache = da.from_zarr(filename, idx_name)

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -763,8 +763,7 @@ class BilinearResampler(BaseResampler):
         self.resampler = None
 
     def precompute(self, mask=None, radius_of_influence=50000, epsilon=0,
-                   reduce_data=True, nprocs=1,
-                   cache_dir=False, **kwargs):
+                   reduce_data=True, cache_dir=False, **kwargs):
         """Create bilinear coefficients and store them for later use.
 
         Note: The `mask` keyword should be provided if geolocation may be valid

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -548,7 +548,7 @@ class KDTreeResampler(BaseResampler):
     def compute(self, data, weight_funcs=None, fill_value=np.nan,
                 with_uncert=False, **kwargs):
         del kwargs
-        LOG.debug("Resampling ", str(data.name))
+        LOG.debug("Resampling %s", str(data.name))
         res = self.resampler.get_sample_from_neighbour_info(data, fill_value)
         return update_resampled_coords(data, res, self.target_geo_def)
 

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -17,7 +17,7 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Satpy resampling module.
 
-Satpyprovides multiple resampling algorithms for resampling geolocated
+Satpy provides multiple resampling algorithms for resampling geolocated
 data to uniform projected grids. The easiest way to perform resampling in
 Satpy is through the :class:`~satpy.scene.Scene` object's
 :meth:`~satpy.scene.Scene.resample` method. Additional utility functions are
@@ -512,6 +512,9 @@ class KDTreeResampler(BaseResampler):
             elif cache_dir:
                 try:
                     cache = da.from_zarr(filename, idx_name)
+                    if idx_name == 'valid_input_index':
+                        # valid input index array needs to be boolean
+                        cache = cache.astype(np.bool)
                 except ValueError:
                     raise IOError
                 cache = self._apply_cached_index(cache, idx_name)
@@ -796,6 +799,9 @@ class BilinearResampler(BaseResampler):
             for val in BIL_COORDINATES.keys():
                 try:
                     cache = da.from_zarr(filename, val)
+                    if val == 'valid_input_index':
+                        # valid input index array needs to be boolean
+                        cache = cache.astype(np.bool)
                 except ValueError:
                     raise IOError
                 setattr(self.resampler, val, cache)

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -802,6 +802,8 @@ class BilinearResampler(BaseResampler):
                     if val == 'valid_input_index':
                         # valid input index array needs to be boolean
                         cache = cache.astype(np.bool)
+                    # Compute the cache arrays
+                    cache = cache.compute()
                 except ValueError:
                     raise IOError
                 setattr(self.resampler, val, cache)

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -477,7 +477,7 @@ class TestBilinearResampler(unittest.TestCase):
             # assert data was saved to the on-disk cache
             self.assertEqual(len(mock_dset.to_zarr.mock_calls), 1)
             # assert that from_zarr was called to try to load something from disk
-            self.assertEqual(len(from_zarr.mock_calls), 1)
+            self.assertEqual(len(from_zarr.mock_calls), 5)
 
             nbcalls = len(resampler.resampler.get_bil_info.mock_calls)
             # test reusing the resampler
@@ -489,7 +489,10 @@ class TestBilinearResampler(unittest.TestCase):
                     pass
 
                 def astype(self, dtype):
-                    pass
+                    return self
+
+                def compute(self):
+                    return self
 
             from_zarr.return_value = FakeZarr(bilinear_s=1,
                                               bilinear_t=2,
@@ -505,7 +508,7 @@ class TestBilinearResampler(unittest.TestCase):
             # test loading saved resampler
             resampler = BilinearResampler(source_area, target_area)
             resampler.precompute(cache_dir=the_dir)
-            self.assertEqual(len(from_zarr.mock_calls), 2)
+            self.assertEqual(len(from_zarr.mock_calls), 9)
             self.assertEqual(len(resampler.resampler.get_bil_info.mock_calls), nbcalls)
             # we should have cached things in-memory now
             # self.assertEqual(len(resampler._index_caches), 1)

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -135,11 +135,13 @@ class TestHLResample(unittest.TestCase):
 class TestKDTreeResampler(unittest.TestCase):
     """Test the kd-tree resampler."""
 
+    @mock.patch('satpy.resample.KDTreeResampler._check_numpy_cache')
     @mock.patch('satpy.resample.xr.Dataset')
     @mock.patch('satpy.resample.da.from_zarr')
     @mock.patch('satpy.resample.KDTreeResampler._create_cache_filename')
     @mock.patch('satpy.resample.XArrayResamplerNN')
-    def test_kd_resampling(self, resampler, create_filename, from_zarr, xr_dset):
+    def test_kd_resampling(self, resampler, create_filename, from_zarr,
+                           xr_dset, cnc):
         """Test the kd resampler."""
         import numpy as np
         import dask.array as da
@@ -154,6 +156,7 @@ class TestKDTreeResampler(unittest.TestCase):
         # swath definitions should not be cached
         self.assertFalse(len(mock_dset.to_zarr.mock_calls), 0)
         resampler.resampler.reset_mock()
+        cnc.assert_called_once()
 
         resampler = KDTreeResampler(source_area, target_area)
         resampler.precompute()

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ from setuptools import find_packages, setup
 
 requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.11.0', 'trollsift',
             'trollimage >=1.5.1', 'pykdtree', 'six', 'pyyaml', 'xarray >=0.10.1',
-            'dask[array] >=0.17.1', 'pyproj']
+            'dask[array] >=0.17.1', 'pyproj', 'zarr']
 
 test_requires = ['behave', 'h5py', 'netCDF4', 'pyhdf', 'imageio', 'libtiff',
                  'rasterio', 'geoviews']


### PR DESCRIPTION

Another go at making a draft PR for using Zarr instead of Numpy for storing resampling LUTs. The first try, from wrong branch, is here for reference https://github.com/pytroll/satpy/pull/879

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
