### PR TITLE
Fix VIIRS EDR Active Fires not assigning a _FillValue to confidence_pct

### DIFF
--- a/satpy/etc/readers/viirs_edr_active_fires.yaml
+++ b/satpy/etc/readers/viirs_edr_active_fires.yaml
@@ -46,6 +46,10 @@ datasets:
         file_key: "{variable_prefix}FP_confidence"
         coordinates: [longitude, latitude]
         units: '%'
+        # this is not a category product but we should define a fill value
+        # since we aren't going to scale the data to a float data type in
+        # the python code
+        _FillValue: 255
     longitude:
         name: longitude
         standard_name: longitude

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -49,7 +49,7 @@ DEFAULT_LATLON_FILE_DTYPE = np.float32
 DEFAULT_LATLON_FILE_DATA = np.arange(start=43, stop=45, step=0.02,
                                      dtype=DEFAULT_LATLON_FILE_DTYPE).reshape(DEFAULT_FILE_SHAPE)
 
-DEFAULT_DETECTION_FILE_DTYPE = np.ubyte
+DEFAULT_DETECTION_FILE_DTYPE = np.uint8
 DEFAULT_DETECTION_FILE_DATA = np.arange(start=60, stop=100, step=0.4,
                                         dtype=DEFAULT_DETECTION_FILE_DTYPE).reshape(DEFAULT_FILE_SHAPE)
 
@@ -203,6 +203,8 @@ class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
         self.assertEqual(len(datasets), 1)
         for v in datasets.values():
             self.assertEqual(v.attrs['units'], '%')
+            self.assertEqual(v.attrs['_FillValue'], 255)
+            self.assertTrue(np.issubdtype(v.dtype, DEFAULT_DETECTION_FILE_DTYPE))
 
         datasets = r.load(['T13'])
         self.assertEqual(len(datasets), 1)


### PR DESCRIPTION
The `confidence_pct` data is stored as unsigned 8-bit integers in the active fires files. There is no scale factor or offset and no defined fill value in the file. This means that there is no operation causing Satpy to convert these unsigned 8-bit integers in to floats where NaN can be used as a fill value. Without this _FillValue the resampling code in Satpy was defaulting to NaN which would cause a warning to show up in pyresample because NaN can't be a fill value for an integer data type.

This PR provides a fallback _FillValue of 255 and lets the remainder 0-100 integer values act as valid data points. This stops the warning from showing up.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
