### PR TITLE
Keep history attribute  when header_attrs are provided

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -337,6 +337,7 @@ class TestCFWriter(unittest.TestCase):
                               flatten_attrs=True,
                               writer='cf')
             with xr.open_dataset(filename) as f:
+                self.assertIn('history', f.attrs)
                 self.assertEqual(f.attrs['sensor'], 'SEVIRI')
                 self.assertEqual(f.attrs['orbit'], 99999)
                 np.testing.assert_array_equal(f.attrs['list'], [1, 2, 3])

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -639,11 +639,12 @@ class CFWriter(Writer):
         # Write global attributes to file root (creates the file)
         filename = filename or self.get_filename(**datasets[0].attrs)
 
-        root = xr.Dataset({}, attrs={'history': 'Created by pytroll/satpy on {}'.format(datetime.utcnow())})
+        root = xr.Dataset({}, attrs={})
         if header_attrs is not None:
             if flatten_attrs:
                 header_attrs = flatten_dict(header_attrs)
             root.attrs = encode_attrs_nc(header_attrs)
+        root.attrs['history'] = 'Created by pytroll/satpy on {}'.format(datetime.utcnow())
         if groups is None:
             # Groups are not CF-1.7 compliant
             root.attrs['Conventions'] = CF_VERSION


### PR DESCRIPTION
Set the history attribute in cf_writer also when header_attrs are provided.

I did not add a test, but updated the one for cf_writer header_attrs.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

