### PR TITLE
Fix geostationary utilities assuming a/b radii are always available

### DIFF
--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -70,8 +70,21 @@ def get_geostationary_angle_extent(geos_area):
     # TODO: take into account sweep_axis_angle parameter
 
     # get some projection parameters
-    req = float(geos_area.proj_dict['a']) / 1000
-    rp = float(geos_area.proj_dict['b']) / 1000
+    try:
+        crs = geos_area.crs
+        a = crs.ellipsoid.semi_major_metre
+        b = crs.ellipsoid.semi_minor_metre
+        if np.isnan(b):
+            # see https://github.com/pyproj4/pyproj/issues/457
+            raise AttributeError("'semi_minor_metre' attribute is not valid "
+                                 "in older versions of pyproj.")
+    except AttributeError:
+        # older versions of pyproj don't have CRS objects
+        from pyresample.utils import proj4_radius_parameters
+        a, b = proj4_radius_parameters(geos_area.proj_dict)
+
+    req = float(a) / 1000
+    rp = float(b) / 1000
     h = float(geos_area.proj_dict['h']) / 1000 + req
 
     # compute some constants

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -35,6 +35,7 @@ class TestAHIHSDNavigation(unittest.TestCase):
     @mock.patch('satpy.readers.ahi_hsd.np.fromfile')
     def test_region(self, fromfile, np2str):
         """Test region navigation."""
+        from pyresample.utils import proj4_radius_parameters
         np2str.side_effect = lambda x: x
         m = mock.mock_open()
         with mock.patch('satpy.readers.ahi_hsd.open', m, create=True):
@@ -67,8 +68,9 @@ class TestAHIHSDNavigation(unittest.TestCase):
 
             area_def = fh.get_area_def(None)
             proj_dict = area_def.proj_dict
-            self.assertEqual(proj_dict['a'], 6378137.0)
-            self.assertEqual(proj_dict['b'], 6356752.3)
+            a, b = proj4_radius_parameters(proj_dict)
+            self.assertEqual(a, 6378137.0)
+            self.assertEqual(b, 6356752.3)
             self.assertEqual(proj_dict['h'], 35785863.0)
             self.assertEqual(proj_dict['lon_0'], 140.7)
             self.assertEqual(proj_dict['proj'], 'geos')
@@ -80,6 +82,7 @@ class TestAHIHSDNavigation(unittest.TestCase):
     @mock.patch('satpy.readers.ahi_hsd.np.fromfile')
     def test_segment(self, fromfile, np2str):
         """Test segment navigation."""
+        from pyresample.utils import proj4_radius_parameters
         np2str.side_effect = lambda x: x
         m = mock.mock_open()
         with mock.patch('satpy.readers.ahi_hsd.open', m, create=True):
@@ -112,8 +115,9 @@ class TestAHIHSDNavigation(unittest.TestCase):
 
             area_def = fh.get_area_def(None)
             proj_dict = area_def.proj_dict
-            self.assertEqual(proj_dict['a'], 6378137.0)
-            self.assertEqual(proj_dict['b'], 6356752.3)
+            a, b = proj4_radius_parameters(proj_dict)
+            self.assertEqual(a, 6378137.0)
+            self.assertEqual(b, 6356752.3)
             self.assertEqual(proj_dict['h'], 35785863.0)
             self.assertEqual(proj_dict['lon_0'], 140.7)
             self.assertEqual(proj_dict['proj'], 'geos')

--- a/satpy/tests/reader_tests/test_geos_area.py
+++ b/satpy/tests/reader_tests/test_geos_area.py
@@ -132,6 +132,7 @@ class TestGEOSProjectionUtil(unittest.TestCase):
 
     def test_get_area_definition(self):
         """Test the retrieval of the area definition."""
+        from pyresample.utils import proj4_radius_parameters
         pdict, extent = self.make_pdict_ext(1, 'N2S')
         good_res = (-3000.4032785810186, -3000.4032785810186)
 
@@ -140,6 +141,7 @@ class TestGEOSProjectionUtil(unittest.TestCase):
         self.assertEqual(a_def.resolution, good_res)
         self.assertEqual(a_def.proj_dict['proj'], 'geos')
         self.assertEqual(a_def.proj_dict['units'], 'm')
-        self.assertEqual(a_def.proj_dict['a'], 6378169)
-        self.assertEqual(a_def.proj_dict['b'], 6356583.8)
+        a, b = proj4_radius_parameters(a_def.proj_dict)
+        self.assertEqual(a, 6378169)
+        self.assertEqual(b, 6356583.8)
         self.assertEqual(a_def.proj_dict['h'], 35785831)

--- a/satpy/tests/reader_tests/test_hrit_base.py
+++ b/satpy/tests/reader_tests/test_hrit_base.py
@@ -15,8 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""The HRIT base reader tests package.
-"""
+"""The HRIT base reader tests package."""
 
 import os
 import unittest
@@ -33,6 +32,7 @@ class TestHRITDecompress(unittest.TestCase):
     """Test the on-the-fly decompression."""
 
     def test_xrit_cmd(self):
+        """Test running the xrit decompress command."""
         old_env = os.environ.get('XRIT_DECOMPRESS_PATH', None)
 
         os.environ['XRIT_DECOMPRESS_PATH'] = '/path/to/my/bin'
@@ -54,13 +54,14 @@ class TestHRITDecompress(unittest.TestCase):
         self.assertEqual(fname, res)
 
     def test_xrit_outfile(self):
+        """Test the right decompression filename is used."""
         stdout = [b"Decompressed file: bla.__\n"]
         outfile = get_xritdecompress_outfile(stdout)
         self.assertEqual(outfile, b'bla.__')
 
     @mock.patch('satpy.readers.hrit_base.Popen')
     def test_decompress(self, popen):
-
+        """Test decompression works."""
         popen.return_value.returncode = 0
         popen.return_value.communicate.return_value = [b"Decompressed file: bla.__\n"]
 
@@ -83,7 +84,7 @@ class TestHRITFileHandler(unittest.TestCase):
 
     @mock.patch('satpy.readers.hrit_base.np.fromfile')
     def setUp(self, fromfile):
-        """Setup the hrit file handler for testing."""
+        """Set up the hrit file handler for testing."""
         m = mock.mock_open()
         fromfile.return_value = np.array([(1, 2)], dtype=[('total_header_length', int),
                                                           ('hdr_id', int)])
@@ -126,12 +127,14 @@ class TestHRITFileHandler(unittest.TestCase):
         self.assertEqual(131072, y__)
 
     def test_get_area_extent(self):
+        """Test getting the area extent."""
         res = self.reader.get_area_extent((20, 20), (10, 10), (5, 5), 33)
         exp = (-71717.44995740513, -71717.44995740513,
                79266.655216079365, 79266.655216079365)
         self.assertTupleEqual(res, exp)
 
     def test_get_area_def(self):
+        """Test getting an area definition."""
         from pyresample.utils import proj4_radius_parameters
         area = self.reader.get_area_def('VIS06')
         proj_dict = area.proj_dict
@@ -148,6 +151,7 @@ class TestHRITFileHandler(unittest.TestCase):
 
     @mock.patch('satpy.readers.hrit_base.np.memmap')
     def test_read_band(self, memmap):
+        """Test reading a single band."""
         nbits = self.reader.mda['number_of_bits_per_pixel']
         memmap.return_value = np.random.randint(0, 256,
                                                 size=int((464 * 3712 * nbits) / 8),

--- a/satpy/tests/reader_tests/test_hrit_base.py
+++ b/satpy/tests/reader_tests/test_hrit_base.py
@@ -132,10 +132,12 @@ class TestHRITFileHandler(unittest.TestCase):
         self.assertTupleEqual(res, exp)
 
     def test_get_area_def(self):
+        from pyresample.utils import proj4_radius_parameters
         area = self.reader.get_area_def('VIS06')
         proj_dict = area.proj_dict
-        self.assertEqual(proj_dict['a'], 6378169.0)
-        self.assertEqual(proj_dict['b'], 6356583.8)
+        a, b = proj4_radius_parameters(proj_dict)
+        self.assertEqual(a, 6378169.0)
+        self.assertEqual(b, 6356583.8)
         self.assertEqual(proj_dict['h'], 35785831.0)
         self.assertEqual(proj_dict['lon_0'], 44.0)
         self.assertEqual(proj_dict['proj'], 'geos')

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -240,12 +240,14 @@ class TestHRITMSGFileHandlerHRV(unittest.TestCase):
 
     def test_get_area_def(self):
         """Test getting the area def."""
+        from pyresample.utils import proj4_radius_parameters
         area = self.reader.get_area_def(DatasetID('HRV'))
         self.assertEqual(area.area_extent,
                          (-45561979844414.07, -3720765401003.719, 45602912357076.38, 77771774058.38356))
         proj_dict = area.proj_dict
-        self.assertEqual(proj_dict['a'], 6378169.0)
-        self.assertEqual(proj_dict['b'], 6356583.8)
+        a, b = proj4_radius_parameters(proj_dict)
+        self.assertEqual(a, 6378169.0)
+        self.assertEqual(b, 6356583.8)
         self.assertEqual(proj_dict['h'], 35785831.0)
         self.assertEqual(proj_dict['lon_0'], 44.0)
         self.assertEqual(proj_dict['proj'], 'geos')
@@ -323,10 +325,12 @@ class TestHRITMSGFileHandler(unittest.TestCase):
 
     def test_get_area_def(self):
         """Test getting the area def."""
+        from pyresample.utils import proj4_radius_parameters
         area = self.reader.get_area_def(DatasetID('VIS006'))
         proj_dict = area.proj_dict
-        self.assertEqual(proj_dict['a'], 6378169.0)
-        self.assertEqual(proj_dict['b'], 6356583.8)
+        a, b = proj4_radius_parameters(proj_dict)
+        self.assertEqual(a, 6378169.0)
+        self.assertEqual(b, 6356583.8)
         self.assertEqual(proj_dict['h'], 35785831.0)
         self.assertEqual(proj_dict['lon_0'], 44.0)
         self.assertEqual(proj_dict['proj'], 'geos')

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -73,11 +73,15 @@ class TestHelpers(unittest.TestCase):
     def test_get_geostationary_bbox(self):
         """Get the geostationary bbox."""
         geos_area = mock.MagicMock()
+        del geos_area.crs
         lon_0 = 0
-        geos_area.proj_dict = {'a': 6378169.00,
-                               'b': 6356583.80,
-                               'h': 35785831.00,
-                               'lon_0': lon_0}
+        geos_area.proj_dict = {
+            'proj': 'geos',
+            'lon_0': lon_0,
+            'a': 6378169.00,
+            'b': 6356583.80,
+            'h': 35785831.00,
+            'units': 'm'}
         geos_area.area_extent = [-5500000., -5500000., 5500000., 5500000.]
 
         lon, lat = hf.get_geostationary_bounding_box(geos_area, 20)
@@ -101,20 +105,36 @@ class TestHelpers(unittest.TestCase):
     def test_get_geostationary_angle_extent(self):
         """Get max geostationary angles."""
         geos_area = mock.MagicMock()
-        geos_area.proj_dict = {'a': 6378169.00,
-                               'b': 6356583.80,
-                               'h': 35785831.00}
+        del geos_area.crs
+        geos_area.proj_dict = {
+            'proj': 'geos',
+            'sweep': 'x',
+            'lon_0': -89.5,
+            'a': 6378169.00,
+            'b': 6356583.80,
+            'h': 35785831.00,
+            'units': 'm'}
 
         expected = (0.15185342867090912, 0.15133555510297725)
-
         np.testing.assert_allclose(expected,
                                    hf.get_geostationary_angle_extent(geos_area))
 
-        geos_area.proj_dict = {'a': 1000.0,
-                               'b': 1000.0,
-                               'h': np.sqrt(2) * 1000.0 - 1000.0}
+        geos_area.proj_dict['a'] = 1000.0
+        geos_area.proj_dict['b'] = 1000.0
+        geos_area.proj_dict['h'] = np.sqrt(2) * 1000.0 - 1000.0
 
         expected = (np.deg2rad(45), np.deg2rad(45))
+        np.testing.assert_allclose(expected,
+                                   hf.get_geostationary_angle_extent(geos_area))
+
+        geos_area.proj_dict = {
+            'proj': 'geos',
+            'sweep': 'x',
+            'lon_0': -89.5,
+            'ellps': 'GRS80',
+            'h': 35785831.00,
+            'units': 'm'}
+        expected = (0.15185277703584374, 0.15133971368991794)
 
         np.testing.assert_allclose(expected,
                                    hf.get_geostationary_angle_extent(geos_area))


### PR DESCRIPTION
This goes along with a PR I'm working on for pyresample. While working on that PR which effects how the `proj_dict` of an `AreaDefinition` is created I noticed that certain tests in satpy were failing. This was caused by the `get_geostationary_angle_extent` function assuming that `area_def.proj_dict` would always have an `a` and `b` parameter. This isn't always true if an ellipsoid model is used (`+ellps=GRS80`) or if PROJ is able to determine that an a/b combination matches a defined ellipsoid in which case it will replace those parameters with `+ellps`.

This PR switches the `get_geostationary_angle_extent` to use the `CRS` object of an AreaDefinition if it exists, otherwise fallback to `proj4_radius_parameters` from pyresample.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

