### PR TITLE
Fix cf writing of 3d arrays

### DIFF
--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -167,7 +167,8 @@ def area2lonlat(dataarray):
     """Convert an area to longitudes and latitudes."""
     dataarray = dataarray.copy()
     area = dataarray.attrs['area']
-    chunks = getattr(dataarray.data, 'chunks', None)
+    ignore_dims = {dim: 0 for dim in dataarray.dims if dim not in ['x', 'y']}
+    chunks = getattr(dataarray.isel(**ignore_dims), 'chunks', None)
     lons, lats = area.get_lonlats(chunks=chunks)
     lons = xr.DataArray(lons, dims=['y', 'x'],
                         attrs={'name': "longitude",

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -170,18 +170,16 @@ def area2lonlat(dataarray):
     ignore_dims = {dim: 0 for dim in dataarray.dims if dim not in ['x', 'y']}
     chunks = getattr(dataarray.isel(**ignore_dims), 'chunks', None)
     lons, lats = area.get_lonlats(chunks=chunks)
-    lons = xr.DataArray(lons, dims=['y', 'x'],
-                        attrs={'name': "longitude",
-                               'standard_name': "longitude",
-                               'units': 'degrees_east'},
-                        name='longitude')
-    lats = xr.DataArray(lats, dims=['y', 'x'],
-                        attrs={'name': "latitude",
-                               'standard_name': "latitude",
-                               'units': 'degrees_north'},
-                        name='latitude')
-    dataarray['longitude'] = lons
-    dataarray['latitude'] = lats
+    dataarray['longitude'] = xr.DataArray(lons, dims=['y', 'x'],
+                                          attrs={'name': "longitude",
+                                                 'standard_name': "longitude",
+                                                 'units': 'degrees_east'},
+                                          name='longitude')
+    dataarray['latitude'] = xr.DataArray(lats, dims=['y', 'x'],
+                                         attrs={'name': "latitude",
+                                                'standard_name': "latitude",
+                                                'units': 'degrees_north'},
+                                         name='latitude')
     return dataarray
 
 


### PR DESCRIPTION
This is a fix for a bug discovered yesterday by @TAlonglong : the CF writer wasn't able to write images, because of the chunks handling when converting an area to lons and lats.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

