### PR TITLE
Fix HDF4 handling of scalar attributes

### DIFF
--- a/satpy/readers/hdf4_utils.py
+++ b/satpy/readers/hdf4_utils.py
@@ -68,13 +68,16 @@ class HDF4FileHandler(BaseFileHandler):
     def _collect_attrs(self, name, attrs):
         for key, value in six.iteritems(attrs):
             value = np.squeeze(value)
-            if issubclass(value.dtype.type, np.string_) and not value.shape:
-                value = np.asscalar(value)
+            if issubclass(value.dtype.type, (np.string_, np.unicode_)) and not value.shape:
+                value = value.item()  # convert to scalar
                 if not isinstance(value, str):
                     # python 3 - was scalar numpy array of bytes
                     # otherwise python 2 - scalar numpy array of 'str'
                     value = value.decode()
                 self.file_content["{}/attr/{}".format(name, key)] = value
+            elif not value.shape:
+                # convert to a scalar
+                self.file_content["{}/attr/{}".format(name, key)] = value.item()
             else:
                 self.file_content["{}/attr/{}".format(name, key)] = value
 

--- a/satpy/tests/reader_tests/test_hdf4_utils.py
+++ b/satpy/tests/reader_tests/test_hdf4_utils.py
@@ -109,9 +109,12 @@ class TestHDF4FileHandler(unittest.TestCase):
             self.assertEqual(attrs.get('test_attr_int'), 0)
             self.assertEqual(attrs.get('test_attr_float'), 1.2)
 
+        self.assertIsInstance(file_handler['/attr/test_attr_str'], str)
         self.assertEqual(file_handler['/attr/test_attr_str'], 'test_string')
         # self.assertEqual(file_handler['/attr/test_attr_str_arr'], 'test_string2')
+        self.assertIsInstance(file_handler['/attr/test_attr_int'], int)
         self.assertEqual(file_handler['/attr/test_attr_int'], 0)
+        self.assertIsInstance(file_handler['/attr/test_attr_float'], float)
         self.assertEqual(file_handler['/attr/test_attr_float'], 1.2)
 
         self.assertIsInstance(file_handler.get('ds1_f'), xr.DataArray)


### PR DESCRIPTION
I'm not sure if this is caused by a new version of numpy, changes to the dtype handling that I did a while back in the HDF4 file handler, or something else. The HDF4 utility file handler is returning all attributes as numpy arrays even if they are scalar attributes. This PR should fix this.

The other option I thought about doing is adding an if statement earlier in the attribute function that checks if the data isn't a numpy array then don't touch it. I'm not sure if this would be good or bad.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
