### PR TITLE
Add parallax correction modifier

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -862,21 +862,6 @@ class ParallaxCorrector(CompositeBase):
         # get the corrected lon and lat based on cloud top height (km)
         lat_corr, lon_corr = self._parallax_corr(optional_datasets, sat_lon, sat_lat, sat_h, lon, lat)
 
-        import matplotlib.pyplot as plt
-        f, axs = plt.subplots(nrows=1, ncols=2)
-
-        ax = axs[0]
-        m = ax.imshow(lon)
-        plt.colorbar(m, ax=ax, cmap='viridis', shrink=0.5)
-        ax.set_title('original lon')
-
-        ax = axs[1]
-        m = ax.imshow(np.rad2deg(lon_corr))
-        plt.colorbar(m, ax=ax, cmap='viridis', shrink=0.5)
-        ax.set_title('parallax_corrected lon')
-        f.savefig('lon_parallax.png')
-        print('-'*10)
-
         # get indices for the pixels for the original position
         (proj_x, proj_y) = band.attrs['area'].get_proj_coords()
         (x, y) = band.attrs['area'].get_xy_from_proj_coords(proj_x, proj_y)

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -769,13 +769,13 @@ class ParallaxCorrector(CompositeBase):
 
         # cartesian coordinates for the satellite
         # satlat_geod is the geodetic satellite latitude
-        sat_lat_geod = arctan(tan(sat_lat)*radius_ratio**2)
+        sat_lat_geod = arctan(tan(sat_lat)/radius_ratio**2)
         xsat = sat_h * cos(sat_lat_geod) * cos(sat_lon)
         ysat = sat_h * cos(sat_lat_geod) * sin(sat_lon)
         zsat = sat_h * sin(sat_lat_geod)
 
         # cartesian coordinates of the surface point
-        lat_geod = arctan(tan(lat)*radius_ratio**2)
+        lat_geod = arctan(tan(lat)/radius_ratio**2)
         radius_surf = sqrt(radius_eq**2*cos(lat_geod)**2 + radius_pole**2*sin(lat_geod)**2)
         xsurf = radius_surf * cos(lat_geod) * cos(lon)
         ysurf = radius_surf * cos(lat_geod) * sin(lon)
@@ -802,8 +802,8 @@ class ParallaxCorrector(CompositeBase):
 
         # convert back to latitude and longitude
         latcorr = arctan(zcorr/sqrt(xcorr**2 + ycorr**2))
-        latcorr = np.deg2rad(arctan(tan(latcorr)*radius_ratio**2))
-        loncorr = np.deg2rad(arctan2(ycorr, xcorr))
+        latcorr = np.rad2deg(arctan(tan(latcorr)*radius_ratio**2))
+        loncorr = np.rad2deg(arctan2(ycorr, xcorr))
 
         return latcorr, loncorr
 


### PR DESCRIPTION
This PR adds the **parallax correction** modifier which is useful for high/convective clouds.
This modifier needs the input of the IR channel L1 data and the cloud top height L2 data.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

