### PR TITLE
Add options for creating geotiff overviews

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -265,5 +265,6 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/reference', None),
     'trollimage': ('https://trollimage.readthedocs.io/en/stable', None),
     'trollsift': ('https://trollsift.readthedocs.io/en/stable', None),
-    'xarray': ('https://xarray.pydata.org/en/stable', None)
+    'xarray': ('https://xarray.pydata.org/en/stable', None),
+    'rasterio': ('https://rasterio.readthedocs.io/en/latest', None),
 }

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -102,7 +102,8 @@ class GeoTIFFWriter(ImageWriter):
 
     def save_image(self, img, filename=None, dtype=None, fill_value=None,
                    compute=True, keep_palette=False, cmap=None, tags=None,
-                   include_scale_offset=False,
+                   overviews=None, overviews_resampling=None,
+                   overviews_minsize=256, include_scale_offset=False,
                    **kwargs):
         """Save the image to the given ``filename`` in geotiff_ format.
 
@@ -147,6 +148,25 @@ class GeoTIFFWriter(ImageWriter):
                 the index range of the palette
                 (ex. `cmap.set_range(0, len(colors))`).
             tags (dict): Extra metadata to store in geotiff.
+            overviews (list): The reduction factors of the overviews to include
+                in the image, eg::
+
+                    scn.save_datasets(overviews=[2, 4, 8, 16])
+
+                If provided as an empty list, then levels will be
+                computed as powers of two until the last level has less
+                pixels than `overviews_minsize`.
+                Default is to not add overviews.
+            overviews_minsize (int): Minimum number of pixels for the smallest
+                overview size generated when `overviews` is auto-generated.
+                Defaults to 256.
+            overviews_resampling (str): Resampling method
+                to use when generating overviews. This must be the name of an
+                enum value from :class:`rasterio.enums.Resampling` and
+                only takes effect if the `overviews` keyword argument is
+                provided. Common values include `nearest` (default),
+                `bilinear`, `average`, and many others. See the rasterio
+                documentation for more information.
             include_scale_offset (bool): Activate inclusion of scale and offset
                 factors in the geotiff to allow retrieving original values from
                 the pixel values. ``False`` by default.
@@ -193,4 +213,7 @@ class GeoTIFFWriter(ImageWriter):
                         dtype=dtype, compute=compute,
                         keep_palette=keep_palette, cmap=cmap,
                         tags=tags, include_scale_offset_tags=include_scale_offset,
+                        overviews=overviews,
+                        overviews_resampling=overviews_resampling,
+                        overviews_minsize=overviews_minsize,
                         **gdal_options)

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -102,8 +102,8 @@ class GeoTIFFWriter(ImageWriter):
 
     def save_image(self, img, filename=None, dtype=None, fill_value=None,
                    compute=True, keep_palette=False, cmap=None, tags=None,
-                   overviews=None, overviews_resampling=None,
-                   overviews_minsize=256, include_scale_offset=False,
+                   overviews=None, overviews_minsize=256,
+                   overviews_resampling=None, include_scale_offset=False,
                    **kwargs):
         """Save the image to the given ``filename`` in geotiff_ format.
 


### PR DESCRIPTION
Adds the additional keyword arguments necessary to take advantage of trollimage's new overviews functionality. See https://github.com/pytroll/trollimage/pull/67.

The basic overviews functionality has existed for a while, but this keyword argument was never actually passed to trollimage. Not sure who was using overviews, but I don't think it ever worked.

Given this is just kwargs, do I need to add tests?

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
