### PR TITLE
Fix avhrr_l1b_aapp reader not including standard_name metadata

### DIFF
--- a/satpy/etc/readers/avhrr_l1b_aapp.yaml
+++ b/satpy/etc/readers/avhrr_l1b_aapp.yaml
@@ -92,6 +92,8 @@ datasets:
             - longitude
             - latitude
         file_type: avhrr_aapp_l1b
+        standard_name: solar_zenith_angle
+        units: degrees
 
     sensor_zenith_angle:
         name: sensor_zenith_angle
@@ -100,6 +102,8 @@ datasets:
             - longitude
             - latitude
         file_type: avhrr_aapp_l1b
+        standard_name: sensor_zenith_angle
+        units: degrees
 
     sun_sensor_azimuth_difference_angle:
         name: sun_sensor_azimuth_difference_angle
@@ -108,18 +112,21 @@ datasets:
             - longitude
             - latitude
         file_type: avhrr_aapp_l1b
+        units: degrees
 
     latitude:
         name: latitude
         resolution: 1050
         file_type: avhrr_aapp_l1b
         standard_name: latitude
+        units: degrees_north
 
     longitude:
         name: longitude
         resolution: 1050
         file_type: avhrr_aapp_l1b
         standard_name: longitude
+        units: degrees_east
 
 file_types:
     avhrr_aapp_l1b:

--- a/satpy/readers/aapp_l1b.py
+++ b/satpy/readers/aapp_l1b.py
@@ -128,9 +128,9 @@ class AVHRRAAPPL1BFile(BaseFileHandler):
         dataset.attrs.update({'platform_name': self.platform_name,
                               'sensor': self.sensor})
         dataset.attrs.update(key.to_dict())
-        for key in ('standard_name', 'units'):
-            if key in info:
-                dataset.attrs.setdefault(key, info[key])
+        for meta_key in ('standard_name', 'units'):
+            if meta_key in info:
+                dataset.attrs.setdefault(meta_key, info[meta_key])
 
         if not self._shape:
             self._shape = dataset.shape


### PR DESCRIPTION
This is a fix to a fix PR (#1006). That PR added the necessary metadata to the YAML files, but the AVHRR AAPP reader was never actually adding that metadata to the returned DataArray object. This PR fixes that.

This reader doesn't have any tests, but I'm not sure I'm the right person to be adding them. I rarely use the AVHRR AAPP reader (more than the other AVHRR readers at least I guess) and I didn't write the reader. If possible, it would be good if someone added tests; either in this PR or another future one.

 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
