### PR TITLE
Add check if prerequisites is used

### DIFF
--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -344,7 +344,7 @@ class MITIFFWriter(ImageWriter):
 
         for i, ds in enumerate(ds_list):
             if ('prerequisites' in ds.attrs and
-                type(ds.attrs['prerequisites']) is list and
+                isinstance(ds.attrs['prerequisites'], list) and
                 len(ds.attrs['prerequisites']) >= i + 1 and
                     isinstance(ds.attrs['prerequisites'][i], DatasetID)):
                 if ds.attrs['prerequisites'][i][0] == ch:

--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -343,7 +343,10 @@ class MITIFFWriter(ImageWriter):
             ds_list = [datasets]
 
         for i, ds in enumerate(ds_list):
-            if 'prerequisites' in ds.attrs and isinstance(ds.attrs['prerequisites'][i], DatasetID):
+            if ('prerequisites' in ds.attrs and
+                type(ds.attrs['prerequisites']) is list and
+                len(ds.attrs['prerequisites']) >= i + 1 and
+                    isinstance(ds.attrs['prerequisites'][i], DatasetID)):
                 if ds.attrs['prerequisites'][i][0] == ch:
                     if ds.attrs['prerequisites'][i][4] == 'RADIANCE':
                         raise NotImplementedError(


### PR DESCRIPTION
If prerequisites is used in the mitiff writer be sure you use the right one.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 