### PR TITLE
Add more sats support in nwcsaf-geo reader

### DIFF
--- a/satpy/etc/readers/nwcsaf-geo.yaml
+++ b/satpy/etc/readers/nwcsaf-geo.yaml
@@ -1,7 +1,7 @@
 reader:
-  description: NetCDF4 reader for the NWCSAF MSG Seviri 2016/2018 format
+  description: NetCDF4 reader for the NWCSAF MSG GEO 2016/2018 format
   name: nwcsaf-geo
-  sensors: [seviri]
+  sensors: [seviri, abi, ahi]
   default_channels: []
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
 

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -47,12 +47,24 @@ SENSOR = {'NOAA-19': 'avhrr/3',
           'EOS-Terra': 'modis',
           'Suomi-NPP': 'viirs',
           'NOAA-20': 'viirs',
-          'JPSS-1': 'viirs', }
+          'JPSS-1': 'viirs',
+          "GOES13": "goes-imager",
+          "GOES14": "goes-imager",
+          "GOES15": "goes-imager",
+          "GOES16": "abi",
+          "GOES17": "abi",
+          "Himawari-08": "ahi"}
 
 PLATFORM_NAMES = {'MSG1': 'Meteosat-8',
                   'MSG2': 'Meteosat-9',
                   'MSG3': 'Meteosat-10',
-                  'MSG4': 'Meteosat-11', }
+                  'MSG4': 'Meteosat-11',
+                  "GOES13": "GOES13",
+                  "GOES14": "GOES14",
+                  "GOES15": "GOES15",
+                  "GOES16": "GOES16",
+                  "GOES17": "GOES17",
+                  "Himawari-08": "Himawari-08"}
 
 
 class NcNWCSAF(BaseFileHandler):

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -48,23 +48,23 @@ SENSOR = {'NOAA-19': 'avhrr/3',
           'Suomi-NPP': 'viirs',
           'NOAA-20': 'viirs',
           'JPSS-1': 'viirs',
-          "GOES13": "goes-imager",
-          "GOES14": "goes-imager",
-          "GOES15": "goes-imager",
-          "GOES16": "abi",
-          "GOES17": "abi",
-          "Himawari-08": "ahi"}
+          "GOES-13": "goes-imager",
+          "GOES-14": "goes-imager",
+          "GOES-15": "goes-imager",
+          "GOES-16": "abi",
+          "GOES-17": "abi",
+          "Himawari-8": "ahi"}
 
 PLATFORM_NAMES = {'MSG1': 'Meteosat-8',
                   'MSG2': 'Meteosat-9',
                   'MSG3': 'Meteosat-10',
                   'MSG4': 'Meteosat-11',
-                  "GOES13": "GOES13",
-                  "GOES14": "GOES14",
-                  "GOES15": "GOES15",
-                  "GOES16": "GOES16",
-                  "GOES17": "GOES17",
-                  "Himawari-08": "Himawari-08"}
+                  "GOES13": "GOES-13",
+                  "GOES14": "GOES-14",
+                  "GOES15": "GOES-15",
+                  "GOES16": "GOES-16",
+                  "GOES17": "GOES-17",
+                  "Himawari-08": "Himawari-8"}
 
 
 class NcNWCSAF(BaseFileHandler):


### PR DESCRIPTION
In the nwcsaf-geo reader, add GOES and HIMAWARI to the platform names.
At least for GOES-16, this appears to enable the reading of NWCSAF
generated GOES-16 data, thus closing #1110, but I have only tested this
for GOES-16.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1110  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
