### PR TITLE
Fix supported Python version in devguide

### DIFF
--- a/doc/source/dev_guide/index.rst
+++ b/doc/source/dev_guide/index.rst
@@ -23,8 +23,9 @@ and all code should follow the
 `PyTroll coding guidelines and best
 practices <http://pytroll.github.io/guidelines.html>`_.
 
-Satpy currently supports Python 2.7 and 3.4+. All code should be written to
-be compatible with these versions.
+Satpy is now Python 3 only and it is no longer needed to support Python 2.
+Check ``setup.py`` for the current Python versions any new code needs
+to support.
 
 Development installation
 ========================


### PR DESCRIPTION
In the developer guide, update the supported Python versions.  Python 2
is no longer supported.  For maintainability, don't mention the specific
Python versions that are supported but refer the reader to ``setup.py``.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
