### PR TITLE
Fix default radius_of_influence for lon/lat AreaDefintions

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -464,30 +464,14 @@ class KDTreeResampler(BaseResampler):
 
         """
         from pyresample.kd_tree import XArrayResamplerNN
-
         del kwargs
-        source_geo_def = self.source_geo_def
-
         if mask is not None and cache_dir is not None:
             LOG.warning("Mask and cache_dir both provided to nearest "
                         "resampler. Cached parameters are affected by "
                         "masked pixels. Will not cache results.")
             cache_dir = None
-        # TODO: move this to pyresample
-        if radius_of_influence is None:
-            try:
-                radius_of_influence = source_geo_def.lons.resolution * 3
-            except AttributeError:
-                try:
-                    radius_of_influence = max(abs(source_geo_def.pixel_size_x),
-                                              abs(source_geo_def.pixel_size_y)) * 3
-                except AttributeError:
-                    radius_of_influence = 1000
 
-            except TypeError:
-                radius_of_influence = 10000
-
-        kwargs = dict(source_geo_def=source_geo_def,
+        kwargs = dict(source_geo_def=self.source_geo_def,
                       target_geo_def=self.target_geo_def,
                       radius_of_influence=radius_of_influence,
                       neighbours=1,

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -140,6 +140,7 @@ import dask
 import dask.array as da
 import zarr
 import six
+import warnings
 
 from pyresample.ewa import fornav, ll2cr
 from pyresample.geometry import SwathDefinition
@@ -470,6 +471,20 @@ class KDTreeResampler(BaseResampler):
                         "resampler. Cached parameters are affected by "
                         "masked pixels. Will not cache results.")
             cache_dir = None
+
+        if radius_of_influence is None and not hasattr(self.source_geo_def, 'geocentric_resolution'):
+            warnings.warn("Upgrade 'pyresample' for a more accurate default 'radius_of_influence'.")
+            try:
+                radius_of_influence = self.source_geo_def.lons.resolution * 3
+            except AttributeError:
+                try:
+                    radius_of_influence = max(abs(self.source_geo_def.pixel_size_x),
+                                              abs(self.source_geo_def.pixel_size_y)) * 3
+                except AttributeError:
+                    radius_of_influence = 1000
+
+            except TypeError:
+                radius_of_influence = 10000
 
         kwargs = dict(source_geo_def=self.source_geo_def,
                       target_geo_def=self.target_geo_def,


### PR DESCRIPTION
Depends on https://github.com/pytroll/pyresample/pull/225. See that PR for more information.

This removes the logic to calculate a decent default radius_of_influence during nearest neighbor resampling. This logic was flawed and produced bad defaults for lon/lat AreaDefinitions. The logic in pyresample should behave in these cases and provided better/more accurate defaults in other cases.

One possible gotcha: the computed radius_of_influence is no longer included in the kwargs which are used to generate the caching key. This shouldn't be an issue since the source_geo_def and target_geo_def are still used.

 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
