### PR TITLE
Cache slicing arrays in bilinear resampler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
         - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff pycoast pydecorate geoviews'
+        - CONDA_DEPENDENCIES='xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff pycoast pydecorate geoviews zarr'
         - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital libtiff'
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
         - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff pycoast pydecorate geoviews zarr'
+        - CONDA_DEPENDENCIES='xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff pycoast pydecorate geoviews zarr six'
         - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital libtiff'
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ environment:
     PYTHON: "C:\\conda"
     MINICONDA_VERSION: "latest"
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-    CONDA_DEPENDENCIES: "xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coverage netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff pycoast pydecorate"
+    CONDA_DEPENDENCIES: "xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coverage netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff pycoast pydecorate zarr"
     PIP_DEPENDENCIES: "trollsift trollimage pyspectral pyorbital libtiff"
     CONDA_CHANNELS: "conda-forge"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ environment:
     PYTHON: "C:\\conda"
     MINICONDA_VERSION: "latest"
     CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\ci-helpers\\appveyor\\windows_sdk.cmd"
-    CONDA_DEPENDENCIES: "xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coverage netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff pycoast pydecorate zarr"
+    CONDA_DEPENDENCIES: "xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coverage netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff pycoast pydecorate zarr six"
     PIP_DEPENDENCIES: "trollsift trollimage pyspectral pyorbital libtiff"
     CONDA_CHANNELS: "conda-forge"
 

--- a/satpy/readers/generic_image.py
+++ b/satpy/readers/generic_image.py
@@ -60,8 +60,10 @@ logger = logging.getLogger(__name__)
 
 
 class GenericImageFileHandler(BaseFileHandler):
+    """Handle reading of generic image files."""
 
     def __init__(self, filename, filename_info, filetype_info):
+        """Initialize filehandler."""
         super(GenericImageFileHandler, self).__init__(
             filename, filename_info, filetype_info)
         self.finfo = filename_info
@@ -75,7 +77,7 @@ class GenericImageFileHandler(BaseFileHandler):
         self.read()
 
     def read(self):
-        """Read the image"""
+        """Read the image."""
         dataset = rasterio.open(self.finfo['filename'])
 
         # Create area definition
@@ -101,22 +103,26 @@ class GenericImageFileHandler(BaseFileHandler):
         self.file_content['image'] = data
 
     def get_area_def(self, dsid):
+        """Get area definition of the image."""
         if self.area is None:
             raise NotImplementedError("No CRS information available from image")
         return self.area
 
     @property
     def start_time(self):
+        """Return start time."""
         return self.finfo['start_time']
 
     @property
     def end_time(self):
+        """Return end time."""
         return self.finfo['end_time']
 
     def get_dataset(self, key, info):
         """Get a dataset from the file."""
         logger.debug("Reading %s.", key)
         return self.file_content[key.name]
+
 
 def mask_image_data(data):
     """Mask image data if alpha channel is present."""

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -433,8 +433,7 @@ class KDTreeResampler(BaseResampler):
 
     Args:
         cache_dir (str): Long term storage directory for intermediate
-                         results. By default only 10 different source/target
-                         combinations are cached to save space.
+                         results.
         mask_area (bool): Force resampled data's invalid pixel mask to be used
                           when searching for nearest neighbor pixels. By
                           default this is True for SwathDefinition source

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -124,7 +124,6 @@ and loaded using pyresample's utility methods::
 Examples coming soon...
 
 """
-
 import hashlib
 import json
 import os
@@ -136,6 +135,7 @@ import xarray as xr
 import dask
 import dask.array as da
 import zarr
+import six
 
 from pyresample.ewa import fornav, ll2cr
 from pyresample.geometry import SwathDefinition
@@ -143,6 +143,11 @@ from pyresample.kd_tree import XArrayResamplerNN
 from pyresample.bilinear.xarr import XArrayResamplerBilinear
 from satpy import CHUNK_SIZE
 from satpy.config import config_search_paths, get_config_path
+
+# In Python3 os.mkdir raises FileExistsError, in Python2 OSError
+if six.PY2:
+    FileExistsError = OSError
+
 
 LOG = getLogger(__name__)
 

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -815,13 +815,7 @@ class BilinearResampler(BaseResampler):
 
     def precompute(self, mask=None, radius_of_influence=50000, epsilon=0,
                    reduce_data=True, cache_dir=False, **kwargs):
-        """Create bilinear coefficients and store them for later use.
-
-        Note: The `mask` keyword should be provided if geolocation may be valid
-        where data points are invalid. This defaults to the `mask` attribute of
-        the `data` numpy masked array passed to the `resample` method.
-
-        """
+        """Create bilinear coefficients and store them for later use."""
         del kwargs
 
         if self.resampler is None:

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -791,7 +791,22 @@ class EWAResampler(BaseResampler):
 
 
 class BilinearResampler(BaseResampler):
-    """Resample using bilinear."""
+    """Resample using bilinear interpolation.
+
+    This resampler implements on-disk caching when the `cache_dir` argument
+    is provided to the `resample` method. This should provide significant
+    performance improvements on consecutive resampling of geostationary data.
+
+    Args:
+        cache_dir (str): Long term storage directory for intermediate
+                         results.
+        radius_of_influence (float): Search radius cut off distance in meters
+        epsilon (float): Allowed uncertainty in meters. Increasing uncertainty
+                         reduces execution time.
+        reduce_data (bool): Reduce the input data to (roughly) match the
+                            target area.
+
+    """
 
     def __init__(self, source_geo_def, target_geo_def):
         """Init BilinearResampler."""
@@ -805,6 +820,7 @@ class BilinearResampler(BaseResampler):
         Note: The `mask` keyword should be provided if geolocation may be valid
         where data points are invalid. This defaults to the `mask` attribute of
         the `data` numpy masked array passed to the `resample` method.
+
         """
         del kwargs
 

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -513,7 +513,7 @@ class KDTreeResampler(BaseResampler):
         fname_zarr = self._create_cache_filename(cache_dir, prefix='nn_lut-',
                                                  mask=mask, fmt='.zarr',
                                                  **kwargs)
-
+        LOG.debug("Check if %s exists", fname_np)
         if os.path.exists(fname_np) and not os.path.exists(fname_zarr):
             import warnings
             warnings.warn("Using Numpy files as resampling cache is "
@@ -526,6 +526,7 @@ class KDTreeResampler(BaseResampler):
 
             # Write indices to Zarr file
             zarr_out.to_zarr(fname_zarr)
+            LOG.debug("Resampling LUT saved to %s", fname_zarr)
 
     def load_neighbour_info(self, cache_dir, mask=None, **kwargs):
         """Read index arrays from either the in-memory or disk cache."""

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -434,10 +434,10 @@ class KDTreeResampler(BaseResampler):
     Args:
         cache_dir (str): Long term storage directory for intermediate
                          results.
-        mask_area (bool): Force resampled data's invalid pixel mask to be used
-                          when searching for nearest neighbor pixels. By
-                          default this is True for SwathDefinition source
-                          areas and False for all other area definition types.
+        mask (bool): Force resampled data's invalid pixel mask to be used
+                     when searching for nearest neighbor pixels. By
+                     default this is True for SwathDefinition source
+                     areas and False for all other area definition types.
         radius_of_influence (float): Search radius cut off distance in meters
         epsilon (float): Allowed uncertainty in meters. Increasing uncertainty
                          reduces execution time.

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -881,7 +881,12 @@ def _move_existing_caches(cache_dir, filename):
         os.mkdir(old_cache_dir)
     except FileExistsError:
         pass
-    shutil.move(filename, old_cache_dir)
+    try:
+        shutil.move(filename, old_cache_dir)
+    except shutil.Error:
+        os.remove(os.path.join(old_cache_dir,
+                               os.path.basename(filename)))
+        shutil.move(filename, old_cache_dir)
     LOG.warning("Old cache file was moved to %s", old_cache_dir)
 
 

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -817,6 +817,7 @@ class BilinearResampler(BaseResampler):
                    reduce_data=True, cache_dir=False, **kwargs):
         """Create bilinear coefficients and store them for later use."""
         del kwargs
+        del mask
 
         if self.resampler is None:
             kwargs = dict(source_geo_def=self.source_geo_def,

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -843,6 +843,9 @@ class BilinearResampler(BaseResampler):
             filename = self._create_cache_filename(cache_dir,
                                                    prefix='bil_lut-',
                                                    **kwargs)
+            # There are some old caches, move them out of the way
+            if os.path.exists(filename):
+                _move_existing_caches(cache_dir, filename)
             LOG.info('Saving BIL neighbour info to %s', filename)
             zarr_out = xr.Dataset()
             for idx_name, coord in BIL_COORDINATES.items():
@@ -867,6 +870,19 @@ class BilinearResampler(BaseResampler):
                                                       output_shape=target_shape)
 
         return update_resampled_coords(data, res, self.target_geo_def)
+
+
+def _move_existing_caches(cache_dir, filename):
+    """Move existing cache files out of the way."""
+    import os
+    import shutil
+    old_cache_dir = os.path.join(cache_dir, 'moved_by_satpy')
+    try:
+        os.mkdir(old_cache_dir)
+    except FileExistsError:
+        pass
+    shutil.move(filename, old_cache_dir)
+    LOG.warning("Old cache file was moved to %s", old_cache_dir)
 
 
 def _mean(data, y_size, x_size):

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -166,7 +166,7 @@ class TestKDTreeResampler(unittest.TestCase):
             the_dir = tempfile.mkdtemp()
             resampler = KDTreeResampler(source_area, target_area)
             create_filename.return_value = os.path.join(the_dir, 'test_cache.zarr')
-            zarr_open.side_effect = IOError()
+            zarr_open.side_effect = ValueError()
             resampler.precompute(cache_dir=the_dir)
             # assert data was saved to the on-disk cache
             self.assertEqual(len(mock_dset.to_zarr.mock_calls), 1)

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -571,6 +571,10 @@ class TestBilinearResampler(unittest.TestCase):
             self.assertTrue(os.path.exists(
                 os.path.join(the_dir, 'moved_by_satpy',
                              'test.zarr')))
+            # Run again to see that the existing dir doesn't matter
+            with open(zarr_file, 'w') as fid:
+                fid.write('42')
+            _move_existing_caches(the_dir, zarr_file)
         finally:
             shutil.rmtree(the_dir)
 

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -137,10 +137,10 @@ class TestKDTreeResampler(unittest.TestCase):
 
     @mock.patch('satpy.resample.KDTreeResampler._check_numpy_cache')
     @mock.patch('satpy.resample.xr.Dataset')
-    @mock.patch('satpy.resample.da.from_zarr')
+    @mock.patch('satpy.resample.zarr.open')
     @mock.patch('satpy.resample.KDTreeResampler._create_cache_filename')
     @mock.patch('satpy.resample.XArrayResamplerNN')
-    def test_kd_resampling(self, resampler, create_filename, from_zarr,
+    def test_kd_resampling(self, resampler, create_filename, zarr_open,
                            xr_dset, cnc):
         """Test the kd resampler."""
         import numpy as np
@@ -166,17 +166,17 @@ class TestKDTreeResampler(unittest.TestCase):
             the_dir = tempfile.mkdtemp()
             resampler = KDTreeResampler(source_area, target_area)
             create_filename.return_value = os.path.join(the_dir, 'test_cache.zarr')
-            from_zarr.side_effect = IOError()
+            zarr_open.side_effect = IOError()
             resampler.precompute(cache_dir=the_dir)
             # assert data was saved to the on-disk cache
             self.assertEqual(len(mock_dset.to_zarr.mock_calls), 1)
-            # assert that from_zarr was called to try to from_zarr something from disk
-            self.assertEqual(len(from_zarr.mock_calls), 1)
+            # assert that zarr_open was called to try to zarr_open something from disk
+            self.assertEqual(len(zarr_open.mock_calls), 1)
             # we should have cached things in-memory
             self.assertEqual(len(resampler._index_caches), 1)
             nbcalls = len(resampler.resampler.get_neighbour_info.mock_calls)
             # test reusing the resampler
-            from_zarr.side_effect = None
+            zarr_open.side_effect = None
 
             class FakeZarr(dict):
 
@@ -186,7 +186,7 @@ class TestKDTreeResampler(unittest.TestCase):
                 def astype(self, dtype):
                     pass
 
-            from_zarr.return_value = FakeZarr(valid_input_index=1,
+            zarr_open.return_value = FakeZarr(valid_input_index=1,
                                               valid_output_index=2,
                                               index_array=3,
                                               distance_array=4)
@@ -194,7 +194,7 @@ class TestKDTreeResampler(unittest.TestCase):
             # we already have things cached in-memory, no need to save again
             self.assertEqual(len(mock_dset.to_zarr.mock_calls), 1)
             # we already have things cached in-memory, don't need to load
-            self.assertEqual(len(from_zarr.mock_calls), 1)
+            self.assertEqual(len(zarr_open.mock_calls), 1)
             # we should have cached things in-memory
             self.assertEqual(len(resampler._index_caches), 1)
             self.assertEqual(len(resampler.resampler.get_neighbour_info.mock_calls), nbcalls)
@@ -202,7 +202,7 @@ class TestKDTreeResampler(unittest.TestCase):
             # test loading saved resampler
             resampler = KDTreeResampler(source_area, target_area)
             resampler.precompute(cache_dir=the_dir)
-            self.assertEqual(len(from_zarr.mock_calls), 4)
+            self.assertEqual(len(zarr_open.mock_calls), 4)
             self.assertEqual(len(resampler.resampler.get_neighbour_info.mock_calls), nbcalls)
             # we should have cached things in-memory now
             self.assertEqual(len(resampler._index_caches), 1)
@@ -418,11 +418,13 @@ class TestNativeResampler(unittest.TestCase):
 class TestBilinearResampler(unittest.TestCase):
     """Test the bilinear resampler."""
 
+    @mock.patch('os.path.exists')
     @mock.patch('satpy.resample.xr.Dataset')
-    @mock.patch('satpy.resample.da.from_zarr')
+    @mock.patch('satpy.resample.zarr.open')
     @mock.patch('satpy.resample.BilinearResampler._create_cache_filename')
     @mock.patch('satpy.resample.XArrayResamplerBilinear')
-    def test_bil_resampling(self, resampler, create_filename, from_zarr, xr_dset):
+    def test_bil_resampling(self, resampler, create_filename, zarr_open,
+                            xr_dset, exists):
         """Test the bilinear resampler."""
         import numpy as np
         import dask.array as da
@@ -432,10 +434,11 @@ class TestBilinearResampler(unittest.TestCase):
 
         mock_dset = mock.MagicMock()
         xr_dset.return_value = mock_dset
+        exists.return_value = False
 
         # Test that bilinear resampling info calculation is called,
         # and the info is saved
-        from_zarr.side_effect = IOError()
+        zarr_open.side_effect = IOError()
         resampler = BilinearResampler(source_swath, target_area)
         resampler.precompute(
             mask=da.arange(5, chunks=5).astype(np.bool))
@@ -443,8 +446,8 @@ class TestBilinearResampler(unittest.TestCase):
         resampler.resampler.get_bil_info.assert_called_with()
         self.assertFalse(len(mock_dset.to_zarr.mock_calls), 1)
         resampler.resampler.reset_mock()
-        from_zarr.reset_mock()
-        from_zarr.side_effect = None
+        zarr_open.reset_mock()
+        zarr_open.side_effect = None
 
         # Test that get_sample_from_bil_info is called properly
         fill_value = 8
@@ -465,26 +468,27 @@ class TestBilinearResampler(unittest.TestCase):
         # Test that the resampling info is tried to read from the disk
         resampler = BilinearResampler(source_swath, target_area)
         resampler.precompute(cache_dir='.')
-        from_zarr.assert_called()
+        zarr_open.assert_called()
 
         # Test caching the resampling info
         try:
             the_dir = tempfile.mkdtemp()
             resampler = BilinearResampler(source_area, target_area)
             create_filename.return_value = os.path.join(the_dir, 'test_cache.zarr')
-            from_zarr.reset_mock()
-            from_zarr.side_effect = IOError()
+            zarr_open.reset_mock()
+            zarr_open.side_effect = IOError()
 
             resampler.precompute(cache_dir=the_dir)
             xr_dset.assert_called()
             # assert data was saved to the on-disk cache
             self.assertEqual(len(mock_dset.to_zarr.mock_calls), 1)
-            # assert that from_zarr was called to try to load something from disk
-            self.assertEqual(len(from_zarr.mock_calls), 5)
+            # assert that zarr.open was called to try to load
+            # something from disk
+            self.assertEqual(len(zarr_open.mock_calls), 1)
 
             nbcalls = len(resampler.resampler.get_bil_info.mock_calls)
             # test reusing the resampler
-            from_zarr.side_effect = None
+            zarr_open.side_effect = None
 
             class FakeZarr(dict):
 
@@ -497,21 +501,24 @@ class TestBilinearResampler(unittest.TestCase):
                 def compute(self):
                     return self
 
-            from_zarr.return_value = FakeZarr(bilinear_s=1,
+            zarr_open.return_value = FakeZarr(bilinear_s=1,
                                               bilinear_t=2,
-                                              valid_input_index=3,
-                                              index_array=4)
+                                              slices_x=3,
+                                              slices_y=4,
+                                              mask_slices=5,
+                                              out_coords_x=6,
+                                              out_coords_y=7)
             resampler.precompute(cache_dir=the_dir)
             # we already have things cached in-memory, no need to save again
             self.assertEqual(len(mock_dset.to_zarr.mock_calls), 1)
             # we already have things cached in-memory, don't need to load
-            # self.assertEqual(len(from_zarr.mock_calls), 1)
+            # self.assertEqual(len(zarr_open.mock_calls), 1)
             self.assertEqual(len(resampler.resampler.get_bil_info.mock_calls), nbcalls)
 
             # test loading saved resampler
             resampler = BilinearResampler(source_area, target_area)
             resampler.precompute(cache_dir=the_dir)
-            self.assertEqual(len(from_zarr.mock_calls), 9)
+            self.assertEqual(len(zarr_open.mock_calls), 2)
             self.assertEqual(len(resampler.resampler.get_bil_info.mock_calls), nbcalls)
             # we should have cached things in-memory now
             # self.assertEqual(len(resampler._index_caches), 1)

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -522,6 +522,16 @@ class TestBilinearResampler(unittest.TestCase):
             self.assertEqual(len(resampler.resampler.get_bil_info.mock_calls), nbcalls)
             # we should have cached things in-memory now
             # self.assertEqual(len(resampler._index_caches), 1)
+
+            # Test that existing cache file is moved away
+            zarr_file = os.path.join(the_dir, 'test.zarr')
+            with open(zarr_file, 'w') as fid:
+                fid.write('42')
+            from satpy.resample import _move_existing_caches
+            _move_existing_caches(the_dir, zarr_file)
+            self.assertFalse(os.path.exists(zarr_file))
+            self.assertTrue(os.path.join(the_dir, 'moved_by_satpy',
+                                         'test.zarr'))
         finally:
             shutil.rmtree(the_dir)
 

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -225,14 +225,19 @@ class TestKDTreeResampler(unittest.TestCase):
         zarr_out = mock.MagicMock()
         xr_Dataset.return_value = zarr_out
 
-        # The correct filenames
-        fname_np = 'resample_lut-2ece018b649510bc57f800b765fb3bb160dc1d5f.npz'
-        fname_zarr = 'nn_lut-2ece018b649510bc57f800b765fb3bb160dc1d5f.zarr'
-
         try:
             the_dir = tempfile.mkdtemp()
-            np_path = os.path.join(the_dir, fname_np)
-            zarr_path = os.path.join(the_dir, fname_zarr)
+            kwargs = {}
+            np_path = resampler._create_cache_filename(the_dir,
+                                                       prefix='resample_lut-',
+                                                       fmt='.npz',
+                                                       mask=None,
+                                                       **kwargs)
+            zarr_path = resampler._create_cache_filename(the_dir,
+                                                         prefix='nn_lut-',
+                                                         fmt='.zarr',
+                                                         mask=None,
+                                                         **kwargs)
             resampler._check_numpy_cache(the_dir)
             np_load.assert_not_called()
             zarr_out.to_zarr.assert_not_called()

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -523,6 +523,13 @@ class TestBilinearResampler(unittest.TestCase):
             # we should have cached things in-memory now
             # self.assertEqual(len(resampler._index_caches), 1)
 
+        finally:
+            shutil.rmtree(the_dir)
+
+    def test_move_existing_caches(self):
+        """Test that existing caches are moved to a subdirectory."""
+        try:
+            the_dir = tempfile.mkdtemp()
             # Test that existing cache file is moved away
             zarr_file = os.path.join(the_dir, 'test.zarr')
             with open(zarr_file, 'w') as fid:
@@ -530,8 +537,9 @@ class TestBilinearResampler(unittest.TestCase):
             from satpy.resample import _move_existing_caches
             _move_existing_caches(the_dir, zarr_file)
             self.assertFalse(os.path.exists(zarr_file))
-            self.assertTrue(os.path.join(the_dir, 'moved_by_satpy',
-                                         'test.zarr'))
+            self.assertTrue(os.path.exists(
+                os.path.join(the_dir, 'moved_by_satpy',
+                             'test.zarr')))
         finally:
             shutil.rmtree(the_dir)
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.11.0', 'trollsift',
             'dask[array] >=0.17.1', 'pyproj', 'zarr']
 
 test_requires = ['behave', 'h5py', 'netCDF4', 'pyhdf', 'imageio', 'libtiff',
-                 'rasterio', 'geoviews']
+                 'rasterio', 'geoviews', 'pycoast', 'pydecorate']
 
 if sys.version < '3.0':
     test_requires.append('mock')


### PR DESCRIPTION
For bilinear interpolation, this PR caches the slicing arrays (for data and masking) instead of the `valid_input_index` and `index_array`, from which the current version would always re-calculate these slicing arrays.

Also, instead of using `da.from_zarr()` to load the cache, direct use of `zarr` seems to make a big difference in speed. When/if someone makes the effort to completely daskify the bilinear resampling, this change might need to be reverted.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
