### PR TITLE
Update mersi2_l1b sensor name to mersi-2 to match pyspectral

### DIFF
--- a/satpy/etc/composites/mersi-2.yaml
+++ b/satpy/etc/composites/mersi-2.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/mersi2
+sensor_name: visir/mersi-2
 
 modifiers:
   rayleigh_corrected:

--- a/satpy/etc/readers/mersi2_l1b.yaml
+++ b/satpy/etc/readers/mersi2_l1b.yaml
@@ -1,7 +1,7 @@
 reader:
   description: FY-3D Medium Resolution Spectral Imager 2 (MERSI-2) L1B Reader
   name: mersi2_l1b
-  sensors: [mersi2]
+  sensors: [mersi-2]
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/readers/mersi2_l1b.py
+++ b/satpy/readers/mersi2_l1b.py
@@ -34,11 +34,8 @@ import dask.array as da
 class MERSI2L1B(HDF5FileHandler):
     """MERSI-2 L1B file reader."""
 
-    def __init__(self, filename, filename_info, filetype_info):
-        super(MERSI2L1B, self).__init__(filename, filename_info, filetype_info)
-
     def _strptime(self, date_attr, time_attr):
-        """Helper to parse date/time strings."""
+        """Parse date/time strings."""
         date = self[date_attr]
         time = self[time_attr]  # "18:27:39.720"
         # cuts off microseconds because of unknown meaning
@@ -47,10 +44,12 @@ class MERSI2L1B(HDF5FileHandler):
 
     @property
     def start_time(self):
+        """Time for first observation."""
         return self._strptime('/attr/Observing Beginning Date', '/attr/Observing Beginning Time')
 
     @property
     def end_time(self):
+        """Time for final observation."""
         return self._strptime('/attr/Observing Ending Date', '/attr/Observing Ending Time')
 
     @property
@@ -58,7 +57,7 @@ class MERSI2L1B(HDF5FileHandler):
         """Map sensor name to Satpy 'standard' sensor names."""
         file_sensor = self['/attr/Sensor Identification Code']
         sensor = {
-            'MERSI': 'mersi2',
+            'MERSI': 'mersi-2',
         }.get(file_sensor, file_sensor)
         return sensor
 


### PR DESCRIPTION
Trying to use rayleigh correction for MERSI-2 data fails because pyspectral doesn't detect "mersi2" as a known sensor. This PR updates the sensor name to match WMO OSCAR named "MERSI-2" (at least as lowercase).

Due to some Satpy inconsistencies the sensor needs to be lowercase (to match composite config names) and pyspectral should be able to match against mersi-2 even though it uses MERSI-2.

 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
