### PR TITLE
Fix ABI L2 reader not scaling and masking data

### DIFF
--- a/satpy/etc/enhancements/abi.yaml
+++ b/satpy/etc/enhancements/abi.yaml
@@ -11,3 +11,12 @@ enhancements:
         kwargs: {gamma: 2.0}
       - name: contrast
         method: !!python/name:satpy.enhancements.abi.cimss_true_color_contrast
+  cmi_reflectance_default:
+    standard_name: toa_lambertian_equivalent_albedo_multiplied_by_cosine_solar_zenith_angle
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0.0, max_stretch: 100.}
+      - name: gamma
+        method: !!python/name:satpy.enhancements.gamma
+        kwargs: {gamma: 1.5}

--- a/satpy/etc/readers/abi_l2_nc.yaml
+++ b/satpy/etc/readers/abi_l2_nc.yaml
@@ -494,9 +494,9 @@ file_types:
 
   abi_l2_vaa:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-VAA{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc', '{system_environment:2s}_{mission_id:3s}-L2-VAA{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-128600_0.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-VAA{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc', '{system_environment:2s}_{mission_id:3s}-L2-VAA{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-128600_0.nc']
 
   # CSPP - Geo Unofficial product
   abi_l2_nav:
     file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-NAV{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc', '{system_environment:2s}_{mission_id:3s}-L2-VAA{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-128600_0.nc']
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-NAV{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']

--- a/satpy/etc/readers/abi_l2_nc.yaml
+++ b/satpy/etc/readers/abi_l2_nc.yaml
@@ -8,270 +8,255 @@ reader:
 
 
 datasets:
-  lon:
-    name: lon
-    file_type:
-      - abi_l2_rsr
-      - abi_l2_dsr
-    units: "degrees_east"
-    standard_name: longitude
-
-  lat:
-    name: lat
-    file_type:
-      - abi_l2_rsr
-      - abi_l2_dsr
-    units: "degrees_north"
-    standard_name: latitude
-
 # --- Cloud Moisture Image Products ---
   CMIP_C01:                          # Cloud Moisture Image Products Channel 1
     name: C01
     wavelength: [0.450, 0.470, 0.490]
-    resolution: 1000
+    calibration: reflectance
     file_type: abi_l2_cmip_c01
     file_key: CMI
 
   CMIP_C02:                           # Cloud Moisture Image Products Channel 2
     name: C02
     wavelength: [0.590, 0.640, 0.690]
-    resolution: 500
+    calibration: reflectance
     file_type: abi_l2_cmip_c02
     file_key: CMI
 
   CMIP_C03:                          # Cloud Moisture Image Products Channel 3
     name: C03
     wavelength: [0.8455, 0.865, 0.8845]
-    resolution: 1000
+    calibration: reflectance
     file_type: abi_l2_cmip_c03
     file_key: CMI
 
   CMIP_C04:                          # Cloud Moisture Image Products Channel 4
     name: C04
     wavelength: [1.3705, 1.378, 1.3855]
-    resolution: 2000
+    calibration: reflectance
     file_type: abi_l2_cmip_c04
     file_key: CMI
 
   CMIP_C05:                          # Cloud Moisture Image Products Channel 5
     name: C05
     wavelength: [1.580, 1.610, 1.640]
-    resolution: 1000
+    calibration: reflectance
     file_type: abi_l2_cmip_c05
     file_key: CMI
 
   CMIP_C06:                          # Cloud Moisture Image Products Channel 6
     name: C06
     wavelength: [2.225, 2.250, 2.275]
-    resolution: 2000
+    calibration: reflectance
     file_type: abi_l2_cmip_c06
     file_key: CMI
 
   CMIP_C07:                          # Cloud Moisture Image Products Channel 7
     name: C07
     wavelength: [3.80, 3.90, 4.00]
-    resolution: 2000
+    calibration: brightness_temperature
     file_type: abi_l2_cmip_c07
     file_key: CMI
 
   CMIP_C08:                          # Cloud Moisture Image Products Channel 8
     name: C08
     wavelength: [5.770, 6.185, 6.600]
-    resolution: 2000
+    calibration: brightness_temperature
     file_type: abi_l2_cmip_c08
     file_key: CMI
 
   CMIP_C09:                          # Cloud Moisture Image Products Channel 9
     name: C09
     wavelength: [6.75, 6.95, 7.15]
-    resolution: 2000
+    calibration: brightness_temperature
     file_type: abi_l2_cmip_c09
     file_key: CMI
 
   CMIP_C10:                          # Cloud Moisture Image Products Channel 10
     name: C10
     wavelength: [7.24, 7.34, 7.44]
-    resolution: 2000
+    calibration: brightness_temperature
     file_type: abi_l2_cmip_c10
     file_key: CMI
 
   CMIP_C11:                          # Cloud Moisture Image Products Channel 11
     name: C11
     wavelength: [8.30, 8.50, 8.70]
-    resolution: 2000
+    calibration: brightness_temperature
     file_type: abi_l2_cmip_c11
     file_key: CMI
 
   CMIP_C12:                          # Cloud Moisture Image Products Channel 12
     name: C12
     wavelength: [9.42, 9.61, 9.80]
-    resolution: 2000
+    calibration: brightness_temperature
     file_type: abi_l2_cmip_c12
     file_key: CMI
 
   CMIP_C13:                          # Cloud Moisture Image Products Channel 13
     name: C13
     wavelength: [10.10, 10.35, 10.60]
-    resolution: 2000
+    calibration: brightness_temperature
     file_type: abi_l2_cmip_c13
     file_key: CMI
 
   CMIP_C14:                          # Cloud Moisture Image Products Channel 14
     name: C14
     wavelength: [10.80, 11.20, 11.60]
-    resolution: 2000
+    calibration: brightness_temperature
     file_type: abi_l2_cmip_c14
     file_key: CMI
 
   CMIP_C15:                          # Cloud Moisture Image Products Channel 15
     name: C15
     wavelength: [11.80, 12.30, 12.80]
-    resolution: 2000
+    calibration: brightness_temperature
     file_type: abi_l2_cmip_c15
     file_key: CMI
 
   CMIP_C16:                          # Cloud Moisture Image Products Channel 16
     name: C16
     wavelength: [13.00, 13.30, 13.60]
-    resolution: 2000
+    calibration: brightness_temperature
     file_type: abi_l2_cmip_c16
     file_key: CMI
 
 # --- Cloud Top Height ---
   cloud_top_height:
     name: HT
-    resolution: 2000
     file_type: abi_l2_acha
     file_key: HT                #  variable name in the nc files
 
 # --- Cloud Top Temperature ---
   cloud_top_temperature:
     name: TEMP
-    resolution: 2000
     file_type: abi_l2_acht
     file_key: TEMP
 
 # --- Cloud Top Phase ---
   cloud_top_phase:
     name: Phase
-    resolution: 2000
     file_type: abi_l2_actp
     file_key: Phase
 
 # --- Clear Sky Mask ---
   clear_sky_mask:
     name: BCM
-    resolution: 2000
     file_type: abi_l2_acm
     file_key: BCM
 
 # --- Aerosol Detection Products ---
   aerosol_binary_mask:
     name: Aerosol
-    resolution: 2000
     file_type: abi_l2_adp
     file_key: Aerosol
 
   smoke_binary_mask:
     name: Smoke
-    resolution: 2000
     file_type: abi_l2_adp
     file_key: Smoke
 
   dust_binary_mask:
     name: Dust
-    resolution: 2000
     file_type: abi_l2_adp
     file_key: Dust
 
 # --- Aerosol Optical Depth at 550 nm ---
   aerosol_optical_depth:
     name: AOD
-    resolution: 2000
     file_type: abi_l2_aod
     file_key: AOD
 
 # --- Cloud Optical Depth at 640 nm ---
   cloud_optical_depth:
     name: COD
-    resolution: 2000
     file_type: abi_l2_cod
+    file_key: COD
+  cloud_optical_depth_day:
+    name: CODD
+    file_type: abi_l2_codd
+    file_key: COD
+  cloud_optical_depth_night:
+    name: CODN
+    file_type: abi_l2_codn
     file_key: COD
 
 # --- Cloud Particle Size ---
   cloud_particle_size:
     name: PSD
-    resolution: 2000
     file_type: abi_l2_cps
+    file_key: PSD
+  cloud_particle_size_day:
+    name: PSDD
+    file_type: abi_l2_cpsd
+    file_key: PSD
+  cloud_particle_size_night:
+    name: PSDN
+    file_type: abi_l2_cpsn
     file_key: PSD
 
 # --- Cloud Top Pressure ---
   cloud_top_pressure:
     name: PRES
-    resolution: 10000
     file_type: abi_l2_ctp
     file_key: PRES
 
 # --- Derived Stability Indices ---
   cape:
     name: CAPE
-    resolution: 2000
     file_type: abi_l2_dsi
     file_key: CAPE
 
   total_totals_index:
     name: TT
-    resolution: 2000
     file_type: abi_l2_dsi
     file_key: TT
 
   lifted_index:
     name: LI
-    resolution: 2000
     file_type: abi_l2_dsi
     file_key: LI
 
   showalter_index:
     name: SI
-    resolution: 2000
     file_type: abi_l2_dsi
     file_key: SI
 
   k_index:
     name: KI
-    resolution: 2000
     file_type: abi_l2_dsi
     file_key: KI
 
 # --- Fire (Hot Spot Characterization) Products ---
   fire_area:
     name: Area
-    resolution: 2000
     file_type: abi_l2_fdc
     file_key: Area
 
   fire_temp:
     name: Temp
-    resolution: 2000
     file_type: abi_l2_fdc
     file_key: Temp
 
   radiative_power:
     name: Power
-    resolution: 2000
     file_type: abi_l2_fdc
     file_key: Power
 
   fire_mask:
     name: Mask
-    resolution: 2000
     file_type: abi_l2_fdc
     file_key: Mask
+
+# --- Snow Cover ---
+  snow_cover_fraction:
+    name: FSC
+    file_type: abi_l2_fsc
+    file_key: FSC
 
 # --- Reflected Shortwave Radiation ---
   reflected_shortwave_radiation:
     name: RSR
-    resolution: 25000
     file_type: abi_l2_rsr
     file_key: RSR
 #    coordinates: [lon, lat]
@@ -279,7 +264,6 @@ datasets:
 # --- Downward Shortwave Radiation: Surface ---
   downward_shortwave_radiation:
     name: DSR
-    resolution: 50000
     file_type: abi_l2_dsr
     file_key: DSR
 #    coordinates: [lon, lat]
@@ -287,105 +271,111 @@ datasets:
 # --- Land Surface (Skin) Temperature ---
   land_surface_temperature:
     name: LST
-    resolution: 2000
     file_type: abi_l2_lst
     file_key: LST
 
 # --- Sea Surface (Skin) Temperature ---
   sea_surface_temperature:
     name: SST
-    resolution: 2000
     file_type: abi_l2_sst
     file_key: SST
 
 # --- Rainfall Rate - Quantitative Prediction Estimate ---
   rainfall_rate:
     name: RRQPE
-    resolution: 2000
     file_type: abi_l2_rrqpe
     file_key: RRQPE
 
 # --- Total Precipitalable Water ---
   total_precipitalable_water:
     name: TPW
-    resolution: 10000
     file_type: abi_l2_tpw
     file_key: TPW
 
 # ---Volcanic Ash Products ---
   ash_cloud_height:
     name: VAH
-    resolution: 2000
     file_type: abi_l2_vaa
     file_key: VAH
 
   ash_mass_loading:
     name: VAML
-    resolution: 2000
     file_type: abi_l2_vaa
     file_key: VAML
+
+# ---Navigation Products - Unofficial ---
+  nav_longitude:
+    name: Longitude
+    file_type: abi_l2_nav
+    file_key: Longitude
+
+  nav_latitude:
+    name: Latitude
+    file_type: abi_l2_nav
+    file_key: Latitude
+
 
 # ----
 file_types:
   abi_l2_cmip_c01:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C01_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C01_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c02:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C02_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C02_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c03:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C03_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C03_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c04:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C04_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C04_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c05:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C05_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C05_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c06:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C06_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C06_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c07:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C07_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C07_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c08:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C08_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C08_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c09:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C09_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C09_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c10:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C10_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C10_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c11:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C11_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C11_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c12:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C12_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C12_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c13:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C13_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C13_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c14:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C14_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C14_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c15:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C15_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:s}-{scan_mode:2s}C15_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cmip_c16:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
@@ -393,76 +383,115 @@ file_types:
 
   abi_l2_acha:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACHA{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACHA{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_acht:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACHT{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACHT{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_acm:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACM{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACM{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_actp:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACTP{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACTP{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_adp:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ADP{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ADP{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_aod:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-AOD{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-AOD{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_cod:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-COD{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns:
+        # F (Full Disk) or C (CONUS)
+        - '{system_environment:2s}_{mission_id:3s}-L2-COD{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+        # M1 or M2 for mesoscale
+        - '{system_environment:2s}_{mission_id:3s}-L2-CODM{area_code:1d}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+
+  # CSPP Geo keeps Day and Night algorithm outputs separate
+  abi_l2_codd:
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns:
+      - '{system_environment:2s}_{mission_id:3s}-L2-CODD{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+
+  abi_l2_codn:
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns:
+      - '{system_environment:2s}_{mission_id:3s}-L2-CODN{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
 
   abi_l2_cps:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CPS{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns:
+          # F (Full Disk) or C (CONUS)
+        - '{system_environment:2s}_{mission_id:3s}-L2-CPS{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+          # M1 or M2 for mesoscale
+        - '{system_environment:2s}_{mission_id:3s}-L2-CPSM{area_code:1d}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+
+  # CSPP Geo keeps Day and Night algorithm outputs separate
+  abi_l2_cpsd:
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns:
+      - '{system_environment:2s}_{mission_id:3s}-L2-CPSD{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+
+  abi_l2_cpsn:
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns:
+      - '{system_environment:2s}_{mission_id:3s}-L2-CPSN{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
 
   abi_l2_ctp:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CTP{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CTP{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_dsi:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-DSI{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-DSI{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_drs:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-DRS{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-DRS{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_fdc:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-FDC{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-FDC{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+
+  abi_l2_fsc:
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-FSC{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_lst:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-LST{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-LST{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_rrqpe:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-RRQPE{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-RRQPE{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_rsr:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-RSR{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-RSR{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_dsr:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-DSR{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-DSR{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_sst:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-SST{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-SST{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_tpw:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-TPW{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-TPW{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 
   abi_l2_vaa:
         file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-VAA{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc', '{system_environment:2s}_{mission_id:3s}-L2-VAA{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-128600_0.nc']
+        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-VAA{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc', '{system_environment:2s}_{mission_id:3s}-L2-VAA{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-128600_0.nc']
+
+  # CSPP - Geo Unofficial product
+  abi_l2_nav:
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-NAV{area_code:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc', '{system_environment:2s}_{mission_id:3s}-L2-VAA{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-128600_0.nc']

--- a/satpy/etc/readers/abi_l2_nc.yaml
+++ b/satpy/etc/readers/abi_l2_nc.yaml
@@ -1,11 +1,16 @@
-# GOES-R PUG vol5 L2+ products
-#  https://www.goes-r.gov/products/docs/PUG-L2+-vol5.pdf
 reader:
-  description: NetCDF4 reader for the GOES-R Level 2+ products from NOAA
   name: abi_l2_nc
+  short_name: ABI L2 NetCDF4
+  long_name: GOES-R ABI Level 2 NetCDF4
+  description: >
+    GOES-R ABI Level 2+ data reader in the NetCDF4 format. The file format is
+    described in the GOES-R Product Definition and Users' Guide (PUG) Volume
+    5. This document can be found
+    `here <https://www.goes-r.gov/products/docs/PUG-L2+-vol5.pdf>`_.
   sensors: ['abi']
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
-
+  # file pattern keys to sort files by with 'satpy.utils.group_files'
+  group_keys: ['start_time', 'platform_shortname', 'scene_abbr']
 
 datasets:
 # --- Cloud Moisture Image Products ---

--- a/satpy/readers/abi_base.py
+++ b/satpy/readers/abi_base.py
@@ -81,27 +81,27 @@ class NC_ABI_BASE(BaseFileHandler):
 
         data = self.nc[item]
         attrs = data.attrs
-        
+
         factor = data.attrs.get('scale_factor', 1)
         offset = data.attrs.get('add_offset', 0)
         fill = data.attrs.get('_FillValue')
         unsigned = data.attrs.get('_Unsigned', None)
-        
+
         # Ref. GOESR PUG-L1B-vol3, section 5.0.2 Unsigned Integer Processing
         if unsigned is not None and unsigned.lower() == 'true':
             # cast the data from int to uint
             data = data.astype('u%s' % data.dtype.itemsize)
-            
+
             if fill is not None:
                 fill = fill.astype('u%s' % fill.dtype.itemsize)
-            
+
         if fill is not None:
             if is_int(data) and is_int(factor) and is_int(offset):
                 new_fill = fill
             else:
                 new_fill = np.nan
             data = data.where(data != fill, new_fill)
-            
+
         if factor != 1 and item in ('x', 'y'):
             # be more precise with x/y coordinates
             # see get_area_def for more information
@@ -113,7 +113,7 @@ class NC_ABI_BASE(BaseFileHandler):
             if not is_int(factor):
                 factor = float(factor)
             data = data * factor + offset
-            
+
         data.attrs = attrs
 
         # handle coordinates (and recursive fun)

--- a/satpy/readers/abi_base.py
+++ b/satpy/readers/abi_base.py
@@ -76,22 +76,31 @@ class NC_ABI_BASE(BaseFileHandler):
         forces the scale factor to a 64-bit float first.
 
         """
+        def is_int(val):
+            return np.issubdtype(val.dtype, np.integer) if hasattr(val, 'dtype') else isinstance(val, int)
+
         data = self.nc[item]
         attrs = data.attrs
-        factor = data.attrs.get('scale_factor')
-        offset = data.attrs.get('add_offset')
+        factor = data.attrs.get('scale_factor', 1)
+        offset = data.attrs.get('add_offset', 0)
         fill = data.attrs.get('_FillValue')
         if fill is not None:
-            data = data.where(data != fill)
-        if factor is not None and item in ('x', 'y'):
+            if is_int(data) and is_int(factor) and is_int(offset):
+                new_fill = fill
+            else:
+                new_fill = np.nan
+            data = data.where(data != fill, new_fill)
+        if factor != 1 and item in ('x', 'y'):
             # be more precise with x/y coordinates
             # set get_area_def for more information
             data = data * np.round(float(factor), 6) + np.round(float(offset), 6)
-        elif factor is not None:
+        elif factor != 1:
             # make sure the factor is a 64-bit float
             # can't do this in place since data is most likely uint16
             # and we are making it a 64-bit float
-            data = data * float(factor) + offset
+            if not is_int(factor):
+                factor = float(factor)
+            data = data * factor + offset
         data.attrs = attrs
 
         # handle coordinates (and recursive fun)

--- a/satpy/readers/abi_l2_nc.py
+++ b/satpy/readers/abi_l2_nc.py
@@ -58,6 +58,10 @@ class NC_ABI_L2(NC_ABI_BASE):
         variable.attrs.pop('add_offset', None)
         variable.attrs.pop('valid_range', None)
         variable.attrs.pop('_Unsigned', None)
+        variable.attrs.pop('ancillary_variables', None)  # Can't currently load DQF
+
+        if 'flag_meanings' in variable.attrs:
+            variable.attrs['flag_meanings'] = variable.attrs['flag_meanings'].split(' ')
 
         # add in information from the filename that may be useful to the user
         for attr in ('scan_mode', 'platform_shortname'):

--- a/satpy/readers/abi_l2_nc.py
+++ b/satpy/readers/abi_l2_nc.py
@@ -68,3 +68,33 @@ class NC_ABI_L2(NC_ABI_BASE):
             variable.attrs[attr] = self.nc.attrs.get(attr)
 
         return variable
+
+    def spatial_resolution_to_number(self):
+        """Convert the 'spatial_resolution' global attribute to meters."""
+        res = self.nc.attrs['spatial_resolution'].split(' ')[0]
+        if res.endswith('km'):
+            res = int(float(res[:-2]) * 1000)
+        elif res.endswith('m'):
+            res = int(res[:-1])
+        else:
+            raise ValueError("Unexpected 'spatial_resolution' attribute '{}'".format(res))
+        return res
+
+    def available_datasets(self, configured_datasets=None):
+        """Add resolution to configured datasets."""
+        for is_avail, ds_info in (configured_datasets or []):
+            # some other file handler knows how to load this
+            # don't override what they've done
+            if is_avail is not None:
+                yield is_avail, ds_info
+            matches = self.file_type_matches(ds_info['file_type'])
+            if matches:
+                # we have this dataset
+                resolution = self.spatial_resolution_to_number()
+                new_info = ds_info.copy()
+                new_info.setdefault('resolution', resolution)
+                yield True, ds_info
+            elif is_avail is None:
+                # we don't know what to do with this
+                # see if another future file handler does
+                yield is_avail, ds_info

--- a/satpy/readers/abi_l2_nc.py
+++ b/satpy/readers/abi_l2_nc.py
@@ -23,6 +23,7 @@ The files read by this reader are described in the official PUG document:
 """
 
 import logging
+import numpy as np
 
 from satpy.readers.abi_base import NC_ABI_BASE
 
@@ -36,7 +37,7 @@ class NC_ABI_L2(NC_ABI_BASE):
         """Load a dataset."""
         var = info['file_key']
         LOG.debug('Reading in get_dataset %s.', var)
-        variable = self.nc[var]
+        variable = self[var]
 
         _units = variable.attrs['units'] if 'units' in variable.attrs else None
 
@@ -50,7 +51,9 @@ class NC_ABI_L2(NC_ABI_BASE):
         variable.attrs.update(key.to_dict())
 
         # remove attributes that could be confusing later
-        variable.attrs.pop('_FillValue', None)
+        if not np.issubdtype(variable.dtype, np.integer):
+            # integer fields keep the _FillValue
+            variable.attrs.pop('_FillValue', None)
         variable.attrs.pop('scale_factor', None)
         variable.attrs.pop('add_offset', None)
         variable.attrs.pop('valid_range', None)


### PR DESCRIPTION
This PR does the following:

* Fix L2 reader so it scales and masks data (it wasn't doing this before)
* Fix ABI L1b and L2 readers so they preserve integer data types of possible (including preserving `_FillValue` attribute for use later in satpy)
* Add `calibration` to C01-C16 CMI products
* Move resolution metadata to the python `available_datasets` method to get it from the file. CSPP Geo's products are supposed to all be 2km but the operational products from NOAA vary.
* Add day and night versions of the COD and CSP products. CSPP Geo does not merge these algorithm's output together so you get two separate files that could both exist for the same time step.
* Fix the `area_code` part of the file name patterns so they catch M1 and M2 for mesoscale data.
* As part of the two above points, separate the plain COD and CSP file patterns so they won't conflict with the CODD/CODN/CSPD/CSPN names.
* Add CSPP Geo's NAV product file for Longitude and Latitude. This is a "nice to have" product that CSPP Geo passes on from the AIT software instead of hiding it from the user. It is an unofficial product.
* Adds the FSC (fractional snow cover) file and dataset to the reader

One more question: Should I remove the `ancillary_variables` attributes from the file so we avoid the warning about not being able to load the `DQF` variable?

@yufeizhu600 Please review/test if possible.

 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->