### PR TITLE
Fix AMI geolocation being off by 1 pixel

### DIFF
--- a/satpy/readers/_geos_area.py
+++ b/satpy/readers/_geos_area.py
@@ -79,7 +79,7 @@ def get_area_extent(pdict):
     # count starts at 1
     cols = 1 - 0.5
 
-    if (pdict['scandir'] == 'S2N'):
+    if pdict['scandir'] == 'S2N':
         lines = 0.5 - 1
         scanmult = -1
     else:

--- a/satpy/readers/ami_l1b.py
+++ b/satpy/readers/ami_l1b.py
@@ -92,8 +92,8 @@ class AMIL1bNetCDF(BaseFileHandler):
 
         # AMI grid appears offset, we can not use the standard get_area_extent
         bit_shift = 2**16
-        ll_x = (0 - pdict['coff'] - 0.5) * bit_shift / pdict['cfac']
-        ll_y = -(0 - pdict['loff'] - 0.5) * bit_shift / pdict['lfac']
+        ll_x = (0 - pdict['coff'] + 0.5) * bit_shift / pdict['cfac']
+        ll_y = -(0 - pdict['loff'] + 0.5) * bit_shift / pdict['lfac']
         ur_x = (pdict['ncols'] - pdict['coff'] + 0.5) * bit_shift / pdict['cfac']
         ur_y = -(pdict['nlines'] - pdict['loff'] + 0.5) * bit_shift / pdict['lfac']
 

--- a/satpy/readers/ami_l1b.py
+++ b/satpy/readers/ami_l1b.py
@@ -25,7 +25,7 @@ import xarray as xr
 import dask.array as da
 import pyproj
 
-from satpy.readers._geos_area import make_ext, get_area_definition
+from satpy.readers._geos_area import make_ext, get_area_definition, get_area_extent
 from pyspectral.blackbody import blackbody_wn_rad2temp as rad2temp
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy import CHUNK_SIZE
@@ -85,26 +85,19 @@ class AMIL1bNetCDF(BaseFileHandler):
         obs_mode = self.nc.attrs['observation_mode']
         resolution = self.nc.attrs['channel_spatial_resolution']
 
+        # Example offset: 11000.5
+        # the 'get_area_extent' will handle this half pixel for us
         pdict['cfac'] = self.nc.attrs['cfac']
         pdict['coff'] = self.nc.attrs['coff']
-        pdict['lfac'] = self.nc.attrs['lfac']
+        pdict['lfac'] = -self.nc.attrs['lfac']
         pdict['loff'] = self.nc.attrs['loff']
-
-        # AMI grid appears offset, we can not use the standard get_area_extent
-        bit_shift = 2**16
-        ll_x = (0 - pdict['coff'] + 0.5) * bit_shift / pdict['cfac']
-        ll_y = -(0 - pdict['loff'] + 0.5) * bit_shift / pdict['lfac']
-        ur_x = (pdict['ncols'] - pdict['coff'] + 0.5) * bit_shift / pdict['cfac']
-        ur_y = -(pdict['nlines'] - pdict['loff'] + 0.5) * bit_shift / pdict['lfac']
-
-        area_extent = make_ext(ll_x, ur_x, ll_y, ur_y, pdict['h'])
-
+        pdict['scandir'] = 'N2S'
         pdict['a_name'] = 'ami_geos_{}'.format(obs_mode.lower())
         pdict['a_desc'] = 'AMI {} Area at {} resolution'.format(obs_mode, resolution)
         pdict['p_id'] = 'ami_fixed_grid'
 
+        area_extent = get_area_extent(pdict)
         fg_area_def = get_area_definition(pdict, area_extent)
-
         return fg_area_def
 
     def get_orbital_parameters(self):

--- a/satpy/readers/ami_l1b.py
+++ b/satpy/readers/ami_l1b.py
@@ -25,7 +25,7 @@ import xarray as xr
 import dask.array as da
 import pyproj
 
-from satpy.readers._geos_area import make_ext, get_area_definition, get_area_extent
+from satpy.readers._geos_area import get_area_definition, get_area_extent
 from pyspectral.blackbody import blackbody_wn_rad2temp as rad2temp
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy import CHUNK_SIZE

--- a/satpy/tests/reader_tests/test_ami_l1b.py
+++ b/satpy/tests/reader_tests/test_ami_l1b.py
@@ -199,7 +199,7 @@ class TestAMIL1bNetCDF(TestAMIL1bNetCDFBase):
         self.assertEqual(call_args[4], self.reader.nc.attrs['number_of_columns'])
         self.assertEqual(call_args[5], self.reader.nc.attrs['number_of_lines'])
         np.testing.assert_allclose(call_args[6],
-                                   [-5511523.904082, -5511523.904082, 5511022.902, 5511022.902])
+                                   [-5511022.902, -5511022.902, 5511022.902, 5511022.902])
 
     def test_get_dataset_vis(self):
         """Test get visible calibrated data."""


### PR DESCRIPTION
I noticed when working with AMI L1b data that the geolocation for a full disk image was not square. Turns out I had a +/- bug in the math for the area extents. This PR fixes this.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

CC @simonrp84 
