### PR TITLE
Fix `grid` argument handling in overlaying

### DIFF
--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -265,11 +265,12 @@ def add_overlay(orig_img, area, coast_dir, color=None, width=None, resolution=No
             level_borders = 1
         overlays.setdefault('borders', {}).setdefault('level', level_borders)
 
-        if grid is not None and 'major_lonlat' in grid and grid['major_lonlat']:
-            major_lonlat = grid.pop('major_lonlat')
-            minor_lonlat = grid.pop('minor_lonlat', major_lonlat)
-            grid_params = {'Dlonlat': major_lonlat, 'dlonlat': minor_lonlat}
-            for key, val in grid_params.items():
+        if grid is not None:
+            if 'major_lonlat' in grid and grid['major_lonlat']:
+                major_lonlat = grid.pop('major_lonlat')
+                minor_lonlat = grid.pop('minor_lonlat', major_lonlat)
+                grid.update({'Dlonlat': major_lonlat, 'dlonlat': minor_lonlat})
+            for key, val in grid.items():
                 overlays.setdefault('grid', {}).setdefault(key, val)
 
     cw_ = ContourWriterAGG(coast_dir)


### PR DESCRIPTION
This was introduced in #934 

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
