### PR TITLE
Fix compact viirs angle interpolation at the poles

### DIFF
--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -136,6 +136,7 @@ class TestUtils(unittest.TestCase):
         self.assertAlmostEqual(z__, sqrt(1) / 2)
 
     def test_xyz2lonlat(self):
+        """Test xyz2lonlat."""
         lon, lat = xyz2lonlat(1, 0, 0)
         self.assertAlmostEqual(lon, 0)
         self.assertAlmostEqual(lat, 0)
@@ -143,6 +144,10 @@ class TestUtils(unittest.TestCase):
         lon, lat = xyz2lonlat(0, 1, 0)
         self.assertAlmostEqual(lon, 90)
         self.assertAlmostEqual(lat, 0)
+
+        lon, lat = xyz2lonlat(0, 0, 1, asin=True)
+        self.assertAlmostEqual(lon, 0)
+        self.assertAlmostEqual(lat, 90)
 
         lon, lat = xyz2lonlat(0, 0, 1)
         self.assertAlmostEqual(lon, 0)
@@ -153,6 +158,7 @@ class TestUtils(unittest.TestCase):
         self.assertAlmostEqual(lat, 0)
 
     def test_xyz2angle(self):
+        """Test xyz2angle."""
         azi, zen = xyz2angle(1, 0, 0)
         self.assertAlmostEqual(azi, 90)
         self.assertAlmostEqual(zen, 90)
@@ -162,6 +168,10 @@ class TestUtils(unittest.TestCase):
         self.assertAlmostEqual(zen, 90)
 
         azi, zen = xyz2angle(0, 0, 1)
+        self.assertAlmostEqual(azi, 0)
+        self.assertAlmostEqual(zen, 0)
+
+        azi, zen = xyz2angle(0, 0, 1, acos=True)
         self.assertAlmostEqual(azi, 0)
         self.assertAlmostEqual(zen, 0)
 
@@ -178,6 +188,7 @@ class TestUtils(unittest.TestCase):
         self.assertAlmostEqual(zen, 90)
 
     def test_proj_units_to_meters(self):
+        """Test proj units to meters conversion."""
         prj = '+asd=123123123123'
         res = proj_units_to_meters(prj)
         self.assertEqual(res, prj)
@@ -196,6 +207,7 @@ class TestUtils(unittest.TestCase):
 
     @mock.patch('satpy.utils.warnings.warn')
     def test_get_satpos(self, warn_mock):
+        """Test getting the satellite position."""
         orb_params = {'nadir_longitude': 1,
                       'satellite_actual_longitude': 1.1,
                       'satellite_nominal_longitude': 1.2,
@@ -244,8 +256,7 @@ class TestUtils(unittest.TestCase):
 
 
 def suite():
-    """The test suite.
-    """
+    """Test suite."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestUtils))

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -155,7 +155,7 @@ def xyz2lonlat(x, y, z, asin=False):
     """Convert cartesian to lon lat."""
     lon = np.rad2deg(np.arctan2(y, x))
     if asin:
-        lat = np.arcsin(z)
+        lat = np.rad2deg(np.arcsin(z))
     else:
         lat = np.rad2deg(np.arctan2(z, np.sqrt(x ** 2 + y ** 2)))
     return lon, lat

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -16,8 +16,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Module defining various utilities.
-"""
+"""Module defining various utilities."""
 
 import logging
 import os
@@ -37,21 +36,21 @@ TRACE_LEVEL = 5
 
 
 class OrderedConfigParser(object):
-
     """Intercepts read and stores ordered section names.
+
     Cannot use inheritance and super as ConfigParser use old style classes.
     """
 
     def __init__(self, *args, **kwargs):
+        """Initialize the instance."""
         self.config_parser = configparser.ConfigParser(*args, **kwargs)
 
     def __getattr__(self, name):
+        """Get the attribute."""
         return getattr(self.config_parser, name)
 
     def read(self, filename):
-        """Reads config file
-        """
-
+        """Read config file."""
         try:
             conf_file = open(filename, 'r')
             config = conf_file.read()
@@ -65,9 +64,7 @@ class OrderedConfigParser(object):
         return self.config_parser.read(filename)
 
     def sections(self):
-        """Get sections from config file
-        """
-
+        """Get sections from config file."""
         try:
             return self.section_keys
         except:  # noqa: E722
@@ -75,7 +72,7 @@ class OrderedConfigParser(object):
 
 
 def ensure_dir(filename):
-    """Checks if the dir of f exists, otherwise create it."""
+    """Check if the dir of f exists, otherwise create it."""
     directory = os.path.dirname(filename)
     if directory and not os.path.isdir(directory):
         os.makedirs(directory)
@@ -92,8 +89,7 @@ def trace_on():
 
 
 def logging_on(level=logging.WARNING):
-    """Turn logging on.
-    """
+    """Turn logging on."""
     global _is_logging_on
 
     if not _is_logging_on:
@@ -112,8 +108,7 @@ def logging_on(level=logging.WARNING):
 
 
 def logging_off():
-    """Turn logging off.
-    """
+    """Turn logging off."""
     logging.getLogger('').handlers = [logging.NullHandler()]
 
 
@@ -136,7 +131,7 @@ def get_logger(name):
 
 
 def in_ipynb():
-    """Are we in a jupyter notebook?"""
+    """Check if we are in a jupyter notebook."""
     try:
         return 'ZMQ' in get_ipython().__class__.__name__
     except NameError:
@@ -156,10 +151,13 @@ def lonlat2xyz(lon, lat):
     return x, y, z
 
 
-def xyz2lonlat(x, y, z):
+def xyz2lonlat(x, y, z, asin=False):
     """Convert cartesian to lon lat."""
     lon = np.rad2deg(np.arctan2(y, x))
-    lat = np.rad2deg(np.arctan2(z, np.sqrt(x ** 2 + y ** 2)))
+    if asin:
+        lat = np.arcsin(z)
+    else:
+        lat = np.rad2deg(np.arctan2(z, np.sqrt(x ** 2 + y ** 2)))
     return lon, lat
 
 
@@ -173,10 +171,13 @@ def angle2xyz(azi, zen):
     return x, y, z
 
 
-def xyz2angle(x, y, z):
+def xyz2angle(x, y, z, acos=False):
     """Convert cartesian to azimuth and zenith."""
     azi = np.rad2deg(np.arctan2(x, y))
-    zen = 90 - np.rad2deg(np.arctan2(z, np.sqrt(x ** 2 + y ** 2)))
+    if acos:
+        zen = np.rad2deg(np.arccos(z))
+    else:
+        zen = 90 - np.rad2deg(np.arctan2(z, np.sqrt(x ** 2 + y ** 2)))
     return azi, zen
 
 
@@ -217,7 +218,6 @@ def sunzen_corr_cos(data, cos_zen, limit=88., max_sza=95.):
     0. Both ``data`` and ``cos_zen`` should be 2D arrays of the same shape.
 
     """
-
     # Convert the zenith angle limit to cosine of zenith angle
     limit_rad = np.deg2rad(limit)
     limit_cos = np.cos(limit_rad)
@@ -295,6 +295,7 @@ def get_satpos(dataset):
 
     Returns:
         Geodetic longitude, latitude, altitude
+
     """
     try:
         orb_params = dataset.attrs['orbital_parameters']


### PR DESCRIPTION
This PR fixes the wrong interpolation done at the poles for satellite and sun angles in the compact viirs reader.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

The effect was very local but led to a dramatic effect on some composites. The following figure exhibits the problem affecting the sun zenith:

![Instab](https://user-images.githubusercontent.com/167802/64780611-1f965280-d561-11e9-9c6f-1fb0e41de305.png)

It turns out it was probably due to some numerical instability. This is addressed now in the cartesian to angles conversion
