### PR TITLE
Fix the MSI / Sentinel-2 reader so it uses new DataID

### DIFF
--- a/satpy/readers/msi_safe.py
+++ b/satpy/readers/msi_safe.py
@@ -184,12 +184,12 @@ class SAFEMSIMDXML(BaseFileHandler):
     def _get_coarse_dataset(self, key, info):
         """Get the coarse dataset refered to by `key` from the XML data."""
         angles = self.root.find('.//Tile_Angles')
-        if key in ['solar_zenith_angle', 'solar_azimuth_angle']:
+        if key['name'] in ['solar_zenith_angle', 'solar_azimuth_angle']:
             elts = angles.findall(info['xml_tag'] + '/Values_List/VALUES')
             return np.array([[val for val in elt.text.split()] for elt in elts],
                             dtype=np.float)
 
-        elif key in ['satellite_zenith_angle', 'satellite_azimuth_angle']:
+        elif key['name'] in ['satellite_zenith_angle', 'satellite_azimuth_angle']:
             arrays = []
             elts = angles.findall(info['xml_tag'] + '[@bandId="1"]')
             for elt in elts:

--- a/satpy/readers/msi_safe.py
+++ b/satpy/readers/msi_safe.py
@@ -129,7 +129,7 @@ class SAFEMSIMDXML(BaseFileHandler):
         try:
             from pyproj import CRS
         except ImportError:
-            CRS = None
+            crs = None
         geocoding = self.root.find('.//Tile_Geocoding')
         epsg = geocoding.find('HORIZONTAL_CS_CODE').text
         rows = int(geocoding.find('Size[@resolution="' + str(dsid['resolution']) + '"]/NROWS').text)
@@ -140,8 +140,8 @@ class SAFEMSIMDXML(BaseFileHandler):
         xdim = float(geoposition.find('XDIM').text)
         ydim = float(geoposition.find('YDIM').text)
         area_extent = (ulx, uly + rows * ydim, ulx + cols * xdim, uly)
-        if CRS is not None:
-            proj = CRS(epsg)
+        if crs is not None:
+            proj = crs(epsg)
         else:
             proj = {'init': epsg}
         area = geometry.AreaDefinition(
@@ -201,7 +201,7 @@ class SAFEMSIMDXML(BaseFileHandler):
             return
 
     def get_dataset(self, key, info):
-        """Get the dataset refered to by `key`."""
+        """Get the dataset referred to by `key`."""
         angles = self._get_coarse_dataset(key, info)
         if angles is None:
             return


### PR DESCRIPTION
Composites with the Sentinel-2 reader (`MSI_SAFE`) won't work with the new DataID types in satpy, as we're searching for angle datasets using the old keys instead of the new dataid:
`if key in ....`
should be:
`if key['name'] in ....`

This PR corrects the issue, enabling composites that require the angles to be generated once again. I've also renamed `CRS` to `crs` as pycharm was (rightly) complaining about it and corrected a typo in a docstring.



 - [ ] Closes #1389 
 - [ ] Passes ``flake8 satpy``