### PR TITLE
Remove deprecated abstractproperty usage

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -40,7 +40,7 @@ the base Satpy installation.
     Satpy's interfaces are not guaranteed stable and may change until version
     1.0 when backwards compatibility will be a main focus.
 
-.. versionchanged:: 0.19.0
+.. versionchanged:: 0.20.0
 
     Dropped Python 2 support.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -40,6 +40,10 @@ the base Satpy installation.
     Satpy's interfaces are not guaranteed stable and may change until version
     1.0 when backwards compatibility will be a main focus.
 
+.. versionchanged:: 0.19.0
+
+    Dropped Python 2 support.
+
 .. _project: http://github.com/pytroll/satpy
 
 .. toctree::

--- a/satpy/config.py
+++ b/satpy/config.py
@@ -20,10 +20,7 @@ from __future__ import print_function
 import glob
 import logging
 import os
-try:
-    from collections.abc import Mapping
-except ImportError:
-    from collections import Mapping
+from collections.abc import Mapping
 from collections import OrderedDict
 
 import yaml

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -21,7 +21,7 @@ import itertools
 import logging
 import os
 import warnings
-from abc import ABCMeta, abstractmethod, abstractproperty
+from abc import ABCMeta, abstractmethod
 from collections import deque, OrderedDict
 from fnmatch import fnmatch
 from weakref import WeakValueDictionary
@@ -145,11 +145,13 @@ class AbstractYAMLReader(six.with_metaclass(ABCMeta, object)):
         """Get names of datasets that are loadable by this reader."""
         return (ds_id.name for ds_id in self.available_dataset_ids)
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def start_time(self):
         """Start time of the reader."""
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def end_time(self):
         """End time of the reader."""
 


### PR DESCRIPTION
I started a list of python 2-isms in #112 but the list was only 1 item long. This PR handles that one issue which was our use of `@abstractproperty`. This is a python 2 incompatible change...but since we dropped python 2 support its OK now.

I also fixed one unnecessary ImportError check for the `from collections.abc import Mapping`. This has been supported since Python 3.3 so we should be good.

 - [x] Closes #112 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
