### PR TITLE
Make colorize compositor dask-compatible

### DIFF
--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -342,35 +342,35 @@ composites:
     standard_name: cloud_top_phase
 
   cloud_drop_effective_radius:
-    compositor: !!python/name:satpy.composites.PaletteCompositor
+    compositor: !!python/name:satpy.composites.ColorizeCompositor
     prerequisites:
     - cpp_reff
     - cpp_reff_pal
     standard_name: cloud_drop_effective_radius
 
   cloud_optical_thickness:
-    compositor: !!python/name:satpy.composites.PaletteCompositor
+    compositor: !!python/name:satpy.composites.ColorizeCompositor
     prerequisites:
     - cpp_cot
     - cpp_cot_pal
     standard_name: cloud_optical_thickness
 
   cloud_water_path:
-    compositor: !!python/name:satpy.composites.PaletteCompositor
+    compositor: !!python/name:satpy.composites.ColorizeCompositor
     prerequisites:
     - cpp_cwp
     - cpp_cwp_pal
     standard_name: cloud_water_path
 
   ice_water_path:
-    compositor: !!python/name:satpy.composites.PaletteCompositor
+    compositor: !!python/name:satpy.composites.ColorizeCompositor
     prerequisites:
     - cpp_iwp
     - cpp_iwp_pal
     standard_name: ice_water_path
 
   liquid_water_path:
-    compositor: !!python/name:satpy.composites.PaletteCompositor
+    compositor: !!python/name:satpy.composites.ColorizeCompositor
     prerequisites:
     - cpp_lwp
     - cpp_lwp_pal

--- a/satpy/etc/readers/nwcsaf-pps_nc.yaml
+++ b/satpy/etc/readers/nwcsaf-pps_nc.yaml
@@ -232,6 +232,7 @@ datasets:
 
   cpp_reff_pal:
     name: cpp_reff_pal
+    scale_offset_dataset: cpp_reff
     file_type: nc_nwcsaf_cpp
 
   cpp_cot:
@@ -241,6 +242,7 @@ datasets:
 
   cpp_cot_pal:
     name: cpp_cot_pal
+    scale_offset_dataset: cpp_cot
     file_type: nc_nwcsaf_cpp
 
   cpp_cwp:
@@ -250,6 +252,7 @@ datasets:
 
   cpp_cwp_pal:
     name: cpp_cwp_pal
+    scale_offset_dataset: cpp_cwp
     file_type: nc_nwcsaf_cpp
 
   cpp_iwp:
@@ -259,6 +262,7 @@ datasets:
 
   cpp_iwp_pal:
     name: cpp_iwp_pal
+    scale_offset_dataset: cpp_iwp
     file_type: nc_nwcsaf_cpp
 
   cpp_lwp:
@@ -268,4 +272,5 @@ datasets:
 
   cpp_lwp_pal:
     name: cpp_lwp_pal
+    scale_offset_dataset: cpp_lwp
     file_type: nc_nwcsaf_cpp


### PR DESCRIPTION
This PR implements a dask-compatible colorizecompositor and uses it in different composites for nwcsaf cloud products.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
