### PR TITLE
Add generic filepatterns for mersi2 reader

### DIFF
--- a/satpy/etc/readers/mersi2_l1b.yaml
+++ b/satpy/etc/readers/mersi2_l1b.yaml
@@ -13,12 +13,16 @@ file_types:
       - 'tf{start_time:%Y%j%H%M%S}.{platform_shortname}-{trans_band:1s}_MERSI_1000M_L1B.{ext}'
       # FY3D_20190808_130200_130300_8965_MERSI_1000M_L1B.HDF
       - '{platform_shortname}_{start_time:%Y%m%d_%H%M%S}_{end_time:%H%M%S}_{orbit_number:s}_MERSI_1000M_L1B.{ext}'
+      # Generic
+      - '{filename_mda}_MERSI_1000M_L1B.{ext:3s}'
   mersi2_l1b_250:
     file_reader: !!python/name:satpy.readers.mersi2_l1b.MERSI2L1B
     rows_per_scan: 40
     file_patterns:
       # tf2019071182739.FY3D-X_MERSI_0250M_L1B.HDF
       - 'tf{start_time:%Y%j%H%M%S}.{platform_shortname}-{trans_band:1s}_MERSI_0250M_L1B.{ext}'
+      # Generic
+      - '{filename_mda}_MERSI_0250M_L1B.{ext:3s}'
   mersi2_l1b_1000_geo:
     file_reader: !!python/name:satpy.readers.mersi2_l1b.MERSI2L1B
     rows_per_scan: 10
@@ -27,12 +31,17 @@ file_types:
       - 'tf{start_time:%Y%j%H%M%S}.{platform_shortname}-{trans_band:1s}_MERSI_GEO1K_L1B.{ext}'
       # FY3D_20190808_130200_130300_8965_MERSI_GEO1K_L1B.HDF
       - '{platform_shortname}_{start_time:%Y%m%d_%H%M%S}_{end_time:%H%M%S}_{orbit_number:s}_MERSI_GEO1K_L1B.{ext}'
+      # Generic
+      - '{filename_mda}_MERSI_GEO1K_L1B.{ext:3s}'
+
   mersi2_l1b_250_geo:
     file_reader: !!python/name:satpy.readers.mersi2_l1b.MERSI2L1B
     rows_per_scan: 40
     file_patterns:
       # tf2019071182739.FY3D-X_MERSI_GEOQK_L1B.HDF
       - 'tf{start_time:%Y%j%H%M%S}.{platform_shortname}-{trans_band:1s}_MERSI_GEOQK_L1B.{ext}'
+      # Generic
+      - '{filename_mda}_MERSI_GEOQK_L1B.{ext:3s}'
 
 # NOTE: OSCAR website currently has bands in wavelength order
 #       https://www.wmo-sat.info/oscar/instruments/view/279


### PR DESCRIPTION
The raw to l0 and l0 to l1 software from CMA for FY3 satellite does not really care about the filename it is given as input, and only appends it's metadata to the filename, meaning that `myfile.cad` when fully processed will generate filenames like `myfile_MERSI_GEO1K_L1B.HDF`. 
The prefix of the file (`myfile` in the example above) depends on the reception software from the station, and so the possibilities are endless.

This PR adds a generic filepattern for each filetype to catch all these possibilities.

 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

