### PR TITLE
Fix area handling in StaticImageCompositor

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1469,8 +1469,8 @@ class StaticImageCompositor(GenericCompositor):
         # most important: set 'name' of the image
         img.attrs.update(self.attrs)
         # Check for proper area definition.  Non-georeferenced images
-        # have None as .ndim
-        if img.area.ndim is None:
+        # do not have `area` in the attributes
+        if 'area' not in img.attrs:
             if self.area is None:
                 raise AttributeError("Area definition needs to be configured")
             img.attrs['area'] = self.area

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -928,7 +928,7 @@ class TestStaticImageCompositor(unittest.TestCase):
         scn = MockScene()
         scn['image'] = img
         Scene.return_value = scn
-        comp = StaticImageCompositor("name", filename="foo.tif")
+        comp = StaticImageCompositor("name", filename="foo.tif", area="euro4")
         res = comp()
         Scene.assert_called_once_with(reader='generic_image',
                                       filenames=[comp.filename])
@@ -939,7 +939,8 @@ class TestStaticImageCompositor(unittest.TestCase):
         self.assertTrue('calibration' not in res.attrs)
 
         # Non-georeferenced image, no area given
-        img.area.ndim = None
+        img.attrs.pop('area')
+        comp = StaticImageCompositor("name", filename="foo.tif")
         with self.assertRaises(AttributeError):
             res = comp()
 

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -709,7 +709,7 @@ class TestSingleBandCompositor(unittest.TestCase):
         self.assertTrue('calibration' in res.attrs)
         self.assertFalse('modifiers' in res.attrs)
         self.assertEqual(res.attrs['wavelength'], 10.8)
-        self.assertEquals(res.attrs['resolution'], 333)
+        self.assertEqual(res.attrs['resolution'], 333)
 
 
 class TestGenericCompositor(unittest.TestCase):


### PR DESCRIPTION
This PR fixes an incorrect access to non-existent `img.area` in `StaticImageCompositor`.

 - [x] Closes #830 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests updated
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
