### PR TITLE
Fix mitiff writer to support sensors as a set

### DIFF
--- a/satpy/tests/writer_tests/test_mitiff.py
+++ b/satpy/tests/writer_tests/test_mitiff.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018 Satpy developers
+# Copyright (c) 2018-2020 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -105,6 +105,72 @@ class TestMITIFFWriter(unittest.TestCase):
         )
         return [ds1, ds2]
 
+    def _get_test_datasets_sensor_set(self):
+        """Helper function to create a datasets list."""
+        import xarray as xr
+        import dask.array as da
+        from datetime import datetime
+        from pyresample.geometry import AreaDefinition
+        from pyresample.utils import proj4_str_to_dict
+        area_def = AreaDefinition(
+            'test',
+            'test',
+            'test',
+            proj4_str_to_dict('+proj=stere +datum=WGS84 +ellps=WGS84 '
+                              '+lon_0=0. +lat_0=90 +lat_ts=60 +units=km'),
+            100,
+            200,
+            (-1000., -1500., 1000., 1500.),
+        )
+
+        ds1 = xr.DataArray(
+            da.zeros((100, 200), chunks=50),
+            dims=('y', 'x'),
+            attrs={'name': '1',
+                   'start_time': datetime.utcnow(),
+                   'platform_name': "TEST_PLATFORM_NAME",
+                   'sensor': set('TEST_SENSOR_NAME'),
+                   'area': area_def,
+                   'prerequisites': ['1'],
+                   'calibration': 'reflectance',
+                   'metadata_requirements': {
+                       'order': ['1'],
+                       'config': {
+                           '1': {'alias': '1-VIS0.63',
+                                 'calibration': 'reflectance',
+                                 'min-val': '0',
+                                 'max-val': '100'},
+                       },
+                       'translate': {'1': '1',
+                                     },
+                       'file_pattern': '1_{start_time:%Y%m%d_%H%M%S}.mitiff'
+                   }}
+        )
+        ds2 = xr.DataArray(
+            da.zeros((100, 200), chunks=50),
+            dims=('y', 'x'),
+            attrs={'name': '4',
+                   'start_time': datetime.utcnow(),
+                   'platform_name': "TEST_PLATFORM_NAME",
+                   'sensor': set('TEST_SENSOR_NAME'),
+                   'area': area_def,
+                   'prerequisites': ['4'],
+                   'calibration': 'brightness_temperature',
+                   'metadata_requirements': {
+                       'order': ['4'],
+                       'config': {
+                           '4': {'alias': '4-IR10.8',
+                                 'calibration': 'brightness_temperature',
+                                 'min-val': '-150',
+                                 'max-val': '50'},
+                       },
+                       'translate': {'4': '4',
+                                     },
+                       'file_pattern': '4_{start_time:%Y%m%d_%H%M%S}.mitiff'}
+                   }
+        )
+        return [ds1, ds2]
+
     def _get_test_dataset(self, bands=3):
         """Helper function to create a single test dataset."""
         import xarray as xr
@@ -160,6 +226,36 @@ class TestMITIFFWriter(unittest.TestCase):
                    'start_time': datetime.utcnow(),
                    'platform_name': "TEST_PLATFORM_NAME",
                    'sensor': 'avhrr',
+                   'area': area_def,
+                   'prerequisites': [10.8]}
+        )
+        return ds1
+
+    def _get_test_one_dataset_sensor_set(self):
+        """Helper function to create a single test dataset."""
+        import xarray as xr
+        import dask.array as da
+        from datetime import datetime
+        from pyresample.geometry import AreaDefinition
+        from pyresample.utils import proj4_str_to_dict
+        area_def = AreaDefinition(
+            'test',
+            'test',
+            'test',
+            proj4_str_to_dict('+proj=geos +datum=WGS84 +ellps=WGS84 '
+                              '+lon_0=0. h=36000. +units=km'),
+            100,
+            200,
+            (-1000., -1500., 1000., 1500.),
+        )
+
+        ds1 = xr.DataArray(
+            da.zeros((100, 200), chunks=50),
+            dims=('y', 'x'),
+            attrs={'name': 'test',
+                   'start_time': datetime.utcnow(),
+                   'platform_name': "TEST_PLATFORM_NAME",
+                   'sensor': set('avhrr'),
                    'area': area_def,
                    'prerequisites': [10.8]}
         )
@@ -416,12 +512,43 @@ class TestMITIFFWriter(unittest.TestCase):
         for image in tif.iter_images():
             np.testing.assert_allclose(image, expected, atol=1.e-6, rtol=0)
 
+    def test_save_datasets_sensor_set(self):
+        """Test basic writer operation save_datasets."""
+        import os
+        import numpy as np
+        from libtiff import TIFF
+        from satpy.writers.mitiff import MITIFFWriter
+        expected = np.full((100, 200), 0)
+        dataset = self._get_test_datasets_sensor_set()
+        w = MITIFFWriter(base_dir=self.base_dir)
+        w.save_datasets(dataset)
+        filename = (dataset[0].attrs['metadata_requirements']['file_pattern']).format(
+            start_time=dataset[0].attrs['start_time'])
+        tif = TIFF.open(os.path.join(self.base_dir, filename))
+        for image in tif.iter_images():
+            np.testing.assert_allclose(image, expected, atol=1.e-6, rtol=0)
+
     def test_save_one_dataset(self):
         """Test basic writer operation with one dataset ie. no bands."""
         import os
         from libtiff import TIFF
         from satpy.writers.mitiff import MITIFFWriter
         dataset = self._get_test_one_dataset()
+        w = MITIFFWriter(base_dir=self.base_dir)
+        w.save_dataset(dataset)
+        tif = TIFF.open(os.path.join(self.base_dir, os.listdir(self.base_dir)[0]))
+        IMAGEDESCRIPTION = 270
+        imgdesc = (tif.GetField(IMAGEDESCRIPTION)).decode('utf-8').split('\n')
+        for key in imgdesc:
+            if 'In this file' in key:
+                self.assertEqual(key, ' Channels: 1 In this file: 1')
+
+    def test_save_one_dataset_sesnor_set(self):
+        """Test basic writer operation with one dataset ie. no bands."""
+        import os
+        from libtiff import TIFF
+        from satpy.writers.mitiff import MITIFFWriter
+        dataset = self._get_test_one_dataset_sensor_set()
         w = MITIFFWriter(base_dir=self.base_dir)
         w.save_dataset(dataset)
         tif = TIFF.open(os.path.join(self.base_dir, os.listdir(self.base_dir)[0]))

--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -51,6 +51,7 @@ class MITIFFWriter(ImageWriter):
         self.translate_channel_name = {}
         self.channel_order = {}
         self.palette = False
+        self.sensor = None
 
     def save_image(self):
         """Save dataset as an image array."""
@@ -73,6 +74,12 @@ class MITIFFWriter(ImageWriter):
                     kwargs['start_time'] = dataset.attrs['start_time']
                 if 'sensor' not in kwargs:
                     kwargs['sensor'] = dataset.attrs['sensor']
+
+                # Sensor attrs could be set. MITIFFs needing to handle sensor can only have one sensor
+                # Assume the first value of set as the sensor.
+                if isinstance(kwargs['sensor'], set):
+                    LOG.warning('Sensor is set, will use the first value: %s', kwargs['sensor'])
+                    kwargs['sensor'] = (list(kwargs['sensor']))[0]
 
                 try:
                     self.mitiff_config[kwargs['sensor']] = dataset.attrs['metadata_requirements']['config']
@@ -122,6 +129,12 @@ class MITIFFWriter(ImageWriter):
                     kwargs['start_time'] = datasets[0].attrs['start_time']
                 if 'sensor' not in kwargs:
                     kwargs['sensor'] = datasets[0].attrs['sensor']
+
+                # Sensor attrs could be set. MITIFFs needing to handle sensor can only have one sensor
+                # Assume the first value of set as the sensor.
+                if isinstance(kwargs['sensor'], set):
+                    LOG.warning('Sensor is set, will use the first value: %s', kwargs['sensor'])
+                    kwargs['sensor'] = (list(kwargs['sensor']))[0]
 
                 try:
                     self.mitiff_config[kwargs['sensor']] = datasets[0].attrs['metadata_requirements']['config']


### PR DESCRIPTION
mitiff writer need to handle if sensor is a set.

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 