### PR TITLE
Delegate dask delays to pyninjotiff

### DIFF
--- a/satpy/tests/writer_tests/test_ninjotiff.py
+++ b/satpy/tests/writer_tests/test_ninjotiff.py
@@ -75,6 +75,8 @@ class TestNinjoTIFFWriter(unittest.TestCase):
         ret = ntw.save_image(img, filename='bla.tif', compute=False)
         nt.save.assert_called()
         assert(nt.save.mock_calls[0][2]['compute'] is False)
+        assert(nt.save.mock_calls[0][2]['ch_min_measurement_unit']
+               < nt.save.mock_calls[0][2]['ch_max_measurement_unit'])
         assert(ret == nt.save.return_value)
 
 

--- a/satpy/tests/writer_tests/test_ninjotiff.py
+++ b/satpy/tests/writer_tests/test_ninjotiff.py
@@ -19,13 +19,9 @@
 
 import sys
 import unittest
+from unittest import mock
+
 import xarray as xr
-from dask.delayed import Delayed
-import six
-if six.PY3:
-    from unittest import mock
-else:
-    import mock
 
 
 class FakeImage:
@@ -71,12 +67,15 @@ class TestNinjoTIFFWriter(unittest.TestCase):
     @mock.patch('satpy.writers.ninjotiff.ImageWriter.save_image')
     def test_image(self, iwsi, save_dataset):
         """Test saving an image."""
+        import pyninjotiff.ninjotiff as nt
         from satpy.writers.ninjotiff import NinjoTIFFWriter
         ntw = NinjoTIFFWriter()
         dataset = xr.DataArray([1, 2, 3], attrs={'units': 'K'})
         img = FakeImage(dataset, 'L')
         ret = ntw.save_image(img, filename='bla.tif', compute=False)
-        self.assertIsInstance(ret, Delayed)
+        nt.save.assert_called()
+        assert(nt.save.mock_calls[0].kwargs['compute'] is False)
+        assert(ret == nt.save.return_value)
 
 
 def suite():

--- a/satpy/tests/writer_tests/test_ninjotiff.py
+++ b/satpy/tests/writer_tests/test_ninjotiff.py
@@ -74,7 +74,7 @@ class TestNinjoTIFFWriter(unittest.TestCase):
         img = FakeImage(dataset, 'L')
         ret = ntw.save_image(img, filename='bla.tif', compute=False)
         nt.save.assert_called()
-        assert(nt.save.mock_calls[0].kwargs['compute'] is False)
+        assert(nt.save.mock_calls[0][2]['compute'] is False)
         assert(ret == nt.save.return_value)
 
 

--- a/satpy/writers/ninjotiff.py
+++ b/satpy/writers/ninjotiff.py
@@ -145,7 +145,7 @@ class NinjoTIFFWriter(ImageWriter):
                     # Here we know that the data if the image is scaled between 0 and 1
                     dmin = offset
                     dmax = scale + offset
-                    ch_min_measurement_unit, ch_max_measurement_unit = np.maximum(dmin, dmax), np.minimum(dmin, dmax)
+                    ch_min_measurement_unit, ch_max_measurement_unit = np.minimum(dmin, dmax), np.maximum(dmin, dmax)
                     kwargs["ch_min_measurement_unit"] = ch_min_measurement_unit
                     kwargs["ch_max_measurement_unit"] = ch_max_measurement_unit
                 except KeyError:

--- a/satpy/writers/ninjotiff.py
+++ b/satpy/writers/ninjotiff.py
@@ -79,7 +79,7 @@ The metadata to provide to the writer can also be stored in a configuration file
 
 import logging
 
-from dask import delayed
+import numpy as np
 
 import pyninjotiff.ninjotiff as nt
 from satpy.writers import ImageWriter
@@ -145,22 +145,14 @@ class NinjoTIFFWriter(ImageWriter):
                     # Here we know that the data if the image is scaled between 0 and 1
                     dmin = offset
                     dmax = scale + offset
-                    if dmin > dmax:
-                        dmin, dmax = dmax, dmin
-                    ch_min_measurement_unit, ch_max_measurement_unit = (
-                        dmin.values,
-                        dmax.values,
-                    )
+                    ch_min_measurement_unit, ch_max_measurement_unit = np.maximum(dmin, dmax), np.minimum(dmin, dmax)
                     kwargs["ch_min_measurement_unit"] = ch_min_measurement_unit
                     kwargs["ch_max_measurement_unit"] = ch_max_measurement_unit
                 except KeyError:
                     raise NotImplementedError(
                         "Don't know how to handle non-scale/offset-based enhancements yet."
                     )
-        if compute:
-            return nt.save(img, filename, data_is_scaled_01=True, **kwargs)
-        else:
-            return delayed(nt.save)(img, filename, data_is_scaled_01=True, **kwargs)
+        return nt.save(img, filename, data_is_scaled_01=True, compute=compute, **kwargs)
 
     def save_dataset(
         self, dataset, filename=None, fill_value=None, compute=True, **kwargs


### PR DESCRIPTION
This PR makes satpy take advantage of the new features in pyninjotiff

 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

