### PR TITLE
Scale valid range if available.

### DIFF
--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-2019 Satpy developers
+# Copyright (c) 2017-2020 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -150,6 +150,9 @@ class NcNWCSAF(BaseFileHandler):
         attrs = variable.attrs.copy()
         variable = variable * scale + offset
         variable.attrs = attrs
+        if 'valid_range' in variable.attrs:
+            variable.attrs['valid_range'] = variable.attrs['valid_range'] * scale + offset
+
         variable.attrs.pop('add_offset', None)
         variable.attrs.pop('scale_factor', None)
 
@@ -194,6 +197,11 @@ class NcNWCSAF(BaseFileHandler):
         if self.sw_version == 'NWC/PPS version v2014' and dsid.name == 'ctth_alti_pal':
             # pps 2014 palette has the nodata color (black) first
             variable = variable[1:, :]
+        if self.sw_version == 'NWC/GEO version v2016' and dsid.name == 'ctth_alti':
+            # Geo 2016/18 valid range and palette don't match
+            # Valid range is 0 to 27000 in the file. But after scaling the valid range becomes -2000 to 25000
+            # This now fixed by the scaling of the valid range above.
+            pass
 
         return variable
 

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2018 Satpy developers
+# Copyright (c) 2018, 2020 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -119,3 +119,15 @@ class TestNcNWCSAF(unittest.TestCase):
         np.testing.assert_allclose(var, [np.nan, 5.5, np.nan])
         self.assertNotIn('scale_factor', var.attrs)
         self.assertNotIn('add_offset', var.attrs)
+
+        # CTTH NWCSAF/Geo v2016/v2018:
+        attrs = {'scale_factor': np.array(1.),
+                 'add_offset': np.array(-2000.),
+                 'valid_range': (0., 27000.)}
+        var = xr.DataArray([1, 2, 3], attrs=attrs)
+        var = self.scn.scale_dataset('dummy', var, 'dummy')
+        np.testing.assert_allclose(var, [-1999., -1998., -1997.])
+        self.assertNotIn('scale_factor', var.attrs)
+        self.assertNotIn('add_offset', var.attrs)
+        self.assertEqual(var.attrs['valid_range'][0], -2000.)
+        self.assertEqual(var.attrs['valid_range'][1], 25000.)


### PR DESCRIPTION
This is to fix the coloring of the NWCSAF cloud parameters. It is not clear from documentation if the color palette applies to the scaled or unscaled values. To get the right coloring, corresponding to the nwcsaf.org examples, we need to scale the valid-range.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
