### PR TITLE
Add AHI airmass, ash, dust, fog, and night_microphysics RGBs

### DIFF
--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -28,6 +28,78 @@ composites:
       modifiers: [sunz_corrected]
     standard_name: toa_bidirectional_reflectance
 
+  airmass:
+    # PDF slides: https://www.eumetsat.int/website/home/News/ConferencesandEvents/DAT_2833302.html
+    # Under session 2 by Akihiro Shimizu (JMA)
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: B08
+          - name: B10
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: B12
+          - name: B14
+      - name: B08
+    standard_name: airmass
+
+  ash:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: B15
+          - name: B13
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: B14
+          - name: B11
+      - name: B13
+    standard_name: ash
+
+  dust:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: B15
+          - name: B13
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: B14
+          - name: B11
+      - name: B13
+    standard_name: dust
+
+  fog:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: B15
+          - name: B13
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: B14
+          - name: B11
+      - name: B13
+    standard_name: fog
+
+  night_microphysics:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: B15
+          - name: B13
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: B14
+          - name: B07
+      - name: B13
+    standard_name: night_microphysics
+
   fire_temperature:
     # CIRA: Original VIIRS
     compositor: !!python/name:satpy.composites.GenericCompositor

--- a/satpy/etc/enhancements/abi.yaml
+++ b/satpy/etc/enhancements/abi.yaml
@@ -20,3 +20,12 @@ enhancements:
       - name: gamma
         method: !!python/name:satpy.enhancements.gamma
         kwargs: {gamma: 1.5}
+  airmass:
+    standard_name: airmass
+    operations:
+      - name: stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs:
+          stretch: crude
+          min_stretch: [-26.2, -43.2, 243.9]
+          max_stretch: [0.6, 6.7, 208.5]

--- a/satpy/etc/enhancements/ahi.yaml
+++ b/satpy/etc/enhancements/ahi.yaml
@@ -1,0 +1,11 @@
+enhancements:
+  airmass:
+    # matches ABI
+    standard_name: airmass
+    operations:
+      - name: stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs:
+          stretch: crude
+          min_stretch: [-26.2, -43.2, 243.9]
+          max_stretch: [0.6, 6.7, 208.5]

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -143,16 +143,6 @@ enhancements:
         min_stretch: [-25, -40, 243]
         max_stretch: [0, 5, 208]
 
-  airmass_abi:
-    standard_name: airmass
-    sensor: abi
-    operations:
-    - name: stretch
-      method: *stretchfun
-      kwargs:
-        stretch: crude
-        min_stretch: [-26.2, -43.2, 243.9]
-        max_stretch: [0.6, 6.7, 208.5]
   green_snow_default:
     standard_name: green_snow
     operations:


### PR DESCRIPTION
The RGBs added in this pull request are common EUMETSAT recipes that are available for most other sensors. However, AHI doesn't have a 10.8um or a 12.0um channel (or channels whose ranges cover those wavelengths). This is my attempt at trying to balance all the information available for what the _best_ AHI RGB recipes are. I've mostly taken this from various slides by JMA found by googling, from opinions by @ScottLindstrom at the SSEC which agreed with the JMA slides, and from existing ABI recipes. See https://github.com/ssec/polar2grid/issues/258 for more discussion on this and why I'm doing it (to add them to CSPP Geo Geo2Grid).

The worst thing is I can't find a definitive guide for AHI recipes. The slides from conferences that I've found (2016 and 2017) are completely different from the training materials (2015?) which are also different from ABI recipes out there.

Note: None of these recipes were loadable for AHI data before this PR so this shouldn't be changing any existing functionality for users.

 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

# Examples

## Airmass

![airmass_20181022_030019](https://user-images.githubusercontent.com/1828519/74178839-e2aeb480-4c01-11ea-9398-25667cb7fcec.png)

## Ash

![ash_20181022_030019](https://user-images.githubusercontent.com/1828519/74178841-e3474b00-4c01-11ea-93b5-3a991d9bd21f.png)

## Dust

![dust_20181022_030019](https://user-images.githubusercontent.com/1828519/74178842-e3474b00-4c01-11ea-9008-77ba6371d96c.png)

## Fog

![fog_20181022_030019](https://user-images.githubusercontent.com/1828519/74178844-e3474b00-4c01-11ea-8db7-308e770b4f9e.png)

## Night Microphysics

![night_microphysics_20181022_030019](https://user-images.githubusercontent.com/1828519/74178845-e3dfe180-4c01-11ea-80b1-d70e93068acc.png)

