### PR TITLE
Add FCI L1C reader short and long name metadata

### DIFF
--- a/satpy/etc/readers/fci_l1c_fdhsi.yaml
+++ b/satpy/etc/readers/fci_l1c_fdhsi.yaml
@@ -3,7 +3,7 @@ reader:
   short_name: FCI L1C FDHSI
   long_name: MTG FCI Level 1C FDHSI
   description: >
-    Generic FCI FDSHI data reader in the NetCDF4 format.
+    Reader for FCI FDSHI data in NetCDF4 format.
     Used to read Meteosat Third Generation (MTG) Flexible
     Combined Imager (FCI) Full Disk High Spectral Imagery (FDHSI) data.
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/etc/readers/fci_l1c_fdhsi.yaml
+++ b/satpy/etc/readers/fci_l1c_fdhsi.yaml
@@ -1,9 +1,13 @@
 reader:
-  description: Generic FCI FDSHI Data Reader
   name: fci_l1c_fdhsi
-  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader ''
+  short_name: FCI L1C FDHSI
+  long_name: MTG FCI Level 1C FDHSI
+  description: >
+    Generic FCI FDSHI data reader in the NetCDF4 format.
+    Used to read Meteosat Third Generation (MTG) Flexible
+    Combined Imager (FCI) Full Disk High Spectral Imagery (FDHSI) data.
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
   sensors: [fci]
-  default_datasets:
 
 datasets:
 


### PR DESCRIPTION
Adds short_name, long_name, and a longer description for the FCI reader. This is so GUI applications like my SIFT tool can display a "prettier" name for this reader.