### PR TITLE
Tropomi l2 reader to handle more types of products

### DIFF
--- a/satpy/etc/readers/tropomi_l2.yaml
+++ b/satpy/etc/readers/tropomi_l2.yaml
@@ -9,7 +9,7 @@ file_types:
         # Ex: S5P_OFFL_L2__NO2____20180709T170334_20180709T184504_03821_01_010002_20180715T184729.nc
         file_reader: !!python/name:satpy.readers.tropomi_l2.TROPOMIL2FileHandler
         file_patterns:
-            - '{platform_shortname:3s}_{data_type:4s}_{level:3s}_{product:3s}____{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{orbit:5d}_{collection:2d}_{processor_version:6d}_{creation_time:%Y%m%dT%H%M%S}.nc'
+            - '{platform_shortname:3s}_{data_type:4s}_{level:3s}_{product:_<6s}_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{orbit:5d}_{collection:2d}_{processor_version:6d}_{creation_time:%Y%m%dT%H%M%S}.nc'
 
 datasets:
     latitude:


### PR DESCRIPTION
A limitation in the tropomi l2 reader filename matching is removed.

 - [X] Closes #1077  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests passed <!-- for all non-documentation changes -->
