### PR TITLE
Delete kdtree after saving cache

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -589,6 +589,8 @@ class KDTreeResampler(BaseResampler):
             zarr_out.to_zarr(filename)
 
             self._index_caches[mask_name] = cache
+            # Delete the kdtree, it's not needed anymore
+            self.resampler.delayed_kdtree = None
 
     def _read_resampler_attrs(self):
         """Read certain attributes from the resampler for caching."""

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -136,7 +136,7 @@ class TestKDTreeResampler(unittest.TestCase):
     @mock.patch('satpy.resample.zarr.open')
     @mock.patch('satpy.resample.KDTreeResampler._create_cache_filename')
     @mock.patch('pyresample.kd_tree.XArrayResamplerNN')
-    def test_kd_resampling(self, resampler, create_filename, zarr_open,
+    def test_kd_resampling(self, xr_resampler, create_filename, zarr_open,
                            xr_dset, cnc):
         """Test the kd resampler."""
         import numpy as np
@@ -148,6 +148,7 @@ class TestKDTreeResampler(unittest.TestCase):
         resampler = KDTreeResampler(source_swath, target_area)
         resampler.precompute(
             mask=da.arange(5, chunks=5).astype(np.bool), cache_dir='.')
+        xr_resampler.assert_called_once()
         resampler.resampler.get_neighbour_info.assert_called()
         # swath definitions should not be cached
         self.assertFalse(len(mock_dset.to_zarr.mock_calls), 0)
@@ -173,6 +174,8 @@ class TestKDTreeResampler(unittest.TestCase):
             nbcalls = len(resampler.resampler.get_neighbour_info.mock_calls)
             # test reusing the resampler
             zarr_open.side_effect = None
+            # The kdtree shouldn't be available after saving cache to disk
+            assert resampler.resampler.delayed_kdtree is None
 
             class FakeZarr(dict):
 


### PR DESCRIPTION
This simple change (delete the kdtree after saving the cache) makes it possible to use `dask.distributed` with `nearest` resampling. The only requirement is that `cache_dir` needs to be used, so this will not be very useful for other than geostationary satellites.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
