### PR TITLE
Update SLSTR composites

### DIFF
--- a/satpy/etc/composites/slstr.yaml
+++ b/satpy/etc/composites/slstr.yaml
@@ -9,6 +9,30 @@ composites:
     - S8_in
     standard_name: overview
 
+  overview_oblique:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - S2_ao
+    - S3_ao
+    - S8_io
+    standard_name: overview_oblique
+
+  natural_color:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - S5_an
+    - S3_an
+    - S2_an
+    standard_name: natural_color
+
+  natural_color_oblique:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - S5_ao
+    - S3_ao
+    - S2_ao
+    standard_name: natural_color_oblique
+
   day_microphysics:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
@@ -17,3 +41,12 @@ composites:
       modifiers: [nir_reflectance]
     - S8_in
     standard_name: day_microphysics
+
+  day_microphysics_oblique:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - S3_ao
+    - name: S7_io
+      modifiers: [nir_reflectance]
+    - S8_io
+    standard_name: day_microphysics_oblique

--- a/satpy/etc/composites/slstr.yaml
+++ b/satpy/etc/composites/slstr.yaml
@@ -1,42 +1,54 @@
 sensor_name: visir/slstr
 
 composites:
+
   overview:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-    - S2_an
-    - S3_an
+    - name: S2_an
+      modifiers: [sunz_corrected]
+    - name: S3_an
+      modifiers: [sunz_corrected]
     - S8_in
     standard_name: overview
 
   overview_oblique:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-    - S2_ao
-    - S3_ao
+    - name: S2_ao
+      modifiers: [sunz_corrected]
+    - name: S3_ao
+      modifiers: [sunz_corrected]
     - S8_io
     standard_name: overview_oblique
 
   natural_color:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-    - S5_an
-    - S3_an
-    - S2_an
+    - name: S5_an
+      modifiers: [sunz_corrected]
+    - name: S3_an
+      modifiers: [sunz_corrected]
+    - name: S2_an
+      modifiers: [sunz_corrected]
     standard_name: natural_color
 
   natural_color_oblique:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-    - S5_ao
-    - S3_ao
-    - S2_ao
+    - name: S5_ao
+      modifiers: [sunz_corrected]
+    - name: S3_ao
+      modifiers: [sunz_corrected]
+    - name: S2_ao
+      modifiers: [sunz_corrected]
     standard_name: natural_color_oblique
 
   day_microphysics:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-    - S3_an
+    - name: S3_an
+      modifiers: [sunz_corrected]
     - name: S7_in
       modifiers: [nir_reflectance]
     - S8_in
@@ -45,7 +57,8 @@ composites:
   day_microphysics_oblique:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-    - S3_ao
+    - name: S3_ao
+      modifiers: [sunz_corrected]
     - name: S7_io
       modifiers: [nir_reflectance]
     - S8_io

--- a/satpy/etc/readers/slstr_l1b.yaml
+++ b/satpy/etc/readers/slstr_l1b.yaml
@@ -712,41 +712,85 @@ datasets:
     file_type: esa_l1b_otir
 
 
-  solar_zenith_angle:
-    name: solar_zenith_angle
+  solar_zenith_angle_n:
+    name: solar_zenith_angle_n
     sensor: slstr
     resolution: 1000
-    coordinates: [longitude, latitude]
+    coordinates: [longitude_in, latitude_in]
+    view: nadir
     standard_name: solar_zenith_angle
     file_type: esa_angles
     file_key: solar_zenith_tn
 
-  solar_azimuth_angle:
-    name: solar_azimuth_angle
+  solar_azimuth_angle_n:
+    name: solar_azimuth_angle_n
     sensor: slstr
     resolution: 1000
-    coordinates: [longitude, latitude]
+    coordinates: [longitude_in, latitude_in]
+    view: nadir
     standard_name: solar_azimuth_angle
     file_type: esa_angles
     file_key: solar_azimuth_tn
 
-  satellite_zenith_angle:
-    name: satellite_zenith_angle
+  satellite_zenith_angle_n:
+    name: satellite_zenith_angle_n
     sensor: slstr
     resolution: 1000
-    coordinates: [longitude, latitude]
+    coordinates: [longitude_in, latitude_in]
+    view: nadir
     standard_name: satellite_zenith_angle
     file_type: esa_angles
     file_key: sat_zenith_tn
 
-  satellite_azimuth_angle:
-    name: satellite_azimuth_angle
+  satellite_azimuth_angle_n:
+    name: satellite_azimuth_angle_n
     sensor: slstr
     resolution: 1000
-    coordinates: [longitude, latitude]
+    coordinates: [longitude_in, latitude_in]
+    view: nadir
     standard_name: satellite_azimuth_angle
     file_type: esa_angles
     file_key: sat_azimuth_tn
+
+  solar_zenith_angle_o:
+    name: solar_zenith_angle_o
+    sensor: slstr
+    resolution: 1000
+    coordinates: [longitude_io, latitude_io]
+    view: oblique
+    standard_name: solar_zenith_angle
+    file_type: esa_angles
+    file_key: solar_zenith_to
+
+  solar_azimuth_angle_o:
+    name: solar_azimuth_angle_o
+    sensor: slstr
+    resolution: 1000
+    coordinates: [longitude_io, latitude_io]
+    view: oblique
+    standard_name: solar_azimuth_angle
+    file_type: esa_angles
+    file_key: solar_azimuth_to
+
+  satellite_zenith_angle_o:
+    name: satellite_zenith_angle
+    sensor: slstr
+    resolution: 1000
+    coordinates: [longitude_io, latitude_io]
+    view: oblique
+    standard_name: satellite_zenith_angle
+    file_type: esa_angles
+    file_key: sat_zenith_to
+
+  satellite_azimuth_angle_o:
+    name: satellite_azimuth_angle_o
+    sensor: slstr
+    resolution: 1000
+    coordinates: [longitude_io, latitude_io]
+    view: oblique
+    standard_name: satellite_azimuth_angle
+    file_type: esa_angles
+    file_key: sat_azimuth_to
 
 # CloudFlags are all bitfields. They are available in nadir (default) and oblique view for
 # each of the a,b,c,i stripes.

--- a/satpy/etc/readers/slstr_l1b.yaml
+++ b/satpy/etc/readers/slstr_l1b.yaml
@@ -773,7 +773,7 @@ datasets:
     file_key: solar_azimuth_to
 
   satellite_zenith_angle_o:
-    name: satellite_zenith_angle
+    name: satellite_zenith_angle_o
     sensor: slstr
     resolution: 1000
     coordinates: [longitude_io, latitude_io]

--- a/satpy/readers/slstr_l1b.py
+++ b/satpy/readers/slstr_l1b.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2016 Satpy developers
+# Copyright (c) 2016-2020 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -15,8 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Compact viirs format.
-"""
+"""SLSTR L1b reader."""
 
 import logging
 import os
@@ -38,8 +37,10 @@ PLATFORM_NAMES = {'S3A': 'Sentinel-3A',
 
 
 class NCSLSTRGeo(BaseFileHandler):
+    """Filehandler for geo info."""
 
     def __init__(self, filename, filename_info, filetype_info):
+        """Initialize the geo filehandler."""
         super(NCSLSTRGeo, self).__init__(filename, filename_info,
                                          filetype_info)
         self.nc = xr.open_dataset(self.filename,
@@ -52,9 +53,7 @@ class NCSLSTRGeo(BaseFileHandler):
         self.cache = {}
 
     def get_dataset(self, key, info):
-        """Load a dataset
-        """
-
+        """Load a dataset."""
         logger.debug('Reading %s.', key.name)
 
         try:
@@ -69,16 +68,20 @@ class NCSLSTRGeo(BaseFileHandler):
 
     @property
     def start_time(self):
+        """Get the start time."""
         return datetime.strptime(self.nc.attrs['start_time'], '%Y-%m-%dT%H:%M:%S.%fZ')
 
     @property
     def end_time(self):
+        """Get the end time."""
         return datetime.strptime(self.nc.attrs['stop_time'], '%Y-%m-%dT%H:%M:%S.%fZ')
 
 
 class NCSLSTR1B(BaseFileHandler):
+    """Filehandler for l1 SLSTR data."""
 
     def __init__(self, filename, filename_info, filetype_info):
+        """Initialize the SLSTR l1 data filehandler."""
         super(NCSLSTR1B, self).__init__(filename, filename_info,
                                         filetype_info)
 
@@ -110,13 +113,13 @@ class NCSLSTR1B(BaseFileHandler):
 
     @staticmethod
     def _cal_rad(rad, didx, solar_flux=None):
+        """Calibrate."""
         indices = np.isfinite(didx)
         rad[indices] /= solar_flux[didx[indices].astype(int)]
         return rad
 
     def get_dataset(self, key, info):
         """Load a dataset."""
-
         if self.channel not in key.name:
             return
 
@@ -153,17 +156,20 @@ class NCSLSTR1B(BaseFileHandler):
 
     @property
     def start_time(self):
+        """Get the start time."""
         return datetime.strptime(self.nc.attrs['start_time'], '%Y-%m-%dT%H:%M:%S.%fZ')
 
     @property
     def end_time(self):
+        """Get the end time."""
         return datetime.strptime(self.nc.attrs['stop_time'], '%Y-%m-%dT%H:%M:%S.%fZ')
 
 
 class NCSLSTRAngles(BaseFileHandler):
+    """Filehandler for angles."""
 
     def __init__(self, filename, filename_info, filetype_info):
-
+        """Initialize the angles reader."""
         super(NCSLSTRAngles, self).__init__(filename, filename_info,
                                             filetype_info)
 
@@ -197,15 +203,14 @@ class NCSLSTRAngles(BaseFileHandler):
                                              'rows': CHUNK_SIZE})
 
     def get_dataset(self, key, info):
-        """Load a dataset
-        """
+        """Load a dataset."""
+        if not info['view'].startswith(self.view):
+            return
         logger.debug('Reading %s.', key.name)
-
         # Check if file_key is specified in the yaml
         file_key = info.get('file_key', key.name)
 
         variable = self.nc[file_key]
-
         l_step = self.nc.attrs.get('al_subsampling_factor', 1)
         c_step = self.nc.attrs.get('ac_subsampling_factor', 16)
 
@@ -225,16 +230,7 @@ class NCSLSTRAngles(BaseFileHandler):
             spl = RectBivariateSpline(
                 tie_y, tie_x, variable.data[:, ::-1])
 
-            valid = np.isfinite(full_y)
-
-            interpolated = spl.ev(full_y[valid],
-                                  full_x[valid])
-
-            values = np.full_like(full_y, np.nan,
-                                  dtype=variable.dtype)
-
-            values[valid] = interpolated
-            values = np.ma.masked_invalid(values, copy=False)
+            values = spl.ev(full_y, full_x)
 
             variable = xr.DataArray(da.from_array(values, chunks=(CHUNK_SIZE, CHUNK_SIZE)),
                                     dims=['y', 'x'], attrs=variable.attrs)
@@ -251,16 +247,20 @@ class NCSLSTRAngles(BaseFileHandler):
 
     @property
     def start_time(self):
+        """Get the start time."""
         return datetime.strptime(self.nc.attrs['start_time'], '%Y-%m-%dT%H:%M:%S.%fZ')
 
     @property
     def end_time(self):
+        """Get the end time."""
         return datetime.strptime(self.nc.attrs['stop_time'], '%Y-%m-%dT%H:%M:%S.%fZ')
 
 
 class NCSLSTRFlag(BaseFileHandler):
+    """File handler for flags."""
 
     def __init__(self, filename, filename_info, filetype_info):
+        """Initialize the flag reader."""
         super(NCSLSTRFlag, self).__init__(filename, filename_info,
                                           filetype_info)
         self.nc = xr.open_dataset(self.filename,
@@ -291,8 +291,10 @@ class NCSLSTRFlag(BaseFileHandler):
 
     @property
     def start_time(self):
+        """Get the start time."""
         return datetime.strptime(self.nc.attrs['start_time'], '%Y-%m-%dT%H:%M:%S.%fZ')
 
     @property
     def end_time(self):
+        """Get the end time."""
         return datetime.strptime(self.nc.attrs['stop_time'], '%Y-%m-%dT%H:%M:%S.%fZ')


### PR DESCRIPTION
This PR adds:
1) A new `natural_color` composite for SLSTR that uses the 0.6, 0.8 and 1.6 micron bands.
2) Composites for the oblique view. `natural_color` and `overview`. Previously, `overview` was for nadir only.

This only changes the `yaml` file, no changes to the python code are needed.
