### PR TITLE
Handle bad orbit coefficients in SEVIRI HRIT header

### DIFF
--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -525,9 +525,10 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
         self.mda['orbital_parameters']['satellite_nominal_longitude'] = self.prologue['SatelliteStatus'][
             'SatelliteDefinition']['NominalLongitude']
         self.mda['orbital_parameters']['satellite_nominal_latitude'] = 0.0
-        self.mda['orbital_parameters']['satellite_actual_longitude'] = actual_lon
-        self.mda['orbital_parameters']['satellite_actual_latitude'] = actual_lat
-        self.mda['orbital_parameters']['satellite_actual_altitude'] = actual_alt
+        if actual_lon is not None:
+            self.mda['orbital_parameters']['satellite_actual_longitude'] = actual_lon
+            self.mda['orbital_parameters']['satellite_actual_latitude'] = actual_lat
+            self.mda['orbital_parameters']['satellite_actual_altitude'] = actual_alt
 
         # Misc
         self.platform_id = self.prologue["SatelliteStatus"][

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -335,16 +335,28 @@ class HRITMSGPrologueFileHandler(HRITMSGPrologueEpilogueBase):
         Returns: Corresponding index in the coefficient list.
 
         """
-        # Find index of interval enclosing the nominal timestamp of the scan
         time = np.datetime64(self.prologue['ImageAcquisition']['PlannedAcquisitionTime']['TrueRepeatCycleStart'])
         intervals_tstart = self.prologue['SatelliteStatus']['Orbit']['OrbitPolynomial']['StartTime'][0].astype(
             'datetime64[us]')
         intervals_tend = self.prologue['SatelliteStatus']['Orbit']['OrbitPolynomial']['EndTime'][0].astype(
             'datetime64[us]')
         try:
-            return np.where(np.logical_and(time >= intervals_tstart, time < intervals_tend))[0][0]
-        except IndexError:
-            raise NoValidOrbitParams('Unable to find orbit coefficients valid for {}'.format(time))
+            # Find index of interval enclosing the nominal timestamp of the scan. If there are
+            # multiple enclosing intervals, use the most recent one.
+            enclosing = np.where(np.logical_and(time >= intervals_tstart, time < intervals_tend))[0]
+            most_recent = np.argmax(intervals_tstart[enclosing])
+            return enclosing[most_recent]
+        except ValueError:
+            # No enclosing interval. Instead, find the interval whose centre is closest to the scan's timestamp
+            # (but not more than 6 hours apart)
+            intervals_centre = intervals_tstart + 0.5 * (intervals_tend - intervals_tstart)
+            diffs_us = (time - intervals_centre).astype('i8')
+            closest_match = np.argmin(np.fabs(diffs_us))
+            if abs(intervals_centre[closest_match] - time) < np.timedelta64(6, 'h'):
+                logger.warning('No orbit coefficients valid for {}. Using closest match.'.format(time))
+                return closest_match
+            else:
+                raise NoValidOrbitParams('Unable to find orbit coefficients valid for {}'.format(time))
 
     def get_earth_radii(self):
         """Get earth radii from prologue.

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -41,7 +41,7 @@ except ImportError:
 
 def new_get_hd(instance, hdr_info):
     """Generate some metadata."""
-    instance.mda = {'spectral_channel_id': 'bla'}
+    instance.mda = {'spectral_channel_id': 1}
     instance.mda.setdefault('number_of_bits_per_pixel', 10)
 
     instance.mda['projection_parameters'] = {'a': 6378169.00,
@@ -532,6 +532,18 @@ class TestHRITMSGFileHandler(unittest.TestCase):
         self.assertTrue(np.all(month[1:-1] == 3))
         self.assertTrue(np.all(day[1:-1] == 3))
         self.assertTrue(np.all(msec[1:-1] == np.arange(len(tline) - 2)))
+
+    def test_get_header(self):
+        # Make sure that the actual satellite position is only included if available
+        self.reader.mda['orbital_parameters'] = {}
+        self.reader.prologue_.get_satpos.return_value = 1, 2, 3
+        self.reader._get_header()
+        self.assertIn('satellite_actual_longitude', self.reader.mda['orbital_parameters'])
+
+        self.reader.mda['orbital_parameters'] = {}
+        self.reader.prologue_.get_satpos.return_value = None, None, None
+        self.reader._get_header()
+        self.assertNotIn('satellite_actual_longitude', self.reader.mda['orbital_parameters'])
 
 
 class TestHRITMSGPrologueFileHandler(unittest.TestCase):

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -612,7 +612,7 @@ class TestHRITMSGPrologueFileHandler(unittest.TestCase):
 
     def test_find_orbit_coefs(self):
         """Test identification of orbit coefficients."""
-        # Contiguous coefficients (that's the norm)
+        # Contiguous validity intervals (that's the norm)
         self.assertEqual(self.reader._find_orbit_coefs(), 1)
 
         # No interval enclosing the given timestamp ...

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -572,9 +572,11 @@ class TestHRITMSGPrologueFileHandler(unittest.TestCase):
                 'Orbit': {
                     'OrbitPolynomial': {
                         'StartTime': np.array([
-                            [datetime(2006, 1, 1, 6), datetime(2006, 1, 1, 12), datetime(2006, 1, 1, 18)]]),
+                            [datetime(2006, 1, 1, 6), datetime(2006, 1, 1, 12), datetime(2006, 1, 1, 18),
+                             datetime(1958, 1, 1, 0)]]),
                         'EndTime': np.array([
-                            [datetime(2006, 1, 1, 12), datetime(2006, 1, 1, 18), datetime(2006, 1, 2, 0)]]),
+                            [datetime(2006, 1, 1, 12), datetime(2006, 1, 1, 18), datetime(2006, 1, 2, 0),
+                             datetime(1958, 1, 1, 0)]]),
                         'X': [np.zeros(8),
                               [8.41607082e+04, 2.94319260e+00, 9.86748617e-01, -2.70135453e-01,
                                -3.84364650e-02, 8.48718433e-03, 7.70548174e-04, -1.44262718e-04],
@@ -657,9 +659,9 @@ class TestHRITMSGPrologueFileHandler(unittest.TestCase):
             'Orbit': {
                 'OrbitPolynomial': {
                     'StartTime': np.array([
-                        [datetime(1959, 1, 1, 0), datetime(1959, 1, 1)]]),
+                        [datetime(1958, 1, 1, 0), datetime(1958, 1, 1)]]),
                     'EndTime': np.array([
-                        [datetime(1959, 1, 1, 0), datetime(1959, 1, 1)]])
+                        [datetime(1958, 1, 1, 0), datetime(1958, 1, 1)]])
                 }
             }
         }

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -612,6 +612,7 @@ class TestHRITMSGPrologueFileHandler(unittest.TestCase):
 
     def test_find_orbit_coefs(self):
         """Test identification of orbit coefficients."""
+        # Contiguous coefficients (that's the norm)
         self.assertEqual(self.reader._find_orbit_coefs(), 1)
 
         # No interval enclosing the given timestamp ...


### PR DESCRIPTION
 We found a SEVIRI scan (2008-02-04 22:15) where the satellite position computation in the `seviri_l1b_hrit` reader fails due to bad orbit coefficients. This PR provides a workaround.


Background: To compute the position for a given time we need to find the matching Chebyshev coefficients in the HRIT header. In each header there is a long list of coefficients and corresponding validity dates:

```
coefs1: valid from t0 to t1
coefs2: valid from t1 to t2
coefs3: valid from t2 to t3
etc
```

According to the format specification the intervals should be contiguous, i.e. the right boundary of interval `i` equals the left boundary of interval `i+1`.  However, for the above mentioned scan this is not the case and there is no interval with  `t_start <= t_scan < t_end`. The workaround is to use the interval whose centre is closest to the scan's timestamp and not more than 6 hours away. A warning is logged as well.

There is also a side effect of this problem: If `dataset.attrs['orbital_parameters']`  contains `None` type entries, `BaseFileHandler.combine_info` fails to average them. So now the satellite position is only included if it's not `None`.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
