### PR TITLE
Add the possibility to include scale and offset in geotiffs

### DIFF
--- a/satpy/tests/writer_tests/test_geotiff.py
+++ b/satpy/tests/writer_tests/test_geotiff.py
@@ -151,8 +151,8 @@ class TestGeoTIFFWriter(unittest.TestCase):
         with mock.patch('satpy.writers.XRImage.save') as save_method:
             save_method.return_value = None
             w.save_datasets(datasets, tags={'test2': 2}, compute=False, include_scale_offset=True)
-            called_tags = save_method.call_args[1]['tags']
-            self.assertEqual(set(called_tags.keys()), set(('test1', 'test2', 'scale', 'offset')))
+            called_include = save_method.call_args[1]['include_scale_offset_tags']
+            self.assertTrue(called_include)
 
 
 def suite():

--- a/satpy/tests/writer_tests/test_geotiff.py
+++ b/satpy/tests/writer_tests/test_geotiff.py
@@ -15,8 +15,8 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Tests for the geotiff writer.
-"""
+"""Tests for the geotiff writer."""
+
 import sys
 import numpy as np
 
@@ -48,7 +48,7 @@ class TestGeoTIFFWriter(unittest.TestCase):
             pass
 
     def _get_test_datasets(self):
-        """Helper function to create a single test dataset."""
+        """Create a single test dataset."""
         import xarray as xr
         import dask.array as da
         from datetime import datetime
@@ -142,9 +142,21 @@ class TestGeoTIFFWriter(unittest.TestCase):
             called_tags = save_method.call_args[1]['tags']
             self.assertDictEqual(called_tags, {'test1': 1, 'test2': 2})
 
+    def test_scale_offset(self):
+        """Test tags being added."""
+        from satpy.writers.geotiff import GeoTIFFWriter
+        datasets = self._get_test_datasets()
+        w = GeoTIFFWriter(tags={'test1': 1}, base_dir=self.base_dir)
+        w.info['fill_value'] = 128
+        with mock.patch('satpy.writers.XRImage.save') as save_method:
+            save_method.return_value = None
+            w.save_datasets(datasets, tags={'test2': 2}, compute=False, include_scale_offset=True)
+            called_tags = save_method.call_args[1]['tags']
+            self.assertEqual(set(called_tags.keys()), set(('test1', 'test2', 'scale', 'offset')))
+
 
 def suite():
-    """The test suite for this writer's tests."""
+    """Test suite for this writer's tests."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestGeoTIFFWriter))

--- a/satpy/tests/writer_tests/test_ninjotiff.py
+++ b/satpy/tests/writer_tests/test_ninjotiff.py
@@ -36,6 +36,10 @@ class FakeImage:
         self.data = data
         self.mode = mode
 
+    def get_scaling_from_history(self):
+        """Return dummy scale and offset."""
+        return xr.DataArray(1), xr.DataArray(0)
+
 
 modules = {'pyninjotiff': mock.Mock(),
            'pyninjotiff.ninjotiff': mock.Mock()}

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -15,9 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""GeoTIFF writer objects for creating GeoTIFF files from `Dataset` objects.
-
-"""
+"""GeoTIFF writer objects for creating GeoTIFF files from `Dataset` objects."""
 
 import logging
 import numpy as np
@@ -25,6 +23,7 @@ from satpy.writers import ImageWriter
 # make sure we have rasterio even though we don't use it until trollimage
 # saves the image
 import rasterio  # noqa
+from satpy.writers.utils import get_scale_offset
 
 LOG = logging.getLogger(__name__)
 
@@ -74,6 +73,7 @@ class GeoTIFFWriter(ImageWriter):
                     "copy_src_overviews",)
 
     def __init__(self, dtype=None, tags=None, **kwargs):
+        """Init the writer."""
         super(GeoTIFFWriter, self).__init__(default_config_filename="writers/geotiff.yaml", **kwargs)
         self.dtype = self.info.get("dtype") if dtype is None else dtype
         self.tags = self.info.get("tags", None) if tags is None else tags
@@ -91,6 +91,7 @@ class GeoTIFFWriter(ImageWriter):
 
     @classmethod
     def separate_init_kwargs(cls, kwargs):
+        """Separate the init keyword args."""
         # FUTURE: Don't pass Scene.save_datasets kwargs to init and here
         init_kwargs, kwargs = super(GeoTIFFWriter, cls).separate_init_kwargs(
             kwargs)
@@ -183,6 +184,10 @@ class GeoTIFFWriter(ImageWriter):
 
         tags = kwargs.get('tags', {})
         tags.update(self.tags)
+        if kwargs.get('include_scale_offset', False):
+            scale, offset = get_scale_offset(img)
+            tags.setdefault('scale', scale)
+            tags.setdefault('offset', offset)
         return img.save(filename, fformat='tif', fill_value=fill_value,
                         dtype=dtype, compute=compute,
                         keep_palette=keep_palette, cmap=cmap,

--- a/satpy/writers/ninjotiff.py
+++ b/satpy/writers/ninjotiff.py
@@ -83,7 +83,7 @@ from dask import delayed
 
 import pyninjotiff.ninjotiff as nt
 from satpy.writers import ImageWriter
-from satpy.writers.utils import get_scale_offset
+from trollimage.xrimage import invert_scale_offset
 
 
 logger = logging.getLogger(__name__)
@@ -136,13 +136,15 @@ class NinjoTIFFWriter(ImageWriter):
             or "ch_max_measurement_unit" not in kwargs
         ):
             try:
-                scale, offset = get_scale_offset(img)
+                scale, offset = img.get_scaling_from_history()
+                scale, offset = invert_scale_offset(scale, offset)
             except ValueError as err:
                 logger.warning(str(err))
             else:
                 try:
+                    # Here we know that the data if the image is scaled between 0 and 1
                     dmin = offset
-                    dmax = scale - offset
+                    dmax = scale + offset
                     if dmin > dmax:
                         dmin, dmax = dmax, dmin
                     ch_min_measurement_unit, ch_max_measurement_unit = (

--- a/satpy/writers/utils.py
+++ b/satpy/writers/utils.py
@@ -15,11 +15,11 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Writer utilities"""
+"""Writer utilities."""
 
 
 def flatten_dict(d, parent_key='', sep='_'):
-    """Flatten a nested dictionary
+    """Flatten a nested dictionary.
 
     Based on https://stackoverflow.com/a/6027615/5703449
     """
@@ -31,3 +31,26 @@ def flatten_dict(d, parent_key='', sep='_'):
         else:
             items.append((new_key, v))
     return dict(items)
+
+
+def get_scale_offset(img):
+    """Get the scale and offset from the images's enhancement history.
+
+    The values can be used to restore the data to it's original span with::
+
+      original_data = scale * data + offset
+
+    """
+    try:
+        history = img.data.attrs["enhancement_history"]
+    except KeyError:
+        raise ValueError("Cannot find information on previous scaling for image.")
+    else:
+        if len(history) > 1:
+            raise NotImplementedError("Don't know how to process large enhancement_history yet")
+
+        scale, offset = history[0]["scale"], history[0]["offset"]
+
+        new_offset = -offset / scale
+        new_scale = 1 / scale
+        return new_scale, new_offset

--- a/satpy/writers/utils.py
+++ b/satpy/writers/utils.py
@@ -31,26 +31,3 @@ def flatten_dict(d, parent_key='', sep='_'):
         else:
             items.append((new_key, v))
     return dict(items)
-
-
-def get_scale_offset(img):
-    """Get the scale and offset from the images's enhancement history.
-
-    The values can be used to restore the data to it's original span with::
-
-      original_data = scale * data + offset
-
-    """
-    try:
-        history = img.data.attrs["enhancement_history"]
-    except KeyError:
-        raise ValueError("Cannot find information on previous scaling for image.")
-    else:
-        if len(history) > 1:
-            raise NotImplementedError("Don't know how to process large enhancement_history yet")
-
-        scale, offset = history[0]["scale"], history[0]["offset"]
-
-        new_offset = -offset / scale
-        new_scale = 1 / scale
-        return new_scale, new_offset


### PR DESCRIPTION
This PR makes it possible to pass dynamically computed scale and offset to the geotiff writer

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
