### PR TITLE
Fix bad error message when Scene was given a bad reader name

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ environment:
     CONDA_DEPENDENCIES: "xarray dask distributed toolz Cython sphinx cartopy pillow matplotlib scipy pyyaml pyproj pyresample coverage netcdf4 h5py h5netcdf gdal rasterio imageio pyhdf libtiff geoviews zarr pytest pytest-cov"
     PIP_DEPENDENCIES: "trollsift trollimage pyspectral pyorbital libtiff"
     CONDA_CHANNELS: "conda-forge"
+    CONDA_CHANNEL_PRIORITY: "strict"
 
   matrix:
     - PYTHON: "C:\\Python38_64"

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -543,13 +543,14 @@ def configs_for_reader(reader=None, ppp_config_dir=None):
 
     for config_file in config_files:
         config_basename = os.path.basename(config_file)
+        reader_name = os.path.splitext(config_basename)[0]
         reader_configs = config_search_paths(
             os.path.join("readers", config_basename), *search_paths)
 
         if not reader_configs:
             # either the reader they asked for does not exist
             # or satpy is improperly configured and can't find its own readers
-            raise ValueError("No reader(s) named: {}".format(reader))
+            raise ValueError("No reader named: {}".format(reader_name))
 
         yield reader_configs
 

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -249,6 +249,15 @@ class TestReaderLoader(unittest.TestCase):
         ri = load_readers(filenames=filenames)
         self.assertListEqual(list(ri.keys()), ['viirs_sdr'])
 
+    def test_filenames_as_dict_bad_reader(self):
+        """Test loading with filenames dict but one of the readers is bad."""
+        from satpy.readers import load_readers
+        filenames = {
+            'viirs_sdr': ['SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'],
+            '__fake__': ['fake.txt'],
+        }
+        self.assertRaisesRegex(ValueError, r'(?=.*__fake__)(?!.*viirs)(^No reader.+)', load_readers, filenames=filenames)
+
     def test_filenames_as_dict_with_reader(self):
         """Test loading from a filenames dict with a single reader specified.
 

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -18,7 +18,6 @@
 """Test classes and functions in the readers/__init__.py module."""
 
 import os
-import sys
 import unittest
 from unittest import mock
 
@@ -256,7 +255,9 @@ class TestReaderLoader(unittest.TestCase):
             'viirs_sdr': ['SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'],
             '__fake__': ['fake.txt'],
         }
-        self.assertRaisesRegex(ValueError, r'(?=.*__fake__)(?!.*viirs)(^No reader.+)', load_readers, filenames=filenames)
+        self.assertRaisesRegex(ValueError,
+                               r'(?=.*__fake__)(?!.*viirs)(^No reader.+)',
+                               load_readers, filenames=filenames)
 
     def test_filenames_as_dict_with_reader(self):
         """Test loading from a filenames dict with a single reader specified.


### PR DESCRIPTION
When given multiple reader names, the Scene (and any reader config loading function) would say that all readers were unknown. This PR fixes this message to be more clear and state exactly what reader it had a problem with.

 - [x] Closes #1201 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

