### PR TITLE
Fix MultiScene.save_animation to work with new dask.distributed versions

### DIFF
--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -15,8 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""MultiScene object to blend satellite data.
-"""
+"""MultiScene object to work with multiple timesteps of satellite data."""
 
 import logging
 import numpy as np
@@ -49,7 +48,7 @@ log = logging.getLogger(__name__)
 
 
 def stack(datasets):
-    """First dataset at the bottom."""
+    """Overlay series of datasets on top of each other."""
     base = datasets[0].copy()
     for dataset in datasets[1:]:
         base = base.where(dataset.isnull(), dataset)
@@ -57,7 +56,7 @@ def stack(datasets):
 
 
 def timeseries(datasets):
-    """Expands dataset with and concats by time dimension"""
+    """Expand dataset with and concatenate by time dimension."""
     expanded_ds = []
     for ds in datasets:
         tmp = ds.expand_dims("time")
@@ -214,6 +213,7 @@ class MultiScene(object):
 
     @property
     def all_same_area(self):
+        """Determine if all contained Scenes have the same 'area'."""
         return self._all_same_area(self.loaded_dataset_ids)
 
     @staticmethod
@@ -304,7 +304,7 @@ class MultiScene(object):
         log.debug("Child thread died successfully")
 
     def _simple_save_datasets(self, scenes_iter, **kwargs):
-        """Helper to simple run save_datasets on each Scene."""
+        """Run save_datasets on each Scene."""
         for scn in scenes_iter:
             scn.save_datasets(**kwargs)
 
@@ -414,11 +414,11 @@ class MultiScene(object):
 
         input_q = Queue(batch_size if batch_size is not None else 1)
         load_thread = Thread(target=load_data, args=(frames_to_write, input_q,))
-        remote_q = client.gather(input_q)
         load_thread.start()
 
         while True:
-            future_dict = remote_q.get()
+            input_future = input_q.get()
+            future_dict = client.gather(input_future)
             if future_dict is None:
                 break
 
@@ -448,7 +448,7 @@ class MultiScene(object):
 
     def save_animation(self, filename, datasets=None, fps=10, fill_value=None,
                        batch_size=1, ignore_missing=False, client=True, **kwargs):
-        """Helper method for saving to movie (MP4) or GIF formats.
+        """Save series of Scenes to movie (MP4) or GIF formats.
 
         Supported formats are dependent on the `imageio` library and are
         determined by filename extension by default.

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -15,8 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for multiscene.py.
-"""
+"""Unit tests for multiscene.py."""
 
 import os
 import sys
@@ -75,12 +74,12 @@ def _create_test_dataset(name, shape=DEFAULT_SHAPE, area=None):
 
 
 def _create_test_scenes(num_scenes=2, shape=DEFAULT_SHAPE, area=None):
-    """Helper to create some test scenes."""
+    """Create some test scenes for various test cases."""
     from satpy import Scene
     ds1 = _create_test_dataset('ds1', shape=shape, area=area)
     ds2 = _create_test_dataset('ds2', shape=shape, area=area)
     scenes = []
-    for scn_idx in range(num_scenes):
+    for _ in range(num_scenes):
         scn = Scene()
         scn['ds1'] = ds1.copy()
         scn['ds2'] = ds2.copy()
@@ -153,11 +152,11 @@ class TestMultiSceneSave(unittest.TestCase):
     """Test saving a MultiScene to various formats."""
 
     def setUp(self):
-        """Create temporary directory to save files to"""
+        """Create temporary directory to save files to."""
         self.base_dir = tempfile.mkdtemp()
 
     def tearDown(self):
-        """Remove the temporary directory created for a test"""
+        """Remove the temporary directory created for a test."""
         try:
             shutil.rmtree(self.base_dir, ignore_errors=True)
         except OSError:
@@ -219,6 +218,7 @@ class TestMultiSceneSave(unittest.TestCase):
     def test_save_mp4_distributed(self):
         """Save a series of fake scenes to an mp4 video."""
         from satpy import MultiScene
+        from dask.distributed import LocalCluster, Client
         area = _create_test_area()
         scenes = _create_test_scenes(area=area)
 
@@ -238,13 +238,17 @@ class TestMultiSceneSave(unittest.TestCase):
             self.base_dir,
             'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
         writer_mock = mock.MagicMock()
-        client_mock = mock.MagicMock()
-        client_mock.compute.side_effect = lambda x: tuple(v.compute() for v in x)
-        client_mock.gather.side_effect = lambda x: x
+        cluster = LocalCluster(n_workers=1)
+        client = Client(cluster)
+        # client_mock = mock.MagicMock()
+        # client_mock.compute.side_effect = lambda x: tuple(v.compute() for v in x)
+        # client_mock.gather.side_effect = lambda x: x
         with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
             get_writer.return_value = writer_mock
             # force order of datasets by specifying them
-            mscn.save_animation(fn, client=client_mock, datasets=['ds1', 'ds2', 'ds3'])
+            mscn.save_animation(fn, client=client, datasets=['ds1', 'ds2', 'ds3'])
+        client.close()
+        cluster.close()
 
         # 2 saves for the first scene + 1 black frame
         # 3 for the second scene
@@ -260,14 +264,18 @@ class TestMultiSceneSave(unittest.TestCase):
             self.base_dir,
             'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
         writer_mock = mock.MagicMock()
-        client_mock = mock.MagicMock()
-        client_mock.compute.side_effect = lambda x: tuple(v.compute() for v in x)
-        client_mock.gather.side_effect = lambda x: x
+        # client_mock = mock.MagicMock()
+        # client_mock.compute.side_effect = lambda x: tuple(v.compute() for v in x)
+        # client_mock.gather.side_effect = lambda x: x
+        cluster = LocalCluster(n_workers=1)
+        client = Client(cluster)
         with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer, \
                 mock.patch('satpy.multiscene.get_client', mock.Mock(side_effect=ValueError("No client"))):
             get_writer.return_value = writer_mock
             # force order of datasets by specifying them
             mscn.save_animation(fn, datasets=['ds1', 'ds2', 'ds3'])
+        client.close()
+        cluster.close()
 
         # 2 saves for the first scene + 1 black frame
         # 3 for the second scene
@@ -461,7 +469,7 @@ class TestBlendFuncs(unittest.TestCase):
 
 
 def suite():
-    """The test suite for test_multiscene."""
+    """Create the test suite for test_multiscene."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestMultiScene))

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -218,7 +218,6 @@ class TestMultiSceneSave(unittest.TestCase):
     def test_save_mp4_distributed(self):
         """Save a series of fake scenes to an mp4 video."""
         from satpy import MultiScene
-        from dask.distributed import LocalCluster, Client
         area = _create_test_area()
         scenes = _create_test_scenes(area=area)
 
@@ -238,17 +237,13 @@ class TestMultiSceneSave(unittest.TestCase):
             self.base_dir,
             'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
         writer_mock = mock.MagicMock()
-        cluster = LocalCluster(n_workers=1)
-        client = Client(cluster)
-        # client_mock = mock.MagicMock()
-        # client_mock.compute.side_effect = lambda x: tuple(v.compute() for v in x)
-        # client_mock.gather.side_effect = lambda x: x
+        client_mock = mock.MagicMock()
+        client_mock.compute.side_effect = lambda x: tuple(v.compute() for v in x)
+        client_mock.gather.side_effect = lambda x: x
         with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
             get_writer.return_value = writer_mock
             # force order of datasets by specifying them
-            mscn.save_animation(fn, client=client, datasets=['ds1', 'ds2', 'ds3'])
-        client.close()
-        cluster.close()
+            mscn.save_animation(fn, client=client_mock, datasets=['ds1', 'ds2', 'ds3'])
 
         # 2 saves for the first scene + 1 black frame
         # 3 for the second scene
@@ -264,18 +259,14 @@ class TestMultiSceneSave(unittest.TestCase):
             self.base_dir,
             'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
         writer_mock = mock.MagicMock()
-        # client_mock = mock.MagicMock()
-        # client_mock.compute.side_effect = lambda x: tuple(v.compute() for v in x)
-        # client_mock.gather.side_effect = lambda x: x
-        cluster = LocalCluster(n_workers=1)
-        client = Client(cluster)
+        client_mock = mock.MagicMock()
+        client_mock.compute.side_effect = lambda x: tuple(v.compute() for v in x)
+        client_mock.gather.side_effect = lambda x: x
         with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer, \
                 mock.patch('satpy.multiscene.get_client', mock.Mock(side_effect=ValueError("No client"))):
             get_writer.return_value = writer_mock
             # force order of datasets by specifying them
             mscn.save_animation(fn, datasets=['ds1', 'ds2', 'ds3'])
-        client.close()
-        cluster.close()
 
         # 2 saves for the first scene + 1 black frame
         # 3 for the second scene


### PR DESCRIPTION
New-ish versions of dask do not allow the distributed Client to be used the way I had originally programmed `save_animation` to use it. This PR fixes it to work with newer versions of dask ~and also updates the tests to use the real distributed Client to avoid this problem in the future~.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
