### PR TITLE
Update hrpt.py for new pygac syntax

### DIFF
--- a/satpy/readers/hrpt.py
+++ b/satpy/readers/hrpt.py
@@ -33,8 +33,11 @@ import logging
 from datetime import datetime
 
 import numpy as np
+try:
+    from pygac.calibration import calibrate_solar, calibrate_thermal
+except ImportError:
+    from pygac.gac_calibration import calibrate_solar, calibrate_thermal
 
-from pygac.gac_calibration import calibrate_solar, calibrate_thermal
 from satpy.dataset import Dataset
 from satpy.readers.file_handlers import BaseFileHandler
 


### PR DESCRIPTION
The method has been renamed in pytroll/pygac@84f58e8f08eb45c60cd6730bff00ea89b0029f4e
