### PR TITLE
Check whether time dimension exists for timeseries

### DIFF
--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -59,8 +59,11 @@ def timeseries(datasets):
     """Expand dataset with and concatenate by time dimension."""
     expanded_ds = []
     for ds in datasets:
-        tmp = ds.expand_dims("time")
-        tmp.coords["time"] = pd.DatetimeIndex([ds.attrs["start_time"]])
+        if 'time' not in ds.dims:
+            tmp = ds.expand_dims("time")
+            tmp.coords["time"] = pd.DatetimeIndex([ds.attrs["start_time"]])
+        else:
+            tmp = ds
         expanded_ds.append(tmp)
 
     res = xr.concat(expanded_ds, dim="time")

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -457,4 +457,3 @@ class TestBlendFuncs(unittest.TestCase):
         self.assertIsInstance(res2, xr.DataArray)
         self.assertTupleEqual((2, self.ds1.shape[0], self.ds1.shape[1]), res.shape)
         self.assertTupleEqual((self.ds3.shape[0], self.ds3.shape[1]+self.ds4.shape[1]), res2.shape)
-

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -434,6 +434,12 @@ class TestBlendFuncs(unittest.TestCase):
         ds2 = xr.DataArray(da.zeros((2, 2), chunks=-1), dims=('y', 'x'),
                            attrs={'start_time': datetime(2018, 1, 1, 1, 0, 0), 'area': area})
         self.ds2 = ds2
+        ds3 = xr.DataArray(da.zeros((2, 2), chunks=-1), dims=('y', 'time'),
+                           attrs={'start_time': datetime(2018, 1, 1, 0, 0, 0), 'area': area})
+        self.ds3 = ds3
+        ds4 = xr.DataArray(da.zeros((2, 2), chunks=-1), dims=('y', 'time'),
+                           attrs={'start_time': datetime(2018, 1, 1, 1, 0, 0), 'area': area})
+        self.ds4 = ds4
 
     def test_stack(self):
         """Test the 'stack' function."""
@@ -446,5 +452,9 @@ class TestBlendFuncs(unittest.TestCase):
         from satpy.multiscene import timeseries
         import xarray as xr
         res = timeseries([self.ds1, self.ds2])
+        res2 = timeseries([self.ds3, self.ds4])
         self.assertIsInstance(res, xr.DataArray)
+        self.assertIsInstance(res2, xr.DataArray)
         self.assertTupleEqual((2, self.ds1.shape[0], self.ds1.shape[1]), res.shape)
+        self.assertTupleEqual((self.ds3.shape[0], self.ds3.shape[1]+self.ds4.shape[1]), res2.shape)
+


### PR DESCRIPTION
If `time` dimension exists, we can blend them directly.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
