### PR TITLE
Add scanline acquisition times to hrit_jma

### DIFF
--- a/doc/source/readers.rst
+++ b/doc/source/readers.rst
@@ -199,22 +199,43 @@ This is described in the developer guide, see :doc:`dev_guide/custom_reader`.
 Implemented readers
 ===================
 
+
 xRIT-based readers
 ------------------
 
 .. automodule:: satpy.readers.hrit_base
+    :noindex:
+
+SEVIRI HRIT format reader
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.seviri_l1b_hrit
+    :noindex:
+
+JMA HRIT format reader
+^^^^^^^^^^^^^^^^^^^^^^
+
 
 .. automodule:: satpy.readers.hrit_jma
+    :noindex:
+
+GOES HRIT format reader
+^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.goes_imager_hrit
+    :noindex:
+
+Electro-L HRIT format reader
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.electrol_hrit
+    :noindex:
 
 hdf-eos based readers
 ---------------------
 
 .. automodule:: satpy.readers.modis_l1b
+    :noindex:
 
 .. automodule:: satpy.readers.modis_l2
+    :noindex:

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -54,10 +54,10 @@ Output:
 .. code-block:: none
 
     <xarray.DataArray (y: 5500, x: 5500)>
-    dask.array<concatenate, shape=(5500, 5500), dtype=float64, chunksize=(550, 4096), chunktype=numpy.ndarray>
+    dask.array<concatenate, shape=(5500, 5500), dtype=float64, chunksize=(550, 4096), ...
     Coordinates:
         acq_time  (y) datetime64[ns] 2018-01-11T09:00:20.995200 ... 2018-01-11T09:09:40.348800
-        crs       object +proj=geos +lon_0=140.7 +h=35785831 +x_0=0 +y_0=0 +a=6378169 +b=6356583.8 +units=m +no_defs +type=crs
+        crs       object +proj=geos +lon_0=140.7 +h=35785831 +x_0=0 +y_0=0 +a=6378169 ...
       * y         (y) float64 5.5e+06 5.498e+06 5.496e+06 ... -5.496e+06 -5.498e+06
       * x         (x) float64 -5.498e+06 -5.496e+06 -5.494e+06 ... 5.498e+06 5.5e+06
     Attributes:

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -319,8 +319,8 @@ class HRITJMAFileHandler(HRITFileHandler):
         times_sparse = [float(s.split(':=')[1]) for s in splits[1::2]]
 
         if self.platform == HIMAWARI8:
-            # Only 3 timestamps, and only the first and last are usable
-            # (the second equals the third).
+            # Only a couple of timestamps in the header, and only the first
+            # and last are usable (duplicates inbetween).
             lines_sparse = [lines_sparse[0], lines_sparse[-1]]
             times_sparse = [times_sparse[0], times_sparse[-1]]
 

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -179,7 +179,7 @@ def mjd2datetime64(mjd):
 
     epoch = np.datetime64('1858-11-17 00:00')
     day2usec = 24 * 3600 * 1E6
-    mjd_usec = (mjd * day2usec).astype(int).astype('timedelta64[us]')
+    mjd_usec = (mjd * day2usec).astype(np.int64).astype('timedelta64[us]')
     return epoch + mjd_usec
 
 

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -276,8 +276,8 @@ class HRITJMAFileHandler(HRITFileHandler):
         res = self._mask_space(self.calibrate(res, key.calibration))
 
         # Add scanline acquisition time
-        res['acq_time'] = ('y', self.acq_time)
-        res['acq_time'].attrs['long_name'] = 'Scanline acquisition time'
+        res.coords['acq_time'] = ('y', self.acq_time)
+        res.coords['acq_time'].attrs['long_name'] = 'Scanline acquisition time'
 
         # Update attributes
         res.attrs.update(info)

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -17,9 +17,76 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """HRIT format reader for JMA data.
 
-References:
-    JMA HRIT - Mission Specific Implementation
-    http://www.jma.go.jp/jma/jma-eng/satellite/introduction/4_2HRIT.pdf
+Introduction
+------------
+
+The JMA HRIT format is described in the `JMA HRIT - Mission Specific
+Implementation`_. Sample data is available `here <https://www.data.jma.go.jp/
+mscweb/en/himawari89/space_segment/sample_hrit.html>`_. There are three
+readers for this format in Satpy:
+
+- ``jami_hrit``: For data from the `JAMI` instrument on MTSAT-1R
+- ``mtsat2-imager_hrit``: For data from the `Imager` instrument on MTSAT-2
+- ``ahi_hrit``: For data from the `AHI` instrument on Himawari-8/9
+
+Although the data format is identical, the instruments have different
+characteristics, which is why there is a dedicated reader for each of them.
+
+
+Example
+-------
+
+Here is an example how to read Himwari-8 HRIT data with Satpy:
+
+.. code-block:: python
+
+    from satpy import Scene
+    import glob
+
+    filenames = glob.glob('data/IMG_DK01B14_2018011109*')
+    scn = Scene(filenames=filenames, reader='ahi_hrit')
+    scn.load(['B14'])
+    print(scn['B14'])
+
+
+Output:
+
+.. code-block:: none
+
+    <xarray.DataArray (y: 5500, x: 5500)>
+    dask.array<concatenate, shape=(5500, 5500), dtype=float64, chunksize=(550, 4096), chunktype=numpy.ndarray>
+    Coordinates:
+        acq_time  (y) datetime64[ns] 2018-01-11T09:00:20.995200 ... 2018-01-11T09:09:40.348800
+        crs       object +proj=geos +lon_0=140.7 +h=35785831 +x_0=0 +y_0=0 +a=6378169 +b=6356583.8 +units=m +no_defs +type=crs
+      * y         (y) float64 5.5e+06 5.498e+06 5.496e+06 ... -5.496e+06 -5.498e+06
+      * x         (x) float64 -5.498e+06 -5.496e+06 -5.494e+06 ... 5.498e+06 5.5e+06
+    Attributes:
+        satellite_longitude:  140.7
+        satellite_latitude:   0.0
+        satellite_altitude:   35785831.0
+        orbital_parameters:   {'projection_longitude': 140.7, 'projection_latitud...
+        standard_name:        toa_brightness_temperature
+        level:                None
+        wavelength:           (11.0, 11.2, 11.4)
+        units:                K
+        calibration:          brightness_temperature
+        file_type:            ['hrit_b14_seg', 'hrit_b14_fd']
+        modifiers:            ()
+        polarization:         None
+        sensor:               ahi
+        name:                 B14
+        platform_name:        Himawari-8
+        resolution:           4000
+        start_time:           2018-01-11 09:00:20.995200
+        end_time:             2018-01-11 09:09:40.348800
+        area:                 Area ID: FLDK, Description: Full Disk, Projection I...
+        ancillary_variables:  []
+
+JMA HRIT data contain the scanline acquisition time for only a subset of scanlines. Timestamps of
+the remaining scanlines are computed using linear interpolation. This is what you'll find in the
+``acq_time`` coordinate of the dataset.
+
+.. _JMA HRIT - Mission Specific Implementation: http://www.jma.go.jp/jma/jma-eng/satellite/introduction/4_2HRIT.pdf
 
 """
 

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -49,7 +49,7 @@ provided through the `Scene` instantiation, eg::
   Scene(reader="seviri_l1b_hrit", filenames=fnames, reader_kwargs={'fill_hrv': False})
 
 To see the full list of arguments that can be provided, look into the documentation
-of `:class:HRITMSGFileHandler`.
+of :class:`HRITMSGFileHandler`.
 
 Example
 -------

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -695,8 +695,8 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
         res.attrs['raw_metadata'] = self._get_raw_mda()
 
         # Add scanline timestamps as additional y-coordinate
-        res['acq_time'] = ('y', self._get_timestamps())
-        res['acq_time'].attrs['long_name'] = 'Mean scanline acquisition time'
+        res.coords['acq_time'] = ('y', self._get_timestamps())
+        res.coords['acq_time'].attrs['long_name'] = 'Mean scanline acquisition time'
 
         return res
 

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -40,10 +40,10 @@ class TestHRITJMAFileHandler(unittest.TestCase):
         """Get sample header entry for scanline acquisition times.
 
         Lines: 1, 21, 41, 61, ..., nlines
-        Times: 1970-01-01 00:00 + (1, 21, 41, 61, ..., nlines) hours
+        Times: 1970-01-01 00:00 + (1, 21, 41, 61, ..., nlines) seconds
 
         So the interpolated times are expected to be 1970-01-01 +
-        (1, 2, 3, 4, ..., nlines) hours. Note that there will be some
+        (1, 2, 3, 4, ..., nlines) seconds. Note that there will be some
         floating point inaccuracies, because timestamps are stored
         with only 6 decimals precision.
         """

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -36,8 +36,27 @@ class TestHRITJMAFileHandler(unittest.TestCase):
         HRITJMAFileHandler.mda = mda
         return HRITJMAFileHandler('filename', filename_info, {})
 
+    def _get_acq_time(self, nlines):
+        """Get sample header entry for scanline acquisition times.
+
+        Lines: 1, 21, 41, 61, ..., nlines
+        Times: 1970-01-01 00:00 + (1, 21, 41, 61, ..., nlines) hours
+
+        So the interpolated times are expected to be 1970-01-01 +
+        (1, 2, 3, 4, ..., nlines) hours. Note that there will be some
+        floating point inaccuracies, because timestamps are stored
+        with only 6 decimals precision.
+        """
+        mjd_1970 = 40587.0
+        lines_sparse = np.array(list(range(1, nlines, 20)) + [nlines])
+        times_sparse = mjd_1970 + lines_sparse / 24 / 3600
+        acq_time_s = ['LINE:={}\rTIME:={:.6f}\r'.format(l, t)
+                      for l, t in zip(lines_sparse, times_sparse)]
+        acq_time_b = ''.join(acq_time_s).encode()
+        return acq_time_b
+
     def _get_mda(self, loff=5500.0, coff=5500.0, nlines=11000, ncols=11000,
-                 segno=0, numseg=1, vis=True):
+                 segno=0, numseg=1, vis=True, platform='Himawari-8'):
         """Create metadata dict like HRITFileHandler would do it."""
         if vis:
             idf = b'$HALFTONE:=16\r_NAME:=VISIBLE\r_UNIT:=ALBEDO(%)\r' \
@@ -45,10 +64,12 @@ class TestHRITJMAFileHandler(unittest.TestCase):
         else:
             idf = b'$HALFTONE:=16\r_NAME:=INFRARED\r_UNIT:=KELVIN\r' \
                   b'0:=329.98\r1023:=130.02\r65535:=130.02\r'
-
+        proj_h8 = b'GEOS(140.70)                    '
+        proj_mtsat2 = b'GEOS(145.00)                    '
+        proj_name = proj_h8 if platform == 'Himawari-8' else proj_mtsat2
         return {'image_segm_seq_no': segno,
                 'total_no_image_segm': numseg,
-                'projection_name': b'GEOS(140.70)                    ',
+                'projection_name': proj_name,
                 'projection_parameters': {
                     'a': 6378169.00,
                     'b': 6356583.80,
@@ -60,7 +81,8 @@ class TestHRITJMAFileHandler(unittest.TestCase):
                 'loff': loff,
                 'number_of_columns': ncols,
                 'number_of_lines': nlines,
-                'image_data_function': idf}
+                'image_data_function': idf,
+                'image_observation_time': self._get_acq_time(nlines)}
 
     def test_init(self):
         """Test creating the file handler."""
@@ -86,6 +108,9 @@ class TestHRITJMAFileHandler(unittest.TestCase):
                                  [1023,  100],
                                  [65535,  100]])
         self.assertTrue(np.all(reader.calibration_table == cal_expected))
+
+        # Check if scanline timestamps are there (dedicated test below)
+        self.assertIsInstance(reader.acq_time, np.ndarray)
 
         # Check platform
         self.assertEqual(reader.platform, HIMAWARI8)
@@ -271,3 +296,23 @@ class TestHRITJMAFileHandler(unittest.TestCase):
         with mock.patch('logging.Logger.error') as log_mock:
             reader.get_dataset(key, {'units': '%', 'sensor': 'jami'})
             log_mock.assert_called()
+
+    def test_mjd2datetime64(self):
+        """Test conversion from modified julian day to datetime64"""
+        from satpy.readers.hrit_jma import mjd2datetime64
+        self.assertEqual(mjd2datetime64(0), np.datetime64('1858-11-17', 'us'))
+        self.assertEqual(mjd2datetime64(40587.5), np.datetime64('1970-01-01 12:00', 'us'))
+
+    def test_get_acq_time(self):
+        """Test computation of scanline acquisition times."""
+        dt_line = np.arange(1, 11000+1).astype('timedelta64[s]')
+        acq_time_exp = np.datetime64('1970-01-01', 'us') + dt_line
+
+        for platform in ['Himawari-8', 'MTSAT-2']:
+            # Results are not exactly identical because timestamps are stored in
+            # the header with only 6 decimals precision (max diff here: 45 msec).
+            mda = self._get_mda(platform=platform)
+            reader = self._get_reader(mda=mda)
+            np.testing.assert_allclose(reader.acq_time.astype(int),
+                                       acq_time_exp.astype(int),
+                                       atol=45000)

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -272,7 +272,8 @@ class TestHRITJMAFileHandler(unittest.TestCase):
         key.calibration = 'reflectance'
 
         base_get_dataset.return_value = DataArray(da.ones((275, 1375),
-                                                          chunks=1024))
+                                                          chunks=1024),
+                                                  dims=('y', 'x'))
 
         # Check attributes
         res = reader.get_dataset(key, {'units': '%', 'sensor': 'ahi'})
@@ -300,8 +301,10 @@ class TestHRITJMAFileHandler(unittest.TestCase):
     def test_mjd2datetime64(self):
         """Test conversion from modified julian day to datetime64"""
         from satpy.readers.hrit_jma import mjd2datetime64
-        self.assertEqual(mjd2datetime64(0), np.datetime64('1858-11-17', 'us'))
-        self.assertEqual(mjd2datetime64(40587.5), np.datetime64('1970-01-01 12:00', 'us'))
+        self.assertEqual(mjd2datetime64(np.array([0])),
+                         np.datetime64('1858-11-17', 'us'))
+        self.assertEqual(mjd2datetime64(np.array([40587.5])),
+                                        np.datetime64('1970-01-01 12:00', 'us'))
 
     def test_get_acq_time(self):
         """Test computation of scanline acquisition times."""

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -287,6 +287,9 @@ class TestHRITJMAFileHandler(unittest.TestCase):
                                                                'projection_latitude': 0.,
                                                                'projection_altitude': 35785831.0})
 
+        # Check if acquisition time is a coordinate
+        self.assertIn('acq_time', res.coords)
+
         # Check called methods
         with mock.patch.object(reader, '_mask_space') as mask_space:
             with mock.patch.object(reader, 'calibrate') as calibrate:

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -304,7 +304,7 @@ class TestHRITJMAFileHandler(unittest.TestCase):
         self.assertEqual(mjd2datetime64(np.array([0])),
                          np.datetime64('1858-11-17', 'us'))
         self.assertEqual(mjd2datetime64(np.array([40587.5])),
-                                        np.datetime64('1970-01-01 12:00', 'us'))
+                         np.datetime64('1970-01-01 12:00', 'us'))
 
     def test_get_acq_time(self):
         """Test computation of scanline acquisition times."""

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -319,6 +319,6 @@ class TestHRITJMAFileHandler(unittest.TestCase):
             # the header with only 6 decimals precision (max diff here: 45 msec).
             mda = self._get_mda(platform=platform)
             reader = self._get_reader(mda=mda)
-            np.testing.assert_allclose(reader.acq_time.astype(int),
-                                       acq_time_exp.astype(int),
+            np.testing.assert_allclose(reader.acq_time.astype(np.int64),
+                                       acq_time_exp.astype(np.int64),
                                        atol=45000)


### PR DESCRIPTION
Add scanline acquisition times to the `hrit_jma` reader.

Example:
```python
In [1]: import satpy                                                                                                                                                                                                                         
In [2]: import glob                                                                                                                                                                                                                                                                                                                                                                                                                                                        
In [3]: scene = satpy.Scene(filenames=glob.glob('/data/georing/ahi_hrit/*2018011109*'), 
   ...:                     reader='ahi_hrit')                                                                                                                                                                                               
In [4]: scene.load(['B14'])                                                                                                                                                                                                                  
In [5]: scene['B14']['acq_time']                                                                                                                                                                                                             
Out[5]: 
<xarray.DataArray 'acq_time' (y: 5500)>
array(['2018-01-11T09:00:20.995200000', '2018-01-11T09:00:21.055948000',
       '2018-01-11T09:00:21.116695000', ...,
       '2018-01-11T09:09:40.226990000', '2018-01-11T09:09:40.287895000',
       '2018-01-11T09:09:40.348800000'], dtype='datetime64[ns]')
Coordinates:
    acq_time  (y) datetime64[ns] 2018-01-11T09:00:20.995200 ... 2018-01-11T09:09:40.348800
    crs       object +proj=geos +lon_0=140.7 +h=35785831 +x_0=0 +y_0=0 +a=6378169 +b=6356583.8 +units=m +no_defs +type=crs
  * y         (y) float64 5.5e+06 5.498e+06 5.496e+06 ... -5.496e+06 -5.498e+06
Attributes:
    long_name:  Scanline acquisition time
```
Tested with JAMI (non-segmented), MTSAT-2 Imager (both segmented and non-segmented) and AHI (segmented).

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [X] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
