### PR TITLE
Add support for SEVIRI data from icare

### DIFF
--- a/satpy/etc/readers/seviri_l1b_icare.yaml
+++ b/satpy/etc/readers/seviri_l1b_icare.yaml
@@ -1,0 +1,184 @@
+# References:
+# - MSG Level 1.5 Image Data Format Description
+# - Radiometric Calibration of MSG SEVIRI Level 1.5 Image Data in Equivalent
+#   Spectral Blackbody Radiance
+
+reader:
+  name: seviri_l1b_icare
+  short_name: SEVIRI L1b ICARE
+  long_name: MSG SEVIRI Level 1b in HDF format from ICARE (Lille)
+  description: >
+    A reader for L1b SEVIRI data that has been retrieved from the ICARE service as HDF.
+  sensors: [seviri]
+  default_channels: [HRV, IR_016, IR_039, IR_087, IR_097, IR_108, IR_120, IR_134, VIS006, VIS008, WV_062, WV_073]
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
+
+file_types:
+    ICARE_HRV:
+        file_reader: !!python/name:satpy.readers.seviri_l1b_icare.SEVIRI_ICARE
+        file_patterns: ['GEO_L1B-{platform_shortname:4s}_{start_time:%Y-%m-%dT%H-%M-%S}_G_HRV_{version:5s}.hdf']
+
+    ICARE_IR_016:
+        file_reader: !!python/name:satpy.readers.seviri_l1b_icare.SEVIRI_ICARE
+        file_patterns: ['GEO_L1B-{platform_shortname:4s}_{start_time:%Y-%m-%dT%H-%M-%S}_G_IR016_{version:5s}.hdf']
+
+    ICARE_IR_039:
+        file_reader: !!python/name:satpy.readers.seviri_l1b_icare.SEVIRI_ICARE
+        file_patterns: ['GEO_L1B-{platform_shortname:4s}_{start_time:%Y-%m-%dT%H-%M-%S}_G_IR039_{version:5s}.hdf']
+
+    ICARE_IR_087:
+        file_reader: !!python/name:satpy.readers.seviri_l1b_icare.SEVIRI_ICARE
+        file_patterns: ['GEO_L1B-{platform_shortname:4s}_{start_time:%Y-%m-%dT%H-%M-%S}_G_IR087_{version:5s}.hdf']
+
+    ICARE_IR_097:
+        file_reader: !!python/name:satpy.readers.seviri_l1b_icare.SEVIRI_ICARE
+        file_patterns: ['GEO_L1B-{platform_shortname:4s}_{start_time:%Y-%m-%dT%H-%M-%S}_G_IR097_{version:5s}.hdf']
+
+    ICARE_IR_108:
+        file_reader: !!python/name:satpy.readers.seviri_l1b_icare.SEVIRI_ICARE
+        file_patterns: ['GEO_L1B-{platform_shortname:4s}_{start_time:%Y-%m-%dT%H-%M-%S}_G_IR108_{version:5s}.hdf']
+
+    ICARE_IR_120:
+        file_reader: !!python/name:satpy.readers.seviri_l1b_icare.SEVIRI_ICARE
+        file_patterns: ['GEO_L1B-{platform_shortname:4s}_{start_time:%Y-%m-%dT%H-%M-%S}_G_IR120_{version:5s}.hdf']
+
+    ICARE_IR_134:
+        file_reader: !!python/name:satpy.readers.seviri_l1b_icare.SEVIRI_ICARE
+        file_patterns: ['GEO_L1B-{platform_shortname:4s}_{start_time:%Y-%m-%dT%H-%M-%S}_G_IR134_{version:5s}.hdf']
+
+    ICARE_VIS006:
+        file_reader: !!python/name:satpy.readers.seviri_l1b_icare.SEVIRI_ICARE
+        file_patterns: ['GEO_L1B-{platform_shortname:4s}_{start_time:%Y-%m-%dT%H-%M-%S}_G_VIS06_{version:5s}.hdf']
+
+    ICARE_VIS008:
+        file_reader: !!python/name:satpy.readers.seviri_l1b_icare.SEVIRI_ICARE
+        file_patterns: ['GEO_L1B-{platform_shortname:4s}_{start_time:%Y-%m-%dT%H-%M-%S}_G_VIS08_{version:5s}.hdf']
+
+    ICARE_WV_062:
+        file_reader: !!python/name:satpy.readers.seviri_l1b_icare.SEVIRI_ICARE
+        file_patterns: ['GEO_L1B-{platform_shortname:4s}_{start_time:%Y-%m-%dT%H-%M-%S}_G_WV062_{version:5s}.hdf']
+
+    ICARE_WV_073:
+        file_reader: !!python/name:satpy.readers.seviri_l1b_icare.SEVIRI_ICARE
+        file_patterns: ['GEO_L1B-{platform_shortname:4s}_{start_time:%Y-%m-%dT%H-%M-%S}_G_WV073_{version:5s}.hdf']
+
+datasets:
+  HRV:
+    name: HRV
+    resolution: 1000.134348869
+    wavelength: [0.5, 0.7, 0.9]
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+    file_type: ICARE_HRV
+
+  IR_016:
+    name: IR_016
+    resolution: 3000.403165817
+    wavelength: [1.5, 1.64, 1.78]
+    calibration:
+      reflectance:
+        standard_name: reflectance
+        units: "%"
+    file_type: ICARE_IR_016
+
+  IR_039:
+    name: IR_039
+    resolution: 3000.403165817
+    wavelength: [3.48, 3.92, 4.36]
+    calibration:
+      brightness_temperature:
+        standard_name: brightness_temperature
+        units: K
+    file_type: ICARE_IR_039
+
+  IR_087:
+    name: IR_087
+    resolution: 3000.403165817
+    wavelength: [8.3, 8.7, 9.1]
+    calibration:
+      brightness_temperature:
+        standard_name: brightness_temperature
+        units: K
+    file_type: ICARE_IR_087
+
+  IR_097:
+    name: IR_097
+    resolution: 3000.403165817
+    wavelength: [9.38, 9.66, 9.94]
+    calibration:
+      brightness_temperature:
+        standard_name: brightness_temperature
+        units: K
+    file_type: ICARE_IR_097
+
+  IR_108:
+    name: IR_108
+    resolution: 3000.403165817
+    wavelength: [9.8, 10.8, 11.8]
+    calibration:
+      brightness_temperature:
+        standard_name: brightness_temperature
+        units: K
+    file_type: ICARE_IR_108
+
+  IR_120:
+    name: IR_120
+    resolution: 3000.403165817
+    wavelength: [11.0, 12.0, 13.0]
+    calibration:
+      brightness_temperature:
+        standard_name: brightness_temperature
+        units: K
+    file_type: ICARE_IR_120
+
+  IR_134:
+    name: IR_134
+    resolution: 3000.403165817
+    wavelength: [12.4, 13.4, 14.4]
+    calibration:
+      brightness_temperature:
+        standard_name: brightness_temperature
+        units: K
+    file_type: ICARE_IR_134
+
+  VIS006:
+    name: VIS006
+    resolution: 3000.403165817
+    wavelength: [0.56, 0.635, 0.71]
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+    file_type: ICARE_VIS006
+
+  VIS008:
+    name: VIS008
+    resolution: 3000.403165817
+    wavelength: [0.74, 0.81, 0.88]
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+    file_type: ICARE_VIS008
+
+  WV_062:
+    name: WV_062
+    resolution: 3000.403165817
+    wavelength: [5.35, 6.25, 7.15]
+    calibration:
+      brightness_temperature:
+        standard_name: brightness_temperature
+        units: "K"
+    file_type: ICARE_WV_062
+
+  WV_073:
+    name: WV_073
+    resolution: 3000.403165817
+    wavelength: [6.85, 7.35, 7.85]
+    calibration:
+      brightness_temperature:
+        standard_name: brightness_temperature
+        units: "K"
+    file_type: ICARE_WV_073

--- a/satpy/readers/seviri_l1b_icare.py
+++ b/satpy/readers/seviri_l1b_icare.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+r"""Interface to SEVIRI L1B data from ICARE (Lille).
+
+Introduction
+------------
+
+The ``seviri_l1b_icare`` reader reads MSG-SEVIRI L1.5 image data in HDF format
+that has been produced by the ICARE Data and Services Center
+Data can be accessed via: http://http://www.icare.univ-lille1.fr
+
+Each SEVIRI timeslot comes as 12 HDF files, one per band. Only those bands
+that are of interest need to be passed to the reader. Others can be ignored.
+Filenames follow the format: GEO_L1B-MSG1_YYYY-MM-DDTHH-MM-SS_G_CHANN_VX-XX.hdf
+Where:
+YYYY, MM, DD, HH, MM, SS specify the timeslot starting time.
+CHANN is the channel (i.e: HRV, IR016, WV073, etc)
+VX-XX is the processing version number
+
+Example
+-------
+Here is an example how to read the data in satpy:
+
+.. code-block:: python
+
+    from satpy import Scene
+    import glob
+
+    filenames = glob.glob('data/*2019-03-01T12-00-00*.hdf')
+    scn = Scene(filenames=filenames, reader='seviri_l1b_icare')
+    scn.load(['VIS006', 'IR_108'])
+    print(scn['IR_108'])
+
+Output:
+
+.. code-block:: none
+
+    <xarray.DataArray 'array-a1d52b7e19ec5a875e2f038df5b60d7e' (y: 3712, x: 3712)>
+    dask.array<add, shape=(3712, 3712), dtype=float32, chunksize=(1024, 1024), chunktype=numpy.ndarray>
+    Coordinates:
+        crs      object +proj=geos +a=6378169.0 +b=6356583.8 +lon_0=0.0 +h=35785831.0 +units=m +type=crs
+      * y        (y) float64 5.566e+06 5.563e+06 5.56e+06 ... -5.566e+06 -5.569e+06
+      * x        (x) float64 -5.566e+06 -5.563e+06 -5.56e+06 ... 5.566e+06 5.569e+06
+    Attributes:
+        start_time:           2004-12-29 12:15:00
+        end_time:             2004-12-29 12:15:00
+        area:                 Area ID: geosmsg\nDescription: MSG/SEVIRI low resol...
+        name:                 IR_108
+        resolution:           3000.403165817
+        calibration:          brightness_temperature
+        polarization:         None
+        level:                None
+        modifiers:            ()
+        ancillary_variables:  []
+
+"""
+from satpy.readers._geos_area import get_area_extent, get_area_definition
+from satpy.readers.hdf4_utils import HDF4FileHandler
+from datetime import datetime
+import numpy as np
+
+
+class SEVIRI_ICARE(HDF4FileHandler):
+    """SEVIRI L1B handler for HDF4 files."""
+    def __init__(self, filename, filename_info, filetype_info):
+        super(SEVIRI_ICARE, self).__init__(filename,
+                                           filename_info,
+                                           filetype_info)
+        # These are VIS bands
+        self.ref_bands = ['HRV', 'VIS006', 'VIS008', 'IR_016']
+        # And these are IR bands
+        self.bt_bands = ['IR_039', 'IR_062', 'IR_073',
+                         'IR_087', 'IR_097', 'IR_108',
+                         'IR_120', 'IR_134',
+                         'WV_062', 'WV_073']
+
+    @property
+    def sensor_name(self):
+        # the sensor and platform names are stored together, eg: MSG1/SEVIRI
+        attr = self['/attr/Sensors']
+        if isinstance(attr, np.ndarray):
+            attr = str(attr.astype(str)).lower()
+        plat = attr[0:4]
+        sens = attr[5:]
+        # icare uses non-standard platform names
+        if plat == 'msg1':
+            plat = 'Meteosat-08'
+        elif plat == 'msg2':
+            plat = 'Meteosat-09'
+        elif plat == 'msg3':
+            plat = 'Meteosat-10'
+        elif plat == 'msg4':
+            plat = 'Meteosat-11'
+        else:
+            raise(NameError, "Unsupported satellite platform:"+plat)
+        return [plat, sens]
+
+    @property
+    def satlon(self):
+        attr = self['/attr/Sub_Satellite_Longitude']
+        if isinstance(attr, np.ndarray):
+            attr = float(attr.astype(str))
+        return attr
+
+    @property
+    def projlon(self):
+        attr = self['/attr/Projection_Longitude']
+        if isinstance(attr, np.ndarray):
+            attr = float(attr.astype(str))
+        return attr
+
+    @property
+    def projection(self):
+        attr = self['/attr/Geographic_Projection']
+        if isinstance(attr, np.ndarray):
+            attr = str(attr.astype(str)).lower()
+        if attr != 'geos':
+            raise(NotImplementedError, "Only the GEOS projection is supported")
+        return attr
+
+    @property
+    def zone(self):
+        attr = self['/attr/Zone']
+        if isinstance(attr, np.ndarray):
+            attr = str(attr.astype(str)).lower()
+        return attr
+
+    @property
+    def res(self):
+        attr = self['/attr/Nadir_Pixel_Size']
+        if isinstance(attr, np.ndarray):
+            attr = str(attr.astype(str)).lower()
+        return float(attr)
+
+    @property
+    def endacq(self):
+        attr = self['/attr/End_Acquisition_Date']
+        if isinstance(attr, np.ndarray):
+            attr = str(attr.astype(str))
+        endacq = datetime.strptime(attr, "%Y-%m-%dT%H:%M:%SZ")
+        return endacq
+
+    @property
+    def stacq(self):
+        attr = self['/attr/Beginning_Acquisition_Date']
+        if isinstance(attr, np.ndarray):
+            attr = str(attr.astype(str))
+        stacq = datetime.strptime(attr, "%Y-%m-%dT%H:%M:%SZ")
+        return stacq
+
+    @property
+    def alt(self):
+        attr = self['/attr/Altitude']
+        if isinstance(attr, np.ndarray):
+            attr = attr.astype(str)
+        attr = float(attr)
+        # This is stored in km, convert to m
+        attr = attr * 1000.
+        return attr
+
+    @property
+    def geoloc(self):
+        attr = self['/attr/Geolocation']
+        if isinstance(attr, np.ndarray):
+            attr = attr.astype(str)
+        cfac = float(attr[0])
+        coff = float(attr[1])
+        lfac = float(attr[2])
+        loff = float(attr[3])
+        return [cfac, lfac, coff, loff]
+
+    def get_metadata(self, data, ds_info):
+        mda = {}
+        mda.update(data.attrs)
+        mda.update(ds_info)
+        geoloc = self.geoloc
+        mda.update({
+                    'start_time': self.stacq,
+                    'end_time': self.endacq,
+                    'platform_name': self.sensor_name[0],
+                    'sensor': self.sensor_name[1],
+                    'zone': self.zone,
+                    'satellite_altitude': self.alt,
+                    'cfac': geoloc[0],
+                    'lfac': geoloc[1],
+                    'coff': geoloc[2],
+                    'loff': geoloc[3],
+                    'resolution': self.res,
+                    'satellite_longitude': self.satlon,
+                    'projection_longitude': self.projlon,
+        })
+
+        return mda
+
+    def get_dataset(self, ds_id, ds_info):
+        if ds_id.name in self.ref_bands:
+            ds_get_name = 'Normalized_Radiance'
+        elif ds_id.name in self.bt_bands:
+            ds_get_name = 'Brightness_Temperature'
+        else:
+            raise(NameError, "Datset type "+ds_id.name+" is not supported.")
+        data = self[ds_get_name]
+
+        data.attrs = self.get_metadata(data, ds_info)
+
+        fill = data.attrs.pop('_FillValue')
+        offset = data.attrs.get('add_offset')
+        scale_factor = data.attrs.get('scale_factor')
+
+        data = data.where(data != fill)
+        data = data.astype(np.float32)
+        if scale_factor is not None and offset is not None:
+            data *= scale_factor
+            data += offset
+            # Now we correct range from 0-1 to 0-100 for VIS:
+            if ds_id.name in self.ref_bands:
+                data *= 100.
+
+        return data
+
+    def get_area_def(self, ds_id):
+        if ds_id.name in self.ref_bands:
+            ds_get_name = 'Normalized_Radiance'
+        elif ds_id.name in self.bt_bands:
+            ds_get_name = 'Brightness_Temperature'
+        else:
+            raise(NameError, "Datset type "+ds_id.name+" is not supported.")
+
+        ds_shape = self[ds_get_name + '/shape']
+        geoloc = self.geoloc
+
+        pdict = {}
+        pdict['cfac'] = np.int32(geoloc[0])
+        pdict['lfac'] = np.int32(geoloc[1])
+        pdict['coff'] = np.float32(geoloc[2])
+        pdict['loff'] = -np.float32(geoloc[3])
+
+        # Unfortunately this dataset does not store a, b or h.
+        # We assume a and b here, and calculate h from altitude
+        # a and b are from SEVIRI data HRIT header (201912101300)
+        pdict['a'] = 6378169
+        pdict['b'] = 6356583.8
+        pdict['h'] = self.alt - pdict['a']
+        pdict['ssp_lon'] = self.projlon
+        pdict['ncols'] = int(ds_shape[0])
+        pdict['nlines'] = int(ds_shape[1])
+
+        # Force scandir to SEVIRI default, not known from file
+        pdict['scandir'] = 'S2N'
+        pdict['a_name'] = 'geosmsg'
+        if ds_id.name == 'HRV':
+            pdict['a_desc'] = 'MSG/SEVIRI HRV channel area'
+            pdict['p_id'] = 'msg_hires'
+        else:
+            pdict['a_desc'] = 'MSG/SEVIRI low resolution channel area'
+            pdict['p_id'] = 'msg_lowres'
+
+        aex = get_area_extent(pdict)
+        area = get_area_definition(pdict, aex)
+
+        return area

--- a/satpy/readers/seviri_l1b_icare.py
+++ b/satpy/readers/seviri_l1b_icare.py
@@ -22,7 +22,7 @@ Introduction
 
 The ``seviri_l1b_icare`` reader reads MSG-SEVIRI L1.5 image data in HDF format
 that has been produced by the ICARE Data and Services Center
-Data can be accessed via: http://http://www.icare.univ-lille1.fr
+Data can be accessed via: http://www.icare.univ-lille1.fr
 
 Each SEVIRI timeslot comes as 12 HDF files, one per band. Only those bands
 that are of interest need to be passed to the reader. Others can be ignored.
@@ -195,13 +195,13 @@ class SEVIRI_ICARE(HDF4FileHandler):
                     'platform_name': self.sensor_name[0],
                     'sensor': self.sensor_name[1],
                     'zone': self.zone,
-                    'satellite_altitude': self.alt,
+                    'projection_altitude': self.alt,
                     'cfac': geoloc[0],
                     'lfac': geoloc[1],
                     'coff': geoloc[2],
                     'loff': geoloc[3],
                     'resolution': self.res,
-                    'satellite_longitude': self.satlon,
+                    'satellite_actual_longitude': self.satlon,
                     'projection_longitude': self.projlon,
         })
 

--- a/satpy/readers/seviri_l1b_icare.py
+++ b/satpy/readers/seviri_l1b_icare.py
@@ -205,6 +205,7 @@ class SEVIRI_ICARE(HDF4FileHandler):
                     'resolution': self.res,
                     'satellite_actual_longitude': self.satlon,
                     'projection_longitude': self.projlon,
+                    'projection_type': self.projection
         })
 
         return mda

--- a/satpy/tests/reader_tests/__init__.py
+++ b/satpy/tests/reader_tests/__init__.py
@@ -102,6 +102,6 @@ def suite():
     mysuite.addTests(test_geos_area.suite())
     mysuite.addTests(test_seviri_l2_bufr.suite())
     mysuite.addTests(test_nwcsaf_msg.suite())
-    mysuite.addTests(test_seviri_l1b_icare.suite())    
+    mysuite.addTests(test_seviri_l1b_icare.suite())   
 
     return mysuite

--- a/satpy/tests/reader_tests/__init__.py
+++ b/satpy/tests/reader_tests/__init__.py
@@ -40,7 +40,7 @@ from satpy.tests.reader_tests import (test_abi_l1b, test_agri_l1, test_hrit_base
                                       test_fci_l1c_fdhsi, test_tropomi_l2,
                                       test_hsaf_grib, test_abi_l2_nc, test_eum_base,
                                       test_ami_l1b, test_viirs_compact, test_seviri_l2_bufr,
-                                      test_geos_area, test_nwcsaf_msg)
+                                      test_geos_area, test_nwcsaf_msg, test_seviri_l1b_icare)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -102,5 +102,6 @@ def suite():
     mysuite.addTests(test_geos_area.suite())
     mysuite.addTests(test_seviri_l2_bufr.suite())
     mysuite.addTests(test_nwcsaf_msg.suite())
+    mysuite.addTests(test_seviri_l1b_icare.suite())    
 
     return mysuite

--- a/satpy/tests/reader_tests/__init__.py
+++ b/satpy/tests/reader_tests/__init__.py
@@ -40,7 +40,8 @@ from satpy.tests.reader_tests import (test_abi_l1b, test_agri_l1, test_hrit_base
                                       test_fci_l1c_fdhsi, test_tropomi_l2,
                                       test_hsaf_grib, test_abi_l2_nc, test_eum_base,
                                       test_ami_l1b, test_viirs_compact, test_seviri_l2_bufr,
-                                      test_geos_area, test_nwcsaf_msg, test_seviri_l1b_icare)
+                                      test_geos_area, test_nwcsaf_msg, test_seviri_l1b_icare,
+                                      test_glm_l2)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -103,5 +104,6 @@ def suite():
     mysuite.addTests(test_seviri_l2_bufr.suite())
     mysuite.addTests(test_nwcsaf_msg.suite())
     mysuite.addTests(test_seviri_l1b_icare.suite())
+    mysuite.addTests(test_glm_l2.suite())
 
     return mysuite

--- a/satpy/tests/reader_tests/__init__.py
+++ b/satpy/tests/reader_tests/__init__.py
@@ -102,6 +102,6 @@ def suite():
     mysuite.addTests(test_geos_area.suite())
     mysuite.addTests(test_seviri_l2_bufr.suite())
     mysuite.addTests(test_nwcsaf_msg.suite())
-    mysuite.addTests(test_seviri_l1b_icare.suite())   
+    mysuite.addTests(test_seviri_l1b_icare.suite())
 
     return mysuite

--- a/satpy/tests/reader_tests/test_seviri_l1b_icare.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_icare.py
@@ -20,6 +20,7 @@ import sys
 import os
 import numpy as np
 from satpy.tests.reader_tests.test_hdf4_utils import FakeHDF4FileHandler
+from satpy.readers import load_reader
 if sys.version_info < (2, 7):
     import unittest2 as unittest
 else:
@@ -108,7 +109,6 @@ class TestSEVIRIICAREReader(unittest.TestCase):
 
     def test_init(self):
         """Test basic init with no extra parameters."""
-        from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
             'GEO_L1B-MSG1_2004-12-29T12-15-00_G_VIS08_V1-04.hdf',
@@ -120,7 +120,6 @@ class TestSEVIRIICAREReader(unittest.TestCase):
 
     def test_load_dataset_vis(self):
         """Test loading all datasets from a full swath file."""
-        from satpy.readers import load_reader
         from datetime import datetime
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -136,7 +135,6 @@ class TestSEVIRIICAREReader(unittest.TestCase):
 
     def test_load_dataset_ir(self):
         """Test loading all datasets from a full swath file."""
-        from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
             'GEO_L1B-MSG1_2004-12-29T12-15-00_G_IR108_V1-04.hdf'
@@ -149,7 +147,6 @@ class TestSEVIRIICAREReader(unittest.TestCase):
 
     def test_area_def(self):
         """Test loading all datasets from an area of interest file."""
-        from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
             'GEO_L1B-MSG1_2004-12-29T12-15-00_G_VIS08_V1-04.hdf',

--- a/satpy/tests/reader_tests/test_seviri_l1b_icare.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_icare.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for the SEVIRI L1b HDF4 from ICARE reader."""
+import sys
+import os
+import numpy as np
+from satpy.tests.reader_tests.test_hdf4_utils import FakeHDF4FileHandler
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+
+DEFAULT_FILE_DTYPE = np.uint16
+DEFAULT_FILE_SHAPE = (10, 300)
+DEFAULT_FILE_DATA = np.arange(DEFAULT_FILE_SHAPE[0] * DEFAULT_FILE_SHAPE[1],
+                              dtype=DEFAULT_FILE_DTYPE).reshape(DEFAULT_FILE_SHAPE)
+
+
+class FakeHDF4FileHandler2(FakeHDF4FileHandler):
+    """Swap in HDF4 file handler."""
+
+    def get_test_content(self, filename, filename_info, filename_type):
+        """Mimic reader input file content."""
+        file_content = {}
+        file_content['/attr/Nadir_Pixel_Size'] = 3000.
+        file_content['/attr/Beginning_Acquisition_Date'] = "2004-12-29T12:15:00Z"
+        file_content['/attr/End_Acquisition_Date'] = "2004-12-29T12:27:44Z"
+        file_content['/attr/Geolocation'] = ('1.3642337E7', '1856.0', '1.3642337E7', '1856.0')
+        file_content['/attr/Altitude'] = '42164.0'
+        file_content['/attr/Geographic_Projection'] = 'geos'
+        file_content['/attr/Projection_Longitude'] = '0.0'
+        file_content['/attr/Sub_Satellite_Longitude'] = '3.4'
+        file_content['/attr/Sensors'] = 'MSG1/SEVIRI'
+        file_content['/attr/Zone'] = 'G'
+        file_content['/attr/_FillValue'] = 1
+        file_content['/attr/scale_factor'] = 1.
+        file_content['/attr/add_offset'] = 0.
+
+        # test one IR and one VIS channel
+        file_content['Normalized_Radiance'] = DEFAULT_FILE_DATA
+        file_content['Normalized_Radiance/attr/_FillValue'] = 1
+        file_content['Normalized_Radiance/attr/scale_factor'] = 1.
+        file_content['Normalized_Radiance/attr/add_offset'] = 0.
+        file_content['Normalized_Radiance/shape'] = DEFAULT_FILE_SHAPE
+
+        file_content['Brightness_Temperature'] = DEFAULT_FILE_DATA
+        file_content['Brightness_Temperature/attr/_FillValue'] = 1
+        file_content['Brightness_Temperature/attr/scale_factor'] = 1.
+        file_content['Brightness_Temperature/attr/add_offset'] = 0.
+        file_content['Brightness_Temperature/shape'] = DEFAULT_FILE_SHAPE
+
+        # convert tp xarrays
+        from xarray import DataArray
+        for key, val in file_content.items():
+            if isinstance(val, np.ndarray):
+                attrs = {}
+                for a in ['_FillValue', 'scale_factor', 'add_offset']:
+                    if key + '/attr/' + a in file_content:
+                        attrs[a] = file_content[key + '/attr/' + a]
+                if val.ndim > 1:
+                    file_content[key] = DataArray(val, dims=('fakeDim0', 'fakeDim1'), attrs=attrs)
+                else:
+                    file_content[key] = DataArray(val, attrs=attrs)
+        if 'y' not in file_content['Normalized_Radiance'].dims:
+            file_content['Normalized_Radiance'] = file_content['Normalized_Radiance'].rename({'fakeDim0': 'x',
+                                                                                              'fakeDim1': 'y'})
+        return file_content
+
+
+class TestSEVIRIICAREReader(unittest.TestCase):
+    """Test SEVIRI L1b HDF4 from ICARE Reader."""
+
+    yaml_file = 'seviri_l1b_icare.yaml'
+
+    def setUp(self):
+        """Wrap HDF4 file handler with own fake file handler."""
+        from satpy.config import config_search_paths
+        from satpy.readers.seviri_l1b_icare import SEVIRI_ICARE
+        self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
+        self.p = mock.patch.object(SEVIRI_ICARE, '__bases__', (FakeHDF4FileHandler2,))
+        self.fake_handler = self.p.start()
+        self.p.is_local = True
+
+    def tearDown(self):
+        """Stop wrapping the HDF4 file handler."""
+        self.p.stop()
+
+    def test_init(self):
+        """Test basic init with no extra parameters."""
+        from satpy.readers import load_reader
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'GEO_L1B-MSG1_2004-12-29T12-15-00_G_VIS08_V1-04.hdf',
+            'GEO_L1B-MSG1_2004-12-29T12-15-00_G_IR108_V1-04.hdf'
+        ])
+        self.assertTrue(len(loadables), 2)
+        r.create_filehandlers(loadables)
+        self.assertTrue(r.file_handlers)
+
+    def test_load_dataset_vis(self):
+        """Test loading all datasets from a full swath file."""
+        from satpy.readers import load_reader
+        from datetime import datetime
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'GEO_L1B-MSG1_2004-12-29T12-15-00_G_VIS08_V1-04.hdf'
+        ])
+        r.create_filehandlers(loadables)
+        datasets = r.load(['VIS008'])
+        self.assertEqual(len(datasets), 1)
+        for v in datasets.values():
+            dt = datetime(2004, 12, 29, 12, 27, 44)
+            self.assertEqual(v.attrs['end_time'], dt)
+            self.assertEqual(v.attrs['calibration'], 'reflectance')
+
+    def test_load_dataset_ir(self):
+        """Test loading all datasets from a full swath file."""
+        from satpy.readers import load_reader
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'GEO_L1B-MSG1_2004-12-29T12-15-00_G_IR108_V1-04.hdf'
+        ])
+        r.create_filehandlers(loadables)
+        datasets = r.load(['IR_108'])
+        self.assertEqual(len(datasets), 1)
+        for v in datasets.values():
+            self.assertEqual(v.attrs['calibration'], 'brightness_temperature')
+
+    def test_area_def(self):
+        """Test loading all datasets from an area of interest file."""
+        from satpy.readers import load_reader
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'GEO_L1B-MSG1_2004-12-29T12-15-00_G_VIS08_V1-04.hdf',
+        ])
+        r.create_filehandlers(loadables)
+        datasets = r.load(['VIS008'])
+        test_area = {'area_id': 'geosmsg',
+                     'width': 10,
+                     'height': 300,
+                     'area_extent': (-5567248.2834071,
+                                     -5570248.6866857,
+                                     -5537244.2506213,
+                                     -4670127.7031114)}
+        for v in datasets.values():
+            self.assertEqual(v.attrs['area'].area_id, test_area['area_id'])
+            self.assertEqual(v.attrs['area'].width, test_area['width'])
+            self.assertEqual(v.attrs['area'].height, test_area['height'])
+            np.testing.assert_almost_equal(v.attrs['area'].area_extent,
+                                           test_area['area_extent'])
+
+
+def suite():
+    """Create the test suite for test_viirs_edr_flood."""
+    loader = unittest.TestLoader()
+    mysuite = unittest.TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(TestSEVIRIICAREReader))
+
+    return mysuite
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The [ICARE](http://www.icare.univ-lille1.fr/) service has the full record of data for many satellites at level 1, including SEVIRI.
This PR adds support for ICARE / SEVIRI data in HDF4 format, which can be accessed with `Scene(files, reader='seviri_l1b_icare')`

There is one HDF file per band and data is padded, meaning that `HRV` data is projected onto a `11136x11136` array rather than being subset into North and South sectors.

 - [x] Tests added and test suite added to parent suite 
 - [x] Tests passed
 - [x] Passes ``flake8 satpy`` 
 - [x] Fully documented 
`