### PR TITLE
cf_writer supports array type in attrs

### DIFF
--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -314,6 +314,8 @@ class AttributeEncoder(json.JSONEncoder):
             for key, val in obj.items():
                 serialized[key] = self.default(val)
             return serialized
+        elif isinstance(obj, np.ndarray) and not obj.shape:
+            return float(obj)
         elif isinstance(obj, (list, tuple, np.ndarray)):
             return [self.default(item) for item in obj]
         return self._encode(obj)

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -315,7 +315,7 @@ class AttributeEncoder(json.JSONEncoder):
                 serialized[key] = self.default(val)
             return serialized
         elif isinstance(obj, np.ndarray) and not obj.shape:
-            return float(obj)
+            return obj.item()
         elif isinstance(obj, (list, tuple, np.ndarray)):
             return [self.default(item) for item in obj]
         return self._encode(obj)


### PR DESCRIPTION
If the attribute type is array, the cf_writer could cause the error which is similar to #1243 .

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->