### PR TITLE
Reintroduce support for pyproj 1.9.6 in cf_writer

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -955,6 +955,18 @@ class TestCFWriter(unittest.TestCase):
         self.assertDictContainsSubset({'name': 'longitude', 'standard_name': 'longitude', 'units': 'degrees_east'},
                                       lon.attrs)
 
+    def test_init_with_old_pyproj(self):
+        """Test that cf_writer can still be loaded with pyproj 1.9.6."""
+        import pyproj # noqa 401
+        import sys
+        import importlib
+        old_version = sys.modules['pyproj'].__version__
+        sys.modules['pyproj'].__version__ = "1.9.6"
+        importlib.reload(sys.modules['satpy.writers.cf_writer'])
+        # Tear down
+        sys.modules['pyproj'].__version__ = old_version
+        importlib.reload(sys.modules['satpy.writers.cf_writer'])
+
 
 def suite():
     """Test suite for this writer's tests."""

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -923,12 +923,10 @@ class TestCFWriter(unittest.TestCase):
         self.assertEqual(set(res.coords), {'longitude', 'latitude'})
         lat = res['latitude']
         lon = res['longitude']
-        self.assertTrue(np.all(lat.data == lats_ref))
-        self.assertTrue(np.all(lon.data == lons_ref))
-        self.assertDictContainsSubset({'name': 'latitude', 'standard_name': 'latitude', 'units': 'degrees_north'},
-                                      lat.attrs)
-        self.assertDictContainsSubset({'name': 'longitude', 'standard_name': 'longitude', 'units': 'degrees_east'},
-                                      lon.attrs)
+        np.testing.assert_array_equal(lat.data, lats_ref)
+        np.testing.assert_array_equal(lon.data, lons_ref)
+        assert {'name': 'latitude', 'standard_name': 'latitude', 'units': 'degrees_north'}.items() <= lat.attrs.items()
+        assert {'name': 'longitude', 'standard_name': 'longitude', 'units': 'degrees_east'}.items() <= lon.attrs.items()
 
         area = pyresample.geometry.AreaDefinition(
             'seviri',
@@ -948,33 +946,21 @@ class TestCFWriter(unittest.TestCase):
         self.assertEqual(set(res.coords), {'longitude', 'latitude'})
         lat = res['latitude']
         lon = res['longitude']
-        self.assertTrue(np.all(lat.data == lats_ref))
-        self.assertTrue(np.all(lon.data == lons_ref))
-        self.assertDictContainsSubset({'name': 'latitude', 'standard_name': 'latitude', 'units': 'degrees_north'},
-                                      lat.attrs)
-        self.assertDictContainsSubset({'name': 'longitude', 'standard_name': 'longitude', 'units': 'degrees_east'},
-                                      lon.attrs)
+        np.testing.assert_array_equal(lat.data, lats_ref)
+        np.testing.assert_array_equal(lon.data, lons_ref)
+        assert {'name': 'latitude', 'standard_name': 'latitude', 'units': 'degrees_north'}.items() <= lat.attrs.items()
+        assert {'name': 'longitude', 'standard_name': 'longitude', 'units': 'degrees_east'}.items() <= lon.attrs.items()
 
-    def test_init_with_old_pyproj(self):
+    def test_load_module_with_old_pyproj(self):
         """Test that cf_writer can still be loaded with pyproj 1.9.6."""
         import pyproj # noqa 401
         import sys
         import importlib
         old_version = sys.modules['pyproj'].__version__
         sys.modules['pyproj'].__version__ = "1.9.6"
-        importlib.reload(sys.modules['satpy.writers.cf_writer'])
-        # Tear down
-        sys.modules['pyproj'].__version__ = old_version
-        importlib.reload(sys.modules['satpy.writers.cf_writer'])
-
-
-def suite():
-    """Test suite for this writer's tests."""
-    loader = unittest.TestLoader()
-    mysuite = unittest.TestSuite()
-    mysuite.addTest(loader.loadTestsFromTestCase(TestCFWriter))
-    return mysuite
-
-
-if __name__ == "__main__":
-    unittest.main()
+        try:
+            importlib.reload(sys.modules['satpy.writers.cf_writer'])
+        finally:
+            # Tear down
+            sys.modules['pyproj'].__version__ = old_version
+            importlib.reload(sys.modules['satpy.writers.cf_writer'])

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -114,10 +114,6 @@ from satpy.writers import Writer
 from satpy.writers.utils import flatten_dict
 
 from distutils.version import LooseVersion
-import pyproj
-if LooseVersion(pyproj.__version__) < LooseVersion('2.4.1'):
-    # technically 2.2, but important bug fixes in 2.4.1
-    raise ImportError("'cf' writer requires pyproj 2.4.1 or greater")
 
 
 logger = logging.getLogger(__name__)
@@ -147,6 +143,10 @@ CF_VERSION = 'CF-1.7'
 
 def create_grid_mapping(area):
     """Create the grid mapping instance for `area`."""
+    import pyproj
+    if LooseVersion(pyproj.__version__) < LooseVersion('2.4.1'):
+        # technically 2.2, but important bug fixes in 2.4.1
+        raise ImportError("'cf' writer requires pyproj 2.4.1 or greater")
     # let pyproj do the heavily lifting
     # pyproj 2.0+ required
     grid_mapping = area.crs.to_cf()


### PR DESCRIPTION
The create_grid_mapping in cf_writer need a newer version of pyproj.
By moving the import of pyproj to that function data with lat/lon can still be written also with pyproj==1.9.6.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

