### PR TITLE
Update sensor min/max wavelengths in the reader YAML files

### DIFF
--- a/satpy/etc/readers/abi_l1b.yaml
+++ b/satpy/etc/readers/abi_l1b.yaml
@@ -76,7 +76,7 @@ file_types:
 datasets:
   C01:
     name: C01
-    wavelength: [0.447, 0.470, 0.494]
+    wavelength: [0.448, 0.470, 0.493]
     resolution: 1000
     calibration:
       radiance:
@@ -89,7 +89,7 @@ datasets:
 
   C02:
     name: C02
-    wavelength: [0.587, 0.640, 0.688]
+    wavelength: [0.589, 0.640, 0.687]
     resolution: 500
     calibration:
       radiance:
@@ -102,7 +102,7 @@ datasets:
 
   C03:
     name: C03
-    wavelength: [0.840, 0.865, 0.889]
+    wavelength: [0.841, 0.865, 0.887]
     resolution: 1000
     calibration:
       radiance:
@@ -115,7 +115,7 @@ datasets:
 
   C04:
     name: C04
-    wavelength: [1.364, 1.378, 1.382]
+    wavelength: [1.365, 1.378, 1.382]
     resolution: 2000
     calibration:
       radiance:
@@ -128,7 +128,7 @@ datasets:
 
   C05:
     name: C05
-    wavelength: [1.576, 1.610, 1.643]
+    wavelength: [1.578, 1.610, 1.641]
     resolution: 1000
     calibration:
       radiance:
@@ -141,7 +141,7 @@ datasets:
 
   C06:
     name: C06
-    wavelength: [2.214, 2.250, 2.272]
+    wavelength: [2.215, 2.250, 2.270]
     resolution: 2000
     calibration:
       radiance:
@@ -154,7 +154,7 @@ datasets:
 
   C07:
     name: C07
-    wavelength: [3.77, 3.90, 4.021]
+    wavelength: [3.777, 3.90, 4.014]
     resolution: 2000
     calibration:
       radiance:
@@ -167,7 +167,7 @@ datasets:
 
   C08:
     name: C08
-    wavelength: [5.749, 6.185, 6.636]
+    wavelength: [5.759, 6.185, 6.625]
     resolution: 2000
     calibration:
       radiance:
@@ -180,7 +180,7 @@ datasets:
 
   C09:
     name: C09
-    wavelength: [6.665, 6.95, 7.199]
+    wavelength: [6.678, 6.95, 7.186]
     resolution: 2000
     calibration:
       radiance:
@@ -193,7 +193,7 @@ datasets:
 
   C10:
     name: C10
-    wavelength: [7.215, 7.34, 7.457]
+    wavelength: [7.221, 7.34, 7.452]
     resolution: 2000
     calibration:
       radiance:
@@ -206,7 +206,7 @@ datasets:
 
   C11:
     name: C11
-    wavelength: [8.174, 8.50, 8.727]
+    wavelength: [8.184, 8.50, 8.713]
     resolution: 2000
     calibration:
       radiance:
@@ -219,7 +219,7 @@ datasets:
 
   C12:
     name: C12
-    wavelength: [9.378, 9.61, 9.850]
+    wavelength: [9.389, 9.61, 9.839]
     resolution: 2000
     calibration:
       radiance:
@@ -232,7 +232,7 @@ datasets:
 
   C13:
     name: C13
-    wavelength: [10.096, 10.35, 10.595]
+    wavelength: [10.115, 10.35, 10.570]
     resolution: 2000
     calibration:
       radiance:
@@ -245,7 +245,7 @@ datasets:
 
   C14:
     name: C14
-    wavelength: [10.695, 11.20, 11.715]
+    wavelength: [10.722, 11.20, 11.690]
     resolution: 2000
     calibration:
       radiance:
@@ -258,7 +258,7 @@ datasets:
 
   C15:
     name: C15
-    wavelength: [11.703, 12.30, 12.883]
+    wavelength: [11.730, 12.30, 12.855]
     resolution: 2000
     calibration:
       radiance:
@@ -271,7 +271,7 @@ datasets:
 
   C16:
     name: C16
-    wavelength: [12.925, 13.30, 13.652]
+    wavelength: [12.938, 13.30, 13.635]
     resolution: 2000
     calibration:
       radiance:

--- a/satpy/etc/readers/abi_l1b.yaml
+++ b/satpy/etc/readers/abi_l1b.yaml
@@ -76,7 +76,7 @@ file_types:
 datasets:
   C01:
     name: C01
-    wavelength: [0.450, 0.470, 0.490]
+    wavelength: [0.447, 0.470, 0.494]
     resolution: 1000
     calibration:
       radiance:
@@ -89,7 +89,7 @@ datasets:
 
   C02:
     name: C02
-    wavelength: [0.590, 0.640, 0.690]
+    wavelength: [0.587, 0.640, 0.688]
     resolution: 500
     calibration:
       radiance:
@@ -102,7 +102,7 @@ datasets:
 
   C03:
     name: C03
-    wavelength: [0.8455, 0.865, 0.8845]
+    wavelength: [0.840, 0.865, 0.889]
     resolution: 1000
     calibration:
       radiance:
@@ -115,7 +115,7 @@ datasets:
 
   C04:
     name: C04
-    wavelength: [1.3705, 1.378, 1.3855]
+    wavelength: [1.364, 1.378, 1.382]
     resolution: 2000
     calibration:
       radiance:
@@ -128,7 +128,7 @@ datasets:
 
   C05:
     name: C05
-    wavelength: [1.580, 1.610, 1.640]
+    wavelength: [1.576, 1.610, 1.643]
     resolution: 1000
     calibration:
       radiance:
@@ -141,7 +141,7 @@ datasets:
 
   C06:
     name: C06
-    wavelength: [2.225, 2.250, 2.275]
+    wavelength: [2.214, 2.250, 2.272]
     resolution: 2000
     calibration:
       radiance:
@@ -154,7 +154,7 @@ datasets:
 
   C07:
     name: C07
-    wavelength: [3.80, 3.90, 4.00]
+    wavelength: [3.77, 3.90, 4.021]
     resolution: 2000
     calibration:
       radiance:
@@ -167,7 +167,7 @@ datasets:
 
   C08:
     name: C08
-    wavelength: [5.770, 6.185, 6.600]
+    wavelength: [5.749, 6.185, 6.636]
     resolution: 2000
     calibration:
       radiance:
@@ -180,7 +180,7 @@ datasets:
 
   C09:
     name: C09
-    wavelength: [6.75, 6.95, 7.15]
+    wavelength: [6.665, 6.95, 7.199]
     resolution: 2000
     calibration:
       radiance:
@@ -193,7 +193,7 @@ datasets:
 
   C10:
     name: C10
-    wavelength: [7.24, 7.34, 7.44]
+    wavelength: [7.215, 7.34, 7.457]
     resolution: 2000
     calibration:
       radiance:
@@ -206,7 +206,7 @@ datasets:
 
   C11:
     name: C11
-    wavelength: [8.30, 8.50, 8.70]
+    wavelength: [8.174, 8.50, 8.727]
     resolution: 2000
     calibration:
       radiance:
@@ -219,7 +219,7 @@ datasets:
 
   C12:
     name: C12
-    wavelength: [9.42, 9.61, 9.80]
+    wavelength: [9.378, 9.61, 9.850]
     resolution: 2000
     calibration:
       radiance:
@@ -232,7 +232,7 @@ datasets:
 
   C13:
     name: C13
-    wavelength: [10.10, 10.35, 10.60]
+    wavelength: [10.096, 10.35, 10.595]
     resolution: 2000
     calibration:
       radiance:
@@ -245,7 +245,7 @@ datasets:
 
   C14:
     name: C14
-    wavelength: [10.80, 11.20, 11.60]
+    wavelength: [10.695, 11.20, 11.715]
     resolution: 2000
     calibration:
       radiance:
@@ -258,7 +258,7 @@ datasets:
 
   C15:
     name: C15
-    wavelength: [11.80, 12.30, 12.80]
+    wavelength: [11.703, 12.30, 12.883]
     resolution: 2000
     calibration:
       radiance:
@@ -271,7 +271,7 @@ datasets:
 
   C16:
     name: C16
-    wavelength: [13.00, 13.30, 13.60]
+    wavelength: [12.925, 13.30, 13.652]
     resolution: 2000
     calibration:
       radiance:

--- a/satpy/etc/readers/abi_l1b.yaml
+++ b/satpy/etc/readers/abi_l1b.yaml
@@ -76,7 +76,7 @@ file_types:
 datasets:
   C01:
     name: C01
-    wavelength: [0.448, 0.470, 0.493]
+    wavelength: [0.448, 0.471, 0.493]
     resolution: 1000
     calibration:
       radiance:
@@ -102,7 +102,7 @@ datasets:
 
   C03:
     name: C03
-    wavelength: [0.841, 0.865, 0.887]
+    wavelength: [0.841, 0.864, 0.887]
     resolution: 1000
     calibration:
       radiance:
@@ -115,7 +115,7 @@ datasets:
 
   C04:
     name: C04
-    wavelength: [1.365, 1.378, 1.382]
+    wavelength: [1.365, 1.373, 1.382]
     resolution: 2000
     calibration:
       radiance:
@@ -141,7 +141,7 @@ datasets:
 
   C06:
     name: C06
-    wavelength: [2.215, 2.250, 2.270]
+    wavelength: [2.215, 2.243, 2.270]
     resolution: 2000
     calibration:
       radiance:
@@ -154,7 +154,7 @@ datasets:
 
   C07:
     name: C07
-    wavelength: [3.777, 3.90, 4.014]
+    wavelength: [3.777, 3.893, 4.014]
     resolution: 2000
     calibration:
       radiance:
@@ -167,7 +167,7 @@ datasets:
 
   C08:
     name: C08
-    wavelength: [5.759, 6.185, 6.625]
+    wavelength: [5.759, 6.198, 6.625]
     resolution: 2000
     calibration:
       radiance:
@@ -180,7 +180,7 @@ datasets:
 
   C09:
     name: C09
-    wavelength: [6.678, 6.95, 7.186]
+    wavelength: [6.678, 6.935, 7.186]
     resolution: 2000
     calibration:
       radiance:
@@ -193,7 +193,7 @@ datasets:
 
   C10:
     name: C10
-    wavelength: [7.221, 7.34, 7.452]
+    wavelength: [7.221, 7.337, 7.452]
     resolution: 2000
     calibration:
       radiance:
@@ -206,7 +206,7 @@ datasets:
 
   C11:
     name: C11
-    wavelength: [8.184, 8.50, 8.713]
+    wavelength: [8.184, 8.451, 8.713]
     resolution: 2000
     calibration:
       radiance:
@@ -219,7 +219,7 @@ datasets:
 
   C12:
     name: C12
-    wavelength: [9.389, 9.61, 9.839]
+    wavelength: [9.389, 9.611, 9.839]
     resolution: 2000
     calibration:
       radiance:
@@ -232,7 +232,7 @@ datasets:
 
   C13:
     name: C13
-    wavelength: [10.115, 10.35, 10.570]
+    wavelength: [10.115, 10.335, 10.570]
     resolution: 2000
     calibration:
       radiance:
@@ -245,7 +245,7 @@ datasets:
 
   C14:
     name: C14
-    wavelength: [10.722, 11.20, 11.690]
+    wavelength: [10.722, 11.202, 11.690]
     resolution: 2000
     calibration:
       radiance:
@@ -258,7 +258,7 @@ datasets:
 
   C15:
     name: C15
-    wavelength: [11.730, 12.30, 12.855]
+    wavelength: [11.730, 12.287, 12.855]
     resolution: 2000
     calibration:
       radiance:
@@ -271,7 +271,7 @@ datasets:
 
   C16:
     name: C16
-    wavelength: [12.938, 13.30, 13.635]
+    wavelength: [12.938, 13.274, 13.635]
     resolution: 2000
     calibration:
       radiance:

--- a/satpy/etc/readers/abi_l1b_scmi.yaml
+++ b/satpy/etc/readers/abi_l1b_scmi.yaml
@@ -114,7 +114,7 @@ datasets:
   C01:
     name: C01
     sensor: abi
-    wavelength: [0.450, 0.470, 0.490]
+    wavelength: [0.448, 0.471, 0.493]
     resolution: 1000
     calibration:
       reflectance:
@@ -125,7 +125,7 @@ datasets:
   C02:
     name: C02
     sensor: abi
-    wavelength: [0.590, 0.640, 0.690]
+    wavelength: [0.589, 0.640, 0.687]
     resolution: 500
     calibration:
       reflectance:
@@ -136,7 +136,7 @@ datasets:
   C03:
     name: C03
     sensor: abi
-    wavelength: [0.8455, 0.865, 0.8845]
+    wavelength: [0.841, 0.864, 0.887]
     resolution: 1000
     calibration:
       reflectance:
@@ -147,7 +147,7 @@ datasets:
   C04:
     name: C04
     sensor: abi
-    wavelength: [1.3705, 1.378, 1.3855]
+    wavelength: [1.365, 1.373, 1.382]
     resolution: 2000
     calibration:
       reflectance:
@@ -158,7 +158,7 @@ datasets:
   C05:
     name: C05
     sensor: abi
-    wavelength: [1.580, 1.610, 1.640]
+    wavelength: [1.578, 1.610, 1.641]
     resolution: 1000
     calibration:
       reflectance:
@@ -169,7 +169,7 @@ datasets:
   C06:
     name: C06
     sensor: abi
-    wavelength: [2.225, 2.250, 2.275]
+    wavelength: [2.215, 2.243, 2.270]
     resolution: 2000
     calibration:
       reflectance:
@@ -180,7 +180,7 @@ datasets:
   C07:
     name: C07
     sensor: abi
-    wavelength: [3.80, 3.90, 4.00]
+    wavelength: [3.777, 3.893, 4.014]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -191,7 +191,7 @@ datasets:
   C08:
     name: C08
     sensor: abi
-    wavelength: [5.770, 6.185, 6.600]
+    wavelength: [5.759, 6.198, 6.625]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -202,7 +202,7 @@ datasets:
   C09:
     name: C09
     sensor: abi
-    wavelength: [6.75, 6.95, 7.15]
+    wavelength: [6.678, 6.935, 7.186]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -213,7 +213,7 @@ datasets:
   C10:
     name: C10
     sensor: abi
-    wavelength: [7.24, 7.34, 7.44]
+    wavelength: [7.221, 7.337, 7.452]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -224,7 +224,7 @@ datasets:
   C11:
     name: C11
     sensor: abi
-    wavelength: [8.30, 8.50, 8.70]
+    wavelength: [8.184, 8.451, 8.713]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -235,7 +235,7 @@ datasets:
   C12:
     name: C12
     sensor: abi
-    wavelength: [9.42, 9.61, 9.80]
+    wavelength: [9.389, 9.611, 9.839]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -246,7 +246,7 @@ datasets:
   C13:
     name: C13
     sensor: abi
-    wavelength: [10.10, 10.35, 10.60]
+    wavelength: [10.115, 10.335, 10.570]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -257,7 +257,7 @@ datasets:
   C14:
     name: C14
     sensor: abi
-    wavelength: [10.80, 11.20, 11.60]
+    wavelength: [10.722, 11.202, 11.690]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -268,7 +268,7 @@ datasets:
   C15:
     name: C15
     sensor: abi
-    wavelength: [11.80, 12.30, 12.80]
+    wavelength: [11.730, 12.287, 12.855]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -279,7 +279,7 @@ datasets:
   C16:
     name: C16
     sensor: abi
-    wavelength: [13.00, 13.30, 13.60]
+    wavelength: [12.938, 13.274, 13.635]
     resolution: 2000
     calibration:
       brightness_temperature:

--- a/satpy/etc/readers/abi_l2_nc.yaml
+++ b/satpy/etc/readers/abi_l2_nc.yaml
@@ -16,112 +16,112 @@ datasets:
 # --- Cloud Moisture Image Products ---
   CMIP_C01:                          # Cloud Moisture Image Products Channel 1
     name: C01
-    wavelength: [0.450, 0.470, 0.490]
+    wavelength: [0.448, 0.471, 0.493]
     calibration: reflectance
     file_type: abi_l2_cmip_c01
     file_key: CMI
 
   CMIP_C02:                           # Cloud Moisture Image Products Channel 2
     name: C02
-    wavelength: [0.590, 0.640, 0.690]
+    wavelength: [0.589, 0.640, 0.687]
     calibration: reflectance
     file_type: abi_l2_cmip_c02
     file_key: CMI
 
   CMIP_C03:                          # Cloud Moisture Image Products Channel 3
     name: C03
-    wavelength: [0.8455, 0.865, 0.8845]
+    wavelength: [0.841, 0.864, 0.887]
     calibration: reflectance
     file_type: abi_l2_cmip_c03
     file_key: CMI
 
   CMIP_C04:                          # Cloud Moisture Image Products Channel 4
     name: C04
-    wavelength: [1.3705, 1.378, 1.3855]
+    wavelength: [1.365, 1.373, 1.382]
     calibration: reflectance
     file_type: abi_l2_cmip_c04
     file_key: CMI
 
   CMIP_C05:                          # Cloud Moisture Image Products Channel 5
     name: C05
-    wavelength: [1.580, 1.610, 1.640]
+    wavelength: [1.578, 1.610, 1.641]
     calibration: reflectance
     file_type: abi_l2_cmip_c05
     file_key: CMI
 
   CMIP_C06:                          # Cloud Moisture Image Products Channel 6
     name: C06
-    wavelength: [2.225, 2.250, 2.275]
+    wavelength: [2.215, 2.243, 2.270]
     calibration: reflectance
     file_type: abi_l2_cmip_c06
     file_key: CMI
 
   CMIP_C07:                          # Cloud Moisture Image Products Channel 7
     name: C07
-    wavelength: [3.80, 3.90, 4.00]
+    wavelength: [3.777, 3.893, 4.014]
     calibration: brightness_temperature
     file_type: abi_l2_cmip_c07
     file_key: CMI
 
   CMIP_C08:                          # Cloud Moisture Image Products Channel 8
     name: C08
-    wavelength: [5.770, 6.185, 6.600]
+    wavelength: [5.759, 6.198, 6.625]
     calibration: brightness_temperature
     file_type: abi_l2_cmip_c08
     file_key: CMI
 
   CMIP_C09:                          # Cloud Moisture Image Products Channel 9
     name: C09
-    wavelength: [6.75, 6.95, 7.15]
+    wavelength: [6.678, 6.935, 7.186]
     calibration: brightness_temperature
     file_type: abi_l2_cmip_c09
     file_key: CMI
 
   CMIP_C10:                          # Cloud Moisture Image Products Channel 10
     name: C10
-    wavelength: [7.24, 7.34, 7.44]
+    wavelength: [7.221, 7.337, 7.452]
     calibration: brightness_temperature
     file_type: abi_l2_cmip_c10
     file_key: CMI
 
   CMIP_C11:                          # Cloud Moisture Image Products Channel 11
     name: C11
-    wavelength: [8.30, 8.50, 8.70]
+    wavelength: [8.184, 8.451, 8.713]
     calibration: brightness_temperature
     file_type: abi_l2_cmip_c11
     file_key: CMI
 
   CMIP_C12:                          # Cloud Moisture Image Products Channel 12
     name: C12
-    wavelength: [9.42, 9.61, 9.80]
+    wavelength: [9.389, 9.611, 9.839]
     calibration: brightness_temperature
     file_type: abi_l2_cmip_c12
     file_key: CMI
 
   CMIP_C13:                          # Cloud Moisture Image Products Channel 13
     name: C13
-    wavelength: [10.10, 10.35, 10.60]
+    wavelength: [10.115, 10.335, 10.570]
     calibration: brightness_temperature
     file_type: abi_l2_cmip_c13
     file_key: CMI
 
   CMIP_C14:                          # Cloud Moisture Image Products Channel 14
     name: C14
-    wavelength: [10.80, 11.20, 11.60]
+    wavelength: [10.722, 11.202, 11.690]
     calibration: brightness_temperature
     file_type: abi_l2_cmip_c14
     file_key: CMI
 
   CMIP_C15:                          # Cloud Moisture Image Products Channel 15
     name: C15
-    wavelength: [11.80, 12.30, 12.80]
+    wavelength: [11.730, 12.287, 12.855]
     calibration: brightness_temperature
     file_type: abi_l2_cmip_c15
     file_key: CMI
 
   CMIP_C16:                          # Cloud Moisture Image Products Channel 16
     name: C16
-    wavelength: [13.00, 13.30, 13.60]
+    wavelength: [12.938, 13.274, 13.635]
     calibration: brightness_temperature
     file_type: abi_l2_cmip_c16
     file_key: CMI

--- a/satpy/etc/readers/agri_l1.yaml
+++ b/satpy/etc/readers/agri_l1.yaml
@@ -29,7 +29,7 @@ file_types:
 datasets:
   C01:
     name: C01
-    wavelength: [0.45, 0.47, 0.49]
+    wavelength: [0.406, 0.472, 0.570]
     resolution:
         1000: {file_type: agri_l1_1000m}
         2000: {file_type: agri_l1_2000m}
@@ -47,7 +47,7 @@ datasets:
 
   C02:
     name: C02
-    wavelength: [0.55, 0.65, 0.75]
+    wavelength: [0.430, 0.652, 0.999]
     resolution:
         500: {file_type: agri_l1_0500m}
         1000: {file_type: agri_l1_1000m}
@@ -66,7 +66,7 @@ datasets:
 
   C03:
     name: C03
-    wavelength: [0.75, 0.83, 0.90]
+    wavelength: [0.620, 0.828, 1.020]
     resolution:
         1000: {file_type: agri_l1_1000m}
         2000: {file_type: agri_l1_2000m}
@@ -84,7 +84,7 @@ datasets:
 
   C04:
     name: C04
-    wavelength: [1.36, 1.37, 1.39]
+    wavelength: [1.329, 1.375, 1.421]
     resolution:
         2000: {file_type: agri_l1_2000m}
         4000: {file_type: agri_l1_4000m}
@@ -101,7 +101,7 @@ datasets:
 
   C05:
     name: C05
-    wavelength: [1.58, 1.61, 1.64]
+    wavelength: [1.450, 1.608, 1.750]
     resolution:
         2000: {file_type: agri_l1_2000m}
         4000: {file_type: agri_l1_4000m}
@@ -118,7 +118,7 @@ datasets:
 
   C06:
     name: C06
-    wavelength: [2.10, 2.22, 2.35]
+    wavelength: [1.621, 2.235, 2.761]
     resolution:
         2000: {file_type: agri_l1_2000m}
         4000: {file_type: agri_l1_4000m}
@@ -135,7 +135,7 @@ datasets:
 
   C07:
     name: C07
-    wavelength: [3.5, 3.72, 4.0]
+    wavelength: [3.002, 3.730, 4.502]
     resolution:
         2000: {file_type: agri_l1_2000m}
         4000: {file_type: agri_l1_4000m}
@@ -155,7 +155,7 @@ datasets:
 
   C08:
     name: C08
-    wavelength: [3.5, 3.72, 4.0]
+    wavelength: [3.002, 3.730, 4.502]
     resolution: 4000
     calibration:
       radiance:
@@ -174,7 +174,7 @@ datasets:
 
   C09:
     name: C09
-    wavelength: [5.8, 6.25, 6.7]
+    wavelength: [4.219, 6.284, 7.884]
     resolution: 4000
     calibration:
       radiance:
@@ -193,7 +193,7 @@ datasets:
 
   C10:
     name: C10
-    wavelength: [6.9, 7.10, 7.3]
+    wavelength: [5.747, 7.123, 7.722]
     resolution: 4000
     calibration:
       radiance:
@@ -212,7 +212,7 @@ datasets:
 
   C11:
     name: C11
-    wavelength: [8.0, 8.5, 9.0]
+    wavelength: [7.263, 8.622, 10.058]
     resolution: 4000
     calibration:
       radiance:
@@ -231,7 +231,7 @@ datasets:
 
   C12:
     name: C12
-    wavelength: [10.3, 10.8, 11.1]
+    wavelength: [9.200, 10.850, 12.300]
     resolution: 4000
     calibration:
       radiance:
@@ -250,7 +250,7 @@ datasets:
 
   C13:
     name: C13
-    wavelength: [11.5, 12.0, 12.5]
+    wavelength: [10.543, 12.089, 13.543]
     resolution: 4000
     calibration:
       radiance:
@@ -269,7 +269,7 @@ datasets:
 
   C14:
     name: C14
-    wavelength: [13.2, 13.5, 13.8]
+    wavelength: [12.517, 13.547, 14.517]
     resolution: 4000
     calibration:
       radiance:

--- a/satpy/etc/readers/ahi_hrit.yaml
+++ b/satpy/etc/readers/ahi_hrit.yaml
@@ -210,7 +210,7 @@ datasets:
   B01:
     name: B01
     sensor: ahi
-    wavelength: [0.45,0.47,0.49]
+    wavelength: [0.445, 0.471, 0.494]
     resolution: 1000
     calibration:
       reflectance:
@@ -224,7 +224,7 @@ datasets:
   B02:
     name: B02
     sensor: ahi
-    wavelength: [0.49,0.51,0.53]
+    wavelength: [0.489, 0.510, 0.530]
     resolution: 1000
     calibration:
       reflectance:
@@ -238,7 +238,7 @@ datasets:
   B03:
     name: B03
     sensor: ahi
-    wavelength: [0.62,0.64,0.66]
+    wavelength: [0.590, 0.639, 0.686]
     resolution: 1000
     calibration:
       reflectance:
@@ -252,7 +252,7 @@ datasets:
   B04:
     name: B04
     sensor: ahi
-    wavelength: [0.83, 0.85, 0.87]
+    wavelength: [0.834, 0.857, 0.880]
     resolution: 4000
     calibration:
       reflectance:
@@ -266,7 +266,7 @@ datasets:
   B05:
     name: B05
     sensor: ahi
-    wavelength: [1.5, 1.6, 1.7]
+    wavelength: [1.580, 1.610, 1.640]
     resolution: 4000
     calibration:
       reflectance:
@@ -280,7 +280,7 @@ datasets:
   B06:
     name: B06
     sensor: ahi
-    wavelength: [2.2, 2.3, 2.4]
+    wavelength: [2.223, 2.257, 2.291]
     resolution: 4000
     calibration:
       reflectance:
@@ -296,7 +296,7 @@ datasets:
     resolution: 4000
 #    resolution: 2000
     sensor: ahi
-    wavelength: [3.7, 3.9, 4.1]
+    wavelength: [3.768, 3.885, 4.012]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -324,7 +324,7 @@ datasets:
   B08:
     name: B08
     sensor: ahi
-    wavelength: [6.0, 6.2, 6.4]
+    wavelength: [5.792, 6.243, 6.686]
     resolution: 4000
     calibration:
       brightness_temperature:
@@ -338,7 +338,7 @@ datasets:
   B09:
     name: B09
     sensor: ahi
-    wavelength: [6.7, 6.9, 7.1]
+    wavelength: [6.707, 6.941, 7.179]
     resolution: 4000
     calibration:
       brightness_temperature:
@@ -352,7 +352,7 @@ datasets:
   B10:
     name: B10
     sensor: ahi
-    wavelength: [7.1, 7.3, 7.5]
+    wavelength: [7.232, 7.347, 7.460]
     resolution: 4000
     calibration:
       brightness_temperature:
@@ -366,7 +366,7 @@ datasets:
   B11:
     name: B11
     sensor: ahi
-    wavelength: [8.4, 8.6, 8.8]
+    wavelength: [8.365, 8.593, 8.817]
     resolution: 4000
     calibration:
       brightness_temperature:
@@ -380,7 +380,7 @@ datasets:
   B12:
     name: B12
     sensor: ahi
-    wavelength: [9.4, 9.6, 9.8]
+    wavelength: [9.410, 9.637, 9.860]
     resolution: 4000
     calibration:
       brightness_temperature:
@@ -394,7 +394,7 @@ datasets:
   B13:
     name: B13
     sensor: ahi
-    wavelength: [10.2, 10.4, 10.6]
+    wavelength: [10.157, 10.407, 10.672]
     resolution: 4000
     calibration:
       brightness_temperature:
@@ -408,7 +408,7 @@ datasets:
   B14:
     name: B14
     sensor: ahi
-    wavelength: [11.0, 11.2, 11.4]
+    wavelength: [10.810, 11.240, 11.669]
     resolution: 4000
     calibration:
       brightness_temperature:
@@ -422,7 +422,7 @@ datasets:
   B15:
     name: B15
     sensor: ahi
-    wavelength: [12.2, 12.4, 12.6]
+    wavelength: [11.809, 12.381, 13.004]
     resolution: 4000
     calibration:
       brightness_temperature:
@@ -436,7 +436,7 @@ datasets:
   B16:
     name: B16
     sensor: ahi
-    wavelength: [13.1, 13.3, 13.5]
+    wavelength: [12.947, 13.281, 13.628]
     resolution: 4000
     calibration:
       brightness_temperature:

--- a/satpy/etc/readers/ahi_hsd.yaml
+++ b/satpy/etc/readers/ahi_hsd.yaml
@@ -15,7 +15,7 @@ datasets:
   B01:
     name: B01
     sensor: ahi
-    wavelength: [0.45,0.47,0.49]
+    wavelength: [0.445, 0.471, 0.494]
     resolution: 1000
     calibration:
       reflectance:
@@ -32,7 +32,7 @@ datasets:
   B02:
     name: B02
     sensor: ahi
-    wavelength: [0.49,0.51,0.53]
+    wavelength: [0.489, 0.510, 0.530]
     resolution: 1000
     calibration:
       reflectance:
@@ -49,7 +49,7 @@ datasets:
   B03:
     name: B03
     sensor: ahi
-    wavelength: [0.62,0.64,0.66]
+    wavelength: [0.590, 0.639, 0.686]
     resolution: 500
     calibration:
       reflectance:
@@ -66,7 +66,7 @@ datasets:
   B04:
     name: B04
     sensor: ahi
-    wavelength: [0.83, 0.85, 0.87]
+    wavelength: [0.834, 0.857, 0.880]
     resolution: 1000
     calibration:
       reflectance:
@@ -83,7 +83,7 @@ datasets:
   B05:
     name: B05
     sensor: ahi
-    wavelength: [1.5, 1.6, 1.7]
+    wavelength: [1.580, 1.610, 1.640]
     resolution: 2000
     calibration:
       reflectance:
@@ -100,7 +100,7 @@ datasets:
   B06:
     name: B06
     sensor: ahi
-    wavelength: [2.2, 2.3, 2.4]
+    wavelength: [2.223, 2.257, 2.291]
     resolution: 2000
     calibration:
       reflectance:
@@ -117,7 +117,7 @@ datasets:
   B07:
     name: B07
     sensor: ahi
-    wavelength: [3.7, 3.9, 4.1]
+    wavelength: [3.768, 3.885, 4.012]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -134,7 +134,7 @@ datasets:
   B08:
     name: B08
     sensor: ahi
-    wavelength: [6.0, 6.2, 6.4]
+    wavelength: [5.792, 6.243, 6.686]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -151,7 +151,7 @@ datasets:
   B09:
     name: B09
     sensor: ahi
-    wavelength: [6.7, 6.9, 7.1]
+    wavelength: [6.707, 6.941, 7.179]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -168,7 +168,7 @@ datasets:
   B10:
     name: B10
     sensor: ahi
-    wavelength: [7.1, 7.3, 7.5]
+    wavelength: [7.232, 7.347, 7.460]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -185,7 +185,7 @@ datasets:
   B11:
     name: B11
     sensor: ahi
-    wavelength: [8.4, 8.6, 8.8]
+    wavelength: [8.365, 8.593, 8.817]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -202,7 +202,7 @@ datasets:
   B12:
     name: B12
     sensor: ahi
-    wavelength: [9.4, 9.6, 9.8]
+    wavelength: [9.410, 9.637, 9.860]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -219,7 +219,7 @@ datasets:
   B13:
     name: B13
     sensor: ahi
-    wavelength: [10.2, 10.4, 10.6]
+    wavelength: [10.157, 10.407, 10.672]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -236,7 +236,7 @@ datasets:
   B14:
     name: B14
     sensor: ahi
-    wavelength: [11.0, 11.2, 11.4]
+    wavelength: [10.810, 11.240, 11.669]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -253,7 +253,7 @@ datasets:
   B15:
     name: B15
     sensor: ahi
-    wavelength: [12.2, 12.4, 12.6]
+    wavelength: [11.809, 12.381, 13.004]
     resolution: 2000
     calibration:
       brightness_temperature:
@@ -270,7 +270,7 @@ datasets:
   B16:
     name: B16
     sensor: ahi
-    wavelength: [13.1, 13.3, 13.5]
+    wavelength: [12.947, 13.281, 13.628]
     resolution: 2000
     calibration:
       brightness_temperature:

--- a/satpy/etc/readers/ahi_l1b_gridded_bin.yaml
+++ b/satpy/etc/readers/ahi_l1b_gridded_bin.yaml
@@ -16,7 +16,7 @@ datasets:
   B01:
     name: B01
     sensor: ahi
-    wavelength: [0.45,0.47,0.49]
+    wavelength: [0.445, 0.471, 0.494]
     resolution: 0.01
     calibration:
       reflectance:
@@ -30,7 +30,7 @@ datasets:
   B02:
     name: B02
     sensor: ahi
-    wavelength: [0.49,0.51,0.53]
+    wavelength: [0.489, 0.510, 0.530]
     resolution: 0.01
     calibration:
       reflectance:
@@ -44,7 +44,7 @@ datasets:
   B03:
     name: B03
     sensor: ahi
-    wavelength: [0.62,0.64,0.66]
+    wavelength: [0.590, 0.639, 0.686]
     resolution: 0.005
     calibration:
       reflectance:
@@ -58,7 +58,7 @@ datasets:
   B04:
     name: B04
     sensor: ahi
-    wavelength: [0.83, 0.85, 0.87]
+    wavelength: [0.834, 0.857, 0.880]
     resolution: 0.01
     calibration:
       reflectance:
@@ -75,7 +75,7 @@ datasets:
   B05:
     name: B05
     sensor: ahi
-    wavelength: [1.5, 1.6, 1.7]
+    wavelength: [1.580, 1.610, 1.640]
     resolution: 0.02
     calibration:
       reflectance:
@@ -89,7 +89,7 @@ datasets:
   B06:
     name: B06
     sensor: ahi
-    wavelength: [2.2, 2.3, 2.4]
+    wavelength: [2.223, 2.257, 2.291]
     resolution: 0.02
     calibration:
       reflectance:
@@ -103,7 +103,7 @@ datasets:
   B07:
     name: B07
     sensor: ahi
-    wavelength: [3.7, 3.9, 4.1]
+    wavelength: [3.768, 3.885, 4.012]
     resolution: 0.02
     calibration:
       brightness_temperature:
@@ -117,7 +117,7 @@ datasets:
   B08:
     name: B08
     sensor: ahi
-    wavelength: [6.0, 6.2, 6.4]
+    wavelength: [5.792, 6.243, 6.686]
     resolution: 0.02
     calibration:
       brightness_temperature:
@@ -131,7 +131,7 @@ datasets:
   B09:
     name: B09
     sensor: ahi
-    wavelength: [6.7, 6.9, 7.1]
+    wavelength: [6.707, 6.941, 7.179]
     resolution: 0.02
     calibration:
       brightness_temperature:
@@ -145,7 +145,7 @@ datasets:
   B10:
     name: B10
     sensor: ahi
-    wavelength: [7.1, 7.3, 7.5]
+    wavelength: [7.232, 7.347, 7.460]
     resolution: 0.02
     calibration:
       brightness_temperature:
@@ -159,7 +159,7 @@ datasets:
   B11:
     name: B11
     sensor: ahi
-    wavelength: [8.4, 8.6, 8.8]
+    wavelength: [8.365, 8.593, 8.817]
     resolution: 0.02
     calibration:
       brightness_temperature:
@@ -173,7 +173,7 @@ datasets:
   B12:
     name: B12
     sensor: ahi
-    wavelength: [9.4, 9.6, 9.8]
+    wavelength: [9.410, 9.637, 9.860]
     resolution: 0.02
     calibration:
       brightness_temperature:
@@ -187,7 +187,7 @@ datasets:
   B13:
     name: B13
     sensor: ahi
-    wavelength: [10.2, 10.4, 10.6]
+    wavelength: [10.157, 10.407, 10.672]
     resolution: 0.02
     calibration:
       brightness_temperature:
@@ -201,7 +201,7 @@ datasets:
   B14:
     name: B14
     sensor: ahi
-    wavelength: [11.0, 11.2, 11.4]
+    wavelength: [10.810, 11.240, 11.669]
     resolution: 0.02
     calibration:
       brightness_temperature:
@@ -215,7 +215,7 @@ datasets:
   B15:
     name: B15
     sensor: ahi
-    wavelength: [12.2, 12.4, 12.6]
+    wavelength: [11.809, 12.381, 13.004]
     resolution: 0.02
     calibration:
       brightness_temperature:
@@ -229,7 +229,7 @@ datasets:
   B16:
     name: B16
     sensor: ahi
-    wavelength: [13.1, 13.3, 13.5]
+    wavelength: [12.947, 13.281, 13.628]
     resolution: 0.02
     calibration:
       brightness_temperature:

--- a/satpy/etc/readers/ami_l1b.yaml
+++ b/satpy/etc/readers/ami_l1b.yaml
@@ -69,7 +69,7 @@ datasets:
   #   https://directory.eoportal.org/web/eoportal/satellite-missions/content/-/article/geo-kompsat-2
   C01:
     name: VI004
-    wavelength: [0.450, 0.470, 0.490]
+    wavelength: [0.446], 0.471, 0.494]
     resolution: 1000
     calibration:
       counts:
@@ -86,7 +86,7 @@ datasets:
 
   C02:
     name: VI005
-    wavelength: [0.495, 0.509, 0.523]
+    wavelength: [0.490, 0.509, 0.528]
     resolution: 1000
     calibration:
       counts:
@@ -103,7 +103,7 @@ datasets:
 
   C03:
     name: VI006
-    wavelength: [0.599, 0.639, 0.679]
+    wavelength: [0.590, 0.639, 0.686]
     resolution: 500
     calibration:
       counts:
@@ -120,7 +120,7 @@ datasets:
 
   C04:
     name: VI008
-    wavelength: [0.846, 0.863, 0.880]
+    wavelength: [0.839, 0.863, 0.885]
     resolution: 1000
     calibration:
       counts:
@@ -137,7 +137,7 @@ datasets:
 
   C05:
     name: NR013
-    wavelength: [1.363, 1.37, 1.377]
+    wavelength: [1.362, 1.374, 1.385]
     resolution: 2000
     calibration:
       counts:
@@ -154,7 +154,7 @@ datasets:
 
   C06:
     name: NR016
-    wavelength: [1.590, 1.61, 1.630]
+    wavelength: [1.579, 1.609, 1.640]
     resolution: 2000
     calibration:
       counts:
@@ -171,7 +171,7 @@ datasets:
 
   C07:
     name: SW038
-    wavelength: [3.74, 3.83, 3.92]
+    wavelength: [3.711, 3.830, 3.947]
     resolution: 2000
     calibration:
       counts:
@@ -188,7 +188,7 @@ datasets:
 
   C08:
     name: WV063
-    wavelength: [5.79, 6.21, 6.63]
+    wavelength: [5.751, 6.212, 6.663]
     resolution: 2000
     calibration:
       counts:
@@ -205,7 +205,7 @@ datasets:
 
   C09:
     name: WV069
-    wavelength: [6.74, 6.94, 7.14]
+    wavelength: [6.709, 6.943, 7.179]
     resolution: 2000
     calibration:
       counts:
@@ -222,7 +222,7 @@ datasets:
 
   C10:
     name: WV073
-    wavelength: [7.24, 7.33, 7.42]
+    wavelength: [7.212, 7.326, 7.439]
     resolution: 2000
     calibration:
       counts:
@@ -239,7 +239,7 @@ datasets:
 
   C11:
     name: IR087
-    wavelength: [8.415, 8.59, 8.765]
+    wavelength: [8.377, 8.588, 8.811]
     resolution: 2000
     calibration:
       counts:
@@ -256,7 +256,7 @@ datasets:
 
   C12:
     name: IR096
-    wavelength: [9.43, 9.62, 9.81]
+    wavelength: [9.398, 9.620, 9.811]
     resolution: 2000
     calibration:
       counts:
@@ -273,7 +273,7 @@ datasets:
 
   C13:
     name: IR105
-    wavelength: [10.115, 10.35, 10.585]
+    wavelength: [10.083, 10.357, 10.639]
     resolution: 2000
     calibration:
       counts:
@@ -290,7 +290,7 @@ datasets:
 
   C14:
     name: IR112
-    wavelength: [10.90, 11.23, 11.56]
+    wavelength: [10.798, 11.227, 11.650]
     resolution: 2000
     calibration:
       counts:
@@ -307,7 +307,7 @@ datasets:
 
   C15:
     name: IR123
-    wavelength: [11.805, 12.36, 12.915]
+    wavelength: [11.716, 12.362, 13.016]
     resolution: 2000
     calibration:
       counts:
@@ -324,7 +324,7 @@ datasets:
 
   C16:
     name: IR133
-    wavelength: [13.005, 13.29, 13.575]
+    wavelength: [12.955, 13.285, 13.639]
     resolution: 2000
     calibration:
       counts:

--- a/satpy/etc/readers/avhrr_l1b_aapp.yaml
+++ b/satpy/etc/readers/avhrr_l1b_aapp.yaml
@@ -8,7 +8,7 @@ reader:
 datasets:
     '1':
         name: '1'
-        wavelength: [0.58, 0.63, 0.68]
+        wavelength: [0.586, 0.638, 0.682]
         resolution: 1050
         calibration:
           reflectance:
@@ -21,7 +21,7 @@ datasets:
         file_type: avhrr_aapp_l1b
     '2':
         name: '2'
-        wavelength: [0.725, 0.8625, 1.0]
+        wavelength: [0.708, 0.844, 0.992]
         resolution: 1050
         calibration:
           reflectance:
@@ -34,7 +34,7 @@ datasets:
         file_type: avhrr_aapp_l1b
     '3a':
         name: '3a'
-        wavelength: [1.58, 1.61, 1.64]
+        wavelength: [1.583, 1.610, 1.638]
         resolution: 1050
         calibration:
           reflectance:
@@ -47,7 +47,7 @@ datasets:
         file_type: avhrr_aapp_l1b
     '3b':
         name: '3b'
-        wavelength: [3.55, 3.74, 3.93]
+        wavelength: [3.540, 3.754, 3.967]
         resolution: 1050
         calibration:
           brightness_temperature:
@@ -60,7 +60,7 @@ datasets:
         file_type: avhrr_aapp_l1b
     '4':
         name: '4'
-        wavelength: [10.3, 10.8, 11.3]
+        wavelength: [10.220, 10.802, 11.380]
         resolution: 1050
         calibration:
           brightness_temperature:
@@ -73,7 +73,7 @@ datasets:
         file_type: avhrr_aapp_l1b
     '5':
         name: '5'
-        wavelength: [11.5, 12.0, 12.5]
+        wavelength: [11.540, 12.052, 12.580]
         resolution: 1050
         calibration:
           brightness_temperature:

--- a/satpy/etc/readers/avhrr_l1b_eps.yaml
+++ b/satpy/etc/readers/avhrr_l1b_eps.yaml
@@ -8,7 +8,7 @@ reader:
 datasets:
     '1':
         name: '1'
-        wavelength: [0.58, 0.63, 0.68]
+        wavelength: [0.586, 0.638, 0.682]
         resolution: 1050
         calibration:
           reflectance:
@@ -21,7 +21,7 @@ datasets:
         file_type: avhrr_eps
     '2':
         name: '2'
-        wavelength: [0.725, 0.8625, 1.0]
+        wavelength: [0.708, 0.844, 0.992]
         resolution: 1050
         calibration:
           reflectance:
@@ -34,7 +34,7 @@ datasets:
         file_type: avhrr_eps
     '3a':
         name: '3a'
-        wavelength: [1.58, 1.61, 1.64]
+        wavelength: [1.583, 1.610, 1.638]
         resolution: 1050
         calibration:
           reflectance:
@@ -47,7 +47,7 @@ datasets:
         file_type: avhrr_eps
     '3b':
         name: '3b'
-        wavelength: [3.55, 3.74, 3.93]
+        wavelength: [3.540, 3.754, 3.967]
         resolution: 1050
         calibration:
           brightness_temperature:
@@ -60,7 +60,7 @@ datasets:
         file_type: avhrr_eps
     '4':
         name: '4'
-        wavelength: [10.3, 10.8, 11.3]
+        wavelength: [10.220, 10.802, 11.380]
         resolution: 1050
         calibration:
           brightness_temperature:
@@ -73,7 +73,7 @@ datasets:
         file_type: avhrr_eps
     '5':
         name: '5'
-        wavelength: [11.5, 12.0, 12.5]
+        wavelength: [11.540, 12.052, 12.580]
         resolution: 1050
         calibration:
           brightness_temperature:

--- a/satpy/etc/readers/avhrr_l1b_gaclac.yaml
+++ b/satpy/etc/readers/avhrr_l1b_gaclac.yaml
@@ -7,7 +7,7 @@ reader:
 datasets:
     '1':
         name: '1'
-        wavelength: [0.58, 0.63, 0.68]
+        wavelength: [0.586, 0.638, 0.682]
         resolution: 1050
         calibration:
           reflectance:
@@ -21,7 +21,7 @@ datasets:
         file_type: gac_lac_l1b
     '2':
         name: '2'
-        wavelength: [0.725, 0.8625, 1.0]
+        wavelength: [0.708, 0.844, 0.992]
         resolution: 1050
         calibration:
           reflectance:
@@ -35,7 +35,7 @@ datasets:
         file_type: gac_lac_l1b
     '3':
         name: '3'
-        wavelength: [3.55, 3.74, 3.93]
+        wavelength: [3.540, 3.754, 3.967]
         resolution: 1050
         calibration:
           brightness_temperature:
@@ -49,7 +49,7 @@ datasets:
         file_type: gac_lac_l1b
     '3a':
         name: '3a'
-        wavelength: [1.58, 1.61, 1.64]
+        wavelength: [1.583, 1.610, 1.638]
         resolution: 1050
         calibration:
           reflectance:
@@ -63,7 +63,7 @@ datasets:
         file_type: gac_lac_l1b
     '3b':
         name: '3b'
-        wavelength: [3.55, 3.74, 3.93]
+        wavelength: [3.540, 3.754, 3.967]
         resolution: 1050
         calibration:
           brightness_temperature:
@@ -77,7 +77,7 @@ datasets:
         file_type: gac_lac_l1b
     '4':
         name: '4'
-        wavelength: [10.3, 10.8, 11.3]
+        wavelength: [10.220, 10.802, 11.380]
         resolution: 1050
         calibration:
           brightness_temperature:
@@ -91,7 +91,7 @@ datasets:
         file_type: gac_lac_l1b
     '5':
         name: '5'
-        wavelength: [11.5, 12.0, 12.5]
+        wavelength: [11.540, 12.052, 12.580]
         resolution: 1050
         calibration:
           brightness_temperature:

--- a/satpy/etc/readers/avhrr_l1b_hrpt.yaml
+++ b/satpy/etc/readers/avhrr_l1b_hrpt.yaml
@@ -8,7 +8,7 @@ reader:
 datasets:
     '1':
         name: '1'
-        wavelength: [0.58, 0.63, 0.68]
+        wavelength: [0.586, 0.638, 0.682]
         resolution: 1050
         calibration:
           reflectance:
@@ -19,7 +19,7 @@ datasets:
         file_type: avhrr_hrpt
     '2':
         name: '2'
-        wavelength: [0.725, 0.8625, 1.0]
+        wavelength: [0.708, 0.844, 0.992]
         resolution: 1050
         calibration:
           reflectance:
@@ -30,7 +30,7 @@ datasets:
         file_type: avhrr_hrpt
     '3a':
         name: '3a'
-        wavelength: [1.58, 1.61, 1.64]
+        wavelength: [1.583, 1.610, 1.638]
         resolution: 1050
         calibration:
           reflectance:
@@ -41,7 +41,7 @@ datasets:
         file_type: avhrr_hrpt
     '3b':
         name: '3b'
-        wavelength: [3.55, 3.74, 3.93]
+        wavelength: [3.540, 3.754, 3.967]
         resolution: 1050
         calibration:
           brightness_temperature:
@@ -52,7 +52,7 @@ datasets:
         file_type: avhrr_hrpt
     '4':
         name: '4'
-        wavelength: [10.3, 10.8, 11.3]
+        wavelength: [10.220, 10.802, 11.380]
         resolution: 1050
         calibration:
           brightness_temperature:
@@ -63,7 +63,7 @@ datasets:
         file_type: avhrr_hrpt
     '5':
         name: '5'
-        wavelength: [11.5, 12.0, 12.5]
+        wavelength: [11.540, 12.052, 12.580]
         resolution: 1050
         calibration:
           brightness_temperature:

--- a/satpy/etc/readers/geocat.yaml
+++ b/satpy/etc/readers/geocat.yaml
@@ -30,7 +30,7 @@ datasets:
   B01:
     name: B01
     sensor: ahi
-    wavelength: [0.45,0.47,0.49]
+    wavelength: [0.445, 0.471, 0.494]
     calibration:
       reflectance:
         file_key: himawari_8_ahi_channel_1_reflectance
@@ -43,7 +43,7 @@ datasets:
   B02:
     name: B02
     sensor: ahi
-    wavelength: [0.49,0.51,0.53]
+    wavelength: [0.489, 0.510, 0.530]
     calibration:
       reflectance:
         file_key: himawari_8_ahi_channel_2_reflectance
@@ -56,7 +56,7 @@ datasets:
   B03:
     name: B03
     sensor: ahi
-    wavelength: [0.62,0.64,0.66]
+    wavelength: [0.590, 0.639, 0.686]
     calibration:
       reflectance:
         file_key: himawari_8_ahi_channel_3_reflectance
@@ -69,7 +69,7 @@ datasets:
   B04:
     name: B04
     sensor: ahi
-    wavelength: [0.83, 0.85, 0.87]
+    wavelength: [0.834, 0.857, 0.880]
     calibration:
       reflectance:
         file_key: himawari_8_ahi_channel_4_reflectance
@@ -82,7 +82,7 @@ datasets:
   B05:
     name: B05
     sensor: ahi
-    wavelength: [1.5, 1.6, 1.7]
+    wavelength: [1.580, 1.610, 1.640]
     calibration:
       reflectance:
         file_key: himawari_8_ahi_channel_5_reflectance
@@ -95,7 +95,7 @@ datasets:
   B06:
     name: B06
     sensor: ahi
-    wavelength: [2.2, 2.3, 2.4]
+    wavelength: [2.223, 2.257, 2.291]
     calibration:
       reflectance:
         file_key: himawari_8_ahi_channel_6_reflectance
@@ -108,7 +108,7 @@ datasets:
   B07:
     name: B07
     sensor: ahi
-    wavelength: [3.7, 3.9, 4.1]
+    wavelength: [3.768, 3.885, 4.012]
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_7_brightness_temperature
@@ -121,7 +121,7 @@ datasets:
   B08:
     name: B08
     sensor: ahi
-    wavelength: [6.0, 6.2, 6.4]
+    wavelength: [5.792, 6.243, 6.686]
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_8_brightness_temperature
@@ -134,7 +134,7 @@ datasets:
   B09:
     name: B09
     sensor: ahi
-    wavelength: [6.7, 6.9, 7.1]
+    wavelength: [6.707, 6.941, 7.179]
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_9_brightness_temperature
@@ -147,7 +147,7 @@ datasets:
   B10:
     name: B10
     sensor: ahi
-    wavelength: [7.1, 7.3, 7.5]
+    wavelength: [7.232, 7.347, 7.460]
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_10_brightness_temperature
@@ -160,7 +160,7 @@ datasets:
   B11:
     name: B11
     sensor: ahi
-    wavelength: [8.4, 8.6, 8.8]
+    wavelength: [8.365, 8.593, 8.817]
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_11_brightness_temperature
@@ -173,7 +173,7 @@ datasets:
   B12:
     name: B12
     sensor: ahi
-    wavelength: [9.4, 9.6, 9.8]
+    wavelength: [9.410, 9.637, 9.860]
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_12_brightness_temperature
@@ -186,7 +186,7 @@ datasets:
   B13:
     name: B13
     sensor: ahi
-    wavelength: [10.2, 10.4, 10.6]
+    wavelength: [10.157, 10.407, 10.672]
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_13_brightness_temperature
@@ -199,7 +199,7 @@ datasets:
   B14:
     name: B14
     sensor: ahi
-    wavelength: [11.0, 11.2, 11.4]
+    wavelength: [10.810, 11.240, 11.669]
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_14_brightness_temperature
@@ -212,7 +212,7 @@ datasets:
   B15:
     name: B15
     sensor: ahi
-    wavelength: [12.2, 12.4, 12.6]
+    wavelength: [11.809, 12.381, 13.004]
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_15_brightness_temperature
@@ -225,7 +225,7 @@ datasets:
   B16:
     name: B16
     sensor: ahi
-    wavelength: [13.1, 13.3, 13.5]
+    wavelength: [12.947, 13.281, 13.628]
     calibration:
       brightness_temperature:
         file_key: himawari_8_ahi_channel_16_brightness_temperature

--- a/satpy/etc/readers/modis_l1b.yaml
+++ b/satpy/etc/readers/modis_l1b.yaml
@@ -23,10 +23,7 @@ datasets:
       1000: {file_type: hdf_eos_data_1000m}
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.62
-    - 0.645
-    - 0.67
+    wavelength: [0.618, 0.646, 0.673]
   '2':
     name: '2'
     resolution:
@@ -35,10 +32,7 @@ datasets:
       1000: {file_type: hdf_eos_data_1000m}
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.841
-    - 0.8585
-    - 0.876
+    wavelength: [0.832, 0.857, 0.879]
   '3':
     name: '3'
     resolution:
@@ -46,10 +40,7 @@ datasets:
       1000: {file_type: hdf_eos_data_1000m}
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.459
-    - 0.469
-    - 0.479
+    wavelength: [0.455, 0.466, 0.478]
   '4':
     name: '4'
     resolution:
@@ -57,10 +48,7 @@ datasets:
       1000: {file_type: hdf_eos_data_1000m}
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.545
-    - 0.555
-    - 0.565
+    wavelength: [0.543, 0.554, 0.566]
   '5':
     name: '5'
     resolution:
@@ -68,10 +56,7 @@ datasets:
       1000: {file_type: hdf_eos_data_1000m}
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 1.23
-    - 1.24
-    - 1.25
+    wavelength: [1.224, 1.241, 1.257]
   '6':
     name: '6'
     resolution:
@@ -79,10 +64,7 @@ datasets:
       1000: {file_type: hdf_eos_data_1000m}
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 1.628
-    - 1.64
-    - 1.652
+    wavelength: [1.608, 1.628, 1.648]
   '7':
     name: '7'
     resolution:
@@ -90,320 +72,224 @@ datasets:
       1000: {file_type: hdf_eos_data_1000m}
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 2.105
-    - 2.13
-    - 2.155
+    wavelength: [2.082, 2.114, 2.152]
   '8':
     file_type: hdf_eos_data_1000m
     name: '8'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.405
-    - 0.4125
-    - 0.42
+    wavelength: [0.404, 0.412, 0.419]
   '9':
     file_type: hdf_eos_data_1000m
     name: '9'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.438
-    - 0.443
-    - 0.448
+    wavelength: [0.436, 0.442, 0.448]
   '10':
     file_type: hdf_eos_data_1000m
     name: '10'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.483
-    - 0.488
-    - 0.493
+    wavelength: [0.480, 0.487, 0.493]
   '11':
     file_type: hdf_eos_data_1000m
     name: '11'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.526
-    - 0.531
-    - 0.536
+    wavelength: [0.522, 0.530, 0.537]
   '12':
     file_type: hdf_eos_data_1000m
     name: '12'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.546
-    - 0.551
-    - 0.556
+    wavelength: [0.540, 0.547, 0.553]
   13hi:
     file_type: hdf_eos_data_1000m
     name: '13hi'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.662
-    - 0.667
-    - 0.672
+    wavelength: [0.660, 0.666, 0.673]
   13lo:
     file_type: hdf_eos_data_1000m
     name: '13lo'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.662
-    - 0.667
-    - 0.672
+    wavelength: [0.660, 0.666, 0.673]
   14hi:
     file_type: hdf_eos_data_1000m
     name: '14hi'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.673
-    - 0.678
-    - 0.683
+    wavelength: [0.670, 0.678, 0.685]
   14lo:
     file_type: hdf_eos_data_1000m
     name: '14lo'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.673
-    - 0.678
-    - 0.683
+    wavelength: [0.670, 0.678, 0.685]
   '15':
     file_type: hdf_eos_data_1000m
     name: '15'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.743
-    - 0.748
-    - 0.753
+    wavelength: [0.740, 0.747, 0.753]
   '16':
     file_type: hdf_eos_data_1000m
     name: '16'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.862
-    - 0.8695
-    - 0.877
+    wavelength: [0.856, 0.867, 0.877]
   '17':
     file_type: hdf_eos_data_1000m
     name: '17'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.89
-    - 0.905
-    - 0.92
+    wavelength: [0.884, 0.904, 0.926]
   '18':
     file_type: hdf_eos_data_1000m
     name: '18'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.931
-    - 0.936
-    - 0.941
+    wavelength: [0.927, 0.936, 0.946]
   '19':
     file_type: hdf_eos_data_1000m
     name: '19'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 0.915
-    - 0.94
-    - 0.965
+    wavelength: [0.907, 0.936, 0.967]
   '20':
     file_type: hdf_eos_data_1000m
     name: '20'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 3.66
-    - 3.75
-    - 3.84
+    wavelength: [3.666, 3.780, 3.886]
   '21':
     file_type: hdf_eos_data_1000m
     name: '21'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 3.929
-    - 3.959
-    - 3.989
+    wavelength: [3.928, 3.982, 4.038]
   '22':
     file_type: hdf_eos_data_1000m
     name: '22'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 3.929
-    - 3.959
-    - 3.989
+    wavelength: [3.917, 3.972, 4.027]
   '23':
     file_type: hdf_eos_data_1000m
     name: '23'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 4.02
-    - 4.05
-    - 4.08
+    wavelength: [4.006, 4.062, 4.111]
   '24':
     file_type: hdf_eos_data_1000m
     name: '24'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 4.433
-    - 4.4655
-    - 4.498
+    wavelength: [4.389, 4.448, 4.504]
   '25':
     file_type: hdf_eos_data_1000m
     name: '25'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 4.482
-    - 4.5155
-    - 4.549
+    wavelength: [4.467, 4.526, 4.587]
   '26':
     file_type: hdf_eos_data_1000m
     name: '26'
     resolution: 1000
     calibration: [reflectance, radiance, counts]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 1.36
-    - 1.375
-    - 1.39
+    wavelength: [1.353, 1.382, 1.409]
   '27':
     file_type: hdf_eos_data_1000m
     name: '27'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 6.535
-    - 6.715
-    - 6.895
+      wavelength: [6.609, 6.787, 6.939]
   '28':
     file_type: hdf_eos_data_1000m
     name: '28'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 7.175
-    - 7.325
-    - 7.475
+    wavelength: [7.129, 7.349, 7.564]
   '29':
     file_type: hdf_eos_data_1000m
     name: '29'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 8.4
-    - 8.55
-    - 8.7
+    wavelength: [8.325, 8.556, 8.775]
   '30':
     file_type: hdf_eos_data_1000m
     name: '30'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 9.58
-    - 9.73
-    - 9.88
+    wavelength: [9.515, 9.724, 9.934]
   '31':
     file_type: hdf_eos_data_1000m
     name: '31'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 10.78
-    - 11.03
-    - 11.28
+    wavelength: [10.668, 11.026, 11.393]
   '32':
     file_type: hdf_eos_data_1000m
     name: '32'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 11.77
-    - 12.02
-    - 12.27
+    wavelength: [11.764, 12.043, 12.339]
   '33':
     file_type: hdf_eos_data_1000m
     name: '33'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 13.185
-    - 13.335
-    - 13.485
+    wavelength: [13.176, 13.365, 13.556]
   '34':
     file_type: hdf_eos_data_1000m
     name: '34'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 13.485
-    - 13.635
-    - 13.785
+    wavelength: [13.477, 13.686, 13.897]
   '35':
     file_type: hdf_eos_data_1000m
     name: '35'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 13.785
-    - 13.935
-    - 14.085
+    wavelength: [13.716, 13.925, 14.136]
   '36':
     file_type: hdf_eos_data_1000m
     name: '36'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
     coordinates: [longitude, latitude]
-    wavelength:
-    - 14.085
-    - 14.235
-    - 14.385
+    wavelength: [14.017, 14.215, 14.417]
 
   longitude:
     name: longitude

--- a/satpy/etc/readers/msi_safe.yaml
+++ b/satpy/etc/readers/msi_safe.yaml
@@ -19,56 +19,56 @@ datasets:
   B01:
     name: B01
     sensor: MSI
-    wavelength: [0.415, 0.443, 0.470]
+    wavelength: [0.432, 0.443, 0.453]
     resolution: 60
     file_type: safe_granule
 
   B02:
     name: B02
     sensor: MSI
-    wavelength: [0.440, 0.490, 0.540]
+    wavelength: [0.458, 0.492, 0.526]
     resolution: 10
     file_type: safe_granule
 
   B03:
     name: B03
     sensor: MSI
-    wavelength: [0.540, 0.560, 0.580]
+    wavelength: [0.541, 0.560, 0.579]
     resolution: 10
     file_type: safe_granule
 
   B04:
     name: B04
     sensor: MSI
-    wavelength: [0.645, 0.665, 0.685]
+    wavelength: [0.649, 0.665, 0.681]
     resolution: 10
     file_type: safe_granule
 
   B05:
     name: B05
     sensor: MSI
-    wavelength: [0.695, 0.705, 0.715]
+    wavelength: [0.697, 0.704, 0.712]
     resolution: 20
     file_type: safe_granule
 
   B06:
     name: B06
     sensor: MSI
-    wavelength: [0.731, 0.740, 0.749]
+    wavelength: [0.733, 0.740, 0.748]
     resolution: 20
     file_type: safe_granule
 
   B07:
     name: B07
     sensor: MSI
-    wavelength: [0.764, 0.783, 0.802]
+    wavelength: [0.772, 0.783, 0.794]
     resolution: 20
     file_type: safe_granule
 
   B08:
     name: B08
     sensor: MSI
-    wavelength: [0.780, 0.842, 0.905]
+    wavelength: [0.780, 0.833, 0.901]
     resolution: 10
     file_type: safe_granule
 
@@ -82,28 +82,28 @@ datasets:
   B09:
     name: B09
     sensor: MSI
-    wavelength: [0.935, 0.945, 0.955]
+    wavelength: [0.934, 0.945, 0.956]
     resolution: 60
     file_type: safe_granule
 
   B10:
     name: B10
     sensor: MSI
-    wavelength: [1.365, 1.375, 1.385]
+    wavelength: [1.357, 1.373, 1.390]
     resolution: 60
     file_type: safe_granule
 
   B11:
     name: B11
     sensor: MSI
-    wavelength: [1.565, 1.610, 1.655]
+    wavelength: [1.565, 1.614, 1.662]
     resolution: 20
     file_type: safe_granule
 
   B12:
     name: B12
     sensor: MSI
-    wavelength: [2.100, 2.190, 2.280]
+    wavelength: [2.104, 2.202, 2.295]
     resolution: 20
     file_type: safe_granule
 

--- a/satpy/etc/readers/olci_l1b.yaml
+++ b/satpy/etc/readers/olci_l1b.yaml
@@ -50,7 +50,7 @@ datasets:
   Oa01:
     name: Oa01
     sensor: olci
-    wavelength: [0.3925,0.4,0.4075]
+    wavelength: [0.392, 0.400, 0.408]
     resolution: 300
     calibration:
       radiance:
@@ -65,7 +65,7 @@ datasets:
   Oa02:
     name: Oa02
     sensor: olci
-    wavelength: [0.4075, 0.4125, 0.4175]
+    wavelength: [0.406, 0.412, 0.417]
     resolution: 300
     calibration:
       radiance:
@@ -80,7 +80,7 @@ datasets:
   Oa03:
     name: Oa03
     sensor: olci
-    wavelength: [0.4375,0.4425,0.4475]
+    wavelength: [0.437, 0.443, 0.449]
     resolution: 300
     calibration:
       radiance:
@@ -95,7 +95,7 @@ datasets:
   Oa04:
     name: Oa04
     sensor: olci
-    wavelength: [0.485,0.49,0.495]
+    wavelength: [0.485, 0.490, 0.496]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -110,7 +110,7 @@ datasets:
   Oa05:
     name: Oa05
     sensor: olci
-    wavelength: [0.505,0.51,0.515]
+    wavelength: [0.505, 0.510, 0.516]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -125,7 +125,7 @@ datasets:
   Oa06:
     name: Oa06
     sensor: olci
-    wavelength: [0.555,0.56,0.565]
+    wavelength: [0.555, 0.560, 0.566]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -140,7 +140,7 @@ datasets:
   Oa07:
     name: Oa07
     sensor: olci
-    wavelength: [0.615,0.62,0.625]
+    wavelength: [0.615, 0.620, 0.626]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -155,7 +155,7 @@ datasets:
   Oa08:
     name: Oa08
     sensor: olci
-    wavelength: [0.66,0.665,0.67]
+    wavelength: [0.660, 0.665, 0.671]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -170,7 +170,7 @@ datasets:
   Oa09:
     name: Oa09
     sensor: olci
-    wavelength: [0.67,0.67375,0.6775]
+    wavelength: [0.670, 0.674, 0.678]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -185,7 +185,7 @@ datasets:
   Oa10:
     name: Oa10
     sensor: olci
-    wavelength: [0.6775,0.68125,0.685]
+    wavelength: [0.677, 0.682, 0.686]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -200,7 +200,7 @@ datasets:
   Oa11:
     name: Oa11
     sensor: olci
-    wavelength: [0.70375,0.70875,0.71375]
+    wavelength: [0.703, 0.709, 0.715]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -215,7 +215,7 @@ datasets:
   Oa12:
     name: Oa12
     sensor: olci
-    wavelength: [0.75,0.75375,0.7575]
+    wavelength: [0.750, 0.754, 0.759]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -230,7 +230,7 @@ datasets:
   Oa13:
     name: Oa13
     sensor: olci
-    wavelength: [0.76,0.76125,0.7625]
+    wavelength: [0.760, 0.762, 0.764]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -245,7 +245,7 @@ datasets:
   Oa14:
     name: Oa14
     sensor: olci
-    wavelength: [0.760625, 0.764375, 0.768125]
+    wavelength: [0.762, 0.765, 0.767]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -260,7 +260,7 @@ datasets:
   Oa15:
     name: Oa15
     sensor: olci
-    wavelength: [0.76625, 0.7675, 0.76875]
+    wavelength: [0.766, 0.768, 0.770]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -275,7 +275,7 @@ datasets:
   Oa16:
     name: Oa16
     sensor: olci
-    wavelength: [0.77125, 0.77875, 0.78625]
+    wavelength: [0.771, 0.779, 0.787]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -290,7 +290,7 @@ datasets:
   Oa17:
     name: Oa17
     sensor: olci
-    wavelength: [0.855, 0.865, 0.875]
+    wavelength: [0.855, 0.865, 0.876]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -305,7 +305,7 @@ datasets:
   Oa18:
     name: Oa18
     sensor: olci
-    wavelength: [0.88, 0.885, 0.89]
+    wavelength: [0.879, 0.884, 0.890]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -320,7 +320,7 @@ datasets:
   Oa19:
     name: Oa19
     sensor: olci
-    wavelength: [0.895, 0.9, 0.905]
+    wavelength: [0.894, 0.899, 0.905]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -335,7 +335,7 @@ datasets:
   Oa20:
     name: Oa20
     sensor: olci
-    wavelength: [0.93, 0.94, 0.95]
+    wavelength: [0.929, 0.939, 0.950]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:
@@ -350,7 +350,7 @@ datasets:
   Oa21:
     name: Oa21
     sensor: olci
-    wavelength: [1.0, 1.02, 1.04]
+    wavelength: [0.999, 1.016, 1.039]
     resolution: 300
     coordinates: [longitude, latitude]
     calibration:

--- a/satpy/etc/readers/olci_l2.yaml
+++ b/satpy/etc/readers/olci_l2.yaml
@@ -54,7 +54,7 @@ datasets:
   Oa01:
     name: Oa01
     sensor: olci
-    wavelength: [0.3925,0.4,0.4075]
+    wavelength: [0.392, 0.400, 0.408]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     calibration:
@@ -67,7 +67,7 @@ datasets:
   Oa02:
     name: Oa02
     sensor: olci
-    wavelength: [0.4075, 0.4125, 0.4175]
+    wavelength: [0.406, 0.412, 0.417]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     calibration:
@@ -80,7 +80,7 @@ datasets:
   Oa03:
     name: Oa03
     sensor: olci
-    wavelength: [0.4375,0.4425,0.4475]
+    wavelength: [0.437, 0.443, 0.449]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     calibration:
@@ -93,7 +93,7 @@ datasets:
   Oa04:
     name: Oa04
     sensor: olci
-    wavelength: [0.485,0.49,0.495]
+    wavelength: [0.485, 0.490, 0.496]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]
@@ -106,7 +106,7 @@ datasets:
   Oa05:
     name: Oa05
     sensor: olci
-    wavelength: [0.505,0.51,0.515]
+    wavelength: [0.505, 0.510, 0.516]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]
@@ -119,7 +119,7 @@ datasets:
   Oa06:
     name: Oa06
     sensor: olci
-    wavelength: [0.555,0.56,0.565]
+    wavelength: [0.555, 0.560, 0.566]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]
@@ -132,7 +132,7 @@ datasets:
   Oa07:
     name: Oa07
     sensor: olci
-    wavelength: [0.615,0.62,0.625]
+    wavelength: [0.615, 0.620, 0.626]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]
@@ -145,7 +145,7 @@ datasets:
   Oa08:
     name: Oa08
     sensor: olci
-    wavelength: [0.66,0.665,0.67]
+    wavelength: [0.660, 0.665, 0.671]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]
@@ -158,7 +158,7 @@ datasets:
   Oa09:
     name: Oa09
     sensor: olci
-    wavelength: [0.67,0.67375,0.6775]
+    wavelength: [0.670, 0.674, 0.678]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]
@@ -171,7 +171,7 @@ datasets:
   Oa10:
     name: Oa10
     sensor: olci
-    wavelength: [0.6775,0.68125,0.685]
+    wavelength: [0.677, 0.682, 0.686]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]
@@ -184,7 +184,7 @@ datasets:
   Oa11:
     name: Oa11
     sensor: olci
-    wavelength: [0.70375,0.70875,0.71375]
+    wavelength: [0.703, 0.709, 0.715]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]
@@ -197,7 +197,7 @@ datasets:
   Oa12:
     name: Oa12
     sensor: olci
-    wavelength: [0.75,0.75375,0.7575]
+    wavelength: [0.750, 0.754, 0.759]
     modifiers: [sunz_corrected, rayleigh_corrected]
     coordinates: [longitude, latitude]
     resolution: 300
@@ -210,7 +210,7 @@ datasets:
   Oa13:
     name: Oa13
     sensor: olci
-    wavelength: [0.76,0.76125,0.7625]
+    wavelength: [0.760, 0.762, 0.764]
     modifiers: [sunz_corrected, rayleigh_corrected]
     coordinates: [longitude, latitude]
     resolution: 300
@@ -223,7 +223,7 @@ datasets:
   Oa14:
     name: Oa14
     sensor: olci
-    wavelength: [0.760625, 0.764375, 0.768125]
+    wavelength: [0.762, 0.765, 0.767]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]
@@ -236,7 +236,7 @@ datasets:
   Oa15:
     name: Oa15
     sensor: olci
-    wavelength: [0.76625, 0.7675, 0.76875]
+    wavelength: [0.766, 0.768, 0.770]
     modifiers: [sunz_corrected, rayleigh_corrected]
     coordinates: [longitude, latitude]
     resolution: 300
@@ -249,7 +249,7 @@ datasets:
   Oa16:
     name: Oa16
     sensor: olci
-    wavelength: [0.77125, 0.77875, 0.78625]
+    wavelength: [0.771, 0.779, 0.787]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]
@@ -262,7 +262,7 @@ datasets:
   Oa17:
     name: Oa17
     sensor: olci
-    wavelength: [0.855, 0.865, 0.875]
+    wavelength: [0.855, 0.865, 0.876]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]
@@ -275,7 +275,7 @@ datasets:
   Oa18:
     name: Oa18
     sensor: olci
-    wavelength: [0.88, 0.885, 0.89]
+    wavelength: [0.879, 0.884, 0.890]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]
@@ -288,7 +288,7 @@ datasets:
   Oa19:
     name: Oa19
     sensor: olci
-    wavelength: [0.895, 0.9, 0.905]
+    wavelength: [0.894, 0.899, 0.905]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]
@@ -301,7 +301,7 @@ datasets:
   Oa20:
     name: Oa20
     sensor: olci
-    wavelength: [0.93, 0.94, 0.95]
+    wavelength: [0.929, 0.939, 0.950]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]
@@ -314,7 +314,7 @@ datasets:
   Oa21:
     name: Oa21
     sensor: olci
-    wavelength: [1.0, 1.02, 1.04]
+    wavelength: [0.999, 1.016, 1.039]
     modifiers: [sunz_corrected, rayleigh_corrected]
     resolution: 300
     coordinates: [longitude, latitude]

--- a/satpy/etc/readers/seviri_l1b_hrit.yaml
+++ b/satpy/etc/readers/seviri_l1b_hrit.yaml
@@ -170,7 +170,7 @@ datasets:
   HRV:
     name: HRV
     resolution: 1000.134348869
-    wavelength: [0.5, 0.7, 0.9]
+    wavelength: [0.456, 0.716, 1.002]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -186,7 +186,7 @@ datasets:
   IR_016:
     name: IR_016
     resolution: 3000.403165817
-    wavelength: [1.5, 1.64, 1.78]
+    wavelength: [1.567, 1.638, 1.707]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -202,7 +202,7 @@ datasets:
   IR_039:
     name: IR_039
     resolution: 3000.403165817
-    wavelength: [3.48, 3.92, 4.36]
+    wavelength: [3.603, 3.920, 4.254]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -218,7 +218,7 @@ datasets:
   IR_087:
     name: IR_087
     resolution: 3000.403165817
-    wavelength: [8.3, 8.7, 9.1]
+    wavelength: [8.492, 8.717, 8.940]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -234,7 +234,7 @@ datasets:
   IR_097:
     name: IR_097
     resolution: 3000.403165817
-    wavelength: [9.38, 9.66, 9.94]
+    wavelength: [9.526, 9.667, 9.817]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -250,7 +250,7 @@ datasets:
   IR_108:
     name: IR_108
     resolution: 3000.403165817
-    wavelength: [9.8, 10.8, 11.8]
+    wavelength: [10.200, 10.796, 11.400]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -266,7 +266,7 @@ datasets:
   IR_120:
     name: IR_120
     resolution: 3000.403165817
-    wavelength: [11.0, 12.0, 13.0]
+    wavelength: [11.400, 11.957, 12.520]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -282,7 +282,7 @@ datasets:
   IR_134:
     name: IR_134
     resolution: 3000.403165817
-    wavelength: [12.4, 13.4, 14.4]
+    wavelength: [12.600, 13.379, 14.160]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -298,7 +298,7 @@ datasets:
   VIS006:
     name: VIS006
     resolution: 3000.403165817
-    wavelength: [0.56, 0.635, 0.71]
+    wavelength: [0.596, 0.638, 0.680]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -314,7 +314,7 @@ datasets:
   VIS008:
     name: VIS008
     resolution: 3000.403165817
-    wavelength: [0.74, 0.81, 0.88]
+    wavelength: [0.776, 0.808, 0.844]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -330,7 +330,7 @@ datasets:
   WV_062:
     name: WV_062
     resolution: 3000.403165817
-    wavelength: [5.35, 6.25, 7.15]
+    wavelength: [5.818, 6.307, 6.790]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -346,7 +346,7 @@ datasets:
   WV_073:
     name: WV_073
     resolution: 3000.403165817
-    wavelength: [6.85, 7.35, 7.85]
+    wavelength: [7.070, 7.364, 7.650]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature

--- a/satpy/etc/readers/seviri_l1b_icare.yaml
+++ b/satpy/etc/readers/seviri_l1b_icare.yaml
@@ -66,7 +66,7 @@ datasets:
   HRV:
     name: HRV
     resolution: 1000.134348869
-    wavelength: [0.5, 0.7, 0.9]
+    wavelength: [0.456, 0.716, 1.002]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -76,7 +76,7 @@ datasets:
   IR_016:
     name: IR_016
     resolution: 3000.403165817
-    wavelength: [1.5, 1.64, 1.78]
+    wavelength: [1.567, 1.638, 1.707]
     calibration:
       reflectance:
         standard_name: reflectance
@@ -86,7 +86,7 @@ datasets:
   IR_039:
     name: IR_039
     resolution: 3000.403165817
-    wavelength: [3.48, 3.92, 4.36]
+    wavelength: [3.603, 3.920, 4.254]
     calibration:
       brightness_temperature:
         standard_name: brightness_temperature
@@ -96,7 +96,7 @@ datasets:
   IR_087:
     name: IR_087
     resolution: 3000.403165817
-    wavelength: [8.3, 8.7, 9.1]
+    wavelength: [8.492, 8.717, 8.940]
     calibration:
       brightness_temperature:
         standard_name: brightness_temperature
@@ -106,7 +106,7 @@ datasets:
   IR_097:
     name: IR_097
     resolution: 3000.403165817
-    wavelength: [9.38, 9.66, 9.94]
+    wavelength: [9.526, 9.667, 9.817]
     calibration:
       brightness_temperature:
         standard_name: brightness_temperature
@@ -116,7 +116,7 @@ datasets:
   IR_108:
     name: IR_108
     resolution: 3000.403165817
-    wavelength: [9.8, 10.8, 11.8]
+    wavelength: [10.200, 10.796, 11.400]
     calibration:
       brightness_temperature:
         standard_name: brightness_temperature
@@ -126,7 +126,7 @@ datasets:
   IR_120:
     name: IR_120
     resolution: 3000.403165817
-    wavelength: [11.0, 12.0, 13.0]
+    wavelength: [11.400, 11.957, 12.520]
     calibration:
       brightness_temperature:
         standard_name: brightness_temperature
@@ -136,7 +136,7 @@ datasets:
   IR_134:
     name: IR_134
     resolution: 3000.403165817
-    wavelength: [12.4, 13.4, 14.4]
+    wavelength: [12.600, 13.379, 14.160]
     calibration:
       brightness_temperature:
         standard_name: brightness_temperature
@@ -146,7 +146,7 @@ datasets:
   VIS006:
     name: VIS006
     resolution: 3000.403165817
-    wavelength: [0.56, 0.635, 0.71]
+    wavelength: [0.596, 0.638, 0.680]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -156,7 +156,7 @@ datasets:
   VIS008:
     name: VIS008
     resolution: 3000.403165817
-    wavelength: [0.74, 0.81, 0.88]
+    wavelength: [0.776, 0.808, 0.844]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -166,7 +166,7 @@ datasets:
   WV_062:
     name: WV_062
     resolution: 3000.403165817
-    wavelength: [5.35, 6.25, 7.15]
+    wavelength: [5.818, 6.307, 6.790]
     calibration:
       brightness_temperature:
         standard_name: brightness_temperature
@@ -176,7 +176,7 @@ datasets:
   WV_073:
     name: WV_073
     resolution: 3000.403165817
-    wavelength: [6.85, 7.35, 7.85]
+    wavelength: [7.070, 7.364, 7.650]
     calibration:
       brightness_temperature:
         standard_name: brightness_temperature

--- a/satpy/etc/readers/seviri_l1b_native.yaml
+++ b/satpy/etc/readers/seviri_l1b_native.yaml
@@ -25,7 +25,7 @@ datasets:
   HRV:
     name: HRV
     resolution: 1000.134348869
-    wavelength: [0.5, 0.7, 0.9]
+    wavelength: [0.456, 0.716, 1.002]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -41,7 +41,7 @@ datasets:
   IR_016:
     name: IR_016
     resolution: 3000.403165817
-    wavelength: [1.5, 1.64, 1.78]
+    wavelength: [1.567, 1.638, 1.707]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -57,7 +57,7 @@ datasets:
   IR_039:
     name: IR_039
     resolution: 3000.403165817
-    wavelength: [3.48, 3.92, 4.36]
+    wavelength: [3.603, 3.920, 4.254]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -73,7 +73,7 @@ datasets:
   IR_087:
     name: IR_087
     resolution: 3000.403165817
-    wavelength: [8.3, 8.7, 9.1]
+    wavelength: [8.492, 8.717, 8.940]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -89,7 +89,7 @@ datasets:
   IR_097:
     name: IR_097
     resolution: 3000.403165817
-    wavelength: [9.38, 9.66, 9.94]
+    wavelength: [9.526, 9.667, 9.817]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -105,7 +105,7 @@ datasets:
   IR_108:
     name: IR_108
     resolution: 3000.403165817
-    wavelength: [9.8, 10.8, 11.8]
+    wavelength: [10.200, 10.796, 11.400]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -121,7 +121,7 @@ datasets:
   IR_120:
     name: IR_120
     resolution: 3000.403165817
-    wavelength: [11.0, 12.0, 13.0]
+    wavelength: [11.400, 11.957, 12.520]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -137,7 +137,7 @@ datasets:
   IR_134:
     name: IR_134
     resolution: 3000.403165817
-    wavelength: [12.4, 13.4, 14.4]
+    wavelength: [12.600, 13.379, 14.160]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -153,7 +153,7 @@ datasets:
   VIS006:
     name: VIS006
     resolution: 3000.403165817
-    wavelength: [0.56, 0.635, 0.71]
+    wavelength: [0.596, 0.638, 0.680]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -169,7 +169,7 @@ datasets:
   VIS008:
     name: VIS008
     resolution: 3000.403165817
-    wavelength: [0.74, 0.81, 0.88]
+    wavelength: [0.776, 0.808, 0.844]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -185,7 +185,7 @@ datasets:
   WV_062:
     name: WV_062
     resolution: 3000.403165817
-    wavelength: [5.35, 6.25, 7.15]
+    wavelength: [5.818, 6.307, 6.790]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -201,7 +201,7 @@ datasets:
   WV_073:
     name: WV_073
     resolution: 3000.403165817
-    wavelength: [6.85, 7.35, 7.85]
+    wavelength: [7.070, 7.364, 7.650]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature

--- a/satpy/etc/readers/seviri_l1b_nc.yaml
+++ b/satpy/etc/readers/seviri_l1b_nc.yaml
@@ -17,7 +17,7 @@ datasets:
   HRV:
     name: HRV
     resolution: 1000.134348869
-    wavelength: [0.5, 0.7, 0.9]
+    wavelength: [0.456, 0.716, 1.002]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -34,7 +34,7 @@ datasets:
   IR_016:
     name: IR_016
     resolution: 3000.403165817
-    wavelength: [1.5, 1.64, 1.78]
+    wavelength: [1.567, 1.638, 1.707]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -51,7 +51,7 @@ datasets:
   IR_039:
     name: IR_039
     resolution: 3000.403165817
-    wavelength: [3.48, 3.92, 4.36]
+    wavelength: [3.603, 3.920, 4.254]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -68,7 +68,7 @@ datasets:
   IR_087:
     name: IR_087
     resolution: 3000.403165817
-    wavelength: [8.3, 8.7, 9.1]
+    wavelength: [8.492, 8.717, 8.940]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -85,7 +85,7 @@ datasets:
   IR_097:
     name: IR_097
     resolution: 3000.403165817
-    wavelength: [9.38, 9.66, 9.94]
+    wavelength: [9.526, 9.667, 9.817]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -102,7 +102,7 @@ datasets:
   IR_108:
     name: IR_108
     resolution: 3000.403165817
-    wavelength: [9.8, 10.8, 11.8]
+    wavelength: [10.200, 10.796, 11.400]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -119,7 +119,7 @@ datasets:
   IR_120:
     name: IR_120
     resolution: 3000.403165817
-    wavelength: [11.0, 12.0, 13.0]
+    wavelength: [11.400, 11.957, 12.520]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -136,7 +136,7 @@ datasets:
   IR_134:
     name: IR_134
     resolution: 3000.403165817
-    wavelength: [12.4, 13.4, 14.4]
+    wavelength: [12.600, 13.379, 14.160]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -153,7 +153,7 @@ datasets:
   VIS006:
     name: VIS006
     resolution: 3000.403165817
-    wavelength: [0.56, 0.635, 0.71]
+    wavelength: [0.596, 0.638, 0.680]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -171,7 +171,7 @@ datasets:
   VIS008:
     name: VIS008
     resolution: 3000.403165817
-    wavelength: [0.74, 0.81, 0.88]
+    wavelength: [0.776, 0.808, 0.844]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -188,7 +188,7 @@ datasets:
   WV_062:
     name: WV_062
     resolution: 3000.403165817
-    wavelength: [5.35, 6.25, 7.15]
+    wavelength: [5.818, 6.307, 6.790]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -205,7 +205,7 @@ datasets:
   WV_073:
     name: WV_073
     resolution: 3000.403165817
-    wavelength: [6.85, 7.35, 7.85]
+    wavelength: [7.070, 7.364, 7.650]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature

--- a/satpy/etc/readers/slstr_l1b.yaml
+++ b/satpy/etc/readers/slstr_l1b.yaml
@@ -93,7 +93,7 @@ datasets:
   S1:
     name: S1
     sensor: slstr
-    wavelength: [0.545,0.555,0.565]
+    wavelength: [0.543, 0.554, 0.566]
     resolution: 500
     view: [nadir, oblique]
     stripe: [a, b]
@@ -110,7 +110,7 @@ datasets:
   S2:
     name: S2
     sensor: slstr
-    wavelength: [0.649, 0.659, 0.669]
+    wavelength: [0.648, 0.659, 0.671]
     resolution: 500
     view: [nadir, oblique]
     stripe: [a, b]
@@ -127,7 +127,7 @@ datasets:
   S3:
     name: S3
     sensor: slstr
-    wavelength: [0.855, 0.865, 0.875]
+    wavelength: [0.856, 0.868, 0.880]
     resolution: 500
     view: [nadir, oblique]
     stripe: [a, b]
@@ -146,7 +146,7 @@ datasets:
   S4:
     name: S4
     sensor: slstr
-    wavelength: [1.3675, 1.375, 1.36825]
+    wavelength: [1.363, 1.375, 1.387]
     resolution: 500
     view: [nadir, oblique]
     stripe: [a, b]
@@ -163,7 +163,7 @@ datasets:
   S5:
     name: S5
     sensor: slstr
-    wavelength: [1.58, 1.61, 1.64]
+    wavelength: [1.575, 1.613, 1.651]
     resolution: 500
     view: [nadir, oblique]
     stripe: [a, b]
@@ -180,7 +180,7 @@ datasets:
   S6:
     name: S6
     sensor: slstr
-    wavelength: [2.225, 2.25, 2.275]
+    wavelength: [2.225, 2.256, 2.287]
     resolution: 500
     view: [nadir, oblique]
     stripe: [a, b]
@@ -198,7 +198,7 @@ datasets:
   S7:
     name: S7
     sensor: slstr
-    wavelength: [3.55, 3.74, 3.93]
+    wavelength: [3.492, 3.742, 4.008]
     resolution: 1000
     view: [nadir, oblique]
     stripe: i
@@ -212,7 +212,7 @@ datasets:
   S8:
     name: S8
     sensor: slstr
-    wavelength: [10.4, 10.85, 11.3]
+    wavelength: [10.370, 10.857, 11.368]
     resolution: 1000
     view: [nadir, oblique]
     stripe: i
@@ -226,7 +226,7 @@ datasets:
   S9:
     name: S9
     sensor: slstr
-    wavelength: [11.57, 12.0225, 12.475]
+    wavelength: [11.415, 12.032, 12.645]
     resolution: 1000
     view: [nadir, oblique]
     stripe: i
@@ -240,7 +240,7 @@ datasets:
   F1:
     name: F1
     sensor: slstr
-    wavelength: [3.55, 3.74, 3.93]
+    wavelength: [3.492, 3.742, 4.008]
     resolution: 1000
     view: [nadir, oblique]
     stripe: f
@@ -254,7 +254,7 @@ datasets:
   F2:
     name: F2
     sensor: slstr
-    wavelength: [10.4, 10.85, 11.3]
+    wavelength: [10.370, 10.857, 11.368]
     resolution: 1000
     view: [nadir, oblique]
     stripe: i

--- a/satpy/etc/readers/viirs_compact.yaml
+++ b/satpy/etc/readers/viirs_compact.yaml
@@ -37,7 +37,7 @@ datasets:
   M01:
     name: M01
     sensor: viirs
-    wavelength: [0.402,0.412,0.422]
+    wavelength: [0.399, 0.412, 0.421]
     resolution: 742
     calibration:
       reflectance:
@@ -52,7 +52,7 @@ datasets:
   M02:
     name: M02
     sensor: viirs
-    wavelength: [0.436,0.445,0.454]
+    wavelength: [0.434, 0.445, 0.454]
     resolution: 742
     calibration:
       reflectance:
@@ -67,7 +67,7 @@ datasets:
   M03:
     name: M03
     sensor: viirs
-    wavelength: [0.478,0.488,0.498]
+    wavelength: [0.478, 0.489, 0.500]
     resolution: 742
     calibration:
       reflectance:
@@ -82,7 +82,7 @@ datasets:
   M04:
     name: M04
     sensor: viirs
-    wavelength: [0.545,0.555,0.565]
+    wavelength: [0.545, 0.557, 0.569]
     resolution: 742
     calibration:
       reflectance:
@@ -97,7 +97,7 @@ datasets:
   M05:
     name: M05
     sensor: viirs
-    wavelength: [0.662,0.672,0.682]
+    wavelength: [0.655, 0.667, 0.678]
     resolution: 742
     calibration:
       reflectance:
@@ -112,7 +112,7 @@ datasets:
   M06:
     name: M06
     sensor: viirs
-    wavelength: [0.739,0.746,0.754]
+    wavelength: [0.737, 0.746, 0.754]
     resolution: 742
     calibration:
       reflectance:
@@ -127,7 +127,7 @@ datasets:
   M07:
     name: M07
     sensor: viirs
-    wavelength: [0.846,0.865,0.885]
+    wavelength: [0.846, 0.867, 0.888]
     resolution: 742
     calibration:
       reflectance:
@@ -142,7 +142,7 @@ datasets:
   M08:
     name: M08
     sensor: viirs
-    wavelength: [1.230,1.240,1.250]
+    wavelength: [1.222, 1.241, 1.254]
     resolution: 742
     calibration:
       reflectance:
@@ -158,7 +158,7 @@ datasets:
     name: M09
     sensor: viirs
     resolution: 742
-    wavelength: [1.371,1.378,1.386]
+    wavelength: [1.365, 1.374, 1.383]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -172,7 +172,7 @@ datasets:
   M10:
     name: M10
     sensor: viirs
-    wavelength: [1.580,1.610,1.640]
+    wavelength: [1.564, 1.603, 1.640]
     resolution: 742
     calibration:
       reflectance:
@@ -188,7 +188,7 @@ datasets:
     name: M11
     sensor: viirs
     resolution: 742
-    wavelength: [2.225,2.250,2.275]
+    wavelength: [2.226, 2.260, 2.294]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -202,7 +202,7 @@ datasets:
   M12:
     name: M12
     sensor: viirs
-    wavelength: [3.610,3.700,3.790]
+    wavelength: [3.579, 3.699, 3.823]
     resolution: 742
     calibration:
       brightness_temperature:
@@ -217,7 +217,7 @@ datasets:
   M13:
     name: M13
     sensor: viirs
-    wavelength: [3.973,4.050,4.128]
+    wavelength: [3.972, 4.071, 4.170]
     resolution: 742
     calibration:
       brightness_temperature:
@@ -233,7 +233,7 @@ datasets:
     name: M14
     sensor: viirs
     resolution: 742
-    wavelength: [8.400,8.550,8.700]
+    wavelength: [8.395, 8.585, 8.775]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -248,7 +248,7 @@ datasets:
     name: M15
     sensor: viirs
     resolution: 742
-    wavelength: [10.263,10.763,11.263]
+    wavelength: [10.117, 10.707, 11.317]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -262,7 +262,7 @@ datasets:
   M16:
     name: M16
     sensor: viirs
-    wavelength: [11.538,12.013,12.489]
+    wavelength: [11.352, 11.861, 12.392]
     resolution: 742
     calibration:
       brightness_temperature:
@@ -277,7 +277,7 @@ datasets:
   DNB:
     name: DNB
     sensor: viirs
-    wavelength: [0.500,0.700,0.900]
+    wavelength: [0.496, 0.703, 0.893]
     resolution: 743
     calibration:
       radiance:

--- a/satpy/etc/readers/viirs_l1b.yaml
+++ b/satpy/etc/readers/viirs_l1b.yaml
@@ -105,7 +105,7 @@ datasets:
     standard_name: latitude
   I01:
     name: I01
-    wavelength: [0.600, 0.640, 0.680]
+    wavelength: [0.600, 0.643, 0.684]
     resolution: 371
     calibration:
       reflectance:
@@ -118,7 +118,7 @@ datasets:
     file_type: vl1bi
   I02:
     name: I02
-    wavelength: [0.845, 0.865, 0.884]
+    wavelength: [0.846, 0.866, 0.888]
     resolution: 371
     calibration:
       reflectance:
@@ -131,7 +131,7 @@ datasets:
     file_type: vl1bi
   I03:
     name: I03
-    wavelength: [1.580, 1.610, 1.640]
+    wavelength: [1.562, 1.601, 1.638]
     resolution: 371
     calibration:
       reflectance:
@@ -144,7 +144,7 @@ datasets:
     file_type: vl1bi
   I04:
     name: I04
-    wavelength: [3.580, 3.740, 3.900]
+    wavelength: [3.526, 3.747, 3.958]
     resolution: 371
     calibration:
       brightness_temperature:
@@ -157,7 +157,7 @@ datasets:
     file_type: vl1bi
   I05:
     name: I05
-    wavelength: [10.500, 11.450, 12.300]
+    wavelength: [10.412, 11.466, 12.732]
     resolution: 371
     calibration:
       brightness_temperature:
@@ -202,7 +202,7 @@ datasets:
     file_key: geolocation_data/sensor_azimuth
   M01:
     name: M01
-    wavelength: [0.402, 0.412, 0.422]
+    wavelength: [0.399, 0.412, 0.421]
     resolution: 742
     calibration:
       reflectance:
@@ -215,7 +215,7 @@ datasets:
     file_type: vl1bm
   M02:
     name: M02
-    wavelength: [0.436, 0.445, 0.454]
+    wavelength: [0.434, 0.445, 0.454]
     resolution: 742
     calibration:
       reflectance:
@@ -228,7 +228,7 @@ datasets:
     file_type: vl1bm
   M03:
     name: M03
-    wavelength: [0.478, 0.488, 0.498]
+    wavelength: [0.478, 0.489, 0.500]
     resolution: 742
     calibration:
       reflectance:
@@ -241,7 +241,7 @@ datasets:
     file_type: vl1bm
   M04:
     name: M04
-    wavelength: [0.545, 0.555, 0.565]
+    wavelength: [0.545, 0.557, 0.569]
     resolution: 742
     calibration:
       reflectance:
@@ -254,7 +254,7 @@ datasets:
     file_type: vl1bm
   M05:
     name: M05
-    wavelength: [0.662, 0.672, 0.682]
+    wavelength: [0.655, 0.667, 0.678]
     resolution: 742
     calibration:
       reflectance:
@@ -267,7 +267,7 @@ datasets:
     file_type: vl1bm
   M06:
     name: M06
-    wavelength: [0.739, 0.746, 0.754]
+    wavelength: [0.737, 0.746, 0.754]
     resolution: 742
     calibration:
       reflectance:
@@ -280,7 +280,7 @@ datasets:
     file_type: vl1bm
   M07:
     name: M07
-    wavelength: [0.846, 0.865, 0.885]
+    wavelength: [0.846, 0.867, 0.888]
     resolution: 742
     calibration:
       reflectance:
@@ -293,7 +293,7 @@ datasets:
     file_type: vl1bm
   M08:
     name: M08
-    wavelength: [1.230, 1.240, 1.250]
+    wavelength: [1.222, 1.241, 1.254]
     resolution: 742
     calibration:
       reflectance:
@@ -306,7 +306,7 @@ datasets:
     file_type: vl1bm
   M09:
     name: M09
-    wavelength: [1.371, 1.378, 1.386]
+    wavelength: [1.365, 1.374, 1.383]
     resolution: 742
     calibration:
       reflectance:
@@ -319,7 +319,7 @@ datasets:
     file_type: vl1bm
   M10:
     name: M10
-    wavelength: [1.580, 1.610, 1.640]
+    wavelength: [1.564, 1.603, 1.640]
     resolution: 742
     calibration:
       reflectance:
@@ -332,7 +332,7 @@ datasets:
     file_type: vl1bm
   M11:
     name: M11
-    wavelength: [2.225, 2.250, 2.275]
+    wavelength: [2.226, 2.260, 2.294]
     resolution: 742
     calibration:
       reflectance:
@@ -345,7 +345,7 @@ datasets:
     file_type: vl1bm
   M12:
     name: M12
-    wavelength: [3.610, 3.700, 3.790]
+    wavelength: [3.579, 3.699, 3.823]
     resolution: 742
     calibration:
       brightness_temperature:
@@ -358,7 +358,7 @@ datasets:
     file_type: vl1bm
   M13:
     name: M13
-    wavelength: [3.973, 4.050, 4.128]
+    wavelength: [3.972, 4.071, 4.170]
     resolution: 742
     calibration:
       brightness_temperature:
@@ -371,7 +371,7 @@ datasets:
     file_type: vl1bm
   M14:
     name: M14
-    wavelength: [8.400, 8.550, 8.700]
+    wavelength: [8.395, 8.585, 8.775]
     resolution: 742
     calibration:
       brightness_temperature:
@@ -384,7 +384,7 @@ datasets:
     file_type: vl1bm
   M15:
     name: M15
-    wavelength: [10.263, 10.763, 11.263]
+    wavelength: [10.117, 10.707, 11.317]
     resolution: 742
     calibration:
       brightness_temperature:
@@ -397,7 +397,7 @@ datasets:
     file_type: vl1bm
   M16:
     name: M16
-    wavelength: [11.538, 12.013, 12.489]
+    wavelength: [11.352, 11.861, 12.392]
     resolution: 742
     calibration:
       brightness_temperature:
@@ -442,7 +442,7 @@ datasets:
     file_key: geolocation_data/sensor_azimuth
   DNB:
     name: DNB
-    wavelength: [0.500, 0.700, 0.900]
+    wavelength: [0.496, 0.703, 0.893]
     resolution: 743
     calibration:
       radiance:

--- a/satpy/etc/readers/viirs_sdr.yaml
+++ b/satpy/etc/readers/viirs_sdr.yaml
@@ -64,7 +64,7 @@ datasets:
     coordinates: [dnb_longitude, dnb_latitude]
   I01:
     name: I01
-    wavelength: [0.600, 0.640, 0.680]
+    wavelength: [0.600, 0.643, 0.684]
     modifiers: [sunz_corrected_iband]
     dataset_groups: [SVI01]
     file_type: generic_file
@@ -80,7 +80,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   I02:
     name: I02
-    wavelength: [0.845, 0.865, 0.884]
+    wavelength: [0.846, 0.866, 0.888]
     modifiers: [sunz_corrected_iband]
     dataset_groups: [SVI02]
     file_type: generic_file
@@ -96,7 +96,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   I03:
     name: I03
-    wavelength: [1.580, 1.610, 1.640]
+    wavelength: [1.562, 1.601, 1.638]
     modifiers: [sunz_corrected_iband]
     dataset_groups: [SVI03]
     file_type: generic_file
@@ -112,7 +112,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   I04:
     name: I04
-    wavelength: [3.580, 3.740, 3.900]
+    wavelength: [3.526, 3.747, 3.958]
     file_type: generic_file
     dataset_groups: [SVI04]
     resolution: 371
@@ -126,7 +126,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   I05:
     name: I05
-    wavelength: [10.500, 11.450, 12.300]
+    wavelength: [10.412, 11.466, 12.732]
     dataset_groups: [SVI05]
     file_type: generic_file
     resolution: 371
@@ -140,7 +140,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M01:
     name: M01
-    wavelength: [0.402, 0.412, 0.422]
+    wavelength: [0.399, 0.412, 0.421]
     modifiers: [sunz_corrected]
     dataset_groups: [SVM01]
     file_type: generic_file
@@ -156,7 +156,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M02:
     name: M02
-    wavelength: [0.436, 0.445, 0.454]
+    wavelength: [0.434, 0.445, 0.454]
     modifiers: [sunz_corrected]
     dataset_groups: [SVM02]
     file_type: generic_file
@@ -172,7 +172,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M03:
     name: M03
-    wavelength: [0.478, 0.488, 0.498]
+    wavelength: [0.478, 0.489, 0.500]
     modifiers: [sunz_corrected]
     dataset_groups: [SVM03]
     file_type: generic_file
@@ -188,7 +188,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M04:
     name: M04
-    wavelength: [0.545, 0.555, 0.565]
+    wavelength: [0.545, 0.557, 0.569]
     modifiers: [sunz_corrected]
     dataset_groups: [SVM04]
     file_type: generic_file
@@ -204,7 +204,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M05:
     name: M05
-    wavelength: [0.662, 0.672, 0.682]
+    wavelength: [0.655, 0.667, 0.678]
     modifiers: [sunz_corrected]
     dataset_groups: [SVM05]
     file_type: generic_file
@@ -220,7 +220,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M06:
     name: M06
-    wavelength: [0.739, 0.746, 0.754]
+    wavelength: [0.737, 0.746, 0.754]
     modifiers: [sunz_corrected]
     dataset_groups: [SVM06]
     file_type: generic_file
@@ -236,7 +236,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M07:
     name: M07
-    wavelength: [0.846, 0.865, 0.885]
+    wavelength: [0.846, 0.867, 0.888]
     modifiers: [sunz_corrected]
     dataset_groups: [SVM07]
     file_type: generic_file
@@ -252,7 +252,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M08:
     name: M08
-    wavelength: [1.230, 1.240, 1.250]
+    wavelength: [1.222, 1.241, 1.254]
     modifiers: [sunz_corrected]
     dataset_groups: [SVM08]
     file_type: generic_file
@@ -268,7 +268,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M09:
     name: M09
-    wavelength: [1.371, 1.378, 1.386]
+    wavelength: [1.365, 1.374, 1.383]
     modifiers: [sunz_corrected]
     dataset_groups: [SVM09]
     file_type: generic_file
@@ -284,7 +284,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M10:
     name: M10
-    wavelength: [1.580, 1.610, 1.640]
+    wavelength: [1.564, 1.603, 1.640]
     modifiers: [sunz_corrected]
     dataset_groups: [SVM10]
     file_type: generic_file
@@ -300,7 +300,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M11:
     name: M11
-    wavelength: [2.225, 2.250, 2.275]
+    wavelength: [2.226, 2.260, 2.294]
     modifiers: [sunz_corrected]
     dataset_groups: [SVM11]
     file_type: generic_file
@@ -316,7 +316,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M12:
     name: M12
-    wavelength: [3.610, 3.700, 3.790]
+    wavelength: [3.579, 3.699, 3.823]
     dataset_groups: [SVM12]
     file_type: generic_file
     resolution: 742
@@ -330,7 +330,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M13:
     name: M13
-    wavelength: [3.973, 4.050, 4.128]
+    wavelength: [3.972, 4.071, 4.170]
     dataset_groups: [SVM13]
     file_type: generic_file
     resolution: 742
@@ -344,7 +344,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M14:
     name: M14
-    wavelength: [8.400, 8.550, 8.700]
+    wavelength: [8.395, 8.585, 8.775]
     dataset_groups: [SVM14]
     file_type: generic_file
     resolution: 742
@@ -358,7 +358,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M15:
     name: M15
-    wavelength: [10.263, 10.763, 11.263]
+    wavelength: [10.117, 10.707, 11.317]
     dataset_groups: [SVM15]
     file_type: generic_file
     resolution: 742
@@ -372,7 +372,7 @@ datasets:
         file_units: W m-2 um-1 sr-1
   M16:
     name: M16
-    wavelength: [11.538, 12.013, 12.489]
+    wavelength: [11.352, 11.861, 12.392]
     dataset_groups: [SVM16]
     file_type: generic_file
     resolution: 742
@@ -459,7 +459,7 @@ datasets:
     file_key: 'All_Data/{dataset_group}_All/SatelliteAzimuthAngle'
   DNB:
     name: DNB
-    wavelength: [0.500, 0.700, 0.900]
+    wavelength: [0.496, 0.703, 0.893]
     resolution: 743
     coordinates: [dnb_longitude, dnb_latitude]
     calibration:


### PR DESCRIPTION
I noticed that for many of the sensors the minimum and maximum wavelengths given in the reader YAML file for a given channel are inconsistent:
`wavelength: [min_wvl, central_wvl, max_wvl]`
These values appear to have been taken from various sources with differing standards. In this PR I'm attempting to standardise things by setting the min and max wavelengths to a fixed spectral response function value.

For a range of SRFS and paired wavelengths, sorted by ascending wavelength, I define:
The minimum wavelength as the first time the instrument SRF is > 0.15
The maximum wavelength as the last time the instrument SRF is > 0.15

In all cases I take the SRFs from the [NWP-SAF / RTTOV webpages](https://nwp-saf.eumetsat.int/site/software/rttov/download/coefficients/spectral-response-functions/#visir).

Currently this is a work in progress. Below is a list of readers I've checked / updated:
 - [x] abi_l1b
 - [x] abi_l1b_scmi
 - [x] abi_l2_nc
 - [ ] acspo
 - [x] agri_l1
 - [x] ahi_hrit
 - [x] ahi_hsd
 - [x] ahi_l1b_gridded_bin
 - [x] ami_l1b
 - [x] amsr2_l1b
 - [x] amsr2_l2
 - [x] avhrr_l1b_aapp
 - [x] avhrr_l1b_eps
 - [x] avhrr_l1b_gaclac
 - [x] avhrr_l1b_hrpt
 - [x] caliop_l2_cloud
 - [x] clavrx
 - [x] cmsaf-claas2_l2_nc
 - [ ] electrol_hrit
 - [ ] fci_l1c_fdhsi
 - [ ] fci_l2_nc
 - [x] generic_image
 - [x] geocat
 - [x] ghrsst_l3c_sst
 - [x] glm_l2
 - [ ] goes-imager_hrit
 - [ ] goes-imager_nc
 - [x] gpm_imerg
 - [x] grib
 - [x] hsaf_grib
 - [x] hy2_scat_l2b_h5
 - [x] iasi_l2
 - [x] iasi_l2_so2_bufr
 - [ ] jami_hrit
 - [x] li_l2
 - [x] maia
 - [ ] mersi2_l1b
 - [x] mimicTPW2_comp
 - [x] modis_l1b
 - [x] modis_l2
 - [x] msi_safe
 - [ ] mtsat2-imager_hrit
 - [x] nucaps
 - [x] nwcsaf-geo
 - [x] nwcsaf-msg2013-hdf5
 - [x] nwcsaf-pps_nc
 - [x] olci_l1b
 - [x] olci_l2
 - [x] omps_edr
 - [x] safe_sar_l2_ocn
 - [x] sar-c_safe
 - [x] scatsat1_l2b
 - [x] seviri_l1b_hrit
 - [x] seviri_l1b_icare
 - [x] seviri_l1b_native
 - [x] seviri_l1b_nc
 - [x] seviri_l2_bufr
 - [x] seviri_l2_grib
 - [x] slstr_l1b
 - [x] slstr_l2
 - [x] smos_l2_wind
 - [x] tropomi_l2
 - [x] vaisala_gld360
 - [ ] vii_l1b_nc
 - [x] vii_l2_nc
 - [x] viirs_compact
 - [x] viirs_edr_active_fires
 - [x] viirs_edr_flood
 - [x] viirs_l1b
 - [x] viirs_sdr
 - [ ] virr_l1b