### PR TITLE
Add sensor-name property to NWCSAF readers

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -236,4 +236,3 @@ composites:
       - name: cimss_green
       - name: C01
     standard_name: cimss_true_color
-

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -193,12 +193,12 @@ composites:
     - ctth_tempe_pal
     standard_name: cloud_top_temperature
 
-  cloud_top_phase:
-    compositor: !!python/name:satpy.composites.PaletteCompositor
-    prerequisites:
-    - cmic_phase
-    - cmic_phase_pal
-    standard_name: cloud_top_phase
+  # cloud_top_phase:
+  #   compositor: !!python/name:satpy.composites.PaletteCompositor
+  #   prerequisites:
+  #   - cmic_phase
+  #   - cmic_phase_pal
+  #   standard_name: cloud_top_phase
 
   cloud_drop_effective_radius:
     compositor: !!python/name:satpy.composites.PaletteCompositor

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -193,12 +193,12 @@ composites:
     - ctth_tempe_pal
     standard_name: cloud_top_temperature
 
-  # cloud_top_phase:
-  #   compositor: !!python/name:satpy.composites.PaletteCompositor
-  #   prerequisites:
-  #   - cmic_phase
-  #   - cmic_phase_pal
-  #   standard_name: cloud_top_phase
+  cloud_top_phase:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_phase
+    - cmic_phase_pal
+    standard_name: cloud_top_phase
 
   cloud_drop_effective_radius:
     compositor: !!python/name:satpy.composites.PaletteCompositor

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -408,3 +408,15 @@ composites:
     compositor: !!python/name:satpy.composites.StaticImageCompositor
     standard_name: night_background_hires
     filename: BlackMarble_2016_3km_geo.tif
+
+# NWCSAF/Geo and PPS products:
+
+  cloud_top_phase:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_phase
+    - cmic_phase_pal
+    standard_name: cloud_top_phase
+
+
+

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -409,14 +409,3 @@ composites:
     standard_name: night_background_hires
     filename: BlackMarble_2016_3km_geo.tif
 
-# NWCSAF/Geo and PPS products:
-
-  cloud_top_phase:
-    compositor: !!python/name:satpy.composites.PaletteCompositor
-    prerequisites:
-    - cmic_phase
-    - cmic_phase_pal
-    standard_name: cloud_top_phase
-
-
-

--- a/satpy/etc/readers/nwcsaf-geo.yaml
+++ b/satpy/etc/readers/nwcsaf-geo.yaml
@@ -1,5 +1,5 @@
 reader:
-  description: NetCDF4 reader for the NWCSAF MSG Seviri 2016/2018 format
+  description: NetCDF4 reader for the NWCSAF GEO 2016/2018 format
   name: nwcsaf-geo
   sensors: [seviri, abi, ahi]
   default_channels: []

--- a/satpy/etc/readers/nwcsaf-geo.yaml
+++ b/satpy/etc/readers/nwcsaf-geo.yaml
@@ -261,7 +261,6 @@ datasets:
 
   cmic_iwp_pal:
     name: cmic_iwp_pal
-    
     resolution: 3000
     file_type: nc_nwcsaf_cmic
 

--- a/satpy/etc/readers/nwcsaf-geo.yaml
+++ b/satpy/etc/readers/nwcsaf-geo.yaml
@@ -1,7 +1,7 @@
 reader:
   description: NetCDF4 reader for the NWCSAF MSG Seviri 2016/2018 format
   name: nwcsaf-geo
-  sensors: [seviri]
+  sensors: [seviri, abi, ahi]
   default_channels: []
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
 
@@ -60,61 +60,51 @@ datasets:
 
   cma:
     name: cma
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cma
 
   cma_pal:
     name: cma_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cma
 
   cma_cloudsnow:
     name: cma_cloudsnow
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cma
 
   cma_cloudsnow_pal:
     name: cma_cloudsnow_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cma
 
   cma_dust:
     name: cma_dust
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cma
 
   cma_dust_pal:
     name: cma_dust_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cma
 
   cma_volcanic:
     name: cma_volcanic
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cma
 
   cma_volcanic_pal:
     name: cma_volcanic_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cma
 
   cma_conditions:
     name: cma_conditions
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cma
 
   cma_status_flag:
     name: cma_status_flag
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cma
 
@@ -122,49 +112,41 @@ datasets:
 
   ct:
     name: ct
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ct
 
   ct_pal:
     name: ct_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ct
 
   ct_cumuliform:
     name: ct_cumuliform
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ct
 
   ct_cumuliform_pal:
     name: ct_cumuliform_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ct
 
   ct_multilayer:
     name: ct_cumuliform
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ct
 
   ct_multilayer_pal:
     name: ct_cumuliform_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ct
 
   ct_quality:
     name: ct_quality
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ct
 
   ct_conditions:
     name: ct_conditions
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ct
 
@@ -172,73 +154,61 @@ datasets:
 
   ctth_alti:
     name: ctth_alti
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ctth
 
   ctth_alti_pal:
     name: ctth_alti_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ctth
 
   ctth_pres:
     name: ctth_pres
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ctth
 
   ctth_pres_pal:
     name: ctth_pres_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ctth
 
   ctth_tempe:
     name: ctth_tempe
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ctth
 
   ctth_tempe_pal:
     name: ctth_tempe_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ctth
 
   ctth_effectiv:
     name: ctth_effectiv
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ctth
 
   ctth_effectiv_pal:
     name: ctth_effectiv_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ctth
 
   ctth_method:
     name: ctth_method
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ctth
 
   ctth_conditions:
     name: ctth_conditions
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ctth
 
   ctth_quality:
     name: ctth_quality
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ctth
 
   ctth_status_flag:
     name: ctth_status_flag
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ctth
 
@@ -246,79 +216,67 @@ datasets:
 
   cmic_phase:
     name: cmic_phase
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cmic
 
   cmic_phase_pal:
     name: cmic_phase_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cmic
 
   cmic_reff:
     name: cmic_reff
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cmic
 
   cmic_reff_pal:
     name: cmic_reff_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cmic
 
   cmic_cot:
     name: cmic_cot
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cmic
 
   cmic_cot_pal:
     name: cmic_cot_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cmic
 
   cmic_lwp:
     name: cmic_lwp
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cmic
 
   cmic_lwp_pal:
     name: cmic_lwp_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cmic
 
   cmic_iwp:
     name: cmic_iwp
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cmic
 
   cmic_iwp_pal:
     name: cmic_iwp_pal
-    sensor: seviri
+    
     resolution: 3000
     file_type: nc_nwcsaf_cmic
 
   cmic_status_flag:
     name: cmic_status_flag
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cmic
 
   cmic_conditions:
     name: cmic_conditions
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cmic
 
   cmic_quality:
     name: cmic_quality
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_cmic
 
@@ -326,25 +284,21 @@ datasets:
 
   pc:
     name: pc
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_pc
 
   pc_pal:
     name: pc_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_pc
 
   pc_conditions:
     name: pc_conditions
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_pc
 
   pc_quality:
     name: pc_quality
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_pc
 
@@ -352,55 +306,46 @@ datasets:
 
   crr:
     name: crr
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_crr
 
   crr_pal:
     name: crr_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_crr
 
   crr_accum:
     name: crr_accum
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_crr
 
   crr_accum_pal:
     name: crr_accum_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_crr
 
   crr_intensity:
     name: crr_intensity
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_crr
 
   crr_intensity_pal:
     name: crr_intensity_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_crr
 
   crr_status_flag:
     name: crr_status_flag
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_crr
 
   crr_conditions:
     name: crr_conditions
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_crr
 
   crr_quality:
     name: crr_quality
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_crr
 
@@ -408,259 +353,216 @@ datasets:
 
   ishai_tpw:
     name: ishai_tpw
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_tpw_pal:
     name: ishai_tpw_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_shw:
     name: ishai_shw
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_shw_pal:
     name: ishai_shw_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_li:
     name: ishai_li
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_li_pal:
     name: ishai_li_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_ki:
     name: ishai_ki
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_ki_pal:
     name: ishai_ki_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_shw:
     name: ishai_shw
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_shw_pal:
     name: ishai_shw_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_bl:
     name: ishai_bl
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_bl_pal:
     name: ishai_bl_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_ml:
     name: ishai_ml
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_ml_pal:
     name: ishai_ml_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_hl:
     name: ishai_hl
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_hl_pal:
     name: ishai_hl_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_toz:
     name: ishai_toz
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_toz_pal:
     name: ishai_toz_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_skt:
     name: ishai_skt
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_skt_pal:
     name: ishai_skt_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_difftpw:
     name: ishai_difftpw
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_difftpw_pal:
     name: ishai_difftpw_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_diffshw:
     name: ishai_diffshw
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_diffshw_pal:
     name: ishai_diffshw_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_diffli:
     name: ishai_diffli
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_diffli_pal:
     name: ishai_diffli_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_diffki:
     name: ishai_diffki
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_diffki_pal:
     name: ishai_diffki_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_diffbl:
     name: ishai_diffbl
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_diffbl_pal:
     name: ishai_diffbl_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_diffml:
     name: ishai_diffml
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_diffml_pal:
     name: ishai_diffml_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_diffhl:
     name: ishai_diffhl
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_diffhl_pal:
     name: ishai_diffhl_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_difftoz:
     name: ishai_difftoz
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_difftoz_pal:
     name: ishai_difftoz_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_diffskt:
     name: ishai_diffskt
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_diffskt_pal:
     name: ishai_diffskt_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ihsai_status_flag:
     name: ihsai_status_flag
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_residual:
     name: ishai_residual
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_residual_pal:
     name: ishai_residual_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_conditions:
     name: ishai_conditions
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
   ishai_quality:
     name: ishai_quality
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ishai
 
@@ -669,51 +571,43 @@ datasets:
 
   ci_prob30:
     name: ci_prob30
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ci
 
   ci_prob60:
     name: ci_prob60
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ci
 
   ci_prob90:
     name: ci_prob90
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ci
 
   # 2018 version
   ci_prob_pal:
     name: ci_prob_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ci
 
   # 2016 Version
   ci_pal:
     name: ci_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ci
 
   ci_status_flag:
     name: ci_status_flag
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ci
 
   ci_conditions:
     name: ci_conditions
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ci
 
   ci_quality:
     name: ci_quality
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_ci
 
@@ -721,38 +615,32 @@ datasets:
 
   MapCellCatType:
     name: MapCellCatType
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_rdt
 
   MapCellCatType_pal:
     name: MapCellCatType_pal
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_rdt
 
   MapCell_conditions:
     name: MapCell_conditions
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_rdt
 
   MapCell_quality:
     name: MapCell_quality
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_rdt
 
 # ----ASII products in multiple files ------------
   asii_turb_trop_prob:
     name: asii_turb_trop_prob
-    sensor: seviri
     resolution: 3000
     file_type: [nc_nwcsaf_asii_tf, nc_nwcsaf_asii]
 
   asii_turb_prob_pal:
     name: asii_turb_prob_pal
-    sensor: seviri
     resolution: 3000
     file_type: [nc_nwcsaf_asii_tf, nc_nwcsaf_asii_gw]
 
@@ -760,19 +648,16 @@ datasets:
 
   asii_turb_prob_status_flag:
     name: asii_turb_trop_prob_status_flag
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_asii_tf
 
   asiitf_conditions:
     name: asiitf_conditions
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_asii_tf
 
   asiitf_quality:
     name: asiitf_quality
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_asii_tf
 
@@ -780,24 +665,20 @@ datasets:
 
   asii_turb_wave_prob:
     name: asii_turb_wave_prob
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_asii_gw
 
   asii_turb_wave_prob_status_flag:
     name: asii_turb_wave_prob_status_flag
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_asii_gw
 
   asiigw_conditions:
     name: asiigw_conditions
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_asii_gw
 
   asiigw_quality:
     name: asiigw_quality
-    sensor: seviri
     resolution: 3000
     file_type: nc_nwcsaf_asii_gw

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -59,6 +59,8 @@ PLATFORM_NAMES = {'MSG1': 'Meteosat-8',
                   'MSG2': 'Meteosat-9',
                   'MSG3': 'Meteosat-10',
                   'MSG4': 'Meteosat-11',
+                  'GOES16': 'GOES-16',
+                  'GOES17': 'GOES-17',
                   }
 
 
@@ -86,10 +88,10 @@ class NcNWCSAF(BaseFileHandler):
         try:
             # NWCSAF/MSG:
             try:
-                kwrgs = {'sat_id': self.nc.attrs['satellite_identifier']}
+                satellite_id = self.nc.attrs['satellite_identifier']
             except KeyError:
-                kwrgs = {'sat_id': self.nc.attrs['satellite_identifier'].astype(str)}
-
+                satellite_id = self.nc.attrs['satellite_identifier'].astype(str)
+            kwrgs = {'sat_id': PLATFORM_NAMES.get(satellite_id, satellite_id)}
         except KeyError:
             # NWCSAF/PPS:
             kwrgs = {'platform_name': self.nc.attrs['platform']}
@@ -102,7 +104,7 @@ class NcNWCSAF(BaseFileHandler):
         self.pps = False
         if 'sat_id' in kwargs:
             # NWCSAF/Geo
-            self.platform_name = PLATFORM_NAMES.get(kwargs['sat_id'])
+            self.platform_name = kwargs['sat_id']
         elif 'platform_name' in kwargs:
             # NWCSAF/PPS
             self.platform_name = kwargs['platform_name']

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -37,22 +37,29 @@ from satpy.readers.utils import unzip_file
 
 logger = logging.getLogger(__name__)
 
-SENSOR = {'NOAA-19': 'avhrr/3',
-          'NOAA-18': 'avhrr/3',
-          'NOAA-15': 'avhrr/3',
-          'Metop-A': 'avhrr/3',
-          'Metop-B': 'avhrr/3',
-          'Metop-C': 'avhrr/3',
+SENSOR = {'NOAA-19': 'avhrr-3',
+          'NOAA-18': 'avhrr-3',
+          'NOAA-15': 'avhrr-3',
+          'Metop-A': 'avhrr-3',
+          'Metop-B': 'avhrr-3',
+          'Metop-C': 'avhrr-3',
           'EOS-Aqua': 'modis',
           'EOS-Terra': 'modis',
           'Suomi-NPP': 'viirs',
           'NOAA-20': 'viirs',
-          'JPSS-1': 'viirs', }
+          'JPSS-1': 'viirs',
+          'GOES-16': 'abi',
+          'GOES-17': 'abi',
+          'Himawari-8': 'ahi',
+          'Himawari-9': 'ahi',
+          }
+
 
 PLATFORM_NAMES = {'MSG1': 'Meteosat-8',
                   'MSG2': 'Meteosat-9',
                   'MSG3': 'Meteosat-10',
-                  'MSG4': 'Meteosat-11', }
+                  'MSG4': 'Meteosat-11',
+                  }
 
 
 class NcNWCSAF(BaseFileHandler):
@@ -89,7 +96,7 @@ class NcNWCSAF(BaseFileHandler):
             self.platform_name = self.nc.attrs['platform']
             self.pps = True
 
-        self.sensor = SENSOR.get(self.platform_name, 'seviri')
+        self.sensors = set([SENSOR.get(self.platform_name, 'seviri')])
 
     def remove_timedim(self, var):
         """Remove time dimension from dataset."""
@@ -157,7 +164,7 @@ class NcNWCSAF(BaseFileHandler):
         variable.attrs.pop('scale_factor', None)
 
         variable.attrs.update({'platform_name': self.platform_name,
-                               'sensor': self.sensor})
+                               'sensor': self.sensors})
 
         if not variable.attrs.get('standard_name', '').endswith('status_flag'):
             # TODO: do we really need to add units to everything ?
@@ -294,6 +301,11 @@ class NcNWCSAF(BaseFileHandler):
             # PPS:
             return datetime.strptime(self.nc.attrs['time_coverage_end'],
                                      '%Y%m%dT%H%M%S%fZ')
+
+    @property
+    def sensor_names(self):
+        """List of sensors represented in this file."""
+        return self.sensors
 
     def _get_projection(self):
         """Get projection from the NetCDF4 attributes."""

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -90,7 +90,7 @@ class NcNWCSAF(BaseFileHandler):
         self.sensor = None
 
         try:
-            # NWCSAF/MSG:
+            # NWCSAF/Geo:
             try:
                 kwrgs = {'sat_id': self.nc.attrs['satellite_identifier']}
             except KeyError:

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -82,18 +82,30 @@ class NcNWCSAF(BaseFileHandler):
 
         self.nc = self.nc.rename({'nx': 'x', 'ny': 'y'})
         self.sw_version = self.nc.attrs['source']
-        self.pps = False
 
         try:
-            # MSG:
-            sat_id = self.nc.attrs['satellite_identifier']
+            # NWCSAF/MSG:
             try:
-                self.platform_name = PLATFORM_NAMES[sat_id]
+                kwrgs = {'sat_id': self.nc.attrs['satellite_identifier']}
             except KeyError:
-                self.platform_name = PLATFORM_NAMES[sat_id.astype(str)]
+                kwrgs = {'sat_id': self.nc.attrs['satellite_identifier'].astype(str)}
+
         except KeyError:
-            # PPS:
-            self.platform_name = self.nc.attrs['platform']
+            # NWCSAF/PPS:
+            kwrgs = {'platform_name': self.nc.attrs['platform']}
+
+        self.set_platform_and_sensor(**kwrgs)
+
+    def set_platform_and_sensor(self, **kwargs):
+        """Set some metadata: platform_name, sensors, and pps (identifying PPS or Geo)."""
+
+        self.pps = False
+        if 'sat_id' in kwargs:
+            # NWCSAF/Geo
+            self.platform_name = PLATFORM_NAMES.get(kwargs['sat_id'])
+        elif 'platform_name' in kwargs:
+            # NWCSAF/PPS
+            self.platform_name = kwargs['platform_name']
             self.pps = True
 
         self.sensors = set([SENSOR.get(self.platform_name, 'seviri')])

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -88,10 +88,9 @@ class NcNWCSAF(BaseFileHandler):
         try:
             # NWCSAF/MSG:
             try:
-                satellite_id = self.nc.attrs['satellite_identifier']
+                kwrgs = {'sat_id': self.nc.attrs['satellite_identifier']}
             except KeyError:
-                satellite_id = self.nc.attrs['satellite_identifier'].astype(str)
-            kwrgs = {'sat_id': PLATFORM_NAMES.get(satellite_id, satellite_id)}
+                kwrgs = {'sat_id': self.nc.attrs['satellite_identifier'].astype(str)}
         except KeyError:
             # NWCSAF/PPS:
             kwrgs = {'platform_name': self.nc.attrs['platform']}
@@ -104,7 +103,7 @@ class NcNWCSAF(BaseFileHandler):
         self.pps = False
         if 'sat_id' in kwargs:
             # NWCSAF/Geo
-            self.platform_name = kwargs['sat_id']
+            self.platform_name = PLATFORM_NAMES.get(kwargs['sat_id'], kwargs['sat_id'])
         elif 'platform_name' in kwargs:
             # NWCSAF/PPS
             self.platform_name = kwargs['platform_name']

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -47,30 +47,30 @@ class TestNcNWCSAF(unittest.TestCase):
         """Test that the correct sensor name is being set"""
 
         self.scn.set_platform_and_sensor(platform_name='Metop-B')
-        self.assertTrue(self.scn.sensors, set(['avhrr-3']))
+        self.assertTrue(self.scn.sensor, set(['avhrr-3']))
         self.assertTrue(self.scn.sensor_names, set(['avhrr-3']))
 
         self.scn.set_platform_and_sensor(platform_name='NOAA-20')
-        self.assertTrue(self.scn.sensors, set(['viirs']))
+        self.assertTrue(self.scn.sensor, set(['viirs']))
         self.assertTrue(self.scn.sensor_names, set(['viirs']))
 
         self.scn.set_platform_and_sensor(platform_name='Himawari-8')
-        self.assertTrue(self.scn.sensors, set(['ahi']))
+        self.assertTrue(self.scn.sensor, set(['ahi']))
         self.assertTrue(self.scn.sensor_names, set(['ahi']))
 
         self.scn.set_platform_and_sensor(sat_id='GOES16')
-        self.assertTrue(self.scn.sensors, set(['abi']))
+        self.assertTrue(self.scn.sensor, set(['abi']))
         self.assertTrue(self.scn.sensor_names, set(['abi']))
 
         self.scn.set_platform_and_sensor(platform_name='GOES-17')
-        self.assertTrue(self.scn.sensors, set(['abi']))
+        self.assertTrue(self.scn.sensor, set(['abi']))
         self.assertTrue(self.scn.sensor_names, set(['abi']))
 
         self.scn.set_platform_and_sensor(sat_id='MSG4')
-        self.assertTrue(self.scn.sensors, set(['seviri']))
+        self.assertTrue(self.scn.sensor, set(['seviri']))
 
         self.scn.set_platform_and_sensor(platform_name='Meteosat-11')
-        self.assertTrue(self.scn.sensors, set(['seviri']))
+        self.assertTrue(self.scn.sensor, set(['seviri']))
         self.assertTrue(self.scn.sensor_names, set(['seviri']))
 
     def test_get_projection(self):

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -58,9 +58,16 @@ class TestNcNWCSAF(unittest.TestCase):
         self.assertTrue(self.scn.sensors, set(['ahi']))
         self.assertTrue(self.scn.sensor_names, set(['ahi']))
 
+        self.scn.set_platform_and_sensor(sat_id='GOES16')
+        self.assertTrue(self.scn.sensors, set(['abi']))
+        self.assertTrue(self.scn.sensor_names, set(['abi']))
+
         self.scn.set_platform_and_sensor(platform_name='GOES-17')
         self.assertTrue(self.scn.sensors, set(['abi']))
         self.assertTrue(self.scn.sensor_names, set(['abi']))
+
+        self.scn.set_platform_and_sensor(sat_id='MSG4')
+        self.assertTrue(self.scn.sensors, set(['seviri']))
 
         self.scn.set_platform_and_sensor(platform_name='Meteosat-11')
         self.assertTrue(self.scn.sensors, set(['seviri']))

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -43,6 +43,20 @@ class TestNcNWCSAF(unittest.TestCase):
         unzip.return_value = ''
         self.scn = NcNWCSAF('filename', {}, {})
 
+    def test_sensor_name(self):
+        """Test that the correct sensor name is being set"""
+
+        self.scn.set_platform_and_sensor(platform_name='Metop-B')
+        self.assertTrue(self.scn.sensors, set(['avhrr-3']))
+        self.scn.set_platform_and_sensor(platform_name='NOAA-20')
+        self.assertTrue(self.scn.sensors, set(['viirs']))
+        self.scn.set_platform_and_sensor(platform_name='Himawari-8')
+        self.assertTrue(self.scn.sensors, set(['ahi']))
+        self.scn.set_platform_and_sensor(platform_name='GOES-17')
+        self.assertTrue(self.scn.sensors, set(['abi']))
+        self.scn.set_platform_and_sensor(platform_name='Meteosat-11')
+        self.assertTrue(self.scn.sensors, set(['seviri']))
+
     def test_get_projection(self):
         """Test generation of the navigation info."""
         # a, b and h in kilometers

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -48,14 +48,23 @@ class TestNcNWCSAF(unittest.TestCase):
 
         self.scn.set_platform_and_sensor(platform_name='Metop-B')
         self.assertTrue(self.scn.sensors, set(['avhrr-3']))
+        self.assertTrue(self.scn.sensor_names, set(['avhrr-3']))
+
         self.scn.set_platform_and_sensor(platform_name='NOAA-20')
         self.assertTrue(self.scn.sensors, set(['viirs']))
+        self.assertTrue(self.scn.sensor_names, set(['viirs']))
+
         self.scn.set_platform_and_sensor(platform_name='Himawari-8')
         self.assertTrue(self.scn.sensors, set(['ahi']))
+        self.assertTrue(self.scn.sensor_names, set(['ahi']))
+
         self.scn.set_platform_and_sensor(platform_name='GOES-17')
         self.assertTrue(self.scn.sensors, set(['abi']))
+        self.assertTrue(self.scn.sensor_names, set(['abi']))
+
         self.scn.set_platform_and_sensor(platform_name='Meteosat-11')
         self.assertTrue(self.scn.sensors, set(['seviri']))
+        self.assertTrue(self.scn.sensor_names, set(['seviri']))
 
     def test_get_projection(self):
         """Test generation of the navigation info."""

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2009-2019 Satpy developers
+# Copyright (c) 2009-2020 Satpy developers
 #
 # This file is part of satpy.
 #


### PR DESCRIPTION
Add the sensor name as a property to the NWCSAF/Geo&PPS readers

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1112, closes #1111  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
