### PR TITLE
Fix reflectance and BT calibration in FCI FDHSI reader

### DIFF
--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -128,7 +128,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         logger.debug('Reading {} from {}'.format(key.name, self.filename))
         # Get the dataset
         # Get metadata for given dataset
-        measured = self.get_channel_group_path(key.name)
+        measured = self.get_channel_measured_group_path(key.name)
         data = self[measured + "/effective_radiance"]
 
         attrs = data.attrs.copy()
@@ -171,16 +171,16 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
 
         return res
 
-    def get_channel_group_path(self, channel):
-        """Get channel group path."""
-        group_path = 'data/{}/measured'.format(channel)
+    def get_channel_measured_group_path(self, channel):
+        """Get the channel's measured group path."""
+        measured_group_path = 'data/{}/measured'.format(channel)
 
-        return group_path
+        return measured_group_path
 
     def calc_area_extent(self, key):
         """Calculate area extent for a dataset."""
         # Get metadata for given dataset
-        measured = self.get_channel_group_path(key.name)
+        measured = self.get_channel_measured_group_path(key.name)
         # Get start/end line and column of loaded swath.
         nlines, ncols = self[measured + "/effective_radiance/shape"]
 
@@ -307,7 +307,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
 
     def calibrate_rad_to_bt(self, radiance, key):
         """IR channel calibration."""
-        measured = self.get_channel_group_path(key.name)
+        measured = self.get_channel_measured_group_path(key.name)
 
         # using the method from RADTOBR and PUG
         vc = self[measured + "/radiance_to_bt_conversion_coefficient_wavenumber"]
@@ -338,7 +338,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
 
     def calibrate_rad_to_refl(self, radiance, key):
         """VIS channel calibration."""
-        measured = self.get_channel_group_path(key.name)
+        measured = self.get_channel_measured_group_path(key.name)
 
         cesi = self[measured + "/channel_effective_solar_irradiance"]
 

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -200,7 +200,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
             ext[c] = (min_c.item(), max_c.item())
 
         area_extent = (ext["x"][1], ext["y"][1], ext["x"][0], ext["y"][0])
-        return (area_extent, nlines, ncols)
+        return area_extent, nlines, ncols
 
     def get_area_def(self, key, info=None):
         """Calculate on-fly area definition for 0 degree geos-projection for a dataset."""
@@ -216,7 +216,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         lon_0 = float(self["data/mtg_geos_projection/attr/longitude_of_projection_origin"])
         sweep = str(self["data/mtg_geos_projection"].sweep_angle_axis)
         # Channel dependent swath resolution
-        (area_extent, nlines, ncols) = self.calc_area_extent(key)
+        area_extent, nlines, ncols = self.calc_area_extent(key)
         logger.debug('Calculated area extent: {}'
                      .format(''.join(str(area_extent))))
 
@@ -308,7 +308,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
                 coords=radiance.coords,
                 attrs=radiance.attrs)
 
-        sun_earth_distance = np.mean(self["state/celestial/earth_sun_distance"]) / 149597870.7 # [AU]
+        sun_earth_distance = np.mean(self["state/celestial/earth_sun_distance"]) / 149597870.7  # [AU]
 
         res = 100 * radiance * np.pi * sun_earth_distance**2 / cesi
         res.attrs["units"] = "%"

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -257,8 +257,8 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
 
     def _ir_calibrate(self, radiance, measured, root):
         """IR channel calibration."""
-        coef = self[measured + "/radiance_unit_conversion_coefficient"]
-        wl_c = self[root + "/central_wavelength_actual"]
+        # using the method from EUM/MET/TEN/11/0569 and PUG
+        vc = self[measured + "/radiance_to_bt_conversion_coefficient_wavenumber"]
 
         a = self[measured + "/radiance_to_bt_conversion_coefficient_a"]
         b = self[measured + "/radiance_to_bt_conversion_coefficient_b"]
@@ -266,7 +266,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         c1 = self[measured + "/radiance_to_bt_conversion_constant_c1"]
         c2 = self[measured + "/radiance_to_bt_conversion_constant_c2"]
 
-        for v in (coef, wl_c, a, b, c1, c2):
+        for v in (vc, a, b, c1, c2):
             if v == v.attrs.get("FillValue",
                                 default_fillvals.get(v.dtype.str[1:])):
                 logger.error(
@@ -283,10 +283,8 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
                         coords=radiance.coords,
                         attrs=radiance.attrs)
 
-        Lv = radiance * coef
-        vc = 1e6/wl_c  # from wl in um to wn in m^-1
         nom = c2 * vc
-        denom = a * np.log(1 + (c1 * vc**3) / Lv)
+        denom = a * np.log(1 + (c1 * vc**3) / radiance)
 
         res = nom / denom - b / a
         res.attrs["units"] = "K"
@@ -294,25 +292,24 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
 
     def _vis_calibrate(self, radiance, measured):
         """VIS channel calibration."""
-        # radiance to reflectance taken as in mipp/xrit/MSG.py
-        # again FCI User Guide is not clear on how to do this
-
         cesilab = measured + "/channel_effective_solar_irradiance"
         cesi = self[cesilab]
+
         if cesi == cesi.attrs.get(
                 "FillValue", default_fillvals.get(cesi.dtype.str[1:])):
             logger.error(
                 "channel effective solar irradiance set to fill value, "
                 "cannot produce reflectance for {:s}.".format(measured))
             return xr.DataArray(
-                    da.full(shape=radiance.shape,
-                            chunks=radiance.chunks,
-                            fill_value=np.nan),
-                    dims=radiance.dims,
-                    coords=radiance.coords,
-                    attrs=radiance.attrs)
+                da.full(shape=radiance.shape,
+                        chunks=radiance.chunks,
+                        fill_value=np.nan),
+                dims=radiance.dims,
+                coords=radiance.coords,
+                attrs=radiance.attrs)
 
-        sirr = float(cesi)
-        res = radiance / sirr * 100
+        sun_earth_distance = np.mean(self["state/celestial/earth_sun_distance"]) / 149597870.7 # [AU]
+
+        res = 100 * radiance * np.pi * sun_earth_distance**2 / cesi
         res.attrs["units"] = "%"
         return res

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -302,7 +302,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         else:
             logger.error(
                 "Received unknown calibration key.  Expected "
-                "'brightness_temperature', 'reflectance' or 'radiance, got "
+                "'brightness_temperature', 'reflectance' or 'radiance', got "
                 + key.calibration + ".")
 
         return data

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -37,7 +37,7 @@ Geolocation is based on information from the data files.  It uses:
       radius
     * From the attribute ``perspective_point_height`` on the same data
       variable, the geostationary altitude in the normalised geostationary
-      projection (see PUG §5.2)
+      projection (see `PUG`_ §5.2)
     * From the attribute ``longitude_of_projection_origin`` on the same
       data variable, the longitude of the projection origin
     * From the attribute ``inverse_flattening`` on the same data variable, the
@@ -53,6 +53,10 @@ geostationary altitude, and longitude of projection origin, are passed on to
 ``pyresample.geometry.AreaDefinition``, which then uses proj4 for the actual
 geolocation calculations.
 
+The brightness temperature calculation is based on the formulas indicated in
+`PUG`_ and `RADTOBR`_.
+
+.. _RADTOBR: https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_EFFECT_RAD_TO_BRIGHTNESS&RevisionSelectionMethod=LatestReleased&Rendition=Web
 .. _PUG: http://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_DMT_719113&RevisionSelectionMethod=LatestReleased&Rendition=Web
 .. _EUMETSAT: https://www.eumetsat.int/website/home/Satellites/FutureSatellites/MeteosatThirdGeneration/MTGDesign/index.html#fci  # noqa: E501
 """
@@ -268,7 +272,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
 
     def _ir_calibrate(self, radiance, measured, root):
         """IR channel calibration."""
-        # using the method from EUM/MET/TEN/11/0569 and PUG
+        # using the method from RADTOBR and PUG
         vc = self[measured + "/radiance_to_bt_conversion_coefficient_wavenumber"]
 
         a = self[measured + "/radiance_to_bt_conversion_coefficient_a"]

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -268,12 +268,13 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
                 data = self._ir_calibrate(data, measured, root)
             elif key.calibration == 'reflectance':
                 data = self._vis_calibrate(data, measured)
-            else:
-                logger.warning(
-                    "Received unknown calibration key.  Expected "
-                    "'brightness_temperature' or 'reflectance', got "
-                    + key.calibration + ". Returning radiances.")
+            elif key.calibration == 'radiance':
                 data.attrs["units"] = original_radiance_units
+            else:
+                logger.error(
+                    "Received unknown calibration key.  Expected "
+                    "'brightness_temperature', 'reflectance' or 'radiance, got "
+                    + key.calibration + ".")
 
         return data
 

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -307,8 +307,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
 
     def _vis_calibrate(self, radiance, measured):
         """VIS channel calibration."""
-        cesilab = measured + "/channel_effective_solar_irradiance"
-        cesi = self[cesilab]
+        cesi = self[measured + "/channel_effective_solar_irradiance"]
 
         if cesi == cesi.attrs.get(
                 "FillValue", default_fillvals.get(cesi.dtype.str[1:])):

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -66,7 +66,6 @@ from __future__ import (division, absolute_import, print_function,
 
 import logging
 import numpy as np
-import dask.array as da
 import xarray as xr
 
 from pyresample import geometry
@@ -330,13 +329,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
                         v.attrs.get("long_name",
                                     "at least one necessary coefficient"),
                         root))
-                return xr.DataArray(
-                        da.full(shape=radiance.shape,
-                                chunks=radiance.chunks,
-                                fill_value=np.nan),
-                        dims=radiance.dims,
-                        coords=radiance.coords,
-                        attrs=radiance.attrs)
+                return radiance*np.nan
 
         nom = c2 * vc
         denom = a * np.log(1 + (c1 * vc**3) / radiance)
@@ -356,13 +349,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
             logger.error(
                 "channel effective solar irradiance set to fill value, "
                 "cannot produce reflectance for {:s}.".format(measured))
-            return xr.DataArray(
-                da.full(shape=radiance.shape,
-                        chunks=radiance.chunks,
-                        fill_value=np.nan),
-                dims=radiance.dims,
-                coords=radiance.coords,
-                attrs=radiance.attrs)
+            return radiance*np.nan
 
         sun_earth_distance = np.mean(self["state/celestial/earth_sun_distance"]) / 149597870.7  # [AU]
 

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -38,17 +38,17 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
                 C_SPEED as c)
         xrda = xr.DataArray
         data = {}
-        data[meas + "/radiance_unit_conversion_coefficient"] = xrda(1)
-        data[chroot + "/central_wavelength_actual"] = xrda(10)
-        data[meas + "/radiance_to_bt_conversion_coefficient_a"] = xrda(1000)
-        data[meas + "/radiance_to_bt_conversion_coefficient_b"] = xrda(1)
-        data[meas + "/radiance_to_bt_conversion_constant_c1"] = xrda(2*h*c**2)
-        data[meas + "/radiance_to_bt_conversion_constant_c2"] = xrda(h*c/k)
+        data[meas + "/radiance_to_bt_conversion_coefficient_wavenumber"] = xrda(955)
+        data[meas + "/radiance_to_bt_conversion_coefficient_a"] = xrda(1)
+        data[meas + "/radiance_to_bt_conversion_coefficient_b"] = xrda(0.4)
+        data[meas + "/radiance_to_bt_conversion_constant_c1"] = xrda(1e11*2*h*c**2)
+        data[meas + "/radiance_to_bt_conversion_constant_c2"] = xrda(1e2*h*c/k)
         return data
 
     def _get_test_calib_for_channel_vis(self, chroot, meas):
         xrda = xr.DataArray
         data = {}
+        data["state/celestial/earth_sun_distance"] = xrda(149597870.7)
         data[meas + "/channel_effective_solar_irradiance"] = xrda(50)
         return data
 
@@ -173,8 +173,7 @@ class FakeNetCDF4FileHandler3(FakeNetCDF4FileHandler2):
         from netCDF4 import default_fillvals
         v = xr.DataArray(default_fillvals["f4"])
         data = {}
-        data[meas + "/radiance_unit_conversion_coefficient"] = v
-        data[chroot + "/central_wavelength_actual"] = v
+        data[meas + "/radiance_to_bt_conversion_coefficient_wavenumber"] = v
         data[meas + "/radiance_to_bt_conversion_coefficient_a"] = v
         data[meas + "/radiance_to_bt_conversion_coefficient_b"] = v
         data[meas + "/radiance_to_bt_conversion_constant_c1"] = v
@@ -337,7 +336,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
             self.assertEqual(res[ch].dtype, np.float64)
             self.assertEqual(res[ch].attrs["calibration"], "reflectance")
             self.assertEqual(res[ch].attrs["units"], "%")
-            numpy.testing.assert_array_equal(res[ch], 15 / 50 * 100)
+            numpy.testing.assert_array_equal(res[ch], 100 * 15 * 1 * np.pi / 50)
 
     def test_load_bt(self):
         """Test loading with bt
@@ -366,7 +365,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
             self.assertEqual(res[ch].attrs["units"], "K")
             numpy.testing.assert_array_almost_equal(
                     res[ch],
-                    181.917084)
+                    209.68274099)
 
     def test_load_composite(self):
         """Test that composites are loadable

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -81,6 +81,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
                     "add_offset": 10,
                     "warm_scale_factor": 2,
                     "warm_add_offset": -300,
+                    "long_name": "Effective Radiance",
                     "units": "mW.m-2.sr-1.(cm-1)-1",
                 }
             )
@@ -92,6 +93,9 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
                     "valid_range": [0, 4095],
                     "scale_factor": 5,
                     "add_offset": 10,
+                    "warm_scale_factor": 1,
+                    "warm_add_offset": 0,
+                    "long_name": "Effective Radiance",
                     "units": "mW.m-2.sr-1.(cm-1)-1",
                 }
             )


### PR DESCRIPTION
This PR fixes the calibration of radiances into reflectances and brightness temperatures (BT) in the FCI FDHSI reader (`fci_l1c_fdhsi`).

- applies earth-sun distance correction to reflectance (as for example in `abi_l1b`)
- implements the warm_scale_factor and warm_add_offset for the extended dynamic range of ir_38
- reorganizes the calibration functions in a set of smaller functions

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
