### PR TITLE
Adjust default blending in DayNightCompositor

### DIFF
--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -105,7 +105,7 @@ zone can be defined when initializing the compositor (default values
 shown in the example below).
 
     >>> from satpy.composites import DayNightCompositor
-    >>> compositor = DayNightCompositor("dnc", lim_low=85., lim_high=95.)
+    >>> compositor = DayNightCompositor("dnc", lim_low=85., lim_high=88.)
     >>> composite = compositor([local_scene['true_color'],
     ...                         local_scene['night_fog']])
 

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1007,7 +1007,7 @@ class PaletteCompositor(ColormapCompositor):
 class DayNightCompositor(GenericCompositor):
     """A compositor that blends a day data with night data."""
 
-    def __init__(self, name, lim_low=85., lim_high=95., **kwargs):
+    def __init__(self, name, lim_low=85., lim_high=88., **kwargs):
         """Collect custom configuration values.
 
         Args:

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -141,7 +141,6 @@ import dask
 import dask.array as da
 import zarr
 import six
-import warnings
 
 from pyresample.ewa import fornav, ll2cr
 from pyresample.geometry import SwathDefinition

--- a/satpy/tests/compositor_tests/__init__.py
+++ b/satpy/tests/compositor_tests/__init__.py
@@ -392,7 +392,7 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test')
         res = comp((self.data_a, self.data_b, self.sza))
         res = res.compute()
-        expected = np.array([[0., 0.2985455], [0.51680423, 1.]])
+        expected = np.array([[0., 0.22122352], [0.5, 1.]])
         np.testing.assert_allclose(res.values[0], expected)
 
     def test_basic_area(self):


### PR DESCRIPTION
This PR adjusts the default Sun zenith angle (SZA) interval where the overlapping day and night products are blended from `85.0 ... 95.0` to `85.0 ... 88.0`.

The default limit of SZA correction in Satpy is the same 88.0 degrees. If the upper limit is higher, there will be a dark band between the products.

The original version:

![natural_with_colorized_ir_clouds_old_20200210_082000](https://user-images.githubusercontent.com/3170788/74161873-624f7a00-4c28-11ea-8105-1c9f29055e80.png)

Proposed version:

![natural_with_colorized_ir_clouds_new_20200210_082000](https://user-images.githubusercontent.com/3170788/74161899-6b404b80-4c28-11ea-9f86-d1746ca1bcbe.png)

 - [x] Tests adjusted
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Documentation updated
