### PR TITLE
GRIB: Add file pattern for NWCSAF input file names

### DIFF
--- a/satpy/etc/readers/grib.yaml
+++ b/satpy/etc/readers/grib.yaml
@@ -17,6 +17,9 @@ file_types:
      # S-OSI_-NOR_-MULT-AHLDLI_FIELD-201805011200Z.grb.gz
      - '{stem}.grb'
      - '{stem}.grb2'
+     # NWCSAF input file name format:
+     # S_NWC_NWP_2017-03-14T00:00:00Z_002.grib
+     - 'S_NWC_NWP_{start_time:%Y-%m-%dT%H:%M:%S}Z_{forecast_time:3d}.grib'
 #  grib_ncep:
 #    file_reader: !!python/name:satpy.readers.grib.GRIBFileHandler
 #    file_patterns:

--- a/satpy/tests/reader_tests/test_grib.py
+++ b/satpy/tests/reader_tests/test_grib.py
@@ -178,6 +178,21 @@ class TestGRIBReader(unittest.TestCase):
         # make sure we have some files
         self.assertTrue(r.file_handlers)
 
+    def test_file_pattern(self):
+        """Test matching of file patterns."""
+        from satpy.readers import load_reader
+
+        filenames = [
+                "quinoia.grb",
+                "tempeh.grb2",
+                "tofu.grib2",
+                "falafel.grib",
+                "S_NWC_NWP_1900-01-01T00:00:00Z_999.grib"]
+
+        r = load_reader(self.reader_configs)
+        files = r.select_files_from_pathnames(filenames)
+        self.assertEqual(len(files), 4)
+
     @mock.patch('satpy.readers.grib.pygrib')
     def test_load_all(self, pg):
         """Test loading all test datasets"""

--- a/satpy/tests/reader_tests/test_grib.py
+++ b/satpy/tests/reader_tests/test_grib.py
@@ -183,7 +183,7 @@ class TestGRIBReader(unittest.TestCase):
         from satpy.readers import load_reader
 
         filenames = [
-                "quinoia.grb",
+                "quinoa.grb",
                 "tempeh.grb2",
                 "tofu.grib2",
                 "falafel.grib",


### PR DESCRIPTION
For the GRIB reader, add the file pattern corresponding to the NWCSAF
input file type, which ends in ``.grib``.  So far ``.grib2``, ``.grb``,
and ``.grb2`` are recognised, but not ``.grib``.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1212 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
