### PR TITLE
Fix wrong number of scanlines in eps reader

### DIFF
--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -227,7 +227,7 @@ class EPSAVHRRFile(BaseFileHandler):
         nav_sample_rate = self["NAV_SAMPLE_RATE"]
         if nav_sample_rate == 20 and self.pixels == 2048:
             from geotiepoints import metop20kmto1km
-            # Note: interpolation asumes lat values values between -90 and 90
+            # Note: interpolation assumes lat values values between -90 and 90
             # Solar and satellite zenith is between 0 and 180.
             # Note: delayed will cast input dask-arrays to numpy arrays (needed by metop20kmto1km).
             sun_azi, sun_zen = metop20kmto1km(solar_azimuth, solar_zenith - 90)

--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -187,17 +187,20 @@ class EPSAVHRRFile(BaseFileHandler):
             keys += val.dtype.fields.keys()
         return keys
 
-    @delayed(nout=2, pure=True)
     def _get_full_lonlats(self, lons, lats):
         nav_sample_rate = self["NAV_SAMPLE_RATE"]
         if nav_sample_rate == 20 and self.pixels == 2048:
-            from geotiepoints import metop20kmto1km
-            return metop20kmto1km(lons, lats)
+            return self._interpolate_20km_to_1km(lons, lats)
         else:
             raise NotImplementedError("Lon/lat expansion not implemented for " +
                                       "sample rate = " + str(nav_sample_rate) +
                                       " and earth views = " +
                                       str(self.pixels))
+
+    @delayed(nout=2, pure=True)
+    def _interpolate_20km_to_1km(self, lons, lats):
+        from geotiepoints import metop20kmto1km
+        return metop20kmto1km(lons, lats)
 
     def get_full_lonlats(self):
         """Get the interpolated lons/lats."""

--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -161,6 +161,7 @@ class EPSAVHRRFile(BaseFileHandler):
         self.scanlines = self['TOTAL_MDR']
         if self.scanlines != len(self.sections[('mdr', 2)]):
             logger.warning("Number of declared records doesn't match number of scanlines in the file.")
+            self.scanlines = len(self.sections[('mdr', 2)])
         self.pixels = self["EARTH_VIEWS_PER_SCANLINE"]
 
     def __getitem__(self, key):

--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -188,7 +188,7 @@ class EPSAVHRRFile(BaseFileHandler):
         return keys
 
     def get_full_lonlats(self):
-        """Get the interpolated lons_like/lats_like."""
+        """Get the interpolated longitudes and latitudes."""
         if self.lons is not None and self.lats is not None:
             return self.lons, self.lats
 
@@ -212,7 +212,7 @@ class EPSAVHRRFile(BaseFileHandler):
                                             shape=(self.scanlines, self.pixels))
             return lons_like_1km, lats_like_1km
         else:
-            raise NotImplementedError("Lon/lat expansion not implemented for " +
+            raise NotImplementedError("Lon/lat and angle expansion not implemented for " +
                                       "sample rate = " + str(nav_sample_rate) +
                                       " and earth views = " +
                                       str(self.pixels))
@@ -241,7 +241,7 @@ class EPSAVHRRFile(BaseFileHandler):
                                       str(self.pixels))
 
     def get_full_angles(self):
-        """Get the interpolated lons_like/lats_like."""
+        """Get the interpolated angles."""
         if (self.sun_azi is not None and self.sun_zen is not None and
                 self.sat_azi is not None and self.sat_zen is not None):
             return self.sun_azi, self.sun_zen, self.sat_azi, self.sat_zen

--- a/satpy/tests/reader_tests/test_eps_l1b.py
+++ b/satpy/tests/reader_tests/test_eps_l1b.py
@@ -24,11 +24,11 @@ from unittest import TestCase
 from unittest import mock
 
 import numpy as np
-import xarray as xr
-import satpy
-from satpy.tests.utils import make_dataid
-from satpy.readers import eps_l1b as eps
 import pytest
+import satpy
+import xarray as xr
+from satpy.readers import eps_l1b as eps
+from satpy.tests.utils import make_dataid
 
 grh_dtype = np.dtype([("record_class", "|i1"),
                       ("INSTRUMENT_GROUP", "|i1"),

--- a/satpy/tests/reader_tests/test_eps_l1b.py
+++ b/satpy/tests/reader_tests/test_eps_l1b.py
@@ -76,6 +76,7 @@ class TestEPSL1B(TestCase):
         sections[('mphr', 0)]['SPACECRAFT_ID'] = b'SPACECRAFT_ID                 = M03\n'
         sections[('mphr', 0)]['INSTRUMENT_ID'] = b'INSTRUMENT_ID                 = AVHR\n'
         sections[('sphr', 0)]['EARTH_VIEWS_PER_SCANLINE'] = b'EARTH_VIEWS_PER_SCANLINE      =  2048\n'
+        sections[('sphr', 0)]['NAV_SAMPLE_RATE'] = b'NAV_SAMPLE_RATE               =  20\n'
 
         _fd, fname = mkstemp()
         fd = open(_fd)
@@ -186,7 +187,7 @@ class TestWrongEPSL1B(TestCase):
         sections[('mphr', 0)]['SPACECRAFT_ID'] = b'SPACECRAFT_ID                 = M03\n'
         sections[('mphr', 0)]['INSTRUMENT_ID'] = b'INSTRUMENT_ID                 = AVHR\n'
         sections[('sphr', 0)]['EARTH_VIEWS_PER_SCANLINE'] = b'EARTH_VIEWS_PER_SCANLINE      =  2048\n'
-
+        sections[('sphr', 0)]['NAV_SAMPLE_RATE'] = b'NAV_SAMPLE_RATE               =  20\n'
         _fd, fname = mkstemp()
         fd = open(_fd)
 

--- a/satpy/tests/reader_tests/test_eps_l1b.py
+++ b/satpy/tests/reader_tests/test_eps_l1b.py
@@ -65,17 +65,23 @@ class TestEPSL1B(TestCase):
     def setUp(self):
         """Set up the tests."""
         # ipr is not present in the xml format ?
+        self.scan_lines = 1080
+        self.earth_views = 2048
         structure = [(1, ('mphr', 0)), (1, ('sphr', 0)), (11, ('ipr', 0)),
                      (1, ('geadr', 1)), (1, ('geadr', 2)), (1, ('geadr', 3)),
                      (1, ('geadr', 4)), (1, ('geadr', 5)), (1, ('geadr', 6)),
                      (1, ('geadr', 7)), (1, ('giadr', 1)), (1, ('giadr', 2)),
-                     (1, ('veadr', 1)), (1080, ('mdr', 2))]
+                     (1, ('veadr', 1)), (self.scan_lines, ('mdr', 2))]
 
         sections = create_sections(structure)
-        sections[('mphr', 0)]['TOTAL_MDR'] = b'TOTAL_MDR                     =   1080\n'
+        sections[('mphr', 0)]['TOTAL_MDR'] = (b'TOTAL_MDR                     =   ' +
+                                              bytes(str(self.scan_lines), encoding='ascii') +
+                                              b'\n')
         sections[('mphr', 0)]['SPACECRAFT_ID'] = b'SPACECRAFT_ID                 = M03\n'
         sections[('mphr', 0)]['INSTRUMENT_ID'] = b'INSTRUMENT_ID                 = AVHR\n'
-        sections[('sphr', 0)]['EARTH_VIEWS_PER_SCANLINE'] = b'EARTH_VIEWS_PER_SCANLINE      =  2048\n'
+        sections[('sphr', 0)]['EARTH_VIEWS_PER_SCANLINE'] = (b'EARTH_VIEWS_PER_SCANLINE      =  ' +
+                                                             bytes(str(self.earth_views), encoding='ascii') +
+                                                             b'\n')
         sections[('sphr', 0)]['NAV_SAMPLE_RATE'] = b'NAV_SAMPLE_RATE               =  20\n'
 
         _fd, fname = mkstemp()
@@ -175,18 +181,23 @@ class TestWrongEPSL1B(TestCase):
     def setUp(self):
         """Set up the tests."""
         # ipr is not present in the xml format ?
+        self.scan_lines = 1080
+        self.earth_views = 2048
         structure = [(1, ('mphr', 0)), (1, ('sphr', 0)), (11, ('ipr', 0)),
                      (1, ('geadr', 1)), (1, ('geadr', 2)), (1, ('geadr', 3)),
                      (1, ('geadr', 4)), (1, ('geadr', 5)), (1, ('geadr', 6)),
                      (1, ('geadr', 7)), (1, ('giadr', 1)), (1, ('giadr', 2)),
-                     (1, ('veadr', 1)), (1080, ('mdr', 2))]
+                     (1, ('veadr', 1)), (self.scan_lines, ('mdr', 2))]
 
         sections = create_sections(structure)
-        # Wrong number of lines, should be 1080 :)
-        sections[('mphr', 0)]['TOTAL_MDR'] = b'TOTAL_MDR                     =   1078\n'
+        sections[('mphr', 0)]['TOTAL_MDR'] = (b'TOTAL_MDR                     =   ' +
+                                              bytes(str(self.scan_lines - 2), encoding='ascii') +
+                                              b'\n')
         sections[('mphr', 0)]['SPACECRAFT_ID'] = b'SPACECRAFT_ID                 = M03\n'
         sections[('mphr', 0)]['INSTRUMENT_ID'] = b'INSTRUMENT_ID                 = AVHR\n'
-        sections[('sphr', 0)]['EARTH_VIEWS_PER_SCANLINE'] = b'EARTH_VIEWS_PER_SCANLINE      =  2048\n'
+        sections[('sphr', 0)]['EARTH_VIEWS_PER_SCANLINE'] = (b'EARTH_VIEWS_PER_SCANLINE      =  ' +
+                                                             bytes(str(self.earth_views), encoding='ascii') +
+                                                             b'\n')
         sections[('sphr', 0)]['NAV_SAMPLE_RATE'] = b'NAV_SAMPLE_RATE               =  20\n'
         _fd, fname = mkstemp()
         fd = open(_fd)
@@ -201,7 +212,7 @@ class TestWrongEPSL1B(TestCase):
     def test_read_all_return_right_number_of_scan_lines(self):
         """Test scanline assignment."""
         self.fh._read_all()
-        assert self.fh.scanlines == 1080
+        assert self.fh.scanlines == self.scan_lines
 
     def test_read_all_warns_about_scan_lines(self):
         """Test scanline assignment."""
@@ -218,7 +229,7 @@ class TestWrongEPSL1B(TestCase):
         """Test that the shape of longitude is 1080."""
         key = make_dataid(name="longitude")
         longitudes = self.fh.get_dataset(key, dict())
-        assert longitudes.shape == (1080, 2048)
+        assert longitudes.shape == (self.scan_lines, self.earth_views)
 
     def tearDown(self):
         """Tear down the tests."""


### PR DESCRIPTION
Sometimes the number of declared scanlines in the eps l1b files is different from the number of MDR records. This PR ensures we use the number of records as truth.

 - [x] Closes #1367 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

@TalfanBarnie Can you test if this works for you?
