### PR TITLE
Add per-frame decoration to MultiScene

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,6 @@ install:
         git+https://github.com/pydata/xarray;
       fi
     - pip install --no-deps -e .
-    - conda list
 script:
 - pytest --cov=satpy satpy/tests
 - coverage run -a --source=satpy -m behave satpy/tests/features --tags=-download

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ install:
         git+https://github.com/pydata/xarray;
       fi
     - pip install --no-deps -e .
+    - conda list
 script:
 - pytest --cov=satpy satpy/tests
 - coverage run -a --source=satpy -m behave satpy/tests/features --tags=-download

--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -185,7 +185,8 @@ applied based on the attributes of the dataset, for example:
 
     >>> mscn.save_animation(
     ...     "{name:s}_{start_time:%Y%m%d_%H%M}.mp4",
-    ...     decorate={
+    ...     enh_args={
+    ...     "decorate": {
     ...         "decorate": [
     ...             {"text": {
     ...                 "txt": "time {start_time:%Y-%m-%d %H:%M}",
@@ -197,7 +198,7 @@ applied based on the attributes of the dataset, for example:
     ...                 "height": 30,
     ...                 "bg": "black",
     ...                 "bg_opacity": 255,
-    ...                 "line": "white"}}]})
+    ...                 "line": "white"}}]}})
 
 If your file covers ABI MESO data for an hour for channel 2 lasting
 from 2020-04-12 01:00-01:59, then the output file will be called

--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -179,6 +179,34 @@ for information on creating a ``Client`` object. If working on a cluster
 you may want to use :doc:`dask jobqueue <jobqueue:index>` to take advantage
 of multiple nodes at a time.
 
+It is possible to add an overlay or decoration to each frame of an
+animation.  For text added as a decoration, string substitution will be
+applied based on the attributes of the dataset, for example:
+
+    >>> mscn.save_animation(
+    ...     "{name:s}_{start_time:%Y%m%d_%H%M}.mp4",
+    ...     decorate={
+    ...         "decorate": [
+    ...             {"text": {
+    ...                 "txt": "time {start_time:%Y-%m-%d %H:%M}",
+    ...                 "align": {
+    ...                     "top_bottom": "bottom",
+    ...                     "left_right": "right"},
+    ...                 "font": '/usr/share/fonts/truetype/arial.ttf',
+    ...                 "font_size": 20,
+    ...                 "height": 30,
+    ...                 "bg": "black",
+    ...                 "bg_opacity": 255,
+    ...                 "line": "white"}}]})
+
+If your file covers ABI MESO data for an hour for channel 2 lasting
+from 2020-04-12 01:00-01:59, then the output file will be called
+``C02_20200412_0100.mp4`` (because the first dataset/frame corresponds to
+an image that started to be taken at 01:00), consist of sixty frames (one
+per minute for MESO data), and each frame will have the start time for
+that frame floored to the minute blended into the frame.  Note that this
+text is "burned" into the video and cannot be switched on or off later.
+
 .. warning::
 
     GIF images, although supported, are not recommended due to the large file

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -412,7 +412,7 @@ class MultiScene(object):
         return this_fn, shape, fill_value
 
     @staticmethod
-    def _maybe_format_decoration(ds, decorate):
+    def _format_decoration(ds, decorate):
         """Maybe format decoration.
 
         If the nested dictionary in decorate (argument to ``save_animation``)
@@ -434,7 +434,7 @@ class MultiScene(object):
         """
         enh_args = enh_args.copy()  # don't change caller's dict!
         if "decorate" in enh_args:
-            enh_args["decorate"] = self._maybe_format_decoration(
+            enh_args["decorate"] = self._format_decoration(
                     ds, enh_args["decorate"])
         img = get_enhanced_image(ds, **enh_args)
         data, mode = img.finalize(fill_value=fill_value)

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -532,7 +532,6 @@ class MultiScene(object):
         writers = {}
         frames = {}
 
-        scene_gen = self._scene_gen
         first_scene = self.first_scene
         scenes = iter(self._scene_gen)
         info_scenes = [first_scene]

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -432,6 +432,7 @@ class MultiScene(object):
 
         Yet a single image frame from a dataset.
         """
+        enh_args = enh_args.copy()  # don't change caller's dict!
         if "decorate" in enh_args:
             enh_args["decorate"] = self._maybe_format_decoration(
                     ds, enh_args["decorate"])

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -411,6 +411,7 @@ class MultiScene(object):
         this_fn = filename.format(**attrs)
         return this_fn, shape, fill_value
 
+    @staticmethod
     def _maybe_format_decoration(ds, decorate):
         """Maybe format decoration.
 
@@ -418,13 +419,13 @@ class MultiScene(object):
         contains a text to be added, format those based on dataset parameters.
         """
 
-        decorate = copy.deepcopy(decorate)
-        if "decorate" in decorate:
+        if decorate and "decorate" in decorate:
             deco_local = copy.deepcopy(decorate)
             for deco in deco_local["decorate"]:
                 if "txt" in deco:
                     deco["txt"] = deco["txt"].format(**ds.attrs)
-        return deco
+            return deco_local
+        return decorate
 
     def _get_animation_frames(self, all_datasets, shape, fill_value=None,
                               ignore_missing=False, enhance=None, overlay=None,

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -423,8 +423,8 @@ class MultiScene(object):
             return decorate
         deco_local = copy.deepcopy(decorate)
         for deco in deco_local["decorate"]:
-            if "txt" in deco:
-                deco["txt"] = deco["txt"].format(**ds.attrs)
+            if "text" in deco and "txt" in deco["text"]:
+                deco["text"]["txt"] = deco["text"]["txt"].format(**ds.attrs)
         return deco_local
 
     def _get_single_frame(self, ds, enhance, decorate, overlay, fill_value):

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -529,8 +529,6 @@ class MultiScene(object):
         Helper function for save_animation.
         """
         scene_gen = self._scene_gen
-        writers = {}
-        frames = {}
 
         first_scene = self.first_scene
         scenes = iter(self._scene_gen)

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -501,7 +501,6 @@ def test_save_mp4(smg, tmp_path):
         scenes[0][ds_id].attrs['end_time'] = datetime(2018, 1, 1, 12)
 
     mscn = MultiScene(scenes)
-    tmp_path
     fn = str(tmp_path /
              'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
     writer_mock = mock.MagicMock()

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -547,10 +547,4 @@ def test_save_mp4(smg, tmp_path):
                         "txt":
                         "Test {start_time:%Y-%m-%d %H:%M} - {end_time:%Y-%m-%d %H:%M}"}]})
     assert writer_mock.append_data.call_count == 2 + 2
-    smg.assert_called_with(
-                scenes[-1]["ds1"], enhance=None,
-                decorate={
-                    "decorate": [{
-                        "txt":
-                        "Test 2018-01-02 00:00 - 2018-01-02 12:00"}]},
-                    overlay=None)
+    assert "2018-01-02" in smg.call_args_list[-1][1]["decorate"]["decorate"][0]["txt"]

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -27,7 +27,7 @@ from unittest import mock
 DEFAULT_SHAPE = (5, 10)
 
 
-def _fake_get_enhanced_image(img):
+def _fake_get_enhanced_image(img, enhance=None, overlay=None, decorate=None):
     from trollimage.xrimage import XRImage
     return XRImage(img)
 
@@ -226,58 +226,6 @@ class TestMultiSceneSave(unittest.TestCase):
             shutil.rmtree(self.base_dir, ignore_errors=True)
         except OSError:
             pass
-
-    @mock.patch('satpy.multiscene.get_enhanced_image', _fake_get_enhanced_image)
-    def test_save_mp4(self):
-        """Save a series of fake scenes to an mp4 video."""
-        from satpy import MultiScene
-        area = _create_test_area()
-        scenes = _create_test_scenes(area=area)
-
-        # Add a dataset to only one of the Scenes
-        scenes[1]['ds3'] = _create_test_dataset('ds3')
-        # Add a start and end time
-        for ds_id in ['ds1', 'ds2', 'ds3']:
-            scenes[1][ds_id].attrs['start_time'] = datetime(2018, 1, 2)
-            scenes[1][ds_id].attrs['end_time'] = datetime(2018, 1, 2, 12)
-            if ds_id == 'ds3':
-                continue
-            scenes[0][ds_id].attrs['start_time'] = datetime(2018, 1, 1)
-            scenes[0][ds_id].attrs['end_time'] = datetime(2018, 1, 1, 12)
-
-        mscn = MultiScene(scenes)
-        fn = os.path.join(
-            self.base_dir,
-            'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
-        writer_mock = mock.MagicMock()
-        with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
-            get_writer.return_value = writer_mock
-            # force order of datasets by specifying them
-            mscn.save_animation(fn, datasets=['ds1', 'ds2', 'ds3'], client=False)
-
-        # 2 saves for the first scene + 1 black frame
-        # 3 for the second scene
-        self.assertEqual(writer_mock.append_data.call_count, 3 + 3)
-        filenames = [os.path.basename(args[0][0]) for args in get_writer.call_args_list]
-        self.assertEqual(filenames[0], 'test_save_mp4_ds1_20180101_00_20180102_12.mp4')
-        self.assertEqual(filenames[1], 'test_save_mp4_ds2_20180101_00_20180102_12.mp4')
-        self.assertEqual(filenames[2], 'test_save_mp4_ds3_20180102_00_20180102_12.mp4')
-
-        # make sure that not specifying datasets still saves all of them
-        fn = os.path.join(
-            self.base_dir,
-            'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
-        writer_mock = mock.MagicMock()
-        with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
-            get_writer.return_value = writer_mock
-            # force order of datasets by specifying them
-            mscn.save_animation(fn, client=False)
-        # the 'ds3' dataset isn't known to the first scene so it doesn't get saved
-        # 2 for first scene, 2 for second scene
-        self.assertEqual(writer_mock.append_data.call_count, 2 + 2)
-        self.assertIn('test_save_mp4_ds1_20180101_00_20180102_12.mp4', filenames)
-        self.assertIn('test_save_mp4_ds2_20180101_00_20180102_12.mp4', filenames)
-        self.assertIn('test_save_mp4_ds3_20180102_00_20180102_12.mp4', filenames)
 
     @mock.patch('satpy.multiscene.get_enhanced_image', _fake_get_enhanced_image)
     def test_save_mp4_distributed(self):
@@ -531,3 +479,79 @@ class TestBlendFuncs(unittest.TestCase):
         self.assertIsInstance(res2, xr.DataArray)
         self.assertTupleEqual((2, self.ds1.shape[0], self.ds1.shape[1]), res.shape)
         self.assertTupleEqual((self.ds3.shape[0], self.ds3.shape[1]+self.ds4.shape[1]), res2.shape)
+
+
+@mock.patch('satpy.multiscene.get_enhanced_image')
+def test_save_mp4(smg, tmp_path):
+    """Save a series of fake scenes to an mp4 video."""
+    from satpy import MultiScene
+    area = _create_test_area()
+    scenes = _create_test_scenes(area=area)
+    smg.side_effect = _fake_get_enhanced_image
+
+    # Add a dataset to only one of the Scenes
+    scenes[1]['ds3'] = _create_test_dataset('ds3')
+    # Add a start and end time
+    for ds_id in ['ds1', 'ds2', 'ds3']:
+        scenes[1][ds_id].attrs['start_time'] = datetime(2018, 1, 2)
+        scenes[1][ds_id].attrs['end_time'] = datetime(2018, 1, 2, 12)
+        if ds_id == 'ds3':
+            continue
+        scenes[0][ds_id].attrs['start_time'] = datetime(2018, 1, 1)
+        scenes[0][ds_id].attrs['end_time'] = datetime(2018, 1, 1, 12)
+
+    mscn = MultiScene(scenes)
+    tmp_path
+    fn = str(tmp_path /
+             'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
+    writer_mock = mock.MagicMock()
+    with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
+        get_writer.return_value = writer_mock
+        # force order of datasets by specifying them
+        mscn.save_animation(fn, datasets=['ds1', 'ds2', 'ds3'], client=False)
+
+    # 2 saves for the first scene + 1 black frame
+    # 3 for the second scene
+    assert writer_mock.append_data.call_count == 3 + 3
+    filenames = [os.path.basename(args[0][0]) for args in get_writer.call_args_list]
+    assert filenames[0] == 'test_save_mp4_ds1_20180101_00_20180102_12.mp4'
+    assert filenames[1] == 'test_save_mp4_ds2_20180101_00_20180102_12.mp4'
+    assert filenames[2] == 'test_save_mp4_ds3_20180102_00_20180102_12.mp4'
+
+    # make sure that not specifying datasets still saves all of them
+    fn = str(tmp_path /
+             'test_save_mp4_{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}.mp4')
+    writer_mock = mock.MagicMock()
+    with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
+        get_writer.return_value = writer_mock
+        # force order of datasets by specifying them
+        mscn.save_animation(fn, client=False)
+    # the 'ds3' dataset isn't known to the first scene so it doesn't get saved
+    # 2 for first scene, 2 for second scene
+    assert writer_mock.append_data.call_count == 2 + 2
+    assert "test_save_mp4_ds1_20180101_00_20180102_12.mp4" in filenames
+    assert "test_save_mp4_ds2_20180101_00_20180102_12.mp4" in filenames
+    assert "test_save_mp4_ds3_20180102_00_20180102_12.mp4" in filenames
+
+    # test decorating and enhancing
+
+    fn = str(tmp_path /
+             'test-{name}_{start_time:%Y%m%d_%H}_{end_time:%Y%m%d_%H}-rich.mp4')
+    writer_mock = mock.MagicMock()
+    with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
+        get_writer.return_value = writer_mock
+        # force order of datasets by specifying them
+        mscn.save_animation(
+                fn, client=False,
+                decorate={
+                    "decorate": [{
+                        "txt":
+                        "Test {start_time:%Y-%m-%d %H:%M - {end_time:%Y-%m-%d %H:%M"}]})
+    assert writer_mock.append_data.call_count == 2 + 2
+    smg.assert_called_with(
+            mock.call(
+                scenes[-1]["ds1"], enhance=None, overlay=None,
+                decorate={
+                    "decorate": [{
+                        "txt":
+                        "Test 2018-01-02 00:00 - 2018-01-02 12:00"}]}))

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -544,7 +544,10 @@ def test_save_mp4(smg, tmp_path):
                 fn, client=False,
                 decorate={
                     "decorate": [{
-                        "txt":
-                        "Test {start_time:%Y-%m-%d %H:%M} - {end_time:%Y-%m-%d %H:%M}"}]})
+                        "text": {
+                            "txt":
+                            "Test {start_time:%Y-%m-%d %H:%M} - "
+                            "{end_time:%Y-%m-%d %H:%M}"}}]})
     assert writer_mock.append_data.call_count == 2 + 2
-    assert "2018-01-02" in smg.call_args_list[-1][1]["decorate"]["decorate"][0]["txt"]
+    assert ("2018-01-02" in smg.call_args_list[-1][1]
+            ["decorate"]["decorate"][0]["text"]["txt"])

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -545,12 +545,12 @@ def test_save_mp4(smg, tmp_path):
                 decorate={
                     "decorate": [{
                         "txt":
-                        "Test {start_time:%Y-%m-%d %H:%M - {end_time:%Y-%m-%d %H:%M"}]})
+                        "Test {start_time:%Y-%m-%d %H:%M} - {end_time:%Y-%m-%d %H:%M}"}]})
     assert writer_mock.append_data.call_count == 2 + 2
     smg.assert_called_with(
-            mock.call(
-                scenes[-1]["ds1"], enhance=None, overlay=None,
+                scenes[-1]["ds1"], enhance=None,
                 decorate={
                     "decorate": [{
                         "txt":
-                        "Test 2018-01-02 00:00 - 2018-01-02 12:00"}]}))
+                        "Test 2018-01-02 00:00 - 2018-01-02 12:00"}]},
+                    overlay=None)

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -548,5 +548,5 @@ def test_save_mp4(smg, tmp_path):
                             "Test {start_time:%Y-%m-%d %H:%M} - "
                             "{end_time:%Y-%m-%d %H:%M}"}}]}})
     assert writer_mock.append_data.call_count == 2 + 2
-    assert ("2018-01" in smg.call_args_list[-1][1]
+    assert ("2018-01-02" in smg.call_args_list[-1][1]
             ["decorate"]["decorate"][0]["text"]["txt"])

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -539,15 +539,14 @@ def test_save_mp4(smg, tmp_path):
     writer_mock = mock.MagicMock()
     with mock.patch('satpy.multiscene.imageio.get_writer') as get_writer:
         get_writer.return_value = writer_mock
-        # force order of datasets by specifying them
         mscn.save_animation(
                 fn, client=False,
-                decorate={
+                enh_args={"decorate": {
                     "decorate": [{
                         "text": {
                             "txt":
                             "Test {start_time:%Y-%m-%d %H:%M} - "
-                            "{end_time:%Y-%m-%d %H:%M}"}}]})
+                            "{end_time:%Y-%m-%d %H:%M}"}}]}})
     assert writer_mock.append_data.call_count == 2 + 2
-    assert ("2018-01-02" in smg.call_args_list[-1][1]
+    assert ("2018-01" in smg.call_args_list[-1][1]
             ["decorate"]["decorate"][0]["text"]["txt"])


### PR DESCRIPTION
In MultiScene.save_animation, add the ability to add decorations,
enhancements, and overlays.  As a special case, decoration text will be
substituted allowing it to vary per frame.  This enables the user to add
the time to every frame.

I took the unit test out of the `unittest.TestCase` class because I
could otherwise not get the call assertions on the `get_enhanced_image`
mock to work.

I also did some refactoring in `save_animation` to make it shorter and simpler, moving some of the functionality to dedicated methods.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1257 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
