### PR TITLE
Add pass through of xr compute, persist and chunk to Scene

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1143,6 +1143,36 @@ class Scene:
                                           **kwargs)
         return writer.save_datasets(dataarrays, compute=compute, **save_kwargs)
 
+    def compute(self, **kwargs):
+        """Call `compute` on all Scene datasets.
+
+        See :meth:`xarray.DataArray.compute` for more details.
+        """
+        new_scn = self.copy()
+        for k in new_scn.datasets.keys():
+            new_scn[k] = new_scn[k].compute(**kwargs)
+        return new_scn
+
+    def persist(self, **kwargs):
+        """Call `persist` on all Scene datasets.
+
+        See :meth:`xarray.DataArray.persist` for more details.
+        """
+        new_scn = self.copy()
+        for k in new_scn.datasets.keys():
+            new_scn[k] = new_scn[k].persist(**kwargs)
+        return new_scn
+
+    def chunk(self, **kwargs):
+        """Call `chunk` on all Scene datasets.
+
+        See :meth:`xarray.DataArray.chunk` for more details.
+        """
+        new_scn = self.copy()
+        for k in new_scn.datasets.keys():
+            new_scn[k] = new_scn[k].chunk(**kwargs)
+        return new_scn
+
     @staticmethod
     def _get_writer_by_ext(extension):
         """Find the writer matching the ``extension``.

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1144,7 +1144,7 @@ class Scene:
         return writer.save_datasets(dataarrays, compute=compute, **save_kwargs)
 
     def compute(self, **kwargs):
-        """Call `compute` on all Scene datasets.
+        """Call `compute` on all Scene data arrays.
 
         See :meth:`xarray.DataArray.compute` for more details.
         """
@@ -1158,7 +1158,7 @@ class Scene:
         return new_scn
 
     def persist(self, **kwargs):
-        """Call `persist` on all Scene datasets.
+        """Call `persist` on all Scene data arrays.
 
         See :meth:`xarray.DataArray.persist` for more details.
         """
@@ -1172,7 +1172,7 @@ class Scene:
         return new_scn
 
     def chunk(self, **kwargs):
-        """Call `chunk` on all Scene datasets.
+        """Call `chunk` on all Scene  data arrays.
 
         See :meth:`xarray.DataArray.chunk` for more details.
         """

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1149,7 +1149,7 @@ class Scene:
         See :meth:`xarray.DataArray.compute` for more details.
         """
         new_scn = self.copy()
-        for k in new_scn.datasets.keys():
+        for k in new_scn._datasets.keys():
             new_scn[k] = new_scn[k].compute(**kwargs)
         return new_scn
 
@@ -1159,7 +1159,7 @@ class Scene:
         See :meth:`xarray.DataArray.persist` for more details.
         """
         new_scn = self.copy()
-        for k in new_scn.datasets.keys():
+        for k in new_scn._datasets.keys():
             new_scn[k] = new_scn[k].persist(**kwargs)
         return new_scn
 
@@ -1169,7 +1169,7 @@ class Scene:
         See :meth:`xarray.DataArray.chunk` for more details.
         """
         new_scn = self.copy()
-        for k in new_scn.datasets.keys():
+        for k in new_scn._datasets.keys():
             new_scn[k] = new_scn[k].chunk(**kwargs)
         return new_scn
 

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1148,9 +1148,13 @@ class Scene:
 
         See :meth:`xarray.DataArray.compute` for more details.
         """
+        from dask import compute
         new_scn = self.copy()
-        for k in new_scn._datasets.keys():
-            new_scn[k] = new_scn[k].compute(**kwargs)
+        datasets = compute(*(new_scn._datasets.values()), **kwargs)
+
+        for i, k in enumerate(new_scn._datasets.keys()):
+            new_scn[k] = datasets[i]
+
         return new_scn
 
     def persist(self, **kwargs):
@@ -1158,9 +1162,13 @@ class Scene:
 
         See :meth:`xarray.DataArray.persist` for more details.
         """
+        from dask import persist
         new_scn = self.copy()
-        for k in new_scn._datasets.keys():
-            new_scn[k] = new_scn[k].persist(**kwargs)
+        datasets = persist(*(new_scn._datasets.values()), **kwargs)
+
+        for i, k in enumerate(new_scn._datasets.keys()):
+            new_scn[k] = datasets[i]
+
         return new_scn
 
     def chunk(self, **kwargs):
@@ -1171,6 +1179,7 @@ class Scene:
         new_scn = self.copy()
         for k in new_scn._datasets.keys():
             new_scn[k] = new_scn[k].chunk(**kwargs)
+
         return new_scn
 
     @staticmethod

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1339,6 +1339,31 @@ class TestSceneLoading:
         available_comp_ids = scene.available_composite_ids()
         assert make_cid(name='static_image') in available_comp_ids
 
+    def test_compute_pass_through(self):
+        """Test pass through of xarray compute."""
+        import numpy as np
+        scene = Scene(filenames=['fake1_1.txt'], reader='fake1')
+        scene.load(['ds1'])
+        scene = scene.compute()
+        assert isinstance(scene['ds1'].data, np.ndarray)
+
+    def test_persist_pass_through(self):
+        """Test pass through of xarray persist."""
+        from dask.array.utils import assert_eq
+        scene = Scene(filenames=['fake1_1.txt'], reader='fake1')
+        scene.load(['ds1'])
+        scenep = scene.persist()
+        assert_eq(scene['ds1'].data, scenep['ds1'].data)
+        assert set(scenep['ds1'].data.dask).issubset(scene['ds1'].data.dask)
+        assert len(scenep["ds1"].data.dask) == scenep['ds1'].data.npartitions
+
+    def test_chunk_pass_through(self):
+        """Test pass through of xarray chunk."""
+        scene = Scene(filenames=['fake1_1.txt'], reader='fake1')
+        scene.load(['ds1'])
+        scene = scene.chunk(chunks=2)
+        assert scene['ds1'].data.chunksize == (2, 2)
+
 
 class TestSceneResampling:
     """Test resampling a Scene to another Scene object."""


### PR DESCRIPTION
Adds the xarray interfaces `compute`, `persist` and `chunk` to Scene.

If for example `scn.compute()` is called it is iterated over all Datasets in the Scene and `compute` is called on every Dataset (which is a xarray.DataArray).

 - [x] Closes #1015
 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
