### PR TITLE
Fix ABI L1b/L2 time dimension causing issues with newer xarray

### DIFF
--- a/satpy/readers/abi_base.py
+++ b/satpy/readers/abi_base.py
@@ -53,7 +53,7 @@ class NC_ABI_BASE(BaseFileHandler):
                                       mask_and_scale=False,
                                       chunks={'lon': CHUNK_SIZE, 'lat': CHUNK_SIZE}, )
 
-        if 't' in self.nc.dims:
+        if 't' in self.nc.dims or 't' in self.nc.coords:
             self.nc = self.nc.rename({'t': 'time'})
         platform_shortname = filename_info['platform_shortname']
         self.platform_name = PLATFORM_NAMES.get(platform_shortname)

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -27,36 +27,6 @@ except ImportError:
     import mock
 
 
-class FakeDataset(object):
-    """Act like an xarray Dataset object for testing."""
-
-    def __init__(self, info, attrs, dims=None):
-        """Set properties to mimic a Dataset object."""
-        for var_name, var_data in list(info.items()):
-            if isinstance(var_data, np.ndarray):
-                info[var_name] = xr.DataArray(var_data)
-        self.info = info
-        self.attrs = attrs
-        self.coords = {}
-        self.dims = dims or tuple()
-
-    def __getitem__(self, key):
-        """Get the info for the fake data."""
-        return self.info[key]
-
-    def __contains__(self, key):
-        """Check if key is in the fake data."""
-        return key in self.info
-
-    def rename(self, *args, **kwargs):
-        """Allow for dimension renaming."""
-        return self
-
-    def close(self):
-        """Pretend to close."""
-        return
-
-
 class Test_NC_ABI_L1B_Base(unittest.TestCase):
     """Common setup for NC_ABI_L1B tests."""
 

--- a/satpy/tests/reader_tests/test_glm_l2.py
+++ b/satpy/tests/reader_tests/test_glm_l2.py
@@ -28,35 +28,6 @@ except ImportError:
     import mock
 
 
-class FakeDataset(object):
-    """Act like an xarray Dataset object for testing."""
-
-    def __init__(self, info, attrs, dims=None):
-        """Set properties to mimic a Dataset object."""
-        for var_name, var_data in list(info.items()):
-            if isinstance(var_data, np.ndarray):
-                info[var_name] = xr.DataArray(var_data)
-        self.info = info
-        self.attrs = attrs
-        self.dims = dims or tuple()
-
-    def __getitem__(self, key):
-        """Get the info for the fake data."""
-        return self.info[key]
-
-    def __contains__(self, key):
-        """Check if key is in the fake data."""
-        return key in self.info
-
-    def rename(self, *args, **kwargs):
-        """Allow for dimension renaming."""
-        return self
-
-    def close(self):
-        """Pretend to close."""
-        return
-
-
 def setup_fake_dataset():
     """Create a fake dataset to avoid opening a file."""
     # flash_extent_density

--- a/satpy/tests/reader_tests/test_glm_l2.py
+++ b/satpy/tests/reader_tests/test_glm_l2.py
@@ -79,10 +79,12 @@ def setup_fake_dataset():
     x__ = xr.DataArray(
         range(5),
         attrs={'scale_factor': 2., 'add_offset': -1.},
+        dims=('x',),
     )
     y__ = xr.DataArray(
         range(2),
         attrs={'scale_factor': -2., 'add_offset': 1.},
+        dims=('y',),
     )
     proj = xr.DataArray(
         [],
@@ -95,20 +97,22 @@ def setup_fake_dataset():
             'sweep_angle_axis': u'x'
         }
     )
-    fake_dataset = FakeDataset({
-        'flash_extent_density': fed,
-        'x': x__,
-        'y': y__,
-        'goes_imager_projection': proj,
-        "nominal_satellite_subpoint_lat": np.array(0.0),
-        "nominal_satellite_subpoint_lon": np.array(-89.5),
-        "nominal_satellite_height": np.array(35786.02)
-    },
-        {
+    fake_dataset = xr.Dataset(
+        data_vars={
+            'flash_extent_density': fed,
+            'x': x__,
+            'y': y__,
+            'goes_imager_projection': proj,
+            "nominal_satellite_subpoint_lat": np.array(0.0),
+            "nominal_satellite_subpoint_lon": np.array(-89.5),
+            "nominal_satellite_height": np.array(35786.02)
+        },
+        attrs={
             "time_coverage_start": "2017-09-20T17:30:40Z",
             "time_coverage_end": "2017-09-20T17:41:17Z",
             "spatial_resolution": "2km at nadir",
-        }, dims=('y', 'x'))
+        }
+    )
     return fake_dataset
 
 


### PR DESCRIPTION
Pointed out originally by @TAlonglong on slack. @yufeizhu600 also helped debug this one.

It seems in newer versions of xarray that the scalar variables in a NetCDF variable like `t` in the ABI L1b files is no longer treated as a dimension (`self.nc.dims`) and is only considered a coordinate variable. The ABI base reader specifically checked for it existing in the `dims` before renaming it to `time` to be more compatible with the rest of Satpy. This PR fixes this by checking the `.dims` and the `.coords` for a `t` variable. Continuing to check in `.dims` may be redundant, but I think it is useful in the case there is a declared dimension in a NetCDF file but no corresponding coordinate variable defined in the file.

To test this I had to update the ABI L1b/L2 and GLM L2 tests to stop using a "FakeDataset" object when a normal xarray Dataset object will do just fine.

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
