### PR TITLE
Bugfix (FY4A AGRI): Correct the type of orbital_parameters to float

### DIFF
--- a/satpy/readers/agri_l1.py
+++ b/satpy/readers/agri_l1.py
@@ -105,9 +105,9 @@ class HDF_AGRI_L1(HDF5FileHandler):
         data.attrs.update({'platform_name': satname,
                            'sensor': self['/attr/Sensor Identification Code'].lower(),
                            'orbital_parameters': {
-                               'satellite_nominal_latitude': self['/attr/NOMCenterLat'],
-                               'satellite_nominal_longitude': self['/attr/NOMCenterLon'],
-                               'satellite_nominal_altitude': self['/attr/NOMSatHeight']}})
+                               'satellite_nominal_latitude': float(self['/attr/NOMCenterLat']),
+                               'satellite_nominal_longitude': float(self['/attr/NOMCenterLon']),
+                               'satellite_nominal_altitude': float(self['/attr/NOMSatHeight'])}})
         data.attrs.update(ds_info)
 
         # remove attributes that could be confusing later

--- a/satpy/readers/agri_l1.py
+++ b/satpy/readers/agri_l1.py
@@ -105,9 +105,9 @@ class HDF_AGRI_L1(HDF5FileHandler):
         data.attrs.update({'platform_name': satname,
                            'sensor': self['/attr/Sensor Identification Code'].lower(),
                            'orbital_parameters': {
-                               'satellite_nominal_latitude': float(self['/attr/NOMCenterLat']),
-                               'satellite_nominal_longitude': float(self['/attr/NOMCenterLon']),
-                               'satellite_nominal_altitude': float(self['/attr/NOMSatHeight'])}})
+                               'satellite_nominal_latitude': self['/attr/NOMCenterLat'].item(),
+                               'satellite_nominal_longitude': self['/attr/NOMCenterLon'].item(),
+                               'satellite_nominal_altitude': self['/attr/NOMSatHeight'].item()}})
         data.attrs.update(ds_info)
 
         # remove attributes that could be confusing later

--- a/satpy/tests/reader_tests/test_agri_l1.py
+++ b/satpy/tests/reader_tests/test_agri_l1.py
@@ -292,7 +292,7 @@ class Test_HDF_AGRI_L1_cal(unittest.TestCase):
             else:
                 self.assertEqual('K', res[band_name].attrs['units'])
 
-        # check the data type of orbital_parameters
+        # check whether the data type of orbital_parameters is float
         orbital_parameters = res[band_names[0]].attrs['orbital_parameters']
         for attr in orbital_parameters:
             self.assertEqual(type(orbital_parameters[attr]), float)

--- a/satpy/tests/reader_tests/test_agri_l1.py
+++ b/satpy/tests/reader_tests/test_agri_l1.py
@@ -184,10 +184,16 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
     def get_test_content(self, filename, filename_info, filetype_info):
         """Mimic reader input file content."""
         global_attrs = {
-            '/attr/NOMCenterLat': 0.0, '/attr/NOMCenterLon': 104.7, '/attr/NOMSatHeight': 3.5786E7,
-            '/attr/dEA': 6378.14, '/attr/dObRecFlat': 298.257223563,
-            '/attr/OBIType': 'REGC', '/attr/RegLength': 2.0, '/attr/RegWidth': 5.0,
-            '/attr/Begin Line Number': 0, '/attr/End Line Number': 1,
+            '/attr/NOMCenterLat': np.array([0.0]),
+            '/attr/NOMCenterLon': np.array([104.7]),
+            '/attr/NOMSatHeight': np.array([3.5786E7]),
+            '/attr/dEA': np.array([6378.14]),
+            '/attr/dObRecFlat': np.array([298.257223563]),
+            '/attr/OBIType': 'REGC',
+            '/attr/RegLength': np.array([2.0]),
+            '/attr/RegWidth': np.array([5.0]),
+            '/attr/Begin Line Number': np.array([0]),
+            '/attr/End Line Number': np.array([1]),
             '/attr/Observing Beginning Date': '2019-06-03', '/attr/Observing Beginning Time': '00:30:01.807',
             '/attr/Observing Ending Date': '2019-06-03', '/attr/Observing Ending Time': '00:34:07.572',
             '/attr/Satellite Name': 'FY4A', '/attr/Sensor Identification Code': 'AGRI', '/attr/Sensor Name': 'AGRI',
@@ -285,6 +291,11 @@ class Test_HDF_AGRI_L1_cal(unittest.TestCase):
                 self.assertEqual('%', res[band_name].attrs['units'])
             else:
                 self.assertEqual('K', res[band_name].attrs['units'])
+
+        # check the data type of orbital_parameters
+        orbital_parameters = res[band_names[0]].attrs['orbital_parameters']
+        for attr in orbital_parameters:
+            self.assertEqual(orbital_parameters[attr].dtype, np.float64)
 
     def test_fy4a_counts_calib(self):
         """Test loading data at counts calibration."""

--- a/satpy/tests/reader_tests/test_agri_l1.py
+++ b/satpy/tests/reader_tests/test_agri_l1.py
@@ -294,8 +294,9 @@ class Test_HDF_AGRI_L1_cal(unittest.TestCase):
 
         # check whether the data type of orbital_parameters is float
         orbital_parameters = res[band_names[0]].attrs['orbital_parameters']
-        for attr in orbital_parameters:
-            self.assertEqual(type(orbital_parameters[attr]), float)
+        self.assertEqual(orbital_parameters['satellite_nominal_latitude'], 0.)
+        self.assertEqual(orbital_parameters['satellite_nominal_longitude'], 104.7)
+        self.assertEqual(orbital_parameters['satellite_nominal_altitude'], 3.5786E7)
 
     def test_fy4a_counts_calib(self):
         """Test loading data at counts calibration."""

--- a/satpy/tests/reader_tests/test_agri_l1.py
+++ b/satpy/tests/reader_tests/test_agri_l1.py
@@ -295,7 +295,7 @@ class Test_HDF_AGRI_L1_cal(unittest.TestCase):
         # check the data type of orbital_parameters
         orbital_parameters = res[band_names[0]].attrs['orbital_parameters']
         for attr in orbital_parameters:
-            self.assertEqual(orbital_parameters[attr].dtype, np.float64)
+            self.assertEqual(type(orbital_parameters[attr]), float)
 
     def test_fy4a_counts_calib(self):
         """Test loading data at counts calibration."""

--- a/satpy/tests/reader_tests/test_agri_l1.py
+++ b/satpy/tests/reader_tests/test_agri_l1.py
@@ -184,16 +184,16 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
     def get_test_content(self, filename, filename_info, filetype_info):
         """Mimic reader input file content."""
         global_attrs = {
-            '/attr/NOMCenterLat': np.array([0.0]),
-            '/attr/NOMCenterLon': np.array([104.7]),
-            '/attr/NOMSatHeight': np.array([3.5786E7]),
-            '/attr/dEA': np.array([6378.14]),
-            '/attr/dObRecFlat': np.array([298.257223563]),
+            '/attr/NOMCenterLat': np.array(0.0),
+            '/attr/NOMCenterLon': np.array(104.7),
+            '/attr/NOMSatHeight': np.array(3.5786E7),
+            '/attr/dEA': np.array(6378.14),
+            '/attr/dObRecFlat': np.array(298.257223563),
             '/attr/OBIType': 'REGC',
-            '/attr/RegLength': np.array([2.0]),
-            '/attr/RegWidth': np.array([5.0]),
-            '/attr/Begin Line Number': np.array([0]),
-            '/attr/End Line Number': np.array([1]),
+            '/attr/RegLength': np.array(2.0),
+            '/attr/RegWidth': np.array(5.0),
+            '/attr/Begin Line Number': np.array(0),
+            '/attr/End Line Number': np.array(1),
             '/attr/Observing Beginning Date': '2019-06-03', '/attr/Observing Beginning Time': '00:30:01.807',
             '/attr/Observing Ending Date': '2019-06-03', '/attr/Observing Ending Time': '00:34:07.572',
             '/attr/Satellite Name': 'FY4A', '/attr/Sensor Identification Code': 'AGRI', '/attr/Sensor Name': 'AGRI',
@@ -294,6 +294,8 @@ class Test_HDF_AGRI_L1_cal(unittest.TestCase):
 
         # check whether the data type of orbital_parameters is float
         orbital_parameters = res[band_names[0]].attrs['orbital_parameters']
+        for attr in orbital_parameters:
+            self.assertEqual(type(orbital_parameters[attr]), float)
         self.assertEqual(orbital_parameters['satellite_nominal_latitude'], 0.)
         self.assertEqual(orbital_parameters['satellite_nominal_longitude'], 104.7)
         self.assertEqual(orbital_parameters['satellite_nominal_altitude'], 3.5786E7)


### PR DESCRIPTION

 - [x] Closes #1243 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->