### PR TITLE
Alphabetize available_readers method and update documentation

### DIFF
--- a/doc/source/readers.rst
+++ b/doc/source/readers.rst
@@ -15,7 +15,9 @@ requested, or added to a Scene object.
 Available Readers
 =================
 
-To get a list of available readers use the `available_readers` function::
+To get a list of available readers use the `available_readers` function. By default,
+it returns the names of available readers. To return additional reader information 
+use `available_readers(as_dict=True)`::
 
     >>> from satpy import available_readers
     >>> available_readers()

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -44,8 +44,9 @@ OLD_READER_NAMES = {
 
 def group_files(files_to_sort, reader=None, time_threshold=10,
                 group_keys=None, ppp_config_dir=None, reader_kwargs=None):
-    """Group series of files by file pattern information."""
-    """By default this will group files by their filename ``start_time``
+    """Group series of files by file pattern information.
+
+    By default this will group files by their filename ``start_time``
     assuming it exists in the pattern. By passing the individual
     dictionaries returned by this function to the Scene classes'
     ``filenames``, a series `Scene` objects can be easily created.
@@ -84,7 +85,6 @@ def group_files(files_to_sort, reader=None, time_threshold=10,
         a `Scene` object.
 
     """
-
     if reader is not None and not isinstance(reader, (list, tuple)):
         reader = [reader]
 
@@ -106,8 +106,9 @@ def group_files(files_to_sort, reader=None, time_threshold=10,
 
 def _assign_files_to_readers(files_to_sort, reader_names, ppp_config_dir,
                              reader_kwargs):
-    """Assign files to readers."""
-    """Given a list of file names (paths), match those to reader instances.
+    """Assign files to readers.
+
+    Given a list of file names (paths), match those to reader instances.
 
     Internal helper for group_files.
 
@@ -122,7 +123,6 @@ def _assign_files_to_readers(files_to_sort, reader_names, ppp_config_dir,
         Mapping where the keys are reader names and the values are tuples of
         (reader_configs, filenames).
     """
-
     files_to_sort = set(files_to_sort)
     reader_dict = {}
     for reader_configs in configs_for_reader(reader_names, ppp_config_dir):
@@ -148,8 +148,9 @@ def _assign_files_to_readers(files_to_sort, reader_names, ppp_config_dir,
 
 
 def _get_file_keys_for_reader_files(reader_files, group_keys=None):
-    """From a mapping from _assign_files_to_readers, get file keys."""
-    """Given a mapping where each key is a reader name and each value is a
+    """From a mapping from _assign_files_to_readers, get file keys.
+
+    Given a mapping where each key is a reader name and each value is a
     tuple of reader instance (typically FileYAMLReader) and a collection
     of files, return a mapping with the same keys, but where the values are
     lists of tuples of (keys, filename), where keys are extracted from the filenames
@@ -161,7 +162,6 @@ def _get_file_keys_for_reader_files(reader_files, group_keys=None):
     Returns:
         Mapping[str, List[Tuple[Tuple, str]]], as described.
     """
-
     file_keys = {}
     for (reader_name, (reader_instance, files_to_sort)) in reader_files.items():
         if group_keys is None:
@@ -312,6 +312,7 @@ def available_readers(as_dict=False):
         try:
             reader_info = read_reader_config(reader_configs)
         except (KeyError, IOError, yaml.YAMLError):
+            LOG.debug("Could not import reader config from: %s", reader_configs)
             LOG.debug("Error loading YAML", exc_info=True)
             continue
         readers.append(reader_info if as_dict else reader_info['name'])

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -44,9 +44,8 @@ OLD_READER_NAMES = {
 
 def group_files(files_to_sort, reader=None, time_threshold=10,
                 group_keys=None, ppp_config_dir=None, reader_kwargs=None):
-    """Group series of files by file pattern information.
-
-    By default this will group files by their filename ``start_time``
+    """Group series of files by file pattern information."""
+    """By default this will group files by their filename ``start_time``
     assuming it exists in the pattern. By passing the individual
     dictionaries returned by this function to the Scene classes'
     ``filenames``, a series `Scene` objects can be easily created.
@@ -107,9 +106,8 @@ def group_files(files_to_sort, reader=None, time_threshold=10,
 
 def _assign_files_to_readers(files_to_sort, reader_names, ppp_config_dir,
                              reader_kwargs):
-    """Assign files to readers.
-
-    Given a list of file names (paths), match those to reader instances.
+    """Assign files to readers."""
+    """Given a list of file names (paths), match those to reader instances.
 
     Internal helper for group_files.
 
@@ -150,9 +148,8 @@ def _assign_files_to_readers(files_to_sort, reader_names, ppp_config_dir,
 
 
 def _get_file_keys_for_reader_files(reader_files, group_keys=None):
-    """From a mapping from _assign_files_to_readers, get file keys.
-
-    Given a mapping where each key is a reader name and each value is a
+    """From a mapping from _assign_files_to_readers, get file keys."""
+    """Given a mapping where each key is a reader name and each value is a
     tuple of reader instance (typically FileYAMLReader) and a collection
     of files, return a mapping with the same keys, but where the values are
     lists of tuples of (keys, filename), where keys are extracted from the filenames
@@ -315,10 +312,13 @@ def available_readers(as_dict=False):
         try:
             reader_info = read_reader_config(reader_configs)
         except (KeyError, IOError, yaml.YAMLError):
-            LOG.warning("Could not import reader config from: %s", reader_configs)
             LOG.debug("Error loading YAML", exc_info=True)
             continue
         readers.append(reader_info if as_dict else reader_info['name'])
+    if as_dict:
+        readers = sorted(readers, key=lambda reader_info: reader_info['name'])
+    else:
+        readers = sorted(readers)
     return readers
 
 

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -625,16 +625,14 @@ class TestYAMLFiles(unittest.TestCase):
         self.assertIsInstance(reader_names[0], str)
         self.assertIn('viirs_sdr', reader_names)  # needs h5py
         self.assertIn('abi_l1b', reader_names)  # needs netcdf4
-        for i in range(1, len(reader_names)):
-            self.assertTrue(reader_names[i] > reader_names[i-1])
+        self.assertEqual(reader_names, sorted(reader_names))
 
         reader_infos = available_readers(as_dict=True)
         self.assertEqual(len(reader_names), len(reader_infos))
         self.assertIsInstance(reader_infos[0], dict)
         for reader_info in reader_infos:
             self.assertIn('name', reader_info)
-        for i in range(1, len(reader_infos)):
-            self.assertTrue(reader_infos[i]['name'] > reader_infos[i-1]['name'])
+        self.assertEqual(reader_infos, sorted(reader_infos, key=lambda reader_info: reader_info['name']))
 
 
 class TestGroupFiles(unittest.TestCase):

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -625,12 +625,16 @@ class TestYAMLFiles(unittest.TestCase):
         self.assertIsInstance(reader_names[0], str)
         self.assertIn('viirs_sdr', reader_names)  # needs h5py
         self.assertIn('abi_l1b', reader_names)  # needs netcdf4
+        for i in range(1, len(reader_names)):
+            self.assertTrue(reader_names[i] > reader_names[i-1])
 
         reader_infos = available_readers(as_dict=True)
         self.assertEqual(len(reader_names), len(reader_infos))
         self.assertIsInstance(reader_infos[0], dict)
         for reader_info in reader_infos:
             self.assertIn('name', reader_info)
+        for i in range(1, len(reader_infos)):
+            self.assertTrue(reader_infos[i]['name'] > reader_infos[i-1]['name'])
 
 
 class TestGroupFiles(unittest.TestCase):


### PR DESCRIPTION
Alphabetized the list of readers returned by the available_readers() method. Updated documentation so users know they can also do as_dict=True to return more information. 


 - [x] Passes ``flake8 satpy`` 
 - [x] Fully documented 
