### PR TITLE
Fixed bug getting name to the calibration in mitiff writer

### DIFF
--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -367,7 +367,7 @@ class MITIFFWriter(ImageWriter):
                 isinstance(ds.attrs['prerequisites'], list) and
                 len(ds.attrs['prerequisites']) >= i + 1 and
                     isinstance(ds.attrs['prerequisites'][i], (DataQuery, DataID))):
-                if ds.attrs['prerequisites'][i]['name'] == str(ch):
+                if ds.attrs['prerequisites'][i].get('name') == str(ch):
                     if ds.attrs['prerequisites'][i].get('calibration') == 'RADIANCE':
                         raise NotImplementedError(
                             "Mitiff radiance calibration not implemented.")


### PR DESCRIPTION
Fixed bug getting name from the prerequisites when the prereq consist of DataQuery objects

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 