### PR TITLE
Add option to supply sunz-threshold applied in Pyspectral

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -589,15 +589,17 @@ class PSPRayleighReflectance(CompositeBase):
 class NIRReflectance(CompositeBase):
     """Get the reflective part of NIR bands."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, sunz_threshold=None, **kwargs):
         """Collect custom configuration values.
 
         Args:
-            max_sza (float): Maximum solar zenith angle in degrees that is
-                considered valid and correctable. Default 95.0.
+            sunz_threshold: The threshold sun zenith angle used when deriving
+                the near infrared reflectance. Above this angle the derivation
+                will assume this sun-zenith everywhere. Default None, in which
+                case the default threshold defined in Pyspectral will be used.
 
         """
-        self.sunz_threshold = kwargs.get('sunz_threshold')
+        self.sunz_threshold = sunz_threshold
         super(NIRReflectance, self).__init__(**kwargs)
 
     def __call__(self, projectables, optional_datasets=None, **info):
@@ -657,17 +659,18 @@ class NIRReflectance(CompositeBase):
 
 
 class NIREmissivePartFromReflectance(NIRReflectance):
-    """Get the emissive par of NIR bands."""
+    """Get the emissive part of NIR bands."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, sunz_threshold=None, **kwargs):
         """Collect custom configuration values.
 
         Args:
-            max_sza (float): Maximum solar zenith angle in degrees that is
-                considered valid and correctable. Default 95.0.
-
+            sunz_threshold: The threshold sun zenith angle used when deriving
+                the near infrared reflectance. Above this angle the derivation
+                will assume this sun-zenith everywhere. Default None, in which
+                case the default threshold defined in Pyspectral will be used.
         """
-        self.sunz_threshold = kwargs.get('sunz_threshold')
+        self.sunz_threshold = sunz_threshold
         super(NIREmissivePartFromReflectance, self).__init__(**kwargs)
 
     def __call__(self, projectables, optional_datasets=None, **info):

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -600,7 +600,7 @@ class NIRReflectance(CompositeBase):
 
         """
         self.sunz_threshold = sunz_threshold
-        super(NIRReflectance, self).__init__(**kwargs)
+        super(NIRReflectance, self).__init__(sunz_threshold=sunz_threshold, **kwargs)
 
     def __call__(self, projectables, optional_datasets=None, **info):
         """Get the reflectance part of an NIR channel.
@@ -671,7 +671,7 @@ class NIREmissivePartFromReflectance(NIRReflectance):
                 case the default threshold defined in Pyspectral will be used.
         """
         self.sunz_threshold = sunz_threshold
-        super(NIREmissivePartFromReflectance, self).__init__(**kwargs)
+        super(NIREmissivePartFromReflectance, self).__init__(sunz_threshold=sunz_threshold, **kwargs)
 
     def __call__(self, projectables, optional_datasets=None, **info):
         """Get the emissive part an NIR channel after having derived the reflectance.

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -684,8 +684,9 @@ class NIREmissivePartFromReflectance(NIRReflectance):
         # needs to be derived first in order to get the emissive part.
         _ = self._get_reflectance(projectables, optional_datasets)
         _nir, _ = projectables
-        proj = xr.DataArray(self._refl3x.emissive_part_3x(), attrs=_nir.attrs,
-                            dims=_nir.dims, coords=_nir.coords)
+
+        emis = self._refl3x.emissive_part_3x()
+        proj = xr.DataArray(emis, attrs=_nir.attrs, dims=_nir.dims, coords=_nir.coords)
 
         proj.attrs['units'] = 'K'
         proj.attrs['sunz_threshold'] = self.sunz_threshold

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -24,6 +24,7 @@ modifiers:
     optional_prerequisites:
     - solar_zenith_angle
     - 13.4
+    sunz_threshold: 85.0
 
   nir_emissive:
     compositor: !!python/name:satpy.composites.NIREmissivePartFromReflectance
@@ -32,7 +33,8 @@ modifiers:
     optional_prerequisites:
     - solar_zenith_angle
     - 13.4
-
+    sunz_threshold: 85.0
+    
   atm_correction:
     compositor: !!python/name:satpy.composites.PSPAtmosphericalCorrection
     optional_prerequisites:

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -34,7 +34,6 @@ modifiers:
     - solar_zenith_angle
     - 13.4
     sunz_threshold: 85.0
-    
   atm_correction:
     compositor: !!python/name:satpy.composites.PSPAtmosphericalCorrection
     optional_prerequisites:
@@ -421,4 +420,3 @@ composites:
     compositor: !!python/name:satpy.composites.StaticImageCompositor
     standard_name: night_background_hires
     filename: BlackMarble_2016_3km_geo.tif
-

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -607,6 +607,71 @@ class TestNIRReflectance(unittest.TestCase):
         calculator.assert_called_with('Meteosat-11', 'seviri', 'IR_039', sunz_threshold=84.0)
 
 
+class TestNIREmissivePartFromReflectance(unittest.TestCase):
+    """Test the NIR Emissive part from reflectance compositor."""
+
+    @mock.patch('satpy.composites.sun_zenith_angle')
+    @mock.patch('satpy.composites.NIREmissivePartFromReflectance.apply_modifier_info')
+    @mock.patch('satpy.composites.Calculator')
+    def test_compositor(self, calculator, apply_modifier_info, sza):
+        """Test the NIR emissive part from reflectance compositor."""
+        import numpy as np
+        import xarray as xr
+        import dask.array as da
+
+        refl_arr = np.random.random((2, 2))
+        refl = da.from_array(refl_arr)
+
+        refl_from_tbs = mock.MagicMock()
+        refl_from_tbs.return_value = refl
+        calculator.return_value = mock.MagicMock(reflectance_from_tbs=refl_from_tbs)
+
+        emissive_arr = np.random.random((2, 2))
+        emissive = da.from_array(emissive_arr)
+        emissive_part = mock.MagicMock()
+        emissive_part.return_value = emissive
+        calculator.return_value = mock.MagicMock(emissive_part_3x=emissive_part)
+
+        from satpy.composites import NIREmissivePartFromReflectance
+
+        comp = NIREmissivePartFromReflectance(name='test', sunz_threshold=86.0)
+        info = {'modifiers': None}
+
+        platform = 'NOAA-20'
+        sensor = 'viirs'
+        chan_name = 'M12'
+
+        get_lonlats = mock.MagicMock()
+        lons, lats = 1, 2
+        get_lonlats.return_value = (lons, lats)
+        area = mock.MagicMock(get_lonlats=get_lonlats)
+
+        nir_arr = np.random.random((2, 2))
+        nir = xr.DataArray(da.from_array(nir_arr), dims=['y', 'x'])
+        nir.attrs['platform_name'] = platform
+        nir.attrs['sensor'] = sensor
+        nir.attrs['name'] = chan_name
+        nir.attrs['area'] = area
+        ir_arr = np.random.random((2, 2))
+        ir_ = xr.DataArray(da.from_array(ir_arr), dims=['y', 'x'])
+        ir_.attrs['area'] = area
+
+        sunz_arr = 100 * np.random.random((2, 2))
+        sunz = xr.DataArray(da.from_array(sunz_arr), dims=['y', 'x'])
+        sunz.attrs['standard_name'] = 'solar_zenith_angle'
+        sunz.attrs['area'] = area
+        sunz2 = da.from_array(sunz_arr)
+        sza.return_value = sunz2
+
+        res = comp([nir, ir_], optional_datasets=[sunz], **info)
+        self.assertEqual(res.attrs['sunz_threshold'], 86.0)
+        self.assertEqual(res.attrs['units'], 'K')
+        self.assertEqual(res.attrs['platform_name'], platform)
+        self.assertEqual(res.attrs['sensor'], sensor)
+        self.assertEqual(res.attrs['name'], chan_name)
+        calculator.assert_called_with('NOAA-20', 'viirs', 'M12', sunz_threshold=86.0)
+
+
 class TestColormapCompositor(unittest.TestCase):
     """Test the ColormapCompositor."""
 

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -580,8 +580,9 @@ class TestNIRReflectance(unittest.TestCase):
         self.assertEqual(res.attrs['platform_name'], platform)
         self.assertEqual(res.attrs['sensor'], sensor)
         self.assertEqual(res.attrs['name'], chan_name)
+        self.assertEqual(res.attrs['sunz_threshold'], None)
         calculator.assert_called()
-        calculator.assert_called_with('Meteosat-11', 'seviri', 'IR_039')
+        calculator.assert_called_with('Meteosat-11', 'seviri', 'IR_039', sunz_threshold=None)
         self.assertTrue(apply_modifier_info.call_args[0][0] is nir)
         self.assertTrue(comp._refl3x is calculator.return_value)
         refl_from_tbs.reset_mock()
@@ -598,6 +599,12 @@ class TestNIRReflectance(unittest.TestCase):
         co2.attrs['units'] = 'K'
         res = comp([nir, ir_], optional_datasets=[co2], **info)
         refl_from_tbs.assert_called_with(sunz2, nir.data, ir_.data, tb_ir_co2=co2.data)
+
+        comp = NIRReflectance(name='test', sunz_threshold=84.0)
+        info = {'modifiers': None}
+        res = comp([nir, ir_], optional_datasets=[sunz], **info)
+        self.assertEqual(res.attrs['sunz_threshold'], 84.0)
+        calculator.assert_called_with('Meteosat-11', 'seviri', 'IR_039', sunz_threshold=84.0)
 
 
 class TestColormapCompositor(unittest.TestCase):


### PR DESCRIPTION
Add option to supply sunz-threshold applied in Pyspectral for the emissive/reflectance separation of the 3.x band

Signed-off-by: Adam.Dybbroe <a000680@c21856.ad.smhi.se>

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
