### PR TITLE
Add level units support to grib reader

### DIFF
--- a/satpy/etc/readers/grib.yaml
+++ b/satpy/etc/readers/grib.yaml
@@ -7,7 +7,10 @@ reader:
     name:
       required: true
     level:
+      type: !!python/name:satpy.readers.utils.ZLevel
+    type_of_level:
     resolution:
+      transitive: False
     modifiers:
       default: []
       type: !!python/name:satpy.dataset.ModifierTuple

--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -68,6 +68,9 @@ class NUCAPSFileHandler(NetCDF4FileHandler):
 
     def __init__(self, *args, **kwargs):
         """Initialize file handler."""
+        # remove kwargs that reader instance used that file handler does not
+        kwargs.pop('mask_surface', None)
+        kwargs.pop('mask_quality', None)
         kwargs.setdefault('xarray_kwargs', {}).setdefault(
             'decode_times', False)
         super(NUCAPSFileHandler, self).__init__(*args, **kwargs)

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -24,12 +24,15 @@ import tempfile
 import bz2
 import os
 import shutil
+import numbers
 import numpy as np
 import pyproj
 import warnings
+from collections import namedtuple
 from io import BytesIO
 from subprocess import Popen, PIPE
 from pyresample.geometry import AreaDefinition
+
 
 from satpy import CHUNK_SIZE
 
@@ -311,3 +314,70 @@ def apply_rad_correction(data, slope, offset):
     """Apply GSICS-like correction factors to radiance data."""
     data = (data - offset) / slope
     return data
+
+
+try:
+    zlklass = namedtuple("ZLevel", "value units", defaults=('hPa',))
+except NameError:  # python 3.6
+    zlklass = namedtuple("Zlevel", "min central max unit")
+    zlklass.__new__.__defaults__ = ('hPa',)
+
+
+class ZLevel(zlklass):
+    """Container for level information in a DataID."""
+
+    @classmethod
+    def convert(cls, zlevel):
+        """Convert `zlevel` to this type if possible."""
+        if isinstance(zlevel, (tuple, list)):
+            return cls(*zlevel)
+        elif isinstance(zlevel, numbers.Number):
+            return cls(zlevel)
+        return zlevel
+
+    def __eq__(self, other):
+        """Return if two levels are the same.
+
+        Args:
+            other (ZLevel, tuple, list, or scalar): Another ZLevel object, a
+                scalar level value, or a tuple/list with either a scalar or
+                (value, units_str).
+
+        Return:
+            True if other is a scalar and equals this value or if other is
+            a tuple equal to self, False otherwise.
+
+        """
+        if other is None:
+            return False
+        elif isinstance(other, numbers.Number):
+            return self == self.convert(other)
+        elif isinstance(other, (tuple, list)) and len(other) == 1:
+            return self == self.convert(other)
+        return super().__eq__(other)
+
+    def __ne__(self, other):
+        """Return the opposite of `__eq__`."""
+        return not self == other
+
+    def __lt__(self, other):
+        """Compare to another level."""
+        if other is None:
+            return False
+        # compare using units first
+        return self[::-1].__lt__(other[::-1])
+
+    def __gt__(self, other):
+        """Compare to another level."""
+        if other is None:
+            return True
+        # compare using units first
+        return self[::-1].__gt__(other[::-1])
+
+    def __hash__(self):
+        """Hash this tuple."""
+        return tuple.__hash__(self)
+
+    def __str__(self):
+        """Format for print out."""
+        return "{0.value} {0.units}".format(self)

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -31,14 +31,22 @@ except ImportError:
 class FakeNetCDF4FileHandler(NetCDF4FileHandler):
     """Swap-in NetCDF4 File Handler for reader tests to use."""
 
-    def __init__(self, filename, filename_info, filetype_info, **kwargs):
+    def __init__(self, filename, filename_info, filetype_info,
+                 auto_maskandscale=False, xarray_kwargs=None,
+                 cache_var_size=0, cache_handle=False, extra_file_content=None):
         """Get fake file content from 'get_test_content'."""
+        # unused kwargs from the real file handler
+        del auto_maskandscale
+        del xarray_kwargs
+        del cache_var_size
+        del cache_handle
         if NetCDF4FileHandler is object:
             raise ImportError("Base 'NetCDF4FileHandler' could not be "
                               "imported.")
         super(NetCDF4FileHandler, self).__init__(filename, filename_info, filetype_info)
         self.file_content = self.get_test_content(filename, filename_info, filetype_info)
-        self.file_content.update(kwargs)
+        if extra_file_content:
+            self.file_content.update(extra_file_content)
 
     def get_test_content(self, filename, filename_info, filetype_info):
         """Mimic reader input file content.

--- a/satpy/tests/reader_tests/test_nucaps.py
+++ b/satpy/tests/reader_tests/test_nucaps.py
@@ -178,6 +178,18 @@ class TestNUCAPSReader(unittest.TestCase):
         # make sure we have some files
         self.assertTrue(r.file_handlers)
 
+    def test_init_with_kwargs(self):
+        """Test basic init with extra parameters."""
+        from satpy.readers import load_reader
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'NUCAPS-EDR_v1r0_npp_s201603011158009_e201603011158307_c201603011222270.nc',
+        ])
+        self.assertEqual(len(loadables), 1)
+        r.create_filehandlers(loadables, fh_kwargs={'mask_surface': True})
+        # make sure we have some files
+        self.assertTrue(r.file_handlers)
+
     def test_load_nonpressure_based(self):
         """Test loading all channels that aren't based on pressure"""
         from satpy.readers import load_reader

--- a/satpy/tests/reader_tests/test_nucaps.py
+++ b/satpy/tests/reader_tests/test_nucaps.py
@@ -54,9 +54,10 @@ ALL_PRESSURE_LEVELS = np.repeat([ALL_PRESSURE_LEVELS], DEFAULT_PRES_FILE_SHAPE[0
 
 
 class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
-    """Swap-in NetCDF4 File Handler"""
+    """Swap-in NetCDF4 File Handler."""
+
     def get_test_content(self, filename, filename_info, filetype_info):
-        """Mimic reader input file content"""
+        """Mimic reader input file content."""
         file_content = {
             '/attr/time_coverage_start': filename_info['start_time'].strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
             '/attr/time_coverage_end': filename_info['end_time'].strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
@@ -149,11 +150,12 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
 
 
 class TestNUCAPSReader(unittest.TestCase):
-    """Test NUCAPS Reader"""
+    """Test NUCAPS Reader."""
+
     yaml_file = "nucaps.yaml"
 
     def setUp(self):
-        """Wrap NetCDF4 file handler with our own fake handler"""
+        """Wrap NetCDF4 file handler with our own fake handler."""
         from satpy.config import config_search_paths
         from satpy.readers.nucaps import NUCAPSFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
@@ -163,7 +165,7 @@ class TestNUCAPSReader(unittest.TestCase):
         self.p.is_local = True
 
     def tearDown(self):
-        """Stop wrapping the NetCDF4 file handler"""
+        """Stop wrapping the NetCDF4 file handler."""
         self.p.stop()
 
     def test_init(self):
@@ -181,17 +183,17 @@ class TestNUCAPSReader(unittest.TestCase):
     def test_init_with_kwargs(self):
         """Test basic init with extra parameters."""
         from satpy.readers import load_reader
-        r = load_reader(self.reader_configs)
+        r = load_reader(self.reader_configs, mask_surface=False)
         loadables = r.select_files_from_pathnames([
             'NUCAPS-EDR_v1r0_npp_s201603011158009_e201603011158307_c201603011222270.nc',
         ])
         self.assertEqual(len(loadables), 1)
-        r.create_filehandlers(loadables, fh_kwargs={'mask_surface': True})
+        r.create_filehandlers(loadables, fh_kwargs={'mask_surface': False})
         # make sure we have some files
         self.assertTrue(r.file_handlers)
 
     def test_load_nonpressure_based(self):
-        """Test loading all channels that aren't based on pressure"""
+        """Test loading all channels that aren't based on pressure."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -213,7 +215,7 @@ class TestNUCAPSReader(unittest.TestCase):
             self.assertEqual(v.attrs['sensor'], ['CrIS', 'ATMS', 'VIIRS'])
 
     def test_load_pressure_based(self):
-        """Test loading all channels based on pressure"""
+        """Test loading all channels based on pressure."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -246,7 +248,7 @@ class TestNUCAPSReader(unittest.TestCase):
             self.assertEqual(v.ndim, 2)
 
     def test_load_individual_pressure_levels_true(self):
-        """Test loading Temperature with individual pressure datasets"""
+        """Test loading Temperature with individual pressure datasets."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -259,7 +261,7 @@ class TestNUCAPSReader(unittest.TestCase):
             self.assertEqual(v.ndim, 1)
 
     def test_load_individual_pressure_levels_min_max(self):
-        """Test loading individual Temperature with min/max level specified"""
+        """Test loading individual Temperature with min/max level specified."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -272,7 +274,7 @@ class TestNUCAPSReader(unittest.TestCase):
             self.assertEqual(v.ndim, 1)
 
     def test_load_individual_pressure_levels_single(self):
-        """Test loading individual Temperature with specific levels"""
+        """Test loading individual Temperature with specific levels."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -285,7 +287,7 @@ class TestNUCAPSReader(unittest.TestCase):
             self.assertEqual(v.ndim, 1)
 
     def test_load_pressure_levels_true(self):
-        """Test loading Temperature with all pressure levels"""
+        """Test loading Temperature with all pressure levels."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -299,7 +301,7 @@ class TestNUCAPSReader(unittest.TestCase):
             self.assertTupleEqual(v.shape, DEFAULT_PRES_FILE_SHAPE)
 
     def test_load_pressure_levels_min_max(self):
-        """Test loading Temperature with min/max level specified"""
+        """Test loading Temperature with min/max level specified."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -314,7 +316,7 @@ class TestNUCAPSReader(unittest.TestCase):
                                   (DEFAULT_PRES_FILE_SHAPE[0], 6))
 
     def test_load_pressure_levels_single(self):
-        """Test loading a specific Temperature level"""
+        """Test loading a specific Temperature level."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -329,7 +331,7 @@ class TestNUCAPSReader(unittest.TestCase):
                                   (DEFAULT_PRES_FILE_SHAPE[0], 1))
 
     def test_load_pressure_levels_single_and_pressure_levels(self):
-        """Test loading a specific Temperature level and pressure levels"""
+        """Test loading a specific Temperature level and pressure levels."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -347,11 +349,12 @@ class TestNUCAPSReader(unittest.TestCase):
 
 
 class TestNUCAPSScienceEDRReader(unittest.TestCase):
-    """Test NUCAPS Science EDR Reader"""
+    """Test NUCAPS Science EDR Reader."""
+
     yaml_file = "nucaps.yaml"
 
     def setUp(self):
-        """Wrap NetCDF4 file handler with our own fake handler"""
+        """Wrap NetCDF4 file handler with our own fake handler."""
         from satpy.config import config_search_paths
         from satpy.readers.nucaps import NUCAPSFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
@@ -361,7 +364,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
         self.p.is_local = True
 
     def tearDown(self):
-        """Stop wrapping the NetCDF4 file handler"""
+        """Stop wrapping the NetCDF4 file handler."""
         self.p.stop()
 
     def test_init(self):
@@ -377,7 +380,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
         self.assertTrue(r.file_handlers)
 
     def test_load_nonpressure_based(self):
-        """Test loading all channels that aren't based on pressure"""
+        """Test loading all channels that aren't based on pressure."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -396,7 +399,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
             self.assertEqual(v.attrs['sensor'], ['CrIS', 'ATMS', 'VIIRS'])
 
     def test_load_pressure_based(self):
-        """Test loading all channels based on pressure"""
+        """Test loading all channels based on pressure."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -426,7 +429,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
             self.assertEqual(v.ndim, 2)
 
     def test_load_individual_pressure_levels_true(self):
-        """Test loading Temperature with individual pressure datasets"""
+        """Test loading Temperature with individual pressure datasets."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -439,7 +442,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
             self.assertEqual(v.ndim, 1)
 
     def test_load_individual_pressure_levels_min_max(self):
-        """Test loading individual Temperature with min/max level specified"""
+        """Test loading individual Temperature with min/max level specified."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -452,7 +455,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
             self.assertEqual(v.ndim, 1)
 
     def test_load_individual_pressure_levels_single(self):
-        """Test loading individual Temperature with specific levels"""
+        """Test loading individual Temperature with specific levels."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -465,7 +468,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
             self.assertEqual(v.ndim, 1)
 
     def test_load_pressure_levels_true(self):
-        """Test loading Temperature with all pressure levels"""
+        """Test loading Temperature with all pressure levels."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -479,7 +482,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
             self.assertTupleEqual(v.shape, DEFAULT_PRES_FILE_SHAPE)
 
     def test_load_pressure_levels_min_max(self):
-        """Test loading Temperature with min/max level specified"""
+        """Test loading Temperature with min/max level specified."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -494,7 +497,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
                                   (DEFAULT_PRES_FILE_SHAPE[0], 6))
 
     def test_load_pressure_levels_single(self):
-        """Test loading a specific Temperature level"""
+        """Test loading a specific Temperature level."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
@@ -509,7 +512,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
                                   (DEFAULT_PRES_FILE_SHAPE[0], 1))
 
     def test_load_pressure_levels_single_and_pressure_levels(self):
-        """Test loading a specific Temperature level and pressure levels"""
+        """Test loading a specific Temperature level and pressure levels."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([


### PR DESCRIPTION
This adds a new utility `ZLevel` class to be used as a DataID identification key. This PR adds this to the level parameter for the grib reader along with 'type_of_level' . This should allow users to do:

```
scn.load([DataQuery(name='v', level=500)])
scn.load([DataQuery(name='v', level=500, type_of_level='isobaricInhPa')])
scn.load([DataQuery(name='v', level=ZLevel(500, units='hPa'), type_of_level='isobaricInhPa')])
```

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Tests passed <!-- for all non-documentation changes -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

Questions:

1. Where should I put this `ZLevel` class?
2. Better name than `ZLevel` (no I don't care if NWP has a `z` variable that it actually gh or whatever)?