### PR TITLE
Use standard names and recipes and enhancements for the default RGBs

### DIFF
--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -87,7 +87,7 @@ composites:
     - IR_120
     standard_name: cloudtop
 
-  convection:
+  severe_storms:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - compositor: !!python/name:satpy.composites.DifferenceCompositor
@@ -103,8 +103,8 @@ composites:
       prerequisites:
         - IR_016
         - VIS006
-    standard_name: convection
-
+    standard_name: severe_storms
+  
   night_fog:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -134,7 +134,7 @@ composites:
     - 12.0
     standard_name: cloudtop
 
-  convection:
+  severe_storms:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - compositor: !!python/name:satpy.composites.DifferenceCompositor
@@ -149,7 +149,7 @@ composites:
       prerequisites:
         - 1.6
         - 0.6
-    standard_name: convection
+    standard_name: severe_storms
 
   snow:
     compositor: !!python/name:satpy.composites.GenericCompositor

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -156,15 +156,22 @@ enhancements:
     - name: gamma
       method: !!python/name:satpy.enhancements.gamma
       kwargs: {gamma: 1.6}
-  convection_default:
-    standard_name: convection
+      
+  # EUMETrain recipe for the SEVIRI "Severe Storms RGB"
+  severe_storms_default:
     operations:
     - name: stretch
       method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
-        min_stretch: [-30, 0, -70]
-        max_stretch: [0, 55, 20]
+        min_stretch: [-35, -5, -75]
+        max_stretch: [0, 60, 25]
+    - name: gamma
+      method: !!python/name:satpy.enhancements.gamma
+      kwargs:
+        gamma: [1.0, 0.5, 1.0]
+    standard_name: severe_storms
+            
   dust_default:
     standard_name: dust
     operations:


### PR DESCRIPTION
Standardize the naming and RGB recipes and enhanements applied. As far as possible use the ones provided or suggested by EUMETSAT (EUMETrain) and NASA

 [x] Replace non-standard convection RGB with the "severe_storms" standard (EUMETrain)

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
