### PR TITLE
Fix ninjotiff writer tests failing when pyninjotiff is installed

### DIFF
--- a/satpy/tests/writer_tests/test_ninjotiff.py
+++ b/satpy/tests/writer_tests/test_ninjotiff.py
@@ -36,10 +36,6 @@ class FakeImage:
         return xr.DataArray(1), xr.DataArray(0)
 
 
-modules = {'pyninjotiff': mock.Mock(),
-           'pyninjotiff.ninjotiff': mock.Mock()}
-
-
 class TestNinjoTIFFWriter(unittest.TestCase):
     """The ninjo tiff writer tests."""
 

--- a/satpy/tests/writer_tests/test_ninjotiff.py
+++ b/satpy/tests/writer_tests/test_ninjotiff.py
@@ -17,7 +17,6 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for the NinJoTIFF writer."""
 
-import sys
 import unittest
 from unittest import mock
 
@@ -41,11 +40,11 @@ modules = {'pyninjotiff': mock.Mock(),
            'pyninjotiff.ninjotiff': mock.Mock()}
 
 
-@mock.patch.dict(sys.modules, modules)
 class TestNinjoTIFFWriter(unittest.TestCase):
     """The ninjo tiff writer tests."""
 
-    def test_init(self):
+    @mock.patch('satpy.writers.ninjotiff.nt')
+    def test_init(self, nt):
         """Test the init."""
         from satpy.writers.ninjotiff import NinjoTIFFWriter
         ninjo_tags = {40000: 'NINJO'}
@@ -54,7 +53,8 @@ class TestNinjoTIFFWriter(unittest.TestCase):
 
     @mock.patch('satpy.writers.ninjotiff.ImageWriter.save_dataset')
     @mock.patch('satpy.writers.ninjotiff.convert_units')
-    def test_dataset(self, uconv, iwsd):
+    @mock.patch('satpy.writers.ninjotiff.nt')
+    def test_dataset(self, nt, uconv, iwsd):
         """Test saving a dataset."""
         from satpy.writers.ninjotiff import NinjoTIFFWriter
         ntw = NinjoTIFFWriter()
@@ -65,9 +65,9 @@ class TestNinjoTIFFWriter(unittest.TestCase):
 
     @mock.patch('satpy.writers.ninjotiff.NinjoTIFFWriter.save_dataset')
     @mock.patch('satpy.writers.ninjotiff.ImageWriter.save_image')
-    def test_image(self, iwsi, save_dataset):
+    @mock.patch('satpy.writers.ninjotiff.nt')
+    def test_image(self, nt, iwsi, save_dataset):
         """Test saving an image."""
-        import pyninjotiff.ninjotiff as nt
         from satpy.writers.ninjotiff import NinjoTIFFWriter
         ntw = NinjoTIFFWriter()
         dataset = xr.DataArray([1, 2, 3], attrs={'units': 'K'})

--- a/satpy/tests/writer_tests/test_ninjotiff.py
+++ b/satpy/tests/writer_tests/test_ninjotiff.py
@@ -17,6 +17,7 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for the NinJoTIFF writer."""
 
+import sys
 import unittest
 from unittest import mock
 
@@ -36,11 +37,16 @@ class FakeImage:
         return xr.DataArray(1), xr.DataArray(0)
 
 
+pyninjotiff_mock = mock.Mock()
+pyninjotiff_mock.ninjotiff = mock.Mock()
+
+
+@mock.patch.dict(sys.modules, {'pyninjotiff': pyninjotiff_mock, 'pyninjotiff.ninjotiff': pyninjotiff_mock.ninjotiff})
 class TestNinjoTIFFWriter(unittest.TestCase):
     """The ninjo tiff writer tests."""
 
-    @mock.patch('satpy.writers.ninjotiff.nt')
-    def test_init(self, nt):
+    @mock.patch('satpy.writers.ninjotiff.nt', pyninjotiff_mock.ninjotiff)
+    def test_init(self):
         """Test the init."""
         from satpy.writers.ninjotiff import NinjoTIFFWriter
         ninjo_tags = {40000: 'NINJO'}
@@ -49,8 +55,8 @@ class TestNinjoTIFFWriter(unittest.TestCase):
 
     @mock.patch('satpy.writers.ninjotiff.ImageWriter.save_dataset')
     @mock.patch('satpy.writers.ninjotiff.convert_units')
-    @mock.patch('satpy.writers.ninjotiff.nt')
-    def test_dataset(self, nt, uconv, iwsd):
+    @mock.patch('satpy.writers.ninjotiff.nt', pyninjotiff_mock.ninjotiff)
+    def test_dataset(self, uconv, iwsd):
         """Test saving a dataset."""
         from satpy.writers.ninjotiff import NinjoTIFFWriter
         ntw = NinjoTIFFWriter()
@@ -61,9 +67,11 @@ class TestNinjoTIFFWriter(unittest.TestCase):
 
     @mock.patch('satpy.writers.ninjotiff.NinjoTIFFWriter.save_dataset')
     @mock.patch('satpy.writers.ninjotiff.ImageWriter.save_image')
-    @mock.patch('satpy.writers.ninjotiff.nt')
-    def test_image(self, nt, iwsi, save_dataset):
+    @mock.patch('satpy.writers.ninjotiff.nt', pyninjotiff_mock.ninjotiff)
+    def test_image(self, iwsi, save_dataset):
         """Test saving an image."""
+        nt = pyninjotiff_mock.ninjotiff
+        nt.reset_mock()
         from satpy.writers.ninjotiff import NinjoTIFFWriter
         ntw = NinjoTIFFWriter()
         dataset = xr.DataArray([1, 2, 3], attrs={'units': 'K'})


### PR DESCRIPTION
See #1096 for details. The summary is that the tests for `available_writers` was importing the `ninjotiff` writer before the tests for that specific writer were run. The ninjotiff writer tests were mocking the `pyninjotiff` package but *not* the ninjotiff writer module. This meant when the tests imported the ninjotiff writer they were getting the already imported ninjotiff writer module with the already imported *real* pyninjotiff package.

 - [x] Closes #1096 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added and test suite added to parent suite <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
