### PR TITLE
Make an alias for the snow composite in viirs

### DIFF
--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -424,7 +424,7 @@ composites:
     - name: I05
     standard_name: cloudtop
 
-  snow_lowres:
+  snow_lowres: &snow_lowres
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - name: M07
@@ -434,6 +434,8 @@ composites:
     - name: M12
       modifiers: [nir_reflectance_lowres]
     standard_name: snow
+
+  snow: *snow_lowres
 
   snow_hires:
     compositor: !!python/name:satpy.composites.GenericCompositor

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -424,7 +424,7 @@ composites:
     - name: I05
     standard_name: cloudtop
 
-  snow_lowres: &snow_lowres
+  snow_lowres:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - name: M07
@@ -435,9 +435,7 @@ composites:
       modifiers: [nir_reflectance_lowres]
     standard_name: snow
 
-  snow: *snow_lowres
-
-  snow_hires:
+  snow_hires: &snow_hires
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - name: I02
@@ -447,6 +445,8 @@ composites:
     - name: I04
       modifiers: [nir_reflectance_hires]
     standard_name: snow
+
+  snow: *snow_hires
 
   histogram_dnb:
     compositor: !!python/name:satpy.composites.viirs.HistogramDNB


### PR DESCRIPTION
This is a workaround for #151, but also making sure the right channels are used for viirs.

Otherwise, DNB is used as the visible channel, and the nir reflectance computation mixes up resolutions.

 - [ ] Tests passed <!-- for all non-documentation changes -->
