### PR TITLE
Add missing_ok option to find_files_and_readers

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -579,7 +579,7 @@ def available_readers(as_dict=False):
 def find_files_and_readers(start_time=None, end_time=None, base_dir=None,
                            reader=None, sensor=None, ppp_config_dir=None,
                            filter_parameters=None, reader_kwargs=None,
-                           notfound_ok=False):
+                           missing_ok=False):
     """Find on-disk files matching the provided parameters.
 
     Use `start_time` and/or `end_time` to limit found filenames by the times
@@ -612,7 +612,7 @@ def find_files_and_readers(start_time=None, end_time=None, base_dir=None,
                                   `reader_kwargs['filter_parameters']`.
         reader_kwargs (dict): Keyword arguments to pass to specific reader
                               instances to further configure file searching.
-        notfound_ok (bool): If False (default), raise ValueError if no files
+        missing_ok (bool): If False (default), raise ValueError if no files
                             are found.  If True, return empty dictionary if no
                             files are found.
 
@@ -657,7 +657,7 @@ def find_files_and_readers(start_time=None, end_time=None, base_dir=None,
     if sensor and not sensor_supported:
         raise ValueError("Sensor '{}' not supported by any readers".format(sensor))
 
-    if not (reader_files or notfound_ok):
+    if not (reader_files or missing_ok):
         raise ValueError("No supported files found")
     return reader_files
 

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -578,7 +578,8 @@ def available_readers(as_dict=False):
 
 def find_files_and_readers(start_time=None, end_time=None, base_dir=None,
                            reader=None, sensor=None, ppp_config_dir=None,
-                           filter_parameters=None, reader_kwargs=None):
+                           filter_parameters=None, reader_kwargs=None,
+                           notfound_ok=False):
     """Find on-disk files matching the provided parameters.
 
     Use `start_time` and/or `end_time` to limit found filenames by the times
@@ -611,6 +612,9 @@ def find_files_and_readers(start_time=None, end_time=None, base_dir=None,
                                   `reader_kwargs['filter_parameters']`.
         reader_kwargs (dict): Keyword arguments to pass to specific reader
                               instances to further configure file searching.
+        notfound_ok (bool): If False (default), raise ValueError if no files
+                            are found.  If True, return empty dictionary if no
+                            files are found.
 
     Returns: Dictionary mapping reader name string to list of filenames
 
@@ -653,7 +657,7 @@ def find_files_and_readers(start_time=None, end_time=None, base_dir=None,
     if sensor and not sensor_supported:
         raise ValueError("Sensor '{}' not supported by any readers".format(sensor))
 
-    if not reader_files:
+    if not (reader_files or notfound_ok):
         raise ValueError("No supported files found")
     return reader_files
 

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -531,7 +531,7 @@ class TestFindFilesAndReaders(unittest.TestCase):
         # 'viirs' so we just pass it and hope that this works
         self.assertRaises(ValueError, find_files_and_readers, sensor='viirs')
         self.assertEqual(
-                find_files_and_readers(sensor='viirs', notfound_ok=True),
+                find_files_and_readers(sensor='viirs', missing_ok=True),
                 {})
 
     def test_reader_load_failed(self):

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -530,6 +530,9 @@ class TestFindFilesAndReaders(unittest.TestCase):
         # we can't easily know how many readers satpy has that support
         # 'viirs' so we just pass it and hope that this works
         self.assertRaises(ValueError, find_files_and_readers, sensor='viirs')
+        self.assertEqual(
+                find_files_and_readers(sensor='viirs', notfound_ok=True),
+                {})
 
     def test_reader_load_failed(self):
         """Test that an exception is raised when a reader can't be loaded."""


### PR DESCRIPTION
Add an optional keyword argument `missing_ok` to
`satpy.readers.find_files_and_readers`.  It defaults to `False` (the current
behaviour), but if set to `True`, getting zero results is no longer
considered an error but will result in an empty dictionary instead.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1165<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
