### PR TITLE
Add hrv_clouds, hrv_fog and natural_with_night_fog composites to seviri.yaml

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -35,6 +35,7 @@ The following people have made contributions to this project:
 - [Oana Nicola](https://github.com/)
 - [Esben S. Nielsen (storpipfugl)](https://github.com/storpipfugl)
 - [Tom Parker (tparker-usgs)](https://github.com/tparker-usgs)
+- [Christian Peters (peters77)](https://github.com/peters77)
 - [Simon R. Proud (simonrp84)](https://github.com/simonrp84)
 - [Lars Ørum Rasmussen (loerum)](https://github.com/loerum)
 - [Martin Raspaud (mraspaud)](https://github.com/mraspaud)

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -358,7 +358,7 @@ composites:
     compositor: !!python/name:satpy.composites.DayNightCompositor
     standard_name: natural_with_night_fog
     prerequisites:
-      - natural_color
+      - natural_color_sun
       - night_fog
 
   natural_color_with_night_ir:

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -334,6 +334,33 @@ composites:
         modifiers: [sunz_corrected]
       - name: colorized_ir_clouds
 
+  hrv_clouds:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    standard_name: hrv_clouds
+    prerequisites:
+      - name: HRV
+        modifiers: [sunz_corrected]
+      - name: HRV
+        modifiers: [sunz_corrected]
+      - IR_108
+  hrv_fog:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    standard_name: hrv_fog
+    prerequisites:
+      - name: IR_016
+        modifiers: [sunz_corrected]
+      - name: HRV
+        modifiers: [sunz_corrected]
+      - name: HRV
+        modifiers: [sunz_corrected]
+
+  natural_with_night_fog:
+    compositor: !!python/name:satpy.composites.DayNightCompositor
+    standard_name: natural_with_night_fog
+    prerequisites:
+      - natural_color
+      - night_fog
+
   natural_color_with_night_ir:
     compositor: !!python/name:satpy.composites.DayNightCompositor
     standard_name: natural_color_with_night_ir

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -784,6 +784,26 @@ enhancements:
           min_stretch: [0, 0, 0]
           max_stretch: [1, 1, 1]
 
+  hrv_clouds:
+    operations:
+      - name: stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs:
+          stretch: crude
+          min_stretch: [0, 0, 323]
+          max_stretch: [100, 100, 203]
+    standard_name: hrv_clouds
+
+  hrv_fog:
+    operations:
+      - name: stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs:
+          stretch: crude
+          min_stretch: [0, 0, 0]
+          max_stretch: [70, 100, 100]
+    standard_name: hrv_fog
+
   true_color_with_night_ir:
     standard_name: true_color_with_night_ir
     operations:


### PR DESCRIPTION
This PR adds two hrv composites to seviri.yaml. Recipes are provide by @pnuu . I added the 

```
natural_with_night_fog:
    compositor: !!python/name:satpy.composites.DayNightCompositor
    standard_name: natural_with_night_fog
    prerequisites:
      - natural_color
      - night_fog
```
to seviri.yaml as the composite version of visir.yaml doesn't work with seviri. 

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
