### PR TITLE
Support multiple readers in group_files and MultiScene.from_files

### DIFF
--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -237,7 +237,7 @@ Combining multiple readers
 
 Since Satpy 0.23, it is possible to automatically
 combine multiple readers into a single MultiScene using the
-:meth:`~satpy.multiscene.MultiScene.fromFiles` constructor.  It is
+:meth:`~satpy.multiscene.MultiScene.from_files` constructor.  It is
 no longer necessary for the user to create the :meth:`~satpy.Scene`
 objects themselves.  For example, you can combine Advanced Baseline Imager
 (ABI) and Global Lightning Mapper (GLM) measurements.  Constructing a
@@ -245,29 +245,20 @@ multi-reader MultiScene requires more parameters than a single-reader
 MultiScene, because Satpy can poorly guess how to group files belonging
 to different instruments.  For an example creating a video with lightning
 superimposed on ABI channel 14 (11.2 micrometre), using the built-in
-composite ``C14_flash_extent_density``.
+composite ``C14_flash_extent_density``:
 
-    import datetime
-
-    import satpy
-    import satpy.utils
-    satpy.utils.debug_on()
-    import glob
-
-    glm_dir = "/path/to/GLMC/"
-    abi_dir = "/path/to/ABI/"
-
-    ms = satpy.MultiScene.from_files(
-            glob.glob(glm_dir + "OR_GLM-L2-GLMC-M3_G16_s202010418*.nc") +
-            glob.glob(abi_dir + "C*/OR_ABI-L1b-RadC-M6C*_G16_s202010418*_e*_c*.nc"),
-            reader=["glm_l2", "abi_l1b"],
-            ensure_all_readers=True,
-            group_keys=["start_time"],
-            time_threshold=30)
-    ms.load(["C14_flash_extent_density"])
-    ms = ms.resample(ms.first_scene["C14"].attrs["area"])
-
-    ms.save_animation("/path/for/output/{name:s}_{start_time:%Y%m%d_%H%M}.mp4")
+    >>> glm_dir = "/path/to/GLMC/"
+    >>> abi_dir = "/path/to/ABI/"
+    >>> ms = satpy.MultiScene.from_files(
+    ...        glob.glob(glm_dir + "OR_GLM-L2-GLMC-M3_G16_s202010418*.nc") +
+    ...        glob.glob(abi_dir + "C*/OR_ABI-L1b-RadC-M6C*_G16_s202010418*_e*_c*.nc"),
+    ...        reader=["glm_l2", "abi_l1b"],
+    ...        ensure_all_readers=True,
+    ...        group_keys=["start_time"],
+    ...        time_threshold=30)
+    >>> ms.load(["C14_flash_extent_density"])
+    >>> ms = ms.resample(ms.first_scene["C14"].attrs["area"])
+    >>> ms.save_animation("/path/for/output/{name:s}_{start_time:%Y%m%d_%H%M}.mp4")
 
 In this example, we pass to
 :meth:`~satpy.multiscene.MultiScene.from_files` the additional parameters

--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -235,8 +235,11 @@ multiple Scenes use:
 Combining multiple readers
 --------------------------
 
-Since Satpy 0.23, it is possible to combine multiple readers into a
-single MultiScene.  For example, you can combine Advanced Baseline Imager
+Since Satpy 0.23, it is possible to automatically
+combine multiple readers into a single MultiScene using the
+:meth:`~satpy.multiscene.MultiScene.fromFiles` constructor.  It is
+no longer necessary for the user to create the :meth:`~satpy.Scene`
+objects themselves.  For example, you can combine Advanced Baseline Imager
 (ABI) and Global Lightning Mapper (GLM) measurements.  Constructing a
 multi-reader MultiScene requires more parameters than a single-reader
 MultiScene, because Satpy can poorly guess how to group files belonging
@@ -266,9 +269,12 @@ composite ``C14_flash_extent_density``.
 
     ms.save_animation("/path/for/output/{name:s}_{start_time:%Y%m%d_%H%M}.mp4")
 
-In this example, we pass to :meth:`~satpy.MultiScene.from_files`
-the additional parameters ``ensure_all_readers=True,
-group_keys=["start_time"], time_threshold=30`` so we only get scenes
-at times that both ABI and GLM have a file starting within 30 seconds
-from each other, and ignore all differences for the purposes of grouping
-the two.
+In this example, we pass to
+:meth:`~satpy.multiscene.MultiScene.from_files` the additional parameters
+``ensure_all_readers=True, group_keys=["start_time"], time_threshold=30``
+so we only get scenes at times that both ABI and GLM have a file starting
+within 30 seconds from each other, and ignore all other differences for
+the purposes of grouping the two.  For this example, the ABI files occur
+every 5 minutes but the GLM files (processed with glmtools) every minute.
+Scenes where there is a GLM file without an ABI file starting within at
+most ±30 seconds are skipped.

--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -248,7 +248,7 @@ Constructing a multi-reader MultiScene requires more parameters than a
 single-reader MultiScene, because Satpy can poorly guess how to group
 files belonging to different instruments.  For an example creating
 a video with lightning superimposed on ABI channel 14 (11.2 |_| µm)
-micrometre), using the built-in composite ``C14_flash_extent_density``,
+using the built-in composite ``C14_flash_extent_density``,
 which superimposes flash extent density from GLM (read with the
 :class:`~satpy.readers.glm_l2.NCGriddedGLML2` or ``glm_l2`` reader) on ABI
 channel 14 data (read with the :class:`~satpy.readers.abi_l1b.NC_ABI_L1B`

--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -235,16 +235,19 @@ multiple Scenes use:
 Combining multiple readers
 --------------------------
 
-Since Satpy 0.23, it is possible to automatically
-combine multiple readers into a single MultiScene using the
-:meth:`~satpy.multiscene.MultiScene.from_files` constructor.  It is
-no longer necessary for the user to create the :class:`~satpy.scene.Scene`
+.. versionadded:: 0.23
+.. |_| unicode:: 0xA0
+   :trim:
+
+The :meth:`~satpy.multiscene.MultiScene.from_files` constructor allows to
+automatically combine multiple readers into a single MultiScene.  It is no
+longer necessary for the user to create the :class:`~satpy.scene.Scene`
 objects themselves.  For example, you can combine Advanced Baseline
 Imager (ABI) and Global Lightning Mapper (GLM) measurements.
-Constructing a multi-reader MultiScene requires more parameters
-than a single-reader MultiScene, because Satpy can poorly guess how
-to group files belonging to different instruments.  For an example
-creating a video with lightning superimposed on ABI channel 14 (11.2
+Constructing a multi-reader MultiScene requires more parameters than a
+single-reader MultiScene, because Satpy can poorly guess how to group
+files belonging to different instruments.  For an example creating
+a video with lightning superimposed on ABI channel 14 (11.2 |_| µm)
 micrometre), using the built-in composite ``C14_flash_extent_density``,
 which superimposes flash extent density from GLM (read with the
 :class:`~satpy.readers.glm_l2.NCGriddedGLML2` or ``glm_l2`` reader) on ABI
@@ -273,4 +276,8 @@ within 30 seconds from each other, and ignore all other differences for
 the purposes of grouping the two.  For this example, the ABI files occur
 every 5 minutes but the GLM files (processed with glmtools) every minute.
 Scenes where there is a GLM file without an ABI file starting within at
-most ±30 seconds are skipped.
+most ±30 seconds are skipped.  The ``group_keys`` and ``time_threshold``
+keyword arguments are processed by the :func:`~satpy.readers.group_files`
+function.  The heavy work of blending the two instruments together is
+performed by the :class:`~satpy.composites.BackgroundCompositor` class
+through the `"C14_flash_extent_density"` composite.

--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -236,8 +236,6 @@ Combining multiple readers
 --------------------------
 
 .. versionadded:: 0.23
-.. |_| unicode:: 0xA0
-   :trim:
 
 The :meth:`~satpy.multiscene.MultiScene.from_files` constructor allows to
 automatically combine multiple readers into a single MultiScene.  It is no
@@ -247,7 +245,7 @@ Imager (ABI) and Global Lightning Mapper (GLM) measurements.
 Constructing a multi-reader MultiScene requires more parameters than a
 single-reader MultiScene, because Satpy can poorly guess how to group
 files belonging to different instruments.  For an example creating
-a video with lightning superimposed on ABI channel 14 (11.2 |_| µm)
+a video with lightning superimposed on ABI channel 14 (11.2 µm)
 using the built-in composite ``C14_flash_extent_density``,
 which superimposes flash extent density from GLM (read with the
 :class:`~satpy.readers.glm_l2.NCGriddedGLML2` or ``glm_l2`` reader) on ABI

--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -238,14 +238,19 @@ Combining multiple readers
 Since Satpy 0.23, it is possible to automatically
 combine multiple readers into a single MultiScene using the
 :meth:`~satpy.multiscene.MultiScene.from_files` constructor.  It is
-no longer necessary for the user to create the :meth:`~satpy.Scene`
-objects themselves.  For example, you can combine Advanced Baseline Imager
-(ABI) and Global Lightning Mapper (GLM) measurements.  Constructing a
-multi-reader MultiScene requires more parameters than a single-reader
-MultiScene, because Satpy can poorly guess how to group files belonging
-to different instruments.  For an example creating a video with lightning
-superimposed on ABI channel 14 (11.2 micrometre), using the built-in
-composite ``C14_flash_extent_density``:
+no longer necessary for the user to create the :class:`~satpy.scene.Scene`
+objects themselves.  For example, you can combine Advanced Baseline
+Imager (ABI) and Global Lightning Mapper (GLM) measurements.
+Constructing a multi-reader MultiScene requires more parameters
+than a single-reader MultiScene, because Satpy can poorly guess how
+to group files belonging to different instruments.  For an example
+creating a video with lightning superimposed on ABI channel 14 (11.2
+micrometre), using the built-in composite ``C14_flash_extent_density``,
+which superimposes flash extent density from GLM (read with the
+:class:`~satpy.readers.glm_l2.NCGriddedGLML2` or ``glm_l2`` reader) on ABI
+channel 14 data (read with the :class:`~satpy.readers.abi_l1b.NC_ABI_L1B`
+or ``abi_l1b`` reader), and therefore needs Scene objects that combine
+both readers:
 
     >>> glm_dir = "/path/to/GLMC/"
     >>> abi_dir = "/path/to/ABI/"

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -174,18 +174,29 @@ class MultiScene(object):
         return self._scene_gen.first
 
     @classmethod
-    def from_files(cls, files_to_sort, reader=None, **kwargs):
+    def from_files(cls, files_to_sort, reader=None,
+                   ensure_all_readers=False, **kwargs):
         """Create multiple Scene objects from multiple files.
 
+        Args:
+            files_to_sort (Collection[str]): files to read
+            reader (str or Collection[str]): reader or readers to use
+            ensure_all_readers (bool): If True, limit to scenes where all
+                readers have at least one file.  If False (default), include
+                all scenes where at least one reader has at least one file.
+
         This uses the :func:`satpy.readers.group_files` function to group
-        files. See this function for more details on possible keyword
-        arguments.
+        files. See this function for more details on additional possible
+        keyword arguments.  In particular, it is strongly recommended to pass
+        `"group_keys"` when using multiple instruments.
 
         .. versionadded:: 0.12
 
         """
         from satpy.readers import group_files
         file_groups = group_files(files_to_sort, reader=reader, **kwargs)
+        if ensure_all_readers:
+            file_groups = [fg for fg in file_groups if all(fg.values())]
         scenes = (Scene(filenames=fg) for fg in file_groups)
         return cls(scenes)
 

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -467,13 +467,13 @@ def _assign_files_to_readers(files_to_sort, reader_names, ppp_config_dir,
     for reader_configs in configs_for_reader(reader_names, ppp_config_dir):
         try:
             reader = load_reader(reader_configs, **reader_kwargs)
-        except yaml.constructor.ConstructorError as e:
+        except yaml.constructor.ConstructorError:
             LOG.exception(
                     f"ConstructorError loading {reader_configs!s}, "
-                     "probably a missing dependency, skipping "
-                     "corresponding reader (if you did not explicitly "
-                     "specify the reader, Satpy tries all; performance "
-                     "will improve if you pass readers explicitly).")
+                    "probably a missing dependency, skipping "
+                    "corresponding reader (if you did not explicitly "
+                    "specify the reader, Satpy tries all; performance "
+                    "will improve if you pass readers explicitly).")
         reader_name = reader.info["name"]
         files_matching = set(reader.filter_selected_filenames(files_to_sort))
         files_to_sort -= files_matching

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -379,7 +379,7 @@ class DatasetDict(dict):
             return super(DatasetDict, self).__delitem__(key)
 
 
-def group_files(files_to_sort, reader=None, time_threshold=10,
+def group_files(files_to_sort, *, reader, time_threshold=10,
                 group_keys=None, ppp_config_dir=None, reader_kwargs=None):
     """Group series of files by file pattern information.
 
@@ -421,9 +421,7 @@ def group_files(files_to_sort, reader=None, time_threshold=10,
 
     """
     # FUTURE: Find the best reader for each filename using `find_files_and_readers`
-    if reader is None:
-        raise ValueError("'reader' keyword argument is required.")
-    elif not isinstance(reader, (list, tuple)):
+    if not isinstance(reader, (list, tuple)):
         reader = [reader]
 
     # FUTURE: Handle multiple readers

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -474,6 +474,7 @@ def _assign_files_to_readers(files_to_sort, reader_names, ppp_config_dir,
                     "corresponding reader (if you did not explicitly "
                     "specify the reader, Satpy tries all; performance "
                     "will improve if you pass readers explicitly).")
+            continue
         reader_name = reader.info["name"]
         files_matching = set(reader.filter_selected_filenames(files_to_sort))
         files_to_sort -= files_matching

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -407,7 +407,9 @@ def group_files(files_to_sort, reader=None, time_threshold=10,
             the first key in ``group_keys``. Otherwise, there is a good chance
             that files will not be grouped properly (datetimes being barely
             unequal). Defaults to a reader's ``group_keys`` configuration (set
-            in YAML), otherwise ``('start_time',)``.
+            in YAML), otherwise ``('start_time',)``.  When passing multiple
+            readers, passing group_keys is strongly recommended as the
+            behaviour without doing so is undefined.
         ppp_config_dir (str): Root usser configuration directory for Satpy.
             This will be deprecated in the future, but is here for consistency
             with other Satpy features.

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -465,7 +465,15 @@ def _assign_files_to_readers(files_to_sort, reader_names, ppp_config_dir,
     files_to_sort = set(files_to_sort)
     D = {}
     for reader_configs in configs_for_reader(reader_names, ppp_config_dir):
-        reader = load_reader(reader_configs, **reader_kwargs)
+        try:
+            reader = load_reader(reader_configs, **reader_kwargs)
+        except yaml.constructor.ConstructorError as e:
+            LOG.exception(
+                    f"ConstructorError loading {reader_configs!s}, "
+                     "probably a missing dependency, skipping "
+                     "corresponding reader (if you did not explicitly "
+                     "specify the reader, Satpy tries all; performance "
+                     "will improve if you pass readers explicitly).")
         reader_name = reader.info["name"]
         files_matching = set(reader.filter_selected_filenames(files_to_sort))
         files_to_sort -= files_matching

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -124,18 +124,31 @@ class TestMultiScene(unittest.TestCase):
     def test_from_files(self):
         """Test creating a multiscene from multiple files."""
         from satpy import MultiScene
-        input_files = [
+        input_files_abi = [
             "OR_ABI-L1b-RadC-M3C01_G16_s20171171502203_e20171171504576_c20171171505018.nc",
             "OR_ABI-L1b-RadC-M3C01_G16_s20171171507203_e20171171509576_c20171171510018.nc",
             "OR_ABI-L1b-RadC-M3C01_G16_s20171171512203_e20171171514576_c20171171515017.nc",
             "OR_ABI-L1b-RadC-M3C01_G16_s20171171517203_e20171171519577_c20171171520019.nc",
             "OR_ABI-L1b-RadC-M3C01_G16_s20171171522203_e20171171524576_c20171171525020.nc",
             "OR_ABI-L1b-RadC-M3C01_G16_s20171171527203_e20171171529576_c20171171530017.nc",
+            ]
+        input_files_glm = [
+            "OR_GLM-L2-GLMC-M3_G16_s20171171502203_e20171171504576_c20171171505018.nc",
+            "OR_GLM-L2-GLMC-M3_G16_s20171171507203_e20171171509576_c20171171510018.nc",
+            "OR_GLM-L2-GLMC-M3_G16_s20171171512203_e20171171514576_c20171171515017.nc",
+            "OR_GLM-L2-GLMC-M3_G16_s20171171517203_e20171171519577_c20171171520019.nc",
+            "OR_GLM-L2-GLMC-M3_G16_s20171171522203_e20171171524576_c20171171525020.nc",
+            "OR_GLM-L2-GLMC-M3_G16_s20171171527203_e20171171529576_c20171171530017.nc",
         ]
         with mock.patch('satpy.multiscene.Scene') as scn_mock:
-            mscn = MultiScene.from_files(input_files, reader='abi_l1b')
-            self.assertTrue(len(mscn.scenes), 6)
-            calls = [mock.call(filenames={'abi_l1b': [in_file]}) for in_file in input_files]
+            mscn = MultiScene.from_files(
+                    input_files_abi + input_files_glm,
+                    reader=('abi_l1b', "glm_l2"))
+            assert len(mscn.scenes) == 6
+            calls = [mock.call(
+                filenames={'abi_l1b': [in_file_abi], 'glm_l2': [in_file_glm]})
+                for (in_file_abi, in_file_glm) in zip(input_files_abi,
+                    input_files_glm)]
             scn_mock.assert_has_calls(calls)
 
     def test_group(self):

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -142,13 +142,23 @@ class TestMultiScene(unittest.TestCase):
         ]
         with mock.patch('satpy.multiscene.Scene') as scn_mock:
             mscn = MultiScene.from_files(
+                    input_files_abi,
+                    reader=('abi_l1b'))
+            assert len(mscn.scenes) == 6
+            calls = [mock.call(
+                filenames={'abi_l1b': [in_file_abi]})
+                for in_file_abi in input_files_abi]
+            scn_mock.assert_has_calls(calls)
+
+            scn_mock.reset_mock()
+            mscn = MultiScene.from_files(
                     input_files_abi + input_files_glm,
                     reader=('abi_l1b', "glm_l2"))
             assert len(mscn.scenes) == 6
             calls = [mock.call(
                 filenames={'abi_l1b': [in_file_abi], 'glm_l2': [in_file_glm]})
-                for (in_file_abi, in_file_glm) in zip(input_files_abi,
-                    input_files_glm)]
+                for (in_file_abi, in_file_glm) in
+                zip(input_files_abi, input_files_glm)]
             scn_mock.assert_has_calls(calls)
 
     def test_group(self):

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -133,12 +133,14 @@ class TestMultiScene(unittest.TestCase):
             "OR_ABI-L1b-RadC-M3C01_G16_s20171171527203_e20171171529576_c20171171530017.nc",
             ]
         input_files_glm = [
-            "OR_GLM-L2-GLMC-M3_G16_s20171171502203_e20171171504576_c20171171505018.nc",
-            "OR_GLM-L2-GLMC-M3_G16_s20171171507203_e20171171509576_c20171171510018.nc",
-            "OR_GLM-L2-GLMC-M3_G16_s20171171512203_e20171171514576_c20171171515017.nc",
-            "OR_GLM-L2-GLMC-M3_G16_s20171171517203_e20171171519577_c20171171520019.nc",
-            "OR_GLM-L2-GLMC-M3_G16_s20171171522203_e20171171524576_c20171171525020.nc",
-            "OR_GLM-L2-GLMC-M3_G16_s20171171527203_e20171171529576_c20171171530017.nc",
+            "OR_GLM-L2-GLMC-M3_G16_s20171171500000_e20171171501000_c20380190314080.nc",
+            "OR_GLM-L2-GLMC-M3_G16_s20171171501000_e20171171502000_c20380190314080.nc",
+            "OR_GLM-L2-GLMC-M3_G16_s20171171502000_e20171171503000_c20380190314080.nc",
+            "OR_GLM-L2-GLMC-M3_G16_s20171171503000_e20171171504000_c20380190314080.nc",
+            "OR_GLM-L2-GLMC-M3_G16_s20171171504000_e20171171505000_c20380190314080.nc",
+            "OR_GLM-L2-GLMC-M3_G16_s20171171505000_e20171171506000_c20380190314080.nc",
+            "OR_GLM-L2-GLMC-M3_G16_s20171171506000_e20171171507000_c20380190314080.nc",
+            "OR_GLM-L2-GLMC-M3_G16_s20171171507000_e20171171508000_c20380190314080.nc",
         ]
         with mock.patch('satpy.multiscene.Scene') as scn_mock:
             mscn = MultiScene.from_files(
@@ -153,13 +155,25 @@ class TestMultiScene(unittest.TestCase):
             scn_mock.reset_mock()
             mscn = MultiScene.from_files(
                     input_files_abi + input_files_glm,
-                    reader=('abi_l1b', "glm_l2"))
-            assert len(mscn.scenes) == 6
+                    reader=('abi_l1b', "glm_l2"),
+                    group_keys=["start_time"],
+                    ensure_all_readers=True,
+                    time_threshold=30)
+            assert len(mscn.scenes) == 2
             calls = [mock.call(
                 filenames={'abi_l1b': [in_file_abi], 'glm_l2': [in_file_glm]})
                 for (in_file_abi, in_file_glm) in
-                zip(input_files_abi, input_files_glm)]
+                zip(input_files_abi[0:2],
+                    [input_files_glm[2]] + [input_files_glm[7]])]
             scn_mock.assert_has_calls(calls)
+            scn_mock.reset_mock()
+            mscn = MultiScene.from_files(
+                    input_files_abi + input_files_glm,
+                    reader=('abi_l1b', "glm_l2"),
+                    group_keys=["start_time"],
+                    ensure_all_readers=False,
+                    time_threshold=30)
+            assert len(mscn.scenes) == 12
 
     def test_group(self):
         from satpy import Scene, MultiScene, DatasetID

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -650,9 +650,12 @@ class TestGroupFiles(unittest.TestCase):
         ]
 
     def test_no_reader(self):
-        """Test that reader must be provided."""
+        """Test that reader does not need to be provided."""
         from satpy.readers import group_files
-        self.assertRaises(ValueError, group_files, [])
+        # without files it's going to be an empty result
+        assert group_files([]) == []
+        groups = group_files(self.g16_files)
+        self.assertEqual(6, len(groups))
 
     def test_bad_reader(self):
         """Test that reader not existing causes an error."""
@@ -763,3 +766,10 @@ class TestGroupFiles(unittest.TestCase):
         self.assertEqual(6, len(groups[0]['viirs_sdr']))
         # 5 granules * 3 file types
         self.assertEqual(5 * 3, len(groups[1]['viirs_sdr']))
+
+    def test_multi_readers(self):
+        from satpy.readers import group_files
+        groups = group_files(
+                self.g16_files + self.noaa20_files,
+                reader=("abi_l1b", "viirs_sdr"))
+        assert len(groups) == 11

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -790,6 +790,14 @@ class TestGroupFiles(unittest.TestCase):
         groups = group_files(
                 self.g16_files + self.noaa20_files,
                 reader=("abi_l1b", "viirs_sdr"),
-                group_keys=("start_time"),
+                group_keys=("start_time",),
                 time_threshold=10**9)
         assert len(groups) == 1
+        # test that a warning is raised when a string is passed (meaning no
+        # group keys found in common)
+        with pytest.warns(UserWarning):
+            groups = group_files(
+                    self.g16_files + self.noaa20_files,
+                    reader=("abi_l1b", "viirs_sdr"),
+                    group_keys=("start_time"),
+                    time_threshold=10**9)


### PR DESCRIPTION
Support multiple readers in group_files and `MultiScene.from_files`

Adapt `group_files` so that `group_files` and `MultiScene.from_files` can support multiple readers.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1268 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
