### PR TITLE
Keep int type and fix scale_factor/dim bug in tropomi_l2 reader

### DIFF
--- a/satpy/etc/readers/tropomi_l2.yaml
+++ b/satpy/etc/readers/tropomi_l2.yaml
@@ -64,4 +64,9 @@ datasets:
         file_type: tropomi_l2
         file_key: 'PRODUCT/tm5_constant_b'
         standard_name: tm5_constant_b
+    time_utc:
+        name: 'time_utc'
+        file_type: tropomi_l2
+        file_key: 'PRODUCT/time_utc'
+        standard_name: time_utc
 

--- a/satpy/readers/tropomi_l2.py
+++ b/satpy/readers/tropomi_l2.py
@@ -206,7 +206,7 @@ class TROPOMIL2FileHandler(NetCDF4FileHandler):
         file_key = ds_info.get('file_key', ds_id.name)
         data = self[file_key]
         data.attrs = self.get_metadata(data, ds_info)
-        fill_value = data.attrs.pop('_FillValue')
+        fill_value = data._FillValue
         data = data.squeeze()
 
         # preserve integer data types if possible

--- a/satpy/readers/tropomi_l2.py
+++ b/satpy/readers/tropomi_l2.py
@@ -224,9 +224,13 @@ class TROPOMIL2FileHandler(NetCDF4FileHandler):
 
         data = data.where(good_mask, new_fill)
         data = self._rename_dims(data)
-        # drop x and y because the units are not meters
-        if all(coord in data.coords for coord in ['y', 'x']):
-            data = data.drop(['y', 'x'])
+
+        # drop coords whose units are not meters
+        drop_list = ['y', 'x', 'layer', 'vertices']
+        coords_exist = list(coord in data.coords for coord in drop_list)
+        if any(coords_exist):
+            data = data.drop(np.array(drop_list)[np.array(coords_exist)])
+
         if ds_id.name in ['assembled_lat_bounds', 'assembled_lon_bounds']:
             data = self.prepare_geo(data)
         return data

--- a/satpy/readers/tropomi_l2.py
+++ b/satpy/readers/tropomi_l2.py
@@ -227,9 +227,9 @@ class TROPOMIL2FileHandler(NetCDF4FileHandler):
 
         # drop coords whose units are not meters
         drop_list = ['y', 'x', 'layer', 'vertices']
-        coords_exist = list(coord in data.coords for coord in drop_list)
-        if any(coords_exist):
-            data = data.drop(np.array(drop_list)[np.array(coords_exist)])
+        coords_exist = [coord for coord in drop_list if coord in data.coords]
+        if coords_exist:
+            data = data.drop_vars(coords_exist)
 
         if ds_id.name in ['assembled_lat_bounds', 'assembled_lon_bounds']:
             data = self.prepare_geo(data)

--- a/satpy/readers/tropomi_l2.py
+++ b/satpy/readers/tropomi_l2.py
@@ -195,7 +195,7 @@ class TROPOMIL2FileHandler(NetCDF4FileHandler):
         # Convert to DataArray
         dask_dest = da.from_array(dest, chunks=CHUNK_SIZE)
         dest = xr.DataArray(dask_dest,
-                            dims=('y', 'x'),
+                            dims=('y_bounds', 'x_bounds'),
                             attrs=bounds_data.attrs
                             )
         return dest

--- a/satpy/readers/tropomi_l2.py
+++ b/satpy/readers/tropomi_l2.py
@@ -206,7 +206,7 @@ class TROPOMIL2FileHandler(NetCDF4FileHandler):
         file_key = ds_info.get('file_key', ds_id.name)
         data = self[file_key]
         data.attrs = self.get_metadata(data, ds_info)
-        fill_value = data._FillValue
+        fill_value = data.attrs.get('_FillValue', np.float32(np.nan))
         data = data.squeeze()
 
         # preserve integer data types if possible

--- a/satpy/readers/tropomi_l2.py
+++ b/satpy/readers/tropomi_l2.py
@@ -213,10 +213,7 @@ class TROPOMIL2FileHandler(NetCDF4FileHandler):
         if np.issubdtype(data.dtype, np.integer):
             new_fill = fill_value
         else:
-            if np.issubdtype(data.dtype, np.datetime64):
-                new_fill = np.datetime64('NaT')
-            else:
-                new_fill = np.float32(np.nan)
+            new_fill = np.float32(np.nan)
             data.attrs.pop('_FillValue', None)
         good_mask = data != fill_value
 
@@ -227,6 +224,9 @@ class TROPOMIL2FileHandler(NetCDF4FileHandler):
 
         data = data.where(good_mask, new_fill)
         data = self._rename_dims(data)
+        # drop x and y because the units are not meters
+        if all(coord in data.coords for coord in ['y', 'x']):
+            data = data.drop(['y', 'x'])
         if ds_id.name in ['assembled_lat_bounds', 'assembled_lon_bounds']:
             data = self.prepare_geo(data)
         return data

--- a/satpy/readers/tropomi_l2.py
+++ b/satpy/readers/tropomi_l2.py
@@ -221,8 +221,9 @@ class TROPOMIL2FileHandler(NetCDF4FileHandler):
         good_mask = data != fill_value
 
         scale_factor = data.attrs.get('scale_factor')
+        add_offset = data.attrs.get('add_offset')
         if scale_factor is not None:
-            data = data * scale_factor
+            data = data * scale_factor + add_offset
 
         data = data.where(good_mask, new_fill)
         data = self._rename_dims(data)

--- a/satpy/readers/tropomi_l2.py
+++ b/satpy/readers/tropomi_l2.py
@@ -213,7 +213,10 @@ class TROPOMIL2FileHandler(NetCDF4FileHandler):
         if np.issubdtype(data.dtype, np.integer):
             new_fill = fill_value
         else:
-            new_fill = np.float32(np.nan)
+            if np.issubdtype(data.dtype, np.datetime64):
+                new_fill = np.datetime64('NaT')
+            else:
+                new_fill = np.float32(np.nan)
             data.attrs.pop('_FillValue', None)
         good_mask = data != fill_value
 


### PR DESCRIPTION

 - [ ] Closes #1143 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

### Problems
1. `tm5_tropopause_layer_index` should be `int` type, but it's converted to `float64` after `data = data.where(data != fill)`.

2. `qa_value` has attr `scale_factor` which isn't be applied.

    > "A continuous quality descriptor, varying between 0 (no data) and 1 (full quality data). Recommend to ignore data with qa_value < 0.5"

### Results
<details><summary>Output of `scn['tm5_tropopause_layer_index']` and `scn['qa_value'].values` before bugfix</summary>

```
<xarray.DataArray 'tm5_tropopause_layer_index' (y: 373, x: 450)>
dask.array<where, shape=(373, 450), dtype=float64, chunksize=(373, 450), chunktype=numpy.ndarray>
Coordinates:
    time       datetime64[ns] 2020-04-01
  * x          (x) int32 0 1 2 3 4 5 6 7 8 ... 442 443 444 445 446 447 448 449
  * y          (y) int64 0 1 2 3 4 5 6 7 8 ... 365 366 367 368 369 370 371 372
    latitude   (y, x) float32 dask.array<chunksize=(373, 450), meta=np.ndarray>
    longitude  (y, x) float32 dask.array<chunksize=(373, 450), meta=np.ndarray>
    crs        object +proj=latlong +datum=WGS84 +ellps=WGS84 +type=crs
Attributes:
    start_time:           2020-04-01 05:13:50
    end_time:             2020-04-01 05:18:50
    ancillary_variables:  [<xarray.DataArray 'tm5_constant_a' (layer: 34, ver...
    units:                1
    coordinates:          ('longitude', 'latitude')
    file_key:             PRODUCT/tm5_tropopause_layer_index
    resolution:           None
    modifiers:            ()
    platform_shortname:   S5P
    sensor:               TROPOMI
    long_name:            TM5 layer index of the highest layer in the tropopause
    name:                 tm5_tropopause_layer_index
    file_type:            tropomi_l2
    area:                 Shape: (373, 450)\nLons: <xarray.DataArray 'longitu...
    calibration:          None
    polarization:         None
    level:                None
[[  0.  74.  74. ...  74.  74.  74.]
 [  0.  74.  74. ...  74.  74.  74.]
 [  0.  74.  74. ...  74.  74.  74.]
 ...
 [  0.  74.  74. ... 100. 100. 100.]
 [  0.  74.  74. ... 100. 100. 100.]
 [  0.  74.  74. ... 100. 100. 100.]]
```

</details>

<details><summary>Output after bugfix</summary>

```
<xarray.DataArray 'tm5_tropopause_layer_index' (y: 373, x: 450)>
dask.array<where, shape=(373, 450), dtype=int32, chunksize=(373, 450), chunktype=numpy.ndarray>
Coordinates:
    time       datetime64[ns] 2020-04-01
  * x          (x) int32 0 1 2 3 4 5 6 7 8 ... 442 443 444 445 446 447 448 449
  * y          (y) int64 0 1 2 3 4 5 6 7 8 ... 365 366 367 368 369 370 371 372
    latitude   (y, x) float32 dask.array<chunksize=(373, 450), meta=np.ndarray>
    longitude  (y, x) float32 dask.array<chunksize=(373, 450), meta=np.ndarray>
    crs        object +proj=latlong +datum=WGS84 +ellps=WGS84 +type=crs
Attributes:
    start_time:           2020-04-01 05:13:50
    end_time:             2020-04-01 05:18:50
    file_type:            tropomi_l2
    ancillary_variables:  [<xarray.DataArray 'tm5_constant_a' (layer: 34, ver...
    sensor:               TROPOMI
    coordinates:          ('longitude', 'latitude')
    modifiers:            ()
    platform_shortname:   S5P
    name:                 tm5_tropopause_layer_index
    long_name:            TM5 layer index of the highest layer in the tropopause
    file_key:             PRODUCT/tm5_tropopause_layer_index
    units:                1
    resolution:           None
    area:                 Shape: (373, 450)\nLons: <xarray.DataArray 'longitu...
    calibration:          None
    polarization:         None
    level:                None
[[0.   0.74 0.74 ... 0.74 0.74 0.74]
 [0.   0.74 0.74 ... 0.74 0.74 0.74]
 [0.   0.74 0.74 ... 0.74 0.74 0.74]
 ...
 [0.   0.74 0.74 ... 1.   1.   1.  ]
 [0.   0.74 0.74 ... 1.   1.   1.  ]
 [0.   0.74 0.74 ... 1.   1.   1.  ]]


```

</details>