### PR TITLE
Fix tropomi_l2 reader not using y and x dimension names

### DIFF
--- a/satpy/readers/tropomi_l2.py
+++ b/satpy/readers/tropomi_l2.py
@@ -145,6 +145,15 @@ class TROPOMIL2FileHandler(NetCDF4FileHandler):
 
         return metadata
 
+    def _rename_dims(self, data_arr):
+        """Normalize dimension names with the rest of Satpy."""
+        dims_dict = {}
+        if 'ground_pixel' in data_arr.dims:
+            dims_dict['ground_pixel'] = 'x'
+        if 'scanline' in data_arr.dims:
+            dims_dict['scanline'] = 'y'
+        return data_arr.rename(dims_dict)
+
     def get_dataset(self, ds_id, ds_info):
         """Get dataset."""
         logger.debug("Getting data for: %s", ds_id.name)
@@ -154,4 +163,5 @@ class TROPOMIL2FileHandler(NetCDF4FileHandler):
         fill = data.attrs.pop('_FillValue')
         data = data.squeeze()
         data = data.where(data != fill)
+        data = self._rename_dims(data)
         return data

--- a/satpy/tests/reader_tests/test_tropomi_l2.py
+++ b/satpy/tests/reader_tests/test_tropomi_l2.py
@@ -77,7 +77,7 @@ class FakeNetCDF4FileHandlerTL2(FakeNetCDF4FileHandler):
             for key, val in file_content.items():
                 if isinstance(val, np.ndarray):
                     if val.ndim > 1:
-                        file_content[key] = DataArray(val, dims=('y', 'x'))
+                        file_content[key] = DataArray(val, dims=('scanline', 'ground_pixel'))
                     else:
                         file_content[key] = DataArray(val)
             file_content['PRODUCT/latitude'].attrs['_FillValue'] = -999.0
@@ -139,6 +139,8 @@ class TestTROPOMIL2Reader(unittest.TestCase):
             self.assertEqual(d.attrs['sensor'], 'TROPOMI')
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])
+            self.assertIn('y', d.dims)
+            self.assertIn('x', d.dims)
 
     def test_load_so2(self):
         """Load SO2 dataset"""
@@ -155,6 +157,8 @@ class TestTROPOMIL2Reader(unittest.TestCase):
             self.assertEqual(d.attrs['platform_shortname'], 'S5P')
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])
+            self.assertIn('y', d.dims)
+            self.assertIn('x', d.dims)
 
 
 def suite():


### PR DESCRIPTION
`sateesh` (can't find github username) on slack pointed out that the tropomi_l2 reader can't be resampled. It fails with the error:

```
ValueError: cannot add coordinates with new dimensions to a DataArray
```

This was caused by the reader producing data that didn't include the `y` and `x` dimensions and instead was using the file's original dimensions `scanline` and `ground_pixel`. From what I can tell we don't mention this in the custom reader documentation. I'll make a separate issue or PR for that.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
