### PR TITLE
Update coefficients for FY-3B VIRR reflectance calibration

### DIFF
--- a/satpy/tests/reader_tests/test_virr_l1b.py
+++ b/satpy/tests/reader_tests/test_virr_l1b.py
@@ -126,6 +126,15 @@ class TestVIRRL1BReader(unittest.TestCase):
                        '3': 496.542155, '4': 297.444511, '5': 288.956557, 'solar_zenith_angle': .1,
                        'satellite_zenith_angle': .1, 'solar_azimuth_angle': .1, 'satellite_azimuth_angle': .1,
                        'longitude': 10}
+        if platform_name == 'FY3B':
+            # updated 2015 coefficients
+            band_values['1'] = -0.168
+            band_values['2'] = -0.2706
+            band_values['6'] = -1.5631
+            band_values['7'] = -0.2114
+            band_values['8'] = -0.171
+            band_values['9'] = -0.1606
+            band_values['10'] = -0.1328
         datasets = reader.load([band for band in band_values])
         for dataset in datasets:
             # Object returned by get_dataset.


### PR DESCRIPTION
In my continued effort to figure out why VIRR true colors look so terrible...

@kathys pointed me to some new coefficients for getting the reflectances out of the VIRR files. The images look much better.

 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->