### PR TITLE
Fix "rows_per_scan" not being available from VIIRS SDR readers

### DIFF
--- a/satpy/readers/viirs_compact.py
+++ b/satpy/readers/viirs_compact.py
@@ -155,6 +155,7 @@ class VIIRSCompactFileHandler(BaseFileHandler):
         else:
             m_data = self.read_geo(key, info)
         m_data.attrs.update(info)
+        m_data.attrs['rows_per_scan'] = self.scan_size
         return m_data
 
     def get_bounding_box(self):

--- a/satpy/readers/viirs_compact.py
+++ b/satpy/readers/viirs_compact.py
@@ -42,11 +42,6 @@ from satpy.readers.utils import np2str
 from satpy.utils import angle2xyz, lonlat2xyz, xyz2angle, xyz2lonlat
 from satpy import CHUNK_SIZE
 
-try:
-    import tables
-except ImportError:
-    tables = None
-
 chans_dict = {"M01": "M1",
               "M02": "M2",
               "M03": "M3",
@@ -146,6 +141,13 @@ class VIIRSCompactFileHandler(BaseFileHandler):
         short_name = np2str(self.h5f.attrs['Platform_Short_Name'])
         self.mda['platform_name'] = short_names.get(short_name, short_name)
         self.mda['sensor'] = 'viirs'
+
+    def __del__(self):
+        """Close file handlers when we are done."""
+        try:
+            self.h5f.close()
+        except OSError:
+            pass
 
     def get_dataset(self, key, info):
         """Load a dataset."""

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -293,13 +293,17 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
             expanded.rename({expanded.dims[0]: 'y'})
             return expanded
 
-    def concatenate_dataset(self, dataset_group, var_path):
-        """Concatenate dataset."""
-        if 'I' in dataset_group:
+    def _scan_size(self, dataset_group_name):
+        """Get how many rows of data constitute one scanline."""
+        if 'I' in dataset_group_name:
             scan_size = 32
         else:
             scan_size = 16
-        scans_path = 'All_Data/{dataset_group}_All/NumberOfScans'
+        return scan_size
+
+    def concatenate_dataset(self, dataset_group, var_path):
+        """Concatenate dataset."""
+        scan_size = self._scan_size(dataset_group)
         number_of_granules_path = 'Data_Products/{dataset_group}/{dataset_group}_Aggr/attr/AggregateNumberGranules'
         nb_granules_path = number_of_granules_path.format(dataset_group=DATASET_KEYS[dataset_group])
         scans = []
@@ -372,6 +376,7 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
             "sensor": self.sensor_name,
             "start_orbit": self.start_orbit_number,
             "end_orbit": self.end_orbit_number,
+            "rows_per_scan": self._scan_size(dataset_group),
         })
         i.update(dataset_id.to_dict())
         data.attrs.update(i)

--- a/satpy/tests/reader_tests/test_viirs_compact.py
+++ b/satpy/tests/reader_tests/test_viirs_compact.py
@@ -2447,12 +2447,14 @@ class TestCompact(unittest.TestCase):
         ds = test.get_dataset(dsid, {})
         self.assertEqual(ds.shape, (752, 4064))
         self.assertEqual(ds.dtype, np.float32)
+        self.assertEqual(ds.attrs['rows_per_scan'], 16)
 
-        dsid = DatasetID(name='longitude')
+        dsid = DatasetID(name='longitude_dnb')
         ds = test.get_dataset(dsid, {'standard_name': 'longitude'})
         self.assertEqual(ds.shape, (752, 4064))
         self.assertEqual(ds.dtype, np.float32)
         self.assertEqual(ds.compute().shape, (752, 4064))
+        self.assertEqual(ds.attrs['rows_per_scan'], 16)
 
     def tearDown(self):
         """Destroy."""

--- a/satpy/tests/reader_tests/test_viirs_l1b.py
+++ b/satpy/tests/reader_tests/test_viirs_l1b.py
@@ -178,6 +178,9 @@ class TestVIIRSL1BReader(unittest.TestCase):
         for v in datasets.values():
             self.assertEqual(v.attrs['calibration'], 'brightness_temperature')
             self.assertEqual(v.attrs['units'], 'K')
+            self.assertEqual(v.attrs['rows_per_scan'], 2)
+            self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 2)
+            self.assertEqual(v.attrs['area'].lats.attrs['rows_per_scan'], 2)
 
     def test_load_every_m_band_refl(self):
         """Test loading all M band reflectances"""
@@ -203,6 +206,9 @@ class TestVIIRSL1BReader(unittest.TestCase):
         for v in datasets.values():
             self.assertEqual(v.attrs['calibration'], 'reflectance')
             self.assertEqual(v.attrs['units'], '%')
+            self.assertEqual(v.attrs['rows_per_scan'], 2)
+            self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 2)
+            self.assertEqual(v.attrs['area'].lats.attrs['rows_per_scan'], 2)
 
     def test_load_every_m_band_rad(self):
         """Test loading all M bands as radiances"""
@@ -234,6 +240,9 @@ class TestVIIRSL1BReader(unittest.TestCase):
         for v in datasets.values():
             self.assertEqual(v.attrs['calibration'], 'radiance')
             self.assertEqual(v.attrs['units'], 'W m-2 um-1 sr-1')
+            self.assertEqual(v.attrs['rows_per_scan'], 2)
+            self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 2)
+            self.assertEqual(v.attrs['area'].lats.attrs['rows_per_scan'], 2)
 
     def test_load_dnb_radiance(self):
         """Test loading the main DNB dataset"""
@@ -249,3 +258,6 @@ class TestVIIRSL1BReader(unittest.TestCase):
         for v in datasets.values():
             self.assertEqual(v.attrs['calibration'], 'radiance')
             self.assertEqual(v.attrs['units'], 'W m-2 sr-1')
+            self.assertEqual(v.attrs['rows_per_scan'], 2)
+            self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 2)
+            self.assertEqual(v.attrs['area'].lats.attrs['rows_per_scan'], 2)

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -269,6 +269,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         for d in ds.values():
             self.assertEqual(d.attrs['calibration'], 'reflectance')
             self.assertEqual(d.attrs['units'], '%')
+            self.assertEqual(d.attrs['rows_per_scan'], 16)
             self.assertNotIn('area', d.attrs)
 
     def test_load_all_m_reflectances_find_geo(self):
@@ -313,6 +314,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         for d in ds.values():
             self.assertEqual(d.attrs['calibration'], 'reflectance')
             self.assertEqual(d.attrs['units'], '%')
+            self.assertEqual(d.attrs['rows_per_scan'], 16)
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])
 
@@ -351,10 +353,13 @@ class TestVIIRSSDRReader(unittest.TestCase):
         for d in ds.values():
             self.assertEqual(d.attrs['calibration'], 'reflectance')
             self.assertEqual(d.attrs['units'], '%')
+            self.assertEqual(d.attrs['rows_per_scan'], 16)
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])
             self.assertEqual(d.attrs['area'].lons.min(), 5)
             self.assertEqual(d.attrs['area'].lats.min(), 45)
+            self.assertEqual(d.attrs['area'].lons.attrs['rows_per_scan'], 16)
+            self.assertEqual(d.attrs['area'].lats.attrs['rows_per_scan'], 16)
 
     def test_load_all_m_reflectances_use_nontc(self):
         """Load all M band reflectances but use non-TC geolocation"""
@@ -392,13 +397,16 @@ class TestVIIRSSDRReader(unittest.TestCase):
         for d in ds.values():
             self.assertEqual(d.attrs['calibration'], 'reflectance')
             self.assertEqual(d.attrs['units'], '%')
+            self.assertEqual(d.attrs['rows_per_scan'], 16)
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])
             self.assertEqual(d.attrs['area'].lons.min(), 15)
             self.assertEqual(d.attrs['area'].lats.min(), 55)
+            self.assertEqual(d.attrs['area'].lons.attrs['rows_per_scan'], 16)
+            self.assertEqual(d.attrs['area'].lats.attrs['rows_per_scan'], 16)
 
     def test_load_all_m_reflectances_use_nontc2(self):
-        """Load all M band reflectances but use non-TC geolocation because TC isn't available"""
+        """Load all M band reflectances but use non-TC geolocation because TC isn't available."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs, use_tc=None)
         loadables = r.select_files_from_pathnames([
@@ -432,10 +440,13 @@ class TestVIIRSSDRReader(unittest.TestCase):
         for d in ds.values():
             self.assertEqual(d.attrs['calibration'], 'reflectance')
             self.assertEqual(d.attrs['units'], '%')
+            self.assertEqual(d.attrs['rows_per_scan'], 16)
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])
             self.assertEqual(d.attrs['area'].lons.min(), 15)
             self.assertEqual(d.attrs['area'].lats.min(), 55)
+            self.assertEqual(d.attrs['area'].lons.attrs['rows_per_scan'], 16)
+            self.assertEqual(d.attrs['area'].lats.attrs['rows_per_scan'], 16)
 
     def test_load_all_m_bts(self):
         """Load all M band brightness temperatures"""
@@ -460,6 +471,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         for d in ds.values():
             self.assertEqual(d.attrs['calibration'], 'brightness_temperature')
             self.assertEqual(d.attrs['units'], 'K')
+            self.assertEqual(d.attrs['rows_per_scan'], 16)
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])
 
@@ -510,6 +522,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         for d in ds.values():
             self.assertEqual(d.attrs['calibration'], 'radiance')
             self.assertEqual(d.attrs['units'], 'W m-2 um-1 sr-1')
+            self.assertEqual(d.attrs['rows_per_scan'], 16)
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])
 
@@ -527,6 +540,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         for d in ds.values():
             self.assertEqual(d.attrs['calibration'], 'radiance')
             self.assertEqual(d.attrs['units'], 'W m-2 sr-1')
+            self.assertEqual(d.attrs['rows_per_scan'], 16)
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])
 
@@ -542,6 +556,83 @@ class TestVIIRSSDRReader(unittest.TestCase):
         self.assertNotIn('I01', [x.name for x in r.available_dataset_ids])
         ds = r.load(['I01'])
         self.assertEqual(len(ds), 0)
+
+    def test_load_all_i_reflectances_provided_geo(self):
+        """Load all I band reflectances with geo files provided"""
+        from satpy.readers import load_reader
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
+            'SVI02_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
+            'SVI03_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
+            'GITCO_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
+        ])
+        r.create_filehandlers(loadables)
+        ds = r.load(['I01',
+                     'I02',
+                     'I03',
+                     ])
+        self.assertEqual(len(ds), 3)
+        for d in ds.values():
+            self.assertEqual(d.attrs['calibration'], 'reflectance')
+            self.assertEqual(d.attrs['units'], '%')
+            self.assertEqual(d.attrs['rows_per_scan'], 32)
+            self.assertIn('area', d.attrs)
+            self.assertIsNotNone(d.attrs['area'])
+            self.assertEqual(d.attrs['area'].lons.min(), 5)
+            self.assertEqual(d.attrs['area'].lats.min(), 45)
+            self.assertEqual(d.attrs['area'].lons.attrs['rows_per_scan'], 32)
+            self.assertEqual(d.attrs['area'].lats.attrs['rows_per_scan'], 32)
+
+    def test_load_all_i_bts(self):
+        """Load all I band brightness temperatures"""
+        from satpy.readers import load_reader
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'SVI04_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
+            'SVI05_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
+            'GITCO_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
+        ])
+        r.create_filehandlers(loadables)
+        ds = r.load(['I04',
+                     'I05',
+                     ])
+        self.assertEqual(len(ds), 2)
+        for d in ds.values():
+            self.assertEqual(d.attrs['calibration'], 'brightness_temperature')
+            self.assertEqual(d.attrs['units'], 'K')
+            self.assertEqual(d.attrs['rows_per_scan'], 32)
+            self.assertIn('area', d.attrs)
+            self.assertIsNotNone(d.attrs['area'])
+
+    def test_load_all_i_radiances(self):
+        """Load all I band radiances"""
+        from satpy.readers import load_reader
+        from satpy import DatasetID
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
+            'SVI02_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
+            'SVI03_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
+            'SVI04_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
+            'SVI05_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
+            'GITCO_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
+        ])
+        r.create_filehandlers(loadables)
+        ds = r.load([
+            DatasetID(name='I01', calibration='radiance', modifiers=None),
+            DatasetID(name='I02', calibration='radiance', modifiers=None),
+            DatasetID(name='I03', calibration='radiance', modifiers=None),
+            DatasetID(name='I04', calibration='radiance', modifiers=None),
+            DatasetID(name='I05', calibration='radiance', modifiers=None),
+        ])
+        self.assertEqual(len(ds), 5)
+        for d in ds.values():
+            self.assertEqual(d.attrs['calibration'], 'radiance')
+            self.assertEqual(d.attrs['units'], 'W m-2 um-1 sr-1')
+            self.assertEqual(d.attrs['rows_per_scan'], 32)
+            self.assertIn('area', d.attrs)
+            self.assertIsNotNone(d.attrs['area'])
 
 
 class FakeHDF5FileHandlerAggr(FakeHDF5FileHandler):
@@ -719,8 +810,8 @@ class TestAggrVIIRSSDRReader(unittest.TestCase):
         """Stop wrapping the HDF5 file handler"""
         self.p.stop()
 
-    def test_bouding_box(self):
-        """Test bouding box."""
+    def test_bounding_box(self):
+        """Test bounding box."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -64,15 +64,16 @@ DATASET_KEYS = {'GDNBO': 'VIIRS-DNB-GEO',
 
 
 class FakeHDF5FileHandler2(FakeHDF5FileHandler):
-    """Swap-in HDF5 File Handler"""
+    """Swap-in HDF5 File Handler."""
 
     def __init__(self, filename, filename_info, filetype_info, use_tc=None):
+        """Create fake file handler."""
         super(FakeHDF5FileHandler2, self).__init__(filename, filename_info, filetype_info)
         self.datasets = filename_info['datasets'].split('-')
         self.use_tc = use_tc
 
     def get_test_content(self, filename, filename_info, filetype_info):
-        """Mimic reader input file content"""
+        """Mimic reader input file content."""
         start_time = filename_info['start_time']
         end_time = filename_info['end_time'].replace(year=start_time.year,
                                                      month=start_time.month,
@@ -163,11 +164,12 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
 
 
 class TestVIIRSSDRReader(unittest.TestCase):
-    """Test VIIRS SDR Reader"""
+    """Test VIIRS SDR Reader."""
+
     yaml_file = "viirs_sdr.yaml"
 
     def setUp(self):
-        """Wrap HDF5 file handler with our own fake handler"""
+        """Wrap HDF5 file handler with our own fake handler."""
         from satpy.config import config_search_paths
         from satpy.readers.viirs_sdr import VIIRSSDRFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
@@ -177,7 +179,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         self.p.is_local = True
 
     def tearDown(self):
-        """Stop wrapping the HDF5 file handler"""
+        """Stop wrapping the HDF5 file handler."""
         self.p.stop()
 
     def test_init(self):
@@ -236,7 +238,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         self.assertTrue(r.file_handlers)
 
     def test_load_all_m_reflectances_no_geo(self):
-        """Load all M band reflectances with no geo files provided"""
+        """Load all M band reflectances with no geo files provided."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -273,7 +275,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
             self.assertNotIn('area', d.attrs)
 
     def test_load_all_m_reflectances_find_geo(self):
-        """Load all M band reflectances with geo files not specified but existing"""
+        """Load all M band reflectances with geo files not specified but existing."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -319,7 +321,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
             self.assertIsNotNone(d.attrs['area'])
 
     def test_load_all_m_reflectances_provided_geo(self):
-        """Load all M band reflectances with geo files provided"""
+        """Load all M band reflectances with geo files provided."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -362,7 +364,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
             self.assertEqual(d.attrs['area'].lats.attrs['rows_per_scan'], 16)
 
     def test_load_all_m_reflectances_use_nontc(self):
-        """Load all M band reflectances but use non-TC geolocation"""
+        """Load all M band reflectances but use non-TC geolocation."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs, use_tc=False)
         loadables = r.select_files_from_pathnames([
@@ -449,7 +451,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
             self.assertEqual(d.attrs['area'].lats.attrs['rows_per_scan'], 16)
 
     def test_load_all_m_bts(self):
-        """Load all M band brightness temperatures"""
+        """Load all M band brightness temperatures."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -476,7 +478,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
             self.assertIsNotNone(d.attrs['area'])
 
     def test_load_all_m_radiances(self):
-        """Load all M band radiances"""
+        """Load all M band radiances."""
         from satpy.readers import load_reader
         from satpy import DatasetID
         r = load_reader(self.reader_configs)
@@ -527,7 +529,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
             self.assertIsNotNone(d.attrs['area'])
 
     def test_load_dnb(self):
-        """Load DNB dataset"""
+        """Load DNB dataset."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -545,7 +547,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
             self.assertIsNotNone(d.attrs['area'])
 
     def test_load_i_no_files(self):
-        """Load I01 when only DNB files are provided"""
+        """Load I01 when only DNB files are provided."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -558,7 +560,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         self.assertEqual(len(ds), 0)
 
     def test_load_all_i_reflectances_provided_geo(self):
-        """Load all I band reflectances with geo files provided"""
+        """Load all I band reflectances with geo files provided."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -585,7 +587,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
             self.assertEqual(d.attrs['area'].lats.attrs['rows_per_scan'], 32)
 
     def test_load_all_i_bts(self):
-        """Load all I band brightness temperatures"""
+        """Load all I band brightness temperatures."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -606,7 +608,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
             self.assertIsNotNone(d.attrs['area'])
 
     def test_load_all_i_radiances(self):
-        """Load all I band radiances"""
+        """Load all I band radiances."""
         from satpy.readers import load_reader
         from satpy import DatasetID
         r = load_reader(self.reader_configs)
@@ -636,15 +638,16 @@ class TestVIIRSSDRReader(unittest.TestCase):
 
 
 class FakeHDF5FileHandlerAggr(FakeHDF5FileHandler):
-    """Swap-in HDF5 File Handler"""
+    """Swap-in HDF5 File Handler."""
 
     def __init__(self, filename, filename_info, filetype_info, use_tc=None):
+        """Create fake aggregated file handler."""
         super(FakeHDF5FileHandlerAggr, self).__init__(filename, filename_info, filetype_info)
         self.datasets = filename_info['datasets'].split('-')
         self.use_tc = use_tc
 
     def get_test_content(self, filename, filename_info, filetype_info):
-        """Mimic reader input file content"""
+        """Mimic reader input file content."""
         start_time = filename_info['start_time']
         end_time = filename_info['end_time'].replace(year=start_time.year,
                                                      month=start_time.month,
@@ -793,11 +796,12 @@ class FakeHDF5FileHandlerAggr(FakeHDF5FileHandler):
 
 
 class TestAggrVIIRSSDRReader(unittest.TestCase):
-    """Test VIIRS SDR Reader"""
+    """Test VIIRS SDR Reader."""
+
     yaml_file = "viirs_sdr.yaml"
 
     def setUp(self):
-        """Wrap HDF5 file handler with our own fake handler"""
+        """Wrap HDF5 file handler with our own fake handler."""
         from satpy.config import config_search_paths
         from satpy.readers.viirs_sdr import VIIRSSDRFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
@@ -807,7 +811,7 @@ class TestAggrVIIRSSDRReader(unittest.TestCase):
         self.p.is_local = True
 
     def tearDown(self):
-        """Stop wrapping the HDF5 file handler"""
+        """Stop wrapping the HDF5 file handler."""
         self.p.stop()
 
     def test_bounding_box(self):


### PR DESCRIPTION
The "rows_per_scan" piece of metadata used to be in this reader (I'm 90% sure), but somewhere along the line it disappeared. This PR adds it back in. It's also possible it is in viirs_l1b and maybe the compact reader but never got added to this reader. Anyway...should be fixed now with tests to check for it.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

I checked the flake8 line because I didn't get a warning from pre-commit, but I'm also pretty sure some of the docstrings are wrong. Maybe it isn't checking the full file anymore?