### PR TITLE
Fix name of natural_color composite in quickstart

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -197,13 +197,13 @@ To get a list of all available composites for the current scene:
     >>> global_scene.available_composite_names()
     ['overview_sun',
      'airmass',
-     'natural',
+     'natural_color',
      'night_fog',
      'overview',
      'green_snow',
      'dust',
      'fog',
-     'natural_sun',
+     'natural_color_sun',
      'cloudtop',
      'convection',
      'ash']


### PR DESCRIPTION
As discussed on slack, the quick start document uses old composite names.

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
