### PR TITLE
Add TROPOMI NO2 LEVEL2 composites 

### DIFF
--- a/satpy/etc/composites/tropomi.yaml
+++ b/satpy/etc/composites/tropomi.yaml
@@ -1,0 +1,16 @@
+sensor_name: tropomi
+
+composites:
+
+  no2_tropospheric_clean:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - nitrogendioxide_tropospheric_column
+    standard_name: no2_tropospheric_clean
+
+  no2_tropospheric_polluted:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - nitrogendioxide_tropospheric_column
+    standard_name: no2_tropospheric_polluted
+

--- a/satpy/etc/enhancements/tropomi.yaml
+++ b/satpy/etc/enhancements/tropomi.yaml
@@ -11,7 +11,7 @@ enhancements:
             - {colors: ylgnbu, min_value: 0.0, max_value: 0.00005, reverse: true}
               # 50 to 90 10e-6 mol/m2
             - {colors: ylorrd, min_value: 0.00005, max_value: 0.00009}
-  
+
   no2_tropospheric_polluted:
     standard_name: no2_tropospheric_polluted
     operations:

--- a/satpy/etc/enhancements/tropomi.yaml
+++ b/satpy/etc/enhancements/tropomi.yaml
@@ -1,0 +1,25 @@
+enhancements:
+
+  no2_tropospheric_clean:
+    standard_name: no2_tropospheric_clean
+    operations:
+      - name: colorize_no2_tropospheric_clean
+        method: !!python/name:satpy.enhancements.colorize
+        kwargs:
+          palettes:
+              # 0 to 50 10e-6 mol/m2
+            - {colors: ylgnbu, min_value: 0.0, max_value: 0.00005, reverse: true}
+              # 50 to 90 10e-6 mol/m2
+            - {colors: ylorrd, min_value: 0.00005, max_value: 0.00009}
+  
+  no2_tropospheric_polluted:
+    standard_name: no2_tropospheric_polluted
+    operations:
+      - name: colorize_no2_tropospheric_poulluted
+        method: !!python/name:satpy.enhancements.colorize
+        kwargs:
+          palettes:
+               # 0 to 120 10e-6 mol/m2
+            - {colors: ylgnbu, min_value: 0.0, max_value: 0.00012, reverse: true}
+               # 120 to 600 10e-6 mol/m2
+            - {colors: ylorrd, min_value: 0.00012, max_value: 0.0006}


### PR DESCRIPTION
This PR adds two versions with different ranges to colorize **TROPOMI NO2 LEVEL 2** data. 
A new tropomi.yaml file is added in composites and enhancements dir. 
To get the enhancements/tropomi.yaml file work, #1155 has to be merged first! 

 For 'low' polluted areas: **no2_tropospheric_clean**

```
no2_tropospheric_clean:
    standard_name: no2_tropospheric_clean
    operations:
      - name: colorize_no2_tropospheric_clean
        method: !!python/name:satpy.enhancements.colorize
        kwargs:
          palettes:
              # 0 to 50 10e-6 mol/m2
            - {colors: ylgnbu, min_value: 0.0, max_value: 0.00005, reverse: true}
              # 50 to 90 10e-6 mol/m2
            - {colors: ylorrd, min_value: 0.00005, max_value: 0.00009}
```
![S5P-NO2_euro_clean](https://user-images.githubusercontent.com/8840918/80148282-19675a80-85b5-11ea-9103-66612047ac34.jpg)

for 'high' polluted areas: **no2_tropospheric_polluted**

  ```
no2_tropospheric_polluted:
    standard_name: no2_tropospheric_polluted
    operations:
      - name: colorize_no2_tropospheric_poulluted
        method: !!python/name:satpy.enhancements.colorize
        kwargs:
          palettes:
               # 0 to 120 10e-6 mol/m2
            - {colors: ylgnbu, min_value: 0.0, max_value: 0.00012, reverse: true}
               # 120 to 600 10e-6 mol/m2
            - {colors: ylorrd, min_value: 0.00012, max_value: 0.0006}
```
![S5P-NO2_euro_polluted](https://user-images.githubusercontent.com/8840918/80148304-2126ff00-85b5-11ea-8da8-d12affe69ff6.jpg)

The current composite didn't take care of the `qa_value` which could be added maybe at the upcoming PCW (@pnuu ) ...? A modifier in the composite could be a solution. There are two (recommended) modes:

**- qa_value>0.75**.For most users this is the recommended pixel filter. This removes cloud-covered scenes (cloud radiancefraction>0.5), part of the scenes covered by snow/ice, errors and problematic retrievals.
**- qa_value>0.50**.This adds the good quality retrievals over clouds and over scenes covered by snow/ice.  Errors and problematic retrievals are still filtered out. In particular this choice is useful for assimilation and modelcomparison studies where the averaging kernels are used.

Here an example with **qa_value>0.75** (if #1139 is merged): 

![S5P-NO2_euro](https://user-images.githubusercontent.com/8840918/80149214-8e875f80-85b6-11ea-87fe-7b7fd3458926.jpg)




<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
