### PR TITLE
Fix AMI L1b reader incorrectly grouping files

### DIFF
--- a/satpy/etc/readers/ami_l1b.yaml
+++ b/satpy/etc/readers/ami_l1b.yaml
@@ -17,52 +17,52 @@ file_types:
   # Below list is alphabetical
   ir087:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_ir087_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_ir087_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   ir096:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_ir096_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_ir096_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   ir105:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_ir105_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_ir105_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   ir112:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_ir112_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_ir112_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   ir123:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_ir123_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_ir123_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   ir133:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_ir133_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_ir133_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   nr013:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_nr013_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_nr013_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   nr016:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_nr016_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_nr016_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   sw038:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_sw038_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_sw038_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   vi004:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_vi004_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_vi004_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   vi005:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_vi005_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_vi005_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   vi006:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_vi006_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_vi006_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   vi008:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_vi008_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_vi008_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   wv063:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_wv063_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_wv063_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   wv069:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_wv069_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_wv069_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
   wv073:
     file_reader: !!python/name:satpy.readers.ami_l1b.AMIL1bNetCDF
-    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_wv073_{sector_info:s}_{start_time:%Y%m%d%H%M}.nc']
+    file_patterns: ['{platform_shortname:4s}_{sensor:3s}_le1b_wv073_{sector_info:2s}{res_info:s}_{start_time:%Y%m%d%H%M}.nc']
 
 datasets:
   # Below list is ordered the same as the table:

--- a/satpy/tests/reader_tests/test_ami_l1b.py
+++ b/satpy/tests/reader_tests/test_ami_l1b.py
@@ -22,11 +22,7 @@ import xarray as xr
 import dask.array as da
 
 import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 
 class FakeDataset(object):
@@ -147,6 +143,30 @@ class TestAMIL1bNetCDF(TestAMIL1bNetCDFBase):
         }
         for key, val in exp_params.items():
             self.assertAlmostEqual(val, orb_params[key], places=3)
+
+    def test_filename_grouping(self):
+        """Test that filenames are grouped properly."""
+        from satpy.readers import group_files
+        filenames = [
+            'gk2a_ami_le1b_ir087_fd020ge_201909300300.nc',
+            'gk2a_ami_le1b_ir096_fd020ge_201909300300.nc',
+            'gk2a_ami_le1b_ir105_fd020ge_201909300300.nc',
+            'gk2a_ami_le1b_ir112_fd020ge_201909300300.nc',
+            'gk2a_ami_le1b_ir123_fd020ge_201909300300.nc',
+            'gk2a_ami_le1b_ir133_fd020ge_201909300300.nc',
+            'gk2a_ami_le1b_nr013_fd020ge_201909300300.nc',
+            'gk2a_ami_le1b_nr016_fd020ge_201909300300.nc',
+            'gk2a_ami_le1b_sw038_fd020ge_201909300300.nc',
+            'gk2a_ami_le1b_vi004_fd010ge_201909300300.nc',
+            'gk2a_ami_le1b_vi005_fd010ge_201909300300.nc',
+            'gk2a_ami_le1b_vi006_fd005ge_201909300300.nc',
+            'gk2a_ami_le1b_vi008_fd010ge_201909300300.nc',
+            'gk2a_ami_le1b_wv063_fd020ge_201909300300.nc',
+            'gk2a_ami_le1b_wv069_fd020ge_201909300300.nc',
+            'gk2a_ami_le1b_wv073_fd020ge_201909300300.nc']
+        groups = group_files(filenames, reader='ami_l1b')
+        self.assertEqual(len(groups), 1)
+        self.assertEqual(len(groups[0]['ami_l1b']), 16)
 
     def test_basic_attributes(self):
         """Test getting basic file attributes."""


### PR DESCRIPTION
The `satpy.readers.group_files` function is using the `sector_info` filename metadata as one piece of information to sort files by. However, with names like `gk2a_ami_le1b_nr013_fd020ge_201909300300.nc` where `sector_info` is `fd020ge`, you end up with incorrect sorting because it contains resolution information. Compare this to ABI where sector_info might be "F" or "C" or "M1" or "M2" but does not container resolution information.

This PR modifies the filename pattern to limit the "sector_info" to the first two characters of this portion of the filename. This is a guess as currently (as far as I know) there are no other sectors of AMI data available to the public.

@simonrp84 Have you seen other sectors or other types of files?

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
