### PR TITLE
Check ancillary_variables in exclude_attrs before get_extra_ds

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -140,7 +140,7 @@ class TestCFWriter(unittest.TestCase):
                                  expected_prereq)
 
     def test_ancillary_variables(self):
-        '''Test ancillary_variables cited each other'''
+        """Test ancillary_variables cited each other."""
         import xarray as xr
         from satpy import Scene
         scn = Scene()

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -484,8 +484,9 @@ class CFWriter(Writer):
                           pretty=False, compression=None):
         """Collect and prepare datasets to be written."""
         ds_collection = {}
-        for ds in datasets:
-            ds_collection.update(get_extra_ds(ds))
+        if 'ancillary_variables' not in exclude_attrs:
+            for ds in datasets:
+                ds_collection.update(get_extra_ds(ds))
 
         datas = {}
         start_times = []

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -153,11 +153,12 @@ def create_grid_mapping(area):
     return area.area_id, grid_mapping
 
 
-def get_extra_ds(dataset):
+def get_extra_ds(dataset, extra):
     """Get the extra datasets associated to *dataset*."""
     ds_collection = {}
-    for ds in dataset.attrs.get('ancillary_variables', []):
-        ds_collection.update(get_extra_ds(ds))
+    if extra:
+        for ds in dataset.attrs.get('ancillary_variables', []):
+            ds_collection.update(get_extra_ds(ds))
     ds_collection[dataset.attrs['name']] = dataset
 
     return ds_collection
@@ -484,9 +485,12 @@ class CFWriter(Writer):
                           pretty=False, compression=None):
         """Collect and prepare datasets to be written."""
         ds_collection = {}
-        if 'ancillary_variables' not in exclude_attrs:
-            for ds in datasets:
-                ds_collection.update(get_extra_ds(ds))
+        if 'ancillary_variables' in exclude_attrs:
+            extra = False
+        else:
+            extra = True
+        for i,ds in enumerate(datasets):
+            ds_collection.update(get_extra_ds(ds, extra))
 
         datas = {}
         start_times = []

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -489,7 +489,7 @@ class CFWriter(Writer):
             extra = False
         else:
             extra = True
-        for i,ds in enumerate(datasets):
+        for ds in datasets:
             ds_collection.update(get_extra_ds(ds, extra))
 
         datas = {}

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -153,12 +153,13 @@ def create_grid_mapping(area):
     return area.area_id, grid_mapping
 
 
-def get_extra_ds(dataset, extra):
+def get_extra_ds(dataset, keys=None):
     """Get the extra datasets associated to *dataset*."""
     ds_collection = {}
-    if extra:
-        for ds in dataset.attrs.get('ancillary_variables', []):
-            ds_collection.update(get_extra_ds(ds))
+    for ds in dataset.attrs.get('ancillary_variables', []):
+        if keys and ds.name not in keys:
+            keys.append(ds.name)
+            ds_collection.update(get_extra_ds(ds, keys))
     ds_collection[dataset.attrs['name']] = dataset
 
     return ds_collection
@@ -485,12 +486,8 @@ class CFWriter(Writer):
                           pretty=False, compression=None):
         """Collect and prepare datasets to be written."""
         ds_collection = {}
-        if 'ancillary_variables' in exclude_attrs:
-            extra = False
-        else:
-            extra = True
         for ds in datasets:
-            ds_collection.update(get_extra_ds(ds, extra))
+            ds_collection.update(get_extra_ds(ds))
 
         datas = {}
         start_times = []


### PR DESCRIPTION
I found this problem when I was trying to save tropomi `scene` to `netcdf` file.

There're two variables cited each other by `ancillary_variables`:
```
float cloud_radiance_fraction_nitrogendioxide_window(time=1, scanline=373, ground_pixel=450);
  :units = "1";
  :long_name = "Cloud radiance fraction at 440 nm for NO2 retrieval";
  :coordinates = "/PRODUCT/longitude /PRODUCT/latitude";
  :radiation_wavelength = 440.0f; // float
  :assumed_cloud_albedo = 0.8f; // float
  :ancillary_variables = "cloud_fraction_crb_nitrogendioxide_window /PRODUCT/SUPPORT_DATA/INPUT_DATA/cloud_pressure_crb";
  :_FillValue = 9.96921E36f; // float
  :_ChunkSizes = 1U, 373U, 450U; // uint

float cloud_fraction_crb_nitrogendioxide_window(time=1, scanline=373, ground_pixel=450);
  :proposed_standard_name = "effective_cloud_area_fraction_assuming_fixed_cloud_albedo";
  :units = "1";
  :long_name = "Cloud fraction at 440 nm for NO2 retrieval";
  :coordinates = "/PRODUCT/longitude /PRODUCT/latitude";
  :radiation_wavelength = 440.0f; // float
  :assumed_cloud_albedo = 0.8f; // float
  :ancillary_variables = "cloud_radiance_fraction_nitrogendioxide_window /PRODUCT/SUPPORT_DATA/INPUT_DATA/cloud_pressure_crb";
  :_FillValue = 9.96921E36f; // float
  :_ChunkSizes = 1U, 373U, 450U; // uint
```

I don't know this should be the bug of `tropomi_l2` file or this is correct. This could cause the **infinite recursion** of `get_extra_ds`., like this:
```
  File "/yin_raid/xin/github/satpy/satpy/writers/cf_writer.py", line 160, in get_extra_ds
    ds_collection.update(get_extra_ds(ds))
  [Previous line repeated 988 more times]
  File "/yin_raid/xin/github/satpy/satpy/writers/cf_writer.py", line 159, in get_extra_ds
    for ds in dataset.attrs.get('ancillary_variables', []):
  File "/yin_raid/xin/miniconda3/envs/s5p/lib/python3.7/site-packages/xarray/core/dataarray.py", line 681, in attrs
    return self.variable.attrs
RecursionError: maximum recursion depth exceeded
```

Anyway, I decide to add `ancillary_variables` to `exclude_attrs` when using `save_datasets` for this issue. So, we need to check the exist of `ancillary_variables` before `get_extra_ds`.