### PR TITLE
Fix padding of segmented geostationary images

### DIFF
--- a/satpy/etc/readers/ahi_hsd.yaml
+++ b/satpy/etc/readers/ahi_hsd.yaml
@@ -28,7 +28,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b01
-    expected_segments: 10
 
   B02:
     name: B02
@@ -46,7 +45,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b02
-    expected_segments: 10
 
   B03:
     name: B03
@@ -64,7 +62,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b03
-    expected_segments: 10
 
   B04:
     name: B04
@@ -82,7 +79,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b04
-    expected_segments: 10
 
   B05:
     name: B05
@@ -100,7 +96,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b05
-    expected_segments: 10
 
   B06:
     name: B06
@@ -118,7 +113,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b06
-    expected_segments: 10
 
   B07:
     name: B07
@@ -136,7 +130,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b07
-    expected_segments: 10
 
   B08:
     name: B08
@@ -154,7 +147,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b08
-    expected_segments: 10
 
   B09:
     name: B09
@@ -172,7 +164,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b09
-    expected_segments: 10
 
   B10:
     name: B10
@@ -190,7 +181,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b10
-    expected_segments: 10
 
   B11:
     name: B11
@@ -208,7 +198,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b11
-    expected_segments: 10
 
   B12:
     name: B12
@@ -226,7 +215,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b12
-    expected_segments: 10
 
   B13:
     name: B13
@@ -244,7 +232,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b13
-    expected_segments: 10
 
   B14:
     name: B14
@@ -262,7 +249,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b14
-    expected_segments: 10
 
   B15:
     name: B15
@@ -280,7 +266,6 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b15
-    expected_segments: 10
 
   B16:
     name: B16
@@ -298,71 +283,86 @@ datasets:
         standard_name: counts
         units: 1
     file_type: hsd_b16
-    expected_segments: 10
 
 
 file_types:
   hsd_b01:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B01_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B01_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B01_{area}_R10_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B01_{area}_R10_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b02:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B02_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B02_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B02_{area}_R10_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B02_{area}_R10_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b03:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B03_{area}_R05_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B03_{area}_R05_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B03_{area}_R05_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B03_{area}_R05_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b04:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B04_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B04_{area}_R10_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B04_{area}_R10_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B04_{area}_R10_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b05:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B05_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B05_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B05_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B05_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b06:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B06_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B06_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B06_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B06_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b07:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B07_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B07_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B07_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B07_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b08:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B08_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B08_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B08_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B08_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b09:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B09_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B09_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B09_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B09_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b10:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B10_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B10_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B10_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B10_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b11:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B11_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B11_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B11_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B11_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b12:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B12_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B12_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B12_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B12_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b13:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B13_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B13_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B13_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B13_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b14:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B14_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B14_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B14_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B14_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b15:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B15_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B15_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B15_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B15_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10
   hsd_b16:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler ''
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B16_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B16_{area}_R20_S{segment_number:2d}{total_segments:2d}.DAT.bz2']
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B16_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B16_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
+    expected_segments: 10

--- a/satpy/etc/readers/mtsat2-imager_hrit.yaml
+++ b/satpy/etc/readers/mtsat2-imager_hrit.yaml
@@ -19,38 +19,63 @@ file_types:
     hrit_vis:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
         file_patterns:
-        - 'IMG_DK{area:02d}VIS_{start_time:%Y%m%d%H%M}_{segment:03d}'
         - 'IMG_DK{area:02d}VIS_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}VIS'
 
     hrit_ir1:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
         file_patterns:
-        - 'IMG_DK{area:02d}IR1_{start_time:%Y%m%d%H%M}_{segment:03d}'
         - 'IMG_DK{area:02d}IR1_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR1'
 
     hrit_ir2:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
         file_patterns:
-        - 'IMG_DK{area:02d}IR2_{start_time:%Y%m%d%H%M}_{segment:03d}'
         - 'IMG_DK{area:02d}IR2_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR2'
 
     hrit_ir3:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
         file_patterns:
-        - 'IMG_DK{area:02d}IR3_{start_time:%Y%m%d%H%M}_{segment:03d}'
         - 'IMG_DK{area:02d}IR3_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR3'
-
 
     hrit_ir4:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
         file_patterns:
-        - 'IMG_DK{area:02d}IR4_{start_time:%Y%m%d%H%M}_{segment:03d}'
         - 'IMG_DK{area:02d}IR4_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR4'
+
+    hrit_vis_seg:
+        file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
+        file_patterns:
+        - 'IMG_DK{area:02d}VIS_{start_time:%Y%m%d%H%M}_{segment:03d}'
+        expected_segments: 10
+
+    hrit_ir1_seg:
+        file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
+        file_patterns:
+        - 'IMG_DK{area:02d}IR1_{start_time:%Y%m%d%H%M}_{segment:03d}'
+        expected_segments: 10
+
+    hrit_ir2_seg:
+        file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
+        file_patterns:
+        - 'IMG_DK{area:02d}IR2_{start_time:%Y%m%d%H%M}_{segment:03d}'
+        expected_segments: 10
+
+    hrit_ir3_seg:
+        file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
+        file_patterns:
+        - 'IMG_DK{area:02d}IR3_{start_time:%Y%m%d%H%M}_{segment:03d}'
+        expected_segments: 10
+
+    hrit_ir4_seg:
+        file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
+        file_patterns:
+        - 'IMG_DK{area:02d}IR4_{start_time:%Y%m%d%H%M}_{segment:03d}'
+        expected_segments: 10
+
 
 datasets:
   VIS:
@@ -65,7 +90,7 @@ datasets:
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
-    file_type: hrit_vis
+    file_type: [hrit_vis, hrit_vis_seg]
 
   IR1:
     name: IR1
@@ -79,7 +104,7 @@ datasets:
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
-    file_type: hrit_ir1
+    file_type: [hrit_ir1, hrit_ir1_seg]
 
   IR2:
     name: IR2
@@ -93,7 +118,7 @@ datasets:
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
-    file_type: hrit_ir2
+    file_type: [hrit_ir2, hrit_ir2_seg]
 
   IR3:
     name: IR3
@@ -107,7 +132,7 @@ datasets:
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
-    file_type: hrit_ir3
+    file_type: [hrit_ir3, hrit_ir3_seg]
 
   IR4:
     name: IR4
@@ -121,4 +146,4 @@ datasets:
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
-    file_type: hrit_ir4
+    file_type: [hrit_ir4, hrit_ir4_seg]

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -280,7 +280,7 @@ class AHIHSDFileHandler(BaseFileHandler):
         self._header = dict([(i, None) for i in AHI_CHANNEL_NAMES])
         self.lons = None
         self.lats = None
-        self.segment_number = filename_info['segment_number']
+        self.segment_number = filename_info['segment']
         self.total_segments = filename_info['total_segments']
 
         with open(self.filename) as fd:

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -934,7 +934,7 @@ def _pad_later_segments_area(file_handlers, dsid):
     seg_size = None
     expected_segments = file_handlers[0].filetype_info.get(
         'expected_segments', 1)
-    available_segments = [int(fh.filename_info['segment']) for
+    available_segments = [int(fh.filename_info.get('segment', 1)) for
                           fh in file_handlers]
     area_defs = {}
     for segment in range(available_segments[0], expected_segments + 1):
@@ -961,7 +961,7 @@ def _pad_later_segments_area(file_handlers, dsid):
 
 def _pad_earlier_segments_area(file_handlers, dsid, area_defs):
     """Pad area definitions for missing segments that are earlier in sequence than the first available."""
-    available_segments = [int(fh.filename_info['segment']) for
+    available_segments = [int(fh.filename_info.get('segment', 1)) for
                           fh in file_handlers]
     area = file_handlers[0].get_area_def(dsid)
     seg_size = area.shape
@@ -990,13 +990,13 @@ def _find_missing_segments(file_handlers, ds_info, dsid):
     failure = True
     counter = 1
     expected_segments = 1
-    handlers = sorted(file_handlers, key=lambda x: x.filename_info['segment'])
+    handlers = sorted(file_handlers, key=lambda x: x.filename_info.get('segment', 1))
     projectable = None
     for fh in handlers:
         if fh.filetype_info['file_type'] in ds_info['file_type']:
             expected_segments = fh.filetype_info.get('expected_segments', 1)
 
-        while int(fh.filename_info['segment']) > counter:
+        while int(fh.filename_info.get('segment', 1)) > counter:
             slice_list.append(None)
             counter += 1
         try:

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -43,7 +43,7 @@ class TestAHIHSDNavigation(unittest.TestCase):
         np2str.side_effect = lambda x: x
         m = mock.mock_open()
         with mock.patch('satpy.readers.ahi_hsd.open', m, create=True):
-            fh = AHIHSDFileHandler(None, {'segment_number': 1, 'total_segments': 1}, None)
+            fh = AHIHSDFileHandler(None, {'segment': 1, 'total_segments': 1}, None)
             fh.proj_info = {'CFAC': 40932549,
                             'COFF': -591.5,
                             'LFAC': 40932549,
@@ -88,7 +88,7 @@ class TestAHIHSDNavigation(unittest.TestCase):
         np2str.side_effect = lambda x: x
         m = mock.mock_open()
         with mock.patch('satpy.readers.ahi_hsd.open', m, create=True):
-            fh = AHIHSDFileHandler(None, {'segment_number': 8, 'total_segments': 10}, None)
+            fh = AHIHSDFileHandler(None, {'segment': 8, 'total_segments': 10}, None)
             fh.proj_info = {'CFAC': 40932549,
                             'COFF': 5500.5,
                             'LFAC': 40932549,
@@ -145,10 +145,10 @@ class TestAHIHSDFileHandler(unittest.TestCase):
         with mock.patch('satpy.readers.ahi_hsd.open', m, create=True):
             # Check if file handler raises exception for invalid calibration mode
             with self.assertRaises(ValueError):
-                fh = AHIHSDFileHandler(None, {'segment_number': 8, 'total_segments': 10}, None, calib_mode='BAD_MODE')
+                fh = AHIHSDFileHandler(None, {'segment': 8, 'total_segments': 10}, None, calib_mode='BAD_MODE')
 
             in_fname = 'test_file.bz2'
-            fh = AHIHSDFileHandler(in_fname, {'segment_number': 8, 'total_segments': 10}, None)
+            fh = AHIHSDFileHandler(in_fname, {'segment': 8, 'total_segments': 10}, None)
 
             # Check that the filename is altered for bz2 format files
             self.assertNotEqual(in_fname, fh.filename)
@@ -205,6 +205,7 @@ class TestAHIHSDFileHandler(unittest.TestCase):
         bad_cali = [0.0, 0.0]
         fh = AHIHSDFileHandler()
         fh.calib_mode = 'NOMINAL'
+        fh.is_zipped = False
         fh._header = {
             'block5': {'band_number': [5],
                        'gain_count2rad_conversion': [def_cali[0]],


### PR DESCRIPTION
I noticed some problems with the new padding of geostationary images:

1. `ahi_hsd` does not recognize `segment` from the filename and `expected_segments` from YAML
2. `mtsat2-imager_hrit` doesn't work anymore with non-segmented data (no `segment` key in the filename info)
3. Reading multiple scans at once doesn't work anymore:
    <details>

    ```python
    In [1]: import satpy 
    ...: import glob 
    ...: from satpy.utils import debug_on                                                                                                                                                                                                     

    In [2]: debug_on()                                                                                                                                                                                                                           

    In [3]: scene = satpy.Scene(filenames=glob.glob('test_data/mtsat2_hrit/*'), reader='mtsat2-imager_hrit')                                                                                                                                     
    [DEBUG: 2019-12-17 14:42:36 : satpy.scene] Setting 'PPP_CONFIG_DIR' to '/cmsaf/nfshome/sfinkens/software/devel/satpy/satpy/etc'
    [DEBUG: 2019-12-17 14:42:36 : satpy.readers] Reading ['/cmsaf/nfshome/sfinkens/software/devel/satpy/satpy/etc/readers/mtsat2-imager_hrit.yaml']
    [DEBUG: 2019-12-17 14:42:36 : satpy.readers.yaml_reader] Assigning to mtsat2-imager_hrit: ['test_data/mtsat2_hrit/HRIT_MTSAT2_20140524_0601_DK03IR1', 'test_data/mtsat2_hrit/HRIT_MTSAT2_20140524_1901_DK02IR1', 'test_data/mtsat2_hrit/HRIT_MTSAT2_20140524_0101_DK02IR1', 'test_data/mtsat2_hrit/HRIT_MTSAT2_20140524_1832_DK01IR1', 'test_data/mtsat2_hrit/HRIT_MTSAT2_20140524_1232_DK01IR1', 'test_data/mtsat2_hrit/HRIT_MTSAT2_20140524_0032_DK01IR1', 'test_data/mtsat2_hrit/HRIT_MTSAT2_20140524_0701_DK02IR1', 'test_data/mtsat2_hrit/HRIT_MTSAT2_20140524_0001_DK03IR1', 'test_data/mtsat2_hrit/HRIT_MTSAT2_20140524_1801_DK03IR1', 'test_data/mtsat2_hrit/HRIT_MTSAT2_20140524_1201_DK03IR1', 'test_data/mtsat2_hrit/HRIT_MTSAT2_20140524_1301_DK02IR1', 'test_data/mtsat2_hrit/HRIT_MTSAT2_20140524_0632_DK01IR1']
    [DEBUG: 2019-12-17 14:42:36 : satpy.composites] Looking for composites config file mtsat2_imager.yaml
    [DEBUG: 2019-12-17 14:42:36 : satpy.composites] No composite config found called mtsat2_imager.yaml

    In [4]: scene.load(['IR1'])                                                                                                                                                                                                                  
    [DEBUG: 2019-12-17 14:42:40 : hrit_jma] Calibration time 0:00:00.005258
    [DEBUG: 2019-12-17 14:42:40 : hrit_jma] Calibration time 0:00:00.002388
    [DEBUG: 2019-12-17 14:42:40 : hrit_jma] Calibration time 0:00:00.001838
    [DEBUG: 2019-12-17 14:42:40 : hrit_jma] Calibration time 0:00:00.001775
    [DEBUG: 2019-12-17 14:42:40 : hrit_jma] Calibration time 0:00:00.003688
    [DEBUG: 2019-12-17 14:42:40 : hrit_jma] Calibration time 0:00:00.003702
    [DEBUG: 2019-12-17 14:42:40 : hrit_jma] Calibration time 0:00:00.002927
    [DEBUG: 2019-12-17 14:42:40 : hrit_jma] Calibration time 0:00:00.003964
    [DEBUG: 2019-12-17 14:42:40 : hrit_jma] Calibration time 0:00:00.003751
    [DEBUG: 2019-12-17 14:42:40 : hrit_jma] Calibration time 0:00:00.002497
    [DEBUG: 2019-12-17 14:42:40 : hrit_jma] Calibration time 0:00:00.003398
    [DEBUG: 2019-12-17 14:42:40 : hrit_jma] Calibration time 0:00:00.002341
    [DEBUG: 2019-12-17 14:42:40 : satpy.resample] Could not add 'crs' coordinate with pyproj<2.0
    ---------------------------------------------------------------------------
    ValueError                                Traceback (most recent call last)
    <ipython-input-4-d0ce341080f8> in <module>
    ----> 1 scene.load(['IR1'])

    /cmsaf/nfshome/sfinkens/software/devel/satpy/satpy/scene.py in load(self, wishlist, calibration, resolution, polarization, level, generate, unload, **kwargs)
        971             raise KeyError("Unknown datasets: {}".format(unknown_str))
        972 
    --> 973         self.read(**kwargs)
        974         if generate:
        975             keepables = self.generate_composites()

    /cmsaf/nfshome/sfinkens/software/devel/satpy/satpy/scene.py in read(self, nodes, **kwargs)
        880             required_nodes = self.wishlist - set(self.datasets.keys())
        881             nodes = self.dep_tree.leaves(nodes=required_nodes)
    --> 882         return self._read_datasets(nodes, **kwargs)
        883 
        884     def generate_composites(self, nodes=None):

    /cmsaf/nfshome/sfinkens/software/devel/satpy/satpy/scene.py in _read_datasets(self, dataset_nodes, **kwargs)
        721         for reader_name, ds_ids in reader_datasets.items():
        722             reader_instance = self.readers[reader_name]
    --> 723             new_datasets = reader_instance.load(ds_ids, **kwargs)
        724             loaded_datasets.update(new_datasets)
        725         self.datasets.update(loaded_datasets)

    /cmsaf/nfshome/sfinkens/software/devel/satpy/satpy/readers/yaml_reader.py in load(self, dataset_keys, previous_datasets, **kwargs)
        838             coords = [all_datasets.get(cid, None)
        839                       for cid in coordinates.get(dsid, [])]
    --> 840             ds = self._load_dataset_with_area(dsid, coords, **kwargs)
        841             if ds is not None:
        842                 all_datasets[dsid] = ds

    /cmsaf/nfshome/sfinkens/software/devel/satpy/satpy/readers/yaml_reader.py in _load_dataset_with_area(self, dsid, coords, **kwargs)
        755         if area is not None:
        756             ds.attrs['area'] = area
    --> 757             ds = add_crs_xy_coords(ds, area)
        758         return ds
        759 

    /cmsaf/nfshome/sfinkens/software/devel/satpy/satpy/resample.py in add_crs_xy_coords(data_arr, area)
        300     else:
        301         # Gridded data (AreaDefinition/StackedAreaDefinition)
    --> 302         data_arr = add_xy_coords(data_arr, area, crs=crs)
        303     return data_arr
        304 

    /cmsaf/nfshome/sfinkens/software/devel/satpy/satpy/resample.py in add_xy_coords(data_arr, area, crs)
        245     y = xr.DataArray(y, dims=('y',), attrs=y_attrs)
        246     x = xr.DataArray(x, dims=('x',), attrs=x_attrs)
    --> 247     return data_arr.assign_coords(y=y, x=x)
        248 
        249 

    /cmsaf/cmsaf-ops3/sfinkens/virtualenvs/satpy/lib/python3.7/site-packages/xarray/core/common.py in assign_coords(self, coords, **coords_kwargs)
        457         data = self.copy(deep=False)
        458         results = self._calc_assign_results(coords_kwargs)
    --> 459         data.coords.update(results)
        460         return data
        461 

    /cmsaf/cmsaf-ops3/sfinkens/virtualenvs/satpy/lib/python3.7/site-packages/xarray/core/coordinates.py in update(self, other)
        116             [self.variables, other_vars], priority_arg=1, indexes=self.indexes
        117         )
    --> 118         self._update_coords(coords, indexes)
        119 
        120     def _merge_raw(self, other):

    /cmsaf/cmsaf-ops3/sfinkens/virtualenvs/satpy/lib/python3.7/site-packages/xarray/core/coordinates.py in _update_coords(self, coords, indexes)
        289         coords_plus_data = coords.copy()
        290         coords_plus_data[_THIS_ARRAY] = self._data.variable
    --> 291         dims = calculate_dimensions(coords_plus_data)
        292         if not set(dims) <= set(self.dims):
        293             raise ValueError(

    /cmsaf/cmsaf-ops3/sfinkens/virtualenvs/satpy/lib/python3.7/site-packages/xarray/core/dataset.py in calculate_dimensions(variables)
        187                     "conflicting sizes for dimension %r: "
        188                     "length %s on %r and length %s on %r"
    --> 189                     % (dim, size, k, dims[dim], last_used[dim])
        190                 )
        191     return dims

    ValueError: conflicting sizes for dimension 'y': length 22000 on <this-array> and length 1375 on 'y'
    ```
    </details>

    Where the contens of `test_data/mtsat2_hrit` are: 

    <details>

    ```
    HRIT_MTSAT2_20140524_0001_DK03IR1
    HRIT_MTSAT2_20140524_0032_DK01IR1
    HRIT_MTSAT2_20140524_0101_DK02IR1
    HRIT_MTSAT2_20140524_0601_DK03IR1
    HRIT_MTSAT2_20140524_0632_DK01IR1
    HRIT_MTSAT2_20140524_0701_DK02IR1
    HRIT_MTSAT2_20140524_1201_DK03IR1
    HRIT_MTSAT2_20140524_1232_DK01IR1
    HRIT_MTSAT2_20140524_1301_DK02IR1
    HRIT_MTSAT2_20140524_1801_DK03IR1
    HRIT_MTSAT2_20140524_1832_DK01IR1
    HRIT_MTSAT2_20140524_1901_DK02IR1
    ```
    </details>
    Edit: This isn't supposed to work.

I tried to fix 1 and 2, but I don't know how to handle 3. Any ideas @pnuu?

 - [X] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
