### PR TITLE
Add GOES-17 support to the 'geocat' reader

### DIFF
--- a/satpy/etc/readers/geocat.yaml
+++ b/satpy/etc/readers/geocat.yaml
@@ -8,14 +8,15 @@ file_types:
   level2:
     file_reader: !!python/name:satpy.readers.geocat.GEOCATFileHandler
     file_patterns:
+     # GOES-16 ABI files (must be first to capture things correctly):
+     - 'geocatL{processing_level:1d}.{platform_shortname}.{sector_id}.{start_time:%Y%j.%H%M%S}.hdf'
+     - 'geocatL{processing_level:1d}.{platform_shortname}.{sector_id}.{start_time:%Y%j.%H%M%S}.nc'
+     # Generic file pattern
      - 'geocatL{processing_level:1d}.{platform_shortname}.{start_time:%Y%j.%H%M%S}.hdf'
      - 'geocatL{processing_level:1d}.{platform_shortname}.{start_time:%Y%j.%H%M%S}.nc'
      # Himawari 8 files:
      - 'geocatL2.{platform_shortname}.{start_time:%Y%j.%H%M%S}.{sector_id}.{res_id}.hdf'
      - 'geocatL2.{platform_shortname}.{start_time:%Y%j.%H%M%S}.{sector_id}.{res_id}.nc'
-     # GOES-16 ABI files:
-     - 'geocatL{processing_level:1d}.{platform_shortname}.{sector_id}.{start_time:%Y%j.%H%M%S}.hdf'
-     - 'geocatL{processing_level:1d}.{platform_shortname}.{sector_id}.{start_time:%Y%j.%H%M%S}.nc'
   ahi_level1:
     file_reader: !!python/name:satpy.readers.geocat.GEOCATFileHandler
     file_patterns:

--- a/satpy/readers/geocat.py
+++ b/satpy/readers/geocat.py
@@ -47,6 +47,7 @@ CF_UNITS = {
 # GEOCAT currently doesn't include projection information in it's files
 GEO_PROJS = {
     'GOES-16': '+proj=geos +lon_0={lon_0:0.02f} +h=35786023.0 +a=6378137.0 +b=6356752.31414 +sweep=x +units=m +no_defs',
+    'GOES-17': '+proj=geos +lon_0={lon_0:0.02f} +h=35786023.0 +a=6378137.0 +b=6356752.31414 +sweep=x +units=m +no_defs',
     'HIMAWARI-8': '+proj=geos +over +lon_0=140.7 +h=35785863 +a=6378137 +b=6356752.299581327 +units=m +no_defs',
 }
 

--- a/satpy/tests/reader_tests/test_geocat.py
+++ b/satpy/tests/reader_tests/test_geocat.py
@@ -15,24 +15,15 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Module for testing the satpy.readers.geocat module.
-"""
+"""Module for testing the satpy.readers.geocat module."""
 
 import os
-import sys
 import numpy as np
 from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
 from satpy.tests.utils import convert_file_content_to_data_array
 
-if sys.version_info < (2, 7):
-    import unittest2 as unittest
-else:
-    import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+import unittest
+from unittest import mock
 
 DEFAULT_FILE_DTYPE = np.uint16
 DEFAULT_FILE_SHAPE = (10, 300)
@@ -46,9 +37,10 @@ DEFAULT_LON_DATA = np.repeat([DEFAULT_LON_DATA], DEFAULT_FILE_SHAPE[0], axis=0)
 
 
 class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
-    """Swap-in NetCDF4 File Handler"""
+    """Swap-in NetCDF4 File Handler."""
+
     def get_test_content(self, filename, filename_info, filetype_info):
-        """Mimic reader input file content"""
+        """Mimic reader input file content."""
         file_content = {
             '/attr/Platform_Name': filename_info['platform_shortname'],
             '/attr/Element_Resolution': 2.,
@@ -67,7 +59,8 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         }
         sensor = {
             'HIMAWARI-8': 'himawari8',
-            'GOES-16': 'goes16',
+            'GOES-17': 'goesr',
+            'GOES-16': 'goesr',
             'GOES-13': 'goes',
             'GOES-14': 'goes',
             'GOES-15': 'goes',
@@ -111,11 +104,12 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
 
 
 class TestGEOCATReader(unittest.TestCase):
-    """Test GEOCAT Reader"""
+    """Test GEOCAT Reader."""
+
     yaml_file = "geocat.yaml"
 
     def setUp(self):
-        """Wrap NetCDF4 file handler with our own fake handler"""
+        """Wrap NetCDF4 file handler with our own fake handler."""
         from satpy.config import config_search_paths
         from satpy.readers.geocat import GEOCATFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
@@ -125,7 +119,7 @@ class TestGEOCATReader(unittest.TestCase):
         self.p.is_local = True
 
     def tearDown(self):
-        """Stop wrapping the NetCDF4 file handler"""
+        """Stop wrapping the NetCDF4 file handler."""
         self.p.stop()
 
     def test_init(self):
@@ -141,7 +135,7 @@ class TestGEOCATReader(unittest.TestCase):
         self.assertTrue(r.file_handlers)
 
     def test_load_all_old_goes(self):
-        """Test loading all test datasets"""
+        """Test loading all test datasets from old GOES files."""
         from satpy.readers import load_reader
         import xarray as xr
         r = load_reader(self.reader_configs)
@@ -160,8 +154,9 @@ class TestGEOCATReader(unittest.TestCase):
         self.assertIsNotNone(datasets['variable3'].attrs.get('flag_meanings'))
 
     def test_load_all_himawari8(self):
-        """Test loading all test datasets"""
+        """Test loading all test datasets from H8 NetCDF file."""
         from satpy.readers import load_reader
+        from pyresample.geometry import AreaDefinition
         import xarray as xr
         r = load_reader(self.reader_configs)
         with mock.patch('satpy.readers.geocat.netCDF4.Variable', xr.DataArray):
@@ -169,7 +164,6 @@ class TestGEOCATReader(unittest.TestCase):
                 'geocatL2.HIMAWARI-8.2017092.210730.R304.R20.nc',
             ])
             r.create_filehandlers(loadables)
-        # with mock.patch('satpy.readers.geocat.GEOCATFileHandler._load_nav', lambda self, x: self[x]):
         datasets = r.load(['variable1',
                            'variable2',
                            'variable3'])
@@ -178,10 +172,32 @@ class TestGEOCATReader(unittest.TestCase):
             self.assertIs(v.attrs['calibration'], None)
             self.assertEqual(v.attrs['units'], '1')
         self.assertIsNotNone(datasets['variable3'].attrs.get('flag_meanings'))
+        self.assertIsInstance(datasets['variable1'].attrs['area'], AreaDefinition)
+
+    def test_load_all_goes17_hdf4(self):
+        """Test loading all test datasets from GOES-17 HDF4 file."""
+        from satpy.readers import load_reader
+        from pyresample.geometry import AreaDefinition
+        import xarray as xr
+        r = load_reader(self.reader_configs)
+        with mock.patch('satpy.readers.geocat.netCDF4.Variable', xr.DataArray):
+            loadables = r.select_files_from_pathnames([
+                'geocatL2.GOES-17.CONUS.2020041.163130.hdf',
+            ])
+            r.create_filehandlers(loadables)
+        datasets = r.load(['variable1',
+                           'variable2',
+                           'variable3'])
+        self.assertEqual(len(datasets), 3)
+        for v in datasets.values():
+            self.assertIs(v.attrs['calibration'], None)
+            self.assertEqual(v.attrs['units'], '1')
+        self.assertIsNotNone(datasets['variable3'].attrs.get('flag_meanings'))
+        self.assertIsInstance(datasets['variable1'].attrs['area'], AreaDefinition)
 
 
 def suite():
-    """The test suite for test_viirs_l1b."""
+    """Create test suite for test_geocat."""
     loader = unittest.TestLoader()
     mysuite = unittest.TestSuite()
     mysuite.addTest(loader.loadTestsFromTestCase(TestGEOCATReader))


### PR DESCRIPTION
The 'geocat' group at the SSEC is now working on producing files operationally with GOES-17 data. I had hacked something together for GOES-16, but forgot to include GOES-17. This extends the hack to support GOES-17 until geocat adds projection information to their files (possibly in the future?).

 - [x] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
