### PR TITLE
Add a function to Scene that can compute the pixel size in degrees

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -276,8 +276,6 @@ class Scene(MetadataObject):
 
         Args:
             dataset: A dataset whose area you wish to examine.
-        Returns:
-            diff: A numpy array of pixel sizes.
         """
         in_area = self[dataset].attrs.get('area')
         lons, lats = in_area.get_lonlats()
@@ -290,7 +288,12 @@ class Scene(MetadataObject):
         # Now compute the total difference, in degrees.
         diff = np.sqrt(lonoff*lonoff + latoff*latoff)
 
-        return diff
+        self['PixSize'] = self[dataset].copy()
+        self['PixSize'].attrs['units'] = 'Decimal degrees'
+        self['PixSize'].attrs['wavelength'] = None
+        self['PixSize'].attrs['calibration'] = None
+        self['PixSize'].attrs['standard_name'] = 'Pixel size'
+        self['PixSize'].values = diff
 
     def min_area(self, datasets=None):
         """Get lowest resolution area for the provided datasets.

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -289,10 +289,10 @@ class Scene(MetadataObject):
         diff = np.sqrt(lonoff*lonoff + latoff*latoff)
 
         # First and last columns/rows are suspect
-        diff[0,:] = np.nan
-        diff[-1,:] = np.nan
-        diff[:,0] = np.nan
-        diff[:,-1] = np.nan
+        diff[0, :] = np.nan
+        diff[-1, :] = np.nan
+        diff[:, 0] = np.nan
+        diff[:, -1] = np.nan
 
         self['PixSize'] = self[dataset].copy()
         self['PixSize'].attrs['units'] = 'Decimal degrees'

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -295,7 +295,7 @@ class Scene(MetadataObject):
         diff[:, -1] = np.nan
 
         self['PixSize'] = self[dataset].copy()
-        self['PixSize'].attrs['units'] = 'Decimal degrees'
+        self['PixSize'].attrs['units'] = 'degrees'
         self['PixSize'].attrs['wavelength'] = None
         self['PixSize'].attrs['calibration'] = None
         self['PixSize'].attrs['standard_name'] = 'Pixel size'

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -288,6 +288,12 @@ class Scene(MetadataObject):
         # Now compute the total difference, in degrees.
         diff = np.sqrt(lonoff*lonoff + latoff*latoff)
 
+        # First and last columns/rows are suspect
+        diff[0,:] = np.nan
+        diff[-1,:] = np.nan
+        diff[:,0] = np.nan
+        diff[:,-1] = np.nan
+
         self['PixSize'] = self[dataset].copy()
         self['PixSize'].attrs['units'] = 'Decimal degrees'
         self['PixSize'].attrs['wavelength'] = None

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -271,6 +271,27 @@ class Scene(MetadataObject):
         """
         return self._compare_areas(datasets=datasets, compare_func=max)
 
+    def get_pixsize_from_area(self, dataset):
+        """Compute pixel size in degrees for each pixel in image.
+
+        Args:
+            dataset: A dataset whose area you wish to examine.
+        Returns:
+            diff: A numpy array of pixel sizes.
+        """
+        in_area = self[dataset].attrs.get('area')
+        lons, lats = in_area.get_lonlats()
+        # Compute the difference in lons and lats between neighbouring pixels.
+        # This does not account for differences in one direction or another, but
+        # is close enough for most purposes.
+        lonoff = lons - np.roll(lons, 1, axis=1)
+        latoff = lats - np.roll(lats, 1, axis=0)
+
+        # Now compute the total difference, in degrees.
+        diff = np.sqrt(lonoff*lonoff + latoff*latoff)
+
+        return diff
+
     def min_area(self, datasets=None):
         """Get lowest resolution area for the provided datasets.
 

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -339,8 +339,8 @@ class TestScene(unittest.TestCase):
             area_extent,
         )
         scene["1"] = DataArray(zeros((y_size, x_size)), dims=('y', 'x'),
-                                attrs={'area': area_def})
-        scene.get_pixsize_from_area('1')   
+                               attrs={'area': area_def})
+        scene.get_pixsize_from_area('1')
 
         # Compare the scene pixel sizes against default
         out_pixs = zeros((5, 5))
@@ -349,16 +349,10 @@ class TestScene(unittest.TestCase):
         out_pixs[2, :] = [nan, 0.25494916, 0.25494704, 0.25494717, nan]
         out_pixs[3, :] = [nan, 0.2549499, 0.25494778, 0.25494791, nan]
         out_pixs[4, :] = nan
-                                 
-        print("\n\n\n\n\n\n\n")
-        print(out_pixs)  
-        print("\n")
-        print(scene['PixSize'].values)  
-        print("\n\n\n\n\n\n\n")
+
         self.assertTrue(allclose(out_pixs,
                                  scene['PixSize'].values,
                                  equal_nan=True))
-        
 
     def test_getitem_slices(self):
         """Test __getitem__ with slices."""

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -316,6 +316,50 @@ class TestScene(unittest.TestCase):
                           DatasetID(name='1', modifiers=tuple()))
         self.assertEqual(len(list(scene.keys())), 2)
 
+    def test_get_pixsize_from_area(self):
+        """Test test_get_pixsize_from_area."""
+        from pyresample.geometry import AreaDefinition
+        from numpy import zeros, nan, allclose
+        from xarray import DataArray
+        from satpy import Scene
+        scene = Scene()
+        area_extent = (-50000., -50000., 50000.,
+                       50000.)
+        proj_dict = {'a': 6378169.0, 'b': 6356583.8, 'h': 35785831.0,
+                     'lon_0': 0.0, 'proj': 'geos', 'units': 'm'}
+        x_size = 5
+        y_size = 5
+        area_def = AreaDefinition(
+            'test',
+            'test',
+            'test',
+            proj_dict,
+            x_size,
+            y_size,
+            area_extent,
+        )
+        scene["1"] = DataArray(zeros((y_size, x_size)), dims=('y', 'x'),
+                                attrs={'area': area_def})
+        scene.get_pixsize_from_area('1')   
+
+        # Compare the scene pixel sizes against default
+        out_pixs = zeros((5, 5))
+        out_pixs[0, :] = nan
+        out_pixs[1, :] = [nan, 0.25495191, 0.25494979, 0.25494992, nan]
+        out_pixs[2, :] = [nan, 0.25494916, 0.25494704, 0.25494717, nan]
+        out_pixs[3, :] = [nan, 0.2549499, 0.25494778, 0.25494791, nan]
+        out_pixs[4, :] = nan
+                                 
+        print("\n\n\n\n\n\n\n")
+        print(out_pixs)  
+        print("\n")
+        print(scene['PixSize'].values)  
+        print("\n\n\n\n\n\n\n")
+        self.assertTrue(allclose(out_pixs,
+                                 scene['PixSize'].values,
+                                 equal_nan=True))
+        
+
     def test_getitem_slices(self):
         """Test __getitem__ with slices."""
         from satpy import Scene


### PR DESCRIPTION
This PR enables the user to compute the size of each pixel in an image on a per-pixel basis. It does this by:
1) Computing lat/lon from the area definition
2) Rolling the lat/lon by one pixel and subtracting from the original pixel
3) square-rooting the sum of squared differences.
4) Creating a new dataset in the scene (`PixSize`) to store the output.

This is useful for geostationary satellites where the pixel size is *not* constant across the scene. It is not designed for use with polar sensors. The end-goal of adding this function is to update multiscene so that, rather than just stacking scenes on top of each other, it can optionally compute the ideal scene to use for a given pixel by minimising the pixel size on a per-pixel basis.

It can be called with: `scn.get_pixsize_from_area(my_dataset)`

 - [ ] Tests added 
 - [ ] Tests passed
 - [ ] Passes ``flake8 satpy``
 - [ ] Fully documented
