### PR TITLE
Improve customisation in multiscene creation

### DIFF
--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -171,7 +171,7 @@ class MultiScene(object):
 
     @classmethod
     def from_files(cls, files_to_sort, reader=None,
-                   ensure_all_readers=False, **kwargs):
+                   ensure_all_readers=False, scene_kwargs=None, **kwargs):
         """Create multiple Scene objects from multiple files.
 
         Args:
@@ -180,6 +180,8 @@ class MultiScene(object):
             ensure_all_readers (bool): If True, limit to scenes where all
                 readers have at least one file.  If False (default), include
                 all scenes where at least one reader has at least one file.
+            scene_kwargs (Mapping): additional arguments to pass on to
+                :func:`Scene.__init__` for each created scene.
 
         This uses the :func:`satpy.readers.group_files` function to group
         files. See this function for more details on additional possible
@@ -190,10 +192,12 @@ class MultiScene(object):
 
         """
         from satpy.readers import group_files
+        if scene_kwargs is None:
+            scene_kwargs = {}
         file_groups = group_files(files_to_sort, reader=reader, **kwargs)
         if ensure_all_readers:
             file_groups = [fg for fg in file_groups if all(fg.values())]
-        scenes = (Scene(filenames=fg) for fg in file_groups)
+        scenes = (Scene(filenames=fg, **scene_kwargs) for fg in file_groups)
         return cls(scenes)
 
     def __iter__(self):

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -176,10 +176,12 @@ class TestMultiScene(unittest.TestCase):
         with mock.patch('satpy.multiscene.Scene') as scn_mock:
             mscn = MultiScene.from_files(
                     input_files_abi,
-                    reader='abi_l1b')
+                    reader='abi_l1b',
+                    scene_kwargs={"reader_kwargs": {}})
             assert len(mscn.scenes) == 6
             calls = [mock.call(
-                filenames={'abi_l1b': [in_file_abi]})
+                filenames={'abi_l1b': [in_file_abi]},
+                reader_kwargs={})
                 for in_file_abi in input_files_abi]
             scn_mock.assert_has_calls(calls)
 


### PR DESCRIPTION
When creating a MultiScene using MultiScene.from_files, allow the user
to pass additional keyword arguments to the Scene creation with the
scene_kwargs keyword argument.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1399 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
