### PR TITLE
MITFF writer Prerequisites is not necessarily in order.

### DIFF
--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -695,7 +695,16 @@ class MITIFFWriter(ImageWriter):
                             # Note the last index is a tuple index.
                             cn = cns.get(chn.attrs['prerequisites'][_cn_i][0],
                                          chn.attrs['prerequisites'][_cn_i][0])
-                            data = self._calibrate_data(chn, chn.attrs['prerequisites'][_cn_i][4],
+                            pre_index = _cn_i
+                            if isinstance(chn.attrs['prerequisites'], list):
+                                # if prerequisites is a list, prerequisites is not necessarily in order.
+                                # Need to loop over the prerequisites to find the correct one.
+                                for pre_i, pre in enumerate(chn.attrs['prerequisites']):
+                                    if pre[0] == _cn:
+                                        cn = cns.get(pre[0])
+                                        pre_index = pre_i
+                                        break
+                            data = self._calibrate_data(chn, chn.attrs['prerequisites'][pre_index][4],
                                                         self.mitiff_config[kwargs['sensor']][cn]['min-val'],
                                                         self.mitiff_config[kwargs['sensor']][cn]['max-val'])
 


### PR DESCRIPTION
For the MITFF writer prerequisties is not necessarily in order.

Need to find the correct prerequisites dataset.

 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
