### PR TITLE
Fix MERSI-2 natural_color composite using the wrong band for sharpening

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,13 @@ env:
         - CONDA_CHANNEL_PRIORITY='strict'
 matrix:
   include:
-  - env: PYTHON_VERSION=2.7
+  - env:
+    - PYTHON_VERSION=2.7
+    - NUMPY_VERSION=1.16
     os: linux
-  - env: PYTHON_VERSION=2.7
+  - env:
+    - PYTHON_VERSION=2.7
+    - NUMPY_VERSION=1.16
     os: osx
     language: generic
   - env: PYTHON_VERSION=3.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ matrix:
     os: osx
     language: generic
 install:
-#    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
-    - git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git
+    - git clone --depth 1 git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh
 script:
 - coverage run --source=satpy setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,9 @@ matrix:
     - NUMPY_VERSION=1.16
     os: osx
     language: generic
-  - env: PYTHON_VERSION=3.6
+  - env: PYTHON_VERSION=3.7
     os: linux
-  - env: PYTHON_VERSION=3.6
+  - env: PYTHON_VERSION=3.7
     os: osx
     language: generic
 install:
@@ -35,7 +35,7 @@ script:
 - coverage run --source=satpy setup.py test
 - coverage run -a --source=satpy -m behave satpy/tests/features --tags=-download
 after_success:
-- if [[ $PYTHON_VERSION == 3.6 ]]; then coveralls; codecov; fi
+- if [[ $PYTHON_VERSION == 3.7 ]]; then coveralls; codecov; fi
 deploy:
   - provider: pypi
     user: dhoese

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Python36_64"
-      PYTHON_VERSION: "3.6"
+      PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       NUMPY_VERSION: "stable"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,7 @@ environment:
       NUMPY_VERSION: "stable"
 
 install:
-#    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
-    - "git clone --depth 1 -b all-the-fixes git://github.com/djhoese/ci-helpers.git"
+    - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"
     - "powershell ci-helpers/appveyor/install-miniconda.ps1"
     - "conda activate test"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
     CONDA_CHANNELS: "conda-forge"
 
   matrix:
-    - PYTHON: "C:\\Python36_64"
+    - PYTHON: "C:\\Python37_64"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       NUMPY_VERSION: "stable"

--- a/satpy/etc/composites/mersi-2.yaml
+++ b/satpy/etc/composites/mersi-2.yaml
@@ -72,12 +72,12 @@ composites:
     prerequisites:
       - name: '6'
         modifiers: [sunz_corrected]
-      - name: '4'
+      - name: '15'
         modifiers: [sunz_corrected]
       - name: '3'
         modifiers: [sunz_corrected]
     optional_prerequisites:
-      - name: '15'
+      - name: '4'
         modifiers: [sunz_corrected]
     standard_name: natural_color
     high_resolution_band: green


### PR DESCRIPTION
The ratio sharpening compositor uses the optional (4th) prerequisite as the high resolution band. For MERSI-2's natural_color composite I had the high/low res green bands swapped. Band 4 is the high res and should be optional, band 15 is the low res and should be the required. This should have minimal different on the red and blue bands but is should replace the green band in the final output with the higher resolution band 4 image.

 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->