### PR TITLE
Fix handling of paths with forward slashes on Windows

### DIFF
--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -67,6 +67,8 @@ def listify_string(something):
 
 def get_filebase(path, pattern):
     """Get the end of *path* of same length as *pattern*."""
+    # convert any `/` on Windows to `\\`
+    path = os.path.normpath(path)
     # A pattern can include directories
     tail_len = len(pattern.split(os.path.sep))
     return os.path.join(*str(path).split(os.path.sep)[-tail_len:])

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -22,15 +22,11 @@ import random
 import unittest
 from datetime import datetime
 from tempfile import mkdtemp
+from unittest.mock import MagicMock, patch
 
 import satpy.readers.yaml_reader as yr
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.dataset import DatasetID
-
-try:
-    from unittest.mock import MagicMock, patch
-except ImportError:
-    from mock import MagicMock, patch
 
 
 class FakeFH(BaseFileHandler):
@@ -116,7 +112,7 @@ class TestUtils(unittest.TestCase):
                    '2s}_{collection:3s}.SEN3/geo_coordinates.nc')
         filenames = [os.path.join(base_dir, 'Oa05_radiance.nc').replace(os.sep, '/'),
                      os.path.join(base_dir, 'geo_coordinates.nc').replace(os.sep, '/')]
-        expected = os.path.join(base_dir, 'geo_coordinates.nc')
+        expected = os.path.join(base_dir, 'geo_coordinates.nc').replace(os.sep, '/')
         self.assertEqual(yr.match_filenames(filenames, pattern), [expected])
 
     def test_listify_string(self):

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -97,6 +97,28 @@ class TestUtils(unittest.TestCase):
         expected = os.path.join(base_dir, 'geo_coordinates.nc')
         self.assertEqual(yr.match_filenames(filenames, pattern), [expected])
 
+    def test_match_filenames_windows_forward_slash(self):
+        """Check that matching filenames works on Windows with forward slashes.
+
+        This is common from Qt5 which internally uses forward slashes everywhere.
+
+        """
+        # just a fake path for testing that doesn't have to exist
+        base_dir = os.path.join(os.path.expanduser('~'), 'data',
+                                'satellite', 'Sentinel-3')
+        base_data = ('S3A_OL_1_EFR____20161020T081224_20161020T081524_'
+                     '20161020T102406_0179_010_078_2340_SVL_O_NR_002.SEN3')
+        base_dir = os.path.join(base_dir, base_data)
+        pattern = ('{mission_id:3s}_OL_{processing_level:1s}_{datatype_id:_<6s'
+                   '}_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{cre'
+                   'ation_time:%Y%m%dT%H%M%S}_{duration:4d}_{cycle:3d}_{relati'
+                   've_orbit:3d}_{frame:4d}_{centre:3s}_{mode:1s}_{timeliness:'
+                   '2s}_{collection:3s}.SEN3/geo_coordinates.nc')
+        filenames = [os.path.join(base_dir, 'Oa05_radiance.nc').replace(os.sep, '/'),
+                     os.path.join(base_dir, 'geo_coordinates.nc').replace(os.sep, '/')]
+        expected = os.path.join(base_dir, 'geo_coordinates.nc')
+        self.assertEqual(yr.match_filenames(filenames, pattern), [expected])
+
     def test_listify_string(self):
         """Check listify_string."""
         self.assertEqual(yr.listify_string(None), [])

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -110,6 +110,7 @@ class TestUtils(unittest.TestCase):
                    'ation_time:%Y%m%dT%H%M%S}_{duration:4d}_{cycle:3d}_{relati'
                    've_orbit:3d}_{frame:4d}_{centre:3s}_{mode:1s}_{timeliness:'
                    '2s}_{collection:3s}.SEN3/geo_coordinates.nc')
+        pattern = os.path.join(*pattern.split('/'))
         filenames = [os.path.join(base_dir, 'Oa05_radiance.nc').replace(os.sep, '/'),
                      os.path.join(base_dir, 'geo_coordinates.nc').replace(os.sep, '/')]
         expected = os.path.join(base_dir, 'geo_coordinates.nc').replace(os.sep, '/')


### PR DESCRIPTION
I noticed with the UW SIFT application that paths returned by the file dialog (Qt5) always had forward slashes, even on Windows. This is expected behavior by Qt5. These forward slashes were causing Satpy to not recognize any of the filenames. While I could workaround this in SIFT, Satpy has other users in the past with this issue. I always thought this was a user problem, but now that I find out some applications/frameworks like Qt5 create paths like this, I think Satpy should have the fix.

The one thing I don't like about this PR is that it adds an extra step to `get_filebase` which is used multiple times in the reader loading process. I'm not sure if it is "better" to move this operation higher up in the reader loading functions for not. Additionally, I notice that `match_filenames` creates a list instead of returning a generator. It doesn't seem necessary to do this so I might change that too (feedback welcome).

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
