### PR TITLE
Fix eps infinite loop

### DIFF
--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -155,9 +155,9 @@ class EPSAVHRRFile(BaseFileHandler):
         self.pixels = None
         self.sections = None
 
-    def _read_all(self, filename):
-        logger.debug("Reading %s", filename)
-        self.sections, self.form = read_records(filename)
+    def _read_all(self):
+        logger.debug("Reading %s", self.filename)
+        self.sections, self.form = read_records(self.filename)
         self.scanlines = self['TOTAL_MDR']
         if self.scanlines != len(self.sections[('mdr', 2)]):
             logger.warning("Number of declared records doesn't match number of scanlines in the file.")
@@ -278,7 +278,7 @@ class EPSAVHRRFile(BaseFileHandler):
     def get_bounding_box(self):
         """Get bounding box."""
         if self.sections is None:
-            self._read_all(self.filename)
+            self._read_all()
         lats = np.hstack([self["EARTH_LOCATION_FIRST"][0, [0]],
                           self["EARTH_LOCATION_LAST"][0, [0]],
                           self["EARTH_LOCATION_LAST"][-1, [0]],
@@ -292,7 +292,7 @@ class EPSAVHRRFile(BaseFileHandler):
     def get_dataset(self, key, info):
         """Get calibrated channel data."""
         if self.sections is None:
-            self._read_all(self.filename)
+            self._read_all()
 
         if key.name in ['longitude', 'latitude']:
             lons, lats = self.get_full_lonlats()

--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017 Satpy developers
+# Copyright (c) 2017-2020 Satpy developers
 #
 # This file is part of satpy.
 #

--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -32,7 +32,7 @@ from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.xmlformat import XMLFormat
 from satpy import CHUNK_SIZE
 
-LOG = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 C1 = 1.191062e-05  # mW/(m2*sr*cm-4)
 C2 = 1.4387863  # K/cm-1
@@ -53,7 +53,7 @@ record_class = ["Reserved", "mphr", "sphr",
                 "veadr", "viadr", "mdr"]
 
 
-def read_raw(filename):
+def read_records(filename):
     """Read *filename* without scaling it afterwards."""
     form = XMLFormat(os.path.join(CONFIG_PATH, "eps_avhrrl1b_6.5.xml"))
 
@@ -65,8 +65,13 @@ def read_raw(filename):
                           ("RECORD_START_TIME", "S6"),
                           ("RECORD_STOP_TIME", "S6")])
 
+    max_lines = np.floor((CHUNK_SIZE ** 2) / 2048)
+
     dtypes = []
     cnt = 0
+    counts = []
+    classes = []
+    prev = None
     with open(filename, "rb") as fdes:
         while True:
             grh = np.fromfile(fdes, grh_dtype, 1)
@@ -79,7 +84,7 @@ def read_raw(filename):
             bare_size = expected_size - grh_dtype.itemsize
             try:
                 the_type = form.dtype((rec_class, sub_class))
-                the_descr = grh_dtype.descr + the_type.descr
+                # the_descr = grh_dtype.descr + the_type.descr
             except KeyError:
                 the_type = np.dtype([('unknown', 'V%d' % bare_size)])
             the_descr = grh_dtype.descr + the_type.descr
@@ -88,13 +93,34 @@ def read_raw(filename):
                 padding = [('unknown%d' % cnt, 'V%d' % (expected_size - the_type.itemsize))]
                 cnt += 1
                 the_descr += padding
-            dtypes.append(np.dtype(the_descr))
+            new_dtype = np.dtype(the_descr)
+            key = (rec_class, sub_class)
+            if key == prev:
+                counts[-1] += 1
+            else:
+                dtypes.append(new_dtype)
+                counts.append(1)
+                classes.append(key)
+                prev = key
             fdes.seek(expected_size - grh_dtype.itemsize, 1)
 
-        file_dtype = np.dtype([(str(num), the_dtype) for num, the_dtype in enumerate(dtypes)])
-        records = np.memmap(fdes, mode='r', dtype=file_dtype, shape=1)[0]
+        sections = {}
+        offset = 0
+        for dtype, count, rec_class in zip(dtypes, counts, classes):
+            fdes.seek(offset)
+            if rec_class == ('mdr', 2):
+                record = da.from_array(np.memmap(fdes, mode='r', dtype=dtype, shape=count, offset=offset),
+                                       chunks=(max_lines,))
+            else:
+                record = np.fromfile(fdes, dtype=dtype, count=count)
+            offset += dtype.itemsize * count
+            if rec_class in sections:
+                logger.debug('Multiple records for ', str(rec_class))
+                sections[rec_class] = np.hstack((sections[rec_class], record))
+            else:
+                sections[rec_class] = record
 
-    return records, form
+    return sections, form
 
 
 def create_xarray(arr):
@@ -124,34 +150,17 @@ class EPSAVHRRFile(BaseFileHandler):
         self.three_a_mask, self.three_b_mask = None, None
         self._start_time = filename_info['start_time']
         self._end_time = filename_info['end_time']
-        self.records = None
         self.form = None
-        self.mdrs = None
         self.scanlines = None
         self.pixels = None
         self.sections = None
 
     def _read_all(self, filename):
-        LOG.debug("Reading %s", filename)
-        self.records, self.form = read_raw(filename)
-        self.mdrs = [record
-                     for record in self.records
-                     if record_class[record['record_class']] == "mdr"]
-        self.iprs = [record
-                     for record in self.records
-                     if record_class[record['record_class']] == "ipr"]
-        self.scanlines = len(self.mdrs)
-        self.sections = {("mdr", 2): np.hstack(self.mdrs)}
-        self.sections[("ipr", 0)] = np.hstack(self.iprs)
-        for record in self.records:
-            rec_class = record_class[record['record_class']]
-            sub_class = record["RECORD_SUBCLASS"]
-            if rec_class in ["mdr", "ipr"]:
-                continue
-            if (rec_class, sub_class) in self.sections:
-                raise ValueError("Too many " + str((rec_class, sub_class)))
-            else:
-                self.sections[(rec_class, sub_class)] = record
+        logger.debug("Reading %s", filename)
+        self.sections, self.form = read_records(filename)
+        self.scanlines = self['TOTAL_MDR']
+        if self.scanlines != len(self.sections[('mdr', 2)]):
+            logger.warning("Number of declared records doesn't match number of scanlines in the file.")
         self.pixels = self["EARTH_VIEWS_PER_SCANLINE"]
 
     def __getitem__(self, key):
@@ -159,12 +168,11 @@ class EPSAVHRRFile(BaseFileHandler):
         for altkey in self.form.scales.keys():
             try:
                 try:
-                    return (da.from_array(self.sections[altkey][key], chunks=CHUNK_SIZE)
-                            * self.form.scales[altkey][key])
+                    return self.sections[altkey][key] * self.form.scales[altkey][key]
                 except TypeError:
-                    val = self.sections[altkey][key].decode().split("=")[1]
+                    val = self.sections[altkey][key].item().decode().split("=")[1]
                     try:
-                        return float(val) * self.form.scales[altkey][key]
+                        return float(val) * self.form.scales[altkey][key].item()
                     except ValueError:
                         return val.strip()
             except (KeyError, ValueError):
@@ -179,32 +187,30 @@ class EPSAVHRRFile(BaseFileHandler):
         return keys
 
     @delayed(nout=2, pure=True)
-    def _get_full_lonlats(self):
-        lats = np.hstack((self["EARTH_LOCATION_FIRST"][:, [0]],
-                          self["EARTH_LOCATIONS"][:, :, 0],
-                          self["EARTH_LOCATION_LAST"][:, [0]]))
-
-        lons = np.hstack((self["EARTH_LOCATION_FIRST"][:, [1]],
-                          self["EARTH_LOCATIONS"][:, :, 1],
-                          self["EARTH_LOCATION_LAST"][:, [1]]))
-
+    def _get_full_lonlats(self, lons, lats):
         nav_sample_rate = self["NAV_SAMPLE_RATE"]
-        earth_views_per_scanline = self["EARTH_VIEWS_PER_SCANLINE"]
-        if nav_sample_rate == 20 and earth_views_per_scanline == 2048:
+        if nav_sample_rate == 20 and self.pixels == 2048:
             from geotiepoints import metop20kmto1km
             return metop20kmto1km(lons, lats)
         else:
             raise NotImplementedError("Lon/lat expansion not implemented for " +
                                       "sample rate = " + str(nav_sample_rate) +
                                       " and earth views = " +
-                                      str(earth_views_per_scanline))
+                                      str(self.pixels))
 
     def get_full_lonlats(self):
         """Get the interpolated lons/lats."""
         if self.lons is not None and self.lats is not None:
             return self.lons, self.lats
 
-        self.lons, self.lats = self._get_full_lonlats()
+        raw_lats = np.hstack((self["EARTH_LOCATION_FIRST"][:, [0]],
+                              self["EARTH_LOCATIONS"][:, :, 0],
+                              self["EARTH_LOCATION_LAST"][:, [0]]))
+
+        raw_lons = np.hstack((self["EARTH_LOCATION_FIRST"][:, [1]],
+                              self["EARTH_LOCATIONS"][:, :, 1],
+                              self["EARTH_LOCATION_LAST"][:, [1]]))
+        self.lons, self.lats = self._get_full_lonlats(raw_lons, raw_lats)
         self.lons = da.from_delayed(self.lons, dtype=self["EARTH_LOCATIONS"].dtype,
                                     shape=(self.scanlines, self.pixels))
         self.lats = da.from_delayed(self.lats, dtype=self["EARTH_LOCATIONS"].dtype,
@@ -212,25 +218,10 @@ class EPSAVHRRFile(BaseFileHandler):
         return self.lons, self.lats
 
     @delayed(nout=4, pure=True)
-    def _get_full_angles(self):
-        solar_zenith = np.hstack((self["ANGULAR_RELATIONS_FIRST"][:, [0]],
-                                  self["ANGULAR_RELATIONS"][:, :, 0],
-                                  self["ANGULAR_RELATIONS_LAST"][:, [0]]))
-
-        sat_zenith = np.hstack((self["ANGULAR_RELATIONS_FIRST"][:, [1]],
-                                self["ANGULAR_RELATIONS"][:, :, 1],
-                                self["ANGULAR_RELATIONS_LAST"][:, [1]]))
-
-        solar_azimuth = np.hstack((self["ANGULAR_RELATIONS_FIRST"][:, [2]],
-                                   self["ANGULAR_RELATIONS"][:, :, 2],
-                                   self["ANGULAR_RELATIONS_LAST"][:, [2]]))
-        sat_azimuth = np.hstack((self["ANGULAR_RELATIONS_FIRST"][:, [3]],
-                                 self["ANGULAR_RELATIONS"][:, :, 3],
-                                 self["ANGULAR_RELATIONS_LAST"][:, [3]]))
+    def _get_full_angles(self, solar_zenith, sat_zenith, solar_azimuth, sat_azimuth):
 
         nav_sample_rate = self["NAV_SAMPLE_RATE"]
-        earth_views_per_scanline = self["EARTH_VIEWS_PER_SCANLINE"]
-        if nav_sample_rate == 20 and earth_views_per_scanline == 2048:
+        if nav_sample_rate == 20 and self.pixels == 2048:
             from geotiepoints import metop20kmto1km
             # Note: interpolation asumes lat values values between -90 and 90
             # Solar and satellite zenith is between 0 and 180.
@@ -247,7 +238,7 @@ class EPSAVHRRFile(BaseFileHandler):
             raise NotImplementedError("Angles expansion not implemented for " +
                                       "sample rate = " + str(nav_sample_rate) +
                                       " and earth views = " +
-                                      str(earth_views_per_scanline))
+                                      str(self.pixels))
 
     def get_full_angles(self):
         """Get the interpolated lons/lats."""
@@ -255,7 +246,25 @@ class EPSAVHRRFile(BaseFileHandler):
                 self.sat_azi is not None and self.sat_zen is not None):
             return self.sun_azi, self.sun_zen, self.sat_azi, self.sat_zen
 
-        self.sun_azi, self.sun_zen, self.sat_azi, self.sat_zen = self._get_full_angles()
+        solar_zenith = np.hstack((self["ANGULAR_RELATIONS_FIRST"][:, [0]],
+                                  self["ANGULAR_RELATIONS"][:, :, 0],
+                                  self["ANGULAR_RELATIONS_LAST"][:, [0]]))
+
+        sat_zenith = np.hstack((self["ANGULAR_RELATIONS_FIRST"][:, [1]],
+                                self["ANGULAR_RELATIONS"][:, :, 1],
+                                self["ANGULAR_RELATIONS_LAST"][:, [1]]))
+
+        solar_azimuth = np.hstack((self["ANGULAR_RELATIONS_FIRST"][:, [2]],
+                                   self["ANGULAR_RELATIONS"][:, :, 2],
+                                   self["ANGULAR_RELATIONS_LAST"][:, [2]]))
+        sat_azimuth = np.hstack((self["ANGULAR_RELATIONS_FIRST"][:, [3]],
+                                 self["ANGULAR_RELATIONS"][:, :, 3],
+                                 self["ANGULAR_RELATIONS_LAST"][:, [3]]))
+
+        self.sun_azi, self.sun_zen, self.sat_azi, self.sat_zen = self._get_full_angles(solar_zenith,
+                                                                                       sat_zenith,
+                                                                                       solar_azimuth,
+                                                                                       sat_azimuth)
         self.sun_azi = da.from_delayed(self.sun_azi, dtype=self["ANGULAR_RELATIONS"].dtype,
                                        shape=(self.scanlines, self.pixels))
         self.sun_zen = da.from_delayed(self.sun_zen, dtype=self["ANGULAR_RELATIONS"].dtype,
@@ -268,7 +277,7 @@ class EPSAVHRRFile(BaseFileHandler):
 
     def get_bounding_box(self):
         """Get bounding box."""
-        if self.mdrs is None:
+        if self.sections is None:
             self._read_all(self.filename)
         lats = np.hstack([self["EARTH_LOCATION_FIRST"][0, [0]],
                           self["EARTH_LOCATION_LAST"][0, [0]],
@@ -282,7 +291,7 @@ class EPSAVHRRFile(BaseFileHandler):
 
     def get_dataset(self, key, info):
         """Get calibrated channel data."""
-        if self.mdrs is None:
+        if self.sections is None:
             self._read_all(self.filename)
 
         if key.name in ['longitude', 'latitude']:
@@ -319,7 +328,7 @@ class EPSAVHRRFile(BaseFileHandler):
                 self.three_b_mask = ((self["FRAME_INDICATOR"] & 2 ** 16) != 0)
 
             if key.name not in ["1", "2", "3a", "3A", "3b", "3B", "4", "5"]:
-                LOG.info("Can't load channel in eps_l1b: " + str(key.name))
+                logger.info("Can't load channel in eps_l1b: " + str(key.name))
                 return
 
             if key.name == "1":
@@ -416,19 +425,3 @@ class EPSAVHRRFile(BaseFileHandler):
         """Get end time."""
         # return datetime.strptime(self["SENSING_END"], "%Y%m%d%H%M%SZ")
         return self._end_time
-
-
-if __name__ == '__main__':
-    def norm255(a__):
-        """Normalize array to uint8."""
-        arr = a__ * 1.0
-        arr = (arr - arr.min()) * 255.0 / (arr.max() - arr.min())
-        return arr.astype(np.uint8)
-
-    def show(a__):
-        """Show array."""
-        from PIL import Image
-        Image.fromarray(norm255(a__), "L").show()
-
-    import sys
-    res = read_raw(sys.argv[1])

--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -75,7 +75,7 @@ def read_records(filename):
     with open(filename, "rb") as fdes:
         while True:
             grh = np.fromfile(fdes, grh_dtype, 1)
-            if not grh:
+            if grh.size == 0:
                 break
             rec_class = record_class[int(grh["record_class"])]
             sub_class = grh["RECORD_SUBCLASS"][0]

--- a/satpy/readers/xmlformat.py
+++ b/satpy/readers/xmlformat.py
@@ -66,7 +66,7 @@ def process_field(elt, ascii=False):
 def process_array(elt, ascii=False):
     """Process an 'array' tag."""
     del ascii
-    chld = elt.getchildren()
+    chld = list(elt)
     if len(chld) > 1:
         raise ValueError()
     chld = chld[0]
@@ -141,8 +141,7 @@ def parse_format(xml_file):
     """Parse the xml file to create types, scaling factor types, and scales."""
     tree = ElementTree()
     tree.parse(xml_file)
-
-    for param in tree.find("parameters").getchildren():
+    for param in tree.find("parameters"):
         VARIABLES[param.get("name")] = param.get("value")
 
     types_scales = {}

--- a/satpy/readers/xmlformat.py
+++ b/satpy/readers/xmlformat.py
@@ -15,8 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Reads a format from an xml file to create dtypes and scaling factor arrays.
-"""
+"""Reads a format from an xml file to create dtypes and scaling factor arrays."""
 
 from xml.etree.ElementTree import ElementTree
 
@@ -32,15 +31,12 @@ TYPEC = {"boolean": ">i1",
 
 
 def process_delimiter(elt, ascii=False):
-    """Process a 'delimiter' tag.
-    """
+    """Process a 'delimiter' tag."""
     del elt, ascii
 
 
 def process_field(elt, ascii=False):
-    """Process a 'field' tag.
-    """
-
+    """Process a 'field' tag."""
     # NOTE: if there is a variable defined in this field and it is different
     # from the default, we could change the value and restart.
 
@@ -68,8 +64,7 @@ def process_field(elt, ascii=False):
 
 
 def process_array(elt, ascii=False):
-    """Process an 'array' tag.
-    """
+    """Process an 'array' tag."""
     del ascii
     chld = elt.getchildren()
     if len(chld) > 1:
@@ -98,14 +93,12 @@ CASES = {"delimiter": process_delimiter,
 
 
 def to_dtype(val):
-    """Parse *val* to return a dtype.
-    """
+    """Parse *val* to return a dtype."""
     return np.dtype([i[:-1] for i in val])
 
 
 def to_scaled_dtype(val):
-    """Parse *val* to return a dtype.
-    """
+    """Parse *val* to return a dtype."""
     res = []
     for i in val:
         if i[1].startswith("S"):
@@ -120,8 +113,7 @@ def to_scaled_dtype(val):
 
 
 def to_scales(val):
-    """Parse *val* to return an array of scale factors.
-    """
+    """Parse *val* to return an array of scale factors."""
     res = []
     for i in val:
         if len(i) == 3:
@@ -146,8 +138,7 @@ def to_scales(val):
 
 
 def parse_format(xml_file):
-    """Parse the xml file to create types, scaling factor types, and scales.
-    """
+    """Parse the xml file to create types, scaling factor types, and scales."""
     tree = ElementTree()
     tree.parse(xml_file)
 
@@ -178,8 +169,7 @@ def parse_format(xml_file):
 
 
 def _apply_scales(array, scales, dtype):
-    """Apply scales to the array.
-    """
+    """Apply scales to the array."""
     new_array = np.empty(array.shape, dtype)
     for i in array.dtype.names:
         try:
@@ -193,10 +183,10 @@ def _apply_scales(array, scales, dtype):
 
 
 class XMLFormat(object):
-    """XMLFormat object.
-    """
+    """XMLFormat object."""
 
     def __init__(self, filename):
+        """Init the format reader."""
         self.types, self.stypes, self.scales = parse_format(filename)
 
         self.translator = {}
@@ -205,13 +195,11 @@ class XMLFormat(object):
             self.translator[val] = (self.scales[key], self.stypes[key])
 
     def dtype(self, key):
-        """Get the dtype for the format object.
-        """
+        """Get the dtype for the format object."""
         return self.types[key]
 
     def apply_scales(self, array):
-        """Apply scales to *array*.
-        """
+        """Apply scales to *array*."""
         return _apply_scales(array, *self.translator[array.dtype])
 
 

--- a/satpy/tests/reader_tests/__init__.py
+++ b/satpy/tests/reader_tests/__init__.py
@@ -42,7 +42,7 @@ from satpy.tests.reader_tests import (test_abi_l1b, test_agri_l1, test_hrit_base
                                       test_ami_l1b, test_viirs_compact, test_seviri_l2_bufr,
                                       test_geos_area, test_nwcsaf_msg, test_glm_l2,
                                       test_seviri_l1b_icare, test_mimic_TPW2_nc,
-                                      test_slstr_l2, test_aapp_l1b)
+                                      test_slstr_l2, test_aapp_l1b, test_eps_l1b)
 
 if sys.version_info < (2, 7):
     import unittest2 as unittest
@@ -109,5 +109,6 @@ def suite():
     mysuite.addTests(test_seviri_l1b_icare.suite())
     mysuite.addTests(test_slstr_l2.suite())
     mysuite.addTests(test_aapp_l1b.suite())
+    mysuite.addTests(test_eps_l1b.suite())
 
     return mysuite

--- a/satpy/tests/reader_tests/test_eps_l1b.py
+++ b/satpy/tests/reader_tests/test_eps_l1b.py
@@ -19,7 +19,7 @@
 """Test the eps l1b format."""
 
 import os
-from unittest import TestCase
+from unittest import TestCase, TestLoader, TestSuite
 from tempfile import NamedTemporaryFile
 from satpy import DatasetID
 
@@ -126,3 +126,12 @@ class TestEPSL1B(TestCase):
     def tearDown(self):
         """Tear down the tests."""
         os.remove(self.filename)
+
+
+def suite():
+    """Test suite for test_scene."""
+    loader = TestLoader()
+    mysuite = TestSuite()
+    mysuite.addTest(loader.loadTestsFromTestCase(TestEPSL1B))
+
+    return mysuite

--- a/satpy/tests/reader_tests/test_eps_l1b.py
+++ b/satpy/tests/reader_tests/test_eps_l1b.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2019 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Test the eps l1b format."""
+
+import os
+from unittest import TestCase
+from tempfile import NamedTemporaryFile
+from satpy import DatasetID
+
+from satpy.readers import eps_l1b as eps
+import numpy as np
+import xarray as xr
+
+grh_dtype = np.dtype([("record_class", "|i1"),
+                      ("INSTRUMENT_GROUP", "|i1"),
+                      ("RECORD_SUBCLASS", "|i1"),
+                      ("RECORD_SUBCLASS_VERSION", "|i1"),
+                      ("RECORD_SIZE", ">u4"),
+                      ("RECORD_START_TIME", "S6"),
+                      ("RECORD_STOP_TIME", "S6")])
+
+
+def create_sections(structure):
+    """Create file sections."""
+    sections = {}
+    form = eps.XMLFormat(os.path.join(eps.CONFIG_PATH, "eps_avhrrl1b_6.5.xml"))
+    for count, (rec_class, sub_class) in structure:
+        try:
+            the_dtype = form.dtype((rec_class, sub_class))
+        except KeyError:
+            continue
+        item_size = the_dtype.itemsize + grh_dtype.itemsize
+        the_dtype = np.dtype(grh_dtype.descr + the_dtype.descr)
+        item = np.zeros(count, the_dtype)
+        item['record_class'] = eps.record_class.index(rec_class)
+        item['RECORD_SUBCLASS'] = sub_class
+        item['RECORD_SIZE'] = item_size
+
+        sections[(rec_class, sub_class)] = item
+    return sections
+
+
+class TestEPSL1B(TestCase):
+    """Test the filehandler."""
+
+    def setUp(self):
+        """Set up the tests."""
+        # ipr is not present in the xml format ?
+        structure = [(1, ('mphr', 0)), (1, ('sphr', 0)), (11, ('ipr', 0)),
+                     (1, ('geadr', 1)), (1, ('geadr', 2)), (1, ('geadr', 3)),
+                     (1, ('geadr', 4)), (1, ('geadr', 5)), (1, ('geadr', 6)),
+                     (1, ('geadr', 7)), (1, ('giadr', 1)), (1, ('giadr', 2)),
+                     (1, ('veadr', 1)), (1080, ('mdr', 2))]
+
+        sections = create_sections(structure)
+        sections[('mphr', 0)]['TOTAL_MDR'] = b'TOTAL_MDR                     =   1080\n'
+        sections[('mphr', 0)]['SPACECRAFT_ID'] = b'SPACECRAFT_ID                 = M03\n'
+        sections[('mphr', 0)]['INSTRUMENT_ID'] = b'INSTRUMENT_ID                 = AVHR\n'
+        sections[('sphr', 0)]['EARTH_VIEWS_PER_SCANLINE'] = b'EARTH_VIEWS_PER_SCANLINE      =  2048\n'
+
+        with NamedTemporaryFile(delete=False) as fd:
+            self.filename = fd.name
+            for _, arr in sections.items():
+                arr.tofile(fd)
+        self.fh = eps.EPSAVHRRFile(self.filename, {'start_time': 'now',
+                                                   'end_time': 'later'}, {})
+
+    def test_read_all(self):
+        """Test initialization."""
+        self.fh._read_all()
+        assert(self.fh.scanlines == 1080)
+        assert(self.fh.pixels == 2048)
+
+    def test_dataset(self):
+        """Test getting a dataset."""
+        did = DatasetID('1', calibration='reflectance')
+        res = self.fh.get_dataset(did, {})
+        assert(isinstance(res, xr.DataArray))
+        assert(res.attrs['platform_name'] == 'Metop-C')
+        assert(res.attrs['sensor'] == 'avhrr-3')
+        assert(res.attrs['name'] == '1')
+        assert(res.attrs['calibration'] == 'reflectance')
+
+        did = DatasetID('4', calibration='brightness_temperature')
+        res = self.fh.get_dataset(did, {})
+        assert(isinstance(res, xr.DataArray))
+        assert(res.attrs['platform_name'] == 'Metop-C')
+        assert(res.attrs['sensor'] == 'avhrr-3')
+        assert(res.attrs['name'] == '4')
+        assert(res.attrs['calibration'] == 'brightness_temperature')
+
+    def test_navigation(self):
+        """Test the navigation."""
+        did = DatasetID('longitude')
+        res = self.fh.get_dataset(did, {})
+        assert(isinstance(res, xr.DataArray))
+        assert(res.attrs['platform_name'] == 'Metop-C')
+        assert(res.attrs['sensor'] == 'avhrr-3')
+        assert(res.attrs['name'] == 'longitude')
+
+    def test_angles(self):
+        """Test the navigation."""
+        did = DatasetID('solar_zenith_angle')
+        res = self.fh.get_dataset(did, {})
+        assert(isinstance(res, xr.DataArray))
+        assert(res.attrs['platform_name'] == 'Metop-C')
+        assert(res.attrs['sensor'] == 'avhrr-3')
+        assert(res.attrs['name'] == 'solar_zenith_angle')
+
+    def tearDown(self):
+        """Tear down the tests."""
+        os.remove(self.filename)


### PR DESCRIPTION
This PR fixes an infinite loop in the EPS l1b reader, due to a delayed functions creating dask arrays.

 - [x] Closes #1004, closes #924  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

