### PR TITLE
Fix exception to catch when new namedtuple syntax is used

### DIFF
--- a/satpy/dataset.py
+++ b/satpy/dataset.py
@@ -251,7 +251,7 @@ class ValueList(IntEnum):
 
 try:
     wlklass = namedtuple("WavelengthRange", "min central max unit", defaults=('µm',))
-except NameError:  # python 3.6
+except TypeError:  # python 3.6
     wlklass = namedtuple("WavelengthRange", "min central max unit")
     wlklass.__new__.__defaults__ = ('µm',)
 


### PR DESCRIPTION
This a quick fix for python 3.6 compatibility.

 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

