### PR TITLE
Use nbviewer for linking notebooks.

### DIFF
--- a/doc/source/examples/index.rst
+++ b/doc/source/examples/index.rst
@@ -21,25 +21,25 @@ as explanations in the various sections of this documentation.
 
     * - Name
       - Description
-    * - `Quickstart with MSG data <https://github.com/pytroll/pytroll-examples/blob/master/satpy/hrit_msg_tutorial.ipynb>`_
+    * - `Quickstart with MSG data <https://nbviewer.jupyter.org/github/pytroll/pytroll-examples/blob/master/satpy/hrit_msg_tutorial.ipynb>`_
       - Satpy quickstart for loading and processing satellite data, with MSG data in this examples
-    * - `Cartopy Plot <https://github.com/pytroll/pytroll-examples/blob/master/satpy/Cartopy%20Plot.ipynb>`_
+    * - `Cartopy Plot <https://nbviewer.jupyter.org/github/pytroll/pytroll-examples/blob/master/satpy/Cartopy%20Plot.ipynb>`_
       - Plot a single VIIRS SDR granule using Cartopy and matplotlib
-    * - `Himawari-8 AHI True Color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/ahi_true_color_pyspectral.ipynb>`_
+    * - `Himawari-8 AHI True Color <https://nbviewer.jupyter.org/github/pytroll/pytroll-examples/blob/master/satpy/ahi_true_color_pyspectral.ipynb>`_
       - Generate and resample a rayleigh corrected true color RGB from Himawari-8 AHI data
-    * - `Sentinel-3 OLCI True Color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/OLCI%20L1B.ipynb>`_
+    * - `Sentinel-3 OLCI True Color <https://nbviewer.jupyter.org/github/pytroll/pytroll-examples/blob/master/satpy/OLCI%20L1B.ipynb>`_
       - Reading OLCI data from Sentinel 3 with Pytroll/Satpy
-    * - `Sentinel 2 MSI true color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/Sentinel%202%20MSI%20true%20color.ipynb>`_
+    * - `Sentinel 2 MSI true color <https://nbviewer.jupyter.org/github/pytroll/pytroll-examples/blob/master/satpy/Sentinel%202%20MSI%20true%20color.ipynb>`_
       - Reading MSI data from Sentinel 2 with Pytroll/Satpy
-    * - `Suomi-NPP VIIRS SDR True Color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/satpy_rayleigh_iband_enhanced.ipynb>`_
+    * - `Suomi-NPP VIIRS SDR True Color <https://nbviewer.jupyter.org/github/pytroll/pytroll-examples/blob/master/satpy/satpy_rayleigh_iband_enhanced.ipynb>`_
       - Generate a rayleigh corrected true color RGB from VIIRS I- and M-bands
-    * - `Aqua/Terra MODIS True Color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/satpy_rayleigh_modis.ipynb>`_
+    * - `Aqua/Terra MODIS True Color <https://nbviewer.jupyter.org/github/pytroll/pytroll-examples/blob/master/satpy/satpy_rayleigh_modis.ipynb>`_
       - Generate and resample a rayleigh corrected true color RGB from MODIS
-    * - `Sentinel 1 SAR-C False Color <https://github.com/pytroll/pytroll-examples/blob/master/satpy/sentinel1-false-color.ipynb>`_
+    * - `Sentinel 1 SAR-C False Color <https://nbviewer.jupyter.org/github/pytroll/pytroll-examples/blob/master/satpy/sentinel1-false-color.ipynb>`_
       - Generate a false color composite RGB from SAR-C polarized datasets
-    * - `Level 2 EARS-NWC cloud products <https://github.com/pytroll/pytroll-examples/blob/master/satpy/ears-nwc.ipynb>`_
+    * - `Level 2 EARS-NWC cloud products <https://nbviewer.jupyter.org/github/pytroll/pytroll-examples/blob/master/satpy/ears-nwc.ipynb>`_
       - Reading Level 2 EARS-NWC cloud products
-    * - `Level 2 MAIA cloud products <https://github.com/pytroll/pytroll-examples/blob/master/satpy/polar_maia.ipynb>`_
+    * - `Level 2 MAIA cloud products <https://nbviewer.jupyter.org/github/pytroll/pytroll-examples/blob/master/satpy/polar_maia.ipynb>`_
       - Reading Level 2 MAIA cloud products
     * - :doc:`Meteosat Third Generation FCI Natural Color RGB <fci_l1c_natural_color>`
       - Generate Natural Color RGB from Meteosat Third Generation (MTG) FCI Level 1c data


### PR DESCRIPTION
When linking to jupyter notebooks from the Satpy documentation, add a
direct link to nbviewer rather than to Github.  Github often fails to
render notebooks.

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
