### PR TITLE
Fix resampler imports

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -143,9 +143,6 @@ import six
 
 from pyresample.ewa import fornav, ll2cr
 from pyresample.geometry import SwathDefinition
-from pyresample.kd_tree import XArrayResamplerNN
-from pyresample.bilinear.xarr import XArrayResamplerBilinear
-from pyresample import bucket
 from satpy import CHUNK_SIZE
 from satpy.config import config_search_paths, get_config_path
 
@@ -466,6 +463,8 @@ class KDTreeResampler(BaseResampler):
         where data points are invalid.
 
         """
+        from pyresample.kd_tree import XArrayResamplerNN
+
         del kwargs
         source_geo_def = self.source_geo_def
 
@@ -824,6 +823,8 @@ class BilinearResampler(BaseResampler):
     def precompute(self, mask=None, radius_of_influence=50000, epsilon=0,
                    reduce_data=True, cache_dir=False, **kwargs):
         """Create bilinear coefficients and store them for later use."""
+        from pyresample.bilinear.xarr import XArrayResamplerBilinear
+
         del kwargs
         del mask
 
@@ -1035,15 +1036,17 @@ class NativeResampler(BaseResampler):
 
 
 class BucketResamplerBase(BaseResampler):
-    """Base class for bucket resampling which implements averaging.
-    """
+    """Base class for bucket resampling which implements averaging."""
 
     def __init__(self, source_geo_def, target_geo_def):
+        """Initialize bucket resampler."""
         super(BucketResamplerBase, self).__init__(source_geo_def, target_geo_def)
         self.resampler = None
 
     def precompute(self, **kwargs):
         """Create X and Y indices and store them for later use."""
+        from pyresample import bucket
+
         LOG.debug("Initializing bucket resampler.")
         source_lons, source_lats = self.source_geo_def.get_lonlats(
             chunks=CHUNK_SIZE)
@@ -1062,6 +1065,7 @@ class BucketResamplerBase(BaseResampler):
             data (xarray.DataArray): Data to be resampled
 
         Returns (xarray.DataArray): Data resampled to the target area
+
         """
         self.precompute(**kwargs)
         attrs = data.attrs.copy()
@@ -1116,6 +1120,7 @@ class BucketAvg(BucketResamplerBase):
         Fill value for missing data
     mask_all_nans : boolean (default: False)
         Mask all locations with all-NaN values
+
     """
 
     def compute(self, data, fill_value=np.nan, mask_all_nan=False, **kwargs):
@@ -1147,6 +1152,7 @@ class BucketSum(BucketResamplerBase):
         Fill value for missing data
     mask_all_nans : boolean (default: False)
         Mask all locations with all-NaN values
+
     """
 
     def compute(self, data, mask_all_nan=False, **kwargs):
@@ -1170,6 +1176,7 @@ class BucketCount(BucketResamplerBase):
 
     This resampler calculates the number of occurences of the input
     data closest to each bin and inside the target area.
+
     """
 
     def compute(self, data, **kwargs):
@@ -1177,7 +1184,7 @@ class BucketCount(BucketResamplerBase):
         LOG.debug("Resampling %s", str(data.name))
         results = []
         if data.ndim == 3:
-            for i in range(data.shape[0]):
+            for _i in range(data.shape[0]):
                 res = self.resampler.get_count()
                 results.append(res)
         else:
@@ -1188,10 +1195,11 @@ class BucketCount(BucketResamplerBase):
 
 
 class BucketFraction(BucketResamplerBase):
-    """Class for bucket resampling to compute category fractions
+    """Class for bucket resampling to compute category fractions.
 
     This resampler calculates the fraction of occurences of the input
     data per category.
+
     """
 
     def compute(self, data, fill_value=np.nan, categories=None, **kwargs):

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -139,7 +139,7 @@ class TestKDTreeResampler(unittest.TestCase):
     @mock.patch('satpy.resample.xr.Dataset')
     @mock.patch('satpy.resample.zarr.open')
     @mock.patch('satpy.resample.KDTreeResampler._create_cache_filename')
-    @mock.patch('satpy.resample.XArrayResamplerNN')
+    @mock.patch('pyresample.kd_tree.XArrayResamplerNN')
     def test_kd_resampling(self, resampler, create_filename, zarr_open,
                            xr_dset, cnc):
         """Test the kd resampler."""
@@ -468,7 +468,7 @@ class TestBilinearResampler(unittest.TestCase):
     @mock.patch('satpy.resample.xr.Dataset')
     @mock.patch('satpy.resample.zarr.open')
     @mock.patch('satpy.resample.BilinearResampler._create_cache_filename')
-    @mock.patch('satpy.resample.XArrayResamplerBilinear')
+    @mock.patch('pyresample.bilinear.xarr.XArrayResamplerBilinear')
     def test_bil_resampling(self, resampler, create_filename, zarr_open,
                             xr_dset, move_existing_caches):
         """Test the bilinear resampler."""


### PR DESCRIPTION
This PR moves the pyresample resampler imports inside the methods they are used. In this way users won't be forced to upgrade `pyresample` if they don't need newer resamplers and features.

NOTE: for bilinear interpolation the `pyresample` upgrade is still necessary, and so is if `bucket` resampler is needed. The default `nearest` resampler will work as expected also with older (< 1.13.0) `pyresample` versions without forcing an update.

 - [x] Closes #918  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests updated
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
