### PR TITLE
Remove reference to datasetid in tests.utils.

### DIFF
--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -385,7 +385,7 @@ def make_fake_scene(content_dict, daskify=False, area=True,
 
     Create a fake Scene object from fake data.  Data are provided in
     the ``content_dict`` argument.  In ``content_dict``, keys should be
-    strings or DatasetID/DataID, and values may be either numpy.ndarray
+    strings or DataID, and values may be either numpy.ndarray
     or xarray.DataArray, in either case with exactly two dimensions.
     The function will convert each of the numpy.ndarray objects into
     an xarray.DataArray and assign those as datasets to a Scene object.
@@ -402,7 +402,7 @@ def make_fake_scene(content_dict, daskify=False, area=True,
 
     Args:
         content_dict (Mapping): Mapping where keys correspond to objects
-            accepted by ``Scene.__setitem__``, i.e. strings or DatasetID,
+            accepted by ``Scene.__setitem__``, i.e. strings or DataID,
             and values may be either ``numpy.ndarray`` or
             ``xarray.DataArray``.
         daskify (bool): optional, to use dask when converting


### PR DESCRIPTION
Remove reference to DatasetID in tests.utils.make_a_fake_scene documentation.

 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
