### PR TITLE
Add LAC support to the avhrr-gac-lac reader

### DIFF
--- a/satpy/etc/readers/avhrr_l1b_gaclac.yaml
+++ b/satpy/etc/readers/avhrr_l1b_gaclac.yaml
@@ -178,4 +178,4 @@ file_types:
     gac_lac_l1b:
         file_reader: !!python/name:satpy.readers.avhrr_l1b_gaclac.GACLACFile
         #NSS.GHRR.NJ.D95056.S1116.E1303.B0080506.GC
-        file_patterns: ['NSS.GHRR.{platform_id:2s}.D{start_time:%y%j.S%H%M}.E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}']
+        file_patterns: ['{creation_site:3s}.{transfer_mode:4s}.{platform_id:2s}.D{start_time:%y%j.S%H%M}.E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}']

--- a/satpy/readers/avhrr_l1b_gaclac.py
+++ b/satpy/readers/avhrr_l1b_gaclac.py
@@ -25,12 +25,16 @@
 
 import logging
 from datetime import datetime, timedelta
-import xarray as xr
+
 import dask.array as da
 import numpy as np
+
+import pygac.utils
+import xarray as xr
 from pygac.gac_klm import GACKLMReader
 from pygac.gac_pod import GACPODReader
-import pygac.utils
+from pygac.lac_klm import LACKLMReader
+from pygac.lac_pod import LACPODReader
 from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
 
@@ -53,7 +57,8 @@ class GACLACFile(BaseFileHandler):
                  start_line=None, end_line=None, strip_invalid_coords=True,
                  interpolate_coords=True, adjust_clock_drift=True,
                  tle_dir=None, tle_name=None, tle_thresh=7):
-        """
+        """Init the file handler.
+
         Args:
             start_line: User defined start scanline
             end_line: User defined end scanline
@@ -67,6 +72,7 @@ class GACLACFile(BaseFileHandler):
             tle_name: Filename pattern of TLE files.
             tle_thresh: Maximum number of days between observation and nearest
                 TLE
+
         """
         super(GACLACFile, self).__init__(
             filename, filename_info, filetype_info)
@@ -79,6 +85,7 @@ class GACLACFile(BaseFileHandler):
         self.tle_dir = tle_dir
         self.tle_name = tle_name
         self.tle_thresh = tle_thresh
+        self.creation_site = filename_info.get('creation_site')
         self.reader = None
         self.channels = None
         self.angles = None
@@ -95,27 +102,38 @@ class GACLACFile(BaseFileHandler):
         self.platform_id = filename_info['platform_id']
         if self.platform_id in ['NK', 'NL', 'NM', 'NN', 'NP', 'M1', 'M2',
                                 'M3']:
-            self.reader_class = GACKLMReader
+            if filename_info.get('transfer_mode') == 'GHRR':
+                self.reader_class = GACKLMReader
+            else:
+                self.reader_class = LACKLMReader
             self.chn_dict = AVHRR3_CHANNEL_NAMES
             self.sensor = 'avhrr-3'
         elif self.platform_id in ['NC', 'ND', 'NF', 'NH', 'NJ']:
-            self.reader_class = GACPODReader
+            if filename_info.get('transfer_mode') == 'GHRR':
+                self.reader_class = GACPODReader
+            else:
+                self.reader_class = LACPODReader
             self.chn_dict = AVHRR2_CHANNEL_NAMES
             self.sensor = 'avhrr-2'
         else:
-            self.reader_class = GACPODReader
+            if filename_info.get('transfer_mode') == 'GHRR':
+                self.reader_class = GACPODReader
+            else:
+                self.reader_class = LACPODReader
             self.chn_dict = AVHRR_CHANNEL_NAMES
             self.sensor = 'avhrr'
         self.filename_info = filename_info
 
     def get_dataset(self, key, info):
+        """Get the dataset."""
         if self.reader is None:
             self.reader = self.reader_class(
                 interpolate_coords=self.interpolate_coords,
                 adjust_clock_drift=self.adjust_clock_drift,
                 tle_dir=self.tle_dir,
                 tle_name=self.tle_name,
-                tle_thresh=self.tle_thresh)
+                tle_thresh=self.tle_thresh,
+                creation_site=self.creation_site)
             self.reader.read(self.filename)
         if np.all(self.reader.mask):
             raise ValueError('All data is masked out')
@@ -171,7 +189,10 @@ class GACLACFile(BaseFileHandler):
         res.attrs['platform_name'] = self.reader.spacecraft_name
         res.attrs['orbit_number'] = self.filename_info['orbit_number']
         res.attrs['sensor'] = self.sensor
-        res.attrs['orbital_parameters'] = {'tle': self.reader.get_tle_lines()}
+        try:
+            res.attrs['orbital_parameters'] = {'tle': self.reader.get_tle_lines()}
+        except IndexError:
+            pass
         res.attrs['midnight_scanline'] = self.midnight_scanline
         res.attrs['missing_scanlines'] = self.missing_scanlines
         res['acq_time'] = ('y', times)
@@ -188,6 +209,7 @@ class GACLACFile(BaseFileHandler):
             times: Scanline timestamps
         Returns:
             Sliced data and timestamps
+
         """
         # Slice data, update midnight scanline & list of missing scanlines
         sliced, self.midnight_scanline, miss_lines = self._slice(data)
@@ -205,6 +227,7 @@ class GACLACFile(BaseFileHandler):
 
         Returns:
             Sliced data, updated midnight scanline & list of missing scanlines
+
         """
         start_line = self.start_line if self.start_line is not None else 0
         end_line = self.end_line if self.end_line is not None else 0
@@ -267,6 +290,7 @@ class GACLACFile(BaseFileHandler):
 
         Returns:
             First and last scanline with valid latitudes.
+
         """
         if self.first_valid_lat is None:
             _, lats = self.reader.get_lonlat()
@@ -276,8 +300,10 @@ class GACLACFile(BaseFileHandler):
 
     @property
     def start_time(self):
+        """Get the start time."""
         return self._start_time
 
     @property
     def end_time(self):
+        """Get the end time."""
         return self._end_time

--- a/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
+++ b/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
@@ -25,7 +25,7 @@ try:
 except ImportError:  # python 2
     import mock
 
-GAC_PATTERN = 'NSS.GHRR.{platform_id:2s}.D{start_time:%y%j.S%H%M}.E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}'  # noqa
+GAC_PATTERN = '{creation_site:3s}.{transfer_mode:4s}.{platform_id:2s}.D{start_time:%y%j.S%H%M}.E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}'  # noqa
 
 GAC_POD_FILENAMES = ['NSS.GHRR.NA.D79184.S1150.E1337.B0008384.WI',
                      'NSS.GHRR.NA.D79184.S2350.E0137.B0008384.WI',

--- a/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
+++ b/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
@@ -15,6 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Pygac interface."""
 
 from datetime import datetime
 from unittest import TestCase, main, TestLoader, TestSuite
@@ -26,25 +27,46 @@ except ImportError:  # python 2
 
 GAC_PATTERN = 'NSS.GHRR.{platform_id:2s}.D{start_time:%y%j.S%H%M}.E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}'  # noqa
 
-POD_FILENAMES = ['NSS.GHRR.NA.D79184.S1150.E1337.B0008384.WI',
-                 'NSS.GHRR.NA.D79184.S2350.E0137.B0008384.WI',
-                 'NSS.GHRR.NA.D80021.S0927.E1121.B0295354.WI',
-                 'NSS.GHRR.NA.D80021.S1120.E1301.B0295455.WI',
-                 'NSS.GHRR.NA.D80021.S1256.E1450.B0295556.GC',
-                 'NSS.GHRR.NE.D83208.S1219.E1404.B0171819.WI',
-                 'NSS.GHRR.NG.D88002.S0614.E0807.B0670506.WI',
-                 'NSS.GHRR.TN.D79183.S1258.E1444.B0369697.GC',
-                 'NSS.GHRR.TN.D80003.S1147.E1332.B0630506.GC',
-                 'NSS.GHRR.TN.D80003.S1328.E1513.B0630507.GC',
-                 'NSS.GHRR.TN.D80003.S1509.E1654.B0630608.GC']
+GAC_POD_FILENAMES = ['NSS.GHRR.NA.D79184.S1150.E1337.B0008384.WI',
+                     'NSS.GHRR.NA.D79184.S2350.E0137.B0008384.WI',
+                     'NSS.GHRR.NA.D80021.S0927.E1121.B0295354.WI',
+                     'NSS.GHRR.NA.D80021.S1120.E1301.B0295455.WI',
+                     'NSS.GHRR.NA.D80021.S1256.E1450.B0295556.GC',
+                     'NSS.GHRR.NE.D83208.S1219.E1404.B0171819.WI',
+                     'NSS.GHRR.NG.D88002.S0614.E0807.B0670506.WI',
+                     'NSS.GHRR.TN.D79183.S1258.E1444.B0369697.GC',
+                     'NSS.GHRR.TN.D80003.S1147.E1332.B0630506.GC',
+                     'NSS.GHRR.TN.D80003.S1328.E1513.B0630507.GC',
+                     'NSS.GHRR.TN.D80003.S1509.E1654.B0630608.GC']
 
-KLM_FILENAMES = ['NSS.GHRR.NK.D01235.S0252.E0446.B1703233.GC',
-                 'NSS.GHRR.NL.D01288.S2315.E0104.B0549495.GC',
-                 'NSS.GHRR.NM.D04111.S2305.E0050.B0947778.GC',
-                 'NSS.GHRR.NN.D13011.S0559.E0741.B3939192.WI',
-                 'NSS.GHRR.NP.D15361.S0121.E0315.B3547172.SV',
-                 'NSS.GHRR.M1.D15362.S0031.E0129.B1699697.SV',
-                 'NSS.GHRR.M2.D10178.S2359.E0142.B1914142.SV']
+GAC_KLM_FILENAMES = ['NSS.GHRR.NK.D01235.S0252.E0446.B1703233.GC',
+                     'NSS.GHRR.NL.D01288.S2315.E0104.B0549495.GC',
+                     'NSS.GHRR.NM.D04111.S2305.E0050.B0947778.GC',
+                     'NSS.GHRR.NN.D13011.S0559.E0741.B3939192.WI',
+                     'NSS.GHRR.NP.D15361.S0121.E0315.B3547172.SV',
+                     'NSS.GHRR.M1.D15362.S0031.E0129.B1699697.SV',
+                     'NSS.GHRR.M2.D10178.S2359.E0142.B1914142.SV']
+
+LAC_POD_FILENAMES = ['BRN.HRPT.ND.D95152.S1730.E1715.B2102323.UB',
+                     'BRN.HRPT.ND.D95152.S1910.E1857.B2102424.UB',
+                     'BRN.HRPT.NF.D85152.S1345.E1330.B0241414.UB',
+                     'BRN.HRPT.NJ.D95152.S1233.E1217.B0216060.UB']
+
+LAC_KLM_FILENAMES = ['BRN.HRPT.M1.D14152.S0958.E1012.B0883232.UB',
+                     'BRN.HRPT.M1.D14152.S1943.E1958.B0883838.UB',
+                     'BRN.HRPT.M2.D12153.S0912.E0922.B2914747.UB',
+                     'BRN.HRPT.NN.D12153.S0138.E0152.B3622828.UB',
+                     'BRN.HRPT.NN.D12153.S0139.E0153.B3622828.UB',
+                     'BRN.HRPT.NN.D12153.S1309.E1324.B3623535.UB',
+                     'BRN.HRPT.NP.D12153.S0003.E0016.B1707272.UB',
+                     'BRN.HRPT.NP.D12153.S1134.E1148.B1707979.UB',
+                     'BRN.HRPT.NP.D16184.S1256.E1311.B3813131.UB',
+                     'BRN.HRPT.NP.D16184.S1438.E1451.B3813232.UB',
+                     'BRN.HRPT.NP.D16184.S1439.E1451.B3813232.UB',
+                     'BRN.HRPT.NP.D16185.S1245.E1259.B3814545.UB',
+                     'BRN.HRPT.NP.D16185.S1427.E1440.B3814646.UB',
+                     'NSS.FRAC.M2.D12153.S1729.E1910.B2915354.SV',
+                     'NSS.LHRR.NP.D16306.S1803.E1814.B3985555.WI']
 
 
 class TestGACLACFile(TestCase):
@@ -58,6 +80,8 @@ class TestGACLACFile(TestCase):
             'pygac': self.pygac,
             'pygac.gac_klm': self.pygac.gac_klm,
             'pygac.gac_pod': self.pygac.gac_pod,
+            'pygac.lac_klm': self.pygac.lac_klm,
+            'pygac.lac_pod': self.pygac.lac_pod,
             'pygac.utils': self.pygac.utils
         }
 
@@ -82,16 +106,17 @@ class TestGACLACFile(TestCase):
 
     def test_init(self):
         """Test GACLACFile initialization."""
-
         from pygac.gac_klm import GACKLMReader
         from pygac.gac_pod import GACPODReader
+        from pygac.lac_klm import LACKLMReader
+        from pygac.lac_pod import LACPODReader
 
-        for filenames, reader_cls in zip([POD_FILENAMES, KLM_FILENAMES],
-                                         [GACPODReader, GACKLMReader]):
+        for filenames, reader_cls in zip([GAC_POD_FILENAMES, GAC_KLM_FILENAMES, LAC_POD_FILENAMES, LAC_KLM_FILENAMES],
+                                         [GACPODReader, GACKLMReader, LACPODReader, LACKLMReader]):
             for filename in filenames:
                 fh = self._get_fh(filename)
                 self.assertLess(fh.start_time, fh.end_time,
-                                "Start time must preceed end time.")
+                                "Start time must precede end time.")
                 self.assertIs(fh.reader_class, reader_cls,
                               'Wrong reader class assigned to {}'.format(filename))
 
@@ -346,7 +371,7 @@ class TestGACLACFile(TestCase):
 
 
 def suite():
-    """The test suite."""
+    """Test suite."""
     loader = TestLoader()
     mysuite = TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestGACLACFile))

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if sys.version < '3.0':
 
 extras_require = {
     # Readers:
-    'avhrr_l1b_gaclac': ['pygac >= 1.2.1'],
+    'avhrr_l1b_gaclac': ['pygac >= 1.3.0'],
     'modis_l1b': ['pyhdf', 'python-geotiepoints >= 1.1.7'],
     'geocat': ['pyhdf'],
     'acspo': ['netCDF4 >= 1.1.8'],

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ if sys.version < '3.0':
 
 extras_require = {
     # Readers:
-    'avhrr_l1b_gaclac': ['pygac >= 1.2.0'],
+    'avhrr_l1b_gaclac': ['pygac >= 1.2.1'],
     'modis_l1b': ['pyhdf', 'python-geotiepoints >= 1.1.7'],
     'geocat': ['pyhdf'],
     'acspo': ['netCDF4 >= 1.1.8'],


### PR DESCRIPTION
The newest release of pygac should support LAC data reading. This PR makes sure satpy does too.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
