### PR TITLE
Fix NIRReflectance passing None as sunz_threshold

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -647,8 +647,12 @@ class NIRReflectance(CompositeBase):
             LOG.info("Couldn't load pyspectral")
             raise ImportError("No module named pyspectral.near_infrared_reflectance")
         _nir, _tb11 = projectables
-        self._refl3x = Calculator(_nir.attrs['platform_name'], _nir.attrs['sensor'], _nir.attrs['name'],
-                                  sunz_threshold=self.sunz_threshold)
+        if self.sunz_threshold is not None:
+            self._refl3x = Calculator(_nir.attrs['platform_name'], _nir.attrs['sensor'], _nir.attrs['name'],
+                                      sunz_threshold=self.sunz_threshold)
+        else:
+            self._refl3x = Calculator(_nir.attrs['platform_name'], _nir.attrs['sensor'], _nir.attrs['name'])
+            self.sunz_threshold = self._refl3x.sunz_threshold
 
     def _get_reflectance(self, projectables, optional_datasets):
         """Calculate 3.x reflectance with pyspectral."""


### PR DESCRIPTION
The documentation of the NIRReflectance compositor says about the sunz_threshold parameter:
> Default None, in which case the default threshold defined in Pyspectral will be used.

This wasn't the case, and wasn't tested. This PR fixes the behaviour and adds a test for it.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

