### PR TITLE
Fix eps l1b angles computation returning non deterministic results

### DIFF
--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -226,11 +226,9 @@ class EPSAVHRRFile(BaseFileHandler):
             # Note: interpolation asumes lat values values between -90 and 90
             # Solar and satellite zenith is between 0 and 180.
             # Note: delayed will cast input dask-arrays to numpy arrays (needed by metop20kmto1km).
-            sun_azi, sun_zen = metop20kmto1km(
-                solar_azimuth, solar_zenith - 90)
+            sun_azi, sun_zen = metop20kmto1km(solar_azimuth, solar_zenith - 90)
             sun_zen += 90
-            sat_azi, sat_zen = metop20kmto1km(
-                sat_azimuth, sat_zenith - 90)
+            sat_azi, sat_zen = metop20kmto1km(sat_azimuth, sat_zenith - 90)
             sat_zen += 90
             return sun_azi, sun_zen, sat_azi, sat_zen
         else:

--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -225,13 +225,12 @@ class EPSAVHRRFile(BaseFileHandler):
             from geotiepoints import metop20kmto1km
             # Note: interpolation asumes lat values values between -90 and 90
             # Solar and satellite zenith is between 0 and 180.
-            solar_zenith -= 90
+            # Note: delayed will cast input dask-arrays to numpy arrays (needed by metop20kmto1km).
             sun_azi, sun_zen = metop20kmto1km(
-                solar_azimuth, solar_zenith)
+                solar_azimuth, solar_zenith - 90)
             sun_zen += 90
-            sat_zenith -= 90
             sat_azi, sat_zen = metop20kmto1km(
-                sat_azimuth, sat_zenith)
+                sat_azimuth, sat_zenith - 90)
             sat_zen += 90
             return sun_azi, sun_zen, sat_azi, sat_zen
         else:

--- a/satpy/tests/reader_tests/test_eps_l1b.py
+++ b/satpy/tests/reader_tests/test_eps_l1b.py
@@ -132,6 +132,12 @@ class TestEPSL1B(TestCase):
     @mock.patch('satpy.readers.eps_l1b.EPSAVHRRFile.__init__')
     def test_get_full_angles_twice(self, mock__init__, mock__getitem__):
         """Test get full angles twice."""
+        try:
+            from geotiepoints import metop20kmto1km  # noqa: F401
+        except ModuleNotFoundError:
+            print("No geotiepoints; Not testing test_get_full_angles_twice")
+            return
+
         def mock_getitem(key):
             data = {"ANGULAR_RELATIONS_FIRST": np.zeros((7, 4)),
                     "ANGULAR_RELATIONS": np.zeros((7, 103, 4)),

--- a/satpy/tests/reader_tests/test_eps_l1b.py
+++ b/satpy/tests/reader_tests/test_eps_l1b.py
@@ -22,13 +22,13 @@ import os
 from contextlib import suppress
 from tempfile import mkstemp
 from unittest import TestCase, TestLoader, TestSuite
+from unittest import mock
 
 import numpy as np
 import xarray as xr
-
+import satpy
 from satpy import DatasetID
 from satpy.readers import eps_l1b as eps
-
 grh_dtype = np.dtype([("record_class", "|i1"),
                       ("INSTRUMENT_GROUP", "|i1"),
                       ("RECORD_SUBCLASS", "|i1"),
@@ -127,6 +127,33 @@ class TestEPSL1B(TestCase):
         assert(res.attrs['platform_name'] == 'Metop-C')
         assert(res.attrs['sensor'] == 'avhrr-3')
         assert(res.attrs['name'] == 'solar_zenith_angle')
+
+    @mock.patch('satpy.readers.eps_l1b.EPSAVHRRFile.__getitem__')
+    @mock.patch('satpy.readers.eps_l1b.EPSAVHRRFile.__init__')
+    def test_get_full_angles_twice(self, mock__init__, mock__getitem__):
+        """Test get full angles twice."""
+        def mock_getitem(key):
+            data = {"ANGULAR_RELATIONS_FIRST": np.zeros((7, 4)),
+                    "ANGULAR_RELATIONS": np.zeros((7, 103, 4)),
+                    "ANGULAR_RELATIONS_LAST": np.zeros((7, 4)),
+                    "NAV_SAMPLE_RATE": 20}
+            return data[key]
+        mock__init__.return_value = None
+        mock__getitem__.side_effect = mock_getitem
+        avhrr_reader = satpy.readers.eps_l1b.EPSAVHRRFile()
+        avhrr_reader.sun_azi = None
+        avhrr_reader.sat_azi = None
+        avhrr_reader.sun_zen = None
+        avhrr_reader.sat_zen = None
+        avhrr_reader.scanlines = 7
+        avhrr_reader.pixels = 2048
+        # Get dask arrays
+        sun_azi, sun_zen, sat_azi, sat_zen = avhrr_reader.get_full_angles()
+        # Convert to numpy array
+        sun_zen_np1 = np.array(avhrr_reader.sun_zen)
+        # Convert to numpy array again
+        sun_zen_np2 = np.array(avhrr_reader.sun_zen)
+        assert np.allclose(sun_zen_np1, sun_zen_np2)
 
     def tearDown(self):
         """Tear down the tests."""

--- a/satpy/tests/reader_tests/test_eps_l1b.py
+++ b/satpy/tests/reader_tests/test_eps_l1b.py
@@ -134,7 +134,7 @@ class TestEPSL1B(TestCase):
         """Test get full angles twice."""
         geotiemock = mock.Mock()
         metop20kmto1km = geotiemock.metop20kmto1km
-        metop20kmto1km.side_effect = lambda x, y: (x, y)
+        metop20kmto1km.side_effect = lambda x, y: (x.copy(), y.copy())
 
         def mock_getitem(key):
             data = {"ANGULAR_RELATIONS_FIRST": np.zeros((7, 4)),


### PR DESCRIPTION
Fixing so that values of solar and satellite zenith angles are not modified
each time they are read.
    
For numpy 1.16.2 input to _get_full angles are numpy arrays.
If updated; wrong vales will be used the second time values are requested.
    
For numpy 1.18 input are casted/and copied from numpy arrays to dask arrays by delayed.
As np.hstack() returns dask arrays for dask arrays input for numpy 1.18.1.
And there for the bug did not show for numpy 1.18.1.

 - [x] Closes #1092 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

