### PR TITLE
Correct FCI area definitions in areas.yaml

### DIFF
--- a/satpy/etc/areas.yaml
+++ b/satpy/etc/areas.yaml
@@ -126,18 +126,6 @@ SouthAmerica_flat:
     lower_left_xy: [-8326322.82790897, -4609377.085697311]
     upper_right_xy: [-556597.4539663679, 1535833.8895192828]
     units: m
-worldeqc30km:
-  description: World in 3km, platecarree
-  projection:
-    proj: eqc
-    ellps: WGS84
-  shape:
-    height: 410
-    width: 820
-  area_extent:
-    lower_left_xy: [-20037508.3428, -10018754.1714]
-    upper_right_xy: [20037508.3428, 10018754.1714]
-    units: m
 south_america:
   description: south_america, platecarree
   projection:
@@ -459,12 +447,8 @@ fci_0deg_1km:
     height: 11136
     width: 11136
   area_extent:
-    lower_left_xy:
-    - -5567999.998527619
-    - -5568999.998577043
-    upper_right_xy:
-    - 5567999.998577303
-    - 5566999.998527878
+    lower_left_xy: [-5567999.998527619, -5567999.998577303]
+    upper_right_xy: [5567999.998577303,  5567999.998527619]
     units: m
 fci_0deg_2km:
   description: Full disk FCI view, 2 km (based on pre-launch test data)
@@ -480,12 +464,8 @@ fci_0deg_2km:
     height: 5568
     width: 5568
   area_extent:
-    lower_left_xy:
-    - -5567999.994206558
-    - -5569999.994198508
-    upper_right_xy:
-    - 5567999.994200588
-    - 5565999.9942086395
+    lower_left_xy: [-5567999.994206558, -5567999.994200589]
+    upper_right_xy: [5567999.994200589,  5567999.994206558]
     units: m
 spain:
   description: Spain


### PR DESCRIPTION
This PR corrects the new area definitions for the FCI full disk added to areas.yaml by #1188 .

On the side, it also removes the duplicated `worldeqc30km` areadef. 

 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->