### PR TITLE
Add FCI Natural Color example page to sphinx docs

### DIFF
--- a/doc/source/examples/fci_l1c_natural_color.rst
+++ b/doc/source/examples/fci_l1c_natural_color.rst
@@ -1,0 +1,41 @@
+MTG FCI - Natural Color Example
+===============================
+
+Satpy includes a reader for the Meteosat Third Generation (MTG) FCI Level 1c
+data. The following Python code snippet shows an example on how to use Satpy
+to generate a Natural Color RGB composite over the European area.
+
+.. warning::
+
+    This example is currently a work in progress. Some of the below code may
+    not work with the currently released version of Satpy. Additional updates
+    to this example will be coming soon.
+
+.. code-block:: python
+
+    from satpy.scene import Scene
+    from satpy import find_files_and_readers
+
+    # define path to FCI test data folder
+    path_to_data = 'your/path/to/FCI/data/folder/'
+
+    # find files and assign the FCI reader
+    files = find_files_and_readers(base_dir=path_to_data, reader='fci_l1c_fdhsi')
+
+    # create an FCI scene from the selected files
+    scn = Scene(filenames=files)
+
+    # print available dataset names for this scene (e.g. 'vis_04', 'vis_05','ir_38',...)
+    print(scn.available_dataset_names())
+
+    # print available composite names for this scene (e.g. 'natural_color', 'airmass', 'convection',...)
+    print(scn.available_composite_names())
+
+    # load the datasets/composites of interest
+    scn.load(['natural_color','vis_04'])
+
+    # resample the scene to a specified area (e.g. "eurol1" for Europe in 1km resolution)
+    scn_resampled = scn.resample("eurol", resampler='nearest', radius_of_influence=5000)
+
+    # save the resampled dataset/composite to disk
+    scn_resampled.save_dataset("natural_color", filename='./fci_natural_color_resampled.png')

--- a/doc/source/examples/index.rst
+++ b/doc/source/examples/index.rst
@@ -3,10 +3,17 @@ Examples
 
 Satpy examples are available as Jupyter Notebooks on the
 `pytroll-examples <https://github.com/pytroll/pytroll-examples/tree/master/satpy>`_
-git repository. They include python code, PNG images, and descriptions of
+git repository. Some examples are described in further detail as separate pages
+in this documentation. They include python code, PNG images, and descriptions of
 what the example is doing. Below is a list of some of the examples and a brief
-summary. Additional example can be found at the repository mentioned above or
+summary. Additional examples can be found at the repository mentioned above or
 as explanations in the various sections of this documentation.
+
+.. toctree::
+    :hidden:
+    :maxdepth: 1
+
+    fci_l1c_natural_color
 
 .. list-table::
     :header-rows: 1
@@ -33,3 +40,5 @@ as explanations in the various sections of this documentation.
       - Reading Level 2 EARS-NWC cloud products
     * - `Level 2 MAIA cloud products <https://github.com/pytroll/pytroll-examples/blob/master/satpy/polar_maia.ipynb>`_
       - Reading Level 2 MAIA cloud products
+    * - :doc:`Meteosat Third Generation FCI Natural Color RGB <fci_l1c_natural_color>`
+      - Generate Natural Color RGB from Meteosat Third Generation (MTG) FCI Level 1c data

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -52,7 +52,7 @@ the base Satpy installation.
     overview
     install
     data_download
-    examples
+    examples/index
     quickstart
     readers
     composites


### PR DESCRIPTION
Add placeholder page for an MTG FCI Natural Color RGB example. This is different from the usual examples we have since this is a sphinx page instead of a jupyter notebook. I think it would be good to include a link to a notebook in pytroll-examples so that people can easily run things interactively. It is very likely that we could use a sphinx plugin to accomplish this, but given the tight time frame this is probably good enough.

I will also add a redirect since I've ended up moving the main examples page:

https://docs.readthedocs.io/en/stable/user-defined-redirects.html#page-redirects

