### PR TITLE
Provide platform_name in FCI L1C FDHSI reader.

### DIFF
--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -84,6 +84,20 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
 
     """
 
+    # Platform names according to the MTG FCI L1 Product User Guide,
+    # EUM/MTG/USR/13/719113 from 2019-06-27, pages 32 and 124, are MTI1, MTI2,
+    # MTI3, and MTI4, but we want to use names such as described in WMO OSCAR
+    # MTG-I1, MTG-I2, MTG-I3, and MTG-I4.
+    #
+    # After launch: translate to METEOSAT-xx instead?  Not sure how the
+    # numbering will be considering MTG-S1 and MTG-S2 will be launched
+    # in-between.
+    _platform_name_translate = {
+            "MTI1": "MTG-I1",
+            "MTI2": "MTG-I2",
+            "MTI3": "MTG-I3",
+            "MTI4": "MTG-I4"}
+
     def __init__(self, filename, filename_info, filetype_info):
         """Initialize file handler."""
         super(FCIFDHSIFileHandler, self).__init__(filename, filename_info,
@@ -151,6 +165,8 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         res.attrs.update(key.to_dict())
         res.attrs.update(info)
         res.attrs.update(attrs)
+        res.attrs["platform_name"] = self._platform_name_translate.get(
+                self["/attr/platform"], self["/attr/platform"])
         return res
 
     def get_channel_dataset(self, channel):

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -151,6 +151,13 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
 
         return data
 
+    def _get_global_attributes(self):
+        data = {}
+        attrs = {"platform": "MTI1"}
+        for (k, v) in attrs.items():
+            data["/attr/" + k] = v
+        return data
+
     def get_test_content(self, filename, filename_info, filetype_info):
         # mock global attributes
         # - root groups global
@@ -163,6 +170,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         D = {}
         D.update(self._get_test_content_all_channels())
         D.update(self._get_test_content_areadef())
+        D.update(self._get_global_attributes())
         return D
 
 
@@ -381,6 +389,26 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
         (comps, mods) = cl.load_compositors(["fci"])
         self.assertGreater(len(comps["fci"]), 0)
         self.assertGreater(len(mods["fci"]), 0)
+
+    def test_platform_name(self):
+        """Test that platform name is exposed.
+
+        Test that the FCI reader exposes the platform name.  Corresponds
+        to GH issue 1014.
+        """
+        from satpy.readers import load_reader
+
+        filenames = [
+            "W_XX-EUMETSAT-Darmstadt,IMG+SAT,MTI1+FCI-1C-RRAD-FDHSI-FD--"
+            "CHK-BODY--L2P-NC4E_C_EUMT_20170410114434_GTT_DEV_"
+            "20170410113925_20170410113934_N__C_0070_0067.nc",
+        ]
+
+        reader = load_reader(self.reader_configs)
+        loadables = reader.select_files_from_pathnames(filenames)
+        reader.create_filehandlers(loadables)
+        res = reader.load(["ir_123"])
+        self.assertEqual(res["ir_123"].attrs["platform_name"], "MTG-I1")
 
 
 class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):


### PR DESCRIPTION
In the FCI L1C FDHSI reader, provide the platform name as MTG-I1,
MTG-I2, MTG-I3, or MTG-I4, corresponding to the acronyms used by the WMO
OSCAR database.  The reader translates those from the global NetCDF
attribute `platform` provided in each file, where it has the value
"MTI1" in the currently available test data.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1014 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 