### PR TITLE
Fix available_composite_names including night_background static images

### DIFF
--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -362,11 +362,11 @@ composites:
     standard_name: night_ir_with_background
     prerequisites:
       - night_ir_alpha
-      - night_background
+      - _night_background
 
   night_ir_with_background_hires:
     compositor: !!python/name:satpy.composites.BackgroundCompositor
     standard_name: night_ir_with_background_hires
     prerequisites:
       - night_ir_alpha
-      - night_background_hires
+      - _night_background_hires

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -392,12 +392,12 @@ composites:
     transition_max: 298.15
     transition_gamma: 3.0
 
-  night_background:
+  _night_background:
     compositor: !!python/name:satpy.composites.StaticImageCompositor
     standard_name: night_background
     filename: BlackMarble_2016_01deg_geo.tif
 
-  night_background_hires:
+  _night_background_hires:
     compositor: !!python/name:satpy.composites.StaticImageCompositor
     standard_name: night_background_hires
     filename: BlackMarble_2016_3km_geo.tif


### PR DESCRIPTION
The builtin static image composites `night_background` and `night_background_hires` were being included in the `scn.available_composite_names()` results. This is misleading and can make users think these composites are coming from the reader data, which they are not.

This PR puts a `_` prefix on these composites which tells the Scene to not list them.

 - [x] Closes https://github.com/ssec/polar2grid/issues/239
 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->