### PR TITLE
Add pad_data functionality to FCI L1c FDHSI reader

### DIFF
--- a/satpy/etc/readers/fci_l1c_fdhsi.yaml
+++ b/satpy/etc/readers/fci_l1c_fdhsi.yaml
@@ -6,7 +6,7 @@ reader:
     Reader for FCI FDSHI data in NetCDF4 format.
     Used to read Meteosat Third Generation (MTG) Flexible
     Combined Imager (FCI) Full Disk High Spectral Imagery (FDHSI) data.
-  reader: !!python/name:satpy.readers.yaml_reader.GEOFlippableFileYAMLReader
+  reader: !!python/name:satpy.readers.yaml_reader.GEOSegmentYAMLReader
   sensors: [fci]
 
 datasets:
@@ -379,12 +379,12 @@ datasets:
     resolution: 2000
     file_type: fci_l1c_fdhsi
 
-# Source: FCI L1 Dataset User Guide [FCIL1DUG]
-# ftp://ftp.eumetsat.int/pub/OPS/out/test-data/FCI_L1C_Format_Familiarisation/FCI_L1_Dataset_User_Guide_[FCIL1DUG].pdf
+# Source: MTG FCI L1 Product User Guide [FCIL1PUG]
+# ftp://ftp.eumetsat.int/pub/OPS/out/test-data/Test-data-for-External-Users/MTG/MTG_FCI_L1C_Enhanced_and_Non-Nominal_Test_Data/PDF_MTG_FCI_L1_PUG.pdf
 # and Example Products for Pytroll Workshop Package Description,
 # EUM/MTG/DOC/19/1079228
 file_types:
   fci_l1c_fdhsi:
     file_reader: !!python/name:satpy.readers.fci_l1c_fdhsi.FCIFDHSIFileHandler ''
-    file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_level}-{type}-{subtype}-{coverage}-{subsetting}-{component1}-BODY-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc']
-    expected_segments: 70
+    file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_level}-{type}-{subtype}-{coverage}-{subsetting}-{component1}-BODY-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc']
+    expected_segments: 40

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -259,7 +259,7 @@ class AbstractYAMLReader(metaclass=ABCMeta):
                 if val_type is not None and issubclass(val_type, tuple):
                     # special case: wavelength can be [min, nominal, max]
                     # but is still considered 1 option
-                    id_kwargs.append((val, ))
+                    id_kwargs.append((val,))
                 elif isinstance(val, (list, tuple, set)):
                     # this key has multiple choices
                     # (ex. 250 meter, 500 meter, 1000 meter resolutions)
@@ -1081,6 +1081,9 @@ class GEOSegmentYAMLReader(GEOFlippableFileYAMLReader):
                 ts = fh.filename_info.get('total_segments', 1)
                 # if the YAML has segments explicitly specified then use that
                 fh.filetype_info.setdefault('expected_segments', ts)
+                # add segment key-values for FCI filehandlers
+                if 'segment' not in fh.filename_info:
+                    fh.filename_info['segment'] = fh.filename_info.get('count_in_repeat_cycle', 1)
         return created_fhs
 
     @staticmethod
@@ -1097,13 +1100,28 @@ class GEOSegmentYAMLReader(GEOFlippableFileYAMLReader):
             raise KeyError(
                 "Could not load {} from any provided files".format(dsid))
 
+        padding_fci_scene = file_handlers[0].filetype_info.get('file_type') == 'fci_l1c_fdhsi'
+
         empty_segment = xr.full_like(projectable, np.nan)
         for i, sli in enumerate(slice_list):
             if sli is None:
-                slice_list[i] = empty_segment
+                if padding_fci_scene:
+                    slice_list[i] = _get_empty_segment_with_height(empty_segment,
+                                                                   _get_FCI_L1c_FDHSI_chunk_height(
+                                                                       empty_segment.shape[1], i + 1),
+                                                                   dim=dim)
+                else:
+                    slice_list[i] = empty_segment
 
         while expected_segments > counter:
-            slice_list.append(empty_segment)
+            if padding_fci_scene:
+                slice_list.append(_get_empty_segment_with_height(empty_segment,
+                                                                 _get_FCI_L1c_FDHSI_chunk_height(
+                                                                     empty_segment.shape[1], counter + 1),
+                                                                 dim=dim))
+            else:
+                slice_list.append(empty_segment)
+
             counter += 1
 
         if dim not in slice_list[0].dims:
@@ -1156,6 +1174,8 @@ def _pad_later_segments_area(file_handlers, dsid):
     available_segments = [int(fh.filename_info.get('segment', 1)) for
                           fh in file_handlers]
     area_defs = {}
+    padding_fci_scene = file_handlers[0].filetype_info.get('file_type') == 'fci_l1c_fdhsi'
+
     for segment in range(available_segments[0], expected_segments + 1):
         try:
             idx = available_segments.index(segment)
@@ -1163,13 +1183,15 @@ def _pad_later_segments_area(file_handlers, dsid):
             area = fh.get_area_def(dsid)
         except ValueError:
             logger.debug("Padding to full disk with segment nr. %d", segment)
-            ext_diff = area.area_extent[1] - area.area_extent[3]
-            new_ll_y = area.area_extent[1] + ext_diff
+
+            new_height_proj_coord, new_height_px = _get_new_area_extent_heights(area, seg_size, segment,
+                                                                                padding_fci_scene)
+            new_ll_y = area.area_extent[1] + new_height_proj_coord
             new_ur_y = area.area_extent[1]
             fill_extent = (area.area_extent[0], new_ll_y,
                            area.area_extent[2], new_ur_y)
             area = AreaDefinition('fill', 'fill', 'fill', area.proj_dict,
-                                  seg_size[1], seg_size[0],
+                                  seg_size[1], new_height_px,
                                   fill_extent)
 
         area_defs[segment] = area
@@ -1185,17 +1207,20 @@ def _pad_earlier_segments_area(file_handlers, dsid, area_defs):
     area = file_handlers[0].get_area_def(dsid)
     seg_size = area.shape
     proj_dict = area.proj_dict
+    padding_fci_scene = file_handlers[0].filetype_info.get('file_type') == 'fci_l1c_fdhsi'
+
     for segment in range(available_segments[0] - 1, 0, -1):
         logger.debug("Padding segment %d to full disk.",
                      segment)
-        ext_diff = area.area_extent[1] - area.area_extent[3]
+
+        new_height_proj_coord, new_height_px = _get_new_area_extent_heights(area, seg_size, segment, padding_fci_scene)
         new_ll_y = area.area_extent[3]
-        new_ur_y = area.area_extent[3] - ext_diff
+        new_ur_y = area.area_extent[3] - new_height_proj_coord
         fill_extent = (area.area_extent[0], new_ll_y,
                        area.area_extent[2], new_ur_y)
         area = AreaDefinition('fill', 'fill', 'fill',
                               proj_dict,
-                              seg_size[1], seg_size[0],
+                              seg_size[1], new_height_px,
                               fill_extent)
         area_defs[segment] = area
         seg_size = area.shape
@@ -1235,3 +1260,47 @@ def _find_missing_segments(file_handlers, ds_info, dsid):
         slice_list.append(None)
 
     return counter, expected_segments, slice_list, failure, projectable
+
+
+def _get_new_area_extent_heights(previous_area, previous_seg_size, segment_n, padding_fci_scene):
+    """Get the area extent heights in meters (projection coordinates) and pixels."""
+    if padding_fci_scene:
+        new_height_px = _get_FCI_L1c_FDHSI_chunk_height(previous_seg_size[1], segment_n)
+        new_height_proj_coord = (previous_area.area_extent[1] - previous_area.area_extent[3]) * new_height_px / \
+            previous_seg_size[0]
+    else:
+        new_height_px = previous_seg_size[0]
+        new_height_proj_coord = previous_area.area_extent[1] - previous_area.area_extent[3]
+    return new_height_proj_coord, new_height_px
+
+
+def _get_empty_segment_with_height(empty_segment, new_height, dim):
+    """Get a new empty segment with the specified height."""
+    if empty_segment.shape[0] > new_height:
+        # if current empty segment is too tall, slice the DataArray
+        return empty_segment[:new_height, :]
+    elif empty_segment.shape[0] < new_height:
+        # if current empty segment is too short, concatenate a slice of the DataArray
+        return xr.concat([empty_segment, empty_segment[:new_height - empty_segment.shape[0], :]], dim=dim)
+    else:
+        return empty_segment
+
+
+def _get_FCI_L1c_FDHSI_chunk_height(chunk_width, chunk_n):
+    """Get the height in pixels of a FCI L1c FDHSI chunk given the chunk width and number (starting from 1)."""
+    if chunk_width == 11136:
+        # 1km resolution case
+        if chunk_n in [3, 5, 8, 10, 13, 15, 18, 20, 23, 25, 28, 30, 33, 35, 38, 40]:
+            chunk_height = 279
+        else:
+            chunk_height = 278
+    elif chunk_width == 5568:
+        # 2km resolution case
+        if chunk_n in [5, 10, 15, 20, 25, 30, 35, 40]:
+            chunk_height = 140
+        else:
+            chunk_height = 139
+    else:
+        raise ValueError("FCI L1c FDHSI chunk width not recognized. Must be either 5568 or 11136.")
+
+    return chunk_height

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -313,7 +313,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
         reader.create_filehandlers(loadables)
         res = reader.load(
                 [make_dataid(name=name, calibration="counts") for name in
-                    self._chans["solar"] + self._chans["terran"]])
+                    self._chans["solar"] + self._chans["terran"]], pad_data=False)
         assert 16 == len(res)
         for ch in self._chans["solar"] + self._chans["terran"]:
             assert res[ch].shape == (200*2, 11136)
@@ -342,7 +342,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
         reader.create_filehandlers(loadables)
         res = reader.load(
                 [make_dataid(name=name, calibration="radiance") for name in
-                    self._chans["solar"] + self._chans["terran"]])
+                    self._chans["solar"] + self._chans["terran"]], pad_data=False)
         assert 16 == len(res)
         for ch in self._chans["solar"] + self._chans["terran"]:
             assert res[ch].shape == (200, 11136)
@@ -371,7 +371,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
         reader.create_filehandlers(loadables)
         res = reader.load(
                 [make_dataid(name=name, calibration="reflectance") for name in
-                    self._chans["solar"]])
+                    self._chans["solar"]], pad_data=False)
         assert 8 == len(res)
         for ch in self._chans["solar"]:
             assert res[ch].shape == (200, 11136)
@@ -396,7 +396,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
         with caplog.at_level(logging.WARNING):
             res = reader.load(
                     [make_dataid(name=name, calibration="brightness_temperature") for
-                        name in self._chans["terran"]])
+                        name in self._chans["terran"]], pad_data=False)
             assert caplog.text == ""
         for ch in self._chans["terran"]:
             assert res[ch].shape == (200, 11136)
@@ -435,7 +435,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
         reader = load_reader(reader_configs)
         loadables = reader.select_files_from_pathnames(filenames)
         reader.create_filehandlers(loadables)
-        res = reader.load(["ir_123_pixel_quality"])
+        res = reader.load(["ir_123_pixel_quality"], pad_data=False)
         assert res["ir_123_pixel_quality"].attrs["name"] == "ir_123_pixel_quality"
 
     def test_platform_name(self, reader_configs):
@@ -455,7 +455,7 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
         reader = load_reader(reader_configs)
         loadables = reader.select_files_from_pathnames(filenames)
         reader.create_filehandlers(loadables)
-        res = reader.load(["ir_123"])
+        res = reader.load(["ir_123"], pad_data=False)
         assert res["ir_123"].attrs["platform_name"] == "MTG-I1"
 
     def test_excs(self, reader_configs):
@@ -506,7 +506,7 @@ class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):
         with caplog.at_level("ERROR"):
             reader.load([make_dataid(
                     name="ir_123",
-                    calibration="brightness_temperature")])
+                    calibration="brightness_temperature")], pad_data=False)
             assert "cannot produce brightness temperature" in caplog.text
 
     def test_handling_bad_data_vis(self, reader_configs, caplog):
@@ -526,5 +526,5 @@ class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):
         with caplog.at_level("ERROR"):
             reader.load([make_dataid(
                     name="vis_04",
-                    calibration="reflectance")])
+                    calibration="reflectance")], pad_data=False)
             assert "cannot produce reflectance" in caplog.text

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -562,7 +562,7 @@ class TestFileFileYAMLReaderMultipleFileTypes(unittest.TestCase):
             # need to copy this because the dataset infos will be modified
             _orig_ids = {key: val.copy() for key, val in orig_ids.items()}
             with patch.dict(self.reader.all_ids, _orig_ids, clear=True), \
-                 patch.dict(self.reader.available_ids, {}, clear=True):
+                    patch.dict(self.reader.available_ids, {}, clear=True):
                 # Add a file handler with resolution property
                 fh = MagicMock(filetype_info={'file_type': ftype},
                                resolution=resol)

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -751,12 +751,13 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
     def test_get_expected_segments(self, cfh):
         """Test that expected segments can come from the filename."""
         from satpy.readers.yaml_reader import GEOSegmentYAMLReader
+        reader = GEOSegmentYAMLReader()
 
         fake_fh = MagicMock()
         fake_fh.filename_info = {}
         fake_fh.filetype_info = {}
         cfh.return_value = {'ft1': [fake_fh]}
-        reader = GEOSegmentYAMLReader()
+
         # default (1)
         created_fhs = reader.create_filehandlers(['fake.nc'])
         es = created_fhs['ft1'][0].filetype_info['expected_segments']
@@ -783,14 +784,22 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         es = created_fhs['ft1'][0].filetype_info['expected_segments']
         self.assertEqual(es, 3)
 
+        # check correct FCI chunk number reading into segment
+        fake_fh.filename_info = {'count_in_repeat_cycle': 5}
+        created_fhs = reader.create_filehandlers(['fake.nc'])
+        es = created_fhs['ft1'][0].filename_info['segment']
+        self.assertEqual(es, 5)
+
     @patch.object(yr.FileYAMLReader, "__init__", lambda x: None)
+    @patch('satpy.readers.yaml_reader._get_empty_segment_with_height')
     @patch('satpy.readers.yaml_reader.FileYAMLReader._load_dataset')
     @patch('satpy.readers.yaml_reader.xr')
     @patch('satpy.readers.yaml_reader._find_missing_segments')
-    def test_load_dataset(self, mss, xr, parent_load_dataset):
+    def test_load_dataset(self, mss, xr, parent_load_dataset, geswh):
         """Test _load_dataset()."""
         from satpy.readers.yaml_reader import GEOSegmentYAMLReader
         reader = GEOSegmentYAMLReader()
+
         # Projectable is None
         mss.return_value = [0, 0, 0, False, None]
         with self.assertRaises(KeyError):
@@ -869,11 +878,49 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         self.assertTrue(slice_list[0] is empty_segment)
         self.assertTrue(slice_list[1] is empty_segment)
 
+        # Check that new FCI empty segment is generated if missing in the middle and at the end
+        fake_fh = MagicMock()
+        fake_fh.filename_info = {}
+        fake_fh.filetype_info = {'file_type': 'fci_l1c_fdhsi'}
+        empty_segment.shape = (140, 5568)
+        slice_list[4] = None
+        counter = 7
+        mss.return_value = (counter, expected_segments, slice_list,
+                            failure, projectable)
+        res = reader._load_dataset(dataid, ds_info, [fake_fh])
+        assert 2 == geswh.call_count
+
         # Disable padding
         res = reader._load_dataset(dataid, ds_info, file_handlers,
                                    pad_data=False)
         parent_load_dataset.assert_called_once_with(dataid, ds_info,
                                                     file_handlers)
+
+    def test_get_empty_segment_with_height(self):
+        """Test _get_empty_segment_with_height()."""
+        import xarray as xr
+        import numpy as np
+        from satpy.readers.yaml_reader import _get_empty_segment_with_height as geswh
+
+        dim = 'y'
+
+        # check expansion of empty segment
+        empty_segment = xr.DataArray(np.ones((139, 5568)), dims=['y', 'x'])
+        new_height = 140
+        new_empty_segment = geswh(empty_segment, new_height, dim)
+        assert new_empty_segment.shape == (140, 5568)
+
+        # check reduction of empty segment
+        empty_segment = xr.DataArray(np.ones((140, 5568)), dims=['y', 'x'])
+        new_height = 139
+        new_empty_segment = geswh(empty_segment, new_height, dim)
+        assert new_empty_segment.shape == (139, 5568)
+
+        # check that empty segment is not modified if it has the right height already
+        empty_segment = xr.DataArray(np.ones((140, 5568)), dims=['y', 'x'])
+        new_height = 140
+        new_empty_segment = geswh(empty_segment, new_height, dim)
+        assert new_empty_segment is empty_segment
 
     @patch.object(yr.FileYAMLReader, "__init__", lambda x: None)
     @patch('satpy.readers.yaml_reader._load_area_def')
@@ -923,6 +970,37 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         AreaDefinition.assert_called_once_with(*expected_call)
 
     @patch('satpy.readers.yaml_reader.AreaDefinition')
+    def test_pad_later_segments_area_for_FCI_padding(self, AreaDefinition):
+        """Test _pad_later_segments_area() in the FCI padding case."""
+        from satpy.readers.yaml_reader import _pad_later_segments_area as plsa
+
+        seg1_area = MagicMock()
+        seg1_area.proj_dict = 'proj_dict'
+        seg1_area.area_extent = [0, 1000, 200, 500]
+        seg1_area.shape = [556, 11136]
+        get_area_def = MagicMock()
+        get_area_def.return_value = seg1_area
+        fh_1 = MagicMock()
+        filetype_info = {'expected_segments': 2,
+                         'file_type': 'fci_l1c_fdhsi'}
+        filename_info = {'segment': 1}
+        fh_1.filetype_info = filetype_info
+        fh_1.filename_info = filename_info
+        fh_1.get_area_def = get_area_def
+        file_handlers = [fh_1]
+        dataid = 'dataid'
+        res = plsa(file_handlers, dataid)
+        self.assertEqual(len(res), 2)
+
+        # the previous chunk size is 556, which is exactly double the size of the FCI chunk 2 size (278)
+        # therefore, the new vertical area extent should be half of the previous size (1000-500)/2=250.
+        # The new area extent lower-left row is therefore 1000+250=1250
+        seg2_extent = (0, 1250, 200, 1000)
+        expected_call = ('fill', 'fill', 'fill', 'proj_dict', 11136, 278,
+                         seg2_extent)
+        AreaDefinition.assert_called_once_with(*expected_call)
+
+    @patch('satpy.readers.yaml_reader.AreaDefinition')
     def test_pad_earlier_segments_area(self, AreaDefinition):
         """Test _pad_earlier_segments_area()."""
         from satpy.readers.yaml_reader import _pad_earlier_segments_area as pesa
@@ -946,6 +1024,38 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         self.assertEqual(len(res), 2)
         seg1_extent = (0, 500, 200, 0)
         expected_call = ('fill', 'fill', 'fill', 'proj_dict', 500, 200,
+                         seg1_extent)
+        AreaDefinition.assert_called_once_with(*expected_call)
+
+    @patch('satpy.readers.yaml_reader.AreaDefinition')
+    def test_pad_earlier_segments_area_for_FCI_padding(self, AreaDefinition):
+        """Test _pad_earlier_segments_area() for the FCI case."""
+        from satpy.readers.yaml_reader import _pad_earlier_segments_area as pesa
+
+        seg2_area = MagicMock()
+        seg2_area.proj_dict = 'proj_dict'
+        seg2_area.area_extent = [0, 1000, 200, 500]
+        seg2_area.shape = [278, 5568]
+        get_area_def = MagicMock()
+        get_area_def.return_value = seg2_area
+        fh_2 = MagicMock()
+        filetype_info = {'expected_segments': 2,
+                         'file_type': 'fci_l1c_fdhsi'}
+        filename_info = {'segment': 2}
+        fh_2.filetype_info = filetype_info
+        fh_2.filename_info = filename_info
+        fh_2.get_area_def = get_area_def
+        file_handlers = [fh_2]
+        dataid = 'dataid'
+        area_defs = {2: seg2_area}
+        res = pesa(file_handlers, dataid, area_defs)
+        self.assertEqual(len(res), 2)
+
+        # the previous chunk size is 278, which is exactly double the size of the FCI chunk 1 size (139)
+        # therefore, the new vertical area extent should be half of the previous size (1000-500)/2=250.
+        # The new area extent lower-left row is therefore 500-250=250
+        seg1_extent = (0, 500, 200, 250)
+        expected_call = ('fill', 'fill', 'fill', 'proj_dict', 5568, 139,
                          seg1_extent)
         AreaDefinition.assert_called_once_with(*expected_call)
 


### PR DESCRIPTION
This PR plugs the `fci_l1c_fdhsi` reader into the `GEOSegmentYAMLReader`. With this, missing chunks (aka segments) are padded with nans using the `scn.load([ds_name], pad_data=True)` mechanism.

After switching to the  `GEOSegmentYAMLReader`, the FCI tests were failing due to issues with the "hackyness" in the `TestGEOSegmentYAMLReader`. This was solved using the same unittest patch methods implemented in #1194.  

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
