### PR TITLE
Allow for #mode=bytes in file URLs to support NetCDF byte ranges

### DIFF
--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -69,6 +69,9 @@ def _get_filebase(path, pattern):
     """Get the end of *path* of same length as *pattern*."""
     # convert any `/` on Windows to `\\`
     path = os.path.normpath(path)
+    # remove possible #mode=bytes URL suffix to support HTTP byte range
+    # requests for NetCDF
+    path = path.split('#')[0]
     # A pattern can include directories
     tail_len = len(pattern.split(os.path.sep))
     return os.path.join(*str(path).split(os.path.sep)[-tail_len:])

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -373,6 +373,20 @@ class TestFileFileYAMLReader(unittest.TestCase):
 
         self.assertEqual(0, len(self.reader.select_files_from_pathnames([])))
 
+    def test_select_from_pathnames_with_byte_mode(self):
+        """Check select_files_from_pathnames when given a URL with #mode=bytes added."""
+        filelist = [
+            'http://someurl.com/a001.bla#mode=bytes',
+            'http://someurl.com/a002.bla#mode=bytes',
+            'http://someurl.com/abcd.bla#mode=bytes',
+            'http://someurl.com/k001.bla#mode=bytes',
+            'http://someurl.com/a003.bli#mode=bytes',
+            ]
+
+        res = self.reader.select_files_from_pathnames(filelist)
+        for expected in filelist[:3]:
+            self.assertIn(expected, res)
+
     def test_select_from_directory(self):
         """Check select_files_from_directory."""
         filelist = ['a001.bla', 'a002.bla', 'abcd.bla', 'k001.bla', 'a003.bli']


### PR DESCRIPTION
This takes advantage of recent updates in the NetCDF C library which allows for a special `#mode=bytes` suffix to be added to HTTP/HTTPS to anonymously access remote data stores. This includes S3 buckets that allow for anonymous access and provide a public HTTP endpoint. This work on the C library makes it available from the NetCDF4 python library and therefore xarray (since netcdf4-python is the default open_dataset engine). For example the NOAA GOES-16 ABI data:

```
url = "https://noaa-goes16.s3.amazonaws.com/ABI-L1b-RadC/2019/001/00/OR_ABI-L1b-RadC-M3C14_G16_s20190010002187_e20190010004560_c20190010005009.nc#mode=bytes"
scn = Scene(reader='abi_l1b', filenames=[url])
scn.load(['C14'])
scn['C14']
```

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

I'm not sure where to document something like this to advertise it more. The quick start page? Maybe add a remote data access section? Or maybe we should have a whole separate page for remote data access at this point?

CC @raybellwaves and @carloshorn who have been working with similar features or features adjacent to this. Also @gerritholl who originally added the file system support to find_files_and_readers.