### PR TITLE
Allow different kwargs for different readers

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -477,18 +477,7 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None,
     else:
         remaining_filenames = set(filenames or [])
 
-    reader_kwargs = reader_kwargs or {}
-
-    # ensure one reader_kwargs per reader, None if not provided
-    if reader is None:
-        reader_kwargs = {None: reader_kwargs}
-    elif reader_kwargs.keys() != set(reader):
-        reader_kwargs = dict.fromkeys(reader, reader_kwargs)
-
-    reader_kwargs_without_filter = {}
-    for (k, v) in reader_kwargs.items():
-        reader_kwargs_without_filter[k] = v.copy()
-        reader_kwargs_without_filter[k].pop('filter_parameters', None)
+    (reader_kwargs, reader_kwargs_without_filter) = _get_reader_kwargs(reader, reader_kwargs)
 
     for idx, reader_configs in enumerate(configs_for_reader(reader, ppp_config_dir)):
         if isinstance(filenames, dict):
@@ -527,3 +516,25 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None,
                          "requirements (such as Epilog, Prolog) or none of the "
                          "provided files match the filter parameters.")
     return reader_instances
+
+
+def _get_reader_kwargs(reader, reader_kwargs):
+    """Helper for load_readers to form reader_kwargs.
+
+    Helper for load_readers to get reader_kwargs and
+    reader_kwargs_without_filter in the desirable form.
+    """
+    reader_kwargs = reader_kwargs or {}
+
+    # ensure one reader_kwargs per reader, None if not provided
+    if reader is None:
+        reader_kwargs = {None: reader_kwargs}
+    elif reader_kwargs.keys() != set(reader):
+        reader_kwargs = dict.fromkeys(reader, reader_kwargs)
+
+    reader_kwargs_without_filter = {}
+    for (k, v) in reader_kwargs.items():
+        reader_kwargs_without_filter[k] = v.copy()
+        reader_kwargs_without_filter[k].pop('filter_parameters', None)
+
+    return (reader_kwargs, reader_kwargs_without_filter)

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -441,15 +441,17 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None,
                                       should map reader names to a list of filenames for that reader.
         reader (str or list): The name of the reader to use for loading the data or a list of names.
         reader_kwargs (dict): Keyword arguments to pass to specific reader instances.
+            This can either be a single dictionary that will be passed to all
+            reader instances, or a mapping of reader names to dictionaries.  If
+            the keys of ``reader_kwargs`` match exactly the list of strings in
+            ``reader`` or the keys of filenames, each reader instance will get its
+            own keyword arguments accordingly.
         ppp_config_dir (str): The directory containing the configuration files for satpy.
 
     Returns: Dictionary mapping reader name to reader instance
 
     """
     reader_instances = {}
-    reader_kwargs = reader_kwargs or {}
-    reader_kwargs_without_filter = reader_kwargs.copy()
-    reader_kwargs_without_filter.pop('filter_parameters', None)
 
     if ppp_config_dir is None:
         ppp_config_dir = get_environ_config_dir()
@@ -475,6 +477,19 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None,
     else:
         remaining_filenames = set(filenames or [])
 
+    reader_kwargs = reader_kwargs or {}
+
+    # ensure one reader_kwargs per reader, None if not provided
+    if reader is None:
+        reader_kwargs = {None: reader_kwargs}
+    elif reader_kwargs.keys() != set(reader):
+        reader_kwargs = dict.fromkeys(reader, reader_kwargs)
+
+    reader_kwargs_without_filter = {}
+    for (k, v) in reader_kwargs.items():
+        reader_kwargs_without_filter[k] = v.copy()
+        reader_kwargs_without_filter[k].pop('filter_parameters', None)
+
     for idx, reader_configs in enumerate(configs_for_reader(reader, ppp_config_dir)):
         if isinstance(filenames, dict):
             readers_files = set(filenames[reader[idx]])
@@ -482,7 +497,9 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None,
             readers_files = remaining_filenames
 
         try:
-            reader_instance = load_reader(reader_configs, **reader_kwargs)
+            reader_instance = load_reader(
+                    reader_configs,
+                    **reader_kwargs[None if reader is None else reader[idx]])
         except (KeyError, IOError, yaml.YAMLError) as err:
             LOG.info('Cannot use %s', str(reader_configs))
             LOG.debug(str(err))
@@ -493,7 +510,9 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None,
             continue
         loadables = reader_instance.select_files_from_pathnames(readers_files)
         if loadables:
-            reader_instance.create_filehandlers(loadables, fh_kwargs=reader_kwargs_without_filter)
+            reader_instance.create_filehandlers(
+                    loadables,
+                    fh_kwargs=reader_kwargs_without_filter[None if reader is None else reader[idx]])
             reader_instances[reader_instance.name] = reader_instance
             remaining_filenames -= set(loadables)
         if not remaining_filenames:

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -92,6 +92,10 @@ class Scene:
             filter_parameters (dict): Specify loaded file filtering parameters.
                                       Shortcut for `reader_kwargs['filter_parameters']`.
             reader_kwargs (dict): Keyword arguments to pass to specific reader instances.
+                Either a single dictionary that will be passed onto to all
+                reader instances, or a dictionary mapping reader names to
+                sub-dictionaries to pass different arguments to different
+                reader instances.
             ppp_config_dir (str): The directory containing the configuration files for satpy.
             base_dir (str): (DEPRECATED) The directory to search for files containing the
                             data to load. If *filenames* is also provided,

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -222,6 +222,29 @@ class TestScene(unittest.TestCase):
             self.assertDictEqual(reader_kwargs, r.create_filehandlers.call_args[1]['fh_kwargs'])
             del scene
 
+    def test_create_multiple_reader_different_kwargs(self):
+        """Test passing different kwargs to different readers."""
+        from satpy.scene import Scene
+        from satpy.tests.utils import FakeReader
+        from datetime import datetime
+        with mock.patch('satpy.readers.load_readers') as srl:
+            r1 = FakeReader('strona')
+            r2 = FakeReader('mastallone')
+            def fake_lr(nm):
+                if nm == "strona":
+                    return r1
+                elif nm == "mastallone":
+                    return r2
+                else:
+                    raise RuntimeError("wrong")
+            srl.side_effect = fake_lr
+            scene = Scene(
+                    filenames={"strona": ["campello monti"],
+                               "mastallone": ["rimella"]},
+                    reader_kwargs={"strona": {"mouth": "omegna"},
+                                   "mastallone": {"mouth": "varallo"}})
+            raise NotImplementedError("I don't know how to continue")
+
     def test_iter(self):
         """Test iteration over the scene."""
         from satpy import Scene

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -242,6 +242,7 @@ class TestScene(unittest.TestCase):
                     return r1
                 elif reader_configs == ["/fake/mastallone.yaml"]:
                     return r2
+                raise RuntimeError("Test is broken")  # pragma: no cover
             srl.side_effect = fake_lr
             src.return_value = [["/fake/strona.yaml"], ["/fake/mastallone.yaml"]]
             Scene(filenames={"strona": ["campello monti"],

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -242,8 +242,6 @@ class TestScene(unittest.TestCase):
                     return r1
                 elif reader_configs == ["/fake/mastallone.yaml"]:
                     return r2
-                else:
-                    raise RuntimeError("unit test is broken")
             srl.side_effect = fake_lr
             src.return_value = [["/fake/strona.yaml"], ["/fake/mastallone.yaml"]]
             Scene(filenames={"strona": ["campello monti"],


### PR DESCRIPTION
Allow to pass different keyword arguments to different readers.

 - [x] Closes #1396 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

