### PR TITLE
Fix the omerc-bb area to use a sphere as ellps

### DIFF
--- a/satpy/etc/areas.yaml
+++ b/satpy/etc/areas.yaml
@@ -1,7 +1,8 @@
 omerc_bb:
   description: Oblique Mercator Bounding Box for Polar Overpasses
   projection:
-    ellps: WGS84
+    # The omerc projection does not work well with non-spherical ellipsoids.
+    ellps: sphere
     proj: omerc
   optimize_projection: True
 


### PR DESCRIPTION
This fixes problems at the poles with folding of the omerc-based areas.
See https://github.com/OSGeo/PROJ/issues/1922 for more details.

 - [x] Helps with #1002 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests passed <!-- for all non-documentation changes -->
