### PR TITLE
Add HRV full disk navigation for `seviri_l1b_native`-reader

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -31,6 +31,7 @@ The following people have made contributions to this project:
 - [Ralph Kuehn (ralphk11)](https://github.com/ralphk11)
 - [Panu Lahtinen (pnuu)](https://github.com/pnuu)
 - [Thomas Leppelt (m4sth0)](https://github.com/m4sth0)
+- [Andrea Meraner (ameraner)](https://github.com/ameraner)
 - [Lucas Meyer (LTMeyer)](https://github.com/LTMeyer)
 - [Oana Nicola](https://github.com/)
 - [Esben S. Nielsen (storpipfugl)](https://github.com/storpipfugl)

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -257,7 +257,7 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
             pdict['nlines'] = self.mda['hrv_number_of_lines']
             pdict['ncols'] = self.mda['hrv_number_of_columns']
             pdict['a_name'] = 'geos_seviri_hrv'
-            pdict['a_desc'] = 'MSG/SEVIRI high resolution channel area'
+            pdict['a_desc'] = 'SEVIRI high resolution channel area'
             pdict['p_id'] = 'seviri_hrv'
 
             if self.mda['is_full_disk']:
@@ -288,7 +288,7 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
             pdict['nlines'] = self.mda['number_of_lines']
             pdict['ncols'] = self.mda['number_of_columns']
             pdict['a_name'] = 'geos_seviri_visir'
-            pdict['a_desc'] = 'MSG/SEVIRI low resolution channel area'
+            pdict['a_desc'] = 'SEVIRI low resolution channel area'
             pdict['p_id'] = 'seviri_visir'
 
             area = get_area_definition(pdict, self.get_area_extent(dataset_id))

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -268,6 +268,9 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
 
         data15hd = self.header['15_DATA_HEADER']
         sec15hd = self.header['15_SECONDARY_PRODUCT_HEADER']
+        data15tr = self.trailer['15TRAILER']
+
+
 
         # check for Earth model as this affects the north-south and
         # west-east offsets
@@ -310,8 +313,29 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
             # NOTE: Implement HRV full disk area_extent
             # NotImplementedError does not catch this, it must
             # be used elsewhere already
-            msg = 'HRV full disk area extent not implemented.'
-            raise RuntimeError(msg)
+            msg = 'HRV full disk area extent is being implemented.'
+            #raise RuntimeError(msg)
+            center_point = HRV_NUM_COLUMNS / 2
+            HRV_bounds = data15tr['ImageProductionStats']['ActualL15CoverageHRV'].copy()
+
+            # upper window
+            upper_north_line = HRV_bounds['UpperNorthLineActual']
+            upper_west_column = HRV_bounds['UpperWestColumnActual']
+            upper_south_line= HRV_bounds['UpperSouthLineActual']
+            upper_east_column = HRV_bounds['UpperEastColumnActual']
+
+            # lower window
+            lower_north_line = HRV_bounds['LowerNorthLineActual']
+            lower_west_column = HRV_bounds['LowerWestColumnActual']
+            lower_south_line = HRV_bounds['LowerSouthLineActual']
+            lower_east_column = HRV_bounds['LowerEastColumnActual']
+            a=0
+
+
+
+
+
+
 
         # Otherwise area extent is in one piece, corner points are
         # the same as for VISIR channels, HRV channel is having

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -95,6 +95,8 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
     @staticmethod
     def _calculate_area_extent(center_point, north, east, south, west,
                                we_offset, ns_offset, column_step, line_step):
+        # For Earth model 2 and full disk VISIR, (center_point - west - 0.5 + we_offset) must be 1856.5 .
+        # See MSG Level 1.5 Image Data Format Description Figure 7 - Alignment and numbering of the non-HRV pixels.
 
         ll_c = (center_point - west - 0.5 + we_offset) * column_step
         ll_l = (south - center_point - 0.5 + ns_offset) * line_step
@@ -305,7 +307,6 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
         """
         data15hd = self.header['15_DATA_HEADER']
         sec15hd = self.header['15_SECONDARY_PRODUCT_HEADER']
-        data15tr = self.trailer['15TRAILER']
 
         # check for Earth model as this affects the north-south and
         # west-east offsets
@@ -353,6 +354,7 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
                             'ReferenceGridHRV']['LineDirGridStep'] * 1000.0
 
             # get actual navigation parameters from trailer data
+            data15tr = self.trailer['15TRAILER']
             HRV_bounds = data15tr['ImageProductionStats']['ActualL15CoverageHRV']
 
             # upper window

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -63,10 +63,6 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_FULLDISK = {
     'earth_model': 1,
     'dsid': DatasetID(name='VIS006'),
     'is_full_disk': True,
-    'expected_area_extent': (
-        -5568748.275756836, -5568748.275756836,
-        5568748.275756836, 5568748.275756836
-    ),
     'expected_area_def': {
         'Area ID': 'geosmsg',
         'Description': 'MSG/SEVIRI low resolution channel area',
@@ -84,10 +80,6 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI = {
     'earth_model': 1,
     'dsid': DatasetID(name='VIS006'),
     'is_full_disk': False,
-    'expected_area_extent': (
-        -2205296.3268756866, -333044.75140571594,
-        5337717.231988907, 5154692.638874054
-    ),
     'expected_area_def': {
         'Area ID': 'geosmsg',
         'Description': 'MSG/SEVIRI low resolution channel area',
@@ -101,16 +93,28 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI = {
     }
 }
 
-TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK = None
+TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK = {
+    'earth_model': 1,
+    'dsid': DatasetID(name='HRV'),
+    'is_full_disk': True,
+    'expected_area_def': {
+        'Area ID': 'geosmsg',
+        'Description': 'MSG/SEVIRI low resolution channel area',
+        'Projection ID': 'msg_hires',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 5568,
+        'Number of rows': 11136,
+        'Area extent 0': (-1964263.8611793518, 2623352.397084236, 3604484.1933250427, 5567747.920155525),
+        'Area extent 1': (1000.1343488693237, -5569748.188853264, 5569748.188853264, 2623352.397084236)
+    }
+}
 
 TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI = {
     'earth_model': 1,
     'dsid': DatasetID(name='HRV'),
     'is_full_disk': False,
-    'expected_area_extent': (
-        -2204296.1049079895, -332044.6038246155,
-        5336716.885566711, 5153692.299723625
-    ),
     'expected_area_def': {
         'Area ID': 'geosmsg_hrv',
         'Description': 'MSG/SEVIRI high resolution channel area',
@@ -128,10 +132,6 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_FULLDISK = {
     'earth_model': 2,
     'dsid': DatasetID(name='VIS006'),
     'is_full_disk': True,
-    'expected_area_extent': (
-        -5570248.477339745, -5567248.074173927,
-        5567248.074173927, 5570248.477339745
-    ),
     'expected_area_def': {
         'Area ID': 'geosmsg',
         'Description': 'MSG/SEVIRI low resolution channel area',
@@ -145,16 +145,28 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_FULLDISK = {
     }
 }
 
-TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK = None
+TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK = {
+    'earth_model': 2,
+    'dsid': DatasetID(name='HRV'),
+    'is_full_disk': True,
+    'expected_area_def': {
+        'Area ID': 'geosmsg',
+        'Description': 'MSG/SEVIRI low resolution channel area',
+        'Projection ID': 'msg_hires',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 5568,
+        'Number of rows': 11136,
+        'Area extent 0': (-1965764.0627026558, 2624852.59860754, 3602983.9918017387, 5569248.121678829),
+        'Area extent 1': (-500.06717443466187, -5568247.98732996, 5568247.98732996, 2624852.59860754)
+    }
+}
 
 TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI = {
     'earth_model': 2,
     'dsid': DatasetID(name='VIS006'),
     'is_full_disk': False,
-    'expected_area_extent': (
-        -2206796.5284585953, -331544.5498228073,
-        5336217.030405998, 5156192.840456963
-    ),
     'expected_area_def': {
         'Area ID': 'geosmsg',
         'Description': 'MSG/SEVIRI low resolution channel area',
@@ -172,10 +184,6 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI = {
     'earth_model': 2,
     'dsid': DatasetID(name='HRV'),
     'is_full_disk': False,
-    'expected_area_extent': (
-        -2205796.3064312935, -330544.4023013115,
-        5335216.684043407, 5155192.501246929
-    ),
     'expected_area_def': {
         'Area ID': 'geosmsg_hrv',
         'Description': 'MSG/SEVIRI high resolution channel area',
@@ -193,10 +201,6 @@ TEST_CALIBRATION_MODE = {
     'earth_model': 1,
     'dsid': DatasetID(name='IR_108', calibration='radiance'),
     'is_full_disk': True,
-    'expected_area_extent': (
-        -5568748.275756836, -5568748.275756836,
-        5568748.275756836, 5568748.275756836
-    ),
     'calibration': 'radiance',
     'CalSlope': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.96, 0.97],
     'CalOffset': [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
@@ -209,7 +213,7 @@ TEST_CALIBRATION_MODE = {
 
 
 def assertNumpyArraysEqual(self, other):
-
+    """Assert that Numpy arrays are equal."""
     if self.shape != other.shape:
         raise AssertionError("Shapes don't match")
     if not np.allclose(self, other):
@@ -217,15 +221,10 @@ def assertNumpyArraysEqual(self, other):
 
 
 class TestNativeMSGFileHandler(unittest.TestCase):
-
     """Test the NativeMSGFileHandler."""
 
-    def setUp(self):
-        pass
-
     def test_get_available_channels(self):
-        """Test the derivation of the available channel list"""
-
+        """Test the derivation of the available channel list."""
         available_chs = get_available_channels(TEST1_HEADER_CHNLIST)
         trues = ['WV_062', 'WV_073', 'IR_108', 'VIS006', 'VIS008', 'IR_120']
         for bandname in AVAILABLE_CHANNELS.keys():
@@ -246,22 +245,20 @@ class TestNativeMSGFileHandler(unittest.TestCase):
         for bandname in AVAILABLE_CHANNELS.keys():
             self.assertTrue(available_chs[bandname])
 
-    def tearDown(self):
-        pass
-
 
 class TestNativeMSGArea(unittest.TestCase):
-    """Test NativeMSGFileHandler.get_area_extent
+    """Test NativeMSGFileHandler.get_area_extent.
+
     The expected results have been verified by manually
     inspecting the output of geoferenced imagery.
     """
+
     @staticmethod
     def create_test_header(earth_model, dsid, is_full_disk):
-        """
-        Mocked NativeMSGFileHandler with sufficient attributes for
-        NativeMSGFileHandler.get_area_extent to be able to execute.
-        """
+        """Create mocked NativeMSGFileHandler.
 
+        Containes sufficient attributes for NativeMSGFileHandler.get_area_extent to be able to execute.
+        """
         if dsid.name == 'HRV':
             reference_grid = 'ReferenceGridHRV'
             column_dir_grid_step = 1.0001343488693237
@@ -328,13 +325,39 @@ class TestNativeMSGArea(unittest.TestCase):
 
         return header
 
-    def prepare_area_extents(self, test_dict):
+    @staticmethod
+    def create_test_trailer():
+        """Create Test Trailer.
 
+        Mocked Trailer with sufficient attributes for
+        NativeMSGFileHandler.get_area_extent to be able to execute.
+        """
+        trailer = {
+            '15TRAILER': {
+                'ImageProductionStats': {
+                    'ActualL15CoverageHRV': {
+                        'UpperNorthLineActual': 11136,
+                        'UpperWestColumnActual': 7533,
+                        'UpperSouthLineActual': 8193,
+                        'UpperEastColumnActual': 1966,
+                        'LowerNorthLineActual': 8192,
+                        'LowerWestColumnActual': 5568,
+                        'LowerSouthLineActual': 1,
+                        'LowerEastColumnActual': 1
+                    }
+                }
+            }
+        }
+
+        return trailer
+
+    def prepare_area_defs(self, test_dict):
+        """Prepare calculated and expected area definitions for equal checking."""
         earth_model = test_dict['earth_model']
         dsid = test_dict['dsid']
         is_full_disk = test_dict['is_full_disk']
         header = self.create_test_header(earth_model, dsid, is_full_disk)
-
+        trailer = self.create_test_trailer()
         expected_area_def = test_dict['expected_area_def']
 
         with mock.patch('satpy.readers.seviri_l1b_native.np.fromfile') as fromfile:
@@ -347,17 +370,15 @@ class TestNativeMSGArea(unittest.TestCase):
 
                         fh = NativeMSGFileHandler(None, {}, None)
                         fh.header = header
+                        fh.trailer = trailer
                         calc_area_def = fh.get_area_def(dsid)
 
         return (calc_area_def, expected_area_def)
 
-    def setUp(self):
-        pass
-
     # Earth model 1 tests
     def test_earthmodel1_visir_fulldisk(self):
-
-        calculated, expected = self.prepare_area_extents(
+        """Test the VISIR Fulldisk with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL1_VISIR_FULLDISK
         )
         assertNumpyArraysEqual(np.array(calculated.area_extent),
@@ -366,13 +387,24 @@ class TestNativeMSGArea(unittest.TestCase):
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.proj_id,  expected['Projection ID'])
 
-    # def test_earthmodel1_hrv_fulldisk(self):
-    #     # Not implemented
-    #     pass
+    def test_earthmodel1_hrv_fulldisk(self):
+        """Test the HRV Fulldisk with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK
+        )
+        assertNumpyArraysEqual(np.array(calculated.defs[0].area_extent),
+                               np.array(expected['Area extent 0']))
+        assertNumpyArraysEqual(np.array(calculated.defs[1].area_extent),
+                               np.array(expected['Area extent 1']))
+
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.defs[0].proj_id, expected['Projection ID'])
+        self.assertEqual(calculated.defs[1].proj_id, expected['Projection ID'])
 
     def test_earthmodel1_visir_roi(self):
-
-        calculated, expected = self.prepare_area_extents(
+        """Test the VISIR ROI with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI
         )
         assertNumpyArraysEqual(np.array(calculated.area_extent),
@@ -382,8 +414,8 @@ class TestNativeMSGArea(unittest.TestCase):
         self.assertEqual(calculated.proj_id,  expected['Projection ID'])
 
     def test_earthmodel1_hrv_roi(self):
-
-        calculated, expected = self.prepare_area_extents(
+        """Test the HRV ROI with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI
         )
         assertNumpyArraysEqual(np.array(calculated.area_extent),
@@ -394,8 +426,8 @@ class TestNativeMSGArea(unittest.TestCase):
 
     # Earth model 2 tests
     def test_earthmodel2_visir_fulldisk(self):
-
-        calculated, expected = self.prepare_area_extents(
+        """Test the VISIR Fulldisk with the EarthModel 2."""
+        calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL2_VISIR_FULLDISK
         )
         assertNumpyArraysEqual(np.array(calculated.area_extent),
@@ -404,13 +436,22 @@ class TestNativeMSGArea(unittest.TestCase):
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.proj_id,  expected['Projection ID'])
 
-    # def test_earthmodel2_hrv_fulldisk(self):
-    #     # Not implemented
-    #     pass
+    def test_earthmodel2_hrv_fulldisk(self):
+        """Test the HRV Fulldisk with the EarthModel 2."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK
+        )
+        assertNumpyArraysEqual(np.array(calculated.defs[0].area_extent), np.array(expected['Area extent 0']))
+        assertNumpyArraysEqual(np.array(calculated.defs[1].area_extent), np.array(expected['Area extent 1']))
+
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.defs[0].proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.defs[1].proj_id,  expected['Projection ID'])
 
     def test_earthmodel2_visir_roi(self):
-
-        calculated, expected = self.prepare_area_extents(
+        """Test the VISIR ROI with the EarthModel 2."""
+        calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI
         )
         assertNumpyArraysEqual(np.array(calculated.area_extent),
@@ -420,8 +461,8 @@ class TestNativeMSGArea(unittest.TestCase):
         self.assertEqual(calculated.proj_id,  expected['Projection ID'])
 
     def test_earthmodel2_hrv_roi(self):
-
-        calculated, expected = self.prepare_area_extents(
+        """Test the HRV ROI with the EarthModel 2."""
+        calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI
         )
         assertNumpyArraysEqual(np.array(calculated.area_extent),
@@ -430,18 +471,18 @@ class TestNativeMSGArea(unittest.TestCase):
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.proj_id,  expected['Projection ID'])
 
-    def tearDown(self):
-        pass
-
 
 class TestNativeMSGCalibrationMode(unittest.TestCase):
-    """Test NativeMSGFileHandler.get_area_extent
+    """Test NativeMSGFileHandler.get_area_extent.
+
     The expected results have been verified by manually
     inspecting the output of geoferenced imagery.
     """
+
     @staticmethod
     def create_test_header(earth_model, dsid, is_full_disk):
-        """
+        """Create Test Header.
+
         Mocked NativeMSGFileHandler with sufficient attributes for
         NativeMSGFileHandler.get_area_extent to be able to execute.
         """
@@ -525,6 +566,7 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
         return header
 
     def calibration_mode_test(self, test_dict, cal_mode):
+        """Test the Calibration Mode."""
         # dummy data array
         data = xr.DataArray([255., 200., 300.])
 
@@ -567,10 +609,8 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
 
         return (expected.data, calculated.data)
 
-    def setUp(self):
-        pass
-
     def test_calibration_mode_nominal(self):
+        """Test the nominal calibration mode."""
         # Test using the Nominal calibration mode
         expected, calculated = self.calibration_mode_test(
             TEST_CALIBRATION_MODE,
@@ -579,6 +619,7 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
         assertNumpyArraysEqual(calculated, expected)
 
     def test_calibration_mode_gsics(self):
+        """Test the GSICS calibration mode."""
         # Test using the GSICS calibration mode
         expected, calculated = self.calibration_mode_test(
             TEST_CALIBRATION_MODE,
@@ -587,6 +628,7 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
         assertNumpyArraysEqual(calculated, expected)
 
     def test_calibration_mode_dummy(self):
+        """Test a dummy calibration mode."""
         # pass in a calibration mode that is not recognised by the reader
         # and an exception will be raised
         self.assertRaises(NotImplementedError, self.calibration_mode_test,
@@ -594,12 +636,9 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
                           'dummy',
                           )
 
-    def tearDown(self):
-        pass
-
 
 def suite():
-    """The test suite for test_scene."""
+    """Test suite for test_scene."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestNativeMSGFileHandler))

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -61,12 +61,12 @@ TEST3_HEADER_CHNLIST[SEC15HDR][IDS]['Value'] = 'XXXXXXXXXXXX'
 
 TEST_AREA_EXTENT_EARTHMODEL1_VISIR_FULLDISK = {
     'earth_model': 1,
-    'dsid': DatasetID(name='VIS006'),
+    'dataset_id': DatasetID(name='VIS006'),
     'is_full_disk': True,
     'expected_area_def': {
-        'Area ID': 'geosmsg',
+        'Area ID': 'geos_seviri_visir',
         'Description': 'MSG/SEVIRI low resolution channel area',
-        'Projection ID': 'msg_lowres',
+        'Projection ID': 'seviri_visir',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
@@ -78,12 +78,12 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_FULLDISK = {
 
 TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI = {
     'earth_model': 1,
-    'dsid': DatasetID(name='VIS006'),
+    'dataset_id': DatasetID(name='VIS006'),
     'is_full_disk': False,
     'expected_area_def': {
-        'Area ID': 'geosmsg',
+        'Area ID': 'geos_seviri_visir',
         'Description': 'MSG/SEVIRI low resolution channel area',
-        'Projection ID': 'msg_lowres',
+        'Projection ID': 'seviri_visir',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
@@ -95,12 +95,12 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI = {
 
 TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK = {
     'earth_model': 1,
-    'dsid': DatasetID(name='HRV'),
+    'dataset_id': DatasetID(name='HRV'),
     'is_full_disk': True,
     'expected_area_def': {
-        'Area ID': 'geosmsg',
+        'Area ID': 'geos_seviri_hrv',
         'Description': 'MSG/SEVIRI low resolution channel area',
-        'Projection ID': 'msg_hires',
+        'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
@@ -113,12 +113,12 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK = {
 
 TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI = {
     'earth_model': 1,
-    'dsid': DatasetID(name='HRV'),
+    'dataset_id': DatasetID(name='HRV'),
     'is_full_disk': False,
     'expected_area_def': {
-        'Area ID': 'geosmsg_hrv',
+        'Area ID': 'geos_seviri_hrv',
         'Description': 'MSG/SEVIRI high resolution channel area',
-        'Projection ID': 'msg_hires',
+        'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
@@ -130,12 +130,12 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI = {
 
 TEST_AREA_EXTENT_EARTHMODEL2_VISIR_FULLDISK = {
     'earth_model': 2,
-    'dsid': DatasetID(name='VIS006'),
+    'dataset_id': DatasetID(name='VIS006'),
     'is_full_disk': True,
     'expected_area_def': {
-        'Area ID': 'geosmsg',
+        'Area ID': 'geos_seviri_visir',
         'Description': 'MSG/SEVIRI low resolution channel area',
-        'Projection ID': 'msg_lowres',
+        'Projection ID': 'seviri_visir',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
@@ -147,12 +147,12 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_FULLDISK = {
 
 TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK = {
     'earth_model': 2,
-    'dsid': DatasetID(name='HRV'),
+    'dataset_id': DatasetID(name='HRV'),
     'is_full_disk': True,
     'expected_area_def': {
-        'Area ID': 'geosmsg',
+        'Area ID': 'geos_seviri_hrv',
         'Description': 'MSG/SEVIRI low resolution channel area',
-        'Projection ID': 'msg_hires',
+        'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
@@ -165,12 +165,12 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK = {
 
 TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI = {
     'earth_model': 2,
-    'dsid': DatasetID(name='VIS006'),
+    'dataset_id': DatasetID(name='VIS006'),
     'is_full_disk': False,
     'expected_area_def': {
-        'Area ID': 'geosmsg',
+        'Area ID': 'geos_seviri_visir',
         'Description': 'MSG/SEVIRI low resolution channel area',
-        'Projection ID': 'msg_lowres',
+        'Projection ID': 'seviri_visir',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
@@ -182,12 +182,12 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI = {
 
 TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI = {
     'earth_model': 2,
-    'dsid': DatasetID(name='HRV'),
+    'dataset_id': DatasetID(name='HRV'),
     'is_full_disk': False,
     'expected_area_def': {
-        'Area ID': 'geosmsg_hrv',
+        'Area ID': 'geos_seviri_hrv',
         'Description': 'MSG/SEVIRI high resolution channel area',
-        'Projection ID': 'msg_hires',
+        'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
@@ -199,7 +199,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI = {
 
 TEST_CALIBRATION_MODE = {
     'earth_model': 1,
-    'dsid': DatasetID(name='IR_108', calibration='radiance'),
+    'dataset_id': DatasetID(name='IR_108', calibration='radiance'),
     'is_full_disk': True,
     'calibration': 'radiance',
     'CalSlope': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.96, 0.97],
@@ -254,12 +254,12 @@ class TestNativeMSGArea(unittest.TestCase):
     """
 
     @staticmethod
-    def create_test_header(earth_model, dsid, is_full_disk):
+    def create_test_header(earth_model, dataset_id, is_full_disk):
         """Create mocked NativeMSGFileHandler.
 
-        Containes sufficient attributes for NativeMSGFileHandler.get_area_extent to be able to execute.
+        Contains sufficient attributes for NativeMSGFileHandler.get_area_extent to be able to execute.
         """
-        if dsid.name == 'HRV':
+        if dataset_id.name == 'HRV':
             reference_grid = 'ReferenceGridHRV'
             column_dir_grid_step = 1.0001343488693237
             line_dir_grid_step = 1.0001343488693237
@@ -354,9 +354,9 @@ class TestNativeMSGArea(unittest.TestCase):
     def prepare_area_defs(self, test_dict):
         """Prepare calculated and expected area definitions for equal checking."""
         earth_model = test_dict['earth_model']
-        dsid = test_dict['dsid']
+        dataset_id = test_dict['dataset_id']
         is_full_disk = test_dict['is_full_disk']
-        header = self.create_test_header(earth_model, dsid, is_full_disk)
+        header = self.create_test_header(earth_model, dataset_id, is_full_disk)
         trailer = self.create_test_trailer()
         expected_area_def = test_dict['expected_area_def']
 
@@ -371,7 +371,7 @@ class TestNativeMSGArea(unittest.TestCase):
                         fh = NativeMSGFileHandler(None, {}, None)
                         fh.header = header
                         fh.trailer = trailer
-                        calc_area_def = fh.get_area_def(dsid)
+                        calc_area_def = fh.get_area_def(dataset_id)
 
         return (calc_area_def, expected_area_def)
 
@@ -480,13 +480,13 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
     """
 
     @staticmethod
-    def create_test_header(earth_model, dsid, is_full_disk):
+    def create_test_header(earth_model, dataset_id, is_full_disk):
         """Create Test Header.
 
         Mocked NativeMSGFileHandler with sufficient attributes for
         NativeMSGFileHandler.get_area_extent to be able to execute.
         """
-        if dsid.name == 'HRV':
+        if dataset_id.name == 'HRV':
             # reference_grid = 'ReferenceGridHRV'
             column_dir_grid_step = 1.0001343488693237
             line_dir_grid_step = 1.0001343488693237
@@ -571,8 +571,8 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
         data = xr.DataArray([255., 200., 300.])
 
         earth_model = test_dict['earth_model']
-        dsid = test_dict['dsid']
-        index = CHANNEL_INDEX_LIST.index(dsid.name)
+        dataset_id = test_dict['dataset_id']
+        index = CHANNEL_INDEX_LIST.index(dataset_id.name)
 
         # determine the cal coeffs needed for the expected data calculation
         if cal_mode == 'nominal':
@@ -585,7 +585,7 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
             cal_slope = cal_slope_arr[index]
 
         is_full_disk = test_dict['is_full_disk']
-        header = self.create_test_header(earth_model, dsid, is_full_disk)
+        header = self.create_test_header(earth_model, dataset_id, is_full_disk)
 
         with mock.patch('satpy.readers.seviri_l1b_native.np.fromfile') as fromfile:
             fromfile.return_value = header
@@ -605,7 +605,7 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
                         # Calculate the calibrated vaues using the cal coeffs from the
                         # test header and using the correct calibration mode values
                         fh.header = header
-                        calculated = fh.calibrate(data, dsid)
+                        calculated = fh.calibrate(data, dataset_id)
 
         return (expected.data, calculated.data)
 

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -65,7 +65,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_FULLDISK = {
     'is_full_disk': True,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
-        'Description': 'MSG/SEVIRI low resolution channel area',
+        'Description': 'SEVIRI low resolution channel area',
         'Projection ID': 'seviri_visir',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -82,7 +82,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI = {
     'is_full_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
-        'Description': 'MSG/SEVIRI low resolution channel area',
+        'Description': 'SEVIRI low resolution channel area',
         'Projection ID': 'seviri_visir',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -99,7 +99,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK = {
     'is_full_disk': True,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'MSG/SEVIRI low resolution channel area',
+        'Description': 'SEVIRI low resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -117,7 +117,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI = {
     'is_full_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'MSG/SEVIRI high resolution channel area',
+        'Description': 'SEVIRI high resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -134,7 +134,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_FULLDISK = {
     'is_full_disk': True,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
-        'Description': 'MSG/SEVIRI low resolution channel area',
+        'Description': 'SEVIRI low resolution channel area',
         'Projection ID': 'seviri_visir',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -151,7 +151,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK = {
     'is_full_disk': True,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'MSG/SEVIRI low resolution channel area',
+        'Description': 'SEVIRI low resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -169,7 +169,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI = {
     'is_full_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
-        'Description': 'MSG/SEVIRI low resolution channel area',
+        'Description': 'SEVIRI low resolution channel area',
         'Projection ID': 'seviri_visir',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -186,7 +186,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI = {
     'is_full_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'MSG/SEVIRI high resolution channel area',
+        'Description': 'SEVIRI high resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',


### PR DESCRIPTION
PR implements the navigation for the SEVIRI HRV full disk case in the Native format reader.
The HRV channel covers two separated geographical areas; when ordering the full disk data, the two areas are stacked together and need to be navigated to the original correct geolocations by reading the correspondent metadata and defining two area_definitions. This is now implemented for the Native reader, which now covers all data order combinations.

 - [x] Closes #975 
 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed 
 - [x] Passes ``flake8 satpy`` 
 - [x] Fully documented
 - [x] Add your name to `AUTHORS.md` if not there already
