### PR TITLE
Encode header attributes in CF writer

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -340,7 +340,12 @@ class TestCFWriter(unittest.TestCase):
                 self.assertEqual(f.attrs['sensor'], 'SEVIRI')
                 self.assertEqual(f.attrs['orbit'], 99999)
                 np.testing.assert_array_equal(f.attrs['list'], [1, 2, 3])
-                self.assertEqual(f.attrs['set'], '{1, 2, 3}')
+                if sys.version_info.major == 3:
+                    self.assertEqual(f.attrs['set'], '{1, 2, 3}')
+                else:
+                    # json module seems to encode sets differently in
+                    # Python 2 and 3
+                    self.assertEqual(f.attrs['set'], u'set([1, 2, 3])')
                 self.assertEqual(f.attrs['dict_a'], 1)
                 self.assertEqual(f.attrs['dict_b'], 2)
                 self.assertEqual(f.attrs['nested_outer_inner1'], 1)

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -324,19 +324,14 @@ class TestCFWriter(unittest.TestCase):
                                                     end_time=end_time))
         with TempFile() as filename:
             header_attrs = {'sensor': 'SEVIRI',
-                            'orbit': None,
-                            'empty': [],
-                            'num': 1.1,
-                            'zero': 0}
+                            'orbit': None}
             scn.save_datasets(filename=filename,
                               header_attrs=header_attrs,
                               writer='cf')
             with xr.open_dataset(filename) as f:
-                self.assertEqual(f.attrs['sensor'], 'SEVIRI')
-                self.assertEqual(f.attrs['num'], 1.1)
-                self.assertEqual(f.attrs['zero'], 0)
-                self.assertNotIn('orbit', f.attrs)
-                self.assertNotIn('empty', f.attrs)
+                self.assertTrue(f.attrs['sensor'] == 'SEVIRI')
+                self.assertTrue('sensor' in f.attrs.keys())
+                self.assertTrue('orbit' not in f.attrs.keys())
 
     def get_test_attrs(self):
         """Create some dataset attributes for testing purpose.

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -324,14 +324,19 @@ class TestCFWriter(unittest.TestCase):
                                                     end_time=end_time))
         with TempFile() as filename:
             header_attrs = {'sensor': 'SEVIRI',
-                            'orbit': None}
+                            'orbit': None,
+                            'empty': [],
+                            'num': 1.1,
+                            'zero': 0}
             scn.save_datasets(filename=filename,
                               header_attrs=header_attrs,
                               writer='cf')
             with xr.open_dataset(filename) as f:
-                self.assertTrue(f.attrs['sensor'] == 'SEVIRI')
-                self.assertTrue('sensor' in f.attrs.keys())
-                self.assertTrue('orbit' not in f.attrs.keys())
+                self.assertEqual(f.attrs['sensor'], 'SEVIRI')
+                self.assertEqual(f.attrs['num'], 1.1)
+                self.assertEqual(f.attrs['zero'], 0)
+                self.assertNotIn('orbit', f.attrs)
+                self.assertNotIn('empty', f.attrs)
 
     def get_test_attrs(self):
         """Create some dataset attributes for testing purpose.

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -345,6 +345,7 @@ class TestCFWriter(unittest.TestCase):
                  'end_time': datetime(2018, 1, 1, 0, 15),
                  'int': 1,
                  'float': 1.0,
+                 'none': None,  # should be dropped
                  'numpy_int': np.uint8(1),
                  'numpy_float': np.float32(1),
                  'numpy_bool': np.bool(True),

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -324,14 +324,30 @@ class TestCFWriter(unittest.TestCase):
                                                     end_time=end_time))
         with TempFile() as filename:
             header_attrs = {'sensor': 'SEVIRI',
-                            'orbit': None}
+                            'orbit': 99999,
+                            'none': None,
+                            'list': [1, 2, 3],
+                            'set': {1, 2, 3},
+                            'dict': {'a': 1, 'b': 2},
+                            'nested': {'outer': {'inner1': 1, 'inner2': 2}},
+                            'bool': True,
+                            'bool_': np.bool_(True)}
             scn.save_datasets(filename=filename,
                               header_attrs=header_attrs,
+                              flatten_attrs=True,
                               writer='cf')
             with xr.open_dataset(filename) as f:
-                self.assertTrue(f.attrs['sensor'] == 'SEVIRI')
-                self.assertTrue('sensor' in f.attrs.keys())
-                self.assertTrue('orbit' not in f.attrs.keys())
+                self.assertEqual(f.attrs['sensor'], 'SEVIRI')
+                self.assertEqual(f.attrs['orbit'], 99999)
+                np.testing.assert_array_equal(f.attrs['list'], [1, 2, 3])
+                self.assertEqual(f.attrs['set'], '{1, 2, 3}')
+                self.assertEqual(f.attrs['dict_a'], 1)
+                self.assertEqual(f.attrs['dict_b'], 2)
+                self.assertEqual(f.attrs['nested_outer_inner1'], 1)
+                self.assertEqual(f.attrs['nested_outer_inner2'], 2)
+                self.assertEqual(f.attrs['bool'], 'true')
+                self.assertEqual(f.attrs['bool_'], 'true')
+                self.assertTrue('none' not in f.attrs.keys())
 
     def get_test_attrs(self):
         """Create some dataset attributes for testing purpose.

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -372,21 +372,21 @@ class TestCFWriter(unittest.TestCase):
                    'float': 1.0,
                    'numpy_int': np.uint8(1),
                    'numpy_float': np.float32(1),
-                   'numpy_bool': np.bool(True),
+                   'numpy_bool': 'true',
                    'numpy_void': '[]',
                    'numpy_bytes': 'test',
                    'numpy_string': 'test',
                    'list': [1, 2, np.float64(3)],
                    'nested_list': '["1", ["2", [3]]]',
-                   'bool': True,
+                   'bool': 'true',
                    'array': np.array([1, 2, 3], dtype='uint8'),
-                   'array_bool': ['True', 'False', 'True'],
+                   'array_bool': ['true', 'false', 'true'],
                    'array_2d': '[[1, 2], [3, 4]]',
                    'array_3d': '[[[1, 2], [3, 4]], [[1, 2], [3, 4]]]',
                    'dict': '{"a": 1, "b": 2}',
                    'nested_dict': '{"l1": {"l2": {"l3": [1, 2, 3]}}}',
                    'raw_metadata': '{"recarray": [[0, 0], [0, 0], [0, 0]], '
-                                   '"flag": "True", "dict": {"a": 1, "b": [1, 2, 3]}}'}
+                                   '"flag": "true", "dict": {"a": 1, "b": [1, 2, 3]}}'}
         encoded_flat = {'name': 'IR_108',
                         'start_time': '2018-01-01 00:00:00',
                         'end_time': '2018-01-01 00:15:00',
@@ -394,22 +394,22 @@ class TestCFWriter(unittest.TestCase):
                         'float': 1.0,
                         'numpy_int': np.uint8(1),
                         'numpy_float': np.float32(1),
-                        'numpy_bool': np.bool(True),
+                        'numpy_bool': 'true',
                         'numpy_void': '[]',
                         'numpy_bytes': 'test',
                         'numpy_string': 'test',
                         'list': [1, 2, np.float64(3)],
                         'nested_list': '["1", ["2", [3]]]',
-                        'bool': True,
+                        'bool': 'true',
                         'array': np.array([1, 2, 3], dtype='uint8'),
-                        'array_bool': ['True', 'False', 'True'],
+                        'array_bool': ['true', 'false', 'true'],
                         'array_2d': '[[1, 2], [3, 4]]',
                         'array_3d': '[[[1, 2], [3, 4]], [[1, 2], [3, 4]]]',
                         'dict_a': 1,
                         'dict_b': 2,
                         'nested_dict_l1_l2_l3': np.array([1, 2, 3], dtype='uint8'),
                         'raw_metadata_recarray': '[[0, 0], [0, 0], [0, 0]]',
-                        'raw_metadata_flag': 'True',
+                        'raw_metadata_flag': 'true',
                         'raw_metadata_dict_a': 1,
                         'raw_metadata_dict_b': np.array([1, 2, 3], dtype='uint8')}
         return attrs, encoded, encoded_flat
@@ -441,7 +441,7 @@ class TestCFWriter(unittest.TestCase):
 
         # Test decoding of json-encoded attributes
         raw_md_roundtrip = {'recarray': [[0, 0], [0, 0], [0, 0]],
-                            'flag': "True",
+                            'flag': 'true',
                             'dict': {'a': 1, 'b': [1, 2, 3]}}
         self.assertDictEqual(json.loads(encoded['raw_metadata']), raw_md_roundtrip)
         self.assertListEqual(json.loads(encoded['array_3d']), [[[1, 2], [3, 4]], [[1, 2], [3, 4]]])

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -385,7 +385,7 @@ class AttributeEncoder(json.JSONEncoder):
         """Encode the given object as a json-serializable datatype."""
         if isinstance(obj, (bool, np.bool_)):
             # Bool has to be checked first, because it is a subclass of int
-            return str(obj)
+            return str(obj).lower()
         elif isinstance(obj, (int, float, str)):
             return obj
         elif isinstance(obj, np.integer):
@@ -407,7 +407,9 @@ def _encode_nc(obj):
         ValueError if no such datatype could be found
 
     """
-    if isinstance(obj, (int, float, str, np.integer, np.floating)):
+    if isinstance(obj, int) and not isinstance(obj, (bool, np.bool_)):
+        return obj
+    elif isinstance(obj, (float, str, np.integer, np.floating)):
         return obj
     elif isinstance(obj, np.ndarray):
         # Only plain 1-d arrays are supported. Skip record arrays and multi-dimensional arrays.
@@ -417,8 +419,9 @@ def _encode_nc(obj):
                 return obj
             elif obj.dtype == np.bool_:
                 # Boolean arrays are not supported, convert to array of strings.
-                obj = obj.astype(str)
-            return obj.tolist()
+                return [s.lower() for s in obj.astype(str)]
+            else:
+                return obj.tolist()
 
     raise ValueError('Unable to encode')
 

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -642,7 +642,9 @@ class CFWriter(Writer):
 
         root = xr.Dataset({}, attrs={'history': 'Created by pytroll/satpy on {}'.format(datetime.utcnow())})
         if header_attrs is not None:
-            root.attrs.update({k: v for k, v in header_attrs.items() if v})
+            if flatten_attrs:
+                header_attrs = flatten_dict(header_attrs)
+            root.attrs = encode_attrs_nc(header_attrs)
         if groups is None:
             # Groups are not CF-1.7 compliant
             root.attrs['Conventions'] = CF_VERSION

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -638,8 +638,7 @@ class CFWriter(Writer):
 
         root = xr.Dataset({}, attrs={'history': 'Created by pytroll/satpy on {}'.format(datetime.utcnow())})
         if header_attrs is not None:
-            root.attrs.update({k: v for k, v in header_attrs.items()
-                               if (np.isscalar(v) and v is not None) or v})
+            root.attrs.update({k: v for k, v in header_attrs.items() if v})
         if groups is None:
             # Groups are not CF-1.7 compliant
             root.attrs['Conventions'] = CF_VERSION

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -420,8 +420,7 @@ def _encode_nc(obj):
             elif obj.dtype == np.bool_:
                 # Boolean arrays are not supported, convert to array of strings.
                 return [s.lower() for s in obj.astype(str)]
-            else:
-                return obj.tolist()
+            return obj.tolist()
 
     raise ValueError('Unable to encode')
 

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -638,7 +638,8 @@ class CFWriter(Writer):
 
         root = xr.Dataset({}, attrs={'history': 'Created by pytroll/satpy on {}'.format(datetime.utcnow())})
         if header_attrs is not None:
-            root.attrs.update({k: v for k, v in header_attrs.items() if v})
+            root.attrs.update({k: v for k, v in header_attrs.items()
+                               if (np.isscalar(v) and v is not None) or v})
         if groups is None:
             # Groups are not CF-1.7 compliant
             root.attrs['Conventions'] = CF_VERSION

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -456,7 +456,8 @@ def encode_attrs_nc(attrs):
     """
     encoded_attrs = []
     for key, val in sorted(attrs.items()):
-        encoded_attrs.append((key, encode_nc(val)))
+        if val is not None:
+            encoded_attrs.append((key, encode_nc(val)))
     return OrderedDict(encoded_attrs)
 
 


### PR DESCRIPTION
This PR introduces encoding of header attributes in the CF writer. The same methods are employed as for dataset attributes (i.e. the standard json encoder plus some extra rules). This also fixes the problem of zero-valued header attributes not being included in the global nc attributes.

Furthermore, I harmonized the encoding of `bool` and `np.bool_` attributes. Currently we have `"True"` for `np.bool_` and `"true"` for boolean. I chose `"true"` and `"false"` because that is the json default.

 - [X] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
