### PR TITLE
Remove unused reader xslice/yslice keyword arguments

### DIFF
--- a/satpy/readers/acspo.py
+++ b/satpy/readers/acspo.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""ACSPO SST Reader
+"""ACSPO SST Reader.
 
 See the following page for more information:
 
@@ -38,9 +38,11 @@ ROWS_PER_SCAN = {
 
 
 class ACSPOFileHandler(NetCDF4FileHandler):
-    """ACSPO L2P SST File Reader"""
+    """ACSPO L2P SST File Reader."""
+
     @property
     def platform_name(self):
+        """Get satellite name for this file's data."""
         res = self['/attr/platform']
         if isinstance(res, np.ndarray):
             return str(res.astype(str))
@@ -49,6 +51,7 @@ class ACSPOFileHandler(NetCDF4FileHandler):
 
     @property
     def sensor_name(self):
+        """Get instrument name for this file's data."""
         res = self['/attr/sensor']
         if isinstance(res, np.ndarray):
             return str(res.astype(str))
@@ -85,13 +88,16 @@ class ACSPOFileHandler(NetCDF4FileHandler):
 
     @property
     def start_time(self):
+        """Get first observation time of data."""
         return self._parse_datetime(self['/attr/time_coverage_start'])
 
     @property
     def end_time(self):
+        """Get final observation time of data."""
         return self._parse_datetime(self['/attr/time_coverage_end'])
 
     def get_metadata(self, dataset_id, ds_info):
+        """Collect various metadata about the specified dataset."""
         var_path = ds_info.get('file_key', '{}'.format(dataset_id.name))
         shape = self.get_shape(dataset_id, ds_info)
         units = self[var_path + '/attr/units']
@@ -113,20 +119,12 @@ class ACSPOFileHandler(NetCDF4FileHandler):
         })
         return info
 
-    def get_dataset(self, dataset_id, ds_info, xslice=slice(None), yslice=slice(None)):
+    def get_dataset(self, dataset_id, ds_info):
         """Load data array and metadata from file on disk."""
         var_path = ds_info.get('file_key', '{}'.format(dataset_id.name))
         metadata = self.get_metadata(dataset_id, ds_info)
         shape = metadata['shape']
         file_shape = self[var_path + '/shape']
-        if isinstance(shape, tuple) and len(shape) == 2:
-            # 2D array
-            if xslice.start is not None:
-                shape = (shape[0], xslice.stop - xslice.start)
-            if yslice.start is not None:
-                shape = (yslice.stop - yslice.start, shape[1])
-        elif isinstance(shape, tuple) and len(shape) == 1 and yslice.start is not None:
-            shape = ((yslice.stop - yslice.start) / yslice.step,)
         metadata['shape'] = shape
 
         valid_min = self[var_path + '/attr/valid_min']
@@ -135,14 +133,10 @@ class ACSPOFileHandler(NetCDF4FileHandler):
         scale_factor = self.get(var_path + '/attr/scale_factor')
         add_offset = self.get(var_path + '/attr/add_offset')
 
+        data = self[var_path]
         if isinstance(file_shape, tuple) and len(file_shape) == 3:
-            data = self[var_path][0, yslice, xslice]
-        elif isinstance(file_shape, tuple) and len(file_shape) == 2:
-            data = self[var_path][yslice, xslice]
-        elif isinstance(file_shape, tuple) and len(file_shape) == 1:
-            data = self[var_path][yslice]
-        else:
-            data = self[var_path]
+            # can only read 3D arrays with size 1 in the first dimension
+            data = data[0]
         data = data.where((data >= valid_min) & (data <= valid_max))
         if scale_factor is not None:
             data = data * scale_factor + add_offset

--- a/satpy/readers/geocat.py
+++ b/satpy/readers/geocat.py
@@ -276,16 +276,12 @@ class GEOCATFileHandler(NetCDF4FileHandler):
 
         return info
 
-    def get_dataset(self, dataset_id, ds_info, xslice=None, yslice=None):
+    def get_dataset(self, dataset_id, ds_info):
         """Get dataset."""
-        if xslice is None:
-            xslice = slice(None)
-        if yslice is None:
-            yslice = slice(None)
         var_name = ds_info.get('file_key', dataset_id.name)
         # FUTURE: Metadata retrieval may be separate
         info = self.get_metadata(dataset_id, ds_info)
-        data = self[var_name][yslice, xslice]
+        data = self[var_name]
         fill = self[var_name + '/attr/_FillValue']
         factor = self.get(var_name + '/attr/scale_factor')
         offset = self.get(var_name + '/attr/add_offset')


### PR DESCRIPTION
Before we used dask these keyword arguments allowed us to limit how much data was loaded from disk. With dask this isn't needed since future slicing of the data should limit what dask chunks are loaded.

 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
