### PR TITLE
Fix hardcoded number of scans in viirs-sdr reader

### DIFF
--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -57,6 +57,7 @@ def _get_invalid_info(granule_data):
     VDNE: value does not exist / processing algorithm did not execute
     SOUB: scaled out-of-bounds / solution not within allowed range
     """
+    msg = None
     if issubclass(granule_data.dtype.type, np.integer):
         msg = ("na:" + str((granule_data == 65535).sum()) +
                " miss:" + str((granule_data == 65534).sum()) +
@@ -319,7 +320,7 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
         if variable.size != scans.size:
             for gscans in scans.values:
                 data_chunks.append(self[var_path].isel(y=slice(start_scan, start_scan + gscans * scan_size)))
-                start_scan += scan_size * 48
+                start_scan += gscans * scan_size
             return xr.concat(data_chunks, 'y')
         else:
             return self.expand_single_values(variable, scans)


### PR DESCRIPTION
This fixes a nasty hardcoded scan number, possibly affecting #1256 

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
