### PR TITLE
Fix handling of new date string formats in NUCAPS reader

### DIFF
--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -35,6 +35,7 @@ onboard Joint Polar Satellite System spacecraft.
 
 from datetime import datetime
 import xarray as xr
+import pandas as pd
 import numpy as np
 import logging
 from collections import defaultdict
@@ -81,7 +82,7 @@ class NUCAPSFileHandler(NetCDF4FileHandler):
 
     def _parse_datetime(self, datestr):
         """Parse NUCAPS datetime string."""
-        return datetime.strptime(datestr, "%Y-%m-%dT%H:%M:%S.%fZ")
+        return pd.to_datetime(datestr).to_pydatetime()
 
     @property
     def start_time(self):

--- a/satpy/tests/reader_tests/test_nucaps.py
+++ b/satpy/tests/reader_tests/test_nucaps.py
@@ -19,6 +19,7 @@
 
 import os
 import unittest
+import datetime
 from unittest import mock
 import numpy as np
 from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
@@ -59,8 +60,8 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
     def get_test_content(self, filename, filename_info, filetype_info):
         """Mimic reader input file content."""
         file_content = {
-            '/attr/time_coverage_start': filename_info['start_time'].strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
-            '/attr/time_coverage_end': filename_info['end_time'].strftime('%Y-%m-%dT%H:%M:%SZ'),
+            '/attr/time_coverage_start': "2020-10-20T12:00:00.5Z",
+            '/attr/time_coverage_end': "2020-10-20T12:00:36Z",
             '/attr/start_orbit_number': 1,
             '/attr/end_orbit_number': 2,
             '/attr/platform_name': 'NPP',
@@ -213,8 +214,8 @@ class TestNUCAPSReader(unittest.TestCase):
             # self.assertEqual(v.info['units'], 'degrees')
             self.assertEqual(v.ndim, 1)
             self.assertEqual(v.attrs['sensor'], ['CrIS', 'ATMS', 'VIIRS'])
-            self.assertEqual(v.attrs['start_time'].dtype, np.type(np.datetime64))
-            self.assertEqual(v.attrs['end_time'].dtype, np.type(np.datetime64))
+            self.assertEqual(type(v.attrs['start_time']), datetime.datetime)
+            self.assertEqual(type(v.attrs['end_time']), datetime.datetime)
 
     def test_load_pressure_based(self):
         """Test loading all channels based on pressure."""
@@ -399,8 +400,8 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
         for v in datasets.values():
             self.assertEqual(v.ndim, 1)
             self.assertEqual(v.attrs['sensor'], ['CrIS', 'ATMS', 'VIIRS'])
-            self.assertEqual(v.attrs['start_time'].dtype, np.type(np.datetime64))
-            self.assertEqual(v.attrs['end_time'].dtype, np.type(np.datetime64))
+            self.assertEqual(type(v.attrs['start_time']), datetime.datetime)
+            self.assertEqual(type(v.attrs['end_time']), datetime.datetime)
 
     def test_load_pressure_based(self):
         """Test loading all channels based on pressure."""

--- a/satpy/tests/reader_tests/test_nucaps.py
+++ b/satpy/tests/reader_tests/test_nucaps.py
@@ -60,7 +60,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         """Mimic reader input file content."""
         file_content = {
             '/attr/time_coverage_start': filename_info['start_time'].strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
-            '/attr/time_coverage_end': filename_info['end_time'].strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+            '/attr/time_coverage_end': filename_info['end_time'].strftime('%Y-%m-%dT%H:%M:%SZ'),
             '/attr/start_orbit_number': 1,
             '/attr/end_orbit_number': 2,
             '/attr/platform_name': 'NPP',

--- a/satpy/tests/reader_tests/test_nucaps.py
+++ b/satpy/tests/reader_tests/test_nucaps.py
@@ -213,6 +213,8 @@ class TestNUCAPSReader(unittest.TestCase):
             # self.assertEqual(v.info['units'], 'degrees')
             self.assertEqual(v.ndim, 1)
             self.assertEqual(v.attrs['sensor'], ['CrIS', 'ATMS', 'VIIRS'])
+            self.assertEqual(v.attrs['start_time'].dtype, np.type(np.datetime64))
+            self.assertEqual(v.attrs['end_time'].dtype, np.type(np.datetime64))
 
     def test_load_pressure_based(self):
         """Test loading all channels based on pressure."""
@@ -397,6 +399,8 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
         for v in datasets.values():
             self.assertEqual(v.ndim, 1)
             self.assertEqual(v.attrs['sensor'], ['CrIS', 'ATMS', 'VIIRS'])
+            self.assertEqual(v.attrs['start_time'].dtype, np.type(np.datetime64))
+            self.assertEqual(v.attrs['end_time'].dtype, np.type(np.datetime64))
 
     def test_load_pressure_based(self):
         """Test loading all channels based on pressure."""


### PR DESCRIPTION
NUCAPS reader required a more flexible approach to creating a datetime object, use pandas.to_datetime().to_pydatetime() for this.

NUCAPS data has multiple ways of writing the date string in the file, try to use pandas.to_datetime to minimize the risk ValueError when reading the date string from the NUCAPS file.

 - [x] Closes #1387
