### PR TITLE
FCI: fix areadef when only pixel quality asked

### DIFF
--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -244,12 +244,19 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
 
     def calc_area_extent(self, key):
         """Calculate area extent for a dataset."""
+        # if a user requests a pixel quality before the channel data, the
+        # yaml-reader will ask the area extent of the pixel quality field,
+        # which will ultimately end up here
+        if key.name.endswith("_pixel_quality"):
+            lab = key.name[:-len("_pixel_quality")]
+        else:
+            lab = key.name
         # Get metadata for given dataset
-        measured = self.get_channel_measured_group_path(key.name)
+        measured = self.get_channel_measured_group_path(lab)
         # Get start/end line and column of loaded swath.
         nlines, ncols = self[measured + "/effective_radiance/shape"]
 
-        logger.debug('Channel {} resolution: {}'.format(key.name, ncols))
+        logger.debug('Channel {} resolution: {}'.format(lab, ncols))
         logger.debug('Row/Cols: {} / {}'.format(nlines, ncols))
 
         # Calculate full globe line extent
@@ -257,7 +264,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
 
         ext = {}
         for c in "xy":
-            c_radian = self["data/{:s}/measured/{:s}".format(key.name, c)]
+            c_radian = self["data/{:s}/measured/{:s}".format(lab, c)]
             c_radian_num = c_radian[:] * c_radian.scale_factor + c_radian.add_offset
 
             # FCI defines pixels by centroids (Example Products for Pytroll

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -423,6 +423,22 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
         assert len(comps["fci"]) > 0
         assert len(mods["fci"]) > 0
 
+    def test_load_quality_only(self, reader_configs):
+        """Test that loading quality only works."""
+        from satpy.readers import load_reader
+
+        filenames = [
+            "W_XX-EUMETSAT-Darmstadt,IMG+SAT,MTI1+FCI-1C-RRAD-FDHSI-FD--"
+            "CHK-BODY--L2P-NC4E_C_EUMT_20170410114434_GTT_DEV_"
+            "20170410113925_20170410113934_N__C_0070_0067.nc",
+        ]
+
+        reader = load_reader(reader_configs)
+        loadables = reader.select_files_from_pathnames(filenames)
+        reader.create_filehandlers(loadables)
+        res = reader.load(["ir_123_pixel_quality"])
+        assert res["ir_123_pixel_quality"].attrs["name"] == "ir_123_pixel_quality"
+
     def test_platform_name(self, reader_configs):
         """Test that platform name is exposed.
 


### PR DESCRIPTION
When reading only pixel quality fields from FCI, make sure it can still
correctly calculate the area definition.  Closes #1229.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1229<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
