### PR TITLE
Fix MERSI-2 and VIRR readers being recognized by pyspectral

### DIFF
--- a/satpy/etc/composites/mersi-2.yaml
+++ b/satpy/etc/composites/mersi-2.yaml
@@ -1,4 +1,4 @@
-sensor_name: visir/mersi2
+sensor_name: visir/mersi-2
 
 modifiers:
   rayleigh_corrected:

--- a/satpy/etc/composites/virr.yaml
+++ b/satpy/etc/composites/virr.yaml
@@ -11,7 +11,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: rayleigh_only
     prerequisites:
-    - name: R1
+    - name: '1'
       modifiers: [sunz_corrected]
     optional_prerequisites:
     - name: satellite_azimuth_angle
@@ -23,21 +23,21 @@ composites:
   true_color_raw:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-    - name: R1
+    - name: '1'
       modifiers: [sunz_corrected]
-    - name: R6
+    - name: '9'
       modifiers: [sunz_corrected]
-    - name: R4
+    - name: '7'
       modifiers: [sunz_corrected]
     standard_name: true_color
 
   true_color:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-    - name: R1
+    - name: '1'
       modifiers: [sunz_corrected, rayleigh_corrected]
-    - name: R6
+    - name: '9'
       modifiers: [sunz_corrected, rayleigh_corrected]
-    - name: R4
+    - name: '7'
       modifiers: [sunz_corrected, rayleigh_corrected]
     standard_name: true_color

--- a/satpy/etc/readers/mersi2_l1b.yaml
+++ b/satpy/etc/readers/mersi2_l1b.yaml
@@ -1,7 +1,7 @@
 reader:
   description: FY-3D Medium Resolution Spectral Imager 2 (MERSI-2) L1B Reader
   name: mersi2_l1b
-  sensors: [mersi2]
+  sensors: [mersi-2]
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/virr_l1b.yaml
+++ b/satpy/etc/readers/virr_l1b.yaml
@@ -18,7 +18,7 @@ file_types:
 
 datasets:
   R1:
-    name: R1
+    name: '1'
     wavelength: [0.58, 0.63, 0.68]
     resolution: 1000
     file_type: virr_l1b
@@ -29,7 +29,7 @@ datasets:
     calibration: reflectance
 
   R2:
-    name: R2
+    name: '2'
     wavelength: [0.84, 0.865, 0.89]
     resolution: 1000
     file_type: virr_l1b
@@ -40,7 +40,7 @@ datasets:
     calibration: reflectance
 
   E1:
-    name: E1
+    name: '3'
     wavelength: [3.55, 3.74, 3.93]
     resolution: 1000
     file_type: virr_l1b
@@ -51,7 +51,7 @@ datasets:
     calibration: brightness_temperature
 
   E2:
-    name: E2
+    name: '4'
     wavelength: [10.3, 10.8, 11.3]
     resolution: 1000
     file_type: virr_l1b
@@ -62,7 +62,7 @@ datasets:
     calibration: brightness_temperature
 
   E3:
-    name: E3
+    name: '5'
     wavelength: [11.5, 12.0, 12.5]
     resolution: 1000
     file_type: virr_l1b
@@ -73,7 +73,7 @@ datasets:
     calibration: brightness_temperature
 
   R3:
-    name: R3
+    name: '6'
     wavelength: [1.55, 1.6, 1.64]
     resolution: 1000
     file_type: virr_l1b
@@ -84,7 +84,7 @@ datasets:
     calibration: reflectance
 
   R4:
-    name: R4
+    name: '7'
     wavelength: [0.43, 0.455, 0.48]
     resolution: 1000
     file_type: virr_l1b
@@ -95,7 +95,7 @@ datasets:
     calibration: reflectance
 
   R5:
-    name: R5
+    name: '8'
     wavelength: [0.48, 0.505, 0.53]
     resolution: 1000
     file_type: virr_l1b
@@ -106,7 +106,7 @@ datasets:
     calibration: reflectance
 
   R6:
-    name: R6
+    name: '9'
     wavelength: [0.53, 0.555, 0.58]
     resolution: 1000
     file_type: virr_l1b
@@ -117,7 +117,7 @@ datasets:
     calibration: reflectance
 
   R7:
-    name: R7
+    name: '10'
     wavelength: [1.325, 1.36, 1.395]
     resolution: 1000
     file_type: virr_l1b
@@ -161,10 +161,14 @@ datasets:
     file_type: [virr_l1b, virr_geoxx]
     file_key: Longitude
     standard_name: longitude
+    units: degrees_east
+    coordinates: [longitude, latitude]
 
   latitude:
     name: latitude
     resolution: 1000
     file_type: [virr_l1b, virr_geoxx]
     file_key: Latitude
+    units: degrees_north
     standard_name: latitude
+    coordinates: [longitude, latitude]

--- a/satpy/readers/mersi2_l1b.py
+++ b/satpy/readers/mersi2_l1b.py
@@ -34,11 +34,8 @@ import dask.array as da
 class MERSI2L1B(HDF5FileHandler):
     """MERSI-2 L1B file reader."""
 
-    def __init__(self, filename, filename_info, filetype_info):
-        super(MERSI2L1B, self).__init__(filename, filename_info, filetype_info)
-
     def _strptime(self, date_attr, time_attr):
-        """Helper to parse date/time strings."""
+        """Parse date/time strings."""
         date = self[date_attr]
         time = self[time_attr]  # "18:27:39.720"
         # cuts off microseconds because of unknown meaning
@@ -47,10 +44,12 @@ class MERSI2L1B(HDF5FileHandler):
 
     @property
     def start_time(self):
+        """Time for first observation."""
         return self._strptime('/attr/Observing Beginning Date', '/attr/Observing Beginning Time')
 
     @property
     def end_time(self):
+        """Time for final observation."""
         return self._strptime('/attr/Observing Ending Date', '/attr/Observing Ending Time')
 
     @property
@@ -58,7 +57,7 @@ class MERSI2L1B(HDF5FileHandler):
         """Map sensor name to Satpy 'standard' sensor names."""
         file_sensor = self['/attr/Sensor Identification Code']
         sensor = {
-            'MERSI': 'mersi2',
+            'MERSI': 'mersi-2',
         }.get(file_sensor, file_sensor)
         return sensor
 

--- a/satpy/tests/reader_tests/test_virr_l1b.py
+++ b/satpy/tests/reader_tests/test_virr_l1b.py
@@ -15,8 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Test for readers/virr_l1b.py.
-"""
+"""Test for readers/virr_l1b.py."""
 from satpy.tests.reader_tests.test_hdf5_utils import FakeHDF5FileHandler
 import sys
 import numpy as np
@@ -39,6 +38,7 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
     """Swap-in HDF5 File Handler."""
 
     def make_test_data(self, dims):
+        """Create fake test data."""
         return xr.DataArray(da.from_array(np.ones([dim for dim in dims], dtype=np.float32) * 10, [dim for dim in dims]))
 
     def _make_file(self, platform_id, geolocation_prefix, l1b_prefix, ECWN, Emissive_units):
@@ -92,6 +92,7 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
 
 class TestVIRRL1BReader(unittest.TestCase):
     """Test VIRR L1B Reader."""
+
     yaml_file = "virr_l1b.yaml"
 
     def setUp(self):
@@ -119,9 +120,10 @@ class TestVIRRL1BReader(unittest.TestCase):
         self.assertEqual(('longitude', 'latitude'), attributes['coordinates'])
 
     def _fy3_helper(self, platform_name, reader, Emissive_units):
+        """Load channels and test accurate metadata."""
         import datetime
-        band_values = {'R1': 22.0, 'R2': 22.0, 'R3': 22.0, 'R4': 22.0, 'R5': 22.0, 'R6': 22.0, 'R7': 22.0,
-                       'E1': 496.542155, 'E2': 297.444511, 'E3': 288.956557, 'solar_zenith_angle': .1,
+        band_values = {'1': 22.0, '2': 22.0, '6': 22.0, '7': 22.0, '8': 22.0, '9': 22.0, '10': 22.0,
+                       '3': 496.542155, '4': 297.444511, '5': 288.956557, 'solar_zenith_angle': .1,
                        'satellite_zenith_angle': .1, 'solar_azimuth_angle': .1, 'satellite_azimuth_angle': .1,
                        'longitude': 10}
         datasets = reader.load([band for band in band_values])
@@ -136,11 +138,11 @@ class TestVIRRL1BReader(unittest.TestCase):
             self.assertEqual(datetime.datetime(2018, 12, 25, 21, 47, 28, 254000), attributes['end_time'])
             self.assertEqual((19, 20), datasets[dataset.name].shape)
             self.assertEqual(('y', 'x'), datasets[dataset.name].dims)
-            if 'R' in dataset.name:
+            if dataset.name in ['1', '2', '6', '7', '8', '9', '10']:
                 self._band_helper(attributes, '%', 'reflectance',
                                   'toa_bidirectional_reflectance', 'virr_l1b',
                                   7, 1000)
-            elif 'E' in dataset.name:
+            elif dataset.name in ['3', '4', '5']:
                 self._band_helper(attributes, Emissive_units, 'brightness_temperature',
                                   'toa_brightness_temperature', 'virr_l1b', 3, 1000)
             elif dataset.name in ['longitude', 'latitude']:
@@ -159,6 +161,7 @@ class TestVIRRL1BReader(unittest.TestCase):
                              round(float(np.array(ds[ds.shape[0] // 2][ds.shape[1] // 2])), 6))
 
     def test_fy3b_file(self):
+        """Test that FY3B files are recognized."""
         from satpy.readers import load_reader
         FY3B_reader = load_reader(self.reader_configs)
         FY3B_file = FY3B_reader.select_files_from_pathnames(['tf2018359214943.FY3B-L_VIRRX_L1B.HDF'])
@@ -169,6 +172,7 @@ class TestVIRRL1BReader(unittest.TestCase):
         self._fy3_helper('FY3B', FY3B_reader, 'milliWstts/m^2/cm^(-1)/steradian')
 
     def test_fy3c_file(self):
+        """Test that FY3C files are recognized."""
         from satpy.readers import load_reader
         FY3C_reader = load_reader(self.reader_configs)
         FY3C_files = FY3C_reader.select_files_from_pathnames(['tf2018359143912.FY3C-L_VIRRX_GEOXX.HDF',
@@ -181,7 +185,7 @@ class TestVIRRL1BReader(unittest.TestCase):
 
 
 def suite():
-    """The test suite for test_virr_l1b."""
+    """Create test suite for test_virr_l1b."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestVIRRL1BReader))

--- a/satpy/tests/reader_tests/test_virr_l1b.py
+++ b/satpy/tests/reader_tests/test_virr_l1b.py
@@ -132,7 +132,7 @@ class TestVIRRL1BReader(unittest.TestCase):
             ds = datasets[dataset.name]
             attributes = ds.attrs
             self.assertTrue(isinstance(ds.data, da.Array))
-            self.assertEqual('VIRR', attributes['sensor'])
+            self.assertEqual('virr', attributes['sensor'])
             self.assertEqual(platform_name, attributes['platform_name'])
             self.assertEqual(datetime.datetime(2018, 12, 25, 21, 41, 47, 90000), attributes['start_time'])
             self.assertEqual(datetime.datetime(2018, 12, 25, 21, 47, 28, 254000), attributes['end_time'])


### PR DESCRIPTION
This PR covers just about every category. It is a fix and an enhancement. This includes the changes from #884. Basically, I needed MERSI-2 and VIRR readers to work with rayleigh correct. 

 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

