### PR TITLE
Add support for satpy.composites entry points

### DIFF
--- a/doc/source/dev_guide/index.rst
+++ b/doc/source/dev_guide/index.rst
@@ -14,13 +14,14 @@ at the pages listed below.
     CONTRIBUTING
     xarray_migration
     custom_reader
+    plugins
 
 Coding guidelines
 =================
 
-Satpy is part of `PyTroll <http://pytroll.github.io/>`_,
+Satpy is part of `Pytroll <http://pytroll.github.io/>`_,
 and all code should follow the
-`PyTroll coding guidelines and best
+`Pytroll coding guidelines and best
 practices <http://pytroll.github.io/guidelines.html>`_.
 
 Satpy currently supports Python 2.7 and 3.4+. All code should be written to

--- a/doc/source/dev_guide/plugins.rst
+++ b/doc/source/dev_guide/plugins.rst
@@ -1,0 +1,34 @@
+================================================
+ Adding new functionnality to Satpy via plugins
+================================================
+
+.. warning::
+    This feature is experimental and being modified without warnings.
+    For now, it should not be used for anything else than toy examples and
+    should not be relied on.
+
+Satpy has the capability of using plugins. At the moment, new composites can be
+added to satpy through external plugins. Plugins for reader and writers may be
+added at a later date (PRs are welcome!).
+
+Here is an
+`example <https://github.com/mraspaud/satpy-composites-plugin-example>`_ of a
+composites plugin.
+
+The key is to use the same configuration directory structure as satpy and add
+a `satpy.composites` entry point in the setup.py file of the plugin:
+
+.. code: python
+
+    from setuptools import setup
+    import os
+
+    setup(
+        name='satpy_cpe',
+        entry_points={
+            'satpy.composites': [
+                'example_composites = satpy_cpe',
+            ],
+        },
+        package_data={'satpy_cpe': [os.path.join('etc', 'composites/*.yaml')]},
+    )

--- a/doc/source/dev_guide/plugins.rst
+++ b/doc/source/dev_guide/plugins.rst
@@ -1,5 +1,5 @@
 ================================================
- Adding new functionnality to Satpy via plugins
+ Adding new functionality to Satpy via plugins
 ================================================
 
 .. warning::

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -34,7 +34,7 @@ except ImportError:
     from yaml import Loader as UnsafeLoader
 
 from satpy.config import CONFIG_PATH, config_search_paths, recursive_dict_update
-from satpy.config import get_environ_ancpath
+from satpy.config import get_environ_ancpath, get_entry_points_config_dirs
 from satpy.dataset import DATASET_KEYS, DatasetID, MetadataObject, combine_metadata
 from satpy.readers import DatasetDict
 from satpy.utils import sunzen_corr_cos, atmospheric_path_length_correction, get_satpos
@@ -83,9 +83,11 @@ class CompositorLoader(object):
         """Load all compositor configs for the provided sensor."""
         config_filename = sensor_name + ".yaml"
         LOG.debug("Looking for composites config file %s", config_filename)
+        paths = get_entry_points_config_dirs('satpy.composites')
+        paths.append(self.ppp_config_dir)
         composite_configs = config_search_paths(
             os.path.join("composites", config_filename),
-            self.ppp_config_dir, check_exists=True)
+            *paths, check_exists=True)
         if not composite_configs:
             LOG.debug("No composite config found called {}".format(
                 config_filename))

--- a/satpy/config.py
+++ b/satpy/config.py
@@ -17,20 +17,22 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Satpy Configuration directory and file handling."""
 from __future__ import print_function
+
+import configparser
 import glob
 import logging
 import os
-import configparser
-from collections.abc import Mapping
 from collections import OrderedDict
+from collections.abc import Mapping
 
+import pkg_resources
 import yaml
+from yaml import BaseLoader
 
 try:
     from yaml import UnsafeLoader
 except ImportError:
     from yaml import Loader as UnsafeLoader
-from yaml import BaseLoader
 
 LOG = logging.getLogger(__name__)
 
@@ -60,6 +62,17 @@ def runtime_import(object_path):
     obj_module, obj_element = object_path.rsplit(".", 1)
     loader = __import__(obj_module, globals(), locals(), [str(obj_element)])
     return getattr(loader, obj_element)
+
+
+def get_entry_points_config_dirs(name):
+    """Get the config directories for all entry points of given name."""
+    dirs = []
+    for entry_point in pkg_resources.iter_entry_points(name):
+        package_name = entry_point.module_name.split('.', 1)[0]
+        new_dir = os.path.join(entry_point.dist.module_path, package_name, 'etc')
+        if not dirs or dirs[-1] != new_dir:
+            dirs.append(new_dir)
+    return dirs
 
 
 def config_search_paths(filename, *search_dirs, **kwargs):

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -109,3 +109,20 @@ class TestBuiltinAreas(unittest.TestCase):
                 # pyproj 2.0+ seems to drop wktext from PROJ dict
                 continue
             _ = CRS.from_dict(proj_dict)
+
+
+class TestPluginsConfigs(unittest.TestCase):
+    """Test that plugins are working."""
+
+    @mock.patch('satpy.config.pkg_resources.iter_entry_points')
+    def test_get_plugin_configs(self, iter_entry_points):
+        """Check that the plugin configs are looked for."""
+        import pkg_resources
+        ep = pkg_resources.EntryPoint.parse('example_composites = satpy_cpe')
+        ep.dist = pkg_resources.Distribution.from_filename('satpy_cpe-0.0.0-py3.8.egg')
+        ep.dist.module_path = '/bla/bla'
+        iter_entry_points.return_value = [ep]
+
+        from satpy.config import get_entry_points_config_dirs
+        dirs = get_entry_points_config_dirs('satpy.composites')
+        self.assertListEqual(dirs, ['/bla/bla/satpy_cpe/etc'])

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -17,6 +17,7 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Test objects and functions in the satpy.config module."""
 
+import os
 import unittest
 from unittest import mock
 
@@ -120,9 +121,9 @@ class TestPluginsConfigs(unittest.TestCase):
         import pkg_resources
         ep = pkg_resources.EntryPoint.parse('example_composites = satpy_cpe')
         ep.dist = pkg_resources.Distribution.from_filename('satpy_cpe-0.0.0-py3.8.egg')
-        ep.dist.module_path = '/bla/bla'
+        ep.dist.module_path = os.path.join(os.path.sep + 'bla', 'bla')
         iter_entry_points.return_value = [ep]
 
         from satpy.config import get_entry_points_config_dirs
         dirs = get_entry_points_config_dirs('satpy.composites')
-        self.assertListEqual(dirs, ['/bla/bla/satpy_cpe/etc'])
+        self.assertListEqual(dirs, [os.path.join(ep.dist.module_path, 'satpy_cpe', 'etc')])


### PR DESCRIPTION
This adds support for entry_points in satpy, in particular for composites.
The composites defined in other packages (in yaml files) are now loaded directly into satpy.

An example package to achieve this is on display here:  https://github.com/mraspaud/satpy-composites-plugin-example

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
