### PR TITLE
Add support to Pyspectral NIRReflectance masking limit

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -60,8 +60,6 @@ NEGLIBLE_COORDS = ['time']
 MASKING_COMPOSITOR_METHODS = ['less', 'less_equal', 'equal', 'greater_equal',
                               'greater', 'not_equal', 'isnan', 'isfinite',
                               'isneginf', 'isposinf']
-NIR_REFLECTANCE_TERMINATOR_LIMIT = 85.0
-NIR_REFLECTANCE_MASKING_LIMIT = 88.0
 
 
 class IncompatibleAreas(Exception):
@@ -622,8 +620,11 @@ class PSPRayleighReflectance(CompositeBase):
 class NIRReflectance(CompositeBase):
     """Get the reflective part of NIR bands."""
 
-    def __init__(self, sunz_threshold=NIR_REFLECTANCE_TERMINATOR_LIMIT,
-                 masking_limit=NIR_REFLECTANCE_MASKING_LIMIT, **kwargs):
+    TERMINATOR_LIMIT = 85.0
+    MASKING_LIMIT = 88.0
+
+    def __init__(self, sunz_threshold=TERMINATOR_LIMIT,
+                 masking_limit=MASKING_LIMIT, **kwargs):
         """Collect custom configuration values.
 
         Args:

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -42,10 +42,10 @@ from satpy.utils import sunzen_corr_cos, atmospheric_path_length_correction, get
 from satpy.writers import get_enhanced_image
 
 try:
-    from pyspectral.near_infrared_reflectance import Calculator, TERMINATOR_LIMIT
+    from pyspectral.near_infrared_reflectance import Calculator
 except ImportError:
     Calculator = None
-    TERMINATOR_LIMIT = 85.0
+
 try:
     from pyorbital.astronomy import sun_zenith_angle
 except ImportError:
@@ -60,6 +60,8 @@ NEGLIBLE_COORDS = ['time']
 MASKING_COMPOSITOR_METHODS = ['less', 'less_equal', 'equal', 'greater_equal',
                               'greater', 'not_equal', 'isnan', 'isfinite',
                               'isneginf', 'isposinf']
+NIR_REFLECTANCE_TERMINATOR_LIMIT = 85.0
+NIR_REFLECTANCE_MASKING_LIMIT = 88.0
 
 
 class IncompatibleAreas(Exception):
@@ -620,17 +622,18 @@ class PSPRayleighReflectance(CompositeBase):
 class NIRReflectance(CompositeBase):
     """Get the reflective part of NIR bands."""
 
-    def __init__(self, sunz_threshold=TERMINATOR_LIMIT, masking_limit=TERMINATOR_LIMIT, **kwargs):
+    def __init__(self, sunz_threshold=NIR_REFLECTANCE_TERMINATOR_LIMIT,
+                 masking_limit=NIR_REFLECTANCE_MASKING_LIMIT, **kwargs):
         """Collect custom configuration values.
 
         Args:
             sunz_threshold: The threshold sun zenith angle used when deriving
                 the near infrared reflectance. Above this angle the derivation
                 will assume this sun-zenith everywhere. Unless overridden, the
-                default threshold defined in Pyspectral will be used.
+                default threshold of 85.0 degrees will be used.
             masking_limit: Mask the data (set to NaN) above this Sun zenith angle.
-                By default, use the value defined in Pyspectral.  Setting this to
-                `None` will disable the masking.
+                By default the limit is at 88.0 degrees.  If set to `None`, no masking
+                is done.
 
         """
         self.sun_zenith_threshold = sunz_threshold

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -626,8 +626,11 @@ class NIRReflectance(CompositeBase):
         Args:
             sunz_threshold: The threshold sun zenith angle used when deriving
                 the near infrared reflectance. Above this angle the derivation
-                will assume this sun-zenith everywhere. Default None, in which
-                case the default threshold defined in Pyspectral will be used.
+                will assume this sun-zenith everywhere. Unless overridden, the
+                default threshold defined in Pyspectral will be used.
+            masking_limit: Mask the data (set to NaN) above this Sun zenith angle.
+                By default, use the value defined in Pyspectral.  Setting this to
+                `None` will disable the masking.
 
         """
         self.sun_zenith_threshold = sunz_threshold

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -638,8 +638,6 @@ class TestNIRReflectance(unittest.TestCase):
     @mock.patch('satpy.composites.Calculator')
     def test_provide_sunz_and_threshold(self, calculator, apply_modifier_info, sza):
         """Test NIR reflectance compositor provided sunz and a sunz threshold."""
-        from satpy.composites import NIR_REFLECTANCE_MASKING_LIMIT
-
         calculator.return_value = mock.MagicMock(
             reflectance_from_tbs=self.refl_from_tbs)
         from satpy.composites import NIRReflectance
@@ -651,7 +649,7 @@ class TestNIRReflectance(unittest.TestCase):
 
         self.assertEqual(res.attrs['sun_zenith_threshold'], 84.0)
         calculator.assert_called_with('Meteosat-11', 'seviri', 'IR_039',
-                                      sunz_threshold=84.0, masking_limit=NIR_REFLECTANCE_MASKING_LIMIT)
+                                      sunz_threshold=84.0, masking_limit=NIRReflectance.MASKING_LIMIT)
 
     @mock.patch('satpy.composites.sun_zenith_angle')
     @mock.patch('satpy.composites.NIRReflectance.apply_modifier_info')
@@ -673,8 +671,6 @@ class TestNIRReflectance(unittest.TestCase):
     @mock.patch('satpy.composites.Calculator')
     def test_provide_masking_limit(self, calculator, apply_modifier_info, sza):
         """Test NIR reflectance compositor provided sunz and a sunz threshold."""
-        from satpy.composites import NIR_REFLECTANCE_TERMINATOR_LIMIT
-
         calculator.return_value = mock.MagicMock(
             reflectance_from_tbs=self.refl_from_tbs)
         from satpy.composites import NIRReflectance
@@ -686,7 +682,7 @@ class TestNIRReflectance(unittest.TestCase):
 
         self.assertIsNone(res.attrs['sun_zenith_masking_limit'])
         calculator.assert_called_with('Meteosat-11', 'seviri', 'IR_039',
-                                      sunz_threshold=NIR_REFLECTANCE_TERMINATOR_LIMIT, masking_limit=None)
+                                      sunz_threshold=NIRReflectance.TERMINATOR_LIMIT, masking_limit=None)
 
     @mock.patch('satpy.composites.sun_zenith_angle')
     @mock.patch('satpy.composites.NIRReflectance.apply_modifier_info')
@@ -715,7 +711,7 @@ class TestNIREmissivePartFromReflectance(unittest.TestCase):
         import numpy as np
         import xarray as xr
         import dask.array as da
-        from satpy.composites import NIR_REFLECTANCE_MASKING_LIMIT
+        from satpy.composites import NIRReflectance
 
         refl_arr = np.random.random((2, 2))
         refl = da.from_array(refl_arr)
@@ -768,7 +764,7 @@ class TestNIREmissivePartFromReflectance(unittest.TestCase):
         self.assertEqual(res.attrs['sensor'], sensor)
         self.assertEqual(res.attrs['name'], chan_name)
         calculator.assert_called_with('NOAA-20', 'viirs', 'M12', sunz_threshold=86.0,
-                                      masking_limit=NIR_REFLECTANCE_MASKING_LIMIT)
+                                      masking_limit=NIRReflectance.MASKING_LIMIT)
 
 
 class TestColormapCompositor(unittest.TestCase):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -638,7 +638,7 @@ class TestNIRReflectance(unittest.TestCase):
     @mock.patch('satpy.composites.Calculator')
     def test_provide_sunz_and_threshold(self, calculator, apply_modifier_info, sza):
         """Test NIR reflectance compositor provided sunz and a sunz threshold."""
-        from satpy.composites import TERMINATOR_LIMIT
+        from satpy.composites import NIR_REFLECTANCE_MASKING_LIMIT
 
         calculator.return_value = mock.MagicMock(
             reflectance_from_tbs=self.refl_from_tbs)
@@ -651,7 +651,7 @@ class TestNIRReflectance(unittest.TestCase):
 
         self.assertEqual(res.attrs['sun_zenith_threshold'], 84.0)
         calculator.assert_called_with('Meteosat-11', 'seviri', 'IR_039',
-                                      sunz_threshold=84.0, masking_limit=TERMINATOR_LIMIT)
+                                      sunz_threshold=84.0, masking_limit=NIR_REFLECTANCE_MASKING_LIMIT)
 
     @mock.patch('satpy.composites.sun_zenith_angle')
     @mock.patch('satpy.composites.NIRReflectance.apply_modifier_info')
@@ -673,7 +673,7 @@ class TestNIRReflectance(unittest.TestCase):
     @mock.patch('satpy.composites.Calculator')
     def test_provide_masking_limit(self, calculator, apply_modifier_info, sza):
         """Test NIR reflectance compositor provided sunz and a sunz threshold."""
-        from satpy.composites import TERMINATOR_LIMIT
+        from satpy.composites import NIR_REFLECTANCE_TERMINATOR_LIMIT
 
         calculator.return_value = mock.MagicMock(
             reflectance_from_tbs=self.refl_from_tbs)
@@ -686,7 +686,7 @@ class TestNIRReflectance(unittest.TestCase):
 
         self.assertIsNone(res.attrs['sun_zenith_masking_limit'])
         calculator.assert_called_with('Meteosat-11', 'seviri', 'IR_039',
-                                      sunz_threshold=TERMINATOR_LIMIT, masking_limit=None)
+                                      sunz_threshold=NIR_REFLECTANCE_TERMINATOR_LIMIT, masking_limit=None)
 
     @mock.patch('satpy.composites.sun_zenith_angle')
     @mock.patch('satpy.composites.NIRReflectance.apply_modifier_info')
@@ -715,7 +715,7 @@ class TestNIREmissivePartFromReflectance(unittest.TestCase):
         import numpy as np
         import xarray as xr
         import dask.array as da
-        from satpy.composites import TERMINATOR_LIMIT
+        from satpy.composites import NIR_REFLECTANCE_MASKING_LIMIT
 
         refl_arr = np.random.random((2, 2))
         refl = da.from_array(refl_arr)
@@ -767,7 +767,8 @@ class TestNIREmissivePartFromReflectance(unittest.TestCase):
         self.assertEqual(res.attrs['platform_name'], platform)
         self.assertEqual(res.attrs['sensor'], sensor)
         self.assertEqual(res.attrs['name'], chan_name)
-        calculator.assert_called_with('NOAA-20', 'viirs', 'M12', sunz_threshold=86.0, masking_limit=TERMINATOR_LIMIT)
+        calculator.assert_called_with('NOAA-20', 'viirs', 'M12', sunz_threshold=86.0,
+                                      masking_limit=NIR_REFLECTANCE_MASKING_LIMIT)
 
 
 class TestColormapCompositor(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ extras_require = {
     'amsr2_l1b': ['h5py >= 2.7.0'],
     'hrpt': ['pyorbital >= 1.3.1', 'pygac', 'python-geotiepoints >= 1.1.7'],
     'proj': ['pyresample'],
-    'pyspectral': ['pyspectral >= 0.8.7'],
+    'pyspectral': ['pyspectral >= 0.10.1'],
     'pyorbital': ['pyorbital >= 1.3.1'],
     'hrit_msg': ['pytroll-schedule'],
     'nc_nwcsaf_msg': ['netCDF4 >= 1.1.8'],


### PR DESCRIPTION
This is adds support to `masking_limit` keyword argument for `NIRReflectance` modifier added in https://github.com/pytroll/pyspectral/pull/113

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

I'm not sure where to document this feature, but the usage shown below.

This disables the masking altogether. See https://github.com/pytroll/pyspectral/pull/113 for an example image. This is the old default behaviour, which was changed in Pyspectral May (https://github.com/pytroll/pyspectral/commit/e9a234f317afd56121bb4539b40e225ae53a073c#diff-2a5232e6ece84bcd6cc7c97d82a7a574).
```yaml
  nir_reflectance_no_masking:
    compositor: !!python/name:satpy.composites.NIRReflectance
    prerequisites:
      - name: IR_108
    optional_prerequisites:
    - solar_zenith_angle
    - IR_134
    masking_limit: null
```

And definition of a specific masking limit:

```yaml
  nir_reflectance_no_masking:
    compositor: !!python/name:satpy.composites.NIRReflectance
    prerequisites:
      - name: IR_108
    optional_prerequisites:
    - solar_zenith_angle
    - IR_134
    masking_limit: 88.0
```

The default is to mask with the default limit defined in `pyspectral.near_infrared_reflectance.TERMINATOR_LIMIT`, which is also the current behaviour.