### PR TITLE
Fix BackgroundCompositor not retaining input metadata

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -391,7 +391,7 @@ class SunZenithCorrectorBase(CompositeBase):
             # we were not given SZA, generate SZA then calculate cos(SZA)
             from pyorbital.astronomy import cos_zen
             LOG.debug("Computing sun zenith angles.")
-            lons, lats = vis.attrs["area"].get_lonlats_dask(CHUNK_SIZE)
+            lons, lats = vis.attrs["area"].get_lonlats(chunks=CHUNK_SIZE)
 
             coords = {}
             if 'y' in vis.coords and 'x' in vis.coords:
@@ -512,9 +512,7 @@ class PSPRayleighReflectance(CompositeBase):
         from pyorbital.astronomy import get_alt_az, sun_zenith_angle
         from pyorbital.orbital import get_observer_look
 
-        lons, lats = vis.attrs['area'].get_lonlats_dask(
-            chunks=vis.data.chunks)
-
+        lons, lats = vis.attrs['area'].get_lonlats(chunks=vis.data.chunks)
         sunalt, suna = get_alt_az(vis.attrs['start_time'], lons, lats)
         suna = np.rad2deg(suna)
         sunz = sun_zenith_angle(vis.attrs['start_time'], lons, lats)
@@ -635,7 +633,7 @@ class NIRReflectance(CompositeBase):
         if sun_zenith is None:
             if sun_zenith_angle is None:
                 raise ImportError("No module named pyorbital.astronomy")
-            lons, lats = _nir.attrs["area"].get_lonlats_dask(CHUNK_SIZE)
+            lons, lats = _nir.attrs["area"].get_lonlats(chunks=CHUNK_SIZE)
             sun_zenith = sun_zenith_angle(_nir.attrs['start_time'], lons, lats)
 
         return self._refl3x.reflectance_from_tbs(sun_zenith, _nir, _tb11, tb_ir_co2=tb13_4)
@@ -682,7 +680,7 @@ class PSPAtmosphericalCorrection(CompositeBase):
             satz = optional_datasets[0]
         else:
             from pyorbital.orbital import get_observer_look
-            lons, lats = band.attrs['area'].get_lonlats_dask(CHUNK_SIZE)
+            lons, lats = band.attrs['area'].get_lonlats(chunks=CHUNK_SIZE)
             sat_lon, sat_lat, sat_alt = get_satpos(band)
             try:
                 dummy, satel = get_observer_look(sat_lon,
@@ -787,9 +785,19 @@ class GenericCompositor(CompositeBase):
         Args:
             common_channel_mask (bool): If True, mask all the channels with
                 a mask that combines all the invalid areas of the given data.
+
         """
         self.common_channel_mask = common_channel_mask
         super(GenericCompositor, self).__init__(name, **kwargs)
+
+    @classmethod
+    def infer_mode(cls, data_arr):
+        """Guess at the mode for a particular DataArray."""
+        if 'mode' in data_arr.attrs['mode']:
+            return data_arr.attrs['mode']
+        if 'bands' not in data_arr.dims:
+            return cls.modes[1]
+        return cls.modes[data_arr.sizes['bands']]
 
     def _concat_datasets(self, projectables, mode):
         try:
@@ -866,7 +874,7 @@ class FillingCompositor(GenericCompositor):
 
     def __call__(self, projectables, nonprojectables=None, **info):
         """Generate the composite."""
-        projectables = self.check_areas(projectables)
+        projectables = self.match_data_arrays(projectables)
         projectables[1] = projectables[1].fillna(projectables[0])
         projectables[2] = projectables[2].fillna(projectables[0])
         projectables[3] = projectables[3].fillna(projectables[0])
@@ -878,7 +886,7 @@ class Filler(GenericCompositor):
 
     def __call__(self, projectables, nonprojectables=None, **info):
         """Generate the composite."""
-        projectables = self.check_areas(projectables)
+        projectables = self.match_data_arrays(projectables)
         filled_projectable = projectables[0].fillna(projectables[1])
         return super(Filler, self).__call__([filled_projectable], **info)
 
@@ -1000,6 +1008,7 @@ class DayNightCompositor(GenericCompositor):
                              blending of the given channels
             lim_high (float): upper limit of Sun zenith angle for the
                              blending of the given channels
+
         """
         self.lim_low = lim_low
         self.lim_high = lim_high
@@ -1024,7 +1033,7 @@ class DayNightCompositor(GenericCompositor):
                 chunks = day_data.sel(bands=day_data['bands'][0]).chunks
             except KeyError:
                 chunks = day_data.chunks
-            lons, lats = day_data.attrs["area"].get_lonlats_dask(chunks)
+            lons, lats = day_data.attrs["area"].get_lonlats(chunks=chunks)
             coszen = xr.DataArray(cos_zen(day_data.attrs["start_time"],
                                           lons, lats),
                                   dims=['y', 'x'],
@@ -1069,6 +1078,7 @@ def enhance2dataset(dset):
     # Clip image data to interval [0.0, 1.0]
     data = img.data.clip(0.0, 1.0)
     data.attrs = attrs
+    data.attrs.setdefault('mode', GenericCompositor.infer_mode(data))
 
     return data
 
@@ -1198,7 +1208,7 @@ class RatioSharpenedRGB(GenericCompositor):
     footprint. Note that the input data to this compositor must already be
     resampled so all data arrays are the same shape.
 
-    Example:
+    Example::
 
         R_lo -  1000m resolution - shape=(2000, 2000)
         G - 1000m resolution - shape=(2000, 2000)
@@ -1319,7 +1329,7 @@ def _mean4(data, offset=(0, 0), block_id=None):
 class SelfSharpenedRGB(RatioSharpenedRGB):
     """Sharpen RGB with ratio of a band with a strided-version of itself.
 
-    Example:
+    Example::
 
         R -  500m resolution - shape=(4000, 4000)
         G - 1000m resolution - shape=(2000, 2000)
@@ -1428,6 +1438,7 @@ class StaticImageCompositor(GenericCompositor):
             filename (str): Filename of the image to load
             area (str): Name of area definition for the image.  Optional
                         for images with built-in area definitions (geotiff)
+
         """
         if filename is None:
             raise ValueError("No image configured for static image compositor")
@@ -1479,7 +1490,7 @@ class BackgroundCompositor(GenericCompositor):
 
     def __call__(self, projectables, *args, **kwargs):
         """Call the compositor."""
-        projectables = self.check_areas(projectables)
+        projectables = self.match_data_arrays(projectables)
 
         # Get enhanced datasets
         foreground = enhance2dataset(projectables[0])
@@ -1494,9 +1505,12 @@ class BackgroundCompositor(GenericCompositor):
 
         # Get merged metadata
         attrs = combine_metadata(foreground, background)
+        if attrs.get('sensor') is None:
+            # sensor can be a set
+            attrs['sensor'] = self._get_sensors(projectables)
 
         # Stack the images
-        if 'A' in foreground.mode:
+        if 'A' in foreground.attrs['mode']:
             # Use alpha channel as weight and blend the two composites
             alpha = foreground.sel(bands='A')
             data = []
@@ -1514,6 +1528,5 @@ class BackgroundCompositor(GenericCompositor):
             data = [data.sel(bands=b) for b in data['bands']]
 
         res = super(BackgroundCompositor, self).__call__(data, **kwargs)
-        res.attrs['area'] = attrs['area']
-
+        res.attrs.update(attrs)
         return res

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -793,10 +793,12 @@ class GenericCompositor(CompositeBase):
     @classmethod
     def infer_mode(cls, data_arr):
         """Guess at the mode for a particular DataArray."""
-        if 'mode' in data_arr.attrs['mode']:
+        if 'mode' in data_arr.attrs:
             return data_arr.attrs['mode']
         if 'bands' not in data_arr.dims:
             return cls.modes[1]
+        if 'bands' in data_arr.coords and isinstance(data_arr.coords['bands'][0], str):
+            return ''.join(data_arr.coords['bands'].values)
         return cls.modes[data_arr.sizes['bands']]
 
     def _concat_datasets(self, projectables, mode):
@@ -1078,8 +1080,10 @@ def enhance2dataset(dset):
     # Clip image data to interval [0.0, 1.0]
     data = img.data.clip(0.0, 1.0)
     data.attrs = attrs
-    data.attrs.setdefault('mode', GenericCompositor.infer_mode(data))
-
+    # remove 'mode' if it is specified since it may have been updated
+    data.attrs.pop('mode', None)
+    # update mode since it may have changed (colorized/palettize)
+    data.attrs['mode'] = GenericCompositor.infer_mode(data)
     return data
 
 

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -313,7 +313,7 @@ composites:
     standard_name: overview
 
   colorized_ir_clouds:
-    compositor: !!python/name:satpy.composites.GenericCompositor
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
     prerequisites:
       - name: 'IR_108'
     standard_name: colorized_ir_clouds


### PR DESCRIPTION
While working on #854 I noticed that sensor information wasn't being handled the way I wanted by the BackgroundCompositor. I then discovered that none of the metadata is being handled. This PR attempts to fix that and cleans up a few other things that flake8/pre-commit were complaining about.

This includes removing the use of some deprecated functions.

This might fix #902 (FYI @peters77)

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
