### PR TITLE
Add documentation about y and x dimensions for custom readers

### DIFF
--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -466,8 +466,9 @@ needs to implement a few methods:
    successful, containing the data and :ref:`metadata <dataset_metadata>` of the
    loaded dataset, or return None if the loading was unsuccessful.
 
-   The DataArray should at least have a ``y`` dimension. If it is 2 or more
-   dimensions then it should also have an ``x`` dimension. This applies to
+   The DataArray should at least have a ``y`` dimension. For data covering
+   a 2D region on the Earth, their should be at least a ``y`` and ``x``
+   dimension. This applies to
    non-gridded data like that of a polar-orbiting satellite instrument. The
    latitude dimension is typically named ``y`` and longitude named ``x``.
    This may require renaming dimensions from the file, see for the

--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -466,6 +466,14 @@ needs to implement a few methods:
    successful, containing the data and :ref:`metadata <dataset_metadata>` of the
    loaded dataset, or return None if the loading was unsuccessful.
 
+   The DataArray should at least have a ``y`` dimension. If it is 2 or more
+   dimensions then it should also have an ``x`` dimension. This applies to
+   non-gridded data like that of a polar-orbiting satellite instrument. The
+   latitude dimension is typically named ``y`` and longitude named ``x``.
+   This may require renaming dimensions from the file, see for the
+   :meth:`xarray.DataArray.rename` method for more information and its use
+   in the example below.
+
  - the ``get_area_def`` method, that takes as single argument the
    :class:`~satpy.dataset.DatasetID` for which we want
    the area. It should return a :class:`~pyresample.geometry.AreaDefinition`


### PR DESCRIPTION
After fixing parts of the tropomi_l2 reader in #1031 I noticed that the custom reader documentation doesn't explicitly mention that dimensions should be named `y` and `x`. This PR adds that information.

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
