### PR TITLE
Rename standard_name for various readers to be consistent

### DIFF
--- a/satpy/etc/readers/avhrr_l1b_aapp.yaml
+++ b/satpy/etc/readers/avhrr_l1b_aapp.yaml
@@ -12,9 +12,9 @@ datasets:
         resolution: 1050
         calibration:
           reflectance:
-            standard_name: reflectance
+            standard_name: toa_bidirectional_reflectance
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -25,9 +25,9 @@ datasets:
         resolution: 1050
         calibration:
           reflectance:
-            standard_name: reflectance
+            standard_name: toa_bidirectional_reflectance
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -38,9 +38,9 @@ datasets:
         resolution: 1050
         calibration:
           reflectance:
-            standard_name: reflectance
+            standard_name: toa_bidirectional_reflectance
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -51,9 +51,9 @@ datasets:
         resolution: 1050
         calibration:
           brightness_temperature:
-            standard_name: brightness_temperature
+            standard_name: toa_brightness_temperature
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -64,9 +64,9 @@ datasets:
         resolution: 1050
         calibration:
           brightness_temperature:
-            standard_name: brightness_temperature
+            standard_name: toa_brightness_temperature
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -77,9 +77,9 @@ datasets:
         resolution: 1050
         calibration:
           brightness_temperature:
-            standard_name: brightness_temperature
+            standard_name: toa_brightness_temperature
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude

--- a/satpy/etc/readers/avhrr_l1b_eps.yaml
+++ b/satpy/etc/readers/avhrr_l1b_eps.yaml
@@ -12,9 +12,9 @@ datasets:
         resolution: 1050
         calibration:
           reflectance:
-            standard_name: reflectance
+            standard_name: toa_bidirectional_reflectance
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -25,9 +25,9 @@ datasets:
         resolution: 1050
         calibration:
           reflectance:
-            standard_name: reflectance
+            standard_name: toa_bidirectional_reflectance
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -38,9 +38,9 @@ datasets:
         resolution: 1050
         calibration:
           reflectance:
-            standard_name: reflectance
+            standard_name: toa_bidirectional_reflectance
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -51,9 +51,9 @@ datasets:
         resolution: 1050
         calibration:
           brightness_temperature:
-            standard_name: brightness_temperature
+            standard_name: toa_brightness_temperature
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -64,9 +64,9 @@ datasets:
         resolution: 1050
         calibration:
           brightness_temperature:
-            standard_name: brightness_temperature
+            standard_name: toa_brightness_temperature
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -77,9 +77,9 @@ datasets:
         resolution: 1050
         calibration:
           brightness_temperature:
-            standard_name: brightness_temperature
+            standard_name: toa_brightness_temperature
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude

--- a/satpy/etc/readers/avhrr_l1b_gaclac.yaml
+++ b/satpy/etc/readers/avhrr_l1b_gaclac.yaml
@@ -14,7 +14,7 @@ datasets:
             standard_name: toa_bidirectional_reflectance
             units: '%'
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -28,7 +28,7 @@ datasets:
             standard_name: toa_bidirectional_reflectance
             units: '%'
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -42,7 +42,7 @@ datasets:
             standard_name: toa_bidirectional_reflectance
             units: '%'
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -56,7 +56,7 @@ datasets:
             standard_name: toa_bidirectional_reflectance
             units: '%'
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -70,7 +70,7 @@ datasets:
             standard_name: toa_brightness_temperature
             units: K
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -84,7 +84,7 @@ datasets:
             standard_name: toa_brightness_temperature
             units: K
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude
@@ -98,7 +98,7 @@ datasets:
             standard_name: toa_brightness_temperature
             units: K
           radiance:
-            standard_name: radiance
+            standard_name: toa_outgoing_radiance_per_unit_wavelength
         coordinates:
             - longitude
             - latitude

--- a/satpy/etc/readers/avhrr_l1b_hrpt.yaml
+++ b/satpy/etc/readers/avhrr_l1b_hrpt.yaml
@@ -12,7 +12,7 @@ datasets:
         resolution: 1050
         calibration:
           reflectance:
-            standard_name: reflectance
+            standard_name: toa_bidirectional_reflectance
           counts:
             standard_name: counts
         coordinates: [longitude, latitude]
@@ -23,7 +23,7 @@ datasets:
         resolution: 1050
         calibration:
           reflectance:
-            standard_name: reflectance
+            standard_name: toa_bidirectional_reflectance
           counts:
             standard_name: counts
         coordinates: [longitude, latitude]
@@ -34,7 +34,7 @@ datasets:
         resolution: 1050
         calibration:
           reflectance:
-            standard_name: reflectance
+            standard_name: toa_bidirectional_reflectance
           counts:
             standard_name: counts
         coordinates: [longitude, latitude]
@@ -45,7 +45,7 @@ datasets:
         resolution: 1050
         calibration:
           brightness_temperature:
-            standard_name: brightness_temperature
+            standard_name: toa_brightness_temperature
           counts:
             standard_name: counts
         coordinates: [longitude, latitude]
@@ -56,7 +56,7 @@ datasets:
         resolution: 1050
         calibration:
           brightness_temperature:
-            standard_name: brightness_temperature
+            standard_name: toa_brightness_temperature
           counts:
             standard_name: counts
         coordinates: [longitude, latitude]
@@ -67,7 +67,7 @@ datasets:
         resolution: 1050
         calibration:
           brightness_temperature:
-            standard_name: brightness_temperature
+            standard_name: toa_brightness_temperature
           counts:
             standard_name: counts
         coordinates: [longitude, latitude]

--- a/satpy/etc/readers/electrol_hrit.yaml
+++ b/satpy/etc/readers/electrol_hrit.yaml
@@ -169,7 +169,7 @@ datasets:
     wavelength: [3.5, 3.8, 4.0]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     #   radiance:
     #     standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -185,7 +185,7 @@ datasets:
     wavelength: [5.7, 6.4, 7.0]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     #   radiance:
     #     standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -201,7 +201,7 @@ datasets:
     wavelength: [7.5, 8.0, 8.5]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     #   radiance:
     #     standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -217,7 +217,7 @@ datasets:
     wavelength: [8.2, 8.7, 9.2]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     #   radiance:
     #     standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -233,7 +233,7 @@ datasets:
     wavelength: [9.2, 9.7, 10.2]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     #   radiance:
     #     standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -249,7 +249,7 @@ datasets:
     wavelength: [10.2, 10.8, 11.2]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     #   radiance:
     #     standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -265,7 +265,7 @@ datasets:
     wavelength: [11.2, 11.9, 12.5]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     #   radiance:
     #     standard_name: toa_outgoing_radiance_per_unit_wavelength

--- a/satpy/etc/readers/goes-imager_hrit.yaml
+++ b/satpy/etc/readers/goes-imager_hrit.yaml
@@ -90,7 +90,7 @@ datasets:
     wavelength: [3.8, 3.9, 4.0]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     #   radiance:
     #     standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -105,7 +105,7 @@ datasets:
     wavelength: [6.5, 6.6, 7.0]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     #   radiance:
     #     standard_name: toa_outgoing_radiance_per_unit_wavelength
@@ -120,7 +120,7 @@ datasets:
     wavelength: [10.2, 10.7, 11.2]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     #   radiance:
     #     standard_name: toa_outgoing_radiance_per_unit_wavelength

--- a/satpy/etc/readers/goes-imager_nc.yaml
+++ b/satpy/etc/readers/goes-imager_nc.yaml
@@ -107,7 +107,7 @@ datasets:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: mW m-2 cm-1 sr-1
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     coordinates:
         - longitude_03_9
@@ -125,7 +125,7 @@ datasets:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: mW m-2 cm-1 sr-1
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     coordinates:
         - longitude_06_5
@@ -143,7 +143,7 @@ datasets:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: mW m-2 cm-1 sr-1
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     coordinates:
         - longitude_06_8
@@ -161,7 +161,7 @@ datasets:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: mW m-2 cm-1 sr-1
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     coordinates:
         - longitude_10_7
@@ -179,7 +179,7 @@ datasets:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: mW m-2 cm-1 sr-1
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     coordinates:
         - longitude_12_0
@@ -197,7 +197,7 @@ datasets:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: mW m-2 cm-1 sr-1
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
     coordinates:
         - longitude_13_3

--- a/satpy/etc/readers/seviri_l1b_hrit.yaml
+++ b/satpy/etc/readers/seviri_l1b_hrit.yaml
@@ -165,7 +165,7 @@ datasets:
     wavelength: [1.5, 1.64, 1.78]
     calibration:
       reflectance:
-        standard_name: reflectance
+        standard_name: toa_bidirectional_reflectance
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavenumber
@@ -181,7 +181,7 @@ datasets:
     wavelength: [3.48, 3.92, 4.36]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavenumber
@@ -197,7 +197,7 @@ datasets:
     wavelength: [8.3, 8.7, 9.1]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavenumber
@@ -213,7 +213,7 @@ datasets:
     wavelength: [9.38, 9.66, 9.94]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavenumber
@@ -229,7 +229,7 @@ datasets:
     wavelength: [9.8, 10.8, 11.8]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavenumber
@@ -245,7 +245,7 @@ datasets:
     wavelength: [11.0, 12.0, 13.0]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavenumber
@@ -261,7 +261,7 @@ datasets:
     wavelength: [12.4, 13.4, 14.4]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavenumber
@@ -309,7 +309,7 @@ datasets:
     wavelength: [5.35, 6.25, 7.15]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: "K"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavenumber
@@ -325,7 +325,7 @@ datasets:
     wavelength: [6.85, 7.35, 7.85]
     calibration:
       brightness_temperature:
-        standard_name: brightness_temperature
+        standard_name: toa_brightness_temperature
         units: "K"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavenumber

--- a/satpy/etc/readers/seviri_l2_bufr.yaml
+++ b/satpy/etc/readers/seviri_l2_bufr.yaml
@@ -55,7 +55,7 @@ datasets:
     name: nir39all
     key: '#19#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -67,7 +67,7 @@ datasets:
     name: nir39clr
     key: '#20#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -79,7 +79,7 @@ datasets:
     name: nir39cld
     key: '#21#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -91,7 +91,7 @@ datasets:
     name: nir39low
     key: '#22#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -103,7 +103,7 @@ datasets:
     name: nir39med
     key: '#23#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -115,7 +115,7 @@ datasets:
     name: nir39high
     key: '#24#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -127,7 +127,7 @@ datasets:
     name: wv62all
     key: '#25#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -139,7 +139,7 @@ datasets:
     name: wv62clr
     key: '#26#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -151,7 +151,7 @@ datasets:
     name: wv62cld
     key: '#27#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -163,7 +163,7 @@ datasets:
     name: wv62low
     key: '#28#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -175,7 +175,7 @@ datasets:
     name: wv62med
     key: '#29#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -187,7 +187,7 @@ datasets:
     name: wv62high
     key: '#30#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -199,7 +199,7 @@ datasets:
     name: wv73all
     key: '#31#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -211,7 +211,7 @@ datasets:
     name: wv73clr
     key: '#32#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -223,7 +223,7 @@ datasets:
     name: wv73cld
     key: '#33#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -235,7 +235,7 @@ datasets:
     name: wv73low
     key: '#34#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -247,7 +247,7 @@ datasets:
     name: wv73med
     key: '#35#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -259,7 +259,7 @@ datasets:
     name: wv73high
     key: '#36#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -271,7 +271,7 @@ datasets:
     name: ir87all
     key: '#37#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -283,7 +283,7 @@ datasets:
     name: ir87clr
     key: '#38#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -295,7 +295,7 @@ datasets:
     name: ir87cld
     key: '#39#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -307,7 +307,7 @@ datasets:
     name: ir87low
     key: '#40#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -319,7 +319,7 @@ datasets:
     name: ir87med
     key: '#41#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -331,7 +331,7 @@ datasets:
     name: ir87high
     key: '#42#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -343,7 +343,7 @@ datasets:
     name: ir97all
     key: '#43#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -355,7 +355,7 @@ datasets:
     name: ir97clr
     key: '#44#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -367,7 +367,7 @@ datasets:
     name: ir97cld
     key: '#45#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -379,7 +379,7 @@ datasets:
     name: ir97low
     key: '#46#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -391,7 +391,7 @@ datasets:
     name: ir97med
     key: '#47#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -403,7 +403,7 @@ datasets:
     name: ir97high
     key: '#48#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -415,7 +415,7 @@ datasets:
     name: ir108all
     key: '#49#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -427,7 +427,7 @@ datasets:
     name: ir108clr
     key: '#50#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -439,7 +439,7 @@ datasets:
     name: ir108cld
     key: '#51#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -451,7 +451,7 @@ datasets:
     name: ir108low
     key: '#52#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -463,7 +463,7 @@ datasets:
     name: ir108med
     key: '#53#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -475,7 +475,7 @@ datasets:
     name: ir108high
     key: '#54#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -487,7 +487,7 @@ datasets:
     name: ir120all
     key: '#55#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -499,7 +499,7 @@ datasets:
     name: ir120clr
     key: '#56#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -511,7 +511,7 @@ datasets:
     name: ir120cld
     key: '#57#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -523,7 +523,7 @@ datasets:
     name: ir120low
     key: '#58#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -535,7 +535,7 @@ datasets:
     name: ir120med
     key: '#59#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -547,7 +547,7 @@ datasets:
     name: ir120high
     key: '#60#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -559,7 +559,7 @@ datasets:
     name: ir134all
     key: '#61#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -571,7 +571,7 @@ datasets:
     name: ir134clr
     key: '#62#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -583,7 +583,7 @@ datasets:
     name: ir134cld
     key: '#63#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -595,7 +595,7 @@ datasets:
     name: ir134low
     key: '#64#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -607,7 +607,7 @@ datasets:
     name: ir134med
     key: '#65#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -619,7 +619,7 @@ datasets:
     name: ir134high
     key: '#66#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: K
     file_type: seviri_l2_bufr_asr
     coordinates:
@@ -714,7 +714,7 @@ datasets:
     name: nir39
     key: '#4#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units:  "W/sr-1/m-2"
     file_type: seviri_l2_bufr_csr
     coordinates:
@@ -738,7 +738,7 @@ datasets:
     name: wv62
     key: '#5#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: "W/sr-1/m-2"
     file_type: seviri_l2_bufr_csr
     coordinates:
@@ -762,7 +762,7 @@ datasets:
     name: wv73
     key: '#6#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: "W/sr-1/m-2"
     file_type: seviri_l2_bufr_csr
     coordinates:
@@ -786,7 +786,7 @@ datasets:
     name: ir87
     key: '#7#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: "W/sr-1/m-2"
     file_type: seviri_l2_bufr_csr
     coordinates:
@@ -810,7 +810,7 @@ datasets:
     name: ir97
     key: '#8#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: "W/sr-1/m-2"
     file_type: seviri_l2_bufr_csr
     coordinates:
@@ -834,7 +834,7 @@ datasets:
     name: ir108
     key: '#9#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: "W/sr-1/m-2"
     file_type: seviri_l2_bufr_csr
     coordinates:
@@ -858,7 +858,7 @@ datasets:
     name: ir120
     key: '#10#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: "W/sr-1/m-2"
     file_type: seviri_l2_bufr_csr
     coordinates:
@@ -882,7 +882,7 @@ datasets:
     name: ir134
     key: '#11#brightnessTemperature'
     resolution: 48000
-    standard_name: brightness_temperature
+    standard_name: toa_brightness_temperature
     units: "W/sr-1/m-2"
     file_type: seviri_l2_bufr_csr
     coordinates:


### PR DESCRIPTION
Found out that AVHRR had incorrect `standard_name` from a mailing list issue. While fixing it I found that a couple readers had this issue.

 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
