### PR TITLE
Add the fire temperature products to AHI

### DIFF
--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -28,6 +28,51 @@ composites:
       modifiers: [sunz_corrected]
     standard_name: toa_bidirectional_reflectance
 
+  fire_temperature:
+    # CIRA: Original VIIRS
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - wavelength: 3.85
+      calibration: radiance
+    - wavelength: 2.26
+      calibration: radiance
+    - wavelength: 1.61
+      calibration: radiance
+    standard_name: fire_temperature
+    name: fire_temperature
+  fire_temperature_awips:
+    # CIRA: EUMETSAT
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - wavelength: 3.85
+    - wavelength: 2.26
+    - wavelength: 1.61
+    standard_name: fire_temperature
+    name: fire_temperature_awips
+
+  fire_temperature_eumetsat:
+    # CIRA: AWIPS
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - wavelength: 3.85
+    - wavelength: 2.26
+    - wavelength: 1.61
+    standard_name: fire_temperature
+    name: fire_temperature_eumetsat
+  fire_temperature_39refl:
+    # CIRA: All bands in Reflectance units (%)
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - wavelength: 3.85
+      modifiers: [nir_reflectance]
+    - wavelength: 2.26
+      modifiers: [sunz_corrected]
+    - wavelength: 1.61
+      modifiers: [sunz_corrected]
+    standard_name: fire_temperature
+    name: fire_temperature_39refl
+
+
   overview:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -318,6 +318,6 @@ class HRITJMAFileHandler(HRITFileHandler):
             res = xr.DataArray(res,
                                dims=data.dims, attrs=data.attrs,
                                coords=data.coords)
-        res = res.where(data < 65635)
+        res = res.where(data < 65535)
         logger.debug("Calibration time " + str(datetime.now() - tic))
         return res

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -15,8 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""HRIT format reader for JMA data
-************************************
+"""HRIT format reader for JMA data.
 
 References:
     JMA HRIT - Mission Specific Implementation
@@ -152,7 +151,7 @@ class HRITJMAFileHandler(HRITFileHandler):
         self.area = self._get_area_def()
 
     def _get_platform(self):
-        """Get the platform name
+        """Get the platform name.
 
         The platform is not specified explicitly in JMA HRIT files. For
         segmented data it is not even specified in the filename. But it
@@ -175,6 +174,7 @@ class HRITJMAFileHandler(HRITFileHandler):
         References:
         [MTSAT] http://www.data.jma.go.jp/mscweb/notice/Himawari7_e.html
         [HIMAWARI] http://www.data.jma.go.jp/mscweb/en/himawari89/space_segment/sample_hrit.html
+
         """
         try:
             return PLATFORMS[self.projection_name]
@@ -184,13 +184,14 @@ class HRITJMAFileHandler(HRITFileHandler):
             return UNKNOWN_PLATFORM
 
     def _check_sensor_platform_consistency(self, sensor):
-        """Make sure sensor and platform are consistent
+        """Make sure sensor and platform are consistent.
 
         Args:
             sensor (str) : Sensor name from YAML dataset definition
 
         Raises:
             ValueError if they don't match
+
         """
         ref_sensor = SENSORS.get(self.platform, None)
         if ref_sensor and not sensor == ref_sensor:
@@ -199,7 +200,7 @@ class HRITJMAFileHandler(HRITFileHandler):
                          .format(sensor, self.platform))
 
     def _get_line_offset(self):
-        """Get line offset for the current segment
+        """Get line offset for the current segment.
 
         Read line offset from the file and adapt it to the current segment
         or half disk scan so that
@@ -295,7 +296,7 @@ class HRITJMAFileHandler(HRITFileHandler):
         return res
 
     def _mask_space(self, data):
-        """Mask space pixels"""
+        """Mask space pixels."""
         geomask = get_geostationary_mask(area=self.area)
         return data.where(geomask)
 
@@ -317,6 +318,6 @@ class HRITJMAFileHandler(HRITFileHandler):
             res = xr.DataArray(res,
                                dims=data.dims, attrs=data.attrs,
                                coords=data.coords)
-        res = res.where(data > 0)
+        res = res.where(data < 65635)
         logger.debug("Calibration time " + str(datetime.now() - tic))
         return res

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -15,8 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""The hrit msg reader tests package.
-"""
+"""The hrit msg reader tests package."""
 
 import sys
 import numpy as np
@@ -48,7 +47,7 @@ class TestHRITJMAFileHandler(unittest.TestCase):
 
     def _get_mda(self, loff=5500.0, coff=5500.0, nlines=11000, ncols=11000,
                  segno=0, numseg=1, vis=True):
-        """Create metadata dict like HRITFileHandler would do it"""
+        """Create metadata dict like HRITFileHandler would do it."""
         if vis:
             idf = b'$HALFTONE:=16\r_NAME:=VISIBLE\r_UNIT:=ALBEDO(%)\r' \
                   b'0:=-0.10\r1023:=100.00\r65535:=100.00\r'
@@ -120,7 +119,7 @@ class TestHRITJMAFileHandler(unittest.TestCase):
 
     @mock.patch('satpy.readers.hrit_jma.HRITJMAFileHandler.__init__')
     def test_get_platform(self, mocked_init):
-        """Test platform identification"""
+        """Test platform identification."""
         from satpy.readers.hrit_jma import HRITJMAFileHandler
         from satpy.readers.hrit_jma import PLATFORMS, UNKNOWN_PLATFORM
 
@@ -188,22 +187,24 @@ class TestHRITJMAFileHandler(unittest.TestCase):
                                   case['extent'])
 
     def test_calibrate(self):
-        """Test calibration"""
+        """Test calibration."""
         # Generate test data
-        counts = DataArray(da.linspace(0, 1200, 25, chunks=5).reshape(5, 5))
+        counts = np.linspace(0, 1200, 25).reshape(5, 5)
+        counts[-1, -1] = 65535
+        counts = DataArray(da.from_array(counts, chunks=5))
         refl = np.array(
-            [[np.nan,        4.79247312,   9.68494624,  14.57741935,  19.46989247],
+            [[-0.1,            4.79247312,   9.68494624,  14.57741935,  19.46989247],
              [24.36236559,  29.25483871,  34.14731183,  39.03978495,  43.93225806],
              [48.82473118,  53.7172043,   58.60967742,  63.50215054,  68.39462366],
              [73.28709677,  78.17956989,  83.07204301,  87.96451613,  92.85698925],
-             [97.74946237,  100.,         100.,         100.,         100.]]
+             [97.74946237,  100.,         100.,         100.,         np.nan]]
         )
         bt = np.array(
-            [[np.nan,       320.20678397, 310.43356794, 300.66035191, 290.88713587],
+            [[329.98,            320.20678397, 310.43356794, 300.66035191, 290.88713587],
              [281.11391984, 271.34070381, 261.56748778, 251.79427175, 242.02105572],
              [232.24783969, 222.47462366, 212.70140762, 202.92819159, 193.15497556],
              [183.38175953, 173.6085435,  163.83532747, 154.06211144, 144.28889541],
-             [134.51567937, 130.02,       130.02,       130.02,       130.02]]
+             [134.51567937, 130.02,       130.02,       130.02,       np.nan]]
         )
 
         # Choose an area near the subsatellite point to avoid masking
@@ -229,7 +230,7 @@ class TestHRITJMAFileHandler(unittest.TestCase):
         np.testing.assert_allclose(bt, res.values)  # also compares NaN
 
     def test_mask_space(self):
-        """Test masking of space pixels"""
+        """Test masking of space pixels."""
         mda = self._get_mda(loff=1375.0, coff=1375.0, nlines=275, ncols=1375,
                             segno=1, numseg=10)
         reader = self._get_reader(mda=mda)
@@ -243,7 +244,7 @@ class TestHRITJMAFileHandler(unittest.TestCase):
 
     @mock.patch('satpy.readers.hrit_jma.HRITFileHandler.get_dataset')
     def test_get_dataset(self, base_get_dataset):
-        """Test getting a dataset"""
+        """Test getting a dataset."""
         from satpy.readers.hrit_jma import HIMAWARI8
 
         mda = self._get_mda(loff=1375.0, coff=1375.0, nlines=275, ncols=1375,
@@ -281,8 +282,7 @@ class TestHRITJMAFileHandler(unittest.TestCase):
 
 
 def suite():
-    """The test suite for test_scene.
-    """
+    """Test suite for test_scene."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestHRITJMAFileHandler))

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""The hrit msg reader tests package."""
+"""The hrit ahi reader tests package."""
 
 import sys
 import numpy as np


### PR DESCRIPTION
This also fixes the masking of the `ahi_hrit` reader.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

