### PR TITLE
Add information about multi-threaded compression with geotiff creation

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -116,3 +116,27 @@ in poor performance during computation. Another solution is to increase
 
 For more information see
 `GDAL's documentation <https://trac.osgeo.org/gdal/wiki/ConfigOptions#GDAL_CACHEMAX>`_.
+
+How do I use multi-threaded compression when writing GeoTIFFs?
+--------------------------------------------------------------
+
+The GDAL library's GeoTIFF driver has a lot of options for changing how your
+GeoTIFF is formatted and written. One of the most important ones when it comes
+to writing GeoTIFFs is using multiple threads to compress your data. By
+default Satpy will use DEFLATE compression which can be slower to compress
+than other options out there, but faster to read. GDAL gives us the option to
+control the number of threads used during compression by specifying the
+``num_threads`` option. This option defaults to ``1``, but it is recommended
+to set this to at least the same number of dask workers you use. Do this by
+adding ``num_threads`` to your `save_dataset` or `save_datasets` call::
+
+    scn.save_datasets(base_dir='/tmp', tiled=True, num_threads=8)
+
+Here we're also using the `tiled` option to store our data as "tiles" instead
+of "stripes" which is another way to get more efficient compression of our
+GeoTIFF image.
+
+See the
+`GDAL GeoTIFF documentation <https://gdal.org/drivers/raster/gtiff.html#creation-options>`_
+for more information on the creation options available including other
+compression choices.

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""GeoTIFF writer objects for creating GeoTIFF files from `Dataset` objects."""
+"""GeoTIFF writer objects for creating GeoTIFF files from `DataArray` objects."""
 
 import logging
 import numpy as np


### PR DESCRIPTION
Adding the `num_threads` option to my `save_datasets` calls has reduced my processing time down **a ton**. For example some processing that was taking 20m on a docker container on an older machine is now taking 5m30s by specifying `num_threads=8`. This PR adds documentation to the FAQ page about using this option.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

## Other options

As mentioned on Slack by @pnuu, maybe we should consider setting this by default or changing the default compression algorithm in trollimage to be something other than DEFLATE. If this is done I would recommend no compression.