### PR TITLE
Rename natural_color_sun to natural_color in generic VIS/IR RGB recipes

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -203,7 +203,7 @@ To get a list of all available composites for the current scene:
      'green_snow',
      'dust',
      'fog',
-     'natural_color_sun',
+     'natural_color_raw',
      'cloudtop',
      'convection',
      'ash']

--- a/satpy/etc/composites/mersi-2.yaml
+++ b/satpy/etc/composites/mersi-2.yaml
@@ -87,7 +87,15 @@ composites:
         modifiers: [sunz_corrected]
     standard_name: natural_color
 
-  overview_sun:
+  overview_raw:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: '12'
+      - name: '15'
+      - name: '24'
+    standard_name: overview
+
+  overview:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
       - name: '12'

--- a/satpy/etc/composites/msi.yaml
+++ b/satpy/etc/composites/msi.yaml
@@ -70,7 +70,7 @@ modifiers:
 
 
 composites:
-  natural_color_sun:
+  natural_color:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - name: 'B11'

--- a/satpy/etc/composites/msu-gs.yaml
+++ b/satpy/etc/composites/msu-gs.yaml
@@ -1,14 +1,14 @@
 sensor_name: visir/msu-gs
 
 composites:
-  overview:
+  overview_raw:
     compositor: !!python/name:satpy.composites.RGBCompositor
     prerequisites:
     - 00_9
     - 00_9
     - 10.8
     standard_name: overview
-  overview_sun:
+  overview:
     compositor: !!python/name:satpy.composites.RGBCompositor
     prerequisites:
     - name: 00_9

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -125,7 +125,7 @@ composites:
     - IR_108
     standard_name: day_microphysics_winter
 
-  natural_color:
+  natural_color_raw:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - IR_016
@@ -133,7 +133,7 @@ composites:
     - VIS006
     standard_name: natural_color
 
-  natural_color_sun:
+  natural_color:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - name: IR_016
@@ -325,14 +325,14 @@ composites:
     - IR_120
     standard_name: ir_overview
 
-  overview:
+  overview_raw:
     compositor: !!python/name:satpy.composites.RGBCompositor
     prerequisites:
     - VIS006
     - VIS008
     - IR_108
     standard_name: overview
-  overview_sun:
+  overview:
     compositor: !!python/name:satpy.composites.RGBCompositor
     prerequisites:
     - name: VIS006
@@ -388,7 +388,7 @@ composites:
     compositor: !!python/name:satpy.composites.DayNightCompositor
     standard_name: natural_with_night_fog
     prerequisites:
-      - natural_color_sun
+      - natural_color
       - night_fog
 
   natural_color_with_night_ir:

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -235,7 +235,7 @@ composites:
     - 10.8
     standard_name: night_fog
 
-  overview:
+  overview_raw:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - 0.6
@@ -243,7 +243,7 @@ composites:
     - 10.8
     standard_name: overview
 
-  overview_sun:
+  overview:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - wavelength: 0.6

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -202,7 +202,7 @@ composites:
     - 10.8
     standard_name: green_snow
 
-  natural_color:
+  natural_color_raw:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - 1.63
@@ -210,7 +210,7 @@ composites:
     - 0.635
     standard_name: natural_color
 
-  natural_color_sun:
+  natural_color:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - wavelength: 1.63


### PR DESCRIPTION
Related to #936. For most sensors "natural_color" means the SZA corrected one. The default in VIS/IR does not follow this. There are other sensors where this may be true but this PR specifically addresses the visir.yaml default composite configuration.

 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
