### PR TITLE
Remove use of YAML Anchors for easier understanding

### DIFF
--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -404,7 +404,7 @@ image) for both of the static images::
       standard_name: static_day
       operations:
       - name: stretch
-        method: *stretchfun
+        method: !!python/name:satpy.enhancements.stretch
         kwargs:
           stretch: crude
           min_stretch: [0, 0, 0]

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -6,7 +6,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: marine_clean_aerosol
     prerequisites:
-    - wavelength: 0.65
+    - wavelength: 0.64
       modifiers: [sunz_corrected]
     optional_prerequisites:
     - satellite_azimuth_angle

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -435,7 +435,7 @@ composites:
       modifiers: [nir_reflectance_lowres]
     standard_name: snow
 
-  snow_hires: &snow_hires
+  snow_hires:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - name: I02
@@ -446,7 +446,16 @@ composites:
       modifiers: [nir_reflectance_hires]
     standard_name: snow
 
-  snow: *snow_hires
+  snow:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: I02
+        modifiers: [sunz_corrected_iband]
+      - name: I03
+        modifiers: [sunz_corrected_iband]
+      - name: I04
+        modifiers: [nir_reflectance_hires]
+    standard_name: snow
 
   histogram_dnb:
     compositor: !!python/name:satpy.composites.viirs.HistogramDNB

--- a/satpy/etc/enhancements/abi.yaml
+++ b/satpy/etc/enhancements/abi.yaml
@@ -36,7 +36,7 @@ enhancements:
     sensor: abi
     operations:
     - name: stretch
-      method: &stretchfun !!python/name:satpy.enhancements.stretch ''
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [-6.7, -6.0, 243.6]
@@ -48,13 +48,13 @@ enhancements:
     sensor: abi
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [-6.7, -0.5, 261.2]
         max_stretch: [ 2.6, 20.0, 288.7]
     - name: gamma
-      method: &gammafun !!python/name:satpy.enhancements.gamma ''
+      method: !!python/name:satpy.enhancements.gamma
       kwargs:
         gamma: [1, 2.5, 1]
 
@@ -64,7 +64,7 @@ enhancements:
     sensor: abi
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [-35.0, -5.0, -75]
@@ -76,7 +76,7 @@ enhancements:
     sensor: abi
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [-6.7, -3.1, 243.55]
@@ -88,7 +88,7 @@ enhancements:
     sensor: abi
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs: {stretch: crude, min_stretch: 0, max_stretch: 100}
 
   land_cloud:
@@ -97,7 +97,7 @@ enhancements:
     sensor: abi
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [ 0.0,   0.0,   0.0]

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -1,10 +1,10 @@
-3d_filter: &3d_filter !!python/name:satpy.enhancements.three_d_effect ''
+3d_filter: !!python/name:satpy.enhancements.three_d_effect
 
 enhancements:
   default:
     operations:
     - name: stretch
-      method: &stretchfun !!python/name:satpy.enhancements.stretch
+      method: !!python/name:satpy.enhancements.stretch
       kwargs: {stretch: linear}
   reflectance_default:
     standard_name: toa_bidirectional_reflectance
@@ -40,14 +40,14 @@ enhancements:
     standard_name: overview
     operations:
     - name: inverse
-      method: &inversefun !!python/name:satpy.enhancements.invert ''
+      method: !!python/name:satpy.enhancements.invert
       args:
       - [false, false, true]
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs: {stretch: linear}
     - name: gamma
-      method: &gammafun !!python/name:satpy.enhancements.gamma ''
+      method: !!python/name:satpy.enhancements.gamma
       kwargs: {gamma: 1.6}
   ocean_color_default:
     standard_name: ocean_color
@@ -55,29 +55,29 @@ enhancements:
     - name: cira_stretch
       method: !!python/name:satpy.enhancements.cira_stretch
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs: {gamma: 2.6}
   night_overview_default:
     standard_name: night_overview
     operations:
     - name: inverse
-      method: *inversefun
+      method: !!python/name:satpy.enhancements.invert
       args:
       - [false, false, true]
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs: {stretch: linear}
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs: {gamma: 1.6}
   natural_color_default:
     standard_name: natural_color
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs: {stretch: crude, min_stretch: 0, max_stretch: 120}
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs: {gamma: 1.8}
 
   fire_temperature:
@@ -85,59 +85,59 @@ enhancements:
     name: fire_temperature
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
         max_stretch: [3.5, 35., 85.]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs: {gamma: [1.0, 1.0, 1.0]}
   fire_temperature_awips:
     standard_name: fire_temperature
     name: fire_temperature_awips
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [273.0, 0, 0]
         max_stretch: [333.0, 100., 75.]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs: {gamma: [0.4, 1.0, 1.0]}
   fire_temperature_eumetsat:
     standard_name: fire_temperature
     name: fire_temperature_eumetsat
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [273.0, 0, 0]
         max_stretch: [350.0, 60., 60.]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs: {gamma: [1.0, 1.0, 1.0]}
   fire_temperature_39refl:
     standard_name: fire_temperature
     name: fire_temperature_39refl
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
         max_stretch: [50., 100., 75.]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs: {gamma: [1.0, 1.0, 1.0]}
 
   airmass_default:
     standard_name: airmass
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [-25, -40, 243]
@@ -147,20 +147,20 @@ enhancements:
     standard_name: green_snow
     operations:
     - name: inverse
-      method: *inversefun
+      method: !!python/name:satpy.enhancements.invert
       args:
       - [false, false, true]
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs: {stretch: crude}
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs: {gamma: 1.6}
   convection_default:
     standard_name: convection
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [-30, 0, -70]
@@ -169,20 +169,20 @@ enhancements:
     standard_name: dust
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [-4, 0, 261]
         max_stretch: [2, 15, 289]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs:
         gamma: [1, 2.5, 1]
   ash_default:
     standard_name: ash
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [-4, -4, 243]
@@ -191,7 +191,7 @@ enhancements:
     standard_name: fog
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [-4, 0, 243]
@@ -200,13 +200,13 @@ enhancements:
     standard_name: night_fog
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [-4, 0, 243]
         max_stretch: [2, 6, 293]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs:
         gamma: [1, 2, 1]
 
@@ -214,13 +214,13 @@ enhancements:
     standard_name: snow
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
         max_stretch: [100, 70, 30]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs:
         gamma: [1.7, 1.7, 1.7]
 
@@ -228,13 +228,13 @@ enhancements:
     standard_name: day_microphysics
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 203]
         max_stretch: [100, 60, 323]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs:
         gamma: [1, 2.5, 1]
 
@@ -242,13 +242,13 @@ enhancements:
     standard_name: day_microphysics_winter
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 203]
         max_stretch: [100, 25, 323]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs:
         gamma: [1, 1.5, 1]
 
@@ -256,10 +256,10 @@ enhancements:
     standard_name: cloudtop
     operations:
     - name: inverse
-      method: *inversefun
+      method: !!python/name:satpy.enhancements.invert
       args: [true]
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: linear
         cutoffs: [0.005, 0.005]
@@ -268,14 +268,14 @@ enhancements:
     standard_name: sar-ice
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
         max_stretch: [0.10, 1.37, 0.32 ]
 
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs:
         gamma: [2, 3, 2]
 
@@ -283,12 +283,12 @@ enhancements:
     standard_name: sar-ice-legacy
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: linear
         cutoffs: [0.2, 0.02]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs:
         gamma: [1, 1.2, 1]
 
@@ -296,13 +296,13 @@ enhancements:
     standard_name: sar-land
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0.01, 1. , 0.15 ]
         max_stretch: [0.765, 50., 1.4]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs:
         gamma: [1.5, 2.25, 1.5]
 
@@ -310,11 +310,11 @@ enhancements:
     standard_name: sar-rgb
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: linear
     - name: inverse
-      method: *inversefun
+      method: !!python/name:satpy.enhancements.invert
       args:
       - [true, true, true]
 
@@ -322,7 +322,7 @@ enhancements:
     standard_name: sar-quick
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: linear
         cutoffs: [0.2, 0.02]
@@ -331,7 +331,7 @@ enhancements:
     standard_name: natural_with_night_fog
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -341,7 +341,7 @@ enhancements:
     standard_name: cloudtype
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -350,7 +350,7 @@ enhancements:
     standard_name: cloudmask
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -359,7 +359,7 @@ enhancements:
     standard_name: cloudmask_probability
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -369,7 +369,7 @@ enhancements:
     standard_name: cloud_top_height
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -378,7 +378,7 @@ enhancements:
     standard_name: cloud_top_pressure
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -387,7 +387,7 @@ enhancements:
     standard_name: cloud_top_temperature
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -396,7 +396,7 @@ enhancements:
     standard_name: cloud_top_phase
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -405,7 +405,7 @@ enhancements:
     standard_name: cloud_drop_effective_radius
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -414,7 +414,7 @@ enhancements:
     standard_name: cloud_optical_thickness
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -423,7 +423,7 @@ enhancements:
     standard_name: cloud_liquid_water_path
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -432,7 +432,7 @@ enhancements:
     standard_name: cloud_ice_water_path
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -441,7 +441,7 @@ enhancements:
     standard_name: precipitation_probability
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -450,7 +450,7 @@ enhancements:
     standard_name: convective_rain_rate
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -459,7 +459,7 @@ enhancements:
     standard_name: convective_precipitation_hourly_accumulation
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -468,7 +468,7 @@ enhancements:
     standard_name: total_precipitable_water
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -477,7 +477,7 @@ enhancements:
     standard_name: showalter_index
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -486,7 +486,7 @@ enhancements:
     standard_name: lifted_index
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -495,7 +495,7 @@ enhancements:
     standard_name: convection_initiation_prob30
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -504,7 +504,7 @@ enhancements:
     standard_name: convection_initiation_prob60
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -513,7 +513,7 @@ enhancements:
     standard_name: convection_initiation_prob90
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -522,7 +522,7 @@ enhancements:
     standard_name: rdt_cell_type
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -531,7 +531,7 @@ enhancements:
     standard_name: asii_prob
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -541,7 +541,7 @@ enhancements:
     standard_name: day_microphysics_ahi
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 203]
@@ -550,7 +550,7 @@ enhancements:
     standard_name: cloud_phase_distinction
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [280.67, 0, 1]
@@ -559,33 +559,33 @@ enhancements:
     standard_name: water_vapors1
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [278.96, 242.67, 261.03]
         max_stretch: [202.29, 214.66, 245.12]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs:
         gamma: [10, 5.5, 5.5]
   water_vapors2_default:
     standard_name: water_vapors2
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [30, 278.15, 243.9]
         max_stretch: [-3, 213.15, 208.5]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs:
         gamma: [3.5, 2.5, 2.5]
   ncc_default:
     standard_name: ncc_radiance
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0]
@@ -594,13 +594,13 @@ enhancements:
     standard_name: realistic_colors
     operations:
       - name: stretch
-        method: *stretchfun
+        method: !!python/name:satpy.enhancements.stretch
         kwargs:
           stretch: crude
           min_stretch: [0, 0, 0]
           max_stretch: [110, 110, 110]
       - name: gamma
-        method: *gammafun
+        method: !!python/name:satpy.enhancements.gamma
         kwargs:
           gamma: [1.4, 1.4, 1.2]
   snow_age_default:
@@ -709,7 +709,7 @@ enhancements:
     standard_name: night_microphysics
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [-4, 0, 243]
@@ -718,10 +718,10 @@ enhancements:
     standard_name: ir_overview
     operations:
     - name: inverse
-      method: *inversefun
+      method: !!python/name:satpy.enhancements.invert
       args: [true]
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: histogram
 
@@ -729,27 +729,27 @@ enhancements:
     standard_name: ir108_3d
     operations:
     - name: inverse
-      method: *inversefun
+      method: !!python/name:satpy.enhancements.invert
       args: [true]
     - name: 3d_filter
-      method: *3d_filter
+      method: !!python/name:satpy.enhancements.three_d_effect
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs: {stretch: linear}
 
   ir_cloud_day:
     standard_name: ir_cloud_day
     operations:
       - name: inverse
-        method: *inversefun
+        method: !!python/name:satpy.enhancements.invert
         args:
           - [True, false]
       - name: stretch
-        method: *stretchfun
+        method: !!python/name:satpy.enhancements.stretch
         kwargs:
           stretch: linear
       - name: 3d
-        method: *3d_filter
+        method: !!python/name:satpy.enhancements.three_d_effect
         kwargs:
           weight: 1.0
 
@@ -757,7 +757,7 @@ enhancements:
     standard_name: colorized_ir_clouds
     operations:
       - name: colorize
-        method: &colorizefun !!python/name:satpy.enhancements.colorize ''
+        method: !!python/name:satpy.enhancements.colorize
         kwargs:
           palettes:
             - {colors: spectral, min_value: 193.15, max_value: 253.149999}
@@ -767,7 +767,7 @@ enhancements:
     standard_name: vis_sharpened_ir
     operations:
       - name: stretch
-        method: *stretchfun
+        method: !!python/name:satpy.enhancements.stretch
         kwargs:
           stretch: crude
           min_stretch: [0, 0, 0]
@@ -777,7 +777,7 @@ enhancements:
     standard_name: ir_sandwich
     operations:
       - name: stretch
-        method: *stretchfun
+        method: !!python/name:satpy.enhancements.stretch
         kwargs:
           stretch: crude
           min_stretch: [0, 0, 0]
@@ -787,7 +787,7 @@ enhancements:
    standard_name: natural_enh
    operations:
      - name: stretch
-       method: *stretchfun
+       method: !!python/name:satpy.enhancements.stretch
        kwargs:
          stretch: crude
          min_stretch: [0, 0, 0]
@@ -817,13 +817,13 @@ enhancements:
     standard_name: hrv_severe_storms
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [70, 70, -60]
         max_stretch: [100, 100, -40]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs:
         gamma: [1.7, 1.7, 2.0]
 
@@ -831,14 +831,14 @@ enhancements:
     standard_name: hrv_severe_storms_masked
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         # MaskingCompositor always adds alpha channel
         min_stretch: [70, 70, -60, 0]
         max_stretch: [100, 100, -40, 1]
     - name: gamma
-      method: *gammafun
+      method: !!python/name:satpy.enhancements.gamma
       kwargs:
         # MaskingCompositor always adds alpha channel
         gamma: [1.7, 1.7, 2.0, 1.0]
@@ -847,7 +847,7 @@ enhancements:
     standard_name: true_color_with_night_ir
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -857,7 +857,7 @@ enhancements:
     standard_name: night_background
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -867,10 +867,10 @@ enhancements:
     standard_name: night_ir_alpha
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs: {stretch: linear, cutoffs: [0.02, 0.02]}
     - name: inverse
-      method: *inversefun
+      method: !!python/name:satpy.enhancements.invert
       args:
       - [true, true, true, true]
 
@@ -878,7 +878,7 @@ enhancements:
     standard_name: night_ir_with_background
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [0, 0, 0]
@@ -889,7 +889,7 @@ enhancements:
     standard_name: so2
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [-4, -4, 243.05]
@@ -899,7 +899,7 @@ enhancements:
     standard_name: tropical_airmass
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [26.2,  27.4, 243.9]

--- a/satpy/etc/enhancements/mersi-2.yaml
+++ b/satpy/etc/enhancements/mersi-2.yaml
@@ -2,19 +2,19 @@ enhancements:
   default:
     operations:
     - name: stretch
-      method: &stretchfun !!python/name:satpy.enhancements.stretch
+      method: !!python/name:satpy.enhancements.stretch
       kwargs: {stretch: linear}
 
   cloudtop_default:
     standard_name: cloudtop
     operations:
     - name: stretch
-      method: *stretchfun
+      method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
         min_stretch: [320, 310, 310]
         max_stretch: [220, 220, 220]
     - name: gamma
-      method: &gammafun !!python/name:satpy.enhancements.gamma ''
+      method: !!python/name:satpy.enhancements.gamma
       kwargs:
         gamma: [1.4, 1.4, 1.2]

--- a/satpy/etc/enhancements/scatterometer.yaml
+++ b/satpy/etc/enhancements/scatterometer.yaml
@@ -5,7 +5,7 @@ enhancements:
     name: scat_wind_speed
     operations:
       - name: colorize
-        method: &colorizefun !!python/name:satpy.enhancements.colorize ''
+        method: !!python/name:satpy.enhancements.colorize
         kwargs:
           palettes:
             - {colors: spectral, min_value: 0, max_value: 25}

--- a/satpy/etc/readers/avhrr_l1b_eps.yaml
+++ b/satpy/etc/readers/avhrr_l1b_eps.yaml
@@ -1,7 +1,7 @@
 reader:
     name: avhrr_l1b_eps
     description: EPS Reader for AVHRR
-    reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader ''
+    reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
     sensors: [avhrr-3]
     default_channels: [1, 2, 3a, 3b, 4, 5]
 
@@ -129,7 +129,7 @@ datasets:
 
 file_types:
     avhrr_eps:
-        file_reader: !!python/name:satpy.readers.eps_l1b.EPSAVHRRFile ''
+        file_reader: !!python/name:satpy.readers.eps_l1b.EPSAVHRRFile
         file_patterns: [
                        'AVHR_xxx_1B_{platform_short_name}_{start_time:%Y%m%d%H%M%SZ}_{end_time:%Y%m%d%H%M%SZ}_{processing_mode}_{disposition_mode}_{creation_time:%Y%m%d%H%M%SZ}',
                        'AVHR_xxx_1B_{platform_short_name}_{start_time:%Y%m%d%H%M%SZ}_{end_time:%Y%m%d%H%M%SZ}_{processing_mode}_{disposition_mode}_{creation_time:%Y%m%d%H%M%SZ}.nat']

--- a/satpy/etc/readers/avhrr_l1b_hrpt.yaml
+++ b/satpy/etc/readers/avhrr_l1b_hrpt.yaml
@@ -1,7 +1,7 @@
 reader:
     name: avhrr_l1b_hrpt
     description: HRPT Reader for AVHRR
-    reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader ''
+    reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
     sensors: [avhrr-3, avhrr-2]
     default_channels: [1, 2, 3a, 3b, 4, 5]
 
@@ -90,5 +90,5 @@ datasets:
 
 file_types:
     avhrr_hrpt:
-        file_reader: !!python/name:satpy.readers.hrpt.HRPTFile ''
+        file_reader: !!python/name:satpy.readers.hrpt.HRPTFile
         file_patterns: ['{start_time:%Y%m%d%H%M%S}_{platform_name}.hmf', 'hrpt16_{platform_name:s}_{start_time:%d-%b-%Y_%H:%M:%S.%f}_{orbit_number:05d}']

--- a/satpy/etc/readers/caliop_l2_cloud.yaml
+++ b/satpy/etc/readers/caliop_l2_cloud.yaml
@@ -2,7 +2,7 @@ reader:
   default_datasets: []
   description: CALIOP Level 2 Cloud Layer Version 3 HDF4 reader
   name: caliop_l2_cloud
-  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader ''
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
   sensors: [caliop]
 
 datasets:
@@ -37,4 +37,4 @@ file_types:
   hdf4_caliop:
     file_patterns:
             - 'CAL_LID_L2_0{resolution:1s}kmCLay-ValStage1-V3-30.{start_time:%Y-%m-%dT%H-%M-%S}ZN.hdf'
-    file_reader: !!python/name:satpy.readers.caliop_l2_cloud.HDF4BandReader ''
+    file_reader: !!python/name:satpy.readers.caliop_l2_cloud.HDF4BandReader

--- a/satpy/etc/readers/fci_l1c_fdhsi.yaml
+++ b/satpy/etc/readers/fci_l1c_fdhsi.yaml
@@ -385,6 +385,6 @@ datasets:
 # EUM/MTG/DOC/19/1079228
 file_types:
   fci_l1c_fdhsi:
-    file_reader: !!python/name:satpy.readers.fci_l1c_fdhsi.FCIFDHSIFileHandler ''
+    file_reader: !!python/name:satpy.readers.fci_l1c_fdhsi.FCIFDHSIFileHandler
     file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_level}-{type}-{subtype}-{coverage}-{subsetting}-{component1}-BODY-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc']
     expected_segments: 40

--- a/satpy/etc/readers/ghrsst_l3c_sst.yaml
+++ b/satpy/etc/readers/ghrsst_l3c_sst.yaml
@@ -1,7 +1,7 @@
 reader:
   description: OSISAF SST GHRSST netCDF reader
   name: ghrsst_l3c_sst
-  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader ''
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
   sensors: [avhrr/3, viirs]
 
 datasets:
@@ -13,5 +13,5 @@ datasets:
 
 file_types:
   ghrsst_osisaf_l2:
-    file_reader: !!python/name:satpy.readers.ghrsst_l3c_sst.GHRSST_OSISAFL2 ''
+    file_reader: !!python/name:satpy.readers.ghrsst_l3c_sst.GHRSST_OSISAFL2
     file_patterns: ['S-OSI_-FRA_-{satid:3s}_-NARSST_FIELD-{start_time:%Y%m%d%H00}Z.nc']

--- a/satpy/etc/readers/hy2_scat_l2b_h5.yaml
+++ b/satpy/etc/readers/hy2_scat_l2b_h5.yaml
@@ -1,13 +1,13 @@
 reader:
   description: Generic Eumetsat HY2 L2B H5 Wind field Reader
   name: hy2_scat_l2b_h5
-  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader ''
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
   sensors: [scatterometer]
   default_datasets:
 
 file_types:
   hy2_scat_l2b_h5:
-    file_reader: !!python/name:satpy.readers.hy2_scat_l2b_h5.HY2SCATL2BH5FileHandler ''
+    file_reader: !!python/name:satpy.readers.hy2_scat_l2b_h5.HY2SCATL2BH5FileHandler
     file_patterns: ['W_XX-EUMETSAT-Darmstadt,SURFACE+SATELLITE,{platform_name}+SM_C_EUMP_{start_date:%Y%m%d------}_{orbit_number}_o_250_{product_level}.h5']
 
 datasets:

--- a/satpy/etc/readers/li_l2.yaml
+++ b/satpy/etc/readers/li_l2.yaml
@@ -1,7 +1,7 @@
 reader:
   description: Generic MTG LI L2 product reader
   name: li_l2
-  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader ''
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
   sensors: [li]
   default_datasets:
 
@@ -44,24 +44,24 @@ datasets:
 # Source: LI L2 Product User Guide [LIL2PUG] Draft version -- 2016
 file_types:
   li_l2:
-    file_reader: !!python/name:satpy.readers.li_l2.LIFileHandler ''
+    file_reader: !!python/name:satpy.readers.li_l2.LIFileHandler
     file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_evel}-{type}-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day}.nc']
   li_af:
-    file_reader: !!python/name:satpy.readers.li_l2.LIFileHandler ''
+    file_reader: !!python/name:satpy.readers.li_l2.LIFileHandler
     file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_evel}-AF-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day}.nc']
   li_afa:
-    file_reader: !!python/name:satpy.readers.li_l2.LIFileHandler ''
+    file_reader: !!python/name:satpy.readers.li_l2.LIFileHandler
     file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_evel}-AFA-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day}.nc']
   li_afr:
-    file_reader: !!python/name:satpy.readers.li_l2.LIFileHandler ''
+    file_reader: !!python/name:satpy.readers.li_l2.LIFileHandler
     file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_evel}-AFR-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day}.nc']
   li_lgr:
-    file_reader: !!python/name:satpy.readers.li_l2.LIFileHandler ''
+    file_reader: !!python/name:satpy.readers.li_l2.LIFileHandler
     file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_evel}-LGR-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day}.nc']
   li_lef:
-    file_reader: !!python/name:satpy.readers.li_l2.LIFileHandler ''
+    file_reader: !!python/name:satpy.readers.li_l2.LIFileHandler
     file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_evel}-LEF-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day}.nc']
   li_lfl:
-    file_reader: !!python/name:satpy.readers.li_l2.LIFileHandler ''
+    file_reader: !!python/name:satpy.readers.li_l2.LIFileHandler
     file_patterns: ['{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-{processing_evel}-LFL-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day}.nc']
 

--- a/satpy/etc/readers/modis_l1b.yaml
+++ b/satpy/etc/readers/modis_l1b.yaml
@@ -2,7 +2,7 @@ reader:
   default_datasets: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36]
   description: Generic MODIS HDF-EOS Reader
   name: modis_l1b
-  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader ''
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
   sensors: [modis]
 
 navigations:

--- a/satpy/etc/readers/scatsat1_l2b.yaml
+++ b/satpy/etc/readers/scatsat1_l2b.yaml
@@ -1,7 +1,7 @@
 reader:
   description: Generic Eumetsat Scatsat-1 L2B Wind field Reader
   name: scatsat1_l2b
-  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader ''
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
   sensors: [scatterometer]
   default_datasets:
 
@@ -38,5 +38,5 @@ datasets:
 
 file_types:
   scatsat:
-    file_reader: !!python/name:satpy.readers.scatsat1_l2b.SCATSAT1L2BFileHandler ''
+    file_reader: !!python/name:satpy.readers.scatsat1_l2b.SCATSAT1L2BFileHandler
     file_patterns: ['S1L2B{start_date:%Y%j}_{start_orbit}_{end_orbit}_{direction}_{cell_spacing}_{prod_date}T{prod_time}_{version}.h5']

--- a/satpy/etc/readers/seviri_l1b_native.yaml
+++ b/satpy/etc/readers/seviri_l1b_native.yaml
@@ -10,7 +10,7 @@ reader:
 
 file_types:
   native_msg:
-    file_reader: !!python/name:satpy.readers.seviri_l1b_native.NativeMSGFileHandler ''
+    file_reader: !!python/name:satpy.readers.seviri_l1b_native.NativeMSGFileHandler
     file_patterns: ['{satid:4s}-{instr:4s}-MSG{product_level:2d}-0100-NA-{processing_time1:%Y%m%d%H%M%S.%f}000Z-{order_id:s}.nat',
                     '{satid:4s}-{instr:4s}-MSG{product_level:2d}-0100-NA-{processing_time1:%Y%m%d%H%M%S.%f}000Z']
 

--- a/satpy/etc/readers/vaisala_gld360.yaml
+++ b/satpy/etc/readers/vaisala_gld360.yaml
@@ -1,12 +1,12 @@
 reader:
   description: Vaisala Global Lightning Dataset 360 reader
   name: vaisala_gld360
-  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader ''
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
   sensors: [vaisala_gld360]
 
 file_types:
   vaisala_gld360:
-    file_reader: !!python/name:satpy.readers.vaisala_gld360.VaisalaGLD360TextFileHandler ''
+    file_reader: !!python/name:satpy.readers.vaisala_gld360.VaisalaGLD360TextFileHandler
     file_patterns: ['flashes_{start_time:%Y%m%d}.txt']
 
 datasets:

--- a/satpy/etc/readers/viirs_compact.yaml
+++ b/satpy/etc/readers/viirs_compact.yaml
@@ -1,7 +1,7 @@
 reader:
   description: Generic Eumetsat Compact VIIRS Reader
   name: viirs_compact
-  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader ''
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
   sensors: [viirs]
   default_datasets:
 
@@ -383,8 +383,8 @@ datasets:
 
 file_types:
   compact_m:
-    file_reader: !!python/name:satpy.readers.viirs_compact.VIIRSCompactFileHandler ''
+    file_reader: !!python/name:satpy.readers.viirs_compact.VIIRSCompactFileHandler
     file_patterns: ['SVMC_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time:%Y%m%d%H%M%S%f}_eum_ops.h5']
   compact_dnb:
-    file_reader: !!python/name:satpy.readers.viirs_compact.VIIRSCompactFileHandler ''
+    file_reader: !!python/name:satpy.readers.viirs_compact.VIIRSCompactFileHandler
     file_patterns: ['SVDNBC_{platform_shortname}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time:%Y%m%d%H%M%S%f}_eum_ops.h5']

--- a/satpy/etc/readers/virr_l1b.yaml
+++ b/satpy/etc/readers/virr_l1b.yaml
@@ -9,7 +9,7 @@ file_types:
         file_reader: !!python/name:satpy.readers.virr_l1b.VIRR_L1B
         file_patterns:
         - 'tf{creation_time:%Y%j%H%M%S}.{platform_id}-L_VIRRX_L1B.HDF'
-        geolocation_prefix:
+        geolocation_prefix: ''
     virr_geoxx:
         file_reader: !!python/name:satpy.readers.virr_l1b.VIRR_L1B
         file_patterns:

--- a/satpy/etc/readers/virr_l1b.yaml
+++ b/satpy/etc/readers/virr_l1b.yaml
@@ -9,7 +9,7 @@ file_types:
         file_reader: !!python/name:satpy.readers.virr_l1b.VIRR_L1B
         file_patterns:
         - 'tf{creation_time:%Y%j%H%M%S}.{platform_id}-L_VIRRX_L1B.HDF'
-        geolocation_prefix: ''
+        geolocation_prefix:
     virr_geoxx:
         file_reader: !!python/name:satpy.readers.virr_l1b.VIRR_L1B
         file_patterns:

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -117,7 +117,7 @@ class TestEnhancer(unittest.TestCase):
     standard_name: toa_bidirectional_reflectance
     operations:
     - name: stretch
-      method: &stretchfun !!python/name:satpy.enhancements.stretch ''
+      method: !!python/name:satpy.enhancements.stretch
       kwargs: {stretch: linear}
 """])
         self.assertIsNotNone(e.enhancement_tree)


### PR DESCRIPTION
This removes the use of YAML Anchors (a.k.a. aliases) to make the YAML in Satpy easier to understand for new users. Additionally this should help the sharing of YAML recipes where one YAML file may have been using an anchor but when copied to a new file it wouldn't work.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
