### PR TITLE
Fix accessing uncached root group variable when using NetCDF4FileHandler in caching mode

### DIFF
--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -216,7 +216,10 @@ class NetCDF4FileHandler(BaseFileHandler):
     def _get_var_from_filehandle(self, group, key):
         # Not getting coordinates as this is more work, therefore more
         # overhead, and those are not used downstream.
-        g = self.file_handle[group]
+        if group is None:
+            g = self.file_handle
+        else:
+            g = self.file_handle[group]
         v = g[key]
         x = xr.DataArray(
                 da.from_array(v), dims=v.dimensions, attrs=v.__dict__,

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -155,6 +155,11 @@ class TestNetCDF4FileHandler(unittest.TestCase):
         np.testing.assert_array_equal(h["ds2_s"], np.arange(10))
         np.testing.assert_array_equal(h["test_group/ds1_i"],
                                       np.arange(10 * 100).reshape((10, 100)))
+        # check that root variables can still be read from cached file object,
+        # even if not cached themselves
+        np.testing.assert_array_equal(
+                h["ds2_f"],
+                np.arange(10. * 100).reshape((10, 100)))
         h.__del__()
         self.assertFalse(h.file_handle.isopen())
 


### PR DESCRIPTION
In the NetCDF4FileHandler, when the file handler is being cached, accessing a non-cached variable in the root group was failing with a `TypeError` because None is being passed to `os.fspath`.
This PR adds a (regression) unit test for this problem and a fix so that the problem is avoided.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1195 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
