### PR TITLE
Fix handling of HRV channel navigation for RSS data in seviri_l1b_native reader

### DIFF
--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -53,6 +53,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_FULLDISK = {
     'earth_model': 1,
     'dataset_id': DatasetID(name='VIS006'),
     'is_full_disk': True,
+    'is_rapid_scan': 0,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -70,6 +71,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI = {
     'earth_model': 1,
     'dataset_id': DatasetID(name='VIS006'),
     'is_full_disk': False,
+    'is_rapid_scan': 0,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -87,6 +89,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK = {
     'earth_model': 1,
     'dataset_id': DatasetID(name='HRV'),
     'is_full_disk': True,
+    'is_rapid_scan': 0,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI low resolution channel area',
@@ -101,10 +104,29 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK = {
     }
 }
 
+TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN = {
+    'earth_model': 1,
+    'dataset_id': DatasetID(name='HRV'),
+    'is_full_disk': False,
+    'is_rapid_scan': 1,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_hrv',
+        'Description': 'SEVIRI low resolution channel area',
+        'Projection ID': 'seviri_hrv',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 5568,
+        'Number of rows': 4176,
+        'Area extent': (5567747.920155525, 2625352.665781975, -1000.1343488693237, -5567747.920155525)
+    }
+}
+
 TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI = {
     'earth_model': 1,
     'dataset_id': DatasetID(name='HRV'),
     'is_full_disk': False,
+    'is_rapid_scan': 0,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -122,6 +144,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_FULLDISK = {
     'earth_model': 2,
     'dataset_id': DatasetID(name='VIS006'),
     'is_full_disk': True,
+    'is_rapid_scan': 0,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -139,6 +162,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK = {
     'earth_model': 2,
     'dataset_id': DatasetID(name='HRV'),
     'is_full_disk': True,
+    'is_rapid_scan': 0,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI low resolution channel area',
@@ -153,10 +177,29 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK = {
     }
 }
 
+TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN = {
+    'earth_model': 2,
+    'dataset_id': DatasetID(name='HRV'),
+    'is_full_disk': False,
+    'is_rapid_scan': 1,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_hrv',
+        'Description': 'SEVIRI low resolution channel area',
+        'Projection ID': 'seviri_hrv',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 5568,
+        'Number of rows': 4176,
+        'Area extent': (5566247.718632221, 2626852.867305279, -2500.3358721733093, -5566247.718632221)
+    }
+}
+
 TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI = {
     'earth_model': 2,
     'dataset_id': DatasetID(name='VIS006'),
     'is_full_disk': False,
+    'is_rapid_scan': 0,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -174,6 +217,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI = {
     'earth_model': 2,
     'dataset_id': DatasetID(name='HRV'),
     'is_full_disk': False,
+    'is_rapid_scan': 0,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -191,6 +235,7 @@ TEST_CALIBRATION_MODE = {
     'earth_model': 1,
     'dataset_id': DatasetID(name='IR_108', calibration='radiance'),
     'is_full_disk': True,
+    'is_rapid_scan': 0,
     'calibration': 'radiance',
     'CalSlope': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.96, 0.97],
     'CalOffset': [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
@@ -244,7 +289,7 @@ class TestNativeMSGArea(unittest.TestCase):
     """
 
     @staticmethod
-    def create_test_header(earth_model, dataset_id, is_full_disk):
+    def create_test_header(earth_model, dataset_id, is_full_disk, is_rapid_scan):
         """Create mocked NativeMSGFileHandler.
 
         Contains sufficient attributes for NativeMSGFileHandler.get_area_extent to be able to execute.
@@ -265,6 +310,15 @@ class TestNativeMSGArea(unittest.TestCase):
             south = 1
             n_visir_cols = 3712
             n_visir_lines = 3712
+            n_hrv_lines = 11136
+        elif is_rapid_scan:
+            north = 3712
+            east = 1
+            west = 3712
+            south = 2321
+            n_visir_cols = 3712
+            n_visir_lines = 1392
+            n_hrv_lines = 4176
         else:
             north = 3574
             east = 78
@@ -272,6 +326,7 @@ class TestNativeMSGArea(unittest.TestCase):
             south = 1746
             n_visir_cols = 2516
             n_visir_lines = north - south + 1
+            n_hrv_lines = 11136
 
         header = {
             '15_DATA_HEADER': {
@@ -308,7 +363,7 @@ class TestNativeMSGArea(unittest.TestCase):
                 'NumberColumnsVISIR': {'Value': n_visir_cols},
                 'NumberLinesVISIR': {'Value': n_visir_lines},
                 'NumberColumnsHRV': {'Value': 11136},
-                'NumberLinesHRV': {'Value': 11136},
+                'NumberLinesHRV': {'Value': n_hrv_lines},
             }
 
         }
@@ -316,7 +371,7 @@ class TestNativeMSGArea(unittest.TestCase):
         return header
 
     @staticmethod
-    def create_test_trailer():
+    def create_test_trailer(is_rapid_scan):
         """Create Test Trailer.
 
         Mocked Trailer with sufficient attributes for
@@ -334,6 +389,9 @@ class TestNativeMSGArea(unittest.TestCase):
                         'LowerWestColumnActual': 5568,
                         'LowerSouthLineActual': 1,
                         'LowerEastColumnActual': 1
+                    },
+                    'ActualScanningSummary': {
+                        'ReducedScan': is_rapid_scan
                     }
                 }
             }
@@ -346,8 +404,9 @@ class TestNativeMSGArea(unittest.TestCase):
         earth_model = test_dict['earth_model']
         dataset_id = test_dict['dataset_id']
         is_full_disk = test_dict['is_full_disk']
-        header = self.create_test_header(earth_model, dataset_id, is_full_disk)
-        trailer = self.create_test_trailer()
+        is_rapid_scan = test_dict['is_rapid_scan']
+        header = self.create_test_header(earth_model, dataset_id, is_full_disk, is_rapid_scan)
+        trailer = self.create_test_trailer(is_rapid_scan)
         expected_area_def = test_dict['expected_area_def']
 
         with mock.patch('satpy.readers.seviri_l1b_native.np.fromfile') as fromfile:
@@ -391,6 +450,19 @@ class TestNativeMSGArea(unittest.TestCase):
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.defs[0].proj_id, expected['Projection ID'])
         self.assertEqual(calculated.defs[1].proj_id, expected['Projection ID'])
+
+    def test_earthmodel1_hrv_rapidscan(self):
+        """Test the HRV Fulldisk with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN
+        )
+        print(calculated.area_extent)
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
     def test_earthmodel1_visir_roi(self):
         """Test the VISIR ROI with the EarthModel 1."""
@@ -439,6 +511,18 @@ class TestNativeMSGArea(unittest.TestCase):
         self.assertEqual(calculated.defs[0].proj_id,  expected['Projection ID'])
         self.assertEqual(calculated.defs[1].proj_id,  expected['Projection ID'])
 
+    def test_earthmodel2_hrv_rapidscan(self):
+        """Test the HRV Fulldisk with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN
+        )
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
     def test_earthmodel2_visir_roi(self):
         """Test the VISIR ROI with the EarthModel 2."""
         calculated, expected = self.prepare_area_defs(
@@ -470,11 +554,11 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
     """
 
     @staticmethod
-    def create_test_header(earth_model, dataset_id, is_full_disk):
+    def create_test_header(earth_model, dataset_id, is_full_disk, is_rapid_scan):
         """Create Test Header.
 
         Mocked NativeMSGFileHandler with sufficient attributes for
-        NativeMSGFileHandler.get_area_extent to be able to execute.
+        NativeMSGFileHandler._convert_to_radiance and NativeMSGFileHandler.calibrate to be able to execute.
         """
         if dataset_id.name == 'HRV':
             # reference_grid = 'ReferenceGridHRV'
@@ -492,6 +576,15 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
             south = 1
             n_visir_cols = 3712
             n_visir_lines = 3712
+            n_hrv_lines = 11136
+        elif is_rapid_scan:
+            north = 3712
+            east = 1
+            west = 3712
+            south = 2321
+            n_visir_cols = 3712
+            n_visir_lines = 1392
+            n_hrv_lines = 4176
         else:
             north = 3574
             east = 78
@@ -499,6 +592,7 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
             south = 1746
             n_visir_cols = 2516
             n_visir_lines = north - south + 1
+            n_hrv_lines = 11136
 
         header = {
             '15_DATA_HEADER': {
@@ -548,7 +642,7 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
                 'NumberColumnsVISIR': {'Value': n_visir_cols},
                 'NumberLinesVISIR': {'Value': n_visir_lines},
                 'NumberColumnsHRV': {'Value': 11136},
-                'NumberLinesHRV': {'Value': 11136},
+                'NumberLinesHRV': {'Value': n_hrv_lines},
             }
 
         }
@@ -575,7 +669,8 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
             cal_slope = cal_slope_arr[index]
 
         is_full_disk = test_dict['is_full_disk']
-        header = self.create_test_header(earth_model, dataset_id, is_full_disk)
+        is_rapid_scan = test_dict['is_rapid_scan']
+        header = self.create_test_header(earth_model, dataset_id, is_full_disk, is_rapid_scan)
 
         with mock.patch('satpy.readers.seviri_l1b_native.np.fromfile') as fromfile:
             fromfile.return_value = header
@@ -588,11 +683,11 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
                         # with the calibration mode to test
                         fh = NativeMSGFileHandler(None, {}, None, calib_mode=cal_mode)
 
-                        # Caluculate the expected calibration values using the coeefs
+                        # Calculate the expected calibration values using the coeffs
                         # from the test data set
                         expected = fh._convert_to_radiance(data, cal_slope, cal_offset)
 
-                        # Calculate the calibrated vaues using the cal coeffs from the
+                        # Calculate the calibrated values using the cal coeffs from the
                         # test header and using the correct calibration mode values
                         fh.header = header
                         calculated = fh.calibrate(data, dataset_id)


### PR DESCRIPTION
This PR fixes the navigation of the HRV channel from Rapid Scanning Service data in the SEVIRI native format reader.

The issue was caused by the wrong assumption that the HRV RSS data is formatted the same way as HRV ROI data. This was causing wrong navigations, with stretched and shifted images. 

Instead, the RSS HRV is handled similarly to the full-disk case; the navigation still needs to be done using the "`Actual`" lines and columns positions stored in the trailer information. The difference w.r.t. the full-disk case is that only one area is present, instead of two separate ones. 

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->