### PR TITLE
Fix "see above" reference at start of enhance docs

### DIFF
--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -402,6 +402,8 @@ image) for both of the static images::
           min_stretch: [0, 0, 0]
           max_stretch: [255, 255, 255]
 
+.. _enhancing-the-images:
+
 Enhancing the images
 ====================
 

--- a/doc/source/enhancements.rst
+++ b/doc/source/enhancements.rst
@@ -8,11 +8,12 @@ Built-in enhancement methods
 stretch
 -------
 
-The most basic operation is to stretch the image so that the data fits
-to the output format.  There are many different ways to stretch the
-data, which are configured by giving them in `kwargs` dictionary, like
-in the example above.  The default, if nothing else is defined, is to
-apply a linear stretch.  For more details, see below.
+The most basic operation is to stretch the image so that the data fits to
+the output format.  There are many different ways to stretch the data,
+which are configured by giving them in `kwargs` dictionary, like in the
+example above.  The default, if nothing else is defined, is to apply
+a linear stretch.  For more details, see
+:ref:`enhancing the images <enhancing-the-images>`.
 
 linear
 ******


### PR DESCRIPTION
Fix a reference to an example "above" that was completely at the start of the enhancements.rst documentation.  From an earlier version, it appears this was intended to refer to an enhancements example in composites.rst.  Change "above" to instead link to this example in composites.rst.

 - [x] Fully documented
