### PR TITLE
Make loading of HRV channel in SEVIRI native reader dask-compliant

### DIFF
--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -443,7 +443,7 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
             data0 = dec10216(raw0.flatten())
             data0 = data0.reshape(shape_layer)
 
-            data = da.stack((data0, data1, data2), axis=1).reshape(shape)
+            data = np.stack((data0, data1, data2), axis=1).reshape(shape)
 
         xarr = xr.DataArray(data, dims=['y', 'x']).where(data != 0).astype(np.float32)
 

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -443,13 +443,7 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
             data0 = dec10216(raw0.flatten())
             data0 = data0.reshape(shape_layer)
 
-            data = np.zeros(shape)
-            idx = range(0, shape[0], 3)
-            data[idx, :] = data0
-            idx = range(1, shape[0], 3)
-            data[idx, :] = data1
-            idx = range(2, shape[0], 3)
-            data[idx, :] = data2
+            data = da.stack((data0, data1, data2), axis=1).reshape(shape)
 
         xarr = xr.DataArray(data, dims=['y', 'x']).where(data != 0).astype(np.float32)
 


### PR DESCRIPTION
This small PR makes the loading of the HRV channel in the `seviri_l1b_native` reader dask-compliant. The issue was observed in #1261 .

The previous implementation was using numpy arrays to perform the HRV lines interleaving, returning a numpy array in the array data. The new implementation replaces this with a horizontal stacking followed by a reshaping of the interleaving (dask) arrays. 

Quick check that the data is now a dask array:
```
from satpy.scene import Scene

scn_sev = Scene(filenames=[sev_filepath], reader='seviri_l1b_native')

scn_sev.load(['HRV'])
print(type(scn_sev['HRV'].data))

# old implementation prints: <class 'numpy.ndarray'>
# new implementation prints: <class 'dask.array.core.Array'>
```
A comparison of the data returned by the old and the new implementation using `np.equal()` yielded no difference, showing that the interleaving is still executed correctly.

Credits to @mraspaud for coming up with the idea of the stack&reshape. 
 - [x] Closes #1261 
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
