### PR TITLE
Update coord2area_def.py

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,6 +19,7 @@ The following people have made contributions to this project:
 - [Ulrik Egede (egede)](https://github.com/egede)
 - [Joleen Feltz (joleenf)](https://github.com/joleenf)
 - [Stephan Finkensieper (sfinkens)](https://github.com/sfinkens)
+- [Andrea Grillini (AppLEaDaY)](https://github.com/AppLEaDaY)
 - [Nina Håkansson (ninahakansson)](https://github.com/ninahakansson)
 - [Ulrich Hamann](https://github.com/)
 - [Gerrit Holl (gerritholl)](https://github.com/gerritholl)
@@ -53,4 +54,3 @@ The following people have made contributions to this project:
 - [praerien (praerien)](https://github.com/praerien)
 - [Xin Zhang (zxdawn)](https://github.com/zxdawn)
 - [Yufei Zhu (yufeizhu600)](https://github.com/yufeizhu600)
-

--- a/utils/coord2area_def.py
+++ b/utils/coord2area_def.py
@@ -147,14 +147,13 @@ if __name__ == '__main__':
     from PIL import Image
     from pycoast import ContourWriterAGG
     img = Image.new('RGB', (xsize, ysize))
-    
-    
+
     area_def = (proj4_string, area_extent)
     cw = ContourWriterAGG(args.shapes)
-    
+
     cw.add_coastlines(img, (proj4_string, area_extent),
                       resolution='l', width=0.5)
 
-    cw.add_grid(img, area_def, (10.0, 10.0), (2.0, 2.0), write_text=False, outline='white', outline_opacity=175, width=1.0,
-                minor_outline='white', minor_outline_opacity=175, minor_width=0.2, minor_is_tick=False)
+    cw.add_grid(img, area_def, (10.0, 10.0), (2.0, 2.0), write_text=False, outline='white', outline_opacity=175,
+                width=1.0, minor_outline='white', minor_outline_opacity=175, minor_width=0.2, minor_is_tick=False)
     img.show()

--- a/utils/coord2area_def.py
+++ b/utils/coord2area_def.py
@@ -51,7 +51,8 @@ import os
 os.environ['PPP_CONFIG_DIR'] = '/my_local_path/for_satpy_configuration'
 
 As a further functionality this script may give a quick display of the defined area,
-provided the path for the GSHHG library is supplied via the "-s" option.
+provided the path for the GSHHG library is supplied via the "-s" option
+and the modules PyCoast, Pillow and AggDraw have been installed.
 
 python coord2area_def.py france stere 42.0 51.5 -5.5 8.0 1.5 -s /path/for/gshhs/library
 

--- a/utils/coord2area_def.py
+++ b/utils/coord2area_def.py
@@ -17,21 +17,46 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Convert human coordinates (lon and lat) to an area definition.
 
-Here is a usage example:
+Here is a usage example.
+
 python coord2area_def.py france stere 42.0 51.5 -5.5 8.0 1.5
-(the arguments are "name proj min_lat max_lat min_lon max_lon resolution(km)")
+The arguments are "name proj min_lat max_lat min_lon max_lon resolution(km)".
+The command above yelds the following result.
+
+### +proj=stere +lat_0=46.75 +lon_0=1.25 +ellps=WGS84
+
+france:
+  description: france
+  projection:
+    proj: stere
+    ellps: WGS84
+    lat_0: 46.75
+    lon_0: 1.25
+  shape:
+    height: 703
+    width: 746
+  area_extent:
+    lower_left_xy: [-559750.381098, -505020.675776]
+    upper_right_xy: [559750.381098, 549517.351948]
 
 
-and the result is:
-REGION: france {
-	NAME:	france
-	PCS_ID:	stere_1.25_46.75
-	PCS_DEF:	proj=stere,lat_0=46.75,lon_0=1.25,ellps=WGS84
-	XSIZE:  746
-	YSIZE:  703
-	AREA_EXTENT:	(-559750.38109755167, -505020.6757764442,
-559750.38109755167, 549517.35194826045)
-};
+The first commented line is just a sum-up. The value of "description" can be changed to any descriptive text.
+
+Such a custom yaml configuration can be profitably saved in a local areas.yaml configuration file that won't be
+overridden by future updates of SatPy package. For that purpose the local processing script may have suitable
+lines as reported below.
+
+# set PPP_CONFIG_DIR for custom composites
+import os
+os.environ['PPP_CONFIG_DIR'] = '/my_local_path/for_satpy_configuration'
+
+As a further functionality this script may give a quick display of the defined area,
+provided the path for the GSHHG library is supplied via the "-s" option.
+
+python coord2area_def.py france stere 42.0 51.5 -5.5 8.0 1.5 -s /path/for/gshhs/library
+
+The command above would first print the seen area definition and then launch a casual representation
+of the area relying on the information about borders involved.
 
 """
 
@@ -100,7 +125,7 @@ if __name__ == '__main__':
         " +".join(("proj=" + proj + ",lat_0=" + str(lat_0) +
                    ",lon_0=" + str(lon_0) + ",ellps=WGS84").split(","))
 
-    print(proj4_string)
+    print('### ' + proj4_string)
     print()
     print(name + ":")
     print("  description: " + name)
@@ -121,11 +146,11 @@ if __name__ == '__main__':
     from PIL import Image
     from pycoast import ContourWriterAGG
     img = Image.new('RGB', (xsize, ysize))
-    #proj4_string = '+proj=geos +lon_0=0.0 +a=6378169.00 +b=6356583.80 +h=35785831.0'
-    #area_extent = (-5570248.4773392612, -5567248.074173444, 5567248.074173444, 5570248.4773392612)
+    
+    
     area_def = (proj4_string, area_extent)
     cw = ContourWriterAGG(args.shapes)
-    #cw = ContourWriterAGG('/usr/share/gshhg-gmt-shp/')
+    
     cw.add_coastlines(img, (proj4_string, area_extent),
                       resolution='l', width=0.5)
 


### PR DESCRIPTION
### coord2area_def.py update

- Adjusted commented text to point to the output actually supplied nowadays (yaml format and not the old format).

- Added instruction in commented text concerning how to display the defined area relying on gshhs library.

- Removed unused commented lines.
