### PR TITLE
Update omps edr reader and hdf5_utils to handle OMPS SO2 data from FMI

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -240,6 +240,9 @@ the base Satpy installation.
     * - HY-2B Scatterometer level 2b data in HDF5 format
       - `hy2_scat_l2b_h5`
       - Beta
+    * - OMPS EDR data in HDF5 format
+      - `omps_edr`
+      - Beta
 
 Indices and tables
 ==================

--- a/satpy/etc/readers/omps_edr.yaml
+++ b/satpy/etc/readers/omps_edr.yaml
@@ -170,74 +170,74 @@ datasets:
     units: degrees
     standard_name: latitude
 
-  Longitude:
-    name: Longitude
+  longitude_sampo:
+    name: longitude_sampo
     resolution: 50000
     file_type: omps_sampo
     file_key: GEOLOCATION_DATA/Longitude
-    units: degrees
+    units: degrees_east
     standard_name: longitude
-  Latitude:
-    name: Latitude
+  latitude_sampo:
+    name: latitude_sampo
     resolution: 50000
     file_type: omps_sampo
     file_key: GEOLOCATION_DATA/Latitude
-    units: degrees
+    units: degrees_north
     standard_name: latitude
 
   ColumnAmountO3:
-    name: ColumnAmountO3
+    name: tco3_sampo
     resolution: 50000
-    coordinates: [Longitude, Latitude]
+    coordinates: [longitude_sampo, latitude_sampo]
     file_type: omps_sampo
     file_key: SCIENCE_DATA/ColumnAmountO3
 
   ColumnAmountSO2_PBL:
-    name: ColumnAmountSO2_PBL
+    name: tcso2_pbl_sampo
     resolution: 50000
-    coordinates: [Longitude, Latitude]
+    coordinates: [longitude_sampo, latitude_sampo]
     file_type: omps_sampo
     file_key: SCIENCE_DATA/ColumnAmountSO2_PBL
 
   ColumnAmountSO2_STL:
-    name: ColumnAmountSO2_STL
+    name: tcso2_stl_sampo
     resolution: 50000
-    coordinates: [Longitude, Latitude]
+    coordinates: [longitude_sampo, latitude_sampo]
     file_type: omps_sampo
-    file_key: SCIENCE_DATA/ColumnAmountSO2_TRL
+    file_key: SCIENCE_DATA/ColumnAmountSO2_STL
 
   ColumnAmountSO2_TRL:
-    name: ColumnAmountSO2_TRL
+    name: tcso2_trl_sampo
     resolution: 50000
-    coordinates: [Longitude, Latitude]
+    coordinates: [longitude_sampo, latitude_sampo]
     file_type: omps_sampo
     file_key: SCIENCE_DATA/ColumnAmountSO2_TRL
 
   ColumnAmountSO2_TRM:
-    name: ColumnAmountSO2_TRM
+    name: tcso2_trm_sampo
     resolution: 50000
-    coordinates: [Longitude, Latitude]
+    coordinates: [longitude_sampo, latitude_sampo]
     file_type: omps_sampo
     file_key: SCIENCE_DATA/ColumnAmountSO2_TRM
 
   ColumnAmountSO2_TRU:
-    name: ColumnAmountSO2_TRU
+    name: tcso2_tru_sampo
     resolution: 50000
-    coordinates: [Longitude, Latitude]
+    coordinates: [longitude_sampo, latitude_sampo]
     file_type: omps_sampo
     file_key: SCIENCE_DATA/ColumnAmountSO2_TRU
 
   UVAerosolIndex:
-    name: UVAerosolIndex
+    name: uvaerosol_index_sampo
     resolution: 50000
-    coordinates: [Longitude, Latitude]
+    coordinates: [longitude_sampo, latitude_sampo]
     file_type: omps_sampo
     file_key: SCIENCE_DATA/UVAerosolIndex
 
   CloudFraction:
-    name: CloudFraction
+    name: cldfra_sampo
     resolution: 50000
-    coordinates: [Longitude, Latitude]
+    coordinates: [longitude_sampo, latitude_sampo]
     file_type: omps_sampo
     file_key: SCIENCE_DATA/CloudFraction
 

--- a/satpy/etc/readers/omps_edr.yaml
+++ b/satpy/etc/readers/omps_edr.yaml
@@ -22,6 +22,10 @@ file_types:
   omps_tc_to3_edr:
     file_reader: !!python/name:satpy.readers.omps_edr.EDRFileHandler
     file_patterns: ['{instrument_shortname}-{platform_shortname}-TC_EDR_TO3-{version}-{start_time:%Ym%m%dt%H%M%S}-o{orbit:05d}-{end_time:%Ym%m%dt%H%M%S}.h5']
+  # HDF5 file from FMI SAMPO https://sampo.fmi.fi/ via Eumetcast
+  omps_sampo:
+    file_reader: !!python/name:satpy.readers.omps_edr.EDRFileHandler
+    file_patterns: ['{instrument_shortname}-{platform_shortname}_NMSO2-PCA-L2_{version}_{start_time:%Ym%m%dt%H%M%S}_o{orbit:05d}_{end_time:%Ym%m%dt%H%M%S}.h5']
 
 # ftp://omisips1.omisips.eosdis.nasa.gov/OMPS/LANCE/NMSO2-L2-NRT-NRT/
 # ftp://omisips1.omisips.eosdis.nasa.gov/OMPS/LANCE/NMSO2-L2-NRT-NRT/OMPS-NPP_NMSO2-L2-NRT_2017m0804t030731_o29890_2017m0804t021637.he5
@@ -166,4 +170,74 @@ datasets:
     units: degrees
     standard_name: latitude
 
+  Longitude:
+    name: Longitude
+    resolution: 50000
+    file_type: omps_sampo
+    file_key: GEOLOCATION_DATA/Longitude
+    units: degrees
+    standard_name: longitude
+  Latitude:
+    name: Latitude
+    resolution: 50000
+    file_type: omps_sampo
+    file_key: GEOLOCATION_DATA/Latitude
+    units: degrees
+    standard_name: latitude
+
+  ColumnAmountO3:
+    name: ColumnAmountO3
+    resolution: 50000
+    coordinates: [Longitude, Latitude]
+    file_type: omps_sampo
+    file_key: SCIENCE_DATA/ColumnAmountO3
+
+  ColumnAmountSO2_PBL:
+    name: ColumnAmountSO2_PBL
+    resolution: 50000
+    coordinates: [Longitude, Latitude]
+    file_type: omps_sampo
+    file_key: SCIENCE_DATA/ColumnAmountSO2_PBL
+
+  ColumnAmountSO2_STL:
+    name: ColumnAmountSO2_STL
+    resolution: 50000
+    coordinates: [Longitude, Latitude]
+    file_type: omps_sampo
+    file_key: SCIENCE_DATA/ColumnAmountSO2_TRL
+
+  ColumnAmountSO2_TRL:
+    name: ColumnAmountSO2_TRL
+    resolution: 50000
+    coordinates: [Longitude, Latitude]
+    file_type: omps_sampo
+    file_key: SCIENCE_DATA/ColumnAmountSO2_TRL
+
+  ColumnAmountSO2_TRM:
+    name: ColumnAmountSO2_TRM
+    resolution: 50000
+    coordinates: [Longitude, Latitude]
+    file_type: omps_sampo
+    file_key: SCIENCE_DATA/ColumnAmountSO2_TRM
+
+  ColumnAmountSO2_TRU:
+    name: ColumnAmountSO2_TRU
+    resolution: 50000
+    coordinates: [Longitude, Latitude]
+    file_type: omps_sampo
+    file_key: SCIENCE_DATA/ColumnAmountSO2_TRU
+
+  UVAerosolIndex:
+    name: UVAerosolIndex
+    resolution: 50000
+    coordinates: [Longitude, Latitude]
+    file_type: omps_sampo
+    file_key: SCIENCE_DATA/UVAerosolIndex
+
+  CloudFraction:
+    name: CloudFraction
+    resolution: 50000
+    coordinates: [Longitude, Latitude]
+    file_type: omps_sampo
+    file_key: SCIENCE_DATA/CloudFraction
 

--- a/satpy/readers/hdf5_utils.py
+++ b/satpy/readers/hdf5_utils.py
@@ -69,8 +69,14 @@ class HDF5FileHandler(BaseFileHandler):
     def get_reference(self, name, key):
         """Get reference."""
         with h5py.File(self.filename, 'r') as hf:
-            if isinstance(hf[name].attrs[key], h5py.h5r.Reference):
-                ref_name = h5py.h5r.get_name(hf[name].attrs[key], hf.id)
+            return self._get_reference(hf, hf[name].attrs[key])
+
+    def _get_reference(self, hf, ref):
+        try:
+            return [self._get_reference(hf, elt) for elt in ref]
+        except TypeError:
+            if isinstance(ref, h5py.h5r.Reference):
+                ref_name = h5py.h5r.get_name(ref, hf.id)
                 return hf[ref_name][()]
 
     def collect_metadata(self, name, obj):

--- a/satpy/readers/omps_edr.py
+++ b/satpy/readers/omps_edr.py
@@ -106,11 +106,6 @@ class EDRFileHandler(HDF5FileHandler):
             fill_value = None
 
         data = self[var_path]
-        if 'DIMENSION_LIST' in data.attrs:
-            data.attrs.pop('DIMENSION_LIST')
-            dimensions = self.get_reference(var_path, 'DIMENSION_LIST')
-            for dim, coord in zip(data.dims, dimensions):
-                data.coords[dim] = coord[0]
         scale_factor_path = var_path + '/attr/ScaleFactor'
         if scale_factor_path in self:
             scale_factor = self[scale_factor_path]
@@ -131,6 +126,11 @@ class EDRFileHandler(HDF5FileHandler):
             data = data * factors[0] + factors[1]
 
         data.attrs.update(metadata)
+        if 'DIMENSION_LIST' in data.attrs:
+            data.attrs.pop('DIMENSION_LIST')
+            dimensions = self.get_reference(var_path, 'DIMENSION_LIST')
+            for dim, coord in zip(data.dims, dimensions):
+                data.coords[dim] = coord[0]
         return data
 
 

--- a/satpy/readers/omps_edr.py
+++ b/satpy/readers/omps_edr.py
@@ -15,9 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Interface to OMPS EDR format
-
-"""
+"""Interface to OMPS EDR format."""
 from datetime import datetime, timedelta
 import numpy as np
 import logging
@@ -30,28 +28,36 @@ LOG = logging.getLogger(__name__)
 
 
 class EDRFileHandler(HDF5FileHandler):
+    """EDR file handler."""
+
     _fill_name = "_FillValue"
 
     @property
     def start_orbit_number(self):
+        """Get the start orbit number."""
         return self.filename_info['orbit']
 
     @property
     def end_orbit_number(self):
+        """Get the end orbit number."""
         return self.filename_info['orbit']
 
     @property
     def platform_name(self):
+        """Get the platform name."""
         return self.filename_info['platform_shortname']
 
     @property
     def sensor_name(self):
+        """Get the sensor name."""
         return self.filename_info['instrument_shortname']
 
     def get_shape(self, ds_id, ds_info):
+        """Get the shape."""
         return self[ds_info['file_key'] + '/shape']
 
     def adjust_scaling_factors(self, factors, file_units, output_units):
+        """Adjust scaling factors."""
         if factors is None or factors[0] is None:
             factors = [1, 0]
         if file_units == output_units:
@@ -60,8 +66,9 @@ class EDRFileHandler(HDF5FileHandler):
         return np.array(factors)
 
     def get_metadata(self, dataset_id, ds_info):
+        """Get the metadata."""
         var_path = ds_info.get('file_key', '{}'.format(dataset_id.name))
-        info = getattr(self[var_path], 'attrs', {})
+        info = getattr(self[var_path], 'attrs', {}).copy()
         info.pop('DIMENSION_LIST', None)
         info.update(ds_info)
 
@@ -90,6 +97,7 @@ class EDRFileHandler(HDF5FileHandler):
         return info
 
     def get_dataset(self, dataset_id, ds_info):
+        """Get the dataset."""
         var_path = ds_info.get('file_key', '{}'.format(dataset_id.name))
         metadata = self.get_metadata(dataset_id, ds_info)
         valid_min, valid_max = self.get(var_path + '/attr/valid_range',
@@ -135,4 +143,6 @@ class EDRFileHandler(HDF5FileHandler):
 
 
 class EDREOSFileHandler(EDRFileHandler):
+    """EDR EOS file handler."""
+
     _fill_name = "MissingValue"

--- a/satpy/tests/reader_tests/test_omps_edr.py
+++ b/satpy/tests/reader_tests/test_omps_edr.py
@@ -37,10 +37,12 @@ DEFAULT_LON_DATA = np.repeat([DEFAULT_LON_DATA], DEFAULT_FILE_SHAPE[0], axis=0)
 
 
 class FakeHDF5FileHandler2(FakeHDF5FileHandler):
-    """Swap-in HDF5 File Handler"""
+    """Swap-in HDF5 File Handler."""
+
     def get_test_content(self, filename, filename_info, filetype_info):
-        """Mimic reader input file content"""
+        """Mimic reader input file content."""
         file_content = {}
+        attrs = []
         if 'SO2NRT' in filename:
             k = 'HDFEOS/SWATHS/OMPS Column Amount SO2/Data Fields/ColumnAmountSO2_TRM'
             file_content[k] = DEFAULT_FILE_DATA
@@ -112,6 +114,7 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
             file_content[k + '/attr/valid_max'] = 2000
             file_content[k + '/attr/valid_min'] = -10
             file_content[k + '/attr/DIMENSION_LIST'] = -10
+            attrs = ['_FillValue', 'long_name', 'units', 'valid_max', 'valid_min', 'DIMENSION_LIST']
         else:
             for k in ['Reflectivity331', 'UVAerosolIndex']:
                 k = 'SCIENCE_DATA/' + k
@@ -138,16 +141,17 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
             file_content['GEOLOCATION_DATA/Latitude/attr/Title'] = 'Geodetic Latitude'
             file_content['GEOLOCATION_DATA/Latitude/attr/Units'] = 'deg'
 
-        convert_file_content_to_data_array(file_content)
+        convert_file_content_to_data_array(file_content, attrs)
         return file_content
 
 
 class TestOMPSEDRReader(unittest.TestCase):
-    """Test OMPS EDR Reader"""
+    """Test OMPS EDR Reader."""
+
     yaml_file = "omps_edr.yaml"
 
     def setUp(self):
-        """Wrap HDF5 file handler with our own fake handler"""
+        """Wrap HDF5 file handler with our own fake handler."""
         from satpy.config import config_search_paths
         from satpy.readers.omps_edr import EDRFileHandler, EDREOSFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
@@ -160,7 +164,7 @@ class TestOMPSEDRReader(unittest.TestCase):
         self.p2.is_local = True
 
     def tearDown(self):
-        """Stop wrapping the NetCDF4 file handler"""
+        """Stop wrapping the NetCDF4 file handler."""
         self.p2.stop()
         self.p.stop()
 
@@ -179,7 +183,7 @@ class TestOMPSEDRReader(unittest.TestCase):
         self.assertTrue(r.file_handlers)
 
     def test_basic_load_so2(self):
-        """Test basic load of so2 datasets"""
+        """Test basic load of so2 datasets."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -210,7 +214,7 @@ class TestOMPSEDRReader(unittest.TestCase):
         self.assertEqual(len(ds), 1)
 
     def test_basic_load_to3(self):
-        """Test basic load of to3 datasets"""
+        """Test basic load of to3 datasets."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([

--- a/satpy/tests/reader_tests/test_omps_edr.py
+++ b/satpy/tests/reader_tests/test_omps_edr.py
@@ -69,6 +69,49 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
             file_content[k + '/attr/MissingValue'] = -1
             file_content[k + '/attr/Title'] = 'Geodetic Latitude'
             file_content[k + '/attr/ValidRange'] = (-90, 90)
+        elif 'NMSO2' in filename:
+            file_content['GEOLOCATION_DATA/Longitude'] = DEFAULT_LON_DATA
+            file_content['GEOLOCATION_DATA/Longitude/shape'] = DEFAULT_FILE_SHAPE
+            file_content['GEOLOCATION_DATA/Longitude/attr/valid_max'] = 180
+            file_content['GEOLOCATION_DATA/Longitude/attr/valid_min'] = -180
+            file_content['GEOLOCATION_DATA/Longitude/attr/_FillValue'] = -1.26765e+30
+            file_content['GEOLOCATION_DATA/Longitude/attr/long_name'] = 'Longitude'
+            file_content['GEOLOCATION_DATA/Longitude/attr/standard_name'] = 'longitude'
+            file_content['GEOLOCATION_DATA/Longitude/attr/units'] = 'degrees_east'
+            file_content['GEOLOCATION_DATA/Latitude'] = DEFAULT_LAT_DATA
+            file_content['GEOLOCATION_DATA/Latitude/shape'] = DEFAULT_FILE_SHAPE
+            file_content['GEOLOCATION_DATA/Latitude/attr/valid_max'] = 90
+            file_content['GEOLOCATION_DATA/Latitude/attr/valid_min'] = -90
+            file_content['GEOLOCATION_DATA/Latitude/attr/_FillValue'] = -1.26765e+30
+            file_content['GEOLOCATION_DATA/Latitude/attr/long_name'] = 'Latitude'
+            file_content['GEOLOCATION_DATA/Latitude/attr/standard_name'] = 'latitude'
+            file_content['GEOLOCATION_DATA/Latitude/attr/units'] = 'degress_north'
+
+            k = 'SCIENCE_DATA/ColumnAmountSO2_TRM'
+            file_content[k] = DEFAULT_FILE_DATA
+            file_content[k + '/shape'] = DEFAULT_FILE_SHAPE
+            file_content[k + '/attr/_FillValue'] = -1.26765e+30
+            file_content[k + '/attr/long_name'] = 'Column Amount SO2 (TRM)'
+            file_content[k + '/attr/units'] = 'DU'
+            file_content[k + '/attr/valid_max'] = 2000
+            file_content[k + '/attr/valid_min'] = -10
+
+            k = 'SCIENCE_DATA/ColumnAmountSO2_STL'
+            file_content[k] = DEFAULT_FILE_DATA
+            file_content[k + '/shape'] = DEFAULT_FILE_SHAPE
+            file_content[k + '/attr/_FillValue'] = -1.26765e+30
+            file_content[k + '/attr/long_name'] = 'Column Amount SO2 (TRM)'
+            file_content[k + '/attr/units'] = 'DU'
+
+            k = 'SCIENCE_DATA/ColumnAmountSO2_TRL'
+            file_content[k] = DEFAULT_FILE_DATA
+            file_content[k + '/shape'] = DEFAULT_FILE_SHAPE
+            file_content[k + '/attr/_FillValue'] = -1.26765e+30
+            file_content[k + '/attr/long_name'] = 'Column Amount SO2 (TRL)'
+            file_content[k + '/attr/units'] = 'DU'
+            file_content[k + '/attr/valid_max'] = 2000
+            file_content[k + '/attr/valid_min'] = -10
+            file_content[k + '/attr/DIMENSION_LIST'] = -10
         else:
             for k in ['Reflectivity331', 'UVAerosolIndex']:
                 k = 'SCIENCE_DATA/' + k
@@ -128,8 +171,9 @@ class TestOMPSEDRReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'OMPS-NPP-TC_EDR_SO2NRT-2016m0607t192031-o00001-2016m0607t192947.he5',
             'OMPS-NPP-TC_EDR_TO3-v1.0-2016m0607t192031-o00001-2016m0607t192947.h5',
+            'OMPS-NPP_NMSO2-PCA-L2_v1.1_2018m1129t112824_o00001_2018m1129t114426.h5',
         ])
-        self.assertTrue(len(loadables), 2)
+        self.assertEqual(len(loadables), 3)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)
@@ -141,8 +185,9 @@ class TestOMPSEDRReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'OMPS-NPP-TC_EDR_SO2NRT-2016m0607t192031-o00001-2016m0607t192947.he5',
             'OMPS-NPP-TC_EDR_TO3-v1.0-2016m0607t192031-o00001-2016m0607t192947.h5',
+            'OMPS-NPP_NMSO2-PCA-L2_v1.1_2018m1129t112824_o00001_2018m1129t114426.h5',
         ])
-        self.assertTrue(len(loadables), 2)
+        self.assertEqual(len(loadables), 3)
         r.create_filehandlers(loadables)
         ds = r.load(['so2_trm'])
         self.assertEqual(len(ds), 1)
@@ -152,6 +197,15 @@ class TestOMPSEDRReader(unittest.TestCase):
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])
 
+        ds = r.load(['tcso2_trm_sampo'])
+        self.assertEqual(len(ds), 1)
+        for d in ds.values():
+            self.assertEqual(d.attrs['resolution'], 50000)
+            self.assertTupleEqual(d.shape, DEFAULT_FILE_SHAPE)
+
+        ds = r.load(['tcso2_stl_sampo'])
+        self.assertEqual(len(ds), 0)
+
     def test_basic_load_to3(self):
         """Test basic load of to3 datasets"""
         from satpy.readers import load_reader
@@ -159,8 +213,9 @@ class TestOMPSEDRReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'OMPS-NPP-TC_EDR_SO2NRT-2016m0607t192031-o00001-2016m0607t192947.he5',
             'OMPS-NPP-TC_EDR_TO3-v1.0-2016m0607t192031-o00001-2016m0607t192947.h5',
+            'OMPS-NPP_NMSO2-PCA-L2_v1.1_2018m1129t112824_o00001_2018m1129t114426.h5',
         ])
-        self.assertTrue(len(loadables), 2)
+        self.assertEqual(len(loadables), 3)
         r.create_filehandlers(loadables)
         ds = r.load(['reflectivity_331', 'uvaerosol_index'])
         self.assertEqual(len(ds), 2)

--- a/satpy/tests/reader_tests/test_omps_edr.py
+++ b/satpy/tests/reader_tests/test_omps_edr.py
@@ -206,6 +206,9 @@ class TestOMPSEDRReader(unittest.TestCase):
         ds = r.load(['tcso2_stl_sampo'])
         self.assertEqual(len(ds), 0)
 
+        ds = r.load(['tcso2_trl_sampo'])
+        self.assertEqual(len(ds), 1)
+
     def test_basic_load_to3(self):
         """Test basic load of to3 datasets"""
         from satpy.readers import load_reader


### PR DESCRIPTION
Update OMPS edr reader and hdf5_utils to handle OMPS SO2 DATA from FMI SAMPO.

The OMPS SO2 data from FMI SAMPO in hdf5 format contains references that need special handling. This update does this.

Also added dataset names special to the data from FMI SAMPO

 - [x] Closes #630, closes #883 
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 