### PR TITLE
Add more explicit error message when string is passed to Scene.load

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -929,14 +929,14 @@ class Scene(MetadataObject):
         Loaded `DataArray` objects are created and stored in the Scene object.
 
         Args:
-            wishlist (iterable): Names (str), wavelengths (float), or
+            wishlist (iterable): List of names (str), wavelengths (float), or
                                  DatasetID objects of the requested datasets
                                  to load. See `available_dataset_ids()` for
                                  what datasets are available.
             calibration (list, str): Calibration levels to limit available
-                                      datasets. This is a shortcut to
-                                      having to list each DatasetID in
-                                      `wishlist`.
+                                     datasets. This is a shortcut to
+                                     having to list each DatasetID in
+                                     `wishlist`.
             resolution (list | float): Resolution to limit available datasets.
                                        This is a shortcut similar to
                                        calibration.
@@ -955,6 +955,8 @@ class Scene(MetadataObject):
                            but are no longer needed.
 
         """
+        if isinstance(wishlist, str):
+            raise TypeError("'load' expects a list of datasets, got a string.")
         dataset_keys = set(wishlist)
         needed_datasets = (self.wishlist | dataset_keys) - \
             set(self.datasets.keys())

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -778,6 +778,21 @@ class TestSceneLoading(unittest.TestCase):
 
     @mock.patch('satpy.composites.CompositorLoader.load_compositors')
     @mock.patch('satpy.scene.Scene.create_reader_instances')
+    def test_load_str(self, cri, cl):
+        """Test passing a string to Scene.load."""
+        import satpy.scene
+        from satpy.tests.utils import FakeReader, test_composites
+        cri.return_value = {'fake_reader': FakeReader(
+            'fake_reader', 'fake_sensor')}
+        comps, mods = test_composites('fake_sensor')
+        cl.return_value = (comps, mods)
+        scene = satpy.scene.Scene(filenames=['bla'],
+                                  base_dir='bli',
+                                  reader='fake_reader')
+        self.assertRaises(TypeError, scene.load, 'ds1')
+
+    @mock.patch('satpy.composites.CompositorLoader.load_compositors')
+    @mock.patch('satpy.scene.Scene.create_reader_instances')
     def test_load_no_exist(self, cri, cl):
         """Test loading a dataset that doesn't exist."""
         import satpy.scene


### PR DESCRIPTION
This comes up a lot for new users when they first call `scn.load('C01')` and they see a message that comes from later on in the function call that is confusing (I don't remember the message). This is all because they didn't pass a list of channels and instead passed a single string. This PR adds a more explicit message.

I realize this is not the only option. I could instead detect a string and convert it to a list, but I think that along the lines of "explicit is better than implicit" that it is just better to limit what types we allow here. Either way of solving this should include and update to the docstring.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
