### PR TITLE
Daskify Earth-Sun distance correction.

### DIFF
--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -334,7 +334,7 @@ def apply_earthsun_distance_correction(reflectance, utc_date=None):
     utc_date = get_array_date(reflectance, utc_date)
     sun_earth_dist = sun_earth_distance_correction(utc_date)
 
-    reflectance.values = reflectance.values * sun_earth_dist * sun_earth_dist
+    reflectance = reflectance * sun_earth_dist * sun_earth_dist
     reflectance.attrs['sun_earth_distance_correction_applied'] = True
     reflectance.attrs['sun_earth_distance_correction_factor'] = sun_earth_dist
     return reflectance
@@ -348,5 +348,5 @@ def remove_earthsun_distance_correction(reflectance, utc_date=None):
 
     reflectance.attrs['sun_earth_distance_correction_applied'] = False
     reflectance.attrs['sun_earth_distance_correction_factor'] = sun_earth_dist
-    reflectance.values = reflectance.values / (sun_earth_dist * sun_earth_dist)
+    reflectance = reflectance / (sun_earth_dist * sun_earth_dist)
     return reflectance

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -17,20 +17,20 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Helper functions for satpy readers."""
 
-import logging
-
-from contextlib import closing
-import tempfile
 import bz2
+import logging
 import os
 import shutil
-import numpy as np
-import pyproj
+import tempfile
 import warnings
+from contextlib import closing
 from io import BytesIO
 from subprocess import Popen, PIPE
-from pyresample.geometry import AreaDefinition
 
+import numpy as np
+import pyproj
+import xarray as xr
+from pyresample.geometry import AreaDefinition
 from satpy import CHUNK_SIZE
 
 try:
@@ -334,9 +334,10 @@ def apply_earthsun_distance_correction(reflectance, utc_date=None):
     utc_date = get_array_date(reflectance, utc_date)
     sun_earth_dist = sun_earth_distance_correction(utc_date)
 
-    reflectance = reflectance * sun_earth_dist * sun_earth_dist
     reflectance.attrs['sun_earth_distance_correction_applied'] = True
     reflectance.attrs['sun_earth_distance_correction_factor'] = sun_earth_dist
+    with xr.set_options(keep_attrs=True):
+        reflectance = reflectance * sun_earth_dist * sun_earth_dist
     return reflectance
 
 
@@ -348,5 +349,6 @@ def remove_earthsun_distance_correction(reflectance, utc_date=None):
 
     reflectance.attrs['sun_earth_distance_correction_applied'] = False
     reflectance.attrs['sun_earth_distance_correction_factor'] = sun_earth_dist
-    reflectance = reflectance / (sun_earth_dist * sun_earth_dist)
+    with xr.set_options(keep_attrs=True):
+        reflectance = reflectance / (sun_earth_dist * sun_earth_dist)
     return reflectance


### PR DESCRIPTION
This PR fixes the calculation of Earth-Sun distance correction. Up to now, this correction converted the data from a dask-array to a numpy-array.

 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
