### PR TITLE
Add support for reading pixel_quality ancillary variables, FCI reader no longer logs warnings

### DIFF
--- a/satpy/etc/readers/fci_l1c_fdhsi.yaml
+++ b/satpy/etc/readers/fci_l1c_fdhsi.yaml
@@ -28,12 +28,6 @@ datasets:
         units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
-  vis_04_pixel_quality:
-    name: vis_04_pixel_quality
-    sensor: fci
-    resolution: 1000
-    file_type: fci_l1c_fdhsi
-
   vis_05:
     name: vis_05
     sensor: fci
@@ -289,6 +283,101 @@ datasets:
         units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
+  vis_04_pixel_quality:
+    name: vis_04_pixel_quality
+    sensor: fci
+    resolution: 1000
+    file_type: fci_l1c_fdhsi
+
+  vis_05_pixel_quality:
+    name: vis_05_pixel_quality
+    sensor: fci
+    resolution: 1000
+    file_type: fci_l1c_fdhsi
+
+  vis_06_pixel_quality:
+    name: vis_06_pixel_quality
+    sensor: fci
+    resolution: 1000
+    file_type: fci_l1c_fdhsi
+
+  vis_08_pixel_quality:
+    name: vis_08_pixel_quality
+    sensor: fci
+    resolution: 1000
+    file_type: fci_l1c_fdhsi
+
+  vis_09_pixel_quality:
+    name: vis_09_pixel_quality
+    sensor: fci
+    resolution: 1000
+    file_type: fci_l1c_fdhsi
+
+  nir_13_pixel_quality:
+    name: nir_13_pixel_quality
+    sensor: fci
+    resolution: 1000
+    file_type: fci_l1c_fdhsi
+
+  nir_16_pixel_quality:
+    name: nir_16_pixel_quality
+    sensor: fci
+    resolution: 1000
+    file_type: fci_l1c_fdhsi
+
+  nir_22_pixel_quality:
+    name: nir_22_pixel_quality
+    sensor: fci
+    resolution: 1000
+    file_type: fci_l1c_fdhsi
+
+  ir_38_pixel_quality:
+    name: ir_38_pixel_quality
+    sensor: fci
+    resolution: 2000
+    file_type: fci_l1c_fdhsi
+
+  wv_63_pixel_quality:
+    name: wv_63_pixel_quality
+    sensor: fci
+    resolution: 2000
+    file_type: fci_l1c_fdhsi
+
+  wv_73_pixel_quality:
+    name: wv_73_pixel_quality
+    sensor: fci
+    resolution: 2000
+    file_type: fci_l1c_fdhsi
+
+  ir_87_pixel_quality:
+    name: ir_87_pixel_quality
+    sensor: fci
+    resolution: 2000
+    file_type: fci_l1c_fdhsi
+
+  ir_97_pixel_quality:
+    name: ir_97_pixel_quality
+    sensor: fci
+    resolution: 2000
+    file_type: fci_l1c_fdhsi
+
+  ir_105_pixel_quality:
+    name: ir_105_pixel_quality
+    sensor: fci
+    resolution: 2000
+    file_type: fci_l1c_fdhsi
+
+  ir_123_pixel_quality:
+    name: ir_123_pixel_quality
+    sensor: fci
+    resolution: 2000
+    file_type: fci_l1c_fdhsi
+
+  ir_133_pixel_quality:
+    name: ir_133_pixel_quality
+    sensor: fci
+    resolution: 2000
+    file_type: fci_l1c_fdhsi
 
 # Source: FCI L1 Dataset User Guide [FCIL1DUG]
 # ftp://ftp.eumetsat.int/pub/OPS/out/test-data/FCI_L1C_Format_Familiarisation/FCI_L1_Dataset_User_Guide_[FCIL1DUG].pdf

--- a/satpy/etc/readers/fci_l1c_fdhsi.yaml
+++ b/satpy/etc/readers/fci_l1c_fdhsi.yaml
@@ -28,6 +28,12 @@ datasets:
         units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
+  vis_04_pixel_quality:
+    name: vis_04_pixel_quality
+    sensor: fci
+    resolution: 1000
+    file_type: fci_l1c_fdhsi
+
   vis_05:
     name: vis_05
     sensor: fci

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -192,7 +192,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         else:
             raise ValueError(
                 "Unexpected value for attribute ancillary_variables, "
-                "which I intend to rewrite (see "
+                "which the FCI file handler intends to rewrite (see "
                 "https://github.com/pytroll/satpy/issues/1171 for why). "
                 f"Expected 'pixel_quality', got {attrs['ancillary_variables']:s}")
 
@@ -224,11 +224,11 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         variables (see also Satpy issue 1171), so some special treatment in
         necessary.
         """
-        # FIXME: replace by .removesuffix once we drop support for Python < 3.9
+        # FIXME: replace by .removesuffix after we drop support for Python < 3.9
         if key.name.endswith("_pixel_quality"):
             chan_lab = key.name[:-len("_pixel_quality")]
         else:
-            raise ValueError("quality label must end with pixel_quality, got "
+            raise ValueError("Quality label must end with pixel_quality, got "
                              f"{key.name:s}")
         grp_path = self.get_channel_measured_group_path(chan_lab)
         dv_path = grp_path + "/pixel_quality"

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -56,6 +56,18 @@ geolocation calculations.
 The brightness temperature calculation is based on the formulas indicated in
 `PUG`_ and `RADTOBR`_.
 
+The reading routine supports channel data in counts, radiances, and (depending
+on channel) brightness temperatures or reflectances.  For each channel, it also
+supports the pixel quality, obtained by prepending the channel name such as
+``"vis_04_pixel_quality"``.
+
+.. warning::
+    The API for the direct reading of pixel quality is temporary and likely to
+    change.  Currently, for each channel, the pixel quality is available by
+    ``<chan>_pixel_quality``.  In the future, they will likely all be called
+    ``pixel_quality`` and disambiguated by a to-be-decided property in the
+    `DatasetID`.
+
 .. _RADTOBR: https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_EFFECT_RAD_TO_BRIGHTNESS&RevisionSelectionMethod=LatestReleased&Rendition=Web
 .. _PUG: http://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_DMT_719113&RevisionSelectionMethod=LatestReleased&Rendition=Web
 .. _EUMETSAT: https://www.eumetsat.int/website/home/Satellites/FutureSatellites/MeteosatThirdGeneration/MTGDesign/index.html#fci  # noqa: E501

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -187,8 +187,9 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         # example, with https://github.com/pytroll/satpy/pull/1088), rewrite
         # the ancillary variable to include the channel.  See also
         # https://github.com/pytroll/satpy/issues/1171.
-        if attrs["ancillary_variables"] == "pixel_quality":
-            attrs["ancillary_variables"] = key.name + "_pixel_quality"
+        if "pixel_quality" in attrs["ancillary_variables"]:
+            attrs["ancillary_variables"] = attrs["ancillary_variables"].replace(
+                    "pixel_quality", key.name + "_pixel_quality")
         else:
             raise ValueError(
                 "Unexpected value for attribute ancillary_variables, "

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -164,10 +164,10 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
             attrs["ancillary_variables"] = key.name + "_pixel_quality"
         else:
             raise ValueError(
-            "Unexpected value for attribute ancillary_variables, "
-            "which I intend to rewrite (see "
-            "https://github.com/pytroll/satpy/issues/1171 for why). "
-            f"Expected 'pixel_quality', got {attrs['ancillary_variables']:s}")
+                "Unexpected value for attribute ancillary_variables, "
+                "which I intend to rewrite (see "
+                "https://github.com/pytroll/satpy/issues/1171 for why). "
+                f"Expected 'pixel_quality', got {attrs['ancillary_variables']:s}")
 
         res.attrs.update(key.to_dict())
         res.attrs.update(info)

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -67,12 +67,12 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         ch_str = pat.format(ch)
         ch_path = rad.format(ch_str)
 
-        common_attrs ={
-                    "scale_factor": 5,
-                    "add_offset": 10,
-                    "long_name": "Effective Radiance",
-                    "units": "mW.m-2.sr-1.(cm-1)-1",
-                    "ancillary_variables": "pixel_quality",
+        common_attrs = {
+                "scale_factor": 5,
+                "add_offset": 10,
+                "long_name": "Effective Radiance",
+                "units": "mW.m-2.sr-1.(cm-1)-1",
+                "ancillary_variables": "pixel_quality"
                 }
         if ch == 38:
             fire_line = da.ones((1, ncols), dtype="uint16", chunks=1024) * 5000

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -59,6 +59,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         chroot = "data/{:s}"
         meas = chroot + "/measured"
         rad = meas + "/effective_radiance"
+        qual = meas + "/pixel_quality"
         pos = meas + "/{:s}_position_{:s}"
         shp = rad + "/shape"
         x = meas + "/x"
@@ -116,6 +117,9 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
                     "add_offset": 0.155619515845,
                     }
                 )
+        data[qual.format(ch_str)] = xrda(
+                da.arange(nrows*ncols, dtype="uint8").reshape(nrows, ncols) % 128,
+                dims=("y", "x"))
 
         data[pos.format(ch_str, "start", "row")] = xrda(0)
         data[pos.format(ch_str, "start", "column")] = xrda(0)

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -311,7 +311,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
 
         reader = load_reader(reader_configs)
         loadables = reader.select_files_from_pathnames(filenames)
-        fhs = reader.create_filehandlers(loadables)
+        reader.create_filehandlers(loadables)
         res = reader.load(
                 [DatasetID(name=name, calibration="counts") for name in
                     self._chans["solar"] + self._chans["terran"]])
@@ -462,10 +462,11 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
             fhs["fci_l1c_fdhsi"][0].get_dataset(DatasetID(name="invalid"), {})
         with pytest.raises(ValueError):
             fhs["fci_l1c_fdhsi"][0]._get_dataset_quality(DatasetID(name="invalid"),
-                    {})
+                                                         {})
         with caplog.at_level(logging.ERROR):
-            fhs["fci_l1c_fdhsi"][0].get_dataset(DatasetID(name="ir_123",
-                calibration="unknown"), {"units": "unknown"})
+            fhs["fci_l1c_fdhsi"][0].get_dataset(
+                    DatasetID(name="ir_123", calibration="unknown"),
+                    {"units": "unknown"})
             assert "unknown calibration key" in caplog.text
 
 
@@ -513,4 +514,3 @@ class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):
                     name="vis_04",
                     calibration="reflectance")])
             assert "cannot produce reflectance" in caplog.text
-

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -67,6 +67,13 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         ch_str = pat.format(ch)
         ch_path = rad.format(ch_str)
 
+        common_attrs ={
+                    "scale_factor": 5,
+                    "add_offset": 10,
+                    "long_name": "Effective Radiance",
+                    "units": "mW.m-2.sr-1.(cm-1)-1",
+                    "ancillary_variables": "pixel_quality",
+                }
         if ch == 38:
             fire_line = da.ones((1, ncols), dtype="uint16", chunks=1024) * 5000
             data_without_fires = da.ones((nrows-1, ncols), dtype="uint16", chunks=1024)
@@ -75,12 +82,9 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
                 dims=("y", "x"),
                 attrs={
                     "valid_range": [0, 8191],
-                    "scale_factor": 5,
-                    "add_offset": 10,
                     "warm_scale_factor": 2,
                     "warm_add_offset": -300,
-                    "long_name": "Effective Radiance",
-                    "units": "mW.m-2.sr-1.(cm-1)-1",
+                    **common_attrs
                 }
             )
         else:
@@ -89,13 +93,9 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
                 dims=("y", "x"),
                 attrs={
                     "valid_range": [0, 4095],
-                    "scale_factor": 5,
-                    "add_offset": 10,
                     "warm_scale_factor": 1,
                     "warm_add_offset": 0,
-                    "long_name": "Effective Radiance",
-                    "units": "mW.m-2.sr-1.(cm-1)-1",
-                    "ancillary_variables": "pixel_quality",
+                    **common_attrs
                     }
                 )
 


### PR DESCRIPTION
Add support for reading pixel quality, closing #1171 

Read pixel quality ancillary variables.  This is done with a small hack, because the data variables have the same name in each group, so Satpy doesn't know where to look when simply told to look for `pixel_quality`.  This may change later when dynamic dataset ids are introduced (see #1088) but so far this is not supported.  Therefore, when reading the parent variable, the filehandler rewrites the `ancillary_variables` variable attribute to prepend the channel name, such that when the same filehandler is called a little later for the variable name, it knows where to find it.  See also the discussion in #1171. 

 - [x] Closes #1171 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
