### PR TITLE
Add night lights composites for ABI, AHI and AMI

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -134,6 +134,12 @@ composites:
     - C14
     standard_name: overview
 
+  colorized_ir_clouds:
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    prerequisites:
+      - name: 'C13'
+    standard_name: colorized_ir_clouds
+
   airmass:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
@@ -236,3 +242,40 @@ composites:
       - name: cimss_green
       - name: C01
     standard_name: cimss_true_color
+
+  true_color_with_night_ir:
+    compositor: !!python/name:satpy.composites.DayNightCompositor
+    standard_name: true_color_with_night_ir
+    prerequisites:
+      - true_color
+      - night_ir_with_background
+
+  true_color_with_night_ir_hires:
+    compositor: !!python/name:satpy.composites.DayNightCompositor
+    standard_name: true_color_with_night_ir_hires
+    prerequisites:
+      - true_color
+      - night_ir_with_background_hires
+
+  night_ir_alpha:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    standard_name: night_ir_alpha
+    prerequisites:
+      - 3.90
+      - 10.3
+      - 12.3
+      - 10.3
+
+  night_ir_with_background:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: night_ir_with_background
+    prerequisites:
+      - night_ir_alpha
+      - _night_background
+
+  night_ir_with_background_hires:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: night_ir_with_background_hires
+    prerequisites:
+      - night_ir_alpha
+      - _night_background_hires

--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -66,6 +66,17 @@ composites:
       modifiers: [sunz_corrected]
     standard_name: toa_bidirectional_reflectance
 
+  green_nocorr:
+    compositor: !!python/name:satpy.composites.abi.SimulatedGreen
+    # FUTURE: Set a wavelength...see what happens. Dependency finding
+    #         probably wouldn't work.
+    prerequisites:
+    # should we be using the most corrected or least corrected inputs?
+    - name: C01
+    - name: C02
+    - name: C03
+    standard_name: toa_reflectance
+
   true_color_crefl:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
@@ -96,6 +107,14 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected]
     standard_name: true_color
 
+  true_color_nocorr:
+    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
+    prerequisites:
+    - name: C02
+    - name: green_nocorr
+    - name: C01
+    standard_name: true_color
+
   natural_color:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
@@ -105,6 +124,15 @@ composites:
       modifiers: [sunz_corrected]
     - name: C02
       modifiers: [sunz_corrected]
+    high_resolution_band: blue
+    standard_name: natural_color
+
+  natural_color_nocorr:
+    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
+    prerequisites:
+    - name: C05
+    - name: C03
+    - name: C02
     high_resolution_band: blue
     standard_name: natural_color
 
@@ -246,6 +274,8 @@ composites:
   true_color_with_night_ir:
     compositor: !!python/name:satpy.composites.DayNightCompositor
     standard_name: true_color_with_night_ir
+    lim_low: 90.0
+    lim_high: 100.0
     prerequisites:
       - true_color
       - night_ir_with_background
@@ -253,6 +283,8 @@ composites:
   true_color_with_night_ir_hires:
     compositor: !!python/name:satpy.composites.DayNightCompositor
     standard_name: true_color_with_night_ir_hires
+    lim_low: 90.0
+    lim_high: 100.0
     prerequisites:
       - true_color
       - night_ir_with_background_hires

--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -165,7 +165,7 @@ composites:
   colorized_ir_clouds:
     compositor: !!python/name:satpy.composites.SingleBandCompositor
     prerequisites:
-      - name: 'C13'
+      - name: C13
     standard_name: colorized_ir_clouds
 
   airmass:

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -229,6 +229,12 @@ composites:
     - wavelength: 1.6
     standard_name: cloud_phase_distinction
 
+  colorized_ir_clouds:
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    prerequisites:
+      - name: '10.4'
+    standard_name: colorized_ir_clouds
+
   water_vapors1:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
@@ -274,3 +280,40 @@ composites:
     compositor: !!python/name:satpy.composites.CloudCompositor
     prerequisites:
       - name: B14
+
+  true_color_with_night_ir:
+    compositor: !!python/name:satpy.composites.DayNightCompositor
+    standard_name: true_color_with_night_ir
+    prerequisites:
+      - true_color
+      - night_ir_with_background
+
+  true_color_with_night_ir_hires:
+    compositor: !!python/name:satpy.composites.DayNightCompositor
+    standard_name: true_color_with_night_ir_hires
+    prerequisites:
+      - true_color
+      - night_ir_with_background_hires
+
+  night_ir_alpha:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    standard_name: night_ir_alpha
+    prerequisites:
+      - 3.85
+      - 10.4
+      - 12.35
+      - 10.4
+
+  night_ir_with_background:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: night_ir_with_background
+    prerequisites:
+      - night_ir_alpha
+      - _night_background
+
+  night_ir_with_background_hires:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: night_ir_with_background_hires
+    prerequisites:
+      - night_ir_alpha
+      - _night_background_hires

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -179,10 +179,10 @@ composites:
   true_color:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
-    - wavelength: 0.65
+    - wavelength: B03
       modifiers: [sunz_corrected, rayleigh_corrected]
     - name: green
-    - wavelength: 0.46
+    - wavelength: B01
       modifiers: [sunz_corrected, rayleigh_corrected]
     high_resolution_band: red
     standard_name: true_color
@@ -190,18 +190,18 @@ composites:
   natural_color_nocorr:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
-    - wavelength: 1.63
-    - wavelength: 0.85
-    - wavelength: 0.635
+    - wavelength: B05
+    - wavelength: B04
+    - wavelength: B03
     high_resolution_band: blue
     standard_name: natural_color
 
   true_color_nocorr:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
-    - wavelength: 0.65
+    - wavelength: B03
     - name: green_nocorr
-    - wavelength: 0.46
+    - wavelength: B01
     high_resolution_band: red
     standard_name: true_color
 
@@ -328,10 +328,10 @@ composites:
     compositor: !!python/name:satpy.composites.GenericCompositor
     standard_name: night_ir_alpha
     prerequisites:
-      - 3.85
-      - 10.4
-      - 12.35
-      - 10.4
+      - B07
+      - B13
+      - B15
+      - B13
 
   night_ir_with_background:
     compositor: !!python/name:satpy.composites.BackgroundCompositor

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -28,6 +28,17 @@ composites:
       modifiers: [sunz_corrected]
     standard_name: toa_bidirectional_reflectance
 
+  green_nocorr:
+    compositor: !!python/name:satpy.composites.ahi.GreenCorrector
+    # FUTURE: Set a wavelength...see what happens. Dependency finding
+    #         probably wouldn't work.
+    prerequisites:
+    # should we be using the most corrected or least corrected inputs?
+    # what happens if something requests more modifiers on top of this?
+    - wavelength: 0.51
+    - wavelength: 0.85
+    standard_name: toa_reflectance
+
   airmass:
     # PDF slides: https://www.eumetsat.int/website/home/News/ConferencesandEvents/DAT_2833302.html
     # Under session 2 by Akihiro Shimizu (JMA)
@@ -173,6 +184,24 @@ composites:
     - name: green
     - wavelength: 0.46
       modifiers: [sunz_corrected, rayleigh_corrected]
+    high_resolution_band: red
+    standard_name: true_color
+
+  natural_color_nocorr:
+    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
+    prerequisites:
+    - wavelength: 1.63
+    - wavelength: 0.85
+    - wavelength: 0.635
+    high_resolution_band: blue
+    standard_name: natural_color
+
+  true_color_nocorr:
+    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
+    prerequisites:
+    - wavelength: 0.65
+    - name: green_nocorr
+    - wavelength: 0.46
     high_resolution_band: red
     standard_name: true_color
 

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -190,18 +190,18 @@ composites:
   natural_color_nocorr:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
-    - wavelength: B05
-    - wavelength: B04
-    - wavelength: B03
+    - name: B05
+    - name: B04
+    - name: B03
     high_resolution_band: blue
     standard_name: natural_color
 
   true_color_nocorr:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
-    - wavelength: B03
+    - name: B03
     - name: green_nocorr
-    - wavelength: B01
+    - name: B01
     high_resolution_band: red
     standard_name: true_color
 
@@ -261,7 +261,7 @@ composites:
   colorized_ir_clouds:
     compositor: !!python/name:satpy.composites.SingleBandCompositor
     prerequisites:
-      - name: '10.4'
+      - name: B13
     standard_name: colorized_ir_clouds
 
   water_vapors1:
@@ -328,10 +328,10 @@ composites:
     compositor: !!python/name:satpy.composites.GenericCompositor
     standard_name: night_ir_alpha
     prerequisites:
-      - B07
-      - B13
-      - B15
-      - B13
+      - name: B07
+      - name: B13
+      - name: B15
+      - name: B13
 
   night_ir_with_background:
     compositor: !!python/name:satpy.composites.BackgroundCompositor

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -179,10 +179,10 @@ composites:
   true_color:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
-    - wavelength: B03
+    - name: B03
       modifiers: [sunz_corrected, rayleigh_corrected]
     - name: green
-    - wavelength: B01
+    - name: B01
       modifiers: [sunz_corrected, rayleigh_corrected]
     high_resolution_band: red
     standard_name: true_color

--- a/satpy/etc/composites/ami.yaml
+++ b/satpy/etc/composites/ami.yaml
@@ -49,6 +49,12 @@ composites:
       - 10.4
     standard_name: overview
 
+  colorized_ir_clouds:
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    prerequisites:
+      - name: '10.4'
+    standard_name: colorized_ir_clouds
+
   natural_color:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
@@ -151,3 +157,40 @@ composites:
           - IR087
       - IR112
     standard_name: ash
+
+  true_color_with_night_ir:
+    compositor: !!python/name:satpy.composites.DayNightCompositor
+    standard_name: true_color_with_night_ir
+    prerequisites:
+      - true_color
+      - night_ir_with_background
+
+  true_color_with_night_ir_hires:
+    compositor: !!python/name:satpy.composites.DayNightCompositor
+    standard_name: true_color_with_night_ir_hires
+    prerequisites:
+      - true_color
+      - night_ir_with_background_hires
+
+  night_ir_alpha:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    standard_name: night_ir_alpha
+    prerequisites:
+      - 3.83
+      - 10.35
+      - 12.36
+      - 10.35
+
+  night_ir_with_background:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: night_ir_with_background
+    prerequisites:
+      - night_ir_alpha
+      - _night_background
+
+  night_ir_with_background_hires:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: night_ir_with_background_hires
+    prerequisites:
+      - night_ir_alpha
+      - _night_background_hires

--- a/satpy/etc/composites/ami.yaml
+++ b/satpy/etc/composites/ami.yaml
@@ -21,6 +21,14 @@ composites:
     standard_name: toa_bidirectional_reflectance
     fractions: [0.85, 0.15]
 
+  green_nocorr:
+    compositor: !!python/name:satpy.composites.ahi.GreenCorrector
+    prerequisites:
+      - name: VI005
+      - name: VI008
+    standard_name: toa_reflectance
+    fractions: [0.85, 0.15]
+
   true_color_raw:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
@@ -39,6 +47,14 @@ composites:
       - name: green
       - name: VI004
         modifiers: [sunz_corrected, rayleigh_corrected]
+    standard_name: true_color
+
+  true_color_nocorr:
+    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
+    prerequisites:
+      - name: VI006
+      - name: green_nocorr
+      - name: VI004
     standard_name: true_color
 
   overview:
@@ -64,6 +80,15 @@ composites:
         modifiers: [sunz_corrected] #, rayleigh_corrected]
       - name: VI006
         modifiers: [sunz_corrected] #, rayleigh_corrected]
+    high_resolution_band: blue
+    standard_name: natural_color
+
+  natural_color_nocorr:
+    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
+    prerequisites:
+      - name: NR016
+      - name: VI008
+      - name: VI006
     high_resolution_band: blue
     standard_name: natural_color
 

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -144,6 +144,14 @@ composites:
       modifiers: [sunz_corrected]
     standard_name: natural_color
 
+  natural_color_nocorr:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - name: IR_016
+    - name: VIS008
+    - name: VIS006
+    standard_name: natural_color
+
   fog:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:


### PR DESCRIPTION
This PR adds true color composites that use the VIIRS night lights as a background for night-time pixels. No code changes have been made, it simply re-uses the existing SEVIRI night lights composite (`natural_color_with_night_ir`). In the case of the new instruments, however, I chose to use `true_color` instead of `natural_color` to reflect the capabilities of the instruments.

 - [x] Tests passed