### PR TITLE
Unify Dataset attribute naming in SEVIRI L2 BUFR-reader

### DIFF
--- a/satpy/readers/seviri_l2_bufr.py
+++ b/satpy/readers/seviri_l2_bufr.py
@@ -69,7 +69,7 @@ class SeviriL2BufrFileHandler(BaseFileHandler):
         return self.start_time + timedelta(minutes=15)
 
     @property
-    def spacecraft_name(self):
+    def platform_name(self):
         """Return spacecraft name."""
         return 'MET{}'.format(self.mpef_header['SpacecraftName'])
 
@@ -123,7 +123,7 @@ class SeviriL2BufrFileHandler(BaseFileHandler):
         xarr['latitude'] = ('y', self.get_array('latitude'))
         xarr['longitude'] = ('y', self.get_array('longitude'))
         xarr.attrs['sensor'] = 'SEVIRI'
-        xarr.attrs['spacecraft_name'] = self.spacecraft_name
+        xarr.attrs['platform_name'] = self.platform_name
         xarr.attrs['ssp_lon'] = self.ssp_lon
         xarr.attrs['seg_size'] = self.seg_size
         xarr.attrs.update(dataset_info)

--- a/satpy/tests/reader_tests/test_seviri_l2_bufr.py
+++ b/satpy/tests/reader_tests/test_seviri_l2_bufr.py
@@ -47,7 +47,7 @@ DATASET_INFO = {
 }
 
 DATASET_ATTRS = {
-    'spacecraft_name': 'MET08',
+    'platform_name': 'MET08',
     'ssp_lon': 41.5,
     'seg_size': 16
 }
@@ -99,8 +99,8 @@ class TestSeviriL2Bufr(unittest.TestCase):
                                 np.testing.assert_array_equal(z.values, x1)
                                 np.testing.assert_array_equal(z.coords['latitude'].values, x2)
                                 np.testing.assert_array_equal(z.coords['longitude'].values, x3)
-                                self.assertEqual(z.attrs['spacecraft_name'],
-                                                 DATASET_ATTRS['spacecraft_name'])
+                                self.assertEqual(z.attrs['platform_name'],
+                                                 DATASET_ATTRS['platform_name'])
                                 self.assertEqual(z.attrs['ssp_lon'],
                                                  DATASET_ATTRS['ssp_lon'])
                                 self.assertEqual(z.attrs['seg_size'],


### PR DESCRIPTION
Unify `Dataset` attribute naming in SEVIRI L2 BUFR-reader to match other Satpy readers. Change `satellite_name` to `platform_name`.

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

