### PR TITLE
Replace incorrect assertTrue usage

### DIFF
--- a/satpy/tests/reader_tests/test_acspo.py
+++ b/satpy/tests/reader_tests/test_acspo.py
@@ -120,7 +120,7 @@ class TestACSPOReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             '20170401174600-STAR-L2P_GHRSST-SSTskin-VIIRS_NPP-ACSPO_V2.40-v02.0-fv01.0.nc',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)

--- a/satpy/tests/reader_tests/test_agri_l1.py
+++ b/satpy/tests/reader_tests/test_agri_l1.py
@@ -246,7 +246,7 @@ class Test_HDF_AGRI_L1_cal(unittest.TestCase):
         ]
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(4, len(files))
+        self.assertEqual(4, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)
@@ -312,7 +312,7 @@ class Test_HDF_AGRI_L1_cal(unittest.TestCase):
         ]
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(4, len(files))
+        self.assertEqual(4, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)
@@ -339,7 +339,7 @@ class Test_HDF_AGRI_L1_cal(unittest.TestCase):
         ]
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(1, len(files))
+        self.assertEqual(1, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)
@@ -399,7 +399,7 @@ class Test_HDF_AGRI_L1_cal(unittest.TestCase):
         ]
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(1, len(files))
+        self.assertEqual(1, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)
@@ -458,7 +458,7 @@ class Test_HDF_AGRI_L1_cal(unittest.TestCase):
         ]
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(1, len(files))
+        self.assertEqual(1, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)
@@ -505,7 +505,7 @@ class Test_HDF_AGRI_L1_cal(unittest.TestCase):
         ]
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(1, len(files))
+        self.assertEqual(1, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)

--- a/satpy/tests/reader_tests/test_amsr2_l1b.py
+++ b/satpy/tests/reader_tests/test_amsr2_l1b.py
@@ -122,7 +122,7 @@ class TestAMSR2L1BReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'GW1AM2_201607201808_128A_L1DLBTBR_1110110.h5',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)
@@ -134,7 +134,7 @@ class TestAMSR2L1BReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'GW1AM2_201607201808_128A_L1DLBTBR_1110110.h5',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         ds = r.load([
             'btemp_10.7v',
@@ -168,7 +168,7 @@ class TestAMSR2L1BReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'GW1AM2_201607201808_128A_L1DLBTBR_1110110.h5',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         ds = r.load([
             'btemp_89.0av',

--- a/satpy/tests/reader_tests/test_amsr2_l2.py
+++ b/satpy/tests/reader_tests/test_amsr2_l2.py
@@ -93,7 +93,7 @@ class TestAMSR2L2Reader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'GW1AM2_202004160129_195B_L2SNSSWLB3300300.h5',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)
@@ -105,7 +105,7 @@ class TestAMSR2L2Reader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'GW1AM2_202004160129_195B_L2SNSSWLB3300300.h5',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         ds = r.load(['ssw'])
         self.assertEqual(len(ds), 1)

--- a/satpy/tests/reader_tests/test_clavrx.py
+++ b/satpy/tests/reader_tests/test_clavrx.py
@@ -129,7 +129,7 @@ class TestCLAVRXReaderPolar(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'clavrx_npp_d20170520_t2053581_e2055223_b28822.level2.hdf',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)
@@ -141,7 +141,7 @@ class TestCLAVRXReaderPolar(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'clavrx_npp_d20170520_t2053581_e2055223_b28822.level2.hdf',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)
@@ -319,7 +319,7 @@ class TestCLAVRXReaderGeo(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'clavrx_H08_20180806_1800.level2.hdf',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)

--- a/satpy/tests/reader_tests/test_geocat.py
+++ b/satpy/tests/reader_tests/test_geocat.py
@@ -129,7 +129,7 @@ class TestGEOCATReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'geocatL2.GOES-13.2015143.234500.nc',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)

--- a/satpy/tests/reader_tests/test_glm_l2.py
+++ b/satpy/tests/reader_tests/test_glm_l2.py
@@ -153,7 +153,7 @@ class TestGLML2Reader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'OR_GLM-L2-GLMC-M3_G16_s20192862159000_e20192862200000_c20192862200350.nc',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         self.reader = r
 

--- a/satpy/tests/reader_tests/test_gpm_imerg.py
+++ b/satpy/tests/reader_tests/test_gpm_imerg.py
@@ -114,7 +114,7 @@ class TestHdf5IMERG(unittest.TestCase):
 
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(1, len(files))
+        self.assertEqual(1, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)

--- a/satpy/tests/reader_tests/test_grib.py
+++ b/satpy/tests/reader_tests/test_grib.py
@@ -173,7 +173,7 @@ class TestGRIBReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'gfs.t18z.sfluxgrbf106.grib2',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)

--- a/satpy/tests/reader_tests/test_hy2_scat_l2b_h5.py
+++ b/satpy/tests/reader_tests/test_hy2_scat_l2b_h5.py
@@ -351,7 +351,7 @@ class TestHY2SCATL2BH5Reader(unittest.TestCase):
 
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(1, len(files))
+        self.assertEqual(1, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)
@@ -367,7 +367,7 @@ class TestHY2SCATL2BH5Reader(unittest.TestCase):
 
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(1, len(files))
+        self.assertEqual(1, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)
@@ -384,7 +384,7 @@ class TestHY2SCATL2BH5Reader(unittest.TestCase):
 
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(1, len(files))
+        self.assertEqual(1, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)
@@ -409,7 +409,7 @@ class TestHY2SCATL2BH5Reader(unittest.TestCase):
 
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(1, len(files))
+        self.assertEqual(1, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)

--- a/satpy/tests/reader_tests/test_mersi2_l1b.py
+++ b/satpy/tests/reader_tests/test_mersi2_l1b.py
@@ -263,7 +263,7 @@ class TestMERSI2L1BReader(unittest.TestCase):
         ]
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(4, len(files))
+        self.assertEqual(4, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)
@@ -326,7 +326,7 @@ class TestMERSI2L1BReader(unittest.TestCase):
         ]
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(4, len(files))
+        self.assertEqual(4, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)
@@ -381,7 +381,7 @@ class TestMERSI2L1BReader(unittest.TestCase):
         ]
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(4, len(files))
+        self.assertEqual(4, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)
@@ -417,7 +417,7 @@ class TestMERSI2L1BReader(unittest.TestCase):
         ]
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(4, len(files))
+        self.assertEqual(4, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)
@@ -478,7 +478,7 @@ class TestMERSI2L1BReader(unittest.TestCase):
         ]
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertTrue(4, len(files))
+        self.assertEqual(4, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)

--- a/satpy/tests/reader_tests/test_mersi2_l1b.py
+++ b/satpy/tests/reader_tests/test_mersi2_l1b.py
@@ -417,7 +417,7 @@ class TestMERSI2L1BReader(unittest.TestCase):
         ]
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertEqual(4, len(files))
+        self.assertEqual(2, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)
@@ -478,7 +478,7 @@ class TestMERSI2L1BReader(unittest.TestCase):
         ]
         reader = load_reader(self.reader_configs)
         files = reader.select_files_from_pathnames(filenames)
-        self.assertEqual(4, len(files))
+        self.assertEqual(2, len(files))
         reader.create_filehandlers(files)
         # Make sure we have some files
         self.assertTrue(reader.file_handlers)

--- a/satpy/tests/reader_tests/test_mimic_TPW2_nc.py
+++ b/satpy/tests/reader_tests/test_mimic_TPW2_nc.py
@@ -109,7 +109,7 @@ class TestMimicTPW2Reader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'comp20190619.130000.nc',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)

--- a/satpy/tests/reader_tests/test_nucaps.py
+++ b/satpy/tests/reader_tests/test_nucaps.py
@@ -173,7 +173,7 @@ class TestNUCAPSReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'NUCAPS-EDR_v1r0_npp_s201603011158009_e201603011158307_c201603011222270.nc',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)
@@ -359,7 +359,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'NUCAPS-sciEDR_am_npp_s20190703223319_e20190703223349_STC_fsr.nc',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -47,31 +47,31 @@ class TestNcNWCSAF(unittest.TestCase):
         """Test that the correct sensor name is being set"""
 
         self.scn.set_platform_and_sensor(platform_name='Metop-B')
-        self.assertTrue(self.scn.sensor, set(['avhrr-3']))
-        self.assertTrue(self.scn.sensor_names, set(['avhrr-3']))
+        self.assertEqual(self.scn.sensor, set(['avhrr-3']))
+        self.assertEqual(self.scn.sensor_names, set(['avhrr-3']))
 
         self.scn.set_platform_and_sensor(platform_name='NOAA-20')
-        self.assertTrue(self.scn.sensor, set(['viirs']))
-        self.assertTrue(self.scn.sensor_names, set(['viirs']))
+        self.assertEqual(self.scn.sensor, set(['viirs']))
+        self.assertEqual(self.scn.sensor_names, set(['viirs']))
 
         self.scn.set_platform_and_sensor(platform_name='Himawari-8')
-        self.assertTrue(self.scn.sensor, set(['ahi']))
-        self.assertTrue(self.scn.sensor_names, set(['ahi']))
+        self.assertEqual(self.scn.sensor, set(['ahi']))
+        self.assertEqual(self.scn.sensor_names, set(['ahi']))
 
         self.scn.set_platform_and_sensor(sat_id='GOES16')
-        self.assertTrue(self.scn.sensor, set(['abi']))
-        self.assertTrue(self.scn.sensor_names, set(['abi']))
+        self.assertEqual(self.scn.sensor, set(['abi']))
+        self.assertEqual(self.scn.sensor_names, set(['abi']))
 
         self.scn.set_platform_and_sensor(platform_name='GOES-17')
-        self.assertTrue(self.scn.sensor, set(['abi']))
-        self.assertTrue(self.scn.sensor_names, set(['abi']))
+        self.assertEqual(self.scn.sensor, set(['abi']))
+        self.assertEqual(self.scn.sensor_names, set(['abi']))
 
         self.scn.set_platform_and_sensor(sat_id='MSG4')
-        self.assertTrue(self.scn.sensor, set(['seviri']))
+        self.assertEqual(self.scn.sensor, set(['seviri']))
 
         self.scn.set_platform_and_sensor(platform_name='Meteosat-11')
-        self.assertTrue(self.scn.sensor, set(['seviri']))
-        self.assertTrue(self.scn.sensor_names, set(['seviri']))
+        self.assertEqual(self.scn.sensor, set(['seviri']))
+        self.assertEqual(self.scn.sensor_names, set(['seviri']))
 
     def test_get_projection(self):
         """Test generation of the navigation info."""

--- a/satpy/tests/reader_tests/test_seviri_l1b_icare.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_icare.py
@@ -106,7 +106,7 @@ class TestSEVIRIICAREReader(unittest.TestCase):
             'GEO_L1B-MSG1_2004-12-29T12-15-00_G_VIS08_V1-04.hdf',
             'GEO_L1B-MSG1_2004-12-29T12-15-00_G_IR108_V1-04.hdf'
         ])
-        self.assertTrue(len(loadables), 2)
+        self.assertEqual(len(loadables), 2)
         r.create_filehandlers(loadables)
         self.assertTrue(r.file_handlers)
 

--- a/satpy/tests/reader_tests/test_smos_l2_wind.py
+++ b/satpy/tests/reader_tests/test_smos_l2_wind.py
@@ -97,7 +97,7 @@ class TestSMOSL2WINDReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'SM_OPER_MIR_SCNFSW_20200420T021649_20200420T035013_110_001_7.nc',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)

--- a/satpy/tests/reader_tests/test_tropomi_l2.py
+++ b/satpy/tests/reader_tests/test_tropomi_l2.py
@@ -115,7 +115,7 @@ class TestTROPOMIL2Reader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'S5P_OFFL_L2__NO2____20180709T170334_20180709T184504_03821_01_010002_20180715T184729.nc',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -178,7 +178,7 @@ class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'AFMOD_j02_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.nc'
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         self.assertTrue(r.file_handlers)
 
@@ -235,7 +235,7 @@ class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'AFIMG_npp_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.nc'
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         self.assertTrue(r.file_handlers)
 
@@ -293,7 +293,7 @@ class TestModVIIRSActiveFiresText(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'AFEDR_j01_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.txt'
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         self.assertTrue(r.file_handlers)
 
@@ -349,7 +349,7 @@ class TestImgVIIRSActiveFiresText(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'AFIMG_npp_d20180829_t2015451_e2017093_b35434_c20180829210527716708_cspp_dev.txt'
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         self.assertTrue(r.file_handlers)
 

--- a/satpy/tests/reader_tests/test_viirs_edr_flood.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_flood.py
@@ -94,7 +94,7 @@ class TestVIIRSEDRFloodReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'WATER_VIIRS_Prj_SVI_npp_d20180824_t1828213_e1839433_b35361_cspp_dev_10_300_01.hdf'
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         self.assertTrue(r.file_handlers)
 

--- a/satpy/tests/reader_tests/test_viirs_l1b.py
+++ b/satpy/tests/reader_tests/test_viirs_l1b.py
@@ -155,7 +155,7 @@ class TestVIIRSL1BReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'VL1BM_snpp_d20161130_t012400_c20161130054822.nc',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -202,10 +202,10 @@ class TestVIIRSSDRReader(unittest.TestCase):
                         filter_parameters={
                             'start_time': datetime(2012, 2, 26)
                         })
-        loadables = r.select_files_from_pathnames([
+        fhs = r.create_filehandlers([
             'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
         ])
-        self.assertEqual(len(loadables), 0)
+        self.assertEqual(len(fhs), 0)
 
     def test_init_end_time_beyond(self):
         """Test basic init with end_time before the provided files."""
@@ -215,10 +215,10 @@ class TestVIIRSSDRReader(unittest.TestCase):
                         filter_parameters={
                             'end_time': datetime(2012, 2, 24)
                         })
-        loadables = r.select_files_from_pathnames([
+        fhs = r.create_filehandlers([
             'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
         ])
-        self.assertEqual(len(loadables), 0)
+        self.assertEqual(len(fhs), 0)
 
     def test_init_start_end_time(self):
         """Test basic init with end_time before the provided files."""

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -189,7 +189,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)
@@ -205,7 +205,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
         ])
-        self.assertTrue(len(loadables), 0)
+        self.assertEqual(len(loadables), 0)
 
     def test_init_end_time_beyond(self):
         """Test basic init with end_time before the provided files."""
@@ -218,7 +218,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
         ])
-        self.assertTrue(len(loadables), 0)
+        self.assertEqual(len(loadables), 0)
 
     def test_init_start_end_time(self):
         """Test basic init with end_time before the provided files."""
@@ -232,7 +232,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
         ])
-        self.assertTrue(len(loadables), 1)
+        self.assertEqual(len(loadables), 1)
         r.create_filehandlers(loadables)
         # make sure we have some files
         self.assertTrue(r.file_handlers)

--- a/satpy/tests/reader_tests/test_virr_l1b.py
+++ b/satpy/tests/reader_tests/test_virr_l1b.py
@@ -166,7 +166,7 @@ class TestVIRRL1BReader(unittest.TestCase):
         from satpy.readers import load_reader
         FY3B_reader = load_reader(self.reader_configs)
         FY3B_file = FY3B_reader.select_files_from_pathnames(['tf2018359214943.FY3B-L_VIRRX_L1B.HDF'])
-        self.assertTrue(1, len(FY3B_file))
+        self.assertEqual(1, len(FY3B_file))
         FY3B_reader.create_filehandlers(FY3B_file)
         # Make sure we have some files
         self.assertTrue(FY3B_reader.file_handlers)
@@ -178,7 +178,7 @@ class TestVIRRL1BReader(unittest.TestCase):
         FY3C_reader = load_reader(self.reader_configs)
         FY3C_files = FY3C_reader.select_files_from_pathnames(['tf2018359143912.FY3C-L_VIRRX_GEOXX.HDF',
                                                               'tf2018359143912.FY3C-L_VIRRX_L1B.HDF'])
-        self.assertTrue(2, len(FY3C_files))
+        self.assertEqual(2, len(FY3C_files))
         FY3C_reader.create_filehandlers(FY3C_files)
         # Make sure we have some files
         self.assertTrue(FY3C_reader.file_handlers)

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -134,7 +134,7 @@ class TestMultiScene(unittest.TestCase):
         ]
         with mock.patch('satpy.multiscene.Scene') as scn_mock:
             mscn = MultiScene.from_files(input_files, reader='abi_l1b')
-            self.assertTrue(len(mscn.scenes), 6)
+            self.assertEqual(len(mscn.scenes), 6)
             calls = [mock.call(filenames={'abi_l1b': [in_file]}) for in_file in input_files]
             scn_mock.assert_has_calls(calls)
 


### PR DESCRIPTION
Multiple places saw incorrect usage of ``self.assertTrue``, where clearly ``self.assertEqual`` was meant.  A test like ``self.assertTrue(4, len(scenes))`` is going to succeed regardless of the length of scenes.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1271 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
