### PR TITLE
Migrate FCI tests to pytest

### DIFF
--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -426,4 +426,4 @@ class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):
             reader.load([DatasetID(
                     name="ir_123",
                     calibration="brightness_temperature")])
-            assert "cannot produce brightness temperatur" in caplog.text
+            assert "cannot produce brightness temperature" in caplog.text

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -242,9 +242,6 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
             "W_XX-EUMETSAT-Darmstadt,IMG+SAT,MTI1+FCI-1C-RRAD-FDHSI-FD--"
             "CHK-BODY--L2P-NC4E_C_EUMT_20170410114500_GTT_DEV_"
             "20170410113951_20170410114000_N__C_0070_0070.nc",
-            "W_XX-EUMETSAT-Darmstadt,IMG+SAT,MTI1+FCI-1C-RRAD-HRFI-FD--"
-            "CHK-BODY--L2P-NC4E_C_EUMT_19700101000000_GTT_DEV_"
-            "19700000000000_19700000000000_N__C_0042_0070.nc",
             "W_XX-EUMETSAT-Darmstadt,IMG+SAT,MTI1+FCI-1C-RRAD-FDHSI-FD--"
             "CHK-TRAIL--L2P-NC4E_C_EUMT_20170410114600_GTT_DEV_"
             "20170410113000_20170410114000_N__C_0070_0071.nc",
@@ -252,7 +249,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
 
         reader = load_reader(reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        # only 4 out of 6 above should match
+        # only 4 out of 5 above should match
         assert len(files) == 4
 
     _chans = {"solar": ["vis_04", "vis_05", "vis_06", "vis_08", "vis_09",

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -17,15 +17,12 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for the 'fci_l1c_fdhsi' reader."""
 
-from __future__ import (division, absolute_import, print_function,
-                        unicode_literals)
-
 import os
 import numpy as np
 import xarray as xr
 import dask.array as da
-import unittest
 import numpy.testing
+import pytest
 from unittest import mock
 from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
 
@@ -190,33 +187,31 @@ class FakeNetCDF4FileHandler3(FakeNetCDF4FileHandler2):
         return data
 
 
-class TestFCIL1CFDHSIReader(unittest.TestCase):
+@pytest.fixture
+def reader_configs():
+    """Return reader configs for FCI.
+    """
+
+    from satpy.config import config_search_paths
+    return config_search_paths(
+        os.path.join("readers", "fci_l1c_fdhsi.yaml"))
+
+
+class TestFCIL1CFDHSIReader:
     yaml_file = "fci_l1c_fdhsi.yaml"
 
     _alt_handler = FakeNetCDF4FileHandler2
 
-    def setUp(self):
-        """Wrap NetCDF4 FileHandler with our own fake handler
-        """
-
-        # implementation strongly inspired by test_viirs_l1b.py
-        from satpy.config import config_search_paths
+    @pytest.fixture(autouse=True, scope="class")
+    def fake_handler(self):
         from satpy.readers.fci_l1c_fdhsi import FCIFDHSIFileHandler
-
-        self.reader_configs = config_search_paths(
-                os.path.join("readers", self.yaml_file))
-        self.p = mock.patch.object(
+        p = mock.patch.object(
                 FCIFDHSIFileHandler,
                 "__bases__",
                 (self._alt_handler,))
-        self.fake_handler = self.p.start()
-        self.p.is_local = True
-
-    def tearDown(self):
-        """Stop wrapping the NetCDF4 file handler
-        """
-        # implementation strongly inspired by test_viirs_l1b.py
-        self.p.stop()
+        with p:
+            p.is_local = True
+            yield p
 
 
 class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
@@ -229,7 +224,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
 
     _alt_handler = FakeNetCDF4FileHandler2
 
-    def test_file_pattern(self):
+    def test_file_pattern(self, reader_configs):
         """Test file pattern matching
         """
         from satpy.readers import load_reader
@@ -255,17 +250,17 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
             "20170410113000_20170410114000_N__C_0070_0071.nc",
         ]
 
-        reader = load_reader(self.reader_configs)
+        reader = load_reader(reader_configs)
         files = reader.select_files_from_pathnames(filenames)
         # only 4 out of 6 above should match
-        self.assertTrue(4, len(files))
+        assert len(files) == 4
 
     _chans = {"solar": ["vis_04", "vis_05", "vis_06", "vis_08", "vis_09",
                         "nir_13", "nir_16", "nir_22"],
               "terran": ["ir_38", "wv_63", "wv_73", "ir_87", "ir_97", "ir_105",
                          "ir_123", "ir_133"]}
 
-    def test_load_counts(self):
+    def test_load_counts(self, reader_configs):
         """Test loading with counts
         """
         from satpy import DatasetID
@@ -281,21 +276,21 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
             "20170410113934_20170410113942_N__C_0070_0068.nc",
         ]
 
-        reader = load_reader(self.reader_configs)
+        reader = load_reader(reader_configs)
         loadables = reader.select_files_from_pathnames(filenames)
         reader.create_filehandlers(loadables)
         res = reader.load(
                 [DatasetID(name=name, calibration="counts") for name in
                     self._chans["solar"] + self._chans["terran"]])
-        self.assertEqual(16, len(res))
+        assert 16 == len(res)
         for ch in self._chans["solar"] + self._chans["terran"]:
-            self.assertEqual(res[ch].shape, (200*2, 11136))
-            self.assertEqual(res[ch].dtype, np.uint16)
-            self.assertEqual(res[ch].attrs["calibration"], "counts")
-            self.assertEqual(res[ch].attrs["units"], "1")
+            assert res[ch].shape == (200*2, 11136)
+            assert res[ch].dtype == np.uint16
+            assert res[ch].attrs["calibration"] == "counts"
+            assert res[ch].attrs["units"] == "1"
             numpy.testing.assert_array_equal(res[ch], 1)
 
-    def test_load_radiance(self):
+    def test_load_radiance(self, reader_configs):
         """Test loading with radiance
         """
         from satpy import DatasetID
@@ -307,21 +302,21 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
             "20170410113925_20170410113934_N__C_0070_0067.nc",
         ]
 
-        reader = load_reader(self.reader_configs)
+        reader = load_reader(reader_configs)
         loadables = reader.select_files_from_pathnames(filenames)
         reader.create_filehandlers(loadables)
         res = reader.load(
                 [DatasetID(name=name, calibration="radiance") for name in
                     self._chans["solar"] + self._chans["terran"]])
-        self.assertEqual(16, len(res))
+        assert 16 == len(res)
         for ch in self._chans["solar"] + self._chans["terran"]:
-            self.assertEqual(res[ch].shape, (200, 11136))
-            self.assertEqual(res[ch].dtype, np.float64)
-            self.assertEqual(res[ch].attrs["calibration"], "radiance")
-            self.assertEqual(res[ch].attrs["units"], 'mW.m-2.sr-1.(cm-1)-1')
+            assert res[ch].shape == (200, 11136)
+            assert res[ch].dtype == np.float64
+            assert res[ch].attrs["calibration"] == "radiance"
+            assert res[ch].attrs["units"] == 'mW.m-2.sr-1.(cm-1)-1'
             numpy.testing.assert_array_equal(res[ch], 15)
 
-    def test_load_reflectance(self):
+    def test_load_reflectance(self, reader_configs):
         """Test loading with reflectance
         """
         from satpy import DatasetID
@@ -333,45 +328,43 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
             "20170410113925_20170410113934_N__C_0070_0067.nc",
         ]
 
-        reader = load_reader(self.reader_configs)
+        reader = load_reader(reader_configs)
         loadables = reader.select_files_from_pathnames(filenames)
         reader.create_filehandlers(loadables)
         res = reader.load(
                 [DatasetID(name=name, calibration="reflectance") for name in
                     self._chans["solar"]])
-        self.assertEqual(8, len(res))
+        assert 8 == len(res)
         for ch in self._chans["solar"]:
-            self.assertEqual(res[ch].shape, (200, 11136))
-            self.assertEqual(res[ch].dtype, np.float64)
-            self.assertEqual(res[ch].attrs["calibration"], "reflectance")
-            self.assertEqual(res[ch].attrs["units"], "%")
+            assert res[ch].shape == (200, 11136)
+            assert res[ch].dtype == np.float64
+            assert res[ch].attrs["calibration"] == "reflectance"
+            assert res[ch].attrs["units"] == "%"
             numpy.testing.assert_array_equal(res[ch], 15 / 50 * 100)
 
-    def test_load_bt(self):
+    def test_load_bt(self, reader_configs):
         """Test loading with bt
         """
         from satpy import DatasetID
         from satpy.readers import load_reader
-
         filenames = [
             "W_XX-EUMETSAT-Darmstadt,IMG+SAT,MTI1+FCI-1C-RRAD-FDHSI-FD--"
             "CHK-BODY--L2P-NC4E_C_EUMT_20170410114434_GTT_DEV_"
             "20170410113925_20170410113934_N__C_0070_0067.nc",
         ]
 
-        reader = load_reader(self.reader_configs)
+        reader = load_reader(reader_configs)
         loadables = reader.select_files_from_pathnames(filenames)
         reader.create_filehandlers(loadables)
         res = reader.load(
                 [DatasetID(name=name, calibration="brightness_temperature") for
                     name in self._chans["terran"]])
-        self.assertEqual(8, len(res))
+        assert 8 == len(res)
         for ch in self._chans["terran"]:
-            self.assertEqual(res[ch].shape, (200, 11136))
-            self.assertEqual(res[ch].dtype, np.float64)
-            self.assertEqual(res[ch].attrs["calibration"],
-                             "brightness_temperature")
-            self.assertEqual(res[ch].attrs["units"], "K")
+            assert res[ch].shape == (200, 11136)
+            assert res[ch].dtype == np.float64
+            assert res[ch].attrs["calibration"] == "brightness_temperature"
+            assert res[ch].attrs["units"] == "K"
             numpy.testing.assert_array_almost_equal(
                     res[ch],
                     181.917084)
@@ -387,10 +380,10 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
         from satpy.composites import CompositorLoader
         cl = CompositorLoader()
         (comps, mods) = cl.load_compositors(["fci"])
-        self.assertGreater(len(comps["fci"]), 0)
-        self.assertGreater(len(mods["fci"]), 0)
+        assert len(comps["fci"]) > 0
+        assert len(mods["fci"]) > 0
 
-    def test_platform_name(self):
+    def test_platform_name(self, reader_configs):
         """Test that platform name is exposed.
 
         Test that the FCI reader exposes the platform name.  Corresponds
@@ -404,17 +397,17 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
             "20170410113925_20170410113934_N__C_0070_0067.nc",
         ]
 
-        reader = load_reader(self.reader_configs)
+        reader = load_reader(reader_configs)
         loadables = reader.select_files_from_pathnames(filenames)
         reader.create_filehandlers(loadables)
         res = reader.load(["ir_123"])
-        self.assertEqual(res["ir_123"].attrs["platform_name"], "MTG-I1")
+        assert res["ir_123"].attrs["platform_name"] == "MTG-I1"
 
 
 class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):
     _alt_handler = FakeNetCDF4FileHandler3
 
-    def test_handling_bad_data_ir(self):
+    def test_handling_bad_data_ir(self, reader_configs, caplog):
         """Test handling of bad data
         """
         from satpy import DatasetID
@@ -426,13 +419,11 @@ class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):
             "20170410113925_20170410113934_N__C_0070_0067.nc",
         ]
 
-        reader = load_reader(self.reader_configs)
+        reader = load_reader(reader_configs)
         loadables = reader.select_files_from_pathnames(filenames)
         reader.create_filehandlers(loadables)
-        with self.assertLogs(
-                'satpy.readers.fci_l1c_fdhsi',
-                level="ERROR") as cm:
+        with caplog.at_level("ERROR"):
             reader.load([DatasetID(
                     name="ir_123",
                     calibration="brightness_temperature")])
-        self.assertRegex(cm.output[0], "cannot produce brightness temperatur")
+            assert "cannot produce brightness temperatur" in caplog.text


### PR DESCRIPTION
Migrate FCI tests to pytest.  This enables the more flexible set of
fixtures available there.  This will be needed by at least one of the
tests to be added in https://github.com/pytroll/satpy/pull/1177

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
