### PR TITLE
Fix GSICS calibration in SEVIRI HRIT reader.

### DIFF
--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -751,7 +751,7 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
             else:
                 coefs = self.prologue["RadiometricProcessing"]['MPEFCalFeedback']
                 int_gain = coefs['GSICSCalCoeff'][band_idx]
-                int_offset = coefs['GSICSOffsetCount'][band_idx]
+                int_offset = coefs['GSICSOffsetCount'][band_idx] * int_gain
 
             # b) Internal or external? External takes precedence.
             gain = self.ext_calib_coefs.get(self.channel_name, {}).get('gain', int_gain)

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -407,6 +407,7 @@ class TestHRITMSGFileHandler(unittest.TestCase):
                 gain, offset = nominal_gain[ch_id - 1], nominal_offset[ch_id - 1]
             else:
                 gain, offset = gsics_gain[ch_id - 1], gsics_offset[ch_id - 1]
+                offset = offset * gain
 
             reader.channel_name = ch_name
             reader.mda['spectral_channel_id'] = ch_id
@@ -425,6 +426,7 @@ class TestHRITMSGFileHandler(unittest.TestCase):
                 gain, offset = coefs[ch_name]['gain'], coefs[ch_name]['offset']
             elif ch_name not in VIS_CHANNELS:
                 gain, offset = gsics_gain[ch_id - 1], gsics_offset[ch_id - 1]
+                offset = offset * gain
             else:
                 gain, offset = nominal_gain[ch_id - 1], nominal_offset[ch_id - 1]
 


### PR DESCRIPTION
The SEVIRI readers (NAT + HRIT) have the option to use the default (IMPF) or updated (GSICS) calibration coefficients for transforming digital number into radiance.

The HRIT reader, however, has a bug that means the calibration is invalid if `GSICS` mode is selected.
This PR fixes the bug by multiplying the GSICS offset by the GSICS slope value, as is recommended in the user guide and as is already done in the NAT reader.

 - [x] Tests passed
 - [x] Passes ``flake8 satpy``