### PR TITLE
Add more information about creating custom readers

### DIFF
--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -143,6 +143,11 @@ The datasets section describes each dataset available in the files. The
 parameters provided are made available to the methods of the
 implementing class.
 
+If your input files contain all the necessary metadata or you have a lot
+of datasets to configure, look at the :ref:`custom_reader_available_datasets`
+section below. Implementing this will save you time from having to write
+a lot of configuration in the YAML files.
+
 Parameters you can define for example are:
  - name
  - sensor
@@ -363,10 +368,38 @@ readers, like for example the ``msg_native`` reader.
             units: count
         file_type: nc_seviri_l1b
 
+The YAML file is now ready and you can move on to writing your python code.
 
+.. _custom_reader_available_datasets:
 
-The YAML file is now ready, let's go on with the corresponding python
-file.
+Dynamic Dataset Configuration
+-----------------------------
+
+The above "datasets" section for reader configuration is the most explicit
+method for specifying metadata about possible data that can be loaded from
+input files. It is also the easiest way for people with little python
+experience to customize or add new datasets to a reader. However, some file
+formats may have 10s or even 100s of datasets or variations of datasets.
+Writing the metadata and access information for every one of these datasets
+can easily become a problem. To help in these cases the
+:meth:`~satpy.readers.file_handlers.BaseFileHandler.available_datasets`
+file handler interface can be used.
+
+The best information for what this information does and how to use it
+is available in the
+:meth:`API documentation <satpy.readers.file_handlers.BaseFileHandler.available_datasets>`.
+This method is good when you want to:
+
+1. Define datasets dynamically without needing to define them in the YAML.
+2. Supplement metadata from the YAML file with information from the file
+   content (ex. `resolution`).
+3. Determine if a dataset is available by the file contents. This differs from
+   the default behavior of a dataset being considered loadable if its
+   "file_type" is loaded.
+
+Note that this is considered an advanced interface and involves more advanced
+Python experience like generators. If you need help with anything feel free
+to ask questions in your pull request or on the :ref:`Pytroll Slack <dev_help>`.
 
 The python file
 ---------------

--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -385,7 +385,8 @@ can easily become a problem. To help in these cases the
 :meth:`~satpy.readers.file_handlers.BaseFileHandler.available_datasets`
 file handler interface can be used.
 
-The best information for what this information does and how to use it
+This method, if needed, should be implemented in your reader's file handler
+classes. The best information for what this method does and how to use it
 is available in the
 :meth:`API documentation <satpy.readers.file_handlers.BaseFileHandler.available_datasets>`.
 This method is good when you want to:
@@ -398,7 +399,7 @@ This method is good when you want to:
    "file_type" is loaded.
 
 Note that this is considered an advanced interface and involves more advanced
-Python experience like generators. If you need help with anything feel free
+Python concepts like generators. If you need help with anything feel free
 to ask questions in your pull request or on the :ref:`Pytroll Slack <dev_help>`.
 
 The python file

--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -141,31 +141,47 @@ The ``datasets`` section
 
 The datasets section describes each dataset available in the files. The
 parameters provided are made available to the methods of the
-implementing class.
+implemented python class.
 
 If your input files contain all the necessary metadata or you have a lot
-of datasets to configure, look at the :ref:`custom_reader_available_datasets`
-section below. Implementing this will save you time from having to write
+of datasets to configure look at the :ref:`custom_reader_available_datasets`
+section below. Implementing this will save you from having to write
 a lot of configuration in the YAML files.
 
 Parameters you can define for example are:
+
  - name
  - sensor
  - resolution
  - wavelength
  - polarization
- - standard\_name: the name used for the
-   dataset, that will be used for knowing what kind of data it is and
-   handle it appropriately
- - units: the units of the data, important to get
-   consistent processing across multiple platforms/instruments
- - modifiers: what modification have already been applied to the data, eg
-   ``sunz_corrected``
- - file\_type
- - coordinates: this tells which datasets
-   to load to navigate the current dataset
- - and any other field that is
-   relevant for the reader
+ - standard\_name: The
+   `CF standard name <http://cfconventions.org/Data/cf-standard-names/70/build/cf-standard-name-table.html>`_
+   for the dataset that will be used to determine the type of data. See
+   existing readers for common standard names in Satpy or the CF standard name
+   documentation for other available names or how to define your own. Satpy
+   does not currently have a hard requirement on these names being completely
+   CF compliant, but consistency across readers is important.
+ - units: The units of the data when returned by the file handler. Although
+   not technically a requirement, it is common for Satpy datasets to use "%"
+   for reflectance fields and "K" for brightness temperature fields.
+ - modifiers: The modification(s) that have already been applied to the data
+   when it is returned by the file handler. Only a few of these have been
+   standardized across Satpy, but are based on the names of the modifiers
+   configured in the "composites" YAML files. Examples include
+   ``sunz_corrected`` or ``rayleigh_corrected``. See the
+   `metadata wiki <https://github.com/pytroll/satpy/wiki/Metadata-names>`_
+   for more information.
+ - file\_type: Name of file type (see above).
+ - coordinates: An optional two-element list with the names of the longitude
+   and latitude datasets describing the location of this dataset. This
+   is optional if the data being read is gridded already. Swath data,
+   from example data from some polar-orbiting satellites, should have these
+   defined or no geolocation information will be available when the data
+   is loaded. For gridded datasets a `get_area_def` function will be
+   implemented in python (see below) to define geolocation information.
+ - Any other field that is relevant for the reader or could be useful metadata
+   provided to the user.
 
 This section can be copied and adapted simply from existing seviri
 readers, like for example the ``msg_native`` reader.

--- a/satpy/readers/olci_nc.py
+++ b/satpy/readers/olci_nc.py
@@ -19,24 +19,22 @@
 
 This reader supports an optional argument to choose the 'engine' for reading
 OLCI netCDF4 files. By default, this reader uses the default xarray choice of
-engine, as defined in the `xarray open_dataset documentation`_.
+engine, as defined in the :func:`xarray.open_dataset` documentation`.
 
 As an alternative, the user may wish to use the 'h5netcdf' engine, but that is
 not default as it typically prints many non-fatal but confusing error messages
 to the terminal.
 To choose between engines the user can  do as follows for the default::
 
-scn = satpyScene(filenames=my_files, reader='olci_l1b')
+    scn = satpyScene(filenames=my_files, reader='olci_l1b')
 
 or as follows for the h5netcdf engine::
 
-scn = Scene(filenames=my_files,
-      reader='olci_l1b'), reader_kwargs={'engine': 'h5netcdf'})
-
+    scn = Scene(filenames=my_files,
+          reader='olci_l1b'), reader_kwargs={'engine': 'h5netcdf'})
 
 References:
-    - `xarray open_dataset documentation`_
-.. _xarray open_dataset: http://xarray.pydata.org/en/stable/generated/xarray.open_dataset.html
+    - :func:`xarray.open_dataset`
 
 """
 

--- a/satpy/readers/olci_nc.py
+++ b/satpy/readers/olci_nc.py
@@ -31,7 +31,7 @@ To choose between engines the user can  do as follows for the default::
 or as follows for the h5netcdf engine::
 
     scn = Scene(filenames=my_files,
-                reader='olci_l1b'), reader_kwargs={'engine': 'h5netcdf'})
+                reader='olci_l1b', reader_kwargs={'engine': 'h5netcdf'})
 
 References:
     - :func:`xarray.open_dataset`

--- a/satpy/readers/olci_nc.py
+++ b/satpy/readers/olci_nc.py
@@ -26,12 +26,12 @@ not default as it typically prints many non-fatal but confusing error messages
 to the terminal.
 To choose between engines the user can  do as follows for the default::
 
-    scn = satpyScene(filenames=my_files, reader='olci_l1b')
+    scn = Scene(filenames=my_files, reader='olci_l1b')
 
 or as follows for the h5netcdf engine::
 
     scn = Scene(filenames=my_files,
-          reader='olci_l1b'), reader_kwargs={'engine': 'h5netcdf'})
+                reader='olci_l1b'), reader_kwargs={'engine': 'h5netcdf'})
 
 References:
     - :func:`xarray.open_dataset`


### PR DESCRIPTION
As mentioned in #782 there is some really important information missing from the documentation on how to write a custom reader. This PR adds that information and fixes other documentation issues that sphinx was complaining about.

CC @gerritholl @simonrp84 

 - [ ] Closes #782 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
