### PR TITLE
Add Sun-Earth distance corrector utility and apply in SEVIRI readers

### DIFF
--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -85,10 +85,10 @@ SATNUM = {321: "8",
 CALIB = {}
 
 # Meteosat 8
-CALIB[321] = {'HRV': {'F': 78.7599 / np.pi},
-              'VIS006': {'F': 65.2296 / np.pi},
-              'VIS008': {'F': 73.0127 / np.pi},
-              'IR_016': {'F': 62.3715 / np.pi},
+CALIB[321] = {'HRV': {'F': 78.7599},
+              'VIS006': {'F': 65.2296},
+              'VIS008': {'F': 73.0127},
+              'IR_016': {'F': 62.3715},
               'IR_039': {'VC': 2567.33,
                          'ALPHA': 0.9956,
                          'BETA': 3.41},
@@ -115,10 +115,10 @@ CALIB[321] = {'HRV': {'F': 78.7599 / np.pi},
                          'BETA': 0.578}}
 
 # Meteosat 9
-CALIB[322] = {'HRV': {'F': 79.0113 / np.pi},
-              'VIS006': {'F': 65.2065 / np.pi},
-              'VIS008': {'F': 73.1869 / np.pi},
-              'IR_016': {'F': 61.9923 / np.pi},
+CALIB[322] = {'HRV': {'F': 79.0113},
+              'VIS006': {'F': 65.2065},
+              'VIS008': {'F': 73.1869},
+              'IR_016': {'F': 61.9923},
               'IR_039': {'VC': 2568.832,
                          'ALPHA': 0.9954,
                          'BETA': 3.438},
@@ -145,10 +145,10 @@ CALIB[322] = {'HRV': {'F': 79.0113 / np.pi},
                          'BETA': 0.561}}
 
 # Meteosat 10
-CALIB[323] = {'HRV': {'F': 78.9416 / np.pi},
-              'VIS006': {'F': 65.5148 / np.pi},
-              'VIS008': {'F': 73.1807 / np.pi},
-              'IR_016': {'F': 62.0208 / np.pi},
+CALIB[323] = {'HRV': {'F': 78.9416},
+              'VIS006': {'F': 65.5148},
+              'VIS008': {'F': 73.1807},
+              'IR_016': {'F': 62.0208},
               'IR_039': {'VC': 2547.771,
                          'ALPHA': 0.9915,
                          'BETA': 2.9002},
@@ -175,10 +175,10 @@ CALIB[323] = {'HRV': {'F': 78.9416 / np.pi},
                          'BETA': 0.5390}}
 
 # Meteosat 11
-CALIB[324] = {'HRV': {'F': 79.0035 / np.pi},
-              'VIS006': {'F': 65.2656 / np.pi},
-              'VIS008': {'F': 73.1692 / np.pi},
-              'IR_016': {'F': 61.9416 / np.pi},
+CALIB[324] = {'HRV': {'F': 79.0035},
+              'VIS006': {'F': 65.2656},
+              'VIS008': {'F': 73.1692},
+              'IR_016': {'F': 61.9416},
               'IR_039': {'VC': 2555.280,
                          'ALPHA': 0.9916,
                          'BETA': 2.9438},
@@ -373,7 +373,7 @@ class SEVIRICalibrationHandler(object):
 
     def _vis_calibrate(self, data, solar_irradiance):
         """Calibrate to reflectance."""
-        return data * 100.0 / solar_irradiance
+        return np.pi * data * 100.0 / solar_irradiance
 
 
 def chebyshev(coefs, time, domain):

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -376,8 +376,8 @@ class SEVIRICalibrationHandler(object):
         """Calibrate to reflectance.
 
         This uses the method described in Conversion from radiances to
-        reflectances for SEVIRI warm channels:
-        https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_MSG_SEVIRI_RAD2REFL&RevisionSelectionMethod=LatestReleased&Rendition=Web"""
+        reflectances for SEVIRI warm channels: https://tinyurl.com/y67zhphm
+        """
         reflectance = np.pi * data * 100.0 / solar_irradiance
         return apply_earthsun_distance_correction(reflectance, self.start_time)
 

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -373,7 +373,11 @@ class SEVIRICalibrationHandler(object):
                 np.log((1.0 / data) * C1 * wavenumber ** 3 + 1.0))
 
     def _vis_calibrate(self, data, solar_irradiance):
-        """Calibrate to reflectance."""
+        """Calibrate to reflectance.
+
+        This uses the method described in Conversion from radiances to
+        reflectances for SEVIRI warm channels:
+        https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_MSG_SEVIRI_RAD2REFL&RevisionSelectionMethod=LatestReleased&Rendition=Web"""
         reflectance = np.pi * data * 100.0 / solar_irradiance
         return apply_earthsun_distance_correction(reflectance, self.start_time)
 

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -27,6 +27,7 @@ import numpy as np
 from numpy.polynomial.chebyshev import Chebyshev
 import dask.array as da
 
+from satpy.readers.utils import apply_earthsun_distance_correction
 from satpy.readers.eum_base import (time_cds_short,
                                     issue_revision)
 
@@ -371,9 +372,10 @@ class SEVIRICalibrationHandler(object):
         return ((C2 * wavenumber) /
                 np.log((1.0 / data) * C1 * wavenumber ** 3 + 1.0))
 
-    def _vis_calibrate(self, data, solar_irradiance):
+    def _vis_calibrate(self, data, solar_irradiance, time):
         """Calibrate to reflectance."""
-        return np.pi * data * 100.0 / solar_irradiance
+        reflectance = np.pi * data * 100.0 / solar_irradiance
+        return apply_earthsun_distance_correction(time, reflectance)
 
 
 def chebyshev(coefs, time, domain):

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -372,10 +372,10 @@ class SEVIRICalibrationHandler(object):
         return ((C2 * wavenumber) /
                 np.log((1.0 / data) * C1 * wavenumber ** 3 + 1.0))
 
-    def _vis_calibrate(self, data, solar_irradiance, time):
+    def _vis_calibrate(self, data, solar_irradiance):
         """Calibrate to reflectance."""
         reflectance = np.pi * data * 100.0 / solar_irradiance
-        return apply_earthsun_distance_correction(time, reflectance)
+        return apply_earthsun_distance_correction(reflectance, self.start_time)
 
 
 def chebyshev(coefs, time, domain):

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -119,16 +119,32 @@ Output:
       scn['IR_108']['y'] = mi
       scn['IR_108'].sel(time=np.datetime64('2019-03-01T12:06:13.052000000'))
 
+Notes:
+    When loading solar channels, this reader applies a correction for the
+    Sun-Earth distance variation throughout the year - as recommended by
+    the EUMETSAT document:
+        'Conversion from radiances to reflectances for SEVIRI warm channels'
+    In the unlikely situation that this correction is not required, it can be
+    removed on a per-channel basis using the
+    satpy.readers.utils.remove_earthsun_distance_correction(channel, utc_time)
+    function.
+
 
 References:
     - `MSG Level 1.5 Image Format Description`_
     - `Radiometric Calibration of MSG SEVIRI Level 1.5 Image Data in Equivalent Spectral Blackbody Radiance`_
+    - `Conversion from radiances to reflectances for SEVIRI warm channels`_
+
 
 .. _MSG Level 1.5 Image Format Description: http://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=
     PDF_TEN_05105_MSG_IMG_DATA&RevisionSelectionMethod=LatestReleased&Rendition=Web
 
 .. _Radiometric Calibration of MSG SEVIRI Level 1.5 Image Data in Equivalent Spectral Blackbody Radiance:
     https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_TEN_MSG_SEVIRI_RAD_CALIB&
+    RevisionSelectionMethod=LatestReleased&Rendition=Web
+
+.. _Conversion from radiances to reflectances for SEVIRI warm channels:
+    https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_MSG_SEVIRI_RAD2REFL&
     RevisionSelectionMethod=LatestReleased&Rendition=Web
 
 """

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -768,7 +768,7 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
 
         if calibration == 'reflectance':
             solar_irradiance = CALIB[self.platform_id][channel_name]["F"]
-            res = self._vis_calibrate(res, solar_irradiance, self.start_time)
+            res = self._vis_calibrate(res, solar_irradiance)
 
         elif calibration == 'brightness_temperature':
             cal_type = self.prologue['ImageDescription'][

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -768,7 +768,7 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
 
         if calibration == 'reflectance':
             solar_irradiance = CALIB[self.platform_id][channel_name]["F"]
-            res = self._vis_calibrate(res, solar_irradiance)
+            res = self._vis_calibrate(res, solar_irradiance, self.start_time)
 
         elif calibration == 'brightness_temperature':
             cal_type = self.prologue['ImageDescription'][

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -502,7 +502,7 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
 
         if calibration == 'reflectance':
             solar_irradiance = CALIB[self.platform_id][channel]["F"]
-            res = self._vis_calibrate(res, solar_irradiance)
+            res = self._vis_calibrate(res, solar_irradiance, self.start_time)
 
         elif calibration == 'brightness_temperature':
             cal_type = data15hdr['ImageDescription'][

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -502,7 +502,7 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
 
         if calibration == 'reflectance':
             solar_irradiance = CALIB[self.platform_id][channel]["F"]
-            res = self._vis_calibrate(res, solar_irradiance, self.start_time)
+            res = self._vis_calibrate(res, solar_irradiance)
 
         elif calibration == 'brightness_temperature':
             cal_type = data15hdr['ImageDescription'][

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -17,11 +17,28 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """SEVIRI native format reader.
 
+Notes:
+    When loading solar channels, this reader applies a correction for the
+    Sun-Earth distance variation throughout the year - as recommended by
+    the EUMETSAT document:
+        'Conversion from radiances to reflectances for SEVIRI warm channels'
+    In the unlikely situation that this correction is not required, it can be
+    removed on a per-channel basis using the
+    satpy.readers.utils.remove_earthsun_distance_correction(channel, utc_time)
+    function.
+
 References:
-    MSG Level 1.5 Native Format File Definition
+    - `MSG Level 1.5 Native Format File Definition`_
+    - `MSG Level 1.5 Image Data Format Description`_
+    - `Conversion from radiances to reflectances for SEVIRI warm channels`_
+
+.. _MSG Level 1.5 Native Format File Definition
     https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_FG15_MSG-NATIVE-FORMAT-15&RevisionSelectionMethod=LatestReleased&Rendition=Web
-    MSG Level 1.5 Image Data Format Description
+.. _MSG Level 1.5 Image Data Format Description
     https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_TEN_05105_MSG_IMG_DATA&RevisionSelectionMethod=LatestReleased&Rendition=Web
+.. _Conversion from radiances to reflectances for SEVIRI warm channels:
+    https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_MSG_SEVIRI_RAD2REFL&
+    RevisionSelectionMethod=LatestReleased&Rendition=Web
 
 """
 

--- a/satpy/readers/seviri_l1b_nc.py
+++ b/satpy/readers/seviri_l1b_nc.py
@@ -17,9 +17,28 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """SEVIRI netcdf format reader.
 
+Notes:
+    When loading solar channels, this reader applies a correction for the
+    Sun-Earth distance variation throughout the year - as recommended by
+    the EUMETSAT document:
+        'Conversion from radiances to reflectances for SEVIRI warm channels'
+    In the unlikely situation that this correction is not required, it can be
+    removed on a per-channel basis using the
+    satpy.readers.utils.remove_earthsun_distance_correction(channel, utc_time)
+    function.
+
 References:
-    MSG Level 1.5 Image Data Format Description
-    https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_TEN_05105_MSG_IMG_DATA&RevisionSelectionMethod=LatestReleased&Rendition=Web
+
+    - `MSG Level 1.5 Image Data Format Description`_
+    - `Conversion from radiances to reflectances for SEVIRI warm channels`_
+
+.. _MSG Level 1.5 Image Data Format Description:
+    https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_TEN_05105_MSG_IMG_DATA&
+    RevisionSelectionMethod=LatestReleased&Rendition=Web
+
+.. _Conversion from radiances to reflectances for SEVIRI warm channels:
+    https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_MSG_SEVIRI_RAD2REFL&
+    RevisionSelectionMethod=LatestReleased&Rendition=Web
 """
 
 from satpy.readers.file_handlers import BaseFileHandler

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -314,23 +314,23 @@ def apply_rad_correction(data, slope, offset):
     return data
 
 
-def _get_array_date(scn_data, utc_date=None):
+def get_array_date(scn_data, utc_date=None):
     """Get start time from a channel data array."""
     if utc_date is None:
         try:
             utc_date = scn_data.attrs['start_time']
-        except AttributeError:
+        except KeyError:
             try:
                 utc_date = scn_data.attrs['scheduled_time']
-            except AttributeError:
-                raise AttributeError('Scene has no start_time '
+            except KeyError:
+                raise KeyError('Scene has no start_time '
                                      'or scheduled_time attribute.')
     return utc_date
 
 def apply_earthsun_distance_correction(reflectance, utc_date=None):
     """Correct reflectance data to account for changing Earth-Sun distance."""
     from pyorbital.astronomy import sun_earth_distance_correction
-    utc_date = _get_array_date(reflectance, utc_date)
+    utc_date = get_array_date(reflectance, utc_date)
     sun_earth_dist = sun_earth_distance_correction(utc_date)
 
     return reflectance * sun_earth_dist * sun_earth_dist
@@ -339,7 +339,7 @@ def apply_earthsun_distance_correction(reflectance, utc_date=None):
 def remove_earthsun_distance_correction(reflectance, utc_date=None):
     """Remove the sun-earth distance correction."""
     from pyorbital.astronomy import sun_earth_distance_correction
-    utc_date = _get_array_date(reflectance, utc_date)
+    utc_date = get_array_date(reflectance, utc_date)
     sun_earth_dist = sun_earth_distance_correction(utc_date)
 
     return reflectance / (sun_earth_dist * sun_earth_dist)

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -314,31 +314,32 @@ def apply_rad_correction(data, slope, offset):
     return data
 
 
+def _get_array_date(scn_data, utc_date=None):
+    """Get start time from a channel data array."""
+    if utc_date is None:
+        try:
+            utc_date = scn_data.attrs['start_time']
+        except AttributeError:
+            try:
+                utc_date = scn_data.attrs['scheduled_time']
+            except AttributeError:
+                raise AttributeError('Scene has no start_time '
+                                     'or scheduled_time attribute.')
+    return utc_date
+
 def apply_earthsun_distance_correction(reflectance, utc_date=None):
     """Correct reflectance data to account for changing Earth-Sun distance."""
     from pyorbital.astronomy import sun_earth_distance_correction
-    if utc_date is None:
-        try:
-            utc_date = reflectance.attrs['start_time']
-        except AttributeError:
-            try:
-                utc_date = reflectance.attrs['scheduled_time']
-            except AttributeError:
-                raise
-    se_dist = sun_earth_distance_correction(utc_date)
-    return reflectance * se_dist * se_dist
+    utc_date = _get_array_date(reflectance, utc_date)
+    sun_earth_dist = sun_earth_distance_correction(utc_date)
+
+    return reflectance * sun_earth_dist * sun_earth_dist
 
 
 def remove_earthsun_distance_correction(reflectance, utc_date=None):
     """Remove the sun-earth distance correction."""
     from pyorbital.astronomy import sun_earth_distance_correction
-    if utc_date is None:
-        try:
-            utc_date = reflectance.attrs['start_time']
-        except AttributeError:
-            try:
-                utc_date = reflectance.attrs['scheduled_time']
-            except AttributeError:
-                raise
-    se_dist = sun_earth_distance_correction(utc_date)
-    return reflectance / (se_dist * se_dist)
+    utc_date = _get_array_date(reflectance, utc_date)
+    sun_earth_dist = sun_earth_distance_correction(utc_date)
+
+    return reflectance / (sun_earth_dist * sun_earth_dist)

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -149,6 +149,7 @@ def get_geostationary_bounding_box(geos_area, nb_points=50):
     """Get the bbox in lon/lats of the valid pixels inside *geos_area*.
 
     Args:
+      geos_area: The geostationary area to analyse.
       nb_points: Number of points on the polygon
 
     """
@@ -311,3 +312,17 @@ def apply_rad_correction(data, slope, offset):
     """Apply GSICS-like correction factors to radiance data."""
     data = (data - offset) / slope
     return data
+
+
+def apply_earthsun_distance_correction(utc_date, reflectance):
+    """Correct reflectance data to account for changing Earth-Sun distance."""
+    from pyorbital.astronomy import sun_earth_distance_correction
+    se_dist = sun_earth_distance_correction(utc_date)
+    return reflectance * se_dist * se_dist
+
+
+def remove_earthsun_distance_correction(utc_date, reflectance):
+    """Remove the sun-earth distance correction."""
+    from pyorbital.astronomy import sun_earth_distance_correction
+    se_dist = sun_earth_distance_correction(utc_date)
+    return reflectance / (se_dist * se_dist)

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -314,15 +314,31 @@ def apply_rad_correction(data, slope, offset):
     return data
 
 
-def apply_earthsun_distance_correction(utc_date, reflectance):
+def apply_earthsun_distance_correction(reflectance, utc_date=None):
     """Correct reflectance data to account for changing Earth-Sun distance."""
     from pyorbital.astronomy import sun_earth_distance_correction
+    if utc_date is None:
+        try:
+            utc_date = reflectance.start_time
+        except AttributeError:
+            try:
+                utc_date = reflectance.scheduled_time
+            except AttributeError:
+                raise
     se_dist = sun_earth_distance_correction(utc_date)
     return reflectance * se_dist * se_dist
 
 
-def remove_earthsun_distance_correction(utc_date, reflectance):
+def remove_earthsun_distance_correction(reflectance, utc_date=None):
     """Remove the sun-earth distance correction."""
     from pyorbital.astronomy import sun_earth_distance_correction
+    if utc_date is None:
+        try:
+            utc_date = reflectance.start_time
+        except AttributeError:
+            try:
+                utc_date = reflectance.scheduled_time
+            except AttributeError:
+                raise
     se_dist = sun_earth_distance_correction(utc_date)
     return reflectance / (se_dist * se_dist)

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -324,8 +324,9 @@ def get_array_date(scn_data, utc_date=None):
                 utc_date = scn_data.attrs['scheduled_time']
             except KeyError:
                 raise KeyError('Scene has no start_time '
-                                     'or scheduled_time attribute.')
+                               'or scheduled_time attribute.')
     return utc_date
+
 
 def apply_earthsun_distance_correction(reflectance, utc_date=None):
     """Correct reflectance data to account for changing Earth-Sun distance."""

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -319,10 +319,10 @@ def apply_earthsun_distance_correction(reflectance, utc_date=None):
     from pyorbital.astronomy import sun_earth_distance_correction
     if utc_date is None:
         try:
-            utc_date = reflectance.start_time
+            utc_date = reflectance.attrs['start_time']
         except AttributeError:
             try:
-                utc_date = reflectance.scheduled_time
+                utc_date = reflectance.attrs['scheduled_time']
             except AttributeError:
                 raise
     se_dist = sun_earth_distance_correction(utc_date)
@@ -334,10 +334,10 @@ def remove_earthsun_distance_correction(reflectance, utc_date=None):
     from pyorbital.astronomy import sun_earth_distance_correction
     if utc_date is None:
         try:
-            utc_date = reflectance.start_time
+            utc_date = reflectance.attrs['start_time']
         except AttributeError:
             try:
-                utc_date = reflectance.scheduled_time
+                utc_date = reflectance.attrs['scheduled_time']
             except AttributeError:
                 raise
     se_dist = sun_earth_distance_correction(utc_date)

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -334,7 +334,10 @@ def apply_earthsun_distance_correction(reflectance, utc_date=None):
     utc_date = get_array_date(reflectance, utc_date)
     sun_earth_dist = sun_earth_distance_correction(utc_date)
 
-    return reflectance * sun_earth_dist * sun_earth_dist
+    reflectance.values = reflectance.values * sun_earth_dist * sun_earth_dist
+    reflectance.attrs['sun_earth_distance_correction_applied'] = True
+    reflectance.attrs['sun_earth_distance_correction_factor'] = sun_earth_dist
+    return reflectance
 
 
 def remove_earthsun_distance_correction(reflectance, utc_date=None):
@@ -343,4 +346,7 @@ def remove_earthsun_distance_correction(reflectance, utc_date=None):
     utc_date = get_array_date(reflectance, utc_date)
     sun_earth_dist = sun_earth_distance_correction(utc_date)
 
-    return reflectance / (sun_earth_dist * sun_earth_dist)
+    reflectance.attrs['sun_earth_distance_correction_applied'] = False
+    reflectance.attrs['sun_earth_distance_correction_factor'] = sun_earth_dist
+    reflectance.values = reflectance.values / (sun_earth_dist * sun_earth_dist)
+    return reflectance

--- a/satpy/tests/reader_tests/test_seviri_base.py
+++ b/satpy/tests/reader_tests/test_seviri_base.py
@@ -34,10 +34,10 @@ class SeviriBaseTest(unittest.TestCase):
         """Test the dec10216 function."""
         res = dec10216(np.array([255, 255, 255, 255, 255], dtype=np.uint8))
         exp = (np.ones((4, )) * 1023).astype(np.uint16)
-        self.assertTrue(np.all(res == exp))
+        np.testing.assert_equal(res, exp)
         res = dec10216(np.array([1, 1, 1, 1, 1], dtype=np.uint8))
         exp = np.array([4,  16,  64, 257], dtype=np.uint16)
-        self.assertTrue(np.all(res == exp))
+        np.testing.assert_equal(res, exp)
 
     def test_chebyshev(self):
         coefs = [1, 2, 3, 4]
@@ -45,7 +45,7 @@ class SeviriBaseTest(unittest.TestCase):
         domain = [120, 130]
         res = chebyshev(coefs=[1, 2, 3, 4], time=time, domain=domain)
         exp = chebyshev4(coefs, time, domain)
-        self.assertTrue(np.allclose(res, exp))
+        np.testing.assert_allclose(res, exp)
 
     def test_get_cds_time(self):
         # Scalar
@@ -58,9 +58,9 @@ class SeviriBaseTest(unittest.TestCase):
         expected = np.array([np.datetime64('2016-03-03 12:00:00.000'),
                              np.datetime64('2016-03-04 13:00:00.001'),
                              np.datetime64('2016-03-05 14:00:00.002')])
-        self.assertTrue(np.all(get_cds_time(days=days, msecs=msecs) == expected))
+        np.testing.assert_equal(get_cds_time(days=days, msecs=msecs), expected)
 
         days = 21246
         msecs = 12*3600*1000
         expected = np.datetime64('2016-03-03 12:00:00.000')
-        self.assertTrue(get_cds_time(days=days, msecs=msecs) == expected)
+        np.testing.assert_equal(get_cds_time(days=days, msecs=msecs), expected)

--- a/satpy/tests/reader_tests/test_seviri_base.py
+++ b/satpy/tests/reader_tests/test_seviri_base.py
@@ -59,3 +59,8 @@ class SeviriBaseTest(unittest.TestCase):
                              np.datetime64('2016-03-04 13:00:00.001'),
                              np.datetime64('2016-03-05 14:00:00.002')])
         self.assertTrue(np.all(get_cds_time(days=days, msecs=msecs) == expected))
+
+        days = 21246
+        msecs = 12*3600*1000
+        expected = np.datetime64('2016-03-03 12:00:00.000')
+        self.assertTrue(get_cds_time(days=days, msecs=msecs) == expected)

--- a/satpy/tests/reader_tests/test_seviri_l1b_calibration.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_calibration.py
@@ -19,6 +19,7 @@
 
 import unittest
 import numpy as np
+import xarray as xr
 from datetime import datetime
 from satpy.readers.seviri_base import SEVIRICalibrationHandler
 
@@ -79,6 +80,7 @@ VIS008_RADIANCE = np.array([[0.62234485,  0.59405649,  0.59405649,  0.59405649, 
                             [0.76378691,  0.79207528,  0.79207528,  0.76378691,  0.79207528],
                             [3.30974245,  3.33803129,  3.33803129,  3.25316572,  3.47947311],
                             [7.52471399,  7.83588648,  8.2602129,  8.57138538,  8.99571133]], dtype=np.float32)
+VIS008_RADIANCE = xr.DataArray(VIS008_RADIANCE)
 
 VIS008_REFLECTANCE = np.array([[2.8066392, 2.6790648, 2.6790648, 2.6790648,
                                 2.6790648],
@@ -192,6 +194,7 @@ class TestSEVIRICalibrationHandler(unittest.TestCase):
         result = self.handler._vis_calibrate(VIS008_RADIANCE,
                                              VIS008_SOLAR_IRRADIANCE)
         assertNumpyArraysEqual(result, VIS008_REFLECTANCE)
+        self.assertTrue(result.sun_earth_distance_correction_applied)
 
     def tearDown(self):
         pass

--- a/satpy/tests/reader_tests/test_seviri_l1b_calibration.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_calibration.py
@@ -163,7 +163,7 @@ class TestSEVIRICalibrationHandler(unittest.TestCase):
 
         self.handler = SEVIRICalibrationHandler()
         self.handler.platform_id = PLATFORM_ID
-        self.handler.start_time  = datetime(2020, 8, 15, 13, 0, 40)
+        self.handler.start_time = datetime(2020, 8, 15, 13, 0, 40)
 
     def test_convert_to_radiance(self):
         """Test the conversion from counts to radiance method"""

--- a/satpy/tests/reader_tests/test_seviri_l1b_calibration.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_calibration.py
@@ -163,6 +163,7 @@ class TestSEVIRICalibrationHandler(unittest.TestCase):
 
         self.handler = SEVIRICalibrationHandler()
         self.handler.platform_id = PLATFORM_ID
+        self.handler.start_time  = datetime(2020, 8, 15, 13, 0, 40)
 
     def test_convert_to_radiance(self):
         """Test the conversion from counts to radiance method"""
@@ -188,10 +189,8 @@ class TestSEVIRICalibrationHandler(unittest.TestCase):
                                        CHANNEL_NAME, CAL_TYPEBAD)
 
     def test_vis_calibrate(self):
-        test_date = datetime(2020, 8, 15, 13, 0, 40)
         result = self.handler._vis_calibrate(VIS008_RADIANCE,
-                                             VIS008_SOLAR_IRRADIANCE,
-                                             test_date)
+                                             VIS008_SOLAR_IRRADIANCE)
         assertNumpyArraysEqual(result, VIS008_REFLECTANCE)
 
     def tearDown(self):

--- a/satpy/tests/reader_tests/test_seviri_l1b_calibration.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_calibration.py
@@ -19,6 +19,7 @@
 
 import unittest
 import numpy as np
+from datetime import datetime
 from satpy.readers.seviri_base import SEVIRICalibrationHandler
 
 COUNTS_INPUT = np.array([[377.,  377.,  377.,  376.,  375.],
@@ -43,6 +44,7 @@ OFFSET = -10.456819486590666
 
 CAL_TYPE1 = 1
 CAL_TYPE2 = 2
+CAL_TYPEBAD = -1
 CHANNEL_NAME = 'IR_108'
 PLATFORM_ID = 323  # Met-10
 
@@ -70,7 +72,7 @@ TBS_OUTPUT2 = np.array([[268.94519043,  268.94519043,  268.94519043,  268.779846
                          256.71188354]], dtype=np.float32)
 
 
-VIS008_SOLAR_IRRADIANCE = 23.29414028785013
+VIS008_SOLAR_IRRADIANCE = 73.1807
 
 VIS008_RADIANCE = np.array([[0.62234485,  0.59405649,  0.59405649,  0.59405649,  0.59405649],
                             [0.59405649,  0.62234485,  0.62234485,  0.59405649,  0.62234485],
@@ -78,17 +80,16 @@ VIS008_RADIANCE = np.array([[0.62234485,  0.59405649,  0.59405649,  0.59405649, 
                             [3.30974245,  3.33803129,  3.33803129,  3.25316572,  3.47947311],
                             [7.52471399,  7.83588648,  8.2602129,  8.57138538,  8.99571133]], dtype=np.float32)
 
-VIS008_REFLECTANCE = np.array([[2.67167997,   2.55024004,   2.55024004,   2.55024004,
-                                2.55024004],
-                               [2.55024004,   2.67167997,   2.67167997,   2.55024004,
-                                2.67167997],
-                               [3.27888012,   3.40032005,   3.40032005,   3.27888012,
-                                3.40032005],
-                               [14.20847702,  14.32991886,  14.32991886,  13.96559715,
-                                14.93711853],
-                               [32.30303574,  33.63887405,  35.46047592,  36.79631805,
-                                38.61791611]], dtype=np.float32)
-
+VIS008_REFLECTANCE = np.array([[2.8066392, 2.6790648, 2.6790648, 2.6790648,
+                                2.6790648],
+                               [2.6790648, 2.8066392, 2.8066392, 2.6790648,
+                                2.8066392],
+                               [3.444512,  3.572086,  3.572086,  3.444512,
+                                3.572086],
+                               [14.926213, 15.053792, 15.053792, 14.671064,
+                                15.691662],
+                               [33.934814, 35.33813,  37.251755, 38.655075,
+                                40.56869]], dtype=np.float32)
 
 # --
 
@@ -182,9 +183,15 @@ class TestSEVIRICalibrationHandler(unittest.TestCase):
                                             CHANNEL_NAME, CAL_TYPE2)
         assertNumpyArraysEqual(result, TBS_OUTPUT2)
 
-    def test_vis_calibrate(self):
+        with self.assertRaises(NotImplementedError):
+            self.handler._ir_calibrate(RADIANCES_OUTPUT,
+                                       CHANNEL_NAME, CAL_TYPEBAD)
 
-        result = self.handler._vis_calibrate(VIS008_RADIANCE, VIS008_SOLAR_IRRADIANCE)
+    def test_vis_calibrate(self):
+        test_date = datetime(2020, 8, 15, 13, 0, 40)
+        result = self.handler._vis_calibrate(VIS008_RADIANCE,
+                                             VIS008_SOLAR_IRRADIANCE,
+                                             test_date)
         assertNumpyArraysEqual(result, VIS008_REFLECTANCE)
 
     def tearDown(self):

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -18,6 +18,7 @@
 """Testing of helper functions."""
 
 import unittest
+from datetime import datetime
 from unittest import mock
 import os
 import numpy as np
@@ -327,3 +328,21 @@ class TestHelpers(unittest.TestCase):
         # Check that incorrect dict keys throw an error
         with self.assertRaises(KeyError):
             hf.get_user_calibration_factors('IR108', radcor_dict)
+
+    def test_apply_sunearth_corr(self):
+        """Test the correction of reflectances with sun-earth distance."""
+        test_date = datetime(2020, 8, 15, 13, 0, 40)
+        in_refl = np.array([10., 20., 40., 1., 98., 50.])
+        exp_refl = np.array([10.50514689, 21.01029379, 42.02058758,
+                             1.05051469, 102.95043957, 52.52573447])
+        out_refl = hf.apply_earthsun_distance_correction(test_date, in_refl)
+        np.testing.assert_allclose(out_refl, exp_refl)
+
+    def test_remove_sunearth_corr(self):
+        """Test the removal of the sun-earth distance correction."""
+        test_date = datetime(2020, 8, 15, 13, 0, 40)
+        in_refl = np.array([10.50514689, 21.01029379, 42.02058758,
+                            1.05051469, 102.95043957, 52.52573447])
+        exp_refl = np.array([10., 20., 40., 1., 98., 50.])
+        out_refl = hf.remove_earthsun_distance_correction(test_date, in_refl)
+        np.testing.assert_allclose(out_refl, exp_refl)

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -355,13 +355,13 @@ class TestHelpers(unittest.TestCase):
         np.testing.assert_allclose(out_refl, exp_refl)
 
         with self.assertRaises(AttributeError):
-            out_refl = hf.apply_earthsun_distance_correction(in_refl)
+            hf.apply_earthsun_distance_correction(in_refl)
 
     def test_remove_sunearth_corr(self):
         """Test the removal of the sun-earth distance correction."""
         test_date = datetime(2020, 8, 15, 13, 0, 40)
         in_refl_arr = np.array([10.50514689, 21.01029379, 42.02058758,
-                            1.05051469, 102.95043957, 52.52573447])
+                                1.05051469, 102.95043957, 52.52573447])
         exp_refl = np.array([10., 20., 40., 1., 98., 50.])
 
         # Check case that array has a start time attr
@@ -382,4 +382,4 @@ class TestHelpers(unittest.TestCase):
         np.testing.assert_allclose(out_refl, exp_refl)
 
         with self.assertRaises(AttributeError):
-            out_refl = hf.remove_earthsun_distance_correction(in_refl)
+            hf.remove_earthsun_distance_correction(in_refl)

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -382,9 +382,11 @@ class TestSunEarthDistanceCorrection(unittest.TestCase):
 
         out_refl = hf.apply_earthsun_distance_correction(self.raw_refl)
         np.testing.assert_allclose(out_refl, self.corr_refl)
+        self.assertTrue(out_refl.attrs['sun_earth_distance_correction_applied'])
 
     def test_remove_sunearth_corr(self):
         """Test the removal of the sun-earth distance correction."""
 
         out_refl = hf.remove_earthsun_distance_correction(self.corr_refl)
         np.testing.assert_allclose(out_refl, self.raw_refl)
+        self.assertFalse(out_refl.attrs['sun_earth_distance_correction_applied'])

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -25,7 +25,6 @@ import xarray as xr
 import numpy as np
 import numpy.testing
 import pyresample.geometry
-from xarray import DataArray
 
 from satpy.readers import utils as hf
 
@@ -344,8 +343,8 @@ class TestSunEarthDistanceCorrection(unittest.TestCase):
                                        'scheduled_time': self.test_date})
 
         corr_refl = xr.DataArray(np.array([10.50514689, 21.01029379,
-                                42.02058758, 1.05051469,
-                                102.95043957, 52.52573447]),
+                                           42.02058758, 1.05051469,
+                                           102.95043957, 52.52573447]),
                                  attrs={'start_time': self.test_date,
                                         'scheduled_time': self.test_date})
         self.raw_refl = raw_refl
@@ -377,7 +376,6 @@ class TestSunEarthDistanceCorrection(unittest.TestCase):
         del tmp_array.attrs['start_time']
         with self.assertRaises(KeyError):
             hf.get_array_date(tmp_array, None)
-
 
     def test_apply_sunearth_corr(self):
         """Test the correction of reflectances with sun-earth distance."""


### PR DESCRIPTION
The distance between the sun and the Earth varies slightly during the year due to the Earth's orbital eccentricity. This means that the incoming solar irradiance, and hence outgoing radiance measured by a satellite sensor, also varies throughout the year as a function of day.

Many sensors do not account for this in their L1 data products, so a correction must be applied.
As an example, for SEVIRI:
```
Reflectance = (pi * se_dist^2 * radiance) / (solar_irradiance * cos(solar_zenith))
```
Where:
`se_dist` is the Sun-Earth distance on a given day.
`radiance` is the satellite-measured pixel radiance.
`solar_irradiance` is the average solar irradiance for the band.
`solar_zenith` is the solar zenith angle (with nadir = 0) for a given pixel.

Currently, the SEVIRI reader (and possibly others too) doesn't apply the `se_dist` factor, and therefore the reflectances given by satpy are slightly incorrect (by up to ~4%).

This PR creates a utility function `apply_earthsun_distance_correction` that applies the correction. It also adds this function to the SEVIRI calibration code and adds the various test functions to ensure everything works.
In addition, a `remove_earthsun_distance_correction` function is also supplied for the case that a user wishes to remove the correction.


 - [x] Closes #1334
 - [x] Tests added
 - [x] Passes ``flake8 satpy``
 - [x] Fully documented
