### PR TITLE
Fix Scene.crop using PROJ definition to create target area definition

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -468,9 +468,10 @@ class Scene(MetadataObject):
                 'crop_area', 'crop_area', 'crop_latlong',
                 {'proj': 'latlong'}, 100, 100, ll_bbox)
         elif xy_bbox is not None:
+            crs = src_area.crs if hasattr(src_area, 'crs') else src_area.proj_dict
             dst_area = AreaDefinition(
                 'crop_area', 'crop_area', 'crop_xy',
-                src_area.proj_dict, src_area.x_size, src_area.y_size,
+                crs, src_area.x_size, src_area.y_size,
                 xy_bbox)
         x_slice, y_slice = src_area.get_area_slices(dst_area)
         return src_area[y_slice, x_slice], y_slice, x_slice

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -464,7 +464,7 @@ class TestScene(unittest.TestCase):
         from pyresample.geometry import AreaDefinition
         import numpy as np
         try:
-            from pyproj import CRS
+            from pyproj import CRS  # noqa
         except ImportError:
             self.skipTest("Test requires pyproj 2.0+")
 

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -457,6 +457,35 @@ class TestScene(unittest.TestCase):
         self.assertTupleEqual(new_scn1['3'].shape, (36, 70))
         self.assertTupleEqual(new_scn1['4'].shape, (18, 35))
 
+    def test_crop_epsg_crs(self):
+        """Test the crop method when source area uses an EPSG code."""
+        from satpy import Scene
+        from xarray import DataArray
+        from pyresample.geometry import AreaDefinition
+        import numpy as np
+        try:
+            from pyproj import CRS
+        except ImportError:
+            self.skipTest("Test requires pyproj 2.0+")
+
+        scene1 = Scene()
+        area_extent = (699960.0, 5390220.0, 809760.0, 5500020.0)
+        x_size = 3712
+        y_size = 3712
+        area_def = AreaDefinition(
+            'test', 'test', 'test',
+            "EPSG:32630",
+            x_size,
+            y_size,
+            area_extent,
+        )
+        scene1["1"] = DataArray(np.zeros((y_size, x_size)), dims=('y', 'x'),
+                                attrs={'area': area_def})
+        # by x/y bbox
+        new_scn1 = scene1.crop(xy_bbox=(719695.7781587119, 5427887.407618969, 725068.1609052602, 5433708.364368956))
+        self.assertIn('1', new_scn1)
+        self.assertTupleEqual(new_scn1['1'].shape, (198, 182))
+
     def test_crop_rgb(self):
         """Test the crop method on multi-dimensional data."""
         from satpy import Scene


### PR DESCRIPTION
This issue is described in #1124. While cropping for `ll_bbox` is not implemented for anything other than the `geos` projection, it should be fine to pass `xy_bbox`. @meresmata was still getting a `NotImplementedError` even after passing `xy_bbox`. After some testing by @mraspaud, we discovered that the destination area was using `src_area.proj_dict` to create the new AreaDefinition. For the case in #1124 which uses an AreaDefinition based on an EPSG code, this results in pyproj expanding the EPSG code definition to a PROJ.4 dictionary. This new dictionary is not the exact same (string-wise) as the original EPSG based definition (`EPSG:32630`).

This PR fixes this by using the pyproj `CRS` object if it exists.

 - [x] Closes #1124 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
