### PR TITLE
Fix 'viirs_sdr' reader not scaling DNB data properly

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -213,7 +213,7 @@ class CompositorLoader(object):
 
         conf = {}
         for composite_config in composite_configs:
-            with open(composite_config) as conf_file:
+            with open(composite_config, 'r', encoding='utf-8') as conf_file:
                 conf = recursive_dict_update(conf, yaml.load(conf_file, Loader=UnsafeLoader))
         try:
             sensor_name = conf['sensor_name']

--- a/satpy/config.py
+++ b/satpy/config.py
@@ -156,7 +156,7 @@ def check_yaml_configs(configs, key):
     diagnostic = {}
     for i in configs:
         for fname in i:
-            with open(fname) as stream:
+            with open(fname, 'r', encoding='utf-8') as stream:
                 try:
                     res = yaml.load(stream, Loader=UnsafeLoader)
                     msg = 'ok'

--- a/satpy/etc/enhancements/viirs.yaml
+++ b/satpy/etc/enhancements/viirs.yaml
@@ -1,4 +1,13 @@
 enhancements:
+  # data comes out of the compositor normalized to 0-1
+  # this makes sure that we aren't dependent on the default dynamic stretch
+  # which would have the same end result
+  dynamic_dnb:
+    name: dynamic_dnb
+    operations:
+      - name: linear_stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0.0, max_stretch: 1.0}
   water_detection:
     name: WaterDetection
     operations:

--- a/satpy/etc/readers/viirs_sdr.yaml
+++ b/satpy/etc/readers/viirs_sdr.yaml
@@ -76,7 +76,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   I02:
     name: I02
     wavelength: [0.845, 0.865, 0.884]
@@ -91,7 +91,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   I03:
     name: I03
     wavelength: [1.580, 1.610, 1.640]
@@ -106,7 +106,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   I04:
     name: I04
     wavelength: [3.580, 3.740, 3.900]
@@ -120,7 +120,7 @@ datasets:
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   I05:
     name: I05
     wavelength: [10.500, 11.450, 12.300]
@@ -134,7 +134,7 @@ datasets:
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M01:
     name: M01
     wavelength: [0.402, 0.412, 0.422]
@@ -149,7 +149,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M02:
     name: M02
     wavelength: [0.436, 0.445, 0.454]
@@ -164,7 +164,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M03:
     name: M03
     wavelength: [0.478, 0.488, 0.498]
@@ -179,7 +179,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M04:
     name: M04
     wavelength: [0.545, 0.555, 0.565]
@@ -194,7 +194,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M05:
     name: M05
     wavelength: [0.662, 0.672, 0.682]
@@ -209,7 +209,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M06:
     name: M06
     wavelength: [0.739, 0.746, 0.754]
@@ -224,7 +224,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M07:
     name: M07
     wavelength: [0.846, 0.865, 0.885]
@@ -239,7 +239,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M08:
     name: M08
     wavelength: [1.230, 1.240, 1.250]
@@ -254,7 +254,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M09:
     name: M09
     wavelength: [1.371, 1.378, 1.386]
@@ -269,7 +269,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M10:
     name: M10
     wavelength: [1.580, 1.610, 1.640]
@@ -284,7 +284,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M11:
     name: M11
     wavelength: [2.225, 2.250, 2.275]
@@ -299,7 +299,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M12:
     name: M12
     wavelength: [3.610, 3.700, 3.790]
@@ -313,7 +313,7 @@ datasets:
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M13:
     name: M13
     wavelength: [3.973, 4.050, 4.128]
@@ -327,7 +327,7 @@ datasets:
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M14:
     name: M14
     wavelength: [8.400, 8.550, 8.700]
@@ -341,7 +341,7 @@ datasets:
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M15:
     name: M15
     wavelength: [10.263, 10.763, 11.263]
@@ -355,7 +355,7 @@ datasets:
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
   M16:
     name: M16
     wavelength: [11.538, 12.013, 12.489]
@@ -369,7 +369,7 @@ datasets:
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        units: W m-2 µm-1 sr-1
 
   I_SOLZ:
     name: solar_zenith_angle

--- a/satpy/etc/readers/viirs_sdr.yaml
+++ b/satpy/etc/readers/viirs_sdr.yaml
@@ -76,7 +76,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   I02:
     name: I02
     wavelength: [0.845, 0.865, 0.884]
@@ -91,7 +91,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   I03:
     name: I03
     wavelength: [1.580, 1.610, 1.640]
@@ -106,7 +106,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   I04:
     name: I04
     wavelength: [3.580, 3.740, 3.900]
@@ -120,7 +120,7 @@ datasets:
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   I05:
     name: I05
     wavelength: [10.500, 11.450, 12.300]
@@ -134,7 +134,7 @@ datasets:
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M01:
     name: M01
     wavelength: [0.402, 0.412, 0.422]
@@ -149,7 +149,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M02:
     name: M02
     wavelength: [0.436, 0.445, 0.454]
@@ -164,7 +164,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M03:
     name: M03
     wavelength: [0.478, 0.488, 0.498]
@@ -179,7 +179,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M04:
     name: M04
     wavelength: [0.545, 0.555, 0.565]
@@ -194,7 +194,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M05:
     name: M05
     wavelength: [0.662, 0.672, 0.682]
@@ -209,7 +209,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M06:
     name: M06
     wavelength: [0.739, 0.746, 0.754]
@@ -224,7 +224,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M07:
     name: M07
     wavelength: [0.846, 0.865, 0.885]
@@ -239,7 +239,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M08:
     name: M08
     wavelength: [1.230, 1.240, 1.250]
@@ -254,7 +254,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M09:
     name: M09
     wavelength: [1.371, 1.378, 1.386]
@@ -269,7 +269,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M10:
     name: M10
     wavelength: [1.580, 1.610, 1.640]
@@ -284,7 +284,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M11:
     name: M11
     wavelength: [2.225, 2.250, 2.275]
@@ -299,7 +299,7 @@ datasets:
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M12:
     name: M12
     wavelength: [3.610, 3.700, 3.790]
@@ -313,7 +313,7 @@ datasets:
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M13:
     name: M13
     wavelength: [3.973, 4.050, 4.128]
@@ -327,7 +327,7 @@ datasets:
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M14:
     name: M14
     wavelength: [8.400, 8.550, 8.700]
@@ -341,7 +341,7 @@ datasets:
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M15:
     name: M15
     wavelength: [10.263, 10.763, 11.263]
@@ -355,7 +355,7 @@ datasets:
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
   M16:
     name: M16
     wavelength: [11.538, 12.013, 12.489]
@@ -369,7 +369,7 @@ datasets:
         units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 µm-1 sr-1
+        units: W m-2 um-1 sr-1
 
   I_SOLZ:
     name: solar_zenith_angle

--- a/satpy/etc/readers/viirs_sdr.yaml
+++ b/satpy/etc/readers/viirs_sdr.yaml
@@ -460,6 +460,7 @@ datasets:
     standard_name: solar_zenith_angle
     resolution: 743
     coordinates: [dnb_longitude, dnb_latitude]
+    units: degrees
     file_type: generic_file
     dataset_groups: [GDNBO]
     file_key: 'All_Data/{dataset_group}_All/SolarZenithAngle'
@@ -468,6 +469,7 @@ datasets:
     standard_name: lunar_zenith_angle
     resolution: 743
     coordinates: [dnb_longitude, dnb_latitude]
+    units: degrees
     file_type: generic_file
     dataset_groups: [GDNBO]
     file_key: 'All_Data/{dataset_group}_All/LunarZenithAngle'
@@ -494,6 +496,7 @@ datasets:
     file_type: generic_file
     dataset_groups: [GDNBO]
     file_key: 'All_Data/{dataset_group}_All/MoonIllumFraction'
+    units: '1'
 
 file_types:
   generic_file:

--- a/satpy/etc/readers/viirs_sdr.yaml
+++ b/satpy/etc/readers/viirs_sdr.yaml
@@ -14,7 +14,7 @@ datasets:
     file_type: generic_file
     dataset_groups: [GITCO, GIMGO]
     file_key: All_Data/{dataset_group}_All/Longitude
-    units: "degrees_east"
+    file_units: "degrees_east"
     standard_name: longitude
     coordinates: [i_longitude, i_latitude]
   i_lat:
@@ -23,7 +23,7 @@ datasets:
     file_type: generic_file
     dataset_groups: [GITCO, GIMGO]
     file_key: All_Data/{dataset_group}_All/Latitude
-    units: "degrees_north"
+    file_units: "degrees_north"
     standard_name: latitude
     coordinates: [i_longitude, i_latitude]
   m_lon:
@@ -32,7 +32,7 @@ datasets:
     file_type: generic_file
     dataset_groups: [GMTCO, GMODO]
     file_key: All_Data/{dataset_group}_All/Longitude
-    units: "degrees_east"
+    file_units: "degrees_east"
     standard_name: longitude
     coordinates: [m_longitude, m_latitude]
   m_lat:
@@ -41,7 +41,7 @@ datasets:
     file_type: generic_file
     dataset_groups: [GMTCO, GMODO]
     file_key: All_Data/{dataset_group}_All/Latitude
-    units: "degrees_north"
+    file_units: "degrees_north"
     standard_name: latitude
     coordinates: [m_longitude, m_latitude]
   dnb_lon:
@@ -50,7 +50,7 @@ datasets:
     file_type: generic_file
     dataset_groups: [GDNBO]
     file_key: All_Data/{dataset_group}_All/Longitude
-    units: "degrees_east"
+    file_units: "degrees_east"
     standard_name: longitude
     coordinates: [dnb_longitude, dnb_latitude]
   dnb_lat:
@@ -59,7 +59,7 @@ datasets:
     file_type: generic_file
     dataset_groups: [GDNBO]
     file_key: All_Data/{dataset_group}_All/Latitude
-    units: "degrees_north"
+    file_units: "degrees_north"
     standard_name: latitude
     coordinates: [dnb_longitude, dnb_latitude]
   I01:
@@ -73,10 +73,11 @@ datasets:
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
+        file_units: "1"
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   I02:
     name: I02
     wavelength: [0.845, 0.865, 0.884]
@@ -88,10 +89,11 @@ datasets:
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
+        file_units: "1"
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   I03:
     name: I03
     wavelength: [1.580, 1.610, 1.640]
@@ -103,10 +105,11 @@ datasets:
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
+        file_units: "1"
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   I04:
     name: I04
     wavelength: [3.580, 3.740, 3.900]
@@ -117,10 +120,10 @@ datasets:
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
-        units: K
+        file_units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   I05:
     name: I05
     wavelength: [10.500, 11.450, 12.300]
@@ -131,10 +134,10 @@ datasets:
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
-        units: K
+        file_units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M01:
     name: M01
     wavelength: [0.402, 0.412, 0.422]
@@ -146,10 +149,11 @@ datasets:
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
+        file_units: "1"
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M02:
     name: M02
     wavelength: [0.436, 0.445, 0.454]
@@ -161,10 +165,11 @@ datasets:
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
+        file_units: "1"
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M03:
     name: M03
     wavelength: [0.478, 0.488, 0.498]
@@ -176,10 +181,11 @@ datasets:
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
+        file_units: "1"
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M04:
     name: M04
     wavelength: [0.545, 0.555, 0.565]
@@ -191,10 +197,11 @@ datasets:
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
+        file_units: "1"
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M05:
     name: M05
     wavelength: [0.662, 0.672, 0.682]
@@ -206,10 +213,11 @@ datasets:
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
+        file_units: "1"
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M06:
     name: M06
     wavelength: [0.739, 0.746, 0.754]
@@ -221,10 +229,11 @@ datasets:
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
+        file_units: "1"
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M07:
     name: M07
     wavelength: [0.846, 0.865, 0.885]
@@ -236,10 +245,11 @@ datasets:
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
+        file_units: "1"
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M08:
     name: M08
     wavelength: [1.230, 1.240, 1.250]
@@ -251,10 +261,11 @@ datasets:
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
+        file_units: "1"
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M09:
     name: M09
     wavelength: [1.371, 1.378, 1.386]
@@ -266,10 +277,11 @@ datasets:
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
+        file_units: "1"
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M10:
     name: M10
     wavelength: [1.580, 1.610, 1.640]
@@ -281,10 +293,11 @@ datasets:
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
+        file_units: "1"
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M11:
     name: M11
     wavelength: [2.225, 2.250, 2.275]
@@ -296,10 +309,11 @@ datasets:
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
+        file_units: "1"
         units: "%"
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M12:
     name: M12
     wavelength: [3.610, 3.700, 3.790]
@@ -310,10 +324,10 @@ datasets:
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
-        units: K
+        file_units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M13:
     name: M13
     wavelength: [3.973, 4.050, 4.128]
@@ -324,10 +338,10 @@ datasets:
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
-        units: K
+        file_units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M14:
     name: M14
     wavelength: [8.400, 8.550, 8.700]
@@ -338,10 +352,10 @@ datasets:
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
-        units: K
+        file_units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M15:
     name: M15
     wavelength: [10.263, 10.763, 11.263]
@@ -352,10 +366,10 @@ datasets:
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
-        units: K
+        file_units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
   M16:
     name: M16
     wavelength: [11.538, 12.013, 12.489]
@@ -366,17 +380,17 @@ datasets:
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
-        units: K
+        file_units: K
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        file_units: W m-2 um-1 sr-1
 
   I_SOLZ:
     name: solar_zenith_angle
     standard_name: solar_zenith_angle
     resolution: 371
     coordinates: [i_longitude, i_latitude]
-    units: degrees
+    file_units: degrees
     file_type: generic_file
     dataset_groups: [GITCO, GIMGO]
     file_key: 'All_Data/{dataset_group}_All/SolarZenithAngle'
@@ -385,7 +399,7 @@ datasets:
     standard_name: solar_azimuth_angle
     resolution: 371
     coordinates: [i_longitude, i_latitude]
-    units: degrees
+    file_units: degrees
     file_type: generic_file
     dataset_groups: [GITCO, GIMGO]
     file_key: 'All_Data/{dataset_group}_All/SolarAzimuthAngle'
@@ -394,7 +408,7 @@ datasets:
     standard_name: sensor_zenith_angle
     resolution: 371
     coordinates: [i_longitude, i_latitude]
-    units: degrees
+    file_units: degrees
     file_type: generic_file
     dataset_groups: [GITCO, GIMGO]
     file_key: 'All_Data/{dataset_group}_All/SatelliteZenithAngle'
@@ -403,7 +417,7 @@ datasets:
     standard_name: sensor_azimuth_angle
     resolution: 371
     coordinates: [i_longitude, i_latitude]
-    units: degrees
+    file_units: degrees
     file_type: generic_file
     dataset_groups: [GITCO, GIMGO]
     file_key: 'All_Data/{dataset_group}_All/SatelliteAzimuthAngle'
@@ -412,7 +426,7 @@ datasets:
     standard_name: solar_zenith_angle
     resolution: 742
     coordinates: [m_longitude, m_latitude]
-    units: degrees
+    file_units: degrees
     file_type: generic_file
     dataset_groups: [GMTCO, GMODO]
     file_key: 'All_Data/{dataset_group}_All/SolarZenithAngle'
@@ -421,7 +435,7 @@ datasets:
     standard_name: solar_azimuth_angle
     resolution: 742
     coordinates: [m_longitude, m_latitude]
-    units: degrees
+    file_units: degrees
     file_type: generic_file
     dataset_groups: [GMTCO, GMODO]
     file_key: 'All_Data/{dataset_group}_All/SolarAzimuthAngle'
@@ -430,7 +444,7 @@ datasets:
     standard_name: sensor_zenith_angle
     resolution: 742
     coordinates: [m_longitude, m_latitude]
-    units: degrees
+    file_units: degrees
     file_type: generic_file
     dataset_groups: [GMTCO, GMODO]
     file_key: 'All_Data/{dataset_group}_All/SatelliteZenithAngle'
@@ -439,7 +453,7 @@ datasets:
     standard_name: sensor_azimuth_angle
     resolution: 742
     coordinates: [m_longitude, m_latitude]
-    units: degrees
+    file_units: degrees
     file_type: generic_file
     dataset_groups: [GMTCO, GMODO]
     file_key: 'All_Data/{dataset_group}_All/SatelliteAzimuthAngle'
@@ -460,7 +474,7 @@ datasets:
     standard_name: solar_zenith_angle
     resolution: 743
     coordinates: [dnb_longitude, dnb_latitude]
-    units: degrees
+    file_units: degrees
     file_type: generic_file
     dataset_groups: [GDNBO]
     file_key: 'All_Data/{dataset_group}_All/SolarZenithAngle'
@@ -469,7 +483,7 @@ datasets:
     standard_name: lunar_zenith_angle
     resolution: 743
     coordinates: [dnb_longitude, dnb_latitude]
-    units: degrees
+    file_units: degrees
     file_type: generic_file
     dataset_groups: [GDNBO]
     file_key: 'All_Data/{dataset_group}_All/LunarZenithAngle'
@@ -478,7 +492,7 @@ datasets:
     standard_name: sensor_zenith_angle
     resolution: 743
     coordinates: [dnb_longitude, dnb_latitude]
-    units: degrees
+    file_units: degrees
     file_type: generic_file
     dataset_groups: [GDNBO]
     file_key: 'All_Data/{dataset_group}_All/SatelliteZenithAngle'
@@ -487,7 +501,7 @@ datasets:
     standard_name: sensor_azimuth_angle
     resolution: 743
     coordinates: [dnb_longitude, dnb_latitude]
-    units: degrees
+    file_units: degrees
     file_type: generic_file
     dataset_groups: [GDNBO]
     file_key: 'All_Data/{dataset_group}_All/SatelliteAzimuthAngle'
@@ -496,7 +510,7 @@ datasets:
     file_type: generic_file
     dataset_groups: [GDNBO]
     file_key: 'All_Data/{dataset_group}_All/MoonIllumFraction'
-    units: '1'
+    file_units: '1'
 
 file_types:
   generic_file:

--- a/satpy/plugin_base.py
+++ b/satpy/plugin_base.py
@@ -68,5 +68,5 @@ class Plugin(object):
 
     def load_yaml_config(self, conf):
         """Load a YAML configuration file and recursively update the overall configuration."""
-        with open(conf) as fd:
+        with open(conf, 'r', encoding='utf-8') as fd:
             self.config = recursive_dict_update(self.config, yaml.load(fd, Loader=UnsafeLoader))

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -500,7 +500,7 @@ def read_reader_config(config_files, loader=UnsafeLoader):
     conf = {}
     LOG.debug('Reading %s', str(config_files))
     for config_file in config_files:
-        with open(config_file) as fd:
+        with open(config_file, 'r', encoding='utf-8') as fd:
             conf.update(yaml.load(fd.read(), Loader=loader))
 
     try:

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -220,8 +220,8 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
         # the file)
         if file_units is None:
             if dataset_id.get('calibration') == 'radiance':
-                if "dnb" in dataset_id['name'].lower():
-                    return 'W m-2 sr-1'
+                if "dnb" not in dataset_id['name'].lower():
+                    return 'W m-2 µm-1 sr-1'
                 else:
                     return 'W cm-2 sr-1'
             elif dataset_id.get('calibration') == 'reflectance':
@@ -229,6 +229,12 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
                 file_units = "1"
             elif dataset_id.get('calibration') == 'brightness_temperature':
                 file_units = "K"
+            elif ds_info.get('standard_name') == 'longitude':
+                file_units = "degrees_east"
+            elif ds_info.get('standard_name') == 'latitude':
+                file_units = "degrees_north"
+            elif 'angle' in ds_info.get('standard_name'):
+                file_units = 'degrees'
             else:
                 LOG.debug("Unknown units for file key '%s'", dataset_id)
 
@@ -259,8 +265,8 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
                       file_units, output_units)
             factors = factors * 100.
         else:
-            LOG.debug("Not sure how to perform unit conversion '%s' to '%s'",
-                      file_units, output_units)
+            raise ValueError("Don't know how to convert '{}' to '{}'".format(
+                file_units, output_units))
         return factors
 
     @staticmethod

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -365,8 +365,14 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
 
         file_units = self.get_file_units(dataset_id, ds_info)
         output_units = ds_info.get("units", file_units)
+        print(var_path, factor_var_path)
+        print(factors, file_units, output_units)
+        print(ds_info)
         factors = self.adjust_scaling_factors(factors, file_units, output_units)
-        data = self.scale_swath_data(data, factors)
+        print("After:")
+        print(factors)
+        if factors is not None:
+            data = self.scale_swath_data(data, factors)
 
         i = getattr(data, 'attrs', {})
         i.update(ds_info)

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -365,12 +365,7 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
 
         file_units = self.get_file_units(dataset_id, ds_info)
         output_units = ds_info.get("units", file_units)
-        print(var_path, factor_var_path)
-        print(factors, file_units, output_units)
-        print(ds_info)
         factors = self.adjust_scaling_factors(factors, file_units, output_units)
-        print("After:")
-        print(factors)
         if factors is not None:
             data = self.scale_swath_data(data, factors)
 

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -221,7 +221,7 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
         if file_units is None:
             if dataset_id.get('calibration') == 'radiance':
                 if "dnb" not in dataset_id['name'].lower():
-                    return 'W m-2 µm-1 sr-1'
+                    return 'W m-2 um-1 sr-1'
                 else:
                     return 'W cm-2 sr-1'
             elif dataset_id.get('calibration') == 'reflectance':

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -212,42 +212,11 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
             'sensor_name', default).format(dataset_group=dataset_group)
         return self[sensor_path].lower()
 
-    @staticmethod
-    def _get_file_units_by_calibration(dataset_id):
-        file_units = None
-        if dataset_id.get('calibration') == 'radiance':
-            if "dnb" not in dataset_id['name'].lower():
-                file_units = 'W m-2 um-1 sr-1'
-            else:
-                file_units = 'W cm-2 sr-1'
-        elif dataset_id.get('calibration') == 'reflectance':
-            # CF compliant unit for dimensionless
-            file_units = "1"
-        elif dataset_id.get('calibration') == 'brightness_temperature':
-            file_units = "K"
-        return file_units
-
-    @staticmethod
-    def _get_file_units_by_standard_name(ds_info):
-        file_units = None
-        if ds_info.get('standard_name') == 'longitude':
-            file_units = "degrees_east"
-        elif ds_info.get('standard_name') == 'latitude':
-            file_units = "degrees_north"
-        elif 'angle' in ds_info.get('standard_name'):
-            file_units = 'degrees'
-        return file_units
-
     def get_file_units(self, dataset_id, ds_info):
-        """Get file units from metadata or make an educated guess."""
+        """Get file units from metadata."""
         file_units = ds_info.get("file_units")
         if file_units is None:
-            file_units = self._get_file_units_by_calibration(dataset_id)
-        if file_units is None:
-            file_units = self._get_file_units_by_standard_name(ds_info)
-        if file_units is None:
             LOG.debug("Unknown units for file key '%s'", dataset_id)
-
         return file_units
 
     def scale_swath_data(self, data, scaling_factors):

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -97,7 +97,7 @@ class AbstractYAMLReader(metaclass=ABCMeta):
         self.config = {}
         self.config_files = config_files
         for config_file in config_files:
-            with open(config_file) as fd:
+            with open(config_file, 'r', encoding='utf-8') as fd:
                 self.config = recursive_dict_update(self.config, yaml.load(fd, Loader=UnsafeLoader))
         self.info = self.config['reader']
         self.name = self.info['name']

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -66,95 +66,156 @@ DATASET_KEYS = {'GDNBO': 'VIIRS-DNB-GEO',
 class FakeHDF5FileHandler2(FakeHDF5FileHandler):
     """Swap-in HDF5 File Handler."""
 
+    _num_test_granules = 1
+
     def __init__(self, filename, filename_info, filetype_info, include_factors=True):
         """Create fake file handler."""
         self.include_factors = include_factors
         super(FakeHDF5FileHandler2, self).__init__(filename, filename_info, filetype_info)
 
-    def get_test_content(self, filename, filename_info, filetype_info):
-        """Mimic reader input file content."""
+    @staticmethod
+    def _add_basic_metadata_to_file_content(file_content, filename_info):
         start_time = filename_info['start_time']
         end_time = filename_info['end_time'].replace(year=start_time.year,
                                                      month=start_time.month,
                                                      day=start_time.day)
-        final_content = {}
-        for dataset in self.datasets:
-            dataset_group = DATASET_KEYS[dataset]
-            prefix1 = 'Data_Products/{dataset_group}'.format(dataset_group=dataset_group)
-            prefix2 = '{prefix}/{dataset_group}_Aggr'.format(prefix=prefix1, dataset_group=dataset_group)
-            prefix3 = 'All_Data/{dataset_group}_All'.format(dataset_group=dataset_group)
-            prefix4 = '{prefix}/{dataset_group}_Gran_0'.format(prefix=prefix1, dataset_group=dataset_group)
-            begin_date = start_time.strftime('%Y%m%d')
-            begin_time = start_time.strftime('%H%M%S.%fZ')
-            ending_date = end_time.strftime('%Y%m%d')
-            ending_time = end_time.strftime('%H%M%S.%fZ')
-            if filename[:3] == 'SVI':
-                geo_prefix = 'GIMGO'
-            elif filename[:3] == 'SVM':
-                geo_prefix = 'GMODO'
-            else:
-                geo_prefix = None
-            file_content = {
-                "{prefix2}/attr/AggregateNumberGranules": 1,
-                "{prefix4}/attr/N_Number_Of_Scans": 48,
-                "{prefix2}/attr/AggregateBeginningDate": begin_date,
-                "{prefix2}/attr/AggregateBeginningTime": begin_time,
-                "{prefix2}/attr/AggregateEndingDate": ending_date,
-                "{prefix2}/attr/AggregateEndingTime": ending_time,
-                "{prefix2}/attr/G-Ring_Longitude": np.array([0.0, 0.1, 0.2, 0.3]),
-                "{prefix2}/attr/G-Ring_Latitude": np.array([0.0, 0.1, 0.2, 0.3]),
-                "{prefix2}/attr/AggregateBeginningOrbitNumber": "{0:d}".format(filename_info['orbit']),
-                "{prefix2}/attr/AggregateEndingOrbitNumber": "{0:d}".format(filename_info['orbit']),
-                "{prefix1}/attr/Instrument_Short_Name": "VIIRS",
-                "/attr/Platform_Short_Name": "NPP",
-            }
-            if geo_prefix:
-                file_content['/attr/N_GEO_Ref'] = geo_prefix + filename[5:]
-            for k, v in list(file_content.items()):
-                file_content[k.format(prefix1=prefix1, prefix2=prefix2, prefix3=prefix3, prefix4=prefix4)] = v
+        begin_date = start_time.strftime('%Y%m%d')
+        begin_time = start_time.strftime('%H%M%S.%fZ')
+        ending_date = end_time.strftime('%Y%m%d')
+        ending_time = end_time.strftime('%H%M%S.%fZ')
+        new_file_content = {
+            "{prefix2}/attr/AggregateNumberGranules": 1,
+            "{prefix2}/attr/AggregateBeginningDate": begin_date,
+            "{prefix2}/attr/AggregateBeginningTime": begin_time,
+            "{prefix2}/attr/AggregateEndingDate": ending_date,
+            "{prefix2}/attr/AggregateEndingTime": ending_time,
+            "{prefix2}/attr/G-Ring_Longitude": np.array([0.0, 0.1, 0.2, 0.3]),
+            "{prefix2}/attr/G-Ring_Latitude": np.array([0.0, 0.1, 0.2, 0.3]),
+            "{prefix2}/attr/AggregateBeginningOrbitNumber": "{0:d}".format(filename_info['orbit']),
+            "{prefix2}/attr/AggregateEndingOrbitNumber": "{0:d}".format(filename_info['orbit']),
+            "{prefix1}/attr/Instrument_Short_Name": "VIIRS",
+            "/attr/Platform_Short_Name": "NPP",
+        }
+        file_content.update(new_file_content)
 
-            if filename[:3] in ['SVM', 'SVI', 'SVD']:
-                if filename[2:5] in ['M{:02d}'.format(x) for x in range(12)] + ['I01', 'I02', 'I03']:
-                    keys = ['Radiance', 'Reflectance']
-                elif filename[2:5] in ['M{:02d}'.format(x) for x in range(12, 17)] + ['I04', 'I05']:
-                    keys = ['Radiance', 'BrightnessTemperature']
-                else:
-                    # DNB
-                    keys = ['Radiance']
+    @staticmethod
+    def _add_granule_specific_info_to_file_content(
+            file_content, dataset_group, num_granules, gran_group_prefix):
+        lats_lists = [
+            np.array(
+                [
+                    67.969505, 65.545685, 63.103046, 61.853905, 55.169273,
+                    57.062447, 58.86063, 66.495514
+                ],
+                dtype=np.float32),
+            np.array(
+                [
+                    72.74879, 70.2493, 67.84738, 66.49691, 58.77254,
+                    60.465942, 62.11525, 71.08249
+                ],
+                dtype=np.float32),
+            np.array(
+                [
+                    77.393425, 74.977875, 72.62976, 71.083435, 62.036346,
+                    63.465122, 64.78075, 75.36842
+                ],
+                dtype=np.float32),
+            np.array(
+                [
+                    81.67615, 79.49934, 77.278656, 75.369415, 64.72178,
+                    65.78417, 66.66166, 79.00025
+                ],
+                dtype=np.float32),
+        ]
+        lons_lists = [
+            np.array(
+                [
+                    50.51393, 49.566296, 48.865967, 18.96082, -4.0238385,
+                    -7.05221, -10.405702, 14.638646
+                ],
+                dtype=np.float32),
+            np.array(
+                [
+                    53.52594, 51.685738, 50.439102, 14.629087, -10.247547,
+                    -13.951393, -18.256989, 8.36572
+                ],
+                dtype=np.float32),
+            np.array(
+                [
+                    59.386833, 55.770416, 53.38952, 8.353765, -18.062435,
+                    -22.608992, -27.867302, -1.3537619
+                ],
+                dtype=np.float32),
+            np.array(
+                [
+                    72.50243, 64.17125, 59.15234, -1.3654504, -27.620953,
+                    -33.091743, -39.28113, -17.749891
+                ],
+                dtype=np.float32)
+        ]
+        file_content["{prefix3}/NumberOfScans"] = np.array([48] * num_granules)
+        for granule_idx in range(num_granules):
+            prefix_gran = '{prefix}/{dataset_group}_Gran_{idx}'.format(prefix=gran_group_prefix,
+                                                                       dataset_group=dataset_group,
+                                                                       idx=granule_idx)
+            file_content[prefix_gran + '/attr/N_Number_Of_Scans'] = 48
+            file_content[prefix_gran + '/attr/G-Ring_Longitude'] = lons_lists[granule_idx]
+            file_content[prefix_gran + '/attr/G-Ring_Latitude'] = lats_lists[granule_idx]
 
-                for k in keys:
-                    k = prefix3 + "/" + k
-                    file_content[k] = DEFAULT_FILE_DATA.copy()
-                    file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
-                    if self.include_factors:
-                        file_content[k + "Factors"] = DEFAULT_FILE_FACTORS.copy()
-            elif filename[0] == 'G':
-                if filename[:5] in ['GMODO', 'GIMGO']:
-                    lon_data = np.linspace(15, 55, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
-                    lat_data = np.linspace(55, 75, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
-                else:
-                    lon_data = np.linspace(5, 45, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
-                    lat_data = np.linspace(45, 65, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
+    def _add_data_info_to_file_content(self, file_content, filename, data_var_prefix):
+        if filename[2:5] in ['M{:02d}'.format(x) for x in range(12)] + ['I01', 'I02', 'I03']:
+            keys = ['Radiance', 'Reflectance']
+        elif filename[2:5] in ['M{:02d}'.format(x) for x in range(12, 17)] + ['I04', 'I05']:
+            keys = ['Radiance', 'BrightnessTemperature']
+        else:
+            # DNB
+            keys = ['Radiance']
 
-                for k in ["Latitude"]:
-                    k = prefix3 + "/" + k
-                    file_content[k] = lat_data
-                    file_content[k] = np.repeat([file_content[k]], DEFAULT_FILE_SHAPE[0], axis=0)
-                    file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
-                for k in ["Longitude"]:
-                    k = prefix3 + "/" + k
-                    file_content[k] = lon_data
-                    file_content[k] = np.repeat([file_content[k]], DEFAULT_FILE_SHAPE[0], axis=0)
-                    file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
-                for k in ["SolarZenithAngle"]:
-                    k = prefix3 + "/" + k
-                    file_content[k] = lon_data  # close enough to SZA
-                    file_content[k] = np.repeat([file_content[k]], DEFAULT_FILE_SHAPE[0], axis=0)
-                    file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
+        for k in keys:
+            k = data_var_prefix + "/" + k
+            file_content[k] = DEFAULT_FILE_DATA.copy()
+            file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
+            if self.include_factors:
+                file_content[k + "Factors"] = DEFAULT_FILE_FACTORS.copy()
 
-        final_content.update(file_content)
+    @staticmethod
+    def _add_geolocation_info_to_file_content(file_content, filename, data_var_prefix):
+        if filename[:5] in ['GMODO', 'GIMGO']:
+            lon_data = np.linspace(15, 55, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
+            lat_data = np.linspace(55, 75, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
+        else:
+            lon_data = np.linspace(5, 45, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
+            lat_data = np.linspace(45, 65, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
 
-        # convert to xarrays
+        for k in ["Latitude"]:
+            k = data_var_prefix + "/" + k
+            file_content[k] = lat_data
+            file_content[k] = np.repeat([file_content[k]], DEFAULT_FILE_SHAPE[0], axis=0)
+            file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
+        for k in ["Longitude"]:
+            k = data_var_prefix + "/" + k
+            file_content[k] = lon_data
+            file_content[k] = np.repeat([file_content[k]], DEFAULT_FILE_SHAPE[0], axis=0)
+            file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
+        for k in ["SolarZenithAngle"]:
+            k = data_var_prefix + "/" + k
+            file_content[k] = lon_data  # close enough to SZA
+            file_content[k] = np.repeat([file_content[k]], DEFAULT_FILE_SHAPE[0], axis=0)
+            file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
+
+    @staticmethod
+    def _add_geo_ref(file_content, filename):
+        if filename[:3] == 'SVI':
+            geo_prefix = 'GIMGO'
+        elif filename[:3] == 'SVM':
+            geo_prefix = 'GMODO'
+        else:
+            geo_prefix = None
+        if geo_prefix:
+            file_content['/attr/N_GEO_Ref'] = geo_prefix + filename[5:]
+
+    @staticmethod
+    def _convert_numpy_content_to_dataarray(final_content):
         from xarray import DataArray
         import dask.array as da
         for key, val in final_content.items():
@@ -165,6 +226,30 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
                 else:
                     final_content[key] = DataArray(val)
 
+    def get_test_content(self, filename, filename_info, filetype_info):
+        """Mimic reader input file content."""
+        final_content = {}
+        for dataset in self.datasets:
+            dataset_group = DATASET_KEYS[dataset]
+            prefix1 = 'Data_Products/{dataset_group}'.format(dataset_group=dataset_group)
+            prefix2 = '{prefix}/{dataset_group}_Aggr'.format(prefix=prefix1, dataset_group=dataset_group)
+            prefix3 = 'All_Data/{dataset_group}_All'.format(dataset_group=dataset_group)
+
+            file_content = {}
+            self._add_basic_metadata_to_file_content(file_content, filename_info)
+            self._add_granule_specific_info_to_file_content(file_content, dataset_group,
+                                                            self._num_test_granules, prefix1)
+            self._add_geo_ref(file_content, filename)
+
+            for k, v in list(file_content.items()):
+                file_content[k.format(prefix1=prefix1, prefix2=prefix2, prefix3=prefix3)] = v
+
+            if filename[:3] in ['SVM', 'SVI', 'SVD']:
+                self._add_data_info_to_file_content(file_content, filename, prefix3)
+            elif filename[0] == 'G':
+                self._add_geolocation_info_to_file_content(file_content, filename, prefix3)
+            final_content.update(file_content)
+        self._convert_numpy_content_to_dataarray(final_content)
         return final_content
 
 
@@ -172,6 +257,39 @@ class TestVIIRSSDRReader(unittest.TestCase):
     """Test VIIRS SDR Reader."""
 
     yaml_file = "viirs_sdr.yaml"
+
+    def _assert_reflectance_properties(self, data_arr, num_scans=16, with_area=True):
+        self.assertTrue(np.issubdtype(data_arr.dtype, np.float32))
+        self.assertEqual(data_arr.attrs['calibration'], 'reflectance')
+        self.assertEqual(data_arr.attrs['units'], '%')
+        self.assertEqual(data_arr.attrs['rows_per_scan'], num_scans)
+        if with_area:
+            self.assertIn('area', data_arr.attrs)
+            self.assertIsNotNone(data_arr.attrs['area'])
+        else:
+            self.assertNotIn('area', data_arr.attrs)
+
+    def _assert_bt_properties(self, data_arr, num_scans=16, with_area=True):
+        self.assertTrue(np.issubdtype(data_arr.dtype, np.float32))
+        self.assertEqual(data_arr.attrs['calibration'], 'brightness_temperature')
+        self.assertEqual(data_arr.attrs['units'], 'K')
+        self.assertEqual(data_arr.attrs['rows_per_scan'], num_scans)
+        if with_area:
+            self.assertIn('area', data_arr.attrs)
+            self.assertIsNotNone(data_arr.attrs['area'])
+        else:
+            self.assertNotIn('area', data_arr.attrs)
+
+    def _assert_dnb_radiance_properties(self, data_arr, with_area=True):
+        self.assertTrue(np.issubdtype(data_arr.dtype, np.float32))
+        self.assertEqual(data_arr.attrs['calibration'], 'radiance')
+        self.assertEqual(data_arr.attrs['units'], 'W m-2 sr-1')
+        self.assertEqual(data_arr.attrs['rows_per_scan'], 16)
+        if with_area:
+            self.assertIn('area', data_arr.attrs)
+            self.assertIsNotNone(data_arr.attrs['area'])
+        else:
+            self.assertNotIn('area', data_arr.attrs)
 
     def setUp(self):
         """Wrap HDF5 file handler with our own fake handler."""
@@ -274,11 +392,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
                      ])
         self.assertEqual(len(ds), 11)
         for d in ds.values():
-            self.assertTrue(np.issubdtype(d.dtype, np.float32))
-            self.assertEqual(d.attrs['calibration'], 'reflectance')
-            self.assertEqual(d.attrs['units'], '%')
-            self.assertEqual(d.attrs['rows_per_scan'], 16)
-            self.assertNotIn('area', d.attrs)
+            self._assert_reflectance_properties(d, with_area=False)
 
     def test_load_all_m_reflectances_find_geo(self):
         """Load all M band reflectances with geo files not specified but existing."""
@@ -320,12 +434,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
 
         self.assertEqual(len(ds), 11)
         for d in ds.values():
-            self.assertTrue(np.issubdtype(d.dtype, np.float32))
-            self.assertEqual(d.attrs['calibration'], 'reflectance')
-            self.assertEqual(d.attrs['units'], '%')
-            self.assertEqual(d.attrs['rows_per_scan'], 16)
-            self.assertIn('area', d.attrs)
-            self.assertIsNotNone(d.attrs['area'])
+            self._assert_reflectance_properties(d, with_area=True)
 
     def test_load_all_m_reflectances_provided_geo(self):
         """Load all M band reflectances with geo files provided."""
@@ -360,12 +469,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
                      ])
         self.assertEqual(len(ds), 11)
         for d in ds.values():
-            self.assertTrue(np.issubdtype(d.dtype, np.float32))
-            self.assertEqual(d.attrs['calibration'], 'reflectance')
-            self.assertEqual(d.attrs['units'], '%')
-            self.assertEqual(d.attrs['rows_per_scan'], 16)
-            self.assertIn('area', d.attrs)
-            self.assertIsNotNone(d.attrs['area'])
+            self._assert_reflectance_properties(d, with_area=True)
             self.assertEqual(d.attrs['area'].lons.min(), 5)
             self.assertEqual(d.attrs['area'].lats.min(), 45)
             self.assertEqual(d.attrs['area'].lons.attrs['rows_per_scan'], 16)
@@ -405,12 +509,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
                      ])
         self.assertEqual(len(ds), 11)
         for d in ds.values():
-            self.assertTrue(np.issubdtype(d.dtype, np.float32))
-            self.assertEqual(d.attrs['calibration'], 'reflectance')
-            self.assertEqual(d.attrs['units'], '%')
-            self.assertEqual(d.attrs['rows_per_scan'], 16)
-            self.assertIn('area', d.attrs)
-            self.assertIsNotNone(d.attrs['area'])
+            self._assert_reflectance_properties(d, with_area=True)
             self.assertEqual(d.attrs['area'].lons.min(), 15)
             self.assertEqual(d.attrs['area'].lats.min(), 55)
             self.assertEqual(d.attrs['area'].lons.attrs['rows_per_scan'], 16)
@@ -449,12 +548,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
                      ])
         self.assertEqual(len(ds), 11)
         for d in ds.values():
-            self.assertTrue(np.issubdtype(d.dtype, np.float32))
-            self.assertEqual(d.attrs['calibration'], 'reflectance')
-            self.assertEqual(d.attrs['units'], '%')
-            self.assertEqual(d.attrs['rows_per_scan'], 16)
-            self.assertIn('area', d.attrs)
-            self.assertIsNotNone(d.attrs['area'])
+            self._assert_reflectance_properties(d, with_area=True)
             self.assertEqual(d.attrs['area'].lons.min(), 15)
             self.assertEqual(d.attrs['area'].lats.min(), 55)
             self.assertEqual(d.attrs['area'].lons.attrs['rows_per_scan'], 16)
@@ -481,12 +575,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
                      ])
         self.assertEqual(len(ds), 5)
         for d in ds.values():
-            self.assertTrue(np.issubdtype(d.dtype, np.float32))
-            self.assertEqual(d.attrs['calibration'], 'brightness_temperature')
-            self.assertEqual(d.attrs['units'], 'K')
-            self.assertEqual(d.attrs['rows_per_scan'], 16)
-            self.assertIn('area', d.attrs)
-            self.assertIsNotNone(d.attrs['area'])
+            self._assert_bt_properties(d, with_area=True)
 
     def test_load_dnb_sza_no_factors(self):
         """Load DNB solar zenith angle with no scaling factors.
@@ -574,7 +663,6 @@ class TestVIIRSSDRReader(unittest.TestCase):
         ds = r.load(['DNB'])
         self.assertEqual(len(ds), 1)
         for d in ds.values():
-            self.assertTrue(np.issubdtype(d.dtype, np.float32))
             data = d.values
             # default scale factors are 2 and offset 1
             # multiply DNB by 10000 should mean the first value of 0 should be:
@@ -584,11 +672,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
             # the second value of 1 should be:
             # 1 * 2 * 10000 + 1 * 10000 => 30000
             self.assertEqual(data[0, 1], 30000)
-            self.assertEqual(d.attrs['calibration'], 'radiance')
-            self.assertEqual(d.attrs['units'], 'W m-2 sr-1')
-            self.assertEqual(d.attrs['rows_per_scan'], 16)
-            self.assertIn('area', d.attrs)
-            self.assertIsNotNone(d.attrs['area'])
+            self._assert_dnb_radiance_properties(d, with_area=True)
 
     def test_load_dnb_no_factors(self):
         """Load DNB dataset with no provided scale factors."""
@@ -602,7 +686,6 @@ class TestVIIRSSDRReader(unittest.TestCase):
         ds = r.load(['DNB'])
         self.assertEqual(len(ds), 1)
         for d in ds.values():
-            self.assertTrue(np.issubdtype(d.dtype, np.float32))
             data = d.values
             # no scale factors, default factor 1 and offset 0
             # multiply DNB by 10000 should mean the first value of 0 should be:
@@ -612,11 +695,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
             # the second value of 1 should be:
             # 1 * 1 * 10000 + 0 * 10000 => 10000
             self.assertEqual(data[0, 1], 10000)
-            self.assertEqual(d.attrs['calibration'], 'radiance')
-            self.assertEqual(d.attrs['units'], 'W m-2 sr-1')
-            self.assertEqual(d.attrs['rows_per_scan'], 16)
-            self.assertIn('area', d.attrs)
-            self.assertIsNotNone(d.attrs['area'])
+            self._assert_dnb_radiance_properties(d, with_area=True)
 
     def test_load_i_no_files(self):
         """Load I01 when only DNB files are provided."""
@@ -648,12 +727,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
                      ])
         self.assertEqual(len(ds), 3)
         for d in ds.values():
-            self.assertTrue(np.issubdtype(d.dtype, np.float32))
-            self.assertEqual(d.attrs['calibration'], 'reflectance')
-            self.assertEqual(d.attrs['units'], '%')
-            self.assertEqual(d.attrs['rows_per_scan'], 32)
-            self.assertIn('area', d.attrs)
-            self.assertIsNotNone(d.attrs['area'])
+            self._assert_reflectance_properties(d, num_scans=32)
             self.assertEqual(d.attrs['area'].lons.min(), 5)
             self.assertEqual(d.attrs['area'].lats.min(), 45)
             self.assertEqual(d.attrs['area'].lons.attrs['rows_per_scan'], 32)
@@ -674,12 +748,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
                      ])
         self.assertEqual(len(ds), 2)
         for d in ds.values():
-            self.assertTrue(np.issubdtype(d.dtype, np.float32))
-            self.assertEqual(d.attrs['calibration'], 'brightness_temperature')
-            self.assertEqual(d.attrs['units'], 'K')
-            self.assertEqual(d.attrs['rows_per_scan'], 32)
-            self.assertIn('area', d.attrs)
-            self.assertIsNotNone(d.attrs['area'])
+            self._assert_bt_properties(d, num_scans=32)
 
     def test_load_all_i_radiances(self):
         """Load all I band radiances."""
@@ -712,160 +781,10 @@ class TestVIIRSSDRReader(unittest.TestCase):
             self.assertIsNotNone(d.attrs['area'])
 
 
-class FakeHDF5FileHandlerAggr(FakeHDF5FileHandler):
-    """Swap-in HDF5 File Handler."""
+class FakeHDF5FileHandlerAggr(FakeHDF5FileHandler2):
+    """Swap-in HDF5 File Handler with 4 VIIRS Granules per file."""
 
-    def __init__(self, filename, filename_info, filetype_info):
-        """Create fake aggregated file handler."""
-        super(FakeHDF5FileHandlerAggr, self).__init__(filename, filename_info, filetype_info)
-
-    def get_test_content(self, filename, filename_info, filetype_info):
-        """Mimic reader input file content."""
-        start_time = filename_info['start_time']
-        end_time = filename_info['end_time'].replace(year=start_time.year,
-                                                     month=start_time.month,
-                                                     day=start_time.day)
-        final_content = {}
-        for dataset in self.datasets:
-            dataset_group = DATASET_KEYS[dataset]
-            prefix1 = 'Data_Products/{dataset_group}'.format(dataset_group=dataset_group)
-            prefix2 = '{prefix}/{dataset_group}_Aggr'.format(prefix=prefix1, dataset_group=dataset_group)
-            prefix3 = 'All_Data/{dataset_group}_All'.format(dataset_group=dataset_group)
-            begin_date = start_time.strftime('%Y%m%d')
-            begin_time = start_time.strftime('%H%M%S.%fZ')
-            ending_date = end_time.strftime('%Y%m%d')
-            ending_time = end_time.strftime('%H%M%S.%fZ')
-            if filename[:3] == 'SVI':
-                geo_prefix = 'GIMGO'
-            elif filename[:3] == 'SVM':
-                geo_prefix = 'GMODO'
-            else:
-                geo_prefix = None
-            file_content = {
-                "{prefix3}/NumberOfScans": np.array([48, 48, 48, 48]),
-                "{prefix2}/attr/AggregateBeginningDate": begin_date,
-                "{prefix2}/attr/AggregateBeginningTime": begin_time,
-                "{prefix2}/attr/AggregateEndingDate": ending_date,
-                "{prefix2}/attr/AggregateEndingTime": ending_time,
-                "{prefix2}/attr/G-Ring_Longitude": np.array([0.0, 0.1, 0.2, 0.3]),
-                "{prefix2}/attr/G-Ring_Latitude": np.array([0.0, 0.1, 0.2, 0.3]),
-                "{prefix2}/attr/AggregateBeginningOrbitNumber": "{0:d}".format(filename_info['orbit']),
-                "{prefix2}/attr/AggregateEndingOrbitNumber": "{0:d}".format(filename_info['orbit']),
-                "{prefix1}/attr/Instrument_Short_Name": "VIIRS",
-                "/attr/Platform_Short_Name": "NPP",
-            }
-
-            lats_lists = [
-                np.array(
-                    [
-                        67.969505, 65.545685, 63.103046, 61.853905, 55.169273,
-                        57.062447, 58.86063, 66.495514
-                    ],
-                    dtype=np.float32),
-                np.array(
-                    [
-                        72.74879, 70.2493, 67.84738, 66.49691, 58.77254,
-                        60.465942, 62.11525, 71.08249
-                    ],
-                    dtype=np.float32),
-                np.array(
-                    [
-                        77.393425, 74.977875, 72.62976, 71.083435, 62.036346,
-                        63.465122, 64.78075, 75.36842
-                    ],
-                    dtype=np.float32),
-                np.array(
-                    [
-                        81.67615, 79.49934, 77.278656, 75.369415, 64.72178,
-                        65.78417, 66.66166, 79.00025
-                    ],
-                    dtype=np.float32)
-            ]
-            lons_lists = [
-                np.array(
-                    [
-                        50.51393, 49.566296, 48.865967, 18.96082, -4.0238385,
-                        -7.05221, -10.405702, 14.638646
-                    ],
-                    dtype=np.float32),
-                np.array(
-                    [
-                        53.52594, 51.685738, 50.439102, 14.629087, -10.247547,
-                        -13.951393, -18.256989, 8.36572
-                    ],
-                    dtype=np.float32),
-                np.array(
-                    [
-                        59.386833, 55.770416, 53.38952, 8.353765, -18.062435,
-                        -22.608992, -27.867302, -1.3537619
-                    ],
-                    dtype=np.float32),
-                np.array(
-                    [
-                        72.50243, 64.17125, 59.15234, -1.3654504, -27.620953,
-                        -33.091743, -39.28113, -17.749891
-                    ],
-                    dtype=np.float32)
-            ]
-
-            for granule in range(4):
-                prefix_gran = '{prefix}/{dataset_group}_Gran_{idx}'.format(prefix=prefix1,
-                                                                           dataset_group=dataset_group,
-                                                                           idx=granule)
-                file_content[prefix_gran + '/attr/G-Ring_Longitude'] = lons_lists[granule]
-                file_content[prefix_gran + '/attr/G-Ring_Latitude'] = lats_lists[granule]
-            if geo_prefix:
-                file_content['/attr/N_GEO_Ref'] = geo_prefix + filename[5:]
-            for k, v in list(file_content.items()):
-                file_content[k.format(prefix1=prefix1, prefix2=prefix2, prefix3=prefix3)] = v
-
-            if filename[:3] in ['SVM', 'SVI', 'SVD']:
-                if filename[2:5] in ['M{:02d}'.format(x) for x in range(12)] + ['I01', 'I02', 'I03']:
-                    keys = ['Radiance', 'Reflectance']
-                elif filename[2:5] in ['M{:02d}'.format(x) for x in range(12, 17)] + ['I04', 'I05']:
-                    keys = ['Radiance', 'BrightnessTemperature']
-                else:
-                    # DNB
-                    keys = ['Radiance']
-
-                for k in keys:
-                    k = prefix3 + "/" + k
-                    file_content[k] = DEFAULT_FILE_DATA.copy()
-                    file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
-                    file_content[k + "Factors"] = DEFAULT_FILE_FACTORS.copy()
-            elif filename[0] == 'G':
-                if filename[:5] in ['GMODO', 'GIMGO']:
-                    lon_data = np.linspace(15, 55, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
-                    lat_data = np.linspace(55, 75, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
-                else:
-                    lon_data = np.linspace(5, 45, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
-                    lat_data = np.linspace(45, 65, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
-
-                for k in ["Latitude"]:
-                    k = prefix3 + "/" + k
-                    file_content[k] = lat_data
-                    file_content[k] = np.repeat([file_content[k]], DEFAULT_FILE_SHAPE[0], axis=0)
-                    file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
-                for k in ["Longitude"]:
-                    k = prefix3 + "/" + k
-                    file_content[k] = lon_data
-                    file_content[k] = np.repeat([file_content[k]], DEFAULT_FILE_SHAPE[0], axis=0)
-                    file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
-
-        final_content.update(file_content)
-
-        # convert to xarrays
-        from xarray import DataArray
-        import dask.array as da
-        for key, val in final_content.items():
-            if isinstance(val, np.ndarray):
-                val = da.from_array(val, chunks=val.shape)
-                if val.ndim > 1:
-                    final_content[key] = DataArray(val, dims=('y', 'x'))
-                else:
-                    final_content[key] = DataArray(val)
-
-        return final_content
+    _num_test_granules = 4
 
 
 class TestAggrVIIRSSDRReader(unittest.TestCase):

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -646,7 +646,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         for d in ds.values():
             self.assertTrue(np.issubdtype(d.dtype, np.float32))
             self.assertEqual(d.attrs['calibration'], 'radiance')
-            self.assertEqual(d.attrs['units'], 'W m-2 um-1 sr-1')
+            self.assertEqual(d.attrs['units'], 'W m-2 µm-1 sr-1')
             self.assertEqual(d.attrs['rows_per_scan'], 16)
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])
@@ -775,7 +775,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         for d in ds.values():
             self.assertTrue(np.issubdtype(d.dtype, np.float32))
             self.assertEqual(d.attrs['calibration'], 'radiance')
-            self.assertEqual(d.attrs['units'], 'W m-2 um-1 sr-1')
+            self.assertEqual(d.attrs['units'], 'W m-2 µm-1 sr-1')
             self.assertEqual(d.attrs['rows_per_scan'], 32)
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -646,7 +646,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         for d in ds.values():
             self.assertTrue(np.issubdtype(d.dtype, np.float32))
             self.assertEqual(d.attrs['calibration'], 'radiance')
-            self.assertEqual(d.attrs['units'], 'W m-2 µm-1 sr-1')
+            self.assertEqual(d.attrs['units'], 'W m-2 um-1 sr-1')
             self.assertEqual(d.attrs['rows_per_scan'], 16)
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])
@@ -775,7 +775,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         for d in ds.values():
             self.assertTrue(np.issubdtype(d.dtype, np.float32))
             self.assertEqual(d.attrs['calibration'], 'radiance')
-            self.assertEqual(d.attrs['units'], 'W m-2 µm-1 sr-1')
+            self.assertEqual(d.attrs['units'], 'W m-2 um-1 sr-1')
             self.assertEqual(d.attrs['rows_per_scan'], 32)
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])


### PR DESCRIPTION
A couple users noticed that the hncc_dnb and dynamic_dnb composites for the VIIRS sensor weren't producing the expected images. I tracked it down and it was caused by this commit:

https://github.com/pytroll/satpy/commit/8213c910c8fb52bf6004129d0bdd16760dfd138e#diff-49c440a59542a8e15ac930d14a080b32R256

The main issue is that these compositors expect the DNB data to be in the default units (the units that come from the file) but in the `viirs_sdr` reader we chose to scale these to "standardize" units (maybe make them CF-compatible, I don't remember). Anyway, the `viirs_sdr` reader was returning the data with one units, but wasn't actually scaling the data to be that unit because of the commit above. This only happened when the HDF5 file didn't have any scale factors for the DNB data, but this seems to always be the case.

In this PR I fix this missing scaling by 10000, add checks in the tests for the actual values of the DNB data both with and without scaling factors provided, and add checks for array data types to make sure they are 32-bit floats (@mraspaud how did you not have these already?).

Lastly, I didn't implement it here but I need to reread the documents these composites are based off of. Right now Satpy is dynamically scaling them but I'm 90% sure they are supposed to be static 0 to 1 linear.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Tests passed <!-- for all non-documentation changes -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
