### PR TITLE
Cache dimension per variable

### DIFF
--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -149,6 +149,7 @@ class NetCDF4FileHandler(BaseFileHandler):
             self.file_content[var_name] = var_obj
             self.file_content[var_name + "/dtype"] = var_obj.dtype
             self.file_content[var_name + "/shape"] = var_obj.shape
+            self.file_content[var_name + "/dimensions"] = var_obj.dimensions
             self._collect_attrs(var_name, var_obj)
         self._collect_attrs(name, obj)
 

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -54,6 +54,7 @@ class FakeNetCDF4FileHandler(NetCDF4FileHandler):
             - '/attr/global_attr'
             - 'dataset/attr/global_attr'
             - 'dataset/shape'
+            - 'dataset/dimensions'
             - '/dimension/my_dim'
 
         """
@@ -122,6 +123,7 @@ class TestNetCDF4FileHandler(unittest.TestCase):
         for ds in ('test_group/ds1_f', 'test_group/ds1_i', 'ds2_f', 'ds2_i'):
             self.assertEqual(file_handler[ds].dtype, np.float32 if ds.endswith('f') else np.int32)
             self.assertTupleEqual(file_handler[ds + '/shape'], (10, 100))
+            self.assertEqual(file_handler[ds + '/dimensions'], ("rows", "cols"))
             self.assertEqual(file_handler[ds + '/attr/test_attr_str'], 'test_string')
             self.assertEqual(file_handler[ds + '/attr/test_attr_int'], 0)
             self.assertEqual(file_handler[ds + '/attr/test_attr_float'], 1.2)


### PR DESCRIPTION
In the NetCDF4FileHandler class, cache the tuple of dimension names for
each variable processed.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1198<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

