### PR TITLE
Fix sst standard name

### DIFF
--- a/satpy/etc/readers/slstr_l2.yaml
+++ b/satpy/etc/readers/slstr_l2.yaml
@@ -56,4 +56,4 @@ datasets:
     file_type: SLSTRB
     resolution: 1000
     view: nadir
-    standard_name: sea_ice_fraction
+    standard_name: quality_level


### PR DESCRIPTION
Fix error in standard_name for quality_level in Sentinel-3 slstr_l2 reader