### PR TITLE
Add link to documentation and a new file pattern for test data.

### DIFF
--- a/satpy/etc/readers/vii_l1b_nc.yaml
+++ b/satpy/etc/readers/vii_l1b_nc.yaml
@@ -11,7 +11,8 @@ file_types:
   # EUMETSAT EPSG-SG Visual Infrared Imager Level 1B Radiance files in NetCDF4 format
   nc_vii_l1b_rad:
     file_reader: !!python/name:satpy.readers.vii_l1b_nc.ViiL1bNCFileHandler
-    file_patterns: ['W_xx-eumetsat-darmstadt,SAT,{spacecraft_name:s}-VII-1B-RAD_C_EUM_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
+    file_patterns: ['W_xx-eumetsat-darmstadt,SAT,{spacecraft_name:s}-VII-1B-RAD_C_EUM_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc',
+    'W_xx-eumetsat-darmstadt,SAT,{spacecraft_name:s}-VII-1B-RAD_C_EUMT_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
     cached_longitude: data/measurement_data/longitude
     cached_latitude: data/measurement_data/latitude
 

--- a/satpy/readers/vii_base_nc.py
+++ b/satpy/readers/vii_base_nc.py
@@ -206,12 +206,20 @@ class ViiNCBaseFileHandler(NetCDF4FileHandler):
     @property
     def start_time(self):
         """Get observation start time."""
-        return datetime.strptime(self['/attr/sensing_start_time_utc'], '%Y%m%d%H%M%S.%f')
+        try:
+            start_time = datetime.strptime(self['/attr/sensing_start_time_utc'], '%Y%m%d%H%M%S.%f')
+        except ValueError:
+            start_time = datetime.strptime(self['/attr/sensing_start_time_utc'], '%Y-%m-%d %H:%M:%S.%f')
+        return start_time
 
     @property
     def end_time(self):
         """Get observation end time."""
-        return datetime.strptime(self['/attr/sensing_end_time_utc'], '%Y%m%d%H%M%S.%f')
+        try:
+            end_time = datetime.strptime(self['/attr/sensing_end_time_utc'], '%Y%m%d%H%M%S.%f')
+        except ValueError:
+            end_time = datetime.strptime(self['/attr/sensing_end_time_utc'], '%Y-%m-%d %H:%M:%S.%f')
+        return end_time
 
     @property
     def spacecraft_name(self):

--- a/satpy/readers/vii_l1b_nc.py
+++ b/satpy/readers/vii_l1b_nc.py
@@ -15,8 +15,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""EUMETSAT EPS-SG Visible/Infrared Imager (VII) Level 1B products reader.
 
-"""EUMETSAT EPS-SG Visible/Infrared Imager (VII) Level 1B products reader."""
+The ``vii_l1b_nc`` reader reads and calibrates EPS-SG VII L1b image data in netCDF format. The format is explained
+in the `EPS-SG VII Level 1B Product Format Specification`_.
+References:
+.. _EPS-SG VII Level 1B Product Format Specification: https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService
+   =GET_FILE&dDocName=PDF_EPSSG_VII_L1B_PFS&RevisionSelectionMethod=LatestReleased&Rendition=Web
+
+"""
 
 import logging
 import numpy as np


### PR DESCRIPTION
This PR adds the documentation link to the EPS-SG L1B product format specification. Also, a new file pattern is added so that the reader can read both the internal test data at EUM, but also the test data released to the users. These formats use a different string format for `sensing_start_time_utc` and `sensing_end_time_utc`. Reader adopted accordingly. 

 - [x] Closes #1232 
 - [x] Tests passed
 - [x] Passes ``flake8 satpy``
 - [x] Fully documented

