### PR TITLE
Add test utility to make a scene.

### DIFF
--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -248,3 +248,40 @@ class TestUtils(unittest.TestCase):
         dataset.attrs.pop('orbital_parameters')
         lon, lat, alt = get_satpos(dataset)
         self.assertTupleEqual((lon, lat, alt), (-1, -2, -3))
+
+
+def test_make_fake_scene():
+    """Test the make_fake_scene utility.
+
+    Although the make_fake_scene utility is for internal testing
+    purposes, it has grown sufficiently complex that it needs its own
+    testing.
+    """
+    import numpy as np
+    import dask.array as da
+    import xarray as xr
+    from satpy.tests.utils import make_fake_scene
+
+    assert make_fake_scene({}).keys() == []
+    sc = make_fake_scene({
+        "six": np.arange(25).reshape(5, 5)})
+    assert len(sc.keys()) == 1
+    assert sc.keys().pop().name == "six"
+    assert sc["six"].attrs["area"].shape == (5, 5)
+    sc = make_fake_scene({
+        "seven": np.arange(3*7).reshape(3, 7),
+        "eight": np.arange(3*8).reshape(3, 8)},
+        daskify=True,
+        area=False,
+        common_attrs={"repetency": "fourteen hundred per centimetre"})
+    assert "area" not in sc["seven"].attrs.keys()
+    assert (sc["seven"].attrs["repetency"] == sc["eight"].attrs["repetency"] ==
+            "fourteen hundred per centimetre")
+    assert isinstance(sc["seven"].data, da.Array)
+    sc = make_fake_scene({
+        "nine": xr.DataArray(
+            np.arange(2*9).reshape(2, 9),
+            dims=("y", "x"),
+            attrs={"please": "preserve", "answer": 42})},
+        common_attrs={"bad words": "semprini bahnhof veerooster winterbanden"})
+    assert sc["nine"].attrs.keys() >= {"please", "answer", "bad words", "area"}

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -427,6 +427,7 @@ def test_make_a_scene():
     """
     import numpy as np
     import dask.array as da
+    import xarray as xr
 
     assert make_a_scene({}).keys() == []
     sc = make_a_scene({
@@ -444,3 +445,10 @@ def test_make_a_scene():
     assert (sc["seven"].attrs["repetency"] == sc["eight"].attrs["repetency"] ==
             "fourteen hundred per centimetre")
     assert isinstance(sc["seven"].data, da.Array)
+    sc = make_a_scene({
+        "nine": xr.DataArray(
+            np.arange(2*9).reshape(2, 9),
+            dims=("y", "x"),
+            attrs={"please": "preserve", "answer": 42})},
+        common_attrs={"bad words": "semprini bahnhof veerooster winterbanden"})
+    assert sc["nine"].attrs.keys() >= {"please", "answer", "bad words", "area"}

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -357,13 +357,14 @@ class CustomScheduler(object):
         return dask.get(dsk, keys, **kwargs)
 
 
-def make_a_scene(cont_dict, daskify=False, area=True, common_attrs=None):
+def make_a_fake_scene(content_dict, daskify=False, area=True,
+                      common_attrs=None):
     """Make a fake Scene.
 
-    Make a Scene from fake data.  Data are provided in the
-    ``cont_dict`` argument.  In ``cont_dict``, keys should be strings
-    or DatasetID/DataID, and values may be either numpy.ndarray or
-    xarray.DataArray, in either case with exactly two dimensions.
+    Make a fake Scene from fake data.  Data are provided in the
+    ``content_dict`` argument.  In ``content_dict``, keys should be
+    strings or DatasetID/DataID, and values may be either numpy.ndarray
+    or xarray.DataArray, in either case with exactly two dimensions.
     The function will convert each of the numpy.ndarray objects into
     an xarray.DataArray and assign those as datasets to a Scene object.
     A fake AreaDefinition will be assigned for each array, unless disabled
@@ -378,13 +379,26 @@ def make_a_scene(cont_dict, daskify=False, area=True, common_attrs=None):
     objects then this flag has no effect.
 
     Args:
-        cont_dict: mapping with str/datasetid/dataid to ndarrays
-        daskify, optional: boolean, use dask or not, default False
-        area, optional: boolean, add areas, default True
-        common_attrs, optional: dict, attributes to add to every dataset
+        content_dict (Mapping): Mapping where keys correspond to objects
+            accepted by ``Scene.__setitem__``, i.e. strings or DatasetID,
+            and values may be either ``numpy.ndarray`` or
+            ``xarray.DataArray``.
+        daskify (bool): optional, to use dask when converting
+            ``numpy.ndarray`` to ``xarray.DataArray`.  No effect when the
+            values in ``content_dict`` are already ``xarray.DataArray`.
+        area (bool or BaseDefinition): Can be ``True``, ``False``, or an
+            instance of ``pyresample.geometry.BaseDefinition`` such as
+            ``AreaDefinition`` or ``SwathDefinition``.  If ``True``, which is
+            the default, automatically generate areas.  If ``False``, values
+            will not have assigned areas.  If an instance of
+            ``pyresample.geometry.BaseDefinition``, those instances will be
+            used for all generated fake datasets.  Warning: Passing an area as
+            a string (``area="germ"``) is not supported.
+        common_attrs (Mapping): optional, additional attributes that will
+            be added to every dataset in the scene.
 
-    Return:
-        Scene object with datasets corresponding to cont_dict
+    Returns:
+        Scene object with datasets corresponding to content_dict.
     """
     import pyresample
     import satpy
@@ -394,9 +408,11 @@ def make_a_scene(cont_dict, daskify=False, area=True, common_attrs=None):
     if daskify:
         import dask.array
     sc = satpy.Scene()
-    for (did, arr) in cont_dict.items():
+    for (did, arr) in content_dict.items():
         extra_attrs = common_attrs.copy()
-        if area:
+        if isinstance(area, pyresample.geometry.BaseDefinition):
+            extra_attrs["area"] = area
+        elif area:
             extra_attrs["area"] = pyresample.create_area_def(
                     "test-area",
                     {"proj": "eqc", "lat_ts": 0, "lat_0": 0, "lon_0": 0,
@@ -420,22 +436,23 @@ def make_a_scene(cont_dict, daskify=False, area=True, common_attrs=None):
 
 
 def test_make_a_scene():
-    """Test the make_a_scene utility.
+    """Test the make_a_fake_scene utility.
 
-    Although the make_a_scene utility is for internal testing purposes, it has
-    grown sufficiently complex that it needs its own testing.
+    Although the make_a_fake_scene utility is for internal testing
+    purposes, it has grown sufficiently complex that it needs its own
+    testing.
     """
     import numpy as np
     import dask.array as da
     import xarray as xr
 
-    assert make_a_scene({}).keys() == []
-    sc = make_a_scene({
+    assert make_a_fake_scene({}).keys() == []
+    sc = make_a_fake_scene({
         "six": np.arange(25).reshape(5, 5)})
     assert len(sc.keys()) == 1
     assert sc.keys().pop().name == "six"
     assert sc["six"].attrs["area"].shape == (5, 5)
-    sc = make_a_scene({
+    sc = make_a_fake_scene({
         "seven": np.arange(3*7).reshape(3, 7),
         "eight": np.arange(3*8).reshape(3, 8)},
         daskify=True,
@@ -445,7 +462,7 @@ def test_make_a_scene():
     assert (sc["seven"].attrs["repetency"] == sc["eight"].attrs["repetency"] ==
             "fourteen hundred per centimetre")
     assert isinstance(sc["seven"].data, da.Array)
-    sc = make_a_scene({
+    sc = make_a_fake_scene({
         "nine": xr.DataArray(
             np.arange(2*9).reshape(2, 9),
             dims=("y", "x"),

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -357,12 +357,12 @@ class CustomScheduler(object):
         return dask.get(dsk, keys, **kwargs)
 
 
-def make_a_fake_scene(content_dict, daskify=False, area=True,
+def make_fake_scene(content_dict, daskify=False, area=True,
                       common_attrs=None):
-    """Make a fake Scene.
+    """Create a fake Scene.
 
-    Make a fake Scene from fake data.  Data are provided in the
-    ``content_dict`` argument.  In ``content_dict``, keys should be
+    Create a fake Scene object from fake data.  Data are provided in
+    the ``content_dict`` argument.  In ``content_dict``, keys should be
     strings or DatasetID/DataID, and values may be either numpy.ndarray
     or xarray.DataArray, in either case with exactly two dimensions.
     The function will convert each of the numpy.ndarray objects into
@@ -435,10 +435,10 @@ def make_a_fake_scene(content_dict, daskify=False, area=True,
     return sc
 
 
-def test_make_a_scene():
-    """Test the make_a_fake_scene utility.
+def test_make_fake_scene():
+    """Test the make_fake_scene utility.
 
-    Although the make_a_fake_scene utility is for internal testing
+    Although the make_fake_scene utility is for internal testing
     purposes, it has grown sufficiently complex that it needs its own
     testing.
     """
@@ -446,13 +446,13 @@ def test_make_a_scene():
     import dask.array as da
     import xarray as xr
 
-    assert make_a_fake_scene({}).keys() == []
-    sc = make_a_fake_scene({
+    assert make_fake_scene({}).keys() == []
+    sc = make_fake_scene({
         "six": np.arange(25).reshape(5, 5)})
     assert len(sc.keys()) == 1
     assert sc.keys().pop().name == "six"
     assert sc["six"].attrs["area"].shape == (5, 5)
-    sc = make_a_fake_scene({
+    sc = make_fake_scene({
         "seven": np.arange(3*7).reshape(3, 7),
         "eight": np.arange(3*8).reshape(3, 8)},
         daskify=True,
@@ -462,7 +462,7 @@ def test_make_a_scene():
     assert (sc["seven"].attrs["repetency"] == sc["eight"].attrs["repetency"] ==
             "fourteen hundred per centimetre")
     assert isinstance(sc["seven"].data, da.Array)
-    sc = make_a_fake_scene({
+    sc = make_fake_scene({
         "nine": xr.DataArray(
             np.arange(2*9).reshape(2, 9),
             dims=("y", "x"),

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -433,39 +433,3 @@ def make_fake_scene(content_dict, daskify=False, area=True,
                     dims=("y", "x"),
                     attrs=extra_attrs)
     return sc
-
-
-def test_make_fake_scene():
-    """Test the make_fake_scene utility.
-
-    Although the make_fake_scene utility is for internal testing
-    purposes, it has grown sufficiently complex that it needs its own
-    testing.
-    """
-    import numpy as np
-    import dask.array as da
-    import xarray as xr
-
-    assert make_fake_scene({}).keys() == []
-    sc = make_fake_scene({
-        "six": np.arange(25).reshape(5, 5)})
-    assert len(sc.keys()) == 1
-    assert sc.keys().pop().name == "six"
-    assert sc["six"].attrs["area"].shape == (5, 5)
-    sc = make_fake_scene({
-        "seven": np.arange(3*7).reshape(3, 7),
-        "eight": np.arange(3*8).reshape(3, 8)},
-        daskify=True,
-        area=False,
-        common_attrs={"repetency": "fourteen hundred per centimetre"})
-    assert "area" not in sc["seven"].attrs.keys()
-    assert (sc["seven"].attrs["repetency"] == sc["eight"].attrs["repetency"] ==
-            "fourteen hundred per centimetre")
-    assert isinstance(sc["seven"].data, da.Array)
-    sc = make_fake_scene({
-        "nine": xr.DataArray(
-            np.arange(2*9).reshape(2, 9),
-            dims=("y", "x"),
-            attrs={"please": "preserve", "answer": 42})},
-        common_attrs={"bad words": "semprini bahnhof veerooster winterbanden"})
-    assert sc["nine"].attrs.keys() >= {"please", "answer", "bad words", "area"}

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -400,6 +400,6 @@ def make_a_scene(cont_dict, daskify=False):
             arr = dask.array.from_array(arr)
         sc[did] = xarray.DataArray(
                 arr,
-                dims=("x", "y"),
+                dims=("y", "x"),
                 attrs={"area": fake_area})
     return sc


### PR DESCRIPTION
Add a test utility to make a scene from artificial data.  The artificial data are provided by the user, fake areas are added by the routine.  This function shall be exclusively used for testing purposes.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
