### PR TITLE
Fix time extraction from filenames in yaml for SEVIRI Native and NetCDF readers

### DIFF
--- a/satpy/etc/readers/seviri_l1b_native.yaml
+++ b/satpy/etc/readers/seviri_l1b_native.yaml
@@ -7,12 +7,19 @@ reader:
   sensors: [seviri]
   default_channels: [HRV, IR_016, IR_039, IR_087, IR_097, IR_108, IR_120, IR_134, VIS006, VIS008, WV_062, WV_073]
   reader: !!python/name:satpy.readers.yaml_reader.GEOFlippableFileYAMLReader
+  # file pattern keys to sort files by with 'satpy.utils.group_files'
+  group_keys: ['end_time', 'satid']
 
 file_types:
   native_msg:
     file_reader: !!python/name:satpy.readers.seviri_l1b_native.NativeMSGFileHandler ''
-    file_patterns: ['{satid:4s}-{instr:4s}-MSG{product_level:2d}-0100-NA-{processing_time1:%Y%m%d%H%M%S.%f}000Z-{order_id:s}.nat',
-                    '{satid:4s}-{instr:4s}-MSG{product_level:2d}-0100-NA-{processing_time1:%Y%m%d%H%M%S.%f}000Z']
+    file_patterns: ['{satid:4s}-{instr:4s}-MSG{product_level:2d}-0100-NA-{end_time:%Y%m%d%H%M%S.%f}000Z-{processing_time:%Y%m%d%H%M%S}-{order_id:s}.nat',
+                    '{satid:4s}-{instr:4s}-MSG{product_level:2d}-0100-NA-{end_time:%Y%m%d%H%M%S.%f}000Z-{order_id:s}.nat',
+                    '{satid:4s}-{instr:4s}-MSG{product_level:2d}-0100-NA-{end_time:%Y%m%d%H%M%S.%f}000Z'
+                    ]
+    # Note: the end_time value in the SEVIRI native filenames is officially called Nominal Image Time (SNIT field in
+    # the 15_MAIN_PRODUCT_HEADER) marking the time where the product is defined to be valid. This time always matches
+    # the scan acquisition end time (SSST in 15_MAIN_PRODUCT_HEADER).
 
 datasets:
   HRV:

--- a/satpy/etc/readers/seviri_l1b_nc.yaml
+++ b/satpy/etc/readers/seviri_l1b_nc.yaml
@@ -6,12 +6,12 @@ reader:
     NetCDF4 reader for EUMETSAT MSG SEVIRI Level 1b files.
   sensors: [seviri]
   reader: !!python/name:satpy.readers.yaml_reader.GEOFlippableFileYAMLReader
-  group_keys: ["processing_time", "satid"]
+  group_keys: ["start_time", "satid"]
 
 file_types:
     seviri_l1b_nc:
         file_reader: !!python/name:satpy.readers.seviri_l1b_nc.NCSEVIRIFileHandler
-        file_patterns: ['W_XX-EUMETSAT-Darmstadt,VIS+IR+HRV+IMAGERY,{satid:4s}+SEVIRI_C_EUMG_{processing_time:%Y%m%d%H%M%S}.nc']
+        file_patterns: ['W_XX-EUMETSAT-Darmstadt,VIS+IR+HRV+IMAGERY,{satid:4s}+SEVIRI_C_EUMG_{start_time:%Y%m%d%H%M%S}.nc']
 
 datasets:
   HRV:


### PR DESCRIPTION
This PR fixes the start/end/processing time extraction from filenames in the yaml `file_patterns` for the SEVIRI native and netcdf readers. 

 - [x] Tests passed <!-- for all non-documentation changes -->