### PR TITLE
Add on-the-fly decompression to the AHI HSD reader

### DIFF
--- a/satpy/etc/readers/ahi_hsd.yaml
+++ b/satpy/etc/readers/ahi_hsd.yaml
@@ -288,49 +288,65 @@ datasets:
 file_types:
   hsd_b01:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B01_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B01_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B01_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b02:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B02_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B02_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B02_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b03:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B03_{area}_R05_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B03_{area}_R05_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B03_{area}_R05_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b04:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B04_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B04_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B04_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b05:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B05_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B05_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B05_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b06:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B06_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B06_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B06_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b07:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B07_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B07_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B07_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b08:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B08_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B08_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B08_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b09:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B09_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B09_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B09_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b10:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B10_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B10_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B10_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b11:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B11_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B11_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B11_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b12:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B12_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B12_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B12_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b13:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B13_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B13_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B13_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b14:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B14_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B14_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B14_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b15:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B15_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B15_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B15_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
   hsd_b16:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B16_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B16_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B16_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -308,7 +308,7 @@ class AHIHSDFileHandler(BaseFileHandler):
         self.calib_mode = calib_mode.upper()
 
     def __del__(self):
-        if (self.is_zipped):
+        if (self.is_zipped and os.path.exists(self.filename)):
             os.remove(self.filename)
 
     @property

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -42,7 +42,8 @@ import warnings
 
 from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
-from satpy.readers.utils import get_geostationary_mask, np2str, get_earth_radius
+from satpy.readers.utils import unzip_file, get_geostationary_mask, \
+                                np2str, get_earth_radius
 from satpy.readers._geos_area import get_area_extent, get_area_definition
 
 AHI_CHANNEL_NAMES = ("1", "2", "3", "4", "5",
@@ -262,6 +263,9 @@ class AHIHSDFileHandler(BaseFileHandler):
         """Initialize the reader."""
         super(AHIHSDFileHandler, self).__init__(filename, filename_info,
                                                 filetype_info)
+        self._unzipped = unzip_file(self.filename)
+        if self._unzipped:
+            self.filename = self._unzipped
 
         self.channels = dict([(i, None) for i in AHI_CHANNEL_NAMES])
         self.units = dict([(i, 'counts') for i in AHI_CHANNEL_NAMES])

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -200,7 +200,7 @@ def unzip_file(filename):
     """Unzip the file if file is bzipped = ending with 'bz2'."""
     if filename.endswith('bz2'):
         fdn, tmpfilepath = tempfile.mkstemp()
-        LOGGER.info("Using temporary file for BZ2 decompression:",tmpfilepath)
+        LOGGER.info("Using temp file for BZ2 decompression:", tmpfilepath)
         # If in python 3, try pbzip2
         if sys.version_info > (3, 0):
             pbzip = shutil.which('pbzifp2')

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -202,7 +202,7 @@ def unzip_file(filename):
         fdn, tmpfilepath = tempfile.mkstemp()
         LOGGER.info("Using temp file for BZ2 decompression:", tmpfilepath)
         # If in python 3, try pbzip2
-        if sys.version_info > (3, 0):
+        if sys.version_info.major >= 3:
             pbzip = shutil.which('pbzip2')
             # Run external pbzip2
             if pbzip is not None:

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -203,7 +203,7 @@ def unzip_file(filename):
         LOGGER.info("Using temp file for BZ2 decompression:", tmpfilepath)
         # If in python 3, try pbzip2
         if sys.version_info > (3, 0):
-            pbzip = shutil.which('pbzifp2')
+            pbzip = shutil.which('pbzip2')
             # Run external pbzip2
             if pbzip is not None:
                 n_thr = os.environ.get('OMP_NUM_THREADS')

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -202,6 +202,8 @@ def unzip_file(filename):
         fdn, tmpfilepath = tempfile.mkstemp()
         LOGGER.info("Using temp file for BZ2 decompression: %s", tmpfilepath)
         # If in python 3, try pbzip2
+        LOGGER.debug("Python version info is: {} | {}".format(repr(sys.version_info), sys.version_info.major >= 3))
+        print("Python version info is: {} | {}".format(repr(sys.version_info), sys.version_info.major >= 3))
         if sys.version_info.major >= 3:
             pbzip = shutil.which('pbzip2')
             # Run external pbzip2

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -200,7 +200,7 @@ def unzip_file(filename):
     """Unzip the file if file is bzipped = ending with 'bz2'."""
     if filename.endswith('bz2'):
         fdn, tmpfilepath = tempfile.mkstemp()
-        LOGGER.info("Using temp file for BZ2 decompression:", tmpfilepath)
+        LOGGER.info("Using temp file for BZ2 decompression: %s", tmpfilepath)
         # If in python 3, try pbzip2
         if sys.version_info.major >= 3:
             pbzip = shutil.which('pbzip2')

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -34,6 +34,12 @@ from pyresample.boundary import AreaDefBoundary, Boundary
 
 from satpy import CHUNK_SIZE
 
+try:
+    from shutil import which
+except ImportError:
+    # python 2 - won't be used, but needed for mocking in tests
+    which = None
+
 LOGGER = logging.getLogger(__name__)
 
 
@@ -202,10 +208,8 @@ def unzip_file(filename):
         fdn, tmpfilepath = tempfile.mkstemp()
         LOGGER.info("Using temp file for BZ2 decompression: %s", tmpfilepath)
         # If in python 3, try pbzip2
-        LOGGER.debug("Python version info is: {} | {}".format(repr(sys.version_info), sys.version_info.major >= 3))
-        print("Python version info is: {} | {}".format(repr(sys.version_info), sys.version_info.major >= 3))
         if sys.version_info.major >= 3:
-            pbzip = shutil.which('pbzip2')
+            pbzip = which('pbzip2')
             # Run external pbzip2
             if pbzip is not None:
                 n_thr = os.environ.get('OMP_NUM_THREADS')

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -200,14 +200,14 @@ def unzip_file(filename):
     """Unzip the file if file is bzipped = ending with 'bz2'."""
     if filename.endswith('bz2'):
         fdn, tmpfilepath = tempfile.mkstemp()
-        print(tmpfilepath)
+        LOGGER.info("Using temporary file for BZ2 decompression:",tmpfilepath)
         # If in python 3, try pbzip2
-        if (sys.version_info > (3, 0)):
+        if sys.version_info > (3, 0):
             pbzip = shutil.which('pbzifp2')
             # Run external pbzip2
             if pbzip is not None:
                 n_thr = os.environ.get('OMP_NUM_THREADS')
-                if (n_thr):
+                if n_thr:
                     runner = [pbzip,
                               '-dc',
                               '-p'+str(n_thr),
@@ -220,7 +220,6 @@ def unzip_file(filename):
                 stdout = BytesIO(p.communicate()[0])
                 status = p.returncode
                 if status != 0:
-                    print(status)
                     raise IOError("pbzip2 error '%s', failed, status=%d"
                                   % (filename, status))
                 with closing(os.fdopen(fdn, 'wb')) as ofpt:

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -301,7 +301,7 @@ class TestAHIHSDFileHandler(unittest.TestCase):
                               'satellite_actual_latitude': 0.03,
                               'nadir_longitude': 140.67,
                               'nadir_latitude': 0.04}
-            self.assertDictContainsSubset(orb_params_exp, im.attrs['orbital_parameters'])
+            self.assertTrue(set(orb_params_exp.items()).issubset( set(im.attrs['orbital_parameters'].items())))
             self.assertTrue(np.isclose(im.attrs['orbital_parameters']['satellite_actual_altitude'], 35786903.00581372))
 
             # Test if masking space pixels disables with appropriate flag

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -132,8 +132,7 @@ class TestAHIHSDFileHandler(unittest.TestCase):
     def new_unzip(fname):
         if(fname[-3:] == 'bz2'):
             return fname[:-4]
-        else:
-            return fname
+        return fname
 
     @mock.patch('satpy.readers.ahi_hsd.np2str')
     @mock.patch('satpy.readers.ahi_hsd.np.fromfile')

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -147,7 +147,12 @@ class TestAHIHSDFileHandler(unittest.TestCase):
             with self.assertRaises(ValueError):
                 fh = AHIHSDFileHandler(None, {'segment_number': 8, 'total_segments': 10}, None, calib_mode='BAD_MODE')
 
-            fh = AHIHSDFileHandler('test_file.bz2', {'segment_number': 8, 'total_segments': 10}, None)
+            in_fname = 'test_file.bz2'
+            fh = AHIHSDFileHandler(in_fname, {'segment_number': 8, 'total_segments': 10}, None)
+
+            # Check that the filename is altered for bz2 format files
+            self.assertNotEqual(in_fname,fh.filename)
+            
             fh.proj_info = {'CFAC': 40932549,
                             'COFF': 5500.5,
                             'LFAC': 40932549,

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -151,7 +151,7 @@ class TestAHIHSDFileHandler(unittest.TestCase):
             fh = AHIHSDFileHandler(in_fname, {'segment_number': 8, 'total_segments': 10}, None)
 
             # Check that the filename is altered for bz2 format files
-            self.assertNotEqual(in_fname,fh.filename)
+            self.assertNotEqual(in_fname, fh.filename)
 
             fh.proj_info = {'CFAC': 40932549,
                             'COFF': 5500.5,

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -130,7 +130,7 @@ class TestAHIHSDNavigation(unittest.TestCase):
 class TestAHIHSDFileHandler(unittest.TestCase):
 
     def new_unzip(fname):
-        if(fname[-3:]=='bz2'):
+        if(fname[-3:] == 'bz2'):
             return fname[:-4]
         else:
             return fname

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -152,7 +152,7 @@ class TestAHIHSDFileHandler(unittest.TestCase):
 
             # Check that the filename is altered for bz2 format files
             self.assertNotEqual(in_fname,fh.filename)
-            
+
             fh.proj_info = {'CFAC': 40932549,
                             'COFF': 5500.5,
                             'LFAC': 40932549,

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -301,7 +301,7 @@ class TestAHIHSDFileHandler(unittest.TestCase):
                               'satellite_actual_latitude': 0.03,
                               'nadir_longitude': 140.67,
                               'nadir_latitude': 0.04}
-            self.assertTrue(set(orb_params_exp.items()).issubset( set(im.attrs['orbital_parameters'].items())))
+            self.assertTrue(set(orb_params_exp.items()).issubset(set(im.attrs['orbital_parameters'].items())))
             self.assertTrue(np.isclose(im.attrs['orbital_parameters']['satellite_actual_altitude'], 35786903.00581372))
 
             # Test if masking space pixels disables with appropriate flag

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -128,8 +128,17 @@ class TestAHIHSDNavigation(unittest.TestCase):
 
 
 class TestAHIHSDFileHandler(unittest.TestCase):
+
+    def new_unzip(fname):
+        if(fname[-3:]=='bz2'):
+            return fname[:-4]
+        else:
+            return fname
+
     @mock.patch('satpy.readers.ahi_hsd.np2str')
     @mock.patch('satpy.readers.ahi_hsd.np.fromfile')
+    @mock.patch('satpy.readers.ahi_hsd.unzip_file',
+                mock.MagicMock(side_effect=new_unzip))
     def setUp(self, fromfile, np2str):
         """Create a test file handler."""
         np2str.side_effect = lambda x: x
@@ -139,7 +148,7 @@ class TestAHIHSDFileHandler(unittest.TestCase):
             with self.assertRaises(ValueError):
                 fh = AHIHSDFileHandler(None, {'segment_number': 8, 'total_segments': 10}, None, calib_mode='BAD_MODE')
 
-            fh = AHIHSDFileHandler(None, {'segment_number': 8, 'total_segments': 10}, None)
+            fh = AHIHSDFileHandler('test_file.bz2', {'segment_number': 8, 'total_segments': 10}, None)
             fh.proj_info = {'CFAC': 40932549,
                             'COFF': 5500.5,
                             'LFAC': 40932549,

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -265,13 +265,15 @@ class TestHelpers(unittest.TestCase):
 
         filename = 'tester.DAT.bz2'
         whichstr = 'satpy.readers.utils.shutil.which'
-        with mock.patch(whichstr, return_value=None):
+        with mock.patch(whichstr) as whichmock:
+            whichmock.return_value = None
             new_fname = hf.unzip_file(filename)
             self.assertTrue(bz2_mock.read.called)
             self.assertTrue(os.path.exists(new_fname))
             if os.path.exists(new_fname):
                 os.remove(new_fname)
-        with mock.patch(whichstr, return_value='/usr/bin/pbzip2'):
+        with mock.patch(whichstr) as whichmock:
+            whichmock.return_value = '/usr/bin/pbzip2'
             new_fname = hf.unzip_file(filename)
             self.assertTrue(mock_popen.called)
             self.assertTrue(os.path.exists(new_fname))

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -25,201 +25,12 @@ try:
 except ImportError:
     import mock
 
+import os
 import numpy as np
 import numpy.testing
 import pyresample.geometry
 
 from satpy.readers import utils as hf
-
-
-class TestSatinHelpers(unittest.TestCase):
-    """Class for testing satpy.satin."""
-
-    def test_boundaries_to_extent(self):
-        """Test conversion of area boundaries to area extent."""
-        from satpy.satin.helper_functions import boundaries_to_extent
-
-        # MSG3 proj4 string from
-        #  xrit.sat.load(..., only_metadata=True).proj4_params
-        proj4_str = 'proj=geos lon_0=0.00 lat_0=0.00 ' \
-            'a=6378169.00 b=6356583.80 h=35785831.00'
-
-        # MSG3 maximum extent
-        msg_extent = [-5567248.07, -5570248.48, 5570248.48, 5567248.07]
-
-        euro4_lons = [np.array([-47.45398384, -43.46278935,
-                                -38.35946515, -31.73014962,
-                                -23.05306111, 11.8361092,
-                                1.9545262, 17.28655348,
-                                32.17162432, 44.92350518,
-                                55.01855232, 56.988557157486078]),
-                      np.array([56.98855716, 50.26011569,
-                                45.1592762, 41.21696892,
-                                38.10602167, 35.60224391,
-                                33.55098034, 31.8438098,
-                                30.40324844, 29.17282762,
-                                28.11061579, 27.886603224354555]),
-                      np.array([27.88660322, 23.94855341,
-                                19.91336672, 15.81854029,
-                                11.70507781, 7.61511006,
-                                3.58934937, -0.33524747,
-                                -4.1272886, -7.76204144,
-                                -11.2217833, -11.991484302295099]),
-                      np.array([-11.9914843, -13.71190987,
-                                -15.65433484, -17.8592324,
-                                -20.37559742, -23.26235124,
-                                -26.5893562, -30.43725577,
-                                -34.8946782, -40.05040055,
-                                -45.97725877, -47.453983842896925])
-                      ]
-
-        euro4_lats = [np.array([60.95152407, 64.07948755,
-                                67.08804237, 69.89447062,
-                                72.37400834, 74.34558786,
-                                75.57997723, 75.8713547,
-                                75.16167548, 73.58553666,
-                                71.37260506, 70.797059167821104]),
-                      np.array([70.79705917, 67.92687675,
-                                64.85946318, 61.67911498,
-                                58.44076323, 55.18141964,
-                                51.92695755, 48.69607712,
-                                45.50265971, 42.35720453,
-                                39.26773508, 38.565754283815295]),
-                      np.array([38.56575428, 39.21556029,
-                                39.65166546, 39.86532337,
-                                39.85213881, 39.61238514,
-                                39.15098428, 38.47715262,
-                                37.60377021, 36.54656798,
-                                35.32324138, 35.020342638475668]),
-                      np.array([35.02034264, 37.76813725,
-                                40.533077, 43.300949,
-                                46.05396441, 48.76986157,
-                                51.42078481, 53.97194327,
-                                56.38014919, 58.59254174,
-                                60.54617556, 60.95152407157881])
-                      ]
-
-        # Correct extent values for these boundaries
-        correct_values_euro4 = [-2041009.079233268, 3502723.3881863873,
-                                2211266.5660426724, 5387911.4915445326]
-
-        maximum_extent_euro4 = boundaries_to_extent(proj4_str,
-                                                    None,
-                                                    msg_extent,
-                                                    euro4_lons, euro4_lats)
-
-        for i in range(4):
-            self.assertAlmostEqual(maximum_extent_euro4[i],
-                                   correct_values_euro4[i], 2)
-
-        # Two of the area corner points is outside the satellite view
-
-        afgh_lons = [np.array([49.94506701, 52.14080597,
-                               54.33654493, 56.53228389,
-                               58.72802285, 60.92376181,
-                               63.11950077, 65.31523973,
-                               67.51097869, 69.70671766,
-                               71.90245662, 74.09819558,
-                               76.29393454, 78.4896735,
-                               80.68541246, 82.88115142]),
-                     np.array([85.05493299, 85.05493299,
-                               85.05493299, 85.05493299,
-                               85.05493299, 85.05493299,
-                               85.05493299, 85.05493299,
-                               85.05493299, 85.05493299,
-                               85.05493299, 85.05493299,
-                               85.05493299, 85.05493299,
-                               85.05493299, 85.05493299]),
-                     np.array([85.05493299, 82.85919403,
-                               80.66345507, 78.46771611,
-                               76.27197715, 74.07623819,
-                               71.88049923, 69.68476027,
-                               67.48902131, 65.29328234,
-                               63.09754338, 60.90180442,
-                               58.70606546, 56.5103265,
-                               54.31458754, 52.11884858]),
-                     np.array([49.94506701, 49.94506701,
-                               49.94506701, 49.94506701,
-                               49.94506701, 49.94506701,
-                               49.94506701, 49.94506701,
-                               49.94506701, 49.94506701,
-                               49.94506701, 49.94506701,
-                               49.94506701, 49.94506701,
-                               49.94506701, 49.94506701])]
-
-        afgh_lats = [np.array([46.52610743, 46.52610743,
-                               46.52610743, 46.52610743,
-                               46.52610743, 46.52610743,
-                               46.52610743, 46.52610743,
-                               46.52610743, 46.52610743,
-                               46.52610743, 46.52610743,
-                               46.52610743, 46.52610743,
-                               46.52610743, 46.52610743]),
-                     np.array([46.52610743, 44.99436458,
-                               43.42055852, 41.804754,
-                               40.14714935, 38.4480861,
-                               36.70805834, 34.92772129,
-                               33.10789917, 31.24959192,
-                               29.35398073, 27.42243208,
-                               25.45649997, 23.4579264,
-                               21.4286396, 19.37075017]),
-                     np.array([17.30750918, 17.30750918,
-                               17.30750918, 17.30750918,
-                               17.30750918, 17.30750918,
-                               17.30750918, 17.30750918,
-                               17.30750918, 17.30750918,
-                               17.30750918, 17.30750918,
-                               17.30750918, 17.30750918,
-                               17.30750918, 17.30750918]),
-                     np.array([17.30750918, 19.39146328,
-                               21.44907771, 23.47806753,
-                               25.47632393, 27.44192051,
-                               29.37311717, 31.26836176,
-                               33.12628971, 34.94572163,
-                               36.72565938, 38.46528046,
-                               40.16393131, 41.82111941,
-                               43.43650469, 45.00989022])
-                     ]
-
-        # Correct values for these borders
-        correct_values_afgh = [3053894.9120028536, 1620176.1036167517,
-                               5187086.4642274799, 4155907.3124084808]
-
-        maximum_extent_afgh = boundaries_to_extent(proj4_str,
-                                                   None,
-                                                   msg_extent,
-                                                   afgh_lons, afgh_lats)
-
-        for i in range(len(maximum_extent_afgh)):
-            self.assertAlmostEqual(maximum_extent_afgh[i],
-                                   correct_values_afgh[i], 2)
-
-        # Correct values for combined boundaries
-        correct_values_comb = [-2041009.079233268, 1620176.1036167517,
-                               5187086.4642274799, 5387911.4915445326]
-
-        maximum_extent_comb = boundaries_to_extent(proj4_str,
-                                                   maximum_extent_euro4,
-                                                   msg_extent,
-                                                   afgh_lons, afgh_lats)
-        for i in range(4):
-            self.assertAlmostEqual(maximum_extent_comb[i],
-                                   correct_values_comb[i], 2)
-
-        # Borders where none of the corners are within the satellite view
-        lons = [np.array([-170., 170., -170., 170])]
-        lats = [np.array([89., 89., -89., -89])]
-
-        # Correct values are the same as the full disc extent
-        correct_values = [-5567248.07, -5570248.48, 5570248.48, 5567248.07]
-
-        maximum_extent_full = boundaries_to_extent(proj4_str,
-                                                   None,
-                                                   msg_extent,
-                                                   lons, lats)
-        for i in range(4):
-            self.assertAlmostEqual(maximum_extent_full[i],
-                                   correct_values[i], 2)
 
 
 class TestHelpers(unittest.TestCase):
@@ -266,7 +77,6 @@ class TestHelpers(unittest.TestCase):
 
     def test_get_geostationary_bbox(self):
         """Get the geostationary bbox."""
-
         geos_area = mock.MagicMock()
         lon_0 = 0
         geos_area.proj_dict = {'a': 6378169.00,
@@ -315,7 +125,7 @@ class TestHelpers(unittest.TestCase):
                                    hf.get_geostationary_angle_extent(geos_area))
 
     def test_geostationary_mask(self):
-        """Test geostationary mask"""
+        """Test geostationary mask."""
         # Compute mask of a very elliptical earth
         area = pyresample.geometry.AreaDefinition(
             'FLDK',
@@ -377,15 +187,15 @@ class TestHelpers(unittest.TestCase):
         """Test the np2str function."""
         # byte object
         npstring = np.string_('hej')
-        self.assertEquals(hf.np2str(npstring), 'hej')
+        self.assertEqual(hf.np2str(npstring), 'hej')
 
         # single element numpy array
         np_arr = np.array([npstring])
-        self.assertEquals(hf.np2str(np_arr), 'hej')
+        self.assertEqual(hf.np2str(np_arr), 'hej')
 
         # scalar numpy array
         np_arr = np.array(npstring)
-        self.assertEquals(hf.np2str(np_arr), 'hej')
+        self.assertEqual(hf.np2str(np_arr), 'hej')
 
         # multi-element array
         npstring = np.array([npstring, npstring])
@@ -395,7 +205,7 @@ class TestHelpers(unittest.TestCase):
         self.assertRaises(ValueError, hf.np2str, 5)
 
     def test_get_earth_radius(self):
-        """Test earth radius computation"""
+        """Test earth radius computation."""
         a = 2.
         b = 1.
 
@@ -416,7 +226,7 @@ class TestHelpers(unittest.TestCase):
         self.assertTrue(np.isclose(hf.get_earth_radius(lon=123, lat=45., a=a, b=b), re(45.)))
 
     def test_reduce_mda(self):
-        """Test metadata size reduction"""
+        """Test metadata size reduction."""
         mda = {'a': 1,
                'b': np.array([1, 2, 3]),
                'c': np.array([1, 2, 3, 4]),
@@ -439,12 +249,49 @@ class TestHelpers(unittest.TestCase):
         self.assertIn('c', mda['d'])
         self.assertIn('c', mda['d']['d'])
 
+    @mock.patch('satpy.readers.utils.bz2.BZ2File.read')
+    @mock.patch('satpy.readers.utils.bz2.BZ2File')
+    @mock.patch('satpy.readers.utils.Popen')
+    def test_unzip_file_pbzip2(self, mock_popen, mock_bz2, mock_read):
+        """Test the bz2 file unzipping techniques."""
+        process_mock = mock.Mock()
+        attrs = {'communicate.return_value': (b'output', b'error'),
+                 'returncode': 0}
+        process_mock.configure_mock(**attrs)
+        mock_popen.return_value = process_mock
+
+        mock_bz2().mock_read.return_value = b'TEST'
+        mock_bz2().read.return_value = b'TEST'
+        mock_read().return_value = b'TEST'
+
+        filename = 'tester.DAT.bz2'
+        whichstr = 'satpy.readers.utils.shutil.which'
+        with mock.patch(whichstr, return_value=None):
+            new_fname = hf.unzip_file(filename)
+            self.assertTrue(mock_read.called)
+            self.assertTrue(os.path.exists(new_fname))
+            if os.path.exists(new_fname):
+                os.remove(new_fname)
+        with mock.patch(whichstr, return_value='/usr/bin/pbzip2'):
+            new_fname = hf.unzip_file(filename)
+            self.assertTrue(mock_popen.called)
+            self.assertTrue(os.path.exists(new_fname))
+            if os.path.exists(new_fname):
+                os.remove(new_fname)
+
+        filename = 'tester.DAT'
+        new_fname = hf.unzip_file(filename)
+        self.assertEqual(None, new_fname)
+
 
 def suite():
-    """The test suite for test_satin_helpers.
-    """
+    """Test suite for utils library."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestHelpers))
 
     return mysuite
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -249,10 +249,9 @@ class TestHelpers(unittest.TestCase):
         self.assertIn('c', mda['d'])
         self.assertIn('c', mda['d']['d'])
 
-    @mock.patch('satpy.readers.utils.bz2.BZ2File.read')
     @mock.patch('satpy.readers.utils.bz2.BZ2File')
     @mock.patch('satpy.readers.utils.Popen')
-    def test_unzip_file_pbzip2(self, mock_popen, mock_bz2, mock_read):
+    def test_unzip_file_pbzip2(self, mock_popen, mock_bz2):
         """Test the bz2 file unzipping techniques."""
         process_mock = mock.Mock()
         attrs = {'communicate.return_value': (b'output', b'error'),
@@ -260,15 +259,15 @@ class TestHelpers(unittest.TestCase):
         process_mock.configure_mock(**attrs)
         mock_popen.return_value = process_mock
 
-        mock_bz2().mock_read.return_value = b'TEST'
-        mock_bz2().read.return_value = b'TEST'
-        mock_read().return_value = b'TEST'
+        bz2_mock = mock.MagicMock()
+        bz2_mock.read.return_value = b'TEST'
+        mock_bz2.return_value = bz2_mock
 
         filename = 'tester.DAT.bz2'
         whichstr = 'satpy.readers.utils.shutil.which'
         with mock.patch(whichstr, return_value=None):
             new_fname = hf.unzip_file(filename)
-            self.assertTrue(mock_read.called)
+            self.assertTrue(bz2_mock.read.called)
             self.assertTrue(os.path.exists(new_fname))
             if os.path.exists(new_fname):
                 os.remove(new_fname)

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -26,6 +26,7 @@ except ImportError:
     import mock
 
 import os
+import sys
 import numpy as np
 import numpy.testing
 import pyresample.geometry
@@ -264,7 +265,8 @@ class TestHelpers(unittest.TestCase):
         mock_bz2.return_value = bz2_mock
 
         filename = 'tester.DAT.bz2'
-        whichstr = 'satpy.readers.utils.shutil.which'
+        whichstr = 'satpy.readers.utils.which'
+        # no bz2 installed
         with mock.patch(whichstr) as whichmock:
             whichmock.return_value = None
             new_fname = hf.unzip_file(filename)
@@ -272,17 +274,19 @@ class TestHelpers(unittest.TestCase):
             self.assertTrue(os.path.exists(new_fname))
             if os.path.exists(new_fname):
                 os.remove(new_fname)
-        with mock.patch(whichstr) as whichmock:
-            whichmock.return_value = '/usr/bin/pbzip2'
-            new_fname = hf.unzip_file(filename)
-            self.assertTrue(mock_popen.called)
-            self.assertTrue(os.path.exists(new_fname))
-            if os.path.exists(new_fname):
-                os.remove(new_fname)
+        # bz2 installed, but python 3 only
+        if sys.version_info.major >= 3:
+            with mock.patch(whichstr) as whichmock:
+                whichmock.return_value = '/usr/bin/pbzip2'
+                new_fname = hf.unzip_file(filename)
+                self.assertTrue(mock_popen.called)
+                self.assertTrue(os.path.exists(new_fname))
+                if os.path.exists(new_fname):
+                    os.remove(new_fname)
 
         filename = 'tester.DAT'
         new_fname = hf.unzip_file(filename)
-        self.assertEqual(None, new_fname)
+        self.assertIsNone(new_fname)
 
 
 def suite():


### PR DESCRIPTION
The `HSD` format data from Himawari/AHI typically comes in individual files compressed with `bzip2`.
At present, satpy requires these files to be decompressed before passing them to the `Scene` function. This PR enables on-the-fly decompression (using the same method as for the `PPS` files).

I also replaced one unit test function (assertDictContainsSubset) that is deprecated.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed 
 - [x] Passes ``flake8 satpy`` 

