### PR TITLE
Fix `ahi_hrit` expected segments

### DIFF
--- a/satpy/etc/readers/ahi_hrit.yaml
+++ b/satpy/etc/readers/ahi_hrit.yaml
@@ -22,7 +22,6 @@ file_types:
     hrit_b01_fd:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
         file_patterns:
-        - 'IMG_DK{area:02d}B01_{start_time:%Y%m%d%H%M}_{segment:3s}'
         - 'IMG_DK{area:02d}B01_{start_time:%Y%m%d%H%M}'
 
     hrit_b02_seg:

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -932,7 +932,8 @@ def _stack_area_defs(area_def_dict):
 def _pad_later_segments_area(file_handlers, dsid):
     """Pad area definitions for missing segments that are later in sequence than the first available."""
     seg_size = None
-    expected_segments = file_handlers[0].filetype_info['expected_segments']
+    expected_segments = file_handlers[0].filetype_info.get(
+        'expected_segments', 1)
     available_segments = [int(fh.filename_info['segment']) for
                           fh in file_handlers]
     area_defs = {}


### PR DESCRIPTION
This PR removes a duplicate file pattern that caused a crash when reading `ahi_hrit` data. Adds also a better access (`.get()`) to `expected_segments` to the `GEOSegmentYAMLReader`.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
