### PR TITLE
Fix HDF4 reading utility using dtype classes instead of instances

### DIFF
--- a/satpy/readers/hdf4_utils.py
+++ b/satpy/readers/hdf4_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017 Satpy developers
+# Copyright (c) 2017-2019 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -15,9 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Helpers for reading hdf4-based files.
-
-"""
+"""Helpers for reading hdf4-based files."""
 import logging
 
 from pyhdf.SD import SD, SDC, SDS
@@ -48,22 +46,22 @@ HTYPE_TO_DTYPE = {
 
 def from_sds(var, *args, **kwargs):
     """Create a dask array from a SD dataset."""
-    var.__dict__['dtype'] = HTYPE_TO_DTYPE[var.info()[3]]
+    var.__dict__['dtype'] = np.dtype(HTYPE_TO_DTYPE[var.info()[3]])
     shape = var.info()[2]
     var.__dict__['shape'] = shape if isinstance(shape, (tuple, list)) else tuple(shape)
     return da.from_array(var, *args, **kwargs)
 
 
 class HDF4FileHandler(BaseFileHandler):
-    """Small class for inspecting a HDF5 file and retrieve its metadata/header data.
-    """
+    """Base class for common HDF4 operations."""
 
     def __init__(self, filename, filename_info, filetype_info):
+        """Open file and collect information."""
         super(HDF4FileHandler, self).__init__(filename, filename_info, filetype_info)
         self.file_content = {}
         file_handle = SD(self.filename, SDC.READ)
         self._collect_attrs('', file_handle.attributes())
-        for k, v in file_handle.datasets().items():
+        for k in file_handle.datasets().keys():
             self.collect_metadata(k, file_handle.select(k))
         del file_handle
 
@@ -81,10 +79,11 @@ class HDF4FileHandler(BaseFileHandler):
                 self.file_content["{}/attr/{}".format(name, key)] = value
 
     def collect_metadata(self, name, obj):
+        """Collect all metadata about file content."""
         if isinstance(obj, SDS):
             self.file_content[name] = obj
             info = obj.info()
-            self.file_content[name + "/dtype"] = HTYPE_TO_DTYPE.get(info[3])
+            self.file_content[name + "/dtype"] = np.dtype(HTYPE_TO_DTYPE.get(info[3]))
             self.file_content[name + "/shape"] = info[2] if isinstance(info[2], (int, float)) else tuple(info[2])
 
     def _open_xarray_dataset(self, val, chunks=CHUNK_SIZE):
@@ -95,6 +94,7 @@ class HDF4FileHandler(BaseFileHandler):
                             attrs=attrs)
 
     def __getitem__(self, key):
+        """Get file content as xarray compatible objects."""
         val = self.file_content[key]
         if isinstance(val, SDS):
             # these datasets are closed and inaccessible when the file is closed, need to reopen
@@ -102,9 +102,11 @@ class HDF4FileHandler(BaseFileHandler):
         return val
 
     def __contains__(self, item):
+        """Check if item is in file content."""
         return item in self.file_content
 
     def get(self, item, default=None):
+        """Get variable as DataArray or return the default."""
         if item in self:
             return self[item]
         else:

--- a/satpy/tests/reader_tests/test_hdf4_utils.py
+++ b/satpy/tests/reader_tests/test_hdf4_utils.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-2018 Satpy developers
+# Copyright (c) 2017-2019 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -15,8 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Module for testing the satpy.readers.hdf4_utils module.
-"""
+"""Module for testing the satpy.readers.hdf4_utils module."""
 
 import os
 import sys
@@ -39,7 +38,7 @@ class FakeHDF4FileHandler(HDF4FileHandler):
     """Swap-in NetCDF4 File Handler for reader tests to use."""
 
     def __init__(self, filename, filename_info, filetype_info, **kwargs):
-        """Get fake file content from 'get_test_content'"""
+        """Get fake file content from 'get_test_content'."""
         if HDF4FileHandler is object:
             raise ImportError("Base 'HDF4FileHandler' could not be "
                               "imported.")
@@ -67,10 +66,10 @@ class FakeHDF4FileHandler(HDF4FileHandler):
 
 
 class TestHDF4FileHandler(unittest.TestCase):
-    """Test HDF4 File Handler Utility class"""
+    """Test HDF4 File Handler Utility class."""
 
     def setUp(self):
-        """Create a test HDF4 file"""
+        """Create a test HDF4 file."""
         from pyhdf.SD import SD, SDC
         h = SD('test.hdf', SDC.WRITE | SDC.CREATE | SDC.TRUNC)
         data = np.arange(10. * 100, dtype=np.float32).reshape((10, 100))
@@ -92,17 +91,19 @@ class TestHDF4FileHandler(unittest.TestCase):
         h.end()
 
     def tearDown(self):
-        """Remove the previously created test file"""
+        """Remove the previously created test file."""
         os.remove('test.hdf')
 
     def test_all_basic(self):
-        """Test everything about the HDF4 class"""
+        """Test everything about the HDF4 class."""
         from satpy.readers.hdf4_utils import HDF4FileHandler
         file_handler = HDF4FileHandler('test.hdf', {}, {})
 
         for ds in ('ds1_f', 'ds1_i'):
             self.assertEqual(file_handler[ds + '/dtype'], np.float32 if ds.endswith('f') else np.int16)
             self.assertTupleEqual(file_handler[ds + '/shape'], (10, 100))
+            # make sure that the dtype is an instance, not the class
+            self.assertEqual(file_handler[ds].dtype.itemsize, 4)
             attrs = file_handler[ds].attrs
             self.assertEqual(attrs.get('test_attr_str'), 'test_string')
             self.assertEqual(attrs.get('test_attr_int'), 0)
@@ -122,7 +123,7 @@ class TestHDF4FileHandler(unittest.TestCase):
 
 
 def suite():
-    """The test suite for test_hdf4_utils."""
+    """Create the test suite for test_hdf4_utils."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestHDF4FileHandler))

--- a/satpy/tests/reader_tests/test_hdf4_utils.py
+++ b/satpy/tests/reader_tests/test_hdf4_utils.py
@@ -103,7 +103,7 @@ class TestHDF4FileHandler(unittest.TestCase):
             self.assertEqual(file_handler[ds + '/dtype'], np.float32 if ds.endswith('f') else np.int16)
             self.assertTupleEqual(file_handler[ds + '/shape'], (10, 100))
             # make sure that the dtype is an instance, not the class
-            self.assertEqual(file_handler[ds].dtype.itemsize, 4)
+            self.assertEqual(file_handler[ds].dtype.itemsize, 4 if ds.endswith('f') else 2)
             attrs = file_handler[ds].attrs
             self.assertEqual(attrs.get('test_attr_str'), 'test_string')
             self.assertEqual(attrs.get('test_attr_int'), 0)


### PR DESCRIPTION
I think we were getting lucky in previous versions of numpy and xarray where a `dtype` class could be used relatively interchangeably with a dytpe instance. Now in numpy 1.17 this isn't magic anymore and we have to fix some of our usage. For example, `np.float32` is a class (a `type`) so things like `np.float32.itemsize` now return a property of a class *not* an instance.

This PR makes it so the HDF4 utility class uses instances of dtypes to avoid some errors I was getting.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
