### PR TITLE
Fix nucaps reader failing when kwargs are passed

### DIFF
--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -68,6 +68,9 @@ class NUCAPSFileHandler(NetCDF4FileHandler):
 
     def __init__(self, *args, **kwargs):
         """Initialize file handler."""
+        # remove kwargs that reader instance used that file handler does not
+        kwargs.pop('mask_surface', None)
+        kwargs.pop('mask_quality', None)
         kwargs.setdefault('xarray_kwargs', {}).setdefault(
             'decode_times', False)
         super(NUCAPSFileHandler, self).__init__(*args, **kwargs)

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -31,14 +31,22 @@ except ImportError:
 class FakeNetCDF4FileHandler(NetCDF4FileHandler):
     """Swap-in NetCDF4 File Handler for reader tests to use."""
 
-    def __init__(self, filename, filename_info, filetype_info, **kwargs):
+    def __init__(self, filename, filename_info, filetype_info,
+                 auto_maskandscale=False, xarray_kwargs=None,
+                 cache_var_size=0, cache_handle=False, extra_file_content=None):
         """Get fake file content from 'get_test_content'."""
+        # unused kwargs from the real file handler
+        del auto_maskandscale
+        del xarray_kwargs
+        del cache_var_size
+        del cache_handle
         if NetCDF4FileHandler is object:
             raise ImportError("Base 'NetCDF4FileHandler' could not be "
                               "imported.")
         super(NetCDF4FileHandler, self).__init__(filename, filename_info, filetype_info)
         self.file_content = self.get_test_content(filename, filename_info, filetype_info)
-        self.file_content.update(kwargs)
+        if extra_file_content:
+            self.file_content.update(extra_file_content)
 
     def get_test_content(self, filename, filename_info, filetype_info):
         """Mimic reader input file content.

--- a/satpy/tests/reader_tests/test_nucaps.py
+++ b/satpy/tests/reader_tests/test_nucaps.py
@@ -178,6 +178,18 @@ class TestNUCAPSReader(unittest.TestCase):
         # make sure we have some files
         self.assertTrue(r.file_handlers)
 
+    def test_init_with_kwargs(self):
+        """Test basic init with extra parameters."""
+        from satpy.readers import load_reader
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'NUCAPS-EDR_v1r0_npp_s201603011158009_e201603011158307_c201603011222270.nc',
+        ])
+        self.assertEqual(len(loadables), 1)
+        r.create_filehandlers(loadables, fh_kwargs={'mask_surface': True})
+        # make sure we have some files
+        self.assertTrue(r.file_handlers)
+
     def test_load_nonpressure_based(self):
         """Test loading all channels that aren't based on pressure"""
         from satpy.readers import load_reader

--- a/satpy/tests/reader_tests/test_nucaps.py
+++ b/satpy/tests/reader_tests/test_nucaps.py
@@ -54,9 +54,10 @@ ALL_PRESSURE_LEVELS = np.repeat([ALL_PRESSURE_LEVELS], DEFAULT_PRES_FILE_SHAPE[0
 
 
 class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
-    """Swap-in NetCDF4 File Handler"""
+    """Swap-in NetCDF4 File Handler."""
+
     def get_test_content(self, filename, filename_info, filetype_info):
-        """Mimic reader input file content"""
+        """Mimic reader input file content."""
         file_content = {
             '/attr/time_coverage_start': filename_info['start_time'].strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
             '/attr/time_coverage_end': filename_info['end_time'].strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
@@ -149,11 +150,12 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
 
 
 class TestNUCAPSReader(unittest.TestCase):
-    """Test NUCAPS Reader"""
+    """Test NUCAPS Reader."""
+
     yaml_file = "nucaps.yaml"
 
     def setUp(self):
-        """Wrap NetCDF4 file handler with our own fake handler"""
+        """Wrap NetCDF4 file handler with our own fake handler."""
         from satpy.config import config_search_paths
         from satpy.readers.nucaps import NUCAPSFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
@@ -163,7 +165,7 @@ class TestNUCAPSReader(unittest.TestCase):
         self.p.is_local = True
 
     def tearDown(self):
-        """Stop wrapping the NetCDF4 file handler"""
+        """Stop wrapping the NetCDF4 file handler."""
         self.p.stop()
 
     def test_init(self):
@@ -181,17 +183,17 @@ class TestNUCAPSReader(unittest.TestCase):
     def test_init_with_kwargs(self):
         """Test basic init with extra parameters."""
         from satpy.readers import load_reader
-        r = load_reader(self.reader_configs)
+        r = load_reader(self.reader_configs, mask_surface=False)
         loadables = r.select_files_from_pathnames([
             'NUCAPS-EDR_v1r0_npp_s201603011158009_e201603011158307_c201603011222270.nc',
         ])
         self.assertEqual(len(loadables), 1)
-        r.create_filehandlers(loadables, fh_kwargs={'mask_surface': True})
+        r.create_filehandlers(loadables, fh_kwargs={'mask_surface': False})
         # make sure we have some files
         self.assertTrue(r.file_handlers)
 
     def test_load_nonpressure_based(self):
-        """Test loading all channels that aren't based on pressure"""
+        """Test loading all channels that aren't based on pressure."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -213,7 +215,7 @@ class TestNUCAPSReader(unittest.TestCase):
             self.assertEqual(v.attrs['sensor'], ['CrIS', 'ATMS', 'VIIRS'])
 
     def test_load_pressure_based(self):
-        """Test loading all channels based on pressure"""
+        """Test loading all channels based on pressure."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -246,7 +248,7 @@ class TestNUCAPSReader(unittest.TestCase):
             self.assertEqual(v.ndim, 2)
 
     def test_load_individual_pressure_levels_true(self):
-        """Test loading Temperature with individual pressure datasets"""
+        """Test loading Temperature with individual pressure datasets."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -259,7 +261,7 @@ class TestNUCAPSReader(unittest.TestCase):
             self.assertEqual(v.ndim, 1)
 
     def test_load_individual_pressure_levels_min_max(self):
-        """Test loading individual Temperature with min/max level specified"""
+        """Test loading individual Temperature with min/max level specified."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -272,7 +274,7 @@ class TestNUCAPSReader(unittest.TestCase):
             self.assertEqual(v.ndim, 1)
 
     def test_load_individual_pressure_levels_single(self):
-        """Test loading individual Temperature with specific levels"""
+        """Test loading individual Temperature with specific levels."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -285,7 +287,7 @@ class TestNUCAPSReader(unittest.TestCase):
             self.assertEqual(v.ndim, 1)
 
     def test_load_pressure_levels_true(self):
-        """Test loading Temperature with all pressure levels"""
+        """Test loading Temperature with all pressure levels."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -299,7 +301,7 @@ class TestNUCAPSReader(unittest.TestCase):
             self.assertTupleEqual(v.shape, DEFAULT_PRES_FILE_SHAPE)
 
     def test_load_pressure_levels_min_max(self):
-        """Test loading Temperature with min/max level specified"""
+        """Test loading Temperature with min/max level specified."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -314,7 +316,7 @@ class TestNUCAPSReader(unittest.TestCase):
                                   (DEFAULT_PRES_FILE_SHAPE[0], 6))
 
     def test_load_pressure_levels_single(self):
-        """Test loading a specific Temperature level"""
+        """Test loading a specific Temperature level."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -329,7 +331,7 @@ class TestNUCAPSReader(unittest.TestCase):
                                   (DEFAULT_PRES_FILE_SHAPE[0], 1))
 
     def test_load_pressure_levels_single_and_pressure_levels(self):
-        """Test loading a specific Temperature level and pressure levels"""
+        """Test loading a specific Temperature level and pressure levels."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -347,11 +349,12 @@ class TestNUCAPSReader(unittest.TestCase):
 
 
 class TestNUCAPSScienceEDRReader(unittest.TestCase):
-    """Test NUCAPS Science EDR Reader"""
+    """Test NUCAPS Science EDR Reader."""
+
     yaml_file = "nucaps.yaml"
 
     def setUp(self):
-        """Wrap NetCDF4 file handler with our own fake handler"""
+        """Wrap NetCDF4 file handler with our own fake handler."""
         from satpy.config import config_search_paths
         from satpy.readers.nucaps import NUCAPSFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
@@ -361,7 +364,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
         self.p.is_local = True
 
     def tearDown(self):
-        """Stop wrapping the NetCDF4 file handler"""
+        """Stop wrapping the NetCDF4 file handler."""
         self.p.stop()
 
     def test_init(self):
@@ -377,7 +380,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
         self.assertTrue(r.file_handlers)
 
     def test_load_nonpressure_based(self):
-        """Test loading all channels that aren't based on pressure"""
+        """Test loading all channels that aren't based on pressure."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -396,7 +399,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
             self.assertEqual(v.attrs['sensor'], ['CrIS', 'ATMS', 'VIIRS'])
 
     def test_load_pressure_based(self):
-        """Test loading all channels based on pressure"""
+        """Test loading all channels based on pressure."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -426,7 +429,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
             self.assertEqual(v.ndim, 2)
 
     def test_load_individual_pressure_levels_true(self):
-        """Test loading Temperature with individual pressure datasets"""
+        """Test loading Temperature with individual pressure datasets."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -439,7 +442,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
             self.assertEqual(v.ndim, 1)
 
     def test_load_individual_pressure_levels_min_max(self):
-        """Test loading individual Temperature with min/max level specified"""
+        """Test loading individual Temperature with min/max level specified."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -452,7 +455,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
             self.assertEqual(v.ndim, 1)
 
     def test_load_individual_pressure_levels_single(self):
-        """Test loading individual Temperature with specific levels"""
+        """Test loading individual Temperature with specific levels."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -465,7 +468,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
             self.assertEqual(v.ndim, 1)
 
     def test_load_pressure_levels_true(self):
-        """Test loading Temperature with all pressure levels"""
+        """Test loading Temperature with all pressure levels."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -479,7 +482,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
             self.assertTupleEqual(v.shape, DEFAULT_PRES_FILE_SHAPE)
 
     def test_load_pressure_levels_min_max(self):
-        """Test loading Temperature with min/max level specified"""
+        """Test loading Temperature with min/max level specified."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -494,7 +497,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
                                   (DEFAULT_PRES_FILE_SHAPE[0], 6))
 
     def test_load_pressure_levels_single(self):
-        """Test loading a specific Temperature level"""
+        """Test loading a specific Temperature level."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -509,7 +512,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
                                   (DEFAULT_PRES_FILE_SHAPE[0], 1))
 
     def test_load_pressure_levels_single_and_pressure_levels(self):
-        """Test loading a specific Temperature level and pressure levels"""
+        """Test loading a specific Temperature level and pressure levels."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([


### PR DESCRIPTION
Polar2Grid can't use the nucaps reader with semi-recent versions of Satpy because it always passes the mask_surface and mask_quality flags to the readers and the file handler blindly passed them on to its base classes. Instead, these were supposed to be provided to the reader and ignored by the file handler.

I think this is a good example of how the tests are maybe a little too low-level and should be using higher level interfaces for testing (creating readers).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

