### PR TITLE
Enable NWCSAF-GEO composites for ABI, AHI, FCI

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -236,3 +236,150 @@ composites:
       - name: cimss_green
       - name: C01
     standard_name: cimss_true_color
+
+  cloudmask:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cma
+    - cma_pal
+    standard_name: cloudmask
+
+  cloudtype:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ct
+    - ct_pal
+    standard_name: cloudtype
+
+  cloud_top_height:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ctth_alti
+    - ctth_alti_pal
+    standard_name: cloud_top_height
+
+  cloud_top_pressure:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ctth_pres
+    - ctth_pres_pal
+    standard_name: cloud_top_pressure
+
+  cloud_top_temperature:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ctth_tempe
+    - ctth_tempe_pal
+    standard_name: cloud_top_temperature
+
+  cloud_top_phase:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_phase
+    - cmic_phase_pal
+    standard_name: cloud_top_phase
+
+  cloud_drop_effective_radius:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_reff
+    - cmic_reff_pal
+    standard_name: cloud_drop_effective_radius
+
+  cloud_optical_thickness:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_cot
+    - cmic_cot_pal
+    standard_name: cloud_optical_thickness
+
+  cloud_liquid_water_path:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_lwp
+    - cmic_lwp_pal
+    standard_name: cloud_liquid_water_path
+
+  cloud_ice_water_path:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_iwp
+    - cmic_iwp_pal
+    standard_name: cloud_ice_water_path
+
+  precipitation_probability:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - pc
+    - pc_pal
+    standard_name: precipitation_probability
+
+  convective_rain_rate:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - crr
+    - crr_pal
+    standard_name: convective_rain_rate
+
+  convective_precipitation_hourly_accumulation:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - crr_accum
+    - crr_pal
+    standard_name: convective_precipitation_hourly_accumulation
+
+  total_precipitable_water:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ishai_tpw
+    - ishai_tpw_pal
+    standard_name: total_precipitable_water
+
+  showalter_index:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ishai_shw
+    - ishai_shw_pal
+    standard_name: showalter_index
+
+  lifted_index:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ishai_li
+    - ishai_li_pal
+    standard_name: lifted_index
+
+  convection_initiation_prob30:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ci_prob30
+    - ci_pal
+    standard_name: convection_initiation_prob30
+
+  convection_initiation_prob60:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ci_prob60
+    - ci_pal
+    standard_name: convection_initiation_prob60
+
+  convection_initiation_prob90:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ci_prob90
+    - ci_pal
+    standard_name: convection_initiation_prob90
+
+  asii_prob:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - asii_turb_trop_prob
+    - asii_turb_prob_pal
+    standard_name: asii_prob
+
+  rdt_cell_type:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - MapCellCatType
+    - MapCellCatType_pal
+    standard_name: rdt_cell_type

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -274,3 +274,150 @@ composites:
     compositor: !!python/name:satpy.composites.CloudCompositor
     prerequisites:
       - name: B14
+
+  cloudmask:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cma
+    - cma_pal
+    standard_name: cloudmask
+
+  cloudtype:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ct
+    - ct_pal
+    standard_name: cloudtype
+
+  cloud_top_height:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ctth_alti
+    - ctth_alti_pal
+    standard_name: cloud_top_height
+
+  cloud_top_pressure:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ctth_pres
+    - ctth_pres_pal
+    standard_name: cloud_top_pressure
+
+  cloud_top_temperature:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ctth_tempe
+    - ctth_tempe_pal
+    standard_name: cloud_top_temperature
+
+  cloud_top_phase:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_phase
+    - cmic_phase_pal
+    standard_name: cloud_top_phase
+
+  cloud_drop_effective_radius:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_reff
+    - cmic_reff_pal
+    standard_name: cloud_drop_effective_radius
+
+  cloud_optical_thickness:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_cot
+    - cmic_cot_pal
+    standard_name: cloud_optical_thickness
+
+  cloud_liquid_water_path:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_lwp
+    - cmic_lwp_pal
+    standard_name: cloud_liquid_water_path
+
+  cloud_ice_water_path:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_iwp
+    - cmic_iwp_pal
+    standard_name: cloud_ice_water_path
+
+  precipitation_probability:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - pc
+    - pc_pal
+    standard_name: precipitation_probability
+
+  convective_rain_rate:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - crr
+    - crr_pal
+    standard_name: convective_rain_rate
+
+  convective_precipitation_hourly_accumulation:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - crr_accum
+    - crr_pal
+    standard_name: convective_precipitation_hourly_accumulation
+
+  total_precipitable_water:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ishai_tpw
+    - ishai_tpw_pal
+    standard_name: total_precipitable_water
+
+  showalter_index:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ishai_shw
+    - ishai_shw_pal
+    standard_name: showalter_index
+
+  lifted_index:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ishai_li
+    - ishai_li_pal
+    standard_name: lifted_index
+
+  convection_initiation_prob30:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ci_prob30
+    - ci_pal
+    standard_name: convection_initiation_prob30
+
+  convection_initiation_prob60:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ci_prob60
+    - ci_pal
+    standard_name: convection_initiation_prob60
+
+  convection_initiation_prob90:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ci_prob90
+    - ci_pal
+    standard_name: convection_initiation_prob90
+
+  asii_prob:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - asii_turb_trop_prob
+    - asii_turb_prob_pal
+    standard_name: asii_prob
+
+  rdt_cell_type:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - MapCellCatType
+    - MapCellCatType_pal
+    standard_name: rdt_cell_type

--- a/satpy/etc/composites/fci.yaml
+++ b/satpy/etc/composites/fci.yaml
@@ -1,1 +1,149 @@
 sensor_name: visir/fci
+
+composites:
+  cloudmask:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cma
+    - cma_pal
+    standard_name: cloudmask
+
+  cloudtype:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ct
+    - ct_pal
+    standard_name: cloudtype
+
+  cloud_top_height:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ctth_alti
+    - ctth_alti_pal
+    standard_name: cloud_top_height
+
+  cloud_top_pressure:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ctth_pres
+    - ctth_pres_pal
+    standard_name: cloud_top_pressure
+
+  cloud_top_temperature:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ctth_tempe
+    - ctth_tempe_pal
+    standard_name: cloud_top_temperature
+
+  cloud_top_phase:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_phase
+    - cmic_phase_pal
+    standard_name: cloud_top_phase
+
+  cloud_drop_effective_radius:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_reff
+    - cmic_reff_pal
+    standard_name: cloud_drop_effective_radius
+
+  cloud_optical_thickness:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_cot
+    - cmic_cot_pal
+    standard_name: cloud_optical_thickness
+
+  cloud_liquid_water_path:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_lwp
+    - cmic_lwp_pal
+    standard_name: cloud_liquid_water_path
+
+  cloud_ice_water_path:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - cmic_iwp
+    - cmic_iwp_pal
+    standard_name: cloud_ice_water_path
+
+  precipitation_probability:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - pc
+    - pc_pal
+    standard_name: precipitation_probability
+
+  convective_rain_rate:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - crr
+    - crr_pal
+    standard_name: convective_rain_rate
+
+  convective_precipitation_hourly_accumulation:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - crr_accum
+    - crr_pal
+    standard_name: convective_precipitation_hourly_accumulation
+
+  total_precipitable_water:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ishai_tpw
+    - ishai_tpw_pal
+    standard_name: total_precipitable_water
+
+  showalter_index:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ishai_shw
+    - ishai_shw_pal
+    standard_name: showalter_index
+
+  lifted_index:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ishai_li
+    - ishai_li_pal
+    standard_name: lifted_index
+
+  convection_initiation_prob30:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ci_prob30
+    - ci_pal
+    standard_name: convection_initiation_prob30
+
+  convection_initiation_prob60:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ci_prob60
+    - ci_pal
+    standard_name: convection_initiation_prob60
+
+  convection_initiation_prob90:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - ci_prob90
+    - ci_pal
+    standard_name: convection_initiation_prob90
+
+  asii_prob:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - asii_turb_trop_prob
+    - asii_turb_prob_pal
+    standard_name: asii_prob
+
+  rdt_cell_type:
+    compositor: !!python/name:satpy.composites.PaletteCompositor
+    prerequisites:
+    - MapCellCatType
+    - MapCellCatType_pal
+    standard_name: rdt_cell_type


### PR DESCRIPTION
Currently the NWCSAF-GEO composites only for for SEVIRI.  This PR
enables them for the other geostationary imagers supported by NWCSAF-GEO
as well: ABI, AHI, and FCI.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1134<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
