### PR TITLE
Only add longitude/latitude variables in cf_writer if they are not included already.

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -664,48 +664,6 @@ class TestCFWriter(unittest.TestCase):
         self.assertNotIn('var1_acq_time', res['var1'].coords)
         self.assertNotIn('var2_acq_time', res['var2'].coords)
 
-    def test_dataset_is_projection_coords(self):
-        """Test the dataset_is_projection_coords function."""
-        import xarray as xr
-        from satpy.writers.cf_writer import dataset_is_projection_coords
-        data = [[1, 2], [3, 4]]
-        y = [1, 2]
-        x = [1, 2]
-        datasets = {'var1': xr.DataArray(data=data,
-                                         dims=('y', 'x'),
-                                         coords={'y': y, 'x': x}),
-                    'var2': xr.DataArray(data=data,
-                                         dims=('y', 'x'),
-                                         coords={'y': y, 'x': x}),
-                    'latitude': xr.DataArray(data=data,
-                                             dims=('y', 'x'),
-                                             coords={'y': y, 'x': x})}
-        datasets['latitude'].attrs['standard_name'] = 'latitude'
-        datasets['var1'].attrs['standard_name'] = 'dummy'
-        self.assertTrue(dataset_is_projection_coords(datasets['latitude']))
-        self.assertFalse(dataset_is_projection_coords(datasets['var1']))
-
-    def test_has_projection_coords(self):
-        """Test the has_projection_coords function."""
-        import xarray as xr
-        from satpy.writers.cf_writer import has_projection_coords
-        data = [[1, 2], [3, 4]]
-        y = [1, 2]
-        x = [1, 2]
-        datasets = {'var1': xr.DataArray(data=data,
-                                         dims=('y', 'x'),
-                                         coords={'y': y, 'x': x}),
-                    'var2': xr.DataArray(data=data,
-                                         dims=('y', 'x'),
-                                         coords={'y': y, 'x': x})}
-        datasets['var1'].attrs['standard_name'] = 'dummy'
-        self.assertFalse(has_projection_coords(datasets))
-        datasets['latitude'] = xr.DataArray(data=data,
-                                            dims=('y', 'x'),
-                                            coords={'y': y, 'x': x})
-        datasets['latitude'].attrs['standard_name'] = 'latitude'
-        self.assertTrue(has_projection_coords(datasets))
-
     def test_area2cf(self):
         """Test the conversion of an area to CF standards."""
         import xarray as xr
@@ -1046,3 +1004,39 @@ class TestCFWriter(unittest.TestCase):
                 self.assertEqual(f.attrs['Conventions'], 'CF-1.7, ACDD-1.3')
                 self.assertIn('TEST add history\n', f.attrs['history'])
                 self.assertIn('Created by pytroll/satpy on', f.attrs['history'])
+
+
+class TestCFWriterData(unittest.TestCase):
+    """Test case for CF writer where data arrays are needed."""
+
+    def setUp(self):
+        """Create some testdata."""
+        import xarray as xr
+        data = [[1, 2], [3, 4]]
+        y = [1, 2]
+        x = [1, 2]
+        self.datasets = {'var1': xr.DataArray(data=data,
+                                              dims=('y', 'x'),
+                                              coords={'y': y, 'x': x}),
+                         'var2': xr.DataArray(data=data,
+                                              dims=('y', 'x'),
+                                              coords={'y': y, 'x': x}),
+                         'latitude': xr.DataArray(data=data,
+                                                  dims=('y', 'x'),
+                                                  coords={'y': y, 'x': x})}
+        self.datasets['latitude'].attrs['standard_name'] = 'latitude'
+        self.datasets['var1'].attrs['standard_name'] = 'dummy'
+        self.datasets['var2'].attrs['standard_name'] = 'dummy'
+
+    def test_dataset_is_projection_coords(self):
+        """Test the dataset_is_projection_coords function."""
+        from satpy.writers.cf_writer import dataset_is_projection_coords
+        self.assertTrue(dataset_is_projection_coords(self.datasets['latitude']))
+        self.assertFalse(dataset_is_projection_coords(self.datasets['var1']))
+
+    def test_has_projection_coords(self):
+        """Test the has_projection_coords function."""
+        from satpy.writers.cf_writer import has_projection_coords
+        self.assertTrue(has_projection_coords(self.datasets))
+        self.datasets['latitude'].attrs['standard_name'] = 'dummy'
+        self.assertFalse(has_projection_coords(self.datasets))

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -1012,31 +1012,69 @@ class TestCFWriterData(unittest.TestCase):
     def setUp(self):
         """Create some testdata."""
         import xarray as xr
-        data = [[1, 2], [3, 4]]
+        import pyresample.geometry
+        data = [[75, 2], [3, 4]]
         y = [1, 2]
         x = [1, 2]
+        geos = pyresample.geometry.AreaDefinition(
+            area_id='geos',
+            description='geos',
+            proj_id='geos',
+            projection={'proj': 'geos', 'h': 35785831., 'a': 6378169., 'b': 6356583.8},
+            width=2, height=2,
+            area_extent=[-1, -1, 1, 1])
         self.datasets = {'var1': xr.DataArray(data=data,
                                               dims=('y', 'x'),
                                               coords={'y': y, 'x': x}),
                          'var2': xr.DataArray(data=data,
                                               dims=('y', 'x'),
                                               coords={'y': y, 'x': x}),
-                         'latitude': xr.DataArray(data=data,
-                                                  dims=('y', 'x'),
-                                                  coords={'y': y, 'x': x})}
-        self.datasets['latitude'].attrs['standard_name'] = 'latitude'
+                         'lat': xr.DataArray(data=data,
+                                             dims=('y', 'x'),
+                                             coords={'y': y, 'x': x}),
+                         'lon': xr.DataArray(data=data,
+                                             dims=('y', 'x'),
+                                             coords={'y': y, 'x': x})}
+        self.datasets['lat'].attrs['standard_name'] = 'latitude'
         self.datasets['var1'].attrs['standard_name'] = 'dummy'
         self.datasets['var2'].attrs['standard_name'] = 'dummy'
+        self.datasets['var2'].attrs['area'] = geos
+        self.datasets['var1'].attrs['area'] = geos
+        self.datasets['lat'].attrs['name'] = 'lat'
+        self.datasets['var1'].attrs['name'] = 'var1'
+        self.datasets['var2'].attrs['name'] = 'var2'
+        self.datasets['lon'].attrs['name'] = 'lon'
 
     def test_dataset_is_projection_coords(self):
         """Test the dataset_is_projection_coords function."""
         from satpy.writers.cf_writer import dataset_is_projection_coords
-        self.assertTrue(dataset_is_projection_coords(self.datasets['latitude']))
+        self.assertTrue(dataset_is_projection_coords(self.datasets['lat']))
         self.assertFalse(dataset_is_projection_coords(self.datasets['var1']))
 
     def test_has_projection_coords(self):
         """Test the has_projection_coords function."""
         from satpy.writers.cf_writer import has_projection_coords
         self.assertTrue(has_projection_coords(self.datasets))
-        self.datasets['latitude'].attrs['standard_name'] = 'dummy'
+        self.datasets['lat'].attrs['standard_name'] = 'dummy'
         self.assertFalse(has_projection_coords(self.datasets))
+
+    @mock.patch('satpy.writers.cf_writer.CFWriter.__init__', return_value=None)
+    def test_collect_datasets_with_latitude_named_lat(self, *mocks):
+        """Test collecting CF datasets with latitude named lat."""
+        from satpy.writers.cf_writer import CFWriter
+        from operator import getitem
+        self.datasets_list = [self.datasets[key] for key in self.datasets]
+        self.datasets_list_no_latlon = [self.datasets[key] for key in ['var1', 'var2']]
+
+        # Collect datasets
+        writer = CFWriter()
+        datas, start_times, end_times = writer._collect_datasets(self.datasets_list, include_lonlats=True)
+        datas2, start_times, end_times = writer._collect_datasets(self.datasets_list_no_latlon, include_lonlats=True)
+        # Test results
+
+        self.assertEqual(len(datas), 5)
+        self.assertEqual(set(datas.keys()), {'var1', 'var2', 'lon', 'lat', 'geos'})
+        self.assertRaises(KeyError, getitem, datas['var1'], 'latitude')
+        self.assertRaises(KeyError, getitem, datas['var1'], 'longitude')
+        self.assertEqual(datas2['var1']['latitude'].attrs['name'], 'latitude')
+        self.assertEqual(datas2['var1']['longitude'].attrs['name'], 'longitude')

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -664,6 +664,48 @@ class TestCFWriter(unittest.TestCase):
         self.assertNotIn('var1_acq_time', res['var1'].coords)
         self.assertNotIn('var2_acq_time', res['var2'].coords)
 
+    def test_dataset_is_projection_coords(self):
+        """Test the dataset_is_projection_coords function."""
+        import xarray as xr
+        from satpy.writers.cf_writer import dataset_is_projection_coords
+        data = [[1, 2], [3, 4]]
+        y = [1, 2]
+        x = [1, 2]
+        datasets = {'var1': xr.DataArray(data=data,
+                                         dims=('y', 'x'),
+                                         coords={'y': y, 'x': x}),
+                    'var2': xr.DataArray(data=data,
+                                         dims=('y', 'x'),
+                                         coords={'y': y, 'x': x}),
+                    'latitude': xr.DataArray(data=data,
+                                             dims=('y', 'x'),
+                                             coords={'y': y, 'x': x})}
+        datasets['latitude'].attrs['standard_name'] = 'latitude'
+        datasets['var1'].attrs['standard_name'] = 'dummy'
+        self.assertTrue(dataset_is_projection_coords(datasets['latitude']))
+        self.assertFalse(dataset_is_projection_coords(datasets['var1']))
+
+    def test_has_projection_coords(self):
+        """Test the has_projection_coords function."""
+        import xarray as xr
+        from satpy.writers.cf_writer import has_projection_coords
+        data = [[1, 2], [3, 4]]
+        y = [1, 2]
+        x = [1, 2]
+        datasets = {'var1': xr.DataArray(data=data,
+                                         dims=('y', 'x'),
+                                         coords={'y': y, 'x': x}),
+                    'var2': xr.DataArray(data=data,
+                                         dims=('y', 'x'),
+                                         coords={'y': y, 'x': x})}
+        datasets['var1'].attrs['standard_name'] = 'dummy'
+        self.assertFalse(has_projection_coords(datasets))
+        datasets['latitude'] = xr.DataArray(data=data,
+                                            dims=('y', 'x'),
+                                            coords={'y': y, 'x': x})
+        datasets['latitude'].attrs['standard_name'] = 'latitude'
+        self.assertTrue(has_projection_coords(datasets))
+
     def test_area2cf(self):
         """Test the conversion of an area to CF standards."""
         import xarray as xr

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -169,17 +169,20 @@ def area2lonlat(dataarray):
     area = dataarray.attrs['area']
     ignore_dims = {dim: 0 for dim in dataarray.dims if dim not in ['x', 'y']}
     chunks = getattr(dataarray.isel(**ignore_dims), 'chunks', None)
-    lons, lats = area.get_lonlats(chunks=chunks)
-    dataarray['longitude'] = xr.DataArray(lons, dims=['y', 'x'],
-                                          attrs={'name': "longitude",
-                                                 'standard_name': "longitude",
-                                                 'units': 'degrees_east'},
-                                          name='longitude')
-    dataarray['latitude'] = xr.DataArray(lats, dims=['y', 'x'],
-                                         attrs={'name': "latitude",
-                                                'standard_name': "latitude",
-                                                'units': 'degrees_north'},
-                                         name='latitude')
+    if ('lat' in dataarray and 'lon' in dataarray) or ('latitude' in dataarray and 'longitude' in dataarray):
+        pass  # lat/lon already included
+    else:
+        lons, lats = area.get_lonlats(chunks=chunks)
+        dataarray['longitude'] = xr.DataArray(lons, dims=['y', 'x'],
+                                              attrs={'name': "longitude",
+                                                     'standard_name': "longitude",
+                                                     'units': 'degrees_east'},
+                                              name='longitude')
+        dataarray['latitude'] = xr.DataArray(lats, dims=['y', 'x'],
+                                             attrs={'name': "latitude",
+                                                    'standard_name': "latitude",
+                                                    'units': 'degrees_north'},
+                                             name='latitude')
     return dataarray
 
 


### PR DESCRIPTION
Only add lon/lat variables if they are not included already.
Level1c4pps ended up with both lat/lon and latitude/longitude coordinates.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

