### PR TITLE
Refactor the combine_metadata function and allow numpy arrays to be combined

### DIFF
--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -160,16 +160,22 @@ def _all_arrays_equal(arrays):
 
     If the arrays are lazy, just check if they have the same identity.
     """
-    result = reduce(nan_allclose, arrays)
-    if hasattr(result, 'compute'):
+    if hasattr(arrays[0], 'compute'):
         return _all_identical(arrays)
     else:
-        return result
+        return _pairwise_all(nan_allclose, arrays)
+
+
+def _pairwise_all(func, values):
+    for value in values[1:]:
+        if not func(values[0], value):
+            return False
+    return True
 
 
 def _all_identical(values):
     """Check that the identities of all values are the same."""
-    return reduce(is_, values)
+    return _pairwise_all(is_, values)
 
 
 def _contain_collections_of_arrays(values):
@@ -197,9 +203,9 @@ def _all_list_of_arrays_equal(array_lists):
 
 def _all_values_equal(values):
     try:
-        return reduce(nan_allclose, values)
+        return _pairwise_all(nan_allclose, values)
     except TypeError:
-        return reduce(eq, values)
+        return _pairwise_all(eq, values)
 
 
 def get_keys_from_config(common_id_keys, config):

--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -95,13 +95,8 @@ def _get_valid_dicts(metadata_objects):
 
 
 def _shared_keys(info_dicts):
-    shared_keys = None
-    for metadata_dict in info_dicts:
-        if shared_keys is None:
-            shared_keys = set(metadata_dict.keys())
-        else:
-            shared_keys &= set(metadata_dict.keys())
-    return shared_keys
+    key_sets = (set(metadata_dict.keys()) for metadata_dict in info_dicts)
+    return reduce(set.intersection, key_sets)
 
 
 def _combined_shared_info(shared_keys, info_dicts, average_times):

--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -80,8 +80,8 @@ def combine_metadata(*metadata_objects, average_times=True):
 
 
 def _get_valid_dicts(metadata_objects):
+    """Get the valid dictionaries matching the metadata_objects."""
     info_dicts = []
-    # grab all of the dictionary objects provided and make a set of the shared keys
     for metadata_object in metadata_objects:
         if isinstance(metadata_object, dict):
             metadata_dict = metadata_object
@@ -194,9 +194,9 @@ def _is_all_arrays(value):
     return all([_is_array(sub_value) for sub_value in value])
 
 
-def _all_list_of_arrays_equal(values):
-    """Check that the list of arrays are equal."""
-    for array_list in zip(*values):
+def _all_list_of_arrays_equal(array_lists):
+    """Check that the lists of arrays are equal."""
+    for array_list in zip(*array_lists):
         if not _all_arrays_equal(array_list):
             return False
     return True

--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -77,7 +77,7 @@ def combine_metadata(*metadata_objects, average_times=True):
 
     shared_keys = _shared_keys(info_dicts)
 
-    return _combined_shared_info(shared_keys, info_dicts, average_times)
+    return _combine_shared_info(shared_keys, info_dicts, average_times)
 
 
 def _get_valid_dicts(metadata_objects):
@@ -99,7 +99,7 @@ def _shared_keys(info_dicts):
     return reduce(set.intersection, key_sets)
 
 
-def _combined_shared_info(shared_keys, info_dicts, average_times):
+def _combine_shared_info(shared_keys, info_dicts, average_times):
     shared_info = {}
     for key in shared_keys:
         values = [info[key] for info in info_dicts]

--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -59,7 +59,7 @@ def combine_metadata(*metadata_objects, average_times=True):
     the returned dictionary.  By default any keys with the word 'time'
     in them and consisting of datetime objects will be averaged. This
     is to handle cases where data were observed at almost the same time
-    but not exactly.  In the interest of time, arrays are compared by
+    but not exactly.  In the interest of time, lazy arrays are compared by
     object identity rather than by their contents.
 
     Args:

--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -27,7 +27,7 @@ from copy import copy, deepcopy
 from datetime import datetime
 from enum import IntEnum, Enum
 from functools import reduce, partial
-from operator import is_
+from operator import is_, eq
 
 import numpy as np
 
@@ -199,7 +199,7 @@ def _all_values_equal(values):
     try:
         return reduce(nan_allclose, values)
     except TypeError:
-        return all(val == values[0] for val in values[1:])
+        return reduce(eq, values)
 
 
 def get_keys_from_config(common_id_keys, config):

--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -27,6 +27,7 @@ from copy import copy, deepcopy
 from datetime import datetime
 from enum import IntEnum, Enum
 from functools import reduce, partial
+from operator import is_
 
 import numpy as np
 
@@ -173,10 +174,7 @@ def _all_arrays_equal(arrays):
 
 def _all_identical(values):
     """Check that the identities of all values are the same."""
-    for val in values[1:]:
-        if val is not values[0]:
-            return False
-    return True
+    return reduce(is_, values)
 
 
 def _contains_collections_of_arrays(values):

--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -130,9 +130,9 @@ def average_datetimes(datetime_list):
 
 def _are_values_combinable(values):
     """Check if the *values* can be combined."""
-    if _contains_arrays(values):
+    if _contain_arrays(values):
         return _all_arrays_equal(values)
-    elif _contains_collections_of_arrays(values):
+    elif _contain_collections_of_arrays(values):
         # in the real world, the `ancillary_variables` attribute may be
         # List[xarray.DataArray], this means our values are now
         # List[List[xarray.DataArray]].
@@ -143,7 +143,7 @@ def _are_values_combinable(values):
     return _all_values_equal(values)
 
 
-def _contains_arrays(values):
+def _contain_arrays(values):
     return any([_is_array(value) for value in values])
 
 
@@ -172,7 +172,7 @@ def _all_identical(values):
     return reduce(is_, values)
 
 
-def _contains_collections_of_arrays(values):
+def _contain_collections_of_arrays(values):
     return any(
         [_is_non_empty_collection(value) and
          _is_all_arrays(value)

--- a/satpy/tests/test_dataset.py
+++ b/satpy/tests/test_dataset.py
@@ -167,6 +167,7 @@ class TestCombineMetadata(unittest.TestCase):
         """Test combining values that are numpy arrays."""
         from satpy.dataset import combine_metadata
         test_metadata = [{'valid_range': np.array([0., 0.00032], dtype=np.float32)},
+                         {'valid_range': np.array([0., 0.00032], dtype=np.float32)},
                          {'valid_range': np.array([0., 0.00032], dtype=np.float32)}]
         result = combine_metadata(*test_metadata)
         assert np.allclose(result['valid_range'], np.array([0., 0.00032], dtype=np.float32))

--- a/satpy/tests/test_dataset.py
+++ b/satpy/tests/test_dataset.py
@@ -73,6 +73,16 @@ class TestDataID(unittest.TestCase):
 class TestCombineMetadata(unittest.TestCase):
     """Test how metadata is combined."""
 
+    def setUp(self):
+        """Set up the test case."""
+        self.datetime_dts = (
+            {'start_time': datetime(2018, 2, 1, 11, 58, 0)},
+            {'start_time': datetime(2018, 2, 1, 11, 59, 0)},
+            {'start_time': datetime(2018, 2, 1, 12, 0, 0)},
+            {'start_time': datetime(2018, 2, 1, 12, 1, 0)},
+            {'start_time': datetime(2018, 2, 1, 12, 2, 0)},
+        )
+
     def test_average_datetimes(self):
         """Test the average_datetimes helper function."""
         from satpy.dataset import average_datetimes
@@ -86,19 +96,16 @@ class TestCombineMetadata(unittest.TestCase):
         ret = average_datetimes(dts)
         self.assertEqual(dts[2], ret)
 
-    def test_combine_times(self):
-        """Test the combine_metadata with times."""
+    def test_combine_times_with_averaging(self):
+        """Test the combine_metadata with times with averaging."""
         from satpy.dataset import combine_metadata
-        dts = (
-            {'start_time': datetime(2018, 2, 1, 11, 58, 0)},
-            {'start_time': datetime(2018, 2, 1, 11, 59, 0)},
-            {'start_time': datetime(2018, 2, 1, 12, 0, 0)},
-            {'start_time': datetime(2018, 2, 1, 12, 1, 0)},
-            {'start_time': datetime(2018, 2, 1, 12, 2, 0)},
-        )
-        ret = combine_metadata(*dts)
-        self.assertEqual(dts[2]['start_time'], ret['start_time'])
-        ret = combine_metadata(*dts, average_times=False)
+        ret = combine_metadata(*self.datetime_dts)
+        self.assertEqual(self.datetime_dts[2]['start_time'], ret['start_time'])
+
+    def test_combine_times_without_averaging(self):
+        """Test the combine_metadata with times without averaging."""
+        from satpy.dataset import combine_metadata
+        ret = combine_metadata(*self.datetime_dts, average_times=False)
         # times are not equal so don't include it in the final result
         self.assertNotIn('start_time', ret)
 
@@ -149,6 +156,94 @@ class TestCombineMetadata(unittest.TestCase):
         from satpy.dataset import combine_metadata
         test_metadata = [{}, {}]
         assert combine_metadata(*test_metadata) == {}
+
+    def test_combine_nans(self):
+        """Test combining nan fill values."""
+        from satpy.dataset import combine_metadata
+        test_metadata = [{'_FillValue': np.nan}, {'_FillValue': np.nan}]
+        assert combine_metadata(*test_metadata) == {'_FillValue': np.nan}
+
+    def test_combine_numpy_arrays(self):
+        """Test combining values that are numpy arrays."""
+        from satpy.dataset import combine_metadata
+        test_metadata = [{'valid_range': np.array([0., 0.00032], dtype=np.float32)},
+                         {'valid_range': np.array([0., 0.00032], dtype=np.float32)}]
+        result = combine_metadata(*test_metadata)
+        assert np.allclose(result['valid_range'], np.array([0., 0.00032], dtype=np.float32))
+
+    def test_combine_dask_arrays(self):
+        """Test combining values that are dask arrays."""
+        from satpy.dataset import combine_metadata
+        import dask.array as da
+        test_metadata = [{'valid_range': da.from_array(np.array([0., 0.00032], dtype=np.float32))},
+                         {'valid_range': da.from_array(np.array([0., 0.00032], dtype=np.float32))}]
+        result = combine_metadata(*test_metadata)
+        assert 'valid_range' not in result
+
+    def test_combine_real_world_mda(self):
+        """Test with real data."""
+        mda_objects = ({'_FillValue': np.nan,
+                        'valid_range': np.array([0., 0.00032], dtype=np.float32),
+                        'ancillary_variables': ['cpp_status_flag',
+                                                'cpp_conditions',
+                                                'cpp_quality',
+                                                'cpp_reff_pal',
+                                                '-'],
+                        'platform_name': 'NOAA-20',
+                        'sensor': {'viirs'}},
+                       {'_FillValue': np.nan,
+                        'valid_range': np.array([0., 0.00032], dtype=np.float32),
+                        'ancillary_variables': ['cpp_status_flag',
+                                                'cpp_conditions',
+                                                'cpp_quality',
+                                                'cpp_reff_pal',
+                                                '-'],
+                        'platform_name': 'NOAA-20',
+                        'sensor': {'viirs'}})
+
+        expected = {'_FillValue': np.nan,
+                    'valid_range': np.array([0., 0.00032], dtype=np.float32),
+                    'ancillary_variables': ['cpp_status_flag',
+                                            'cpp_conditions',
+                                            'cpp_quality',
+                                            'cpp_reff_pal',
+                                            '-'],
+                    'platform_name': 'NOAA-20',
+                    'sensor': {'viirs'}}
+
+        from satpy.dataset import combine_metadata
+        result = combine_metadata(*mda_objects)
+        assert np.allclose(result.pop('_FillValue'), expected.pop('_FillValue'), equal_nan=True)
+        assert np.allclose(result.pop('valid_range'), expected.pop('valid_range'))
+        assert result == expected
+
+    def test_combine_one_metadata_object(self):
+        """Test with real data."""
+        mda_objects = ({'_FillValue': np.nan,
+                        'valid_range': np.array([0., 0.00032], dtype=np.float32),
+                        'ancillary_variables': ['cpp_status_flag',
+                                                'cpp_conditions',
+                                                'cpp_quality',
+                                                'cpp_reff_pal',
+                                                '-'],
+                        'platform_name': 'NOAA-20',
+                        'sensor': {'viirs'}},)
+
+        expected = {'_FillValue': np.nan,
+                    'valid_range': np.array([0., 0.00032], dtype=np.float32),
+                    'ancillary_variables': ['cpp_status_flag',
+                                            'cpp_conditions',
+                                            'cpp_quality',
+                                            'cpp_reff_pal',
+                                            '-'],
+                    'platform_name': 'NOAA-20',
+                    'sensor': {'viirs'}}
+
+        from satpy.dataset import combine_metadata
+        result = combine_metadata(*mda_objects)
+        assert np.allclose(result.pop('_FillValue'), expected.pop('_FillValue'), equal_nan=True)
+        assert np.allclose(result.pop('valid_range'), expected.pop('valid_range'))
+        assert result == expected
 
 
 def test_dataid():

--- a/satpy/tests/test_dataset.py
+++ b/satpy/tests/test_dataset.py
@@ -218,7 +218,7 @@ class TestCombineMetadata(unittest.TestCase):
         assert result == expected
 
     def test_combine_one_metadata_object(self):
-        """Test with real data."""
+        """Test combining one metadata object."""
         mda_objects = ({'_FillValue': np.nan,
                         'valid_range': np.array([0., 0.00032], dtype=np.float32),
                         'ancillary_variables': ['cpp_status_flag',


### PR DESCRIPTION
The `valid_range` array was not being combined properly because each dataarray had it's own copy of it. This refactor changes the behaviour of `combine_metadata` to just check the identities of lazy arrays, and use np.allclose otherwise.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

