### PR TITLE
Switch to configuration file for readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@
 version: 2
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: doc/conf.py
+  configuration: doc/source/conf.py
 
 # Optionally build your docs in additional formats such as PDF and ePub
 formats: all

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,12 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+version: 2
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: doc/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+conda:
+  environment: doc/rtd_environment.yml

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -6,23 +6,17 @@ dependencies:
   - pip
   - dask
   - graphviz
-  - h5py
-  - imageio
-  - imageio-ffmpeg
-  - matplotlib
-  - netcdf4
   - numpy
   - pillow
-  - pyorbital
   - pyresample
-  - pyspectral
-  - rasterio
   - setuptools
   - setuptools_scm
   - setuptools_scm_git_archive
+  - sphinx
+  - sphinx_rtd_theme
   - trollsift
-  - trollimage
   - xarray
   - zarr
   - pip:
     - graphviz
+    - ..  # relative path to the satpy project

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -1,0 +1,28 @@
+name: readthedocs
+channels:
+  - conda-forge
+dependencies:
+  - python=3.7
+  - pip
+  - dask
+  - graphviz
+  - h5py
+  - imageio
+  - imageio-ffmpeg
+  - matplotlib
+  - netcdf4
+  - numpy
+  - pillow
+  - pyorbital
+  - pyresample
+  - pyspectral
+  - rasterio
+  - setuptools
+  - setuptools_scm
+  - setuptools_scm_git_archive
+  - trollsift
+  - trollimage
+  - xarray
+  - zarr
+  - pip:
+    - graphviz

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -69,7 +69,10 @@ MOCK_MODULES = ['h5py']
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()
 
-autodoc_mock_imports = ['h5netcdf', 'pyninjotiff', 'pygac', 'cf', 'glymur', 'pyhdf', 'osgeo', 'mipp']
+autodoc_mock_imports = ['cf', 'glymur', 'h5netcdf', 'imageio', 'mipp', 'netCDF4',
+                        'pygac', 'pygrib', 'pyhdf', 'pyninjotiff',
+                        'pyorbital', 'pyspectral', 'rasterio', 'trollimage',
+                        'zarr']
 autoclass_content = 'both'  # append class __init__ docstring to the class docstring
 
 # -- General configuration -----------------------------------------------------


### PR DESCRIPTION
Documentation building on readthedocs.io is failing because of some complicated build issues. This is mostly caused by no wheels from pyresample: https://github.com/pytroll/pyresample/issues/244

This PR switches the readthedocs builds to use a configuration file. I put this branch on the main repository so I could more easily test things from rtd.
