### PR TITLE
Remove py27 tests and switch to py38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,18 +14,9 @@ env:
         - CONDA_CHANNEL_PRIORITY='strict'
 matrix:
   include:
-  - env:
-    - PYTHON_VERSION=2.7
-    - NUMPY_VERSION=1.16
+  - env: PYTHON_VERSION=3.8
     os: linux
-  - env:
-    - PYTHON_VERSION=2.7
-    - NUMPY_VERSION=1.16
-    os: osx
-    language: generic
-  - env: PYTHON_VERSION=3.7
-    os: linux
-  - env: PYTHON_VERSION=3.7
+  - env: PYTHON_VERSION=3.8
     os: osx
     language: generic
 install:
@@ -35,7 +26,7 @@ script:
 - coverage run --source=satpy setup.py test
 - coverage run -a --source=satpy -m behave satpy/tests/features --tags=-download
 after_success:
-- if [[ $PYTHON_VERSION == 3.7 ]]; then coveralls; codecov; fi
+- if [[ $PYTHON_VERSION == 3.8 ]]; then coveralls; codecov; fi
 deploy:
   - provider: pypi
     user: dhoese

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ matrix:
   - env: PYTHON_VERSION=3.8
     os: osx
     language: generic
+  - env: PYTHON_VERSION=3.7
+    os: linux
+  - env: PYTHON_VERSION=3.7
+    os: osx
+    language: generic
 install:
     - git clone --depth 1 git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ env:
     global:
         # Set defaults to avoid repeating in most cases
         - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
-        - NUMPY_VERSION=stable
+        - NUMPY_VERSION=1.17
         - MAIN_CMD='python setup.py'
         - CONDA_DEPENDENCIES='xarray!=0.13.0 dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj=2.4.1 pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff geoviews zarr six python-eccodes'
         - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital libtiff'

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
         - PYTHON_VERSION=$TRAVIS_PYTHON_VERSION
         - NUMPY_VERSION=stable
         - MAIN_CMD='python setup.py'
-        - CONDA_DEPENDENCIES='xarray!=0.13.0 dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff geoviews zarr six python-eccodes'
+        - CONDA_DEPENDENCIES='xarray!=0.13.0 dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj=2.4.1 pyresample coveralls coverage codecov behave netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf mock libtiff geoviews zarr six python-eccodes'
         - PIP_DEPENDENCIES='trollsift trollimage pyspectral pyorbital libtiff'
         - SETUP_XVFB=False
         - EVENT_TYPE='push pull_request'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,8 @@ environment:
     CONDA_CHANNELS: "conda-forge"
 
   matrix:
-    - PYTHON: "C:\\Python37_64"
-      PYTHON_VERSION: "3.7"
+    - PYTHON: "C:\\Python38_64"
+      PYTHON_VERSION: "3.8"
       PYTHON_ARCH: "64"
       NUMPY_VERSION: "stable"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,10 @@ environment:
       PYTHON_VERSION: "3.8"
       PYTHON_ARCH: "64"
       NUMPY_VERSION: "stable"
+    - PYTHON: "C:\\Python38_64"
+      PYTHON_VERSION: "3.7"
+      PYTHON_ARCH: "64"
+      NUMPY_VERSION: "stable"
 
 install:
     - "git clone --depth 1 git://github.com/astropy/ci-helpers.git"

--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -15,9 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""MITIFF writer objects for creating MITIFF files from `Dataset` objects.
-
-"""
+"""MITIFF writer objects for creating MITIFF files from `Dataset` objects."""
 
 import logging
 import numpy as np
@@ -37,8 +35,10 @@ KELVIN_TO_CELSIUS = -273.15
 
 
 class MITIFFWriter(ImageWriter):
+    """Writer to produce MITIFF image files."""
 
     def __init__(self, name=None, tags=None, **kwargs):
+        """Initialize reader with tag and other configuration information."""
         ImageWriter.__init__(self, name=name, default_config_filename="writers/mitiff.yaml", **kwargs)
         self.tags = self.info.get("tags", None) if tags is None else tags
         if self.tags is None:
@@ -53,10 +53,12 @@ class MITIFFWriter(ImageWriter):
         self.palette = False
 
     def save_image(self):
+        """Save dataset as an image array."""
         raise NotImplementedError("save_image mitiff is not implemented.")
 
     def save_dataset(self, dataset, filename=None, fill_value=None,
                      compute=True, **kwargs):
+        """Save single dataset as mitiff file."""
         LOG.debug("Starting in mitiff save_dataset ... ")
 
         def _delayed_create(create_opts, dataset):
@@ -106,8 +108,7 @@ class MITIFFWriter(ImageWriter):
 
     def save_datasets(self, datasets, filename=None, fill_value=None,
                       compute=True, **kwargs):
-        """Save all datasets to one or more files.
-        """
+        """Save all datasets to one or more files."""
         LOG.debug("Starting in mitiff save_datasets ... ")
 
         def _delayed_create(create_opts, datasets):
@@ -168,10 +169,10 @@ class MITIFFWriter(ImageWriter):
                 else:
                     LOG.error("Is palette but can not find palette_channel_name to name the dataset")
             else:
-                for ch, ds in enumerate(datasets):
+                for ch in range(len(datasets)):
                     channels.append(ch + 1)
         except KeyError:
-            for ch, ds in enumerate(datasets):
+            for ch in range(len(datasets)):
                 channels.append(ch + 1)
         return channels
 
@@ -438,8 +439,7 @@ class MITIFFWriter(ImageWriter):
         return _table_calibration
 
     def _make_image_description(self, datasets, **kwargs):
-        """
-        generate image description for mitiff.
+        r"""Generate image description for mitiff.
 
         Satellite: NOAA 18
         Date and Time: 06:58 31/05-2016
@@ -482,8 +482,8 @@ class MITIFFWriter(ImageWriter):
         Table_calibration: <channel name>, <calibration type>, [<unit>],
         <no of bits of data>,
         [<calibration values space separated>]\n\n
-        """
 
+        """
         translate_platform_name = {'metop01': 'Metop-B',
                                    'metop02': 'Metop-A',
                                    'metop03': 'Metop-C',
@@ -624,19 +624,20 @@ class MITIFFWriter(ImageWriter):
 
             data_type = np.uint8
             # Looks like we need to pass the data to writeencodedstrip as ctypes
-            tif.WriteEncodedStrip(0, np.ascontiguousarray(datasets.data.astype(data_type), data_type).ctypes.data,
+            cont_data = np.ascontiguousarray(datasets.data, data_type)
+            tif.WriteEncodedStrip(0, cont_data.ctypes.data,
                                   datasets.sizes['x'] * datasets.sizes['y'])
             tif.WriteDirectory()
 
     def _save_as_enhanced(self, tif, datasets, **kwargs):
-        """Save datasets as an enhanced RGB image"""
+        """Save datasets as an enhanced RGB image."""
         img = get_enhanced_image(datasets.squeeze(), enhance=self.enhancer)
         if 'bands' in img.data.sizes and 'bands' not in datasets.sizes:
             LOG.debug("Datasets without 'bands' become image with 'bands' due to enhancement.")
             LOG.debug("Needs to regenerate mitiff image description")
             image_description = self._make_image_description(img.data, **kwargs)
             tif.SetField(IMAGEDESCRIPTION, (image_description).encode('utf-8'))
-        for i, band in enumerate(img.data['bands']):
+        for band in img.data['bands']:
             chn = img.data.sel(bands=band)
             data = chn.values.clip(0, 1) * 254. + 1
             data = data.clip(0, 255)
@@ -644,8 +645,10 @@ class MITIFFWriter(ImageWriter):
 
     def _save_datasets_as_mitiff(self, datasets, image_description,
                                  gen_filename, **kwargs):
-        """Put all togehter and save as a tiff file with the special tag
-           making it a mitiff file.
+        """Put all together and save as a tiff file.
+
+        Include the special tags making it a mitiff file.
+
         """
         from libtiff import TIFF
 
@@ -682,7 +685,7 @@ class MITIFFWriter(ImageWriter):
                 tif.write_image(data.astype(np.uint8), compression='deflate')
             else:
                 for _cn_i, _cn in enumerate(self.channel_order[kwargs['sensor']]):
-                    for i, band in enumerate(datasets['bands']):
+                    for band in datasets['bands']:
                         if band == _cn:
                             chn = datasets.sel(bands=band)
                             # Need to possible translate channels names from satpy to mitiff

--- a/setup.py
+++ b/setup.py
@@ -1,31 +1,23 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2009-2017.
-
-# Author(s):
-
-#   Martin Raspaud <martin.raspaud@smhi.se>
-#   Adam Dybbroe <adam.dybbroe@smhi.se>
-#   David Hoese <david.hoese@ssec.wisc.edu>
-
+# Copyright (c) 2009-2019 Satpy developers
+#
 # This file is part of satpy.
-
-# satpy is free software: you can redistribute it and/or modify it
-# under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-
-# satpy is distributed in the hope that it will be useful, but
-# WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-# General Public License for more details.
-
-# You should have received a copy of the GNU General Public License
-# along with satpy.  If not, see <http://www.gnu.org/licenses/>.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Setup file for satpy."""
 
 import os.path
-import sys
 from glob import glob
 
 from setuptools import find_packages, setup
@@ -44,10 +36,6 @@ requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.11.0', 'trollsift',
 
 test_requires = ['behave', 'h5py', 'netCDF4', 'pyhdf', 'imageio', 'libtiff',
                  'rasterio', 'geoviews', 'trollimage']
-
-if sys.version < '3.0':
-    test_requires.append('mock')
-
 
 extras_require = {
     # Readers:
@@ -146,6 +134,6 @@ setup(name=NAME,
       use_scm_version=True,
       install_requires=requires,
       tests_require=test_requires,
-      python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
+      python_requires='>=3.6',
       extras_require=extras_require,
       )


### PR DESCRIPTION
Given some recent user issues with python 3.8 I thought I'd try switching to Python 3.8 for our travis tests. At the same time it didn't seem necessary to keep Python 2.7.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->