### PR TITLE
Add more flexible masking

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1682,7 +1682,7 @@ class MaskingCompositor(GenericCompositor):
             method = condition['method']
             value = condition['value']
             if isinstance(value, str):
-                value = self._get_flag_value(mask_in, value)
+                value = _get_flag_value(mask_in, value)
             transparency = condition['transparency']
             try:
                 func = getattr(np, method)
@@ -1705,13 +1705,19 @@ class MaskingCompositor(GenericCompositor):
         res = super(MaskingCompositor, self).__call__(data, **kwargs)
         return res
 
-    def _get_flag_value(self, mask, val):
-        # Modify alpha based on transparency per class from yaml
-        flag_meanings = mask.attrs['flag_meanings']
-        flag_values = mask.attrs['flag_values']
-        if isinstance(flag_meanings, str):
-            flag_meanings = flag_meanings.split()
 
-        index = flag_meanings.index(val)
+def _get_flag_value(mask, val):
+    """Get a numerical value of the named flag.
 
-        return flag_values[index]
+    This function assumes the naming used in product generated with
+    NWC SAF GEO/PPS softwares.
+
+    """
+    flag_meanings = mask.attrs['flag_meanings']
+    flag_values = mask.attrs['flag_values']
+    if isinstance(flag_meanings, str):
+        flag_meanings = flag_meanings.split()
+
+    index = flag_meanings.index(val)
+
+    return flag_values[index]

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1691,8 +1691,8 @@ class MaskingCompositor(GenericCompositor):
                 raise
             mask = func(mask_data, value)
             if transparency == 100.0:
-                for i in range(len(data)):
-                    data[i] = xr.where(mask, np.nan, data[i])
+                for i, dat in enumerate(data):
+                    data[i] = xr.where(mask, np.nan, dat)
                     data[i].attrs = alpha_attrs
             else:
                 alpha_val = 1. - transparency / 100.

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1694,14 +1694,14 @@ class MaskingCompositor(GenericCompositor):
                 for i, dat in enumerate(data):
                     data[i] = xr.where(mask, np.nan, dat)
                     data[i].attrs = alpha_attrs
-            else:
-                alpha_val = 1. - transparency / 100.
-                alpha = da.where(mask, alpha_val, alpha)
+
+            alpha_val = 1. - transparency / 100.
+            alpha = da.where(mask, alpha_val, alpha)
 
         alpha = xr.DataArray(data=alpha, attrs=alpha_attrs,
                              dims=data[0].dims, coords=data[0].coords)
-
         data.append(alpha)
+
         res = super(MaskingCompositor, self).__call__(data, **kwargs)
         return res
 

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1717,14 +1717,17 @@ class MaskCompositor(GenericCompositor):
                          data[0].sizes['x']),
                         chunks=data[0].chunks)
 
-        for cond in self.conditions:
-            oper, key, val = cond
+        for condition in self.conditions:
+            method = condition['method']
+            value = condition['value']
+            transparency = condition['transparency']
             try:
-                func = getattr(np, oper)
+                func = getattr(np, method)
             except AttributeError:
-                LOG.error("Operator '%s' not found.", oper)
-            mask = func(mask_data, key)
-            alpha_val = 1. - val / 100.
+                LOG.error("Method '%s' not found.", method)
+                raise
+            mask = func(mask_data, value)
+            alpha_val = 1. - transparency / 100.
             alpha = da.where(mask, alpha_val, alpha)
 
         alpha = xr.DataArray(data=alpha, attrs=alpha_attrs,

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1596,30 +1596,34 @@ class BackgroundCompositor(GenericCompositor):
 class MaskingCompositor(GenericCompositor):
     """A compositor that masks e.g. IR 10.8 channel data using cloud products from NWC SAF."""
 
-    def __init__(self, name, transparency=None, **kwargs):
+    def __init__(self, name, transparency=None, conditions=None, **kwargs):
         """Collect custom configuration values.
 
-        Args:
-            transparency: transparency for each cloud type as key-value pairs
-                          in a dictionary
+        Kwargs:
+            transparency (dict): transparency for each cloud type as
+                                 key-value pairs in a dictionary.
+                                 Will be converted to `conditions`.
+                                 DEPRECATED.
+            conditions (list): list of three items determining the masking
+                               settings.
 
-        The `transparencies` can be either the numerical values in the
-        data used as a mask with the corresponding transparency
-        (0...100 %) as the value, or, for NWC SAF products, the flag
-        names in the dataset `flag_meanings` attribute.
-
-        Transparency value of `0` means that the composite being
-        masked will be fully visible, and `100` means it will be
-        completely transparent and not visible in the resulting image.
-
-        For the mask values not listed in `transparencies`, the data will
-        be completely opaque (transparency = 0).
+        Each condition in *conditions* consists of of three items:
+        - `method`: the Numpy-equivalent method name for <, >, <=, ==, >= or >
+        - `value`: threshold value of the *mask* applied with the
+          operator. Can be a string, in which case the corresponding
+          value will be determined from `flag_meanings` and
+          `flag_values` attributes of the mask.
+        - `transparency`: transparency from interval [0 ... 100] used
+          for the method/threshold. Value of 100 is fully transparent.
 
         Example::
 
-          >>> transparency = {0: 100,
-                              1: 80,
-                              2: 0}
+          >>> conditions = [{'method': 'greater_equal', 'value': 0,
+                             'transparency': 100},
+                            {'method': 'greater_equal', 'value': 1,
+                             'transparency': 80},
+                            {'method': 'greater_equal', 'value': 2,
+                             'transparency': 0}]
           >>> compositor = MaskingCompositor("masking compositor",
                                              transparency=transparency)
           >>> result = compositor([data, mask])
@@ -1632,13 +1636,25 @@ class MaskingCompositor(GenericCompositor):
         visible.
 
         The transparency is implemented by adding an alpha layer to
-        the composite.  If the input `data` contains an alpha channel,
-        it will be discarded.
+        the composite.  The locations with transparency of `100` will
+        be set to NaN in the data.  If the input `data` contains an
+        alpha channel, it will be discarded.
 
         """
-        if transparency is None:
-            raise ValueError("No transparency configured for simple masking compositor")
-        self.transparency = transparency
+        if transparency:
+            LOG.warning("Using 'transparency' is deprecated in "
+                        "MaskingCompositor, use 'conditions' instead.")
+            self.conditions = []
+            for key, transp in transparency.items():
+                self.conditions.append({'method': 'equal',
+                                        'value': key,
+                                        'transparency': transp})
+            LOG.info("Converted 'transparency' to 'conditions': %s",
+                     str(self.conditions))
+        else:
+            self.conditions = conditions
+        if self.conditions is None:
+            raise ValueError("Masking conditions not defined.")
 
         super(MaskingCompositor, self).__init__(name, **kwargs)
 
@@ -1647,80 +1663,26 @@ class MaskingCompositor(GenericCompositor):
         if len(projectables) != 2:
             raise ValueError("Expected 2 datasets, got %d" % (len(projectables),))
         projectables = self.match_data_arrays(projectables)
-        cloud_mask = projectables[1]
-        cloud_mask_data = cloud_mask.data
-        data = projectables[0]
-        alpha_attrs = data.attrs.copy()
-        if 'bands' in data.dims:
-            data = [data.sel(bands=b) for b in data['bands'] if b != 'A']
+        data_in = projectables[0]
+        mask_in = projectables[1]
+        mask_data = mask_in.data
+
+        alpha_attrs = data_in.attrs.copy()
+        if 'bands' in data_in.dims:
+            data = [data_in.sel(bands=b) for b in data_in['bands'] if b != 'A']
         else:
-            data = [data]
+            data = [data_in]
 
         # Create alpha band
         alpha = da.ones((data[0].sizes['y'],
                          data[0].sizes['x']),
                         chunks=data[0].chunks)
 
-        # Modify alpha based on transparency per class from yaml
-        flag_meanings = cloud_mask.attrs['flag_meanings']
-        flag_values = cloud_mask.attrs['flag_values']
-
-        if isinstance(flag_meanings, str):
-            flag_meanings = flag_meanings.split()
-
-        for key, val in self.transparency.items():
-            if isinstance(key, str):
-                key_index = flag_meanings.index(key)
-                key = flag_values[key_index]
-            alpha_val = 1. - val / 100.
-            alpha = da.where(cloud_mask_data == key, alpha_val, alpha)
-        alpha = xr.DataArray(data=alpha, attrs=alpha_attrs,
-                             dims=data[0].dims, coords=data[0].coords)
-        data.append(alpha)
-        res = super(MaskingCompositor, self).__call__(data, **kwargs)
-        return res
-
-
-class MaskCompositor(GenericCompositor):
-    """Modifier that applies masking to the given datasets."""
-
-    def __init__(self, name, conditions=None, **kwargs):
-        """Collect custom configuration values.
-
-        Args:
-            conditions (list): list of three items determining the masking
-                               settings.
-
-        The each condition in *conditions* consists of of three items:
-        - operator: the Numpy-equivalent method name for <, >, <=, ==, >= or >
-        - threshold / value of the *mask* applied with the operator
-        - transparency from interval [0 ... 100] used for the
-          operator/threshold, where 100 is fully transparent
-        """
-        self.conditions = conditions or []
-        super(MaskCompositor, self).__init__(name, **kwargs)
-
-    def __call__(self, projectables, *args, **kwargs):
-        """Generate the composite."""
-        projectables = self.match_data_arrays(projectables)
-        data, mask_in = projectables
-        mask_data = mask_in.data
-
-        alpha_attrs = data.attrs.copy()
-        if 'bands' in data.dims:
-            data = [data.sel(bands=b) for b in data['bands'] if b != 'A']
-        else:
-            data = [data]
-
-        # Create alpha band, default to opaque
-        alpha = da.ones((data[0].sizes['y'],
-                         data[0].sizes['x']),
-                        chunks=data[0].chunks)
-        alpha = da.where(np.isnan(data[0]), np.nan, alpha)
-
         for condition in self.conditions:
             method = condition['method']
             value = condition['value']
+            if isinstance(value, str):
+                value = self._get_flag_value(mask_in, value)
             transparency = condition['transparency']
             try:
                 func = getattr(np, method)
@@ -1738,9 +1700,18 @@ class MaskCompositor(GenericCompositor):
 
         alpha = xr.DataArray(data=alpha, attrs=alpha_attrs,
                              dims=data[0].dims, coords=data[0].coords)
+
         data.append(alpha)
-        res = super(MaskCompositor, self).__call__(data, **kwargs)
-
-        LOG.debug("Masking applied.")
-
+        res = super(MaskingCompositor, self).__call__(data, **kwargs)
         return res
+
+    def _get_flag_value(self, mask, val):
+        # Modify alpha based on transparency per class from yaml
+        flag_meanings = mask.attrs['flag_meanings']
+        flag_values = mask.attrs['flag_values']
+        if isinstance(flag_meanings, str):
+            flag_meanings = flag_meanings.split()
+
+        index = flag_meanings.index(val)
+
+        return flag_values[index]

--- a/satpy/etc/composites/avhrr-3.yaml
+++ b/satpy/etc/composites/avhrr-3.yaml
@@ -9,9 +9,19 @@ composites:
     - ct
     standard_name: nwc_pps_ct_masked_ir
     # Default is opaque (transparency = 0)
-    transparency:
-      Cloud-free_land: 100
-      Cloud-free_sea: 100
-      Snow_over_land: 100
-      Sea_ice: 100
-      Fractional_clouds: 45
+    conditions:
+      - method: equal
+        value: Cloud-free_land
+        transparency: 100
+      - method: equal
+        value: Cloud-free_sea
+        transparency: 100
+      - method: equal
+        value: Snow_over_land
+        transparency: 100
+      - method: equal
+        value: Sea_ice
+        transparency: 100
+      - method: equal
+        value: Fractional_clouds
+        transparency: 45

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -35,7 +35,7 @@ composites:
       - method: equal
         value: 4
         transparency: 100
-        method: equal
+      - method: equal
         value: 10
         transparency: 35
 

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -424,6 +424,39 @@ composites:
       - name: HRV
         modifiers: [sunz_corrected]
 
+  hrv_severe_storms:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - name: HRV
+      modifiers: [sunz_corrected]
+    - name: HRV
+      modifiers: [sunz_corrected]
+    - compositor: !!python/name:satpy.composites.DifferenceCompositor
+      prerequisites:
+      - wavelength: 10.8
+      - wavelength: 3.9
+    standard_name: hrv_severe_storms
+
+  hrv_severe_storms_masked:
+    compositor: !!python/name:satpy.composites.MaskingCompositor
+    conditions:
+    # Data will be masked where SZA corrected HRV data is less than 70 %, or NaN
+    - method: less
+      value: 70
+      transparency: 100
+    - method: isnan
+      transparency: 100
+    - method: less
+      value: 75
+      transparency: 70
+    prerequisites:
+    # Composite
+    - name: hrv_severe_storms
+    # Data used in masking
+    - name: HRV
+      modifiers: [sunz_corrected]
+    standard_name: hrv_severe_storms_masked
+
   natural_with_night_fog:
     compositor: !!python/name:satpy.composites.DayNightCompositor
     standard_name: natural_with_night_fog

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -442,13 +442,13 @@ composites:
     conditions:
     # Data will be masked where SZA corrected HRV data is less than 70 %, or NaN
     - method: less
+      value: 75
+      transparency: 70
+    - method: less
       value: 70
       transparency: 100
     - method: isnan
       transparency: 100
-    - method: less
-      value: 75
-      transparency: 70
     prerequisites:
     # Composite
     - name: hrv_severe_storms

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -19,13 +19,25 @@ composites:
     - IR_108
     - ct
     standard_name: ct_masked_ir
-    transparency:
-      0: 100
-      1: 100
-      2: 100
-      3: 100
-      4: 100
-      10: 35
+    conditions:
+      - method: equal
+        value: 0
+        transparency: 100
+      - method: equal
+        value: 1
+        transparency: 100
+      - method: equal
+        value: 2
+        transparency: 100
+      - method: equal
+        value: 3
+        transparency: 100
+      - method: equal
+        value: 4
+        transparency: 100
+        method: equal
+        value: 10
+        transparency: 35
 
   nwc_geo_ct_masked_ir:
     compositor: !!python/name:satpy.composites.MaskingCompositor
@@ -34,14 +46,28 @@ composites:
     - ct
     standard_name: nwc_geo_ct_masked_ir
     # Default is opaque (transparency = 0)
-    transparency:
-      Cloud-free_land: 100
-      Cloud-free_sea: 100
-      Snow_over_land: 100
-      Sea_ice: 100
-      Fractional_clouds: 45
-      High_semitransparent_thin_clouds: 50
-      High_semitransparent_above_snow_ice: 60
+    conditions:
+      - method: equal
+        value: Cloud-free_land
+        transparency: 100
+      - method: equal
+        value: Cloud-free_sea
+        transparency: 100
+      - method: equal
+        value: Snow_over_land
+        transparency: 100
+      - method: equal
+        value: Sea_ice
+        transparency: 100
+      - method: equal
+        value: Fractional_clouds
+        transparency: 45
+      - method: equal
+        value: High_semitransparent_thin_clouds
+        transparency: 50
+      - method: equal
+        value: High_semitransparent_above_snow_ice
+        transparency: 60
 
   cloudtop:
     compositor: !!python/name:satpy.composites.GenericCompositor

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -813,6 +813,36 @@ enhancements:
           max_stretch: [70, 100, 100]
     standard_name: hrv_fog
 
+  hrv_severe_storms:
+    standard_name: hrv_severe_storms
+    operations:
+    - name: stretch
+      method: *stretchfun
+      kwargs:
+        stretch: crude
+        min_stretch: [70, 70, -60]
+        max_stretch: [100, 100, -40]
+    - name: gamma
+      method: *gammafun
+      kwargs:
+        gamma: [1.7, 1.7, 2.0]
+
+  hrv_severe_storms_masked:
+    standard_name: hrv_severe_storms_masked
+    operations:
+    - name: stretch
+      method: *stretchfun
+      kwargs:
+        stretch: crude
+        # MaskingCompositor always adds alpha channel
+        min_stretch: [70, 70, -60, 0]
+        max_stretch: [100, 100, -40, 1]
+    - name: gamma
+      method: *gammafun
+      kwargs:
+        # MaskingCompositor always adds alpha channel
+        gamma: [1.7, 1.7, 2.0, 1.0]
+
   true_color_with_night_ir:
     standard_name: true_color_with_night_ir
     operations:

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -1343,19 +1343,6 @@ class TestMaskingCompositor(unittest.TestCase):
         # The compositor should drop the original alpha band
         np.testing.assert_allclose(res.sel(bands='A'), reference_alpha)
 
-        # Test "isnan" as method
-        arr = np.reshape(np.arange(0, 9), (3, 3))
-        arr[0, 0] = np.nan
-        arr[1, 1] = np.nan
-        arr[2, 2] = np.nan
-        data = xr.DataArray(da.from_array(arr), dims=['y', 'x'])
-        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
-            comp = MaskingCompositor("name", conditions=conditions_v3)
-            res = comp([data, ct_data])
-        self.assertTrue(res.mode == 'LA')
-        np.testing.assert_allclose(res.sel(bands='L'), reference_data)
-        np.testing.assert_allclose(res.sel(bands='A'), reference_alpha)
-
         # incorrect method
         conditions = [{'method': 'foo', 'value': 0, 'transparency': 100}]
         comp = MaskingCompositor("name", conditions=conditions)

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -1252,9 +1252,9 @@ class TestMaskingCompositor(unittest.TestCase):
         ct_data.attrs['flag_meanings'] = flag_meanings
         ct_data.attrs['flag_values'] = flag_values
 
-        reference_alpha = da.array([[1, 0.5, 0.5],
-                                    [0.5, 1, 0.5],
-                                    [0.5, 0.5, 1]])
+        reference_alpha = da.array([[0, 0.5, 0.5],
+                                    [0.5, 0, 0.5],
+                                    [0.5, 0.5, 0]])
         reference_alpha = xr.DataArray(reference_alpha, dims=['y', 'x'])
 
         # The data are set to NaN where ct is `1`

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -1242,6 +1242,8 @@ class TestMaskingCompositor(unittest.TestCase):
                           'transparency': 50}]
         conditions_v3 = [{'method': 'isnan',
                           'transparency': 100}]
+        conditions_v4 = [{'method': 'absolute_import',
+                          'transparency': 'satpy.resample'}]
 
         # 2D data array
         data = xr.DataArray(da.random.random((3, 3)), dims=['y', 'x'])
@@ -1302,6 +1304,16 @@ class TestMaskingCompositor(unittest.TestCase):
         self.assertTrue(res.mode == 'LA')
         np.testing.assert_allclose(res.sel(bands='L'), reference_data_v3)
         np.testing.assert_allclose(res.sel(bands='A'), reference_alpha_v3)
+
+        # Test "absolute_import" as method
+        # This should raise AttributeError
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            comp = MaskingCompositor("name", conditions=conditions_v4)
+            try:
+                res = comp([data, ct_data_v3])
+                raise ValueError("Tried to use 'np.absolute_import'")
+            except AttributeError:
+                pass
 
         # Test RGB dataset
         # 3D data array


### PR DESCRIPTION
This PR adds a more flexible way to apply masking to composites.

 - [x] Closes #1168 
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
