### PR TITLE
Fix bug in OLCI reader that caused multiple error messages to print

### DIFF
--- a/satpy/readers/olci_nc.py
+++ b/satpy/readers/olci_nc.py
@@ -15,7 +15,21 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Sentinel-3 OLCI reader."""
+"""Sentinel-3 OLCI reader.
+This reader supports an optional argument to choose the 'engine' for reading
+OLCI netCDF4 files. By default, the 'netcdf4' engine is used. As an
+alternative, the user may wish to use the 'h5netcdf' engine, but that is
+not default as it typically prints many non-fatal but confusing error
+messages to the terminal.
+To choose between engines the user can  do as follows for the default:
+scn = satpyScene(filenames=my_files,
+                 reader='olci_l1b')
+or as follows for the h5netcdf engine:
+scn = Scene(filenames=my_files,
+            reader='olci_l1b'),
+            reader_kwargs={'engine': 'h5netcdf'})
+
+"""
 
 import logging
 from datetime import datetime

--- a/satpy/readers/olci_nc.py
+++ b/satpy/readers/olci_nc.py
@@ -19,21 +19,27 @@
 
 This reader supports an optional argument to choose the 'engine' for reading
 OLCI netCDF4 files. By default, this reader uses the default xarray choice of
-engine, as defined in the `xarray open_dataset documentation`_. As an
-alternative, the user may wish to use the 'h5netcdf' engine, but that is
-not default as it typically prints many non-fatal but confusing error
-messages to the terminal.
-To choose between engines the user can  do as follows for the default:
+engine, as defined in the `xarray open_dataset documentation`_.
+
+As an alternative, the user may wish to use the 'h5netcdf' engine, but that is
+not default as it typically prints many non-fatal but confusing error messages
+to the terminal.
+To choose between engines the user can  do as follows for the default::
+
 scn = satpyScene(filenames=my_files, reader='olci_l1b')
-or as follows for the h5netcdf engine:
+
+or as follows for the h5netcdf engine::
+
 scn = Scene(filenames=my_files,
-reader='olci_l1b'), reader_kwargs={'engine': 'h5netcdf'})
+      reader='olci_l1b'), reader_kwargs={'engine': 'h5netcdf'})
+
 
 References:
     - `xarray open_dataset documentation`_
 .. _xarray open_dataset: http://xarray.pydata.org/en/stable/generated/xarray.open_dataset.html
 
 """
+
 
 import logging
 from datetime import datetime

--- a/satpy/readers/olci_nc.py
+++ b/satpy/readers/olci_nc.py
@@ -73,13 +73,15 @@ class BitFlags(object):
 class NCOLCIBase(BaseFileHandler):
     """The OLCI reader base."""
 
-    def __init__(self, filename, filename_info, filetype_info):
+    def __init__(self, filename, filename_info, filetype_info,
+                 engine='netcdf4'):
         """Init the olci reader base."""
         super(NCOLCIBase, self).__init__(filename, filename_info,
                                          filetype_info)
         self.nc = xr.open_dataset(self.filename,
                                   decode_cf=True,
                                   mask_and_scale=True,
+                                  engine=engine,
                                   chunks={'columns': CHUNK_SIZE,
                                           'rows': CHUNK_SIZE})
 
@@ -131,7 +133,8 @@ class NCOLCIGeo(NCOLCIBase):
 class NCOLCIChannelBase(NCOLCIBase):
     """Base class for channel reading."""
 
-    def __init__(self, filename, filename_info, filetype_info):
+    def __init__(self, filename, filename_info, filetype_info,
+                 engine='netcdf4'):
         """Init the file handler."""
         super(NCOLCIChannelBase, self).__init__(filename, filename_info,
                                                 filetype_info)
@@ -142,7 +145,8 @@ class NCOLCIChannelBase(NCOLCIBase):
 class NCOLCI1B(NCOLCIChannelBase):
     """File handler for OLCI l1b."""
 
-    def __init__(self, filename, filename_info, filetype_info, cal):
+    def __init__(self, filename, filename_info, filetype_info, cal,
+                 engine='netcdf4'):
         """Init the file handler."""
         super(NCOLCI1B, self).__init__(filename, filename_info,
                                        filetype_info)
@@ -254,7 +258,8 @@ class NCOLCIAngles(BaseFileHandler):
                 'solar_azimuth_angle': 'SAA',
                 'solar_zenith_angle': 'SZA'}
 
-    def __init__(self, filename, filename_info, filetype_info):
+    def __init__(self, filename, filename_info, filetype_info,
+                 engine='netcdf4'):
         """Init the file handler."""
         super(NCOLCIAngles, self).__init__(filename, filename_info,
                                            filetype_info)
@@ -265,6 +270,7 @@ class NCOLCIAngles(BaseFileHandler):
         self.cache = {}
         self._start_time = filename_info['start_time']
         self._end_time = filename_info['end_time']
+        self.engine = engine
 
     def get_dataset(self, key, info):
         """Load a dataset."""
@@ -275,6 +281,7 @@ class NCOLCIAngles(BaseFileHandler):
             self.nc = xr.open_dataset(self.filename,
                                       decode_cf=True,
                                       mask_and_scale=True,
+                                      engine=self.engine,
                                       chunks={'tie_columns': CHUNK_SIZE,
                                               'tie_rows': CHUNK_SIZE})
 

--- a/satpy/readers/olci_nc.py
+++ b/satpy/readers/olci_nc.py
@@ -88,7 +88,7 @@ class NCOLCIBase(BaseFileHandler):
     """The OLCI reader base."""
 
     def __init__(self, filename, filename_info, filetype_info,
-                 engine='netcdf4'):
+                 engine=None):
         """Init the olci reader base."""
         super(NCOLCIBase, self).__init__(filename, filename_info,
                                          filetype_info)
@@ -148,7 +148,7 @@ class NCOLCIChannelBase(NCOLCIBase):
     """Base class for channel reading."""
 
     def __init__(self, filename, filename_info, filetype_info,
-                 engine='netcdf4'):
+                 engine=None):
         """Init the file handler."""
         super(NCOLCIChannelBase, self).__init__(filename, filename_info,
                                                 filetype_info)
@@ -160,7 +160,7 @@ class NCOLCI1B(NCOLCIChannelBase):
     """File handler for OLCI l1b."""
 
     def __init__(self, filename, filename_info, filetype_info, cal,
-                 engine='netcdf4'):
+                 engine=None):
         """Init the file handler."""
         super(NCOLCI1B, self).__init__(filename, filename_info,
                                        filetype_info)
@@ -241,7 +241,7 @@ class NCOLCIAngles(BaseFileHandler):
                 'solar_zenith_angle': 'SZA'}
 
     def __init__(self, filename, filename_info, filetype_info,
-                 engine='netcdf4'):
+                 engine=None):
         """Init the file handler."""
         super(NCOLCIAngles, self).__init__(filename, filename_info,
                                            filetype_info)

--- a/satpy/readers/olci_nc.py
+++ b/satpy/readers/olci_nc.py
@@ -16,18 +16,22 @@
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Sentinel-3 OLCI reader.
+
 This reader supports an optional argument to choose the 'engine' for reading
-OLCI netCDF4 files. By default, the 'netcdf4' engine is used. As an
+OLCI netCDF4 files. By default, this reader uses the default xarray choice of
+engine, as defined in the `xarray open_dataset documentation`_. As an
 alternative, the user may wish to use the 'h5netcdf' engine, but that is
 not default as it typically prints many non-fatal but confusing error
 messages to the terminal.
 To choose between engines the user can  do as follows for the default:
-scn = satpyScene(filenames=my_files,
-                 reader='olci_l1b')
+scn = satpyScene(filenames=my_files, reader='olci_l1b')
 or as follows for the h5netcdf engine:
 scn = Scene(filenames=my_files,
-            reader='olci_l1b'),
-            reader_kwargs={'engine': 'h5netcdf'})
+reader='olci_l1b'), reader_kwargs={'engine': 'h5netcdf'})
+
+References:
+    - `xarray open_dataset documentation`_
+.. _xarray open_dataset: http://xarray.pydata.org/en/stable/generated/xarray.open_dataset.html
 
 """
 

--- a/satpy/tests/reader_tests/test_olci_nc.py
+++ b/satpy/tests/reader_tests/test_olci_nc.py
@@ -38,9 +38,19 @@ class TestOLCIReader(unittest.TestCase):
         from satpy.readers.olci_nc import (NCOLCIBase, NCOLCICal, NCOLCIGeo,
                                            NCOLCIChannelBase, NCOLCI1B, NCOLCI2)
         from satpy import DatasetID
+        import xarray as xr
 
-        ds_id = DatasetID(name='foo')
-        filename_info = {'mission_id': 'S3A', 'dataset_name': 'foo', 'start_time': 0, 'end_time': 0}
+        cal_data = xr.Dataset(
+                   {
+                       'solar_flux': (('bands'), [0, 1, 2]),
+                       'detector_index': (('bands'), [0, 1, 2]),
+                   },
+                   {'bands': [0, 1, 2], },
+                   )
+
+        ds_id = DatasetID(name='Oa01', calibration='reflectance')
+        ds_id2 = DatasetID(name='wsqf', calibration='reflectance')
+        filename_info = {'mission_id': 'S3A', 'dataset_name': 'Oa01', 'start_time': 0, 'end_time': 0}
 
         test = NCOLCIBase('somedir/somefile.nc', filename_info, 'c')
         test.get_dataset(ds_id, filename_info)
@@ -62,21 +72,18 @@ class TestOLCIReader(unittest.TestCase):
         mocked_dataset.assert_called()
         mocked_dataset.reset_mock()
 
-        test = NCOLCI1B('somedir/somefile.nc', filename_info, 'c', mock.Mock())
+        cal = mock.Mock()
+        cal.nc = cal_data
+        test = NCOLCI1B('somedir/somefile.nc', filename_info, 'c', cal)
         test.get_dataset(ds_id, filename_info)
         mocked_dataset.assert_called()
         mocked_dataset.reset_mock()
 
         test = NCOLCI2('somedir/somefile.nc', filename_info, 'c')
         test.get_dataset(ds_id, {'nc_key': 'the_key'})
+        test.get_dataset(ds_id2, {'nc_key': 'the_key'})
         mocked_dataset.assert_called()
         mocked_dataset.reset_mock()
-
-        # ds_id = DatasetID(name='solar_azimuth_angle')
-        # test = NCOLCIAngles('somedir/somefile.nc', filename_info, 'c')
-        # test.get_dataset(ds_id, filename_info)
-        # mocked_dataset.assert_called()
-        # mocked_dataset.reset_mock()
 
     @mock.patch('xarray.open_dataset')
     def test_get_dataset(self, mocked_dataset):
@@ -94,6 +101,38 @@ class TestOLCIReader(unittest.TestCase):
         test = NCOLCI2('somedir/somefile.nc', filename_info, 'c')
         res = test.get_dataset(ds_id, {'nc_key': 'mask'})
         self.assertEqual(res.dtype, np.dtype('bool'))
+
+    @mock.patch('xarray.open_dataset')
+    def test_olci_angles(self, mocked_dataset):
+        """Test reading datasets."""
+        from satpy.readers.olci_nc import NCOLCIAngles
+        from satpy import DatasetID
+        import numpy as np
+        import xarray as xr
+        attr_dict = {
+            'ac_subsampling_factor': 1,
+            'al_subsampling_factor': 2,
+        }
+        mocked_dataset.return_value = xr.Dataset({'SAA': (['tie_rows', 'tie_columns'],
+                                                  np.array([1 << x for x in range(30)]).reshape(5, 6)),
+                                                  'SZA': (['tie_rows', 'tie_columns'],
+                                                          np.array([1 << x for x in range(30)]).reshape(5, 6)),
+                                                  'OAA': (['tie_rows', 'tie_columns'],
+                                                          np.array([1 << x for x in range(30)]).reshape(5, 6)),
+                                                  'OZA': (['tie_rows', 'tie_columns'],
+                                                          np.array([1 << x for x in range(30)]).reshape(5, 6))},
+                                                 coords={'rows': np.arange(5),
+                                                         'columns': np.arange(6)},
+                                                 attrs=attr_dict)
+        filename_info = {'mission_id': 'S3A', 'dataset_name': 'Oa01', 'start_time': 0, 'end_time': 0}
+
+        ds_id = DatasetID(name='solar_azimuth_angle')
+        ds_id2 = DatasetID(name='satellite_zenith_angle')
+        test = NCOLCIAngles('somedir/somefile.nc', filename_info, 'c')
+        test.get_dataset(ds_id, filename_info)
+        test.get_dataset(ds_id2, filename_info)
+        mocked_dataset.assert_called()
+        mocked_dataset.reset_mock()
 
 
 class TestBitFlags(unittest.TestCase):


### PR DESCRIPTION
In issue #944 I describe how the OLCI reader prints numerous error messages to the screen during processing. This PR fixed the error messages by switching to the default `xarray` engine for netCDF4. I have also added functions that explicitly close the `netcdf` files at the end of the processing. This may or may not be needed (I'm not sure) but I thought I'd copy what the `GOES-ABI` reader does here.

Lastly, I also split one line of code onto two, which was previously giving a flake8 style error for being too long.

 - [x] Closes #944 
 - [x] Tests passed
 - [x] Passes ``flake8 satpy``
