### PR TITLE
Optimize readers searching for matching filenames

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -443,6 +443,8 @@ def group_files(files_to_sort, reader=None, time_threshold=10,
     if group_keys is None:
         group_keys = reader_instance.info.get('group_keys', ('start_time',))
     file_keys = []
+    # make a copy because filename_items_for_filetype will modify inplace
+    files_to_sort = set(files_to_sort)
     for _, filetype_info in reader_instance.sorted_filetype_items():
         for f, file_info in reader_instance.filename_items_for_filetype(files_to_sort, filetype_info):
             group_key = tuple(file_info.get(k) for k in group_keys)

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -406,7 +406,7 @@ class FileYAMLReader(AbstractYAMLReader):
         matched_files = []
         for pattern in filetype_info['file_patterns']:
             matches = match_filenames(filenames, pattern)
-            filenames -= matches
+            filenames -= set(matches)
             for filename in matches:
                 try:
                     filename_info = parse(

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -188,9 +188,12 @@ class AbstractYAMLReader(metaclass=ABCMeta):
         filenames = set()
         if directory is None:
             directory = ''
-        for pattern in self.file_patterns:
-            matching = glob.iglob(os.path.join(directory, globify(pattern)))
-            filenames.update(matching)
+        # all the glob patterns that we are going to look at
+        all_globs = set(os.path.join(directory, globify(pattern))
+                        for pattern in self.file_patterns)
+        # get all files matching these patterns
+        for glob_pat in all_globs:
+            filenames.update(glob.iglob(glob_pat))
         return filenames
 
     def select_files_from_pathnames(self, filenames):

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -64,7 +64,7 @@ def listify_string(something):
         return list()
 
 
-def get_filebase(path, pattern):
+def _get_filebase(path, pattern):
     """Get the end of *path* of same length as *pattern*."""
     # convert any `/` on Windows to `\\`
     path = os.path.normpath(path)
@@ -73,14 +73,13 @@ def get_filebase(path, pattern):
     return os.path.join(*str(path).split(os.path.sep)[-tail_len:])
 
 
-def match_filenames(filenames, pattern):
+def _match_filenames(filenames, pattern):
     """Get the filenames matching *pattern*."""
-    matching = []
-
+    matching = set()
     glob_pat = globify(pattern)
     for filename in filenames:
-        if fnmatch(get_filebase(filename, pattern), glob_pat):
-            matching.append(filename)
+        if fnmatch(_get_filebase(filename, pattern), glob_pat):
+            matching.add(filename)
 
     return matching
 
@@ -189,8 +188,8 @@ class AbstractYAMLReader(metaclass=ABCMeta):
         if directory is None:
             directory = ''
         # all the glob patterns that we are going to look at
-        all_globs = set(os.path.join(directory, globify(pattern))
-                        for pattern in self.file_patterns)
+        all_globs = {os.path.join(directory, globify(pattern))
+                     for pattern in self.file_patterns}
         # get all files matching these patterns
         for glob_pat in all_globs:
             filenames.update(glob.iglob(glob_pat))
@@ -202,8 +201,8 @@ class AbstractYAMLReader(metaclass=ABCMeta):
         filenames = set(filenames)  # make a copy of the inputs
 
         for pattern in self.file_patterns:
-            matching = match_filenames(filenames, pattern)
-            filenames -= set(matching)
+            matching = _match_filenames(filenames, pattern)
+            filenames -= matching
             for fname in matching:
                 if fname not in selected_filenames:
                     selected_filenames.append(fname)
@@ -404,20 +403,20 @@ class FileYAMLReader(AbstractYAMLReader):
             # we perform set operations later on to improve performance
             filenames = set(filenames)
         for pattern in filetype_info['file_patterns']:
-            matched_files = []
-            matches = match_filenames(filenames, pattern)
+            matched_files = set()
+            matches = _match_filenames(filenames, pattern)
             for filename in matches:
                 try:
                     filename_info = parse(
-                        pattern, get_filebase(filename, pattern))
+                        pattern, _get_filebase(filename, pattern))
                 except ValueError:
                     logger.debug("Can't parse %s with %s.", filename, pattern)
                     continue
-                matched_files.append(filename)
+                matched_files.add(filename)
                 yield filename, filename_info
-            filenames -= set(matched_files)
+            filenames -= matched_files
 
-    def new_filehandler_instances(self, filetype_info, filename_items, fh_kwargs=None):
+    def _new_filehandler_instances(self, filetype_info, filename_items, fh_kwargs=None):
         """Generate new filehandler instances."""
         requirements = filetype_info.get('requires')
         filetype_cls = filetype_info['file_reader']
@@ -517,20 +516,17 @@ class FileYAMLReader(AbstractYAMLReader):
             for fn, _ in filename_iter:
                 yield fn
 
-    def new_filehandlers_for_filetype(self, filetype_info, filenames, fh_kwargs=None):
+    def _new_filehandlers_for_filetype(self, filetype_info, filenames, fh_kwargs=None):
         """Create filehandlers for a given filetype."""
-        if not isinstance(filenames, set):
-            # we perform set operations later on to improve performance
-            filenames = set(filenames)
         filename_iter = self.filename_items_for_filetype(filenames,
                                                          filetype_info)
         if self.filter_filenames:
             # preliminary filter of filenames based on start/end time
             # to reduce the number of files to open
             filename_iter = self.filter_filenames_by_info(filename_iter)
-        filehandler_iter = self.new_filehandler_instances(filetype_info,
-                                                          filename_iter,
-                                                          fh_kwargs=fh_kwargs)
+        filehandler_iter = self._new_filehandler_instances(filetype_info,
+                                                           filename_iter,
+                                                           fh_kwargs=fh_kwargs)
         filtered_iter = self.filter_fh_by_metadata(filehandler_iter)
         return list(filtered_iter)
 
@@ -544,9 +540,9 @@ class FileYAMLReader(AbstractYAMLReader):
         created_fhs = {}
         # load files that we know about by creating the file handlers
         for filetype, filetype_info in self.sorted_filetype_items():
-            filehandlers = self.new_filehandlers_for_filetype(filetype_info,
-                                                              filename_set,
-                                                              fh_kwargs=fh_kwargs)
+            filehandlers = self._new_filehandlers_for_filetype(filetype_info,
+                                                               filename_set,
+                                                               fh_kwargs=fh_kwargs)
 
             if filehandlers:
                 created_fhs[filetype] = filehandlers

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -403,10 +403,9 @@ class FileYAMLReader(AbstractYAMLReader):
         if not isinstance(filenames, set):
             # we perform set operations later on to improve performance
             filenames = set(filenames)
-        matched_files = []
         for pattern in filetype_info['file_patterns']:
+            matched_files = []
             matches = match_filenames(filenames, pattern)
-            filenames -= set(matches)
             for filename in matches:
                 try:
                     filename_info = parse(
@@ -416,6 +415,7 @@ class FileYAMLReader(AbstractYAMLReader):
                     continue
                 matched_files.append(filename)
                 yield filename, filename_info
+            filenames -= set(matched_files)
 
     def new_filehandler_instances(self, filetype_info, filename_items, fh_kwargs=None):
         """Generate new filehandler instances."""
@@ -548,7 +548,6 @@ class FileYAMLReader(AbstractYAMLReader):
                                                               filename_set,
                                                               fh_kwargs=fh_kwargs)
 
-            filename_set -= set([fhd.filename for fhd in filehandlers])
             if filehandlers:
                 created_fhs[filetype] = filehandlers
                 self.file_handlers[filetype] = sorted(

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -77,8 +77,9 @@ def match_filenames(filenames, pattern):
     """Get the filenames matching *pattern*."""
     matching = []
 
+    glob_pat = globify(pattern)
     for filename in filenames:
-        if fnmatch(get_filebase(filename, pattern), globify(pattern)):
+        if fnmatch(get_filebase(filename, pattern), glob_pat):
             matching.append(filename)
 
     return matching
@@ -184,12 +185,12 @@ class AbstractYAMLReader(metaclass=ABCMeta):
 
         If directory is None or '', look in the current directory.
         """
-        filenames = []
+        filenames = set()
         if directory is None:
             directory = ''
         for pattern in self.file_patterns:
             matching = glob.iglob(os.path.join(directory, globify(pattern)))
-            filenames.extend(matching)
+            filenames.update(matching)
         return filenames
 
     def select_files_from_pathnames(self, filenames):

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -657,6 +657,17 @@ class TestGroupFiles(unittest.TestCase):
         self.assertEqual(6, len(groups))
         self.assertEqual(2, len(groups[0]['abi_l1b']))
 
+    def test_default_behavior_set(self):
+        """Test the default behavior with the 'abi_l1b' reader."""
+        from satpy.readers import group_files
+        files = set(self.g16_files)
+        num_files = len(files)
+        groups = group_files(files, reader='abi_l1b')
+        # we didn't modify it
+        self.assertEqual(len(files), num_files)
+        self.assertEqual(6, len(groups))
+        self.assertEqual(2, len(groups[0]['abi_l1b']))
+
     def test_non_datetime_group_key(self):
         """Test what happens when the start_time isn't used for grouping."""
         from satpy.readers import group_files

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -72,7 +72,7 @@ class TestUtils(unittest.TestCase):
         pattern = os.path.join(*pattern.split('/'))
         filename = os.path.join(base_dir, 'Oa05_radiance.nc')
         expected = os.path.join(base_data, 'Oa05_radiance.nc')
-        self.assertEqual(yr.get_filebase(filename, pattern), expected)
+        self.assertEqual(yr._get_filebase(filename, pattern), expected)
 
     def test_match_filenames(self):
         """Check that matching filenames works."""
@@ -91,7 +91,7 @@ class TestUtils(unittest.TestCase):
         filenames = [os.path.join(base_dir, 'Oa05_radiance.nc'),
                      os.path.join(base_dir, 'geo_coordinates.nc')]
         expected = os.path.join(base_dir, 'geo_coordinates.nc')
-        self.assertEqual(yr.match_filenames(filenames, pattern), [expected])
+        self.assertEqual(yr._match_filenames(filenames, pattern), {expected})
 
     def test_match_filenames_windows_forward_slash(self):
         """Check that matching filenames works on Windows with forward slashes.
@@ -114,7 +114,7 @@ class TestUtils(unittest.TestCase):
         filenames = [os.path.join(base_dir, 'Oa05_radiance.nc').replace(os.sep, '/'),
                      os.path.join(base_dir, 'geo_coordinates.nc').replace(os.sep, '/')]
         expected = os.path.join(base_dir, 'geo_coordinates.nc').replace(os.sep, '/')
-        self.assertEqual(yr.match_filenames(filenames, pattern), [expected])
+        self.assertEqual(yr._match_filenames(filenames, pattern), {expected})
 
     def test_listify_string(self):
         """Check listify_string."""


### PR DESCRIPTION
This addresses some of the performance issues mentioned in #1172. Thanks to @gerritholl's investigating, it was discovered that the base reader's functions for searching for file was taking a long time. We've tracked it down to a few key parts, the main one being that globify was called thousands of times for only hundreds of files. The changes in this PR seem to make a big difference.

Here is a PyCharm profiling graph showing the most called or longest running functions in the call graph of my test script:

![globify_orig](https://user-images.githubusercontent.com/1828519/80979290-c24f5a00-8dec-11ea-860e-3d131a1cdca5.png)

With a total run time of ~16.5s. Here's what it looks like after this PR (globify is not even listed):

![globify_2](https://user-images.githubusercontent.com/1828519/80979306-c8453b00-8dec-11ea-95e6-706f1929608e.png)

With a total run time of ~4.7s.

 - [x] Closes #1172 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

