### PR TITLE
Add tm5_constant_a and tm5_constant_b for tropomi_l2

### DIFF
--- a/satpy/etc/readers/tropomi_l2.yaml
+++ b/satpy/etc/readers/tropomi_l2.yaml
@@ -54,4 +54,14 @@ datasets:
         file_type: tropomi_l2
         file_key: 'PRODUCT/time'
         standard_name: ref_time
+    tm5_constant_a:
+        name: 'tm5_constant_a'
+        file_type: tropomi_l2
+        file_key: 'PRODUCT/tm5_constant_a'
+        standard_name: tm5_constant_a
+    tm5_constant_b:
+        name: 'tm5_constant_b'
+        file_type: tropomi_l2
+        file_key: 'PRODUCT/tm5_constant_b'
+        standard_name: tm5_constant_b
 


### PR DESCRIPTION
Because of different shape, `tm5_constant_a` and `tm5_constant_b` are ignored by the `tropomi_l2.py` reader.
I added them in `tropomi_l2.yaml` now.