### PR TITLE
Update orbit coefficient docstrings in seviri_l1b_hrit

### DIFF
--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -308,7 +308,7 @@ class HRITMSGPrologueFileHandler(HRITMSGPrologueEpilogueBase):
         """
         orbit_polynomial = self.prologue['SatelliteStatus']['Orbit']['OrbitPolynomial']
 
-        # Find Chebyshev coefficients for the given time
+        # Find Chebyshev coefficients for the start time of the scan
         coef_idx = self._find_orbit_coefs()
         tstart = orbit_polynomial['StartTime'][0, coef_idx]
         tend = orbit_polynomial['EndTime'][0, coef_idx]
@@ -326,11 +326,19 @@ class HRITMSGPrologueFileHandler(HRITMSGPrologueEpilogueBase):
         return x*1000, y*1000, z*1000  # km -> m
 
     def _find_orbit_coefs(self):
-        """Find orbit coefficients for the current time.
+        """Find orbit coefficients for the start time of the scan.
 
-        The orbital Chebyshev coefficients are only valid for a certain time interval. The header entry
-        SatelliteStatus/Orbit/OrbitPolynomial contains multiple coefficients for multiple time intervals. Find the
-        coefficients which are valid for the nominal timestamp of the scan.
+        The header entry SatelliteStatus/Orbit/OrbitPolynomial contains multiple coefficients, each
+        of them valid for a certain time interval. Find the coefficients which are valid for the
+        start time of the scan.
+
+        A manoeuvre is a discontinuity in the orbit parameters. The flight dynamic algorithms are
+        not made to interpolate over the time-span of the manoeuvre; hence we have elements
+        describing the orbit before a manoeuvre and a new set of elements describing the orbit after
+        the manoeuvre. The flight dynamic products are created so that there is an intentional gap
+        at the time of the manoeuvre. Also the two pre-manoeuvre elements may overlap. But the
+        overlap is not of an issue as both sets of elements describe the same pre-manoeuvre orbit
+        (with negligible variations).
 
         Returns: Corresponding index in the coefficient list.
 


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
A while ago we were wondering how there can be gaps and overlaps in the list of orbit coefficients in the HRIT header. Now I got a reply from the EUMETSAT Help Desk:

> A manoeuvre is a discontinuity in the orbit parameters. The flight dynamic algorithms are not made to interpolate over the time-span of the manoeuvre; hence we have elements describing the orbit before a manoeuvre and a new set of elements describing the orbit after the manoeuvre.
The flight dynamic products are created so that there is an intentional gap at the time of the manoeuvre. In your example that’s between 22:15 and 22:30. This is achieved by setting the validity-end-time of the last pre-manoeuvre elements to hh:00, hh:15, hh:30 or hh:45 before the manoeuvre. Each set of elements spans six hours. In your example the validity-end-time was set to 22:15 and hence the validity-start-time is 16:15. Now, the overlap is not of an issue as both sets of elements describe the same pre-manoeuvre orbit (with negligible variations).
This mechanism is in place for all MSG satellites since the beginning and still is used like this. 

I updated the docstrings accordingly.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [X] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
