### PR TITLE
Add more reader metadata like long_name and description

### DIFF
--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -81,9 +81,9 @@ The parameters to provide in this section are:
    replacing ``_`` with spaces and uppercasing every letter.
  - long_name: Human-readable title for the reader. This may be used as a
    section title on a website or in GUI applications using Satpy. Default
-   naming scheme is ``<space program> <sensor> Level <level>``. For example,
-   for the ``abi_l1b`` reader this is ``"GOES-R ABI Level 1b"`` where
-   "GOES-R" is the name of the program and **not** the name of the
+   naming scheme is ``<space program> <sensor> Level <level> [<format>]``.
+   For example, for the ``abi_l1b`` reader this is ``"GOES-R ABI Level 1b"``
+   where "GOES-R" is the name of the program and **not** the name of the
    platform/satellite. This scheme may not work for all readers, but in
    general should be followed. See existing readers for more examples.
  - description: General description of the reader. This may include any

--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -73,19 +73,37 @@ The ``reader`` section
 The ``reader`` section, that provides basic parameters for the reader.
 
 The parameters to provide in this section are:
- - description: General description of the reader
- - name: this is the name of the reader, it should be the same as the
+ - name: This is the name of the reader, it should be the same as the
    filename (without the .yaml extension). The naming convention for
    this is described above in the :ref:`reader_naming` section above.
- - sensors: the list of sensors this reader will support
- - reader: the metareader to use, in most cases the
+ - short_name (optional): Human-readable version of the reader 'name'.
+   If not provided, applications using this can default to taking the 'name',
+   replacing ``_`` with spaces and uppercasing every letter.
+ - long_name: Human-readable title for the reader. This may be used as a
+   section title on a website or in GUI applications using Satpy. Default
+   naming scheme is ``<space program> <sensor> Level <level>``. For example,
+   for the ``abi_l1b`` reader this is ``"GOES-R ABI Level 1b"`` where
+   "GOES-R" is the name of the program and **not** the name of the
+   platform/satellite. This scheme may not work for all readers, but in
+   general should be followed. See existing readers for more examples.
+ - description: General description of the reader. This may include any
+   `restructuredtext <http://docutils.sourceforge.net/docs/user/rst/quickref.html>`_
+   formatted text like links to PDFs or sites with more information on the
+   file format. This can be multiline if formatted properly in YAML (see
+   example below).
+ - sensors: The list of sensors this reader will support. This must be
+   all lowercase letters for full support throughout in Satpy.
+ - reader: The main python reader class to use, in most cases the
    ``FileYAMLReader`` is a good choice.
 
 .. code:: yaml
 
     reader:
-      description: NetCDF4 reader for the Eumetsat MSG format
-      name: nc_seviri_l1b
+      name: seviri_l1b_nc
+      short_name: SEVIRI L1b NetCDF4
+      long_name: MSG SEVIRI Level 1b (NetCDF4)
+      description: >
+        NetCDF4 reader for EUMETSAT MSG SEVIRI Level 1b files.
       sensors: [seviri]
       reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
 

--- a/satpy/etc/readers/abi_l1b.yaml
+++ b/satpy/etc/readers/abi_l1b.yaml
@@ -4,9 +4,14 @@
 # Note: Channels < 3 microns have different units than channels > 3 microns
 
 reader:
-  # PUG: https://www.goes-r.gov/users/docs/PUG-L1b-vol3.pdf
-  description: NC Reader for ABI data
   name: abi_l1b
+  short_name: ABI L1b
+  long_name: GOES-R ABI Level 1b
+  description: >
+    GOES-R ABI Level 1b data reader in the NetCDF4 format. The file format is
+    described in the GOES-R Product Definition and Users' Guide (PUG). Volume
+    4 of this document can be found
+    `here <https://www.goes-r.gov/users/docs/PUG-GRB-vol4.pdf>`_.
   sensors: [abi]
   default_channels:
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/etc/readers/ahi_hrit.yaml
+++ b/satpy/etc/readers/ahi_hrit.yaml
@@ -3,8 +3,10 @@
 #   - http://www.data.jma.go.jp/mscweb/en/himawari89/space_segment/sample_hrit.html
 
 reader:
-  description: JMA HRIT Reader
   name: ahi_hrit
+  short_name: AHI HRIT
+  long_name: Himawari AHI Level 1 (HRIT)
+  description: Reader for the JMA Himawari AHI Level 1 data in HRIT format
   sensors: [ahi]
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
   # file pattern keys to sort files by with 'satpy.utils.group_files'

--- a/satpy/etc/readers/ahi_hsd.yaml
+++ b/satpy/etc/readers/ahi_hsd.yaml
@@ -2,8 +2,10 @@
 #  - Himawari-8/9 Himawari Standard Data User's Guide
 
 reader:
-  description: Generic HSD AHI Reader
   name: ahi_hsd
+  short_name: AHI HSD
+  long_name: Himawari AHI Level 1b (HSD)
+  description: Reader for the JMA Himawari AHI Level 1 data in HSD format
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader ''
   sensors: [ahi]
   # file pattern keys to sort files by with 'satpy.utils.group_files'

--- a/satpy/etc/readers/goes-imager_hrit.yaml
+++ b/satpy/etc/readers/goes-imager_hrit.yaml
@@ -1,6 +1,8 @@
 reader:
-  description: GOES HRIT Reader
   name: goes-imager_hrit
+  short_name: GOES Imager HRIT
+  long_name: GOES Imager Level 1 (HRIT)
+  description: Reader for GOES Imager Level 1 data in HRIT format
   sensors: [goes_imager]
   default_channels: [00_7, 03_9, 06_6, 10_7]
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/etc/readers/goes-imager_nc.yaml
+++ b/satpy/etc/readers/goes-imager_nc.yaml
@@ -1,10 +1,14 @@
-# References:
-# GOES 8-12:  https://goes.gsfc.nasa.gov/text/databook/databook.pdf, page 20 ff
-# GOES 13-15: https://goes.gsfc.nasa.gov/text/GOES-N_Databook/databook.pdf, chapter 3.
-
 reader:
-  description: GOES netCDF Reader
   name: goes-imager_nc
+  short_name: GOES Imager netCDF
+  long_name: GOES Imager Level 1 (netCDF)
+  description: >
+    Reader for GOES Imager Level 1 data in netCDF format (from both NOAA CLASS and EUMETCast)
+    References:
+
+    - GOES 8-12: https://goes.gsfc.nasa.gov/text/databook/databook.pdf, page 20 ff.
+    - GOES 13-15: https://goes.gsfc.nasa.gov/text/GOES-N_Databook/databook.pdf, chapter 3.
+
   sensors: [goes_imager]
   default_channels: []
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/etc/readers/jami_hrit.yaml
+++ b/satpy/etc/readers/jami_hrit.yaml
@@ -1,14 +1,16 @@
-# References:
-#   - https://www.wmo-sat.info/oscar/instruments/view/236
-#   - http://www.data.jma.go.jp/mscweb/notice/Himawari7_e.html
-#
-# Note that the there exist two versions of the dataset. A segmented (data
-# split into multiple files) and a non-segmented version (all data in one
-# file).
-
 reader:
-  description: Reader for MTSAT-1R JAMI data in JMA HRIT Format
   name: jami_hrit
+  short_name: JAMI HRIT
+  long_name: MTSAT-1R JAMI Level 1 (HRIT)
+  description: >
+    Reader for MTSAT-1R JAMI data in JMA HRIT format. Note that there
+    exist two versions of the dataset. A segmented (data split into
+    multiple files) and a non-segmented version (all data in one file).
+    References:
+
+    - https://www.wmo-sat.info/oscar/instruments/view/236
+    - http://www.data.jma.go.jp/mscweb/notice/Himawari7_e.html
+
   sensors: [jami]
   default_channels: []
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/etc/readers/mtsat2-imager_hrit.yaml
+++ b/satpy/etc/readers/mtsat2-imager_hrit.yaml
@@ -1,14 +1,16 @@
-# References:
-#   - https://www.wmo-sat.info/oscar/instruments/view/219
-#   - http://www.data.jma.go.jp/mscweb/notice/Himawari7_e.html
-#
-# Note that the there exist two versions of the dataset. A segmented (data
-# split into multiple files) and a non-segmented version (all data in one
-# file).
-
 reader:
-  description: Reader for MTSAT-2 data in JMA HRIT Format
   name: mtsat2-imager_hrit
+  short_name: MTSAT-2 Imager HRIT
+  long_name: MTSAT-2 Imager Level 1 (HRIT)
+  description: >
+    Reader for MTSAT-2 Imager data in JMA HRIT format. Note that there
+    exist two versions of the dataset. A segmented (data split into
+    multiple files) and a non-segmented version (all data in one file).
+    References:
+
+    - https://www.wmo-sat.info/oscar/instruments/view/219
+    - http://www.data.jma.go.jp/mscweb/notice/Himawari7_e.html
+
   sensors: [mtsat2_imager]
   default_channels: []
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/etc/readers/seviri_l1b_hrit.yaml
+++ b/satpy/etc/readers/seviri_l1b_hrit.yaml
@@ -4,8 +4,11 @@
 #   Spectral Blackbody Radiance
 
 reader:
-  description: MSG Seviri HRIT Reader
   name: seviri_l1b_hrit
+  short_name: SEVIRI L1b HRIT
+  long_name: MSG SEVIRI Level 1b (HRIT)
+  description: >
+    HRIT reader for EUMETSAT MSG SEVIRI Level 1b files.
   sensors: [seviri]
   default_channels: [HRV, IR_016, IR_039, IR_087, IR_097, IR_108, IR_120, IR_134, VIS006, VIS008, WV_062, WV_073]
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/etc/readers/seviri_l1b_native.yaml
+++ b/satpy/etc/readers/seviri_l1b_native.yaml
@@ -1,6 +1,9 @@
 reader:
-  description: MSG Seviri Native Reader
   name: seviri_l1b_native
+  short_name: SEVIRI L1b HRIT
+  long_name: MSG SEVIRI Level 1b (Native)
+  description: >
+    Reader for EUMETSAT MSG SEVIRI Level 1b native format files.
   sensors: [seviri]
   default_channels: [HRV, IR_016, IR_039, IR_087, IR_097, IR_108, IR_120, IR_134, VIS006, VIS008, WV_062, WV_073]
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/etc/readers/seviri_l1b_native.yaml
+++ b/satpy/etc/readers/seviri_l1b_native.yaml
@@ -1,6 +1,6 @@
 reader:
   name: seviri_l1b_native
-  short_name: SEVIRI L1b HRIT
+  short_name: SEVIRI L1b Native
   long_name: MSG SEVIRI Level 1b (Native)
   description: >
     Reader for EUMETSAT MSG SEVIRI Level 1b native format files.

--- a/satpy/etc/readers/seviri_l1b_nc.yaml
+++ b/satpy/etc/readers/seviri_l1b_nc.yaml
@@ -1,6 +1,9 @@
 reader:
-  description: NetCDF4 reader for the Eumetsat MSG format
   name: seviri_l1b_nc
+  short_name: SEVIRI L1b NetCDF4
+  long_name: MSG SEVIRI Level 1b NetCDF4
+  description: >
+    NetCDF4 reader for EUMETSAT MSG SEVIRI Level 1b files.
   sensors: [seviri]
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
   group_keys: ["processing_time", "satid"]


### PR DESCRIPTION
I'm creating this as a proof of concept and to continue the discussion from #876 and on slack. The idea is to provide additional human-readable metadata for readers so that they could be documented with more detail, not only in Satpy's documentation but by other applications too. For example, a GUI application using Satpy may want to give the user the option of what reader to use or what readers are available. Having a human-readable name would look "prettier" than the underscored reader name.

This PR, so far, adds short_name, long_name, and description to `abi_l1b`. The `description` is formatted as restructuredtext so it could theoretically be pasted to a restructuredtext document for the sphinx docs.

Other options:

 - Remove `short_name`. I'm not 100% sure on this since it essentially provides a human readable version of the `name`.
 - Separate `resources` dictionary mapping "hyperlink text" to a URL. We had talked about doing this for composites so it would be consistent with that and easier to do than typing a ton of URLs in to sentences in the description; especially in rst. This could also mean that the description could stay a plain string which would be nice for usage.

Thoughts?

 - [x] Closes #876 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
