### PR TITLE
Add night lights compositor and SEVIRI day/night composite

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1418,7 +1418,9 @@ class StaticImageCompositor(GenericCompositor):
         from satpy import Scene
         # Check if filename exists, if not then try from SATPY_ANCPATH
         if (not os.path.isfile(self.filename)):
-            self.filename = os.path.join(get_environ_ancpath(), self.filename)
+                tmp_filename = os.path.join(get_environ_ancpath(), self.filename)
+                if (os.path.isfile(tmp_filename)):
+                        self.filename = tmp_filename
         scn = Scene(reader='generic_image', filenames=[self.filename])
         scn.load(['image'])
         img = scn['image']

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1419,7 +1419,6 @@ class StaticImageCompositor(GenericCompositor):
         # Check if filename exists, if not then try from SATPY_ANCPATH
         if (not os.path.isfile(self.filename)):
             self.filename = os.path.join(get_environ_ancpath(), self.filename)
-        print(self.filename)
         scn = Scene(reader='generic_image', filenames=[self.filename])
         scn.load(['image'])
         img = scn['image']

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -35,6 +35,7 @@ except ImportError:
     from yaml import Loader as UnsafeLoader
 
 from satpy.config import CONFIG_PATH, config_search_paths, recursive_dict_update
+from satpy.config import get_environ_ancpath
 from satpy.dataset import DATASET_KEYS, DatasetID, MetadataObject, combine_metadata
 from satpy.readers import DatasetDict
 from satpy.utils import sunzen_corr_cos, atmospheric_path_length_correction, get_satpos
@@ -1410,6 +1411,10 @@ class StaticImageCompositor(GenericCompositor):
     def __call__(self, *args, **kwargs):
         """Call the compositor."""
         from satpy import Scene
+        # Check if filename exists, if not then try from SATPY_ANCPATH
+        if (not os.path.isfile(self.filename)):
+            self.filename = os.path.join(get_environ_ancpath(), self.filename)
+        print(self.filename)
         scn = Scene(reader='generic_image', filenames=[self.filename])
         scn.load(['image'])
         img = scn['image']

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1388,7 +1388,12 @@ class SandwichCompositor(GenericCompositor):
 
 
 class StaticImageCompositor(GenericCompositor):
-    """A compositor that loads a static image from disk."""
+    """A compositor that loads a static image from disk.
+
+    If the filename passed to this compositor is not valid then
+    the SATPY_ANCPATH environment variable will be checked to see
+    if the image is located there
+    """
 
     def __init__(self, name, filename=None, area=None, **kwargs):
         """Collect custom configuration values.

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1420,7 +1420,7 @@ class StaticImageCompositor(GenericCompositor):
         if (not os.path.isfile(self.filename)):
             tmp_filename = os.path.join(get_environ_ancpath(), self.filename)
             if (os.path.isfile(tmp_filename)):
-                    self.filename = tmp_filename
+                self.filename = tmp_filename
         scn = Scene(reader='generic_image', filenames=[self.filename])
         scn.load(['image'])
         img = scn['image']

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1418,9 +1418,9 @@ class StaticImageCompositor(GenericCompositor):
         from satpy import Scene
         # Check if filename exists, if not then try from SATPY_ANCPATH
         if (not os.path.isfile(self.filename)):
-                tmp_filename = os.path.join(get_environ_ancpath(), self.filename)
-                if (os.path.isfile(tmp_filename)):
-                        self.filename = tmp_filename
+            tmp_filename = os.path.join(get_environ_ancpath(), self.filename)
+            if (os.path.isfile(tmp_filename)):
+                    self.filename = tmp_filename
         scn = Scene(reader='generic_image', filenames=[self.filename])
         scn.load(['image'])
         img = scn['image']

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -333,3 +333,40 @@ composites:
       - name: 'HRV'
         modifiers: [sunz_corrected]
       - name: colorized_ir_clouds
+
+  natural_color_with_night_ir:
+    compositor: !!python/name:satpy.composites.DayNightCompositor
+    standard_name: natural_color_with_night_ir
+    prerequisites:
+      - natural_color
+      - night_ir_with_background
+
+  natural_color_with_night_ir_hires:
+    compositor: !!python/name:satpy.composites.DayNightCompositor
+    standard_name: natural_color_with_night_ir_hires
+    prerequisites:
+      - natural_color
+      - night_ir_with_background_hires
+
+  night_ir_alpha:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    standard_name: night_ir_alpha
+    prerequisites:
+      - name: IR_039
+      - name: IR_108
+      - name: IR_120
+      - name: IR_108
+
+  night_ir_with_background:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: night_ir_with_background
+    prerequisites:
+      - night_ir_alpha
+      - night_background
+
+  night_ir_with_background_hires:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: night_ir_with_background_hires
+    prerequisites:
+      - night_ir_alpha
+      - night_background_hires

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -391,3 +391,13 @@ composites:
     transition_min: 258.15
     transition_max: 298.15
     transition_gamma: 3.0
+
+  night_background:
+    compositor: !!python/name:satpy.composites.StaticImageCompositor
+    standard_name: night_background
+    filename: BlackMarble_2016_01deg_geo.tif
+
+  night_background_hires:
+    compositor: !!python/name:satpy.composites.StaticImageCompositor
+    standard_name: night_background_hires
+    filename: BlackMarble_2016_3km_geo.tif

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -793,10 +793,6 @@ enhancements:
         stretch: crude
         min_stretch: [0, 0, 0]
         max_stretch: [1, 1, 1]
-    - name: inverse
-      method: *inversefun
-      args:
-      - [false, false, false]
 
   night_background:
     standard_name: night_background
@@ -828,7 +824,3 @@ enhancements:
         stretch: crude
         min_stretch: [0, 0, 0]
         max_stretch: [1, 1, 1]
-    - name: inverse
-      method: *inversefun
-      args:
-      - [false, false, false]

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -783,3 +783,52 @@ enhancements:
           stretch: crude
           min_stretch: [0, 0, 0]
           max_stretch: [1, 1, 1]
+
+  true_color_with_night_ir:
+    standard_name: true_color_with_night_ir
+    operations:
+    - name: stretch
+      method: *stretchfun
+      kwargs:
+        stretch: crude
+        min_stretch: [0, 0, 0]
+        max_stretch: [1, 1, 1]
+    - name: inverse
+      method: *inversefun
+      args:
+      - [false, false, false]
+      
+  night_background:
+    standard_name: night_background
+    operations:
+    - name: stretch
+      method: *stretchfun
+      kwargs:
+        stretch: crude
+        min_stretch: [0, 0, 0]
+        max_stretch: [255, 255, 255]
+
+  night_ir_alpha:
+    standard_name: night_ir_alpha
+    operations:
+    - name: stretch
+      method: *stretchfun
+      kwargs: {stretch: linear, cutoffs: [0.02, 0.02]}
+    - name: inverse
+      method: *inversefun
+      args:
+      - [true, true, true, true]
+
+  night_ir_with_background:
+    standard_name: night_ir_with_background
+    operations:
+    - name: stretch
+      method: *stretchfun
+      kwargs:
+        stretch: crude
+        min_stretch: [0, 0, 0]
+        max_stretch: [1, 1, 1]
+    - name: inverse
+      method: *inversefun
+      args:
+      - [false, false, false]

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -797,7 +797,7 @@ enhancements:
       method: *inversefun
       args:
       - [false, false, false]
-      
+
   night_background:
     standard_name: night_background
     operations:


### PR DESCRIPTION
This PR adds two new composites to `visir.yaml`:

- `night_background`: A low resolution (0.1 degree) night lights background image, which can be downloaded here: https://eoimages.gsfc.nasa.gov/images/imagerecords/144000/144898/BlackMarble_2016_01deg_geo.tif
- `night_background_hires`: A medium resolution (3km) night lights background image, which can be downloaded here: https://eoimages.gsfc.nasa.gov/images/imagerecords/144000/144898/BlackMarble_2016_3km_geo.tif

I've added are some new composites to `seviri.yaml` too:
- `natural_color_with_night_ir`: A composite that uses `natural_color` for daylight areas and `night_background` for night areas.
- `natural_color_with_night_ir_hires`: A composite that uses `natural_color` for daylight areas and `night_background_hires` for night areas.

Some associated composites are also added: `night_ir_alpha`, `night_ir_with_background` and `night_ir_with_background_hires`.

Lastly, I have updated the `StaticImageCompositor` in `satpy/composites/__init__.py` to check if the passed filename exists. If not, it will instead try looking in the directory defined by the `SATPY_ANCPATH` environment variable.

The majority of the work was done by @TAlonglong, I just converted this to SEVIRI (from ABI) and created the PR!

 - [ ] Tests added and test suite added to parent suite 
 - [x] Tests passed
 - [x] Passes ``flake8 satpy``
 - [ ] Fully documented
