### PR TITLE
Remove invalid valid_range metadata from abi readers

### DIFF
--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -78,6 +78,8 @@ class NC_ABI_L1B(NC_ABI_BASE):
         res.attrs.pop('add_offset', None)
         res.attrs.pop('_Unsigned', None)
         res.attrs.pop('ancillary_variables', None)  # Can't currently load DQF
+        # although we could compute these, we'd have to update in calibration
+        res.attrs.pop('valid_range', None)
         # add in information from the filename that may be useful to the user
         for attr in ('observation_type', 'scene_abbr', 'scan_mode', 'platform_shortname'):
             res.attrs[attr] = self.filename_info[attr]

--- a/satpy/readers/abi_l2_nc.py
+++ b/satpy/readers/abi_l2_nc.py
@@ -58,6 +58,7 @@ class NC_ABI_L2(NC_ABI_BASE):
         variable.attrs.pop('add_offset', None)
         variable.attrs.pop('valid_range', None)
         variable.attrs.pop('_Unsigned', None)
+        variable.attrs.pop('valid_range', None)
         variable.attrs.pop('ancillary_variables', None)  # Can't currently load DQF
 
         if 'flag_meanings' in variable.attrs:

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -45,7 +45,8 @@ class Test_NC_ABI_L1B_Base(unittest.TestCase):
                     'scale_factor': 0.5,
                     'add_offset': -1.,
                     '_FillValue': 1002,
-                    'units': 'W m-2 um-1 sr-1'
+                    'units': 'W m-2 um-1 sr-1',
+                    'valid_range': (0, 4095),
                 }
             )
         rad.coords['t'] = time


### PR DESCRIPTION
Noticed that the ABI readers were including the original file 16-bit integer `valid_range` metadata. Once things are loaded/scaled/calibrated, these values are no longer valid. It is easiest and most "valid" to just remove them. That's what I've done here.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
