### PR TITLE
Fix mersi 2 angles reading

### DIFF
--- a/satpy/readers/mersi2_l1b.py
+++ b/satpy/readers/mersi2_l1b.py
@@ -92,7 +92,7 @@ class MERSI2L1B(HDF5FileHandler):
 
         fill_value = attrs.pop('FillValue', np.nan)  # covered by valid_range
         valid_range = attrs.pop('valid_range', None)
-        if 'calibration' in dataset_id and dataset_id['calibration'] == 'counts':
+        if dataset_id.get('calibration') == 'counts':
             # preserve integer type of counts if possible
             attrs['_FillValue'] = fill_value
             new_fill = fill_value
@@ -110,20 +110,20 @@ class MERSI2L1B(HDF5FileHandler):
 
         slope = attrs.pop('Slope', None)
         intercept = attrs.pop('Intercept', None)
-        if slope is not None and ('calibration' not in dataset_id or dataset_id['calibration'] != 'counts'):
+        if slope is not None and dataset_id.get('calibration') != 'counts':
             if band_index is not None:
                 slope = slope[band_index]
                 intercept = intercept[band_index]
             data = data * slope + intercept
 
-        if 'calibration' in dataset_id and dataset_id['calibration'] == "reflectance":
+        if dataset_id.get('calibration') == "reflectance":
             # some bands have 0 counts for the first N columns and
             # seem to be invalid data points
             data = data.where(data != 0)
             coeffs = self._get_coefficients(ds_info['calibration_key'],
                                             ds_info['calibration_index'])
             data = coeffs[0] + coeffs[1] * data + coeffs[2] * data**2
-        elif 'calibration' in dataset_id and dataset_id['calibration'] == "brightness_temperature":
+        elif dataset_id.get('calibration') == "brightness_temperature":
             cal_index = ds_info['calibration_index']
             # Apparently we don't use these calibration factors for Rad -> BT
             # coeffs = self._get_coefficients(ds_info['calibration_key'], cal_index)

--- a/satpy/readers/mersi2_l1b.py
+++ b/satpy/readers/mersi2_l1b.py
@@ -92,7 +92,7 @@ class MERSI2L1B(HDF5FileHandler):
 
         fill_value = attrs.pop('FillValue', np.nan)  # covered by valid_range
         valid_range = attrs.pop('valid_range', None)
-        if dataset_id['calibration'] == 'counts':
+        if 'calibration' in dataset_id and dataset_id['calibration'] == 'counts':
             # preserve integer type of counts if possible
             attrs['_FillValue'] = fill_value
             new_fill = fill_value
@@ -110,20 +110,20 @@ class MERSI2L1B(HDF5FileHandler):
 
         slope = attrs.pop('Slope', None)
         intercept = attrs.pop('Intercept', None)
-        if slope is not None and dataset_id['calibration'] != 'counts':
+        if slope is not None and ('calibration' not in dataset_id or dataset_id['calibration'] != 'counts'):
             if band_index is not None:
                 slope = slope[band_index]
                 intercept = intercept[band_index]
             data = data * slope + intercept
 
-        if dataset_id['calibration'] == "reflectance":
+        if 'calibration' in dataset_id and dataset_id['calibration'] == "reflectance":
             # some bands have 0 counts for the first N columns and
             # seem to be invalid data points
             data = data.where(data != 0)
             coeffs = self._get_coefficients(ds_info['calibration_key'],
                                             ds_info['calibration_index'])
             data = coeffs[0] + coeffs[1] * data + coeffs[2] * data**2
-        elif dataset_id['calibration'] == "brightness_temperature":
+        elif 'calibration' in dataset_id and dataset_id['calibration'] == "brightness_temperature":
             cal_index = ds_info['calibration_index']
             # Apparently we don't use these calibration factors for Rad -> BT
             # coeffs = self._get_coefficients(ds_info['calibration_key'], cal_index)

--- a/satpy/tests/reader_tests/test_mersi2_l1b.py
+++ b/satpy/tests/reader_tests/test_mersi2_l1b.py
@@ -196,8 +196,18 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
                         'valid_range': [-180, 180],
                     },
                     dims=('_rows', '_cols')),
+            prefix + 'SensorZenith':
+                xr.DataArray(
+                    da.ones((num_scans * rows_per_scan, num_cols), chunks=1024),
+                    attrs={
+                        'Slope': [.01] * 1, 'Intercept': [0.] * 1,
+                        'units': 'degree',
+                        'valid_range': [0, 28000],
+                    },
+                    dims=('_rows', '_cols')),
         }
         return geo
+
 
     def get_test_content(self, filename, filename_info, filetype_info):
         """Mimic reader input file content."""
@@ -338,8 +348,9 @@ class TestMERSI2L1BReader(unittest.TestCase):
         ds_ids = []
         for band_name in ['1', '2', '3', '4', '5', '20', '24', '25']:
             ds_ids.append(make_dataid(name=band_name, calibration='counts'))
+        ds_ids.append(make_dataid(name='satellite_zenith_angle'))
         res = reader.load(ds_ids)
-        self.assertEqual(8, len(res))
+        self.assertEqual(9, len(res))
         self.assertEqual((2 * 40, 2048 * 2), res['1'].shape)
         self.assertEqual('counts', res['1'].attrs['calibration'])
         self.assertEqual(res['1'].dtype, np.uint16)

--- a/satpy/tests/reader_tests/test_mersi2_l1b.py
+++ b/satpy/tests/reader_tests/test_mersi2_l1b.py
@@ -208,7 +208,6 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
         }
         return geo
 
-
     def get_test_content(self, filename, filename_info, filetype_info):
         """Mimic reader input file content."""
         rows_per_scan = self.filetype_info.get('rows_per_scan', 10)


### PR DESCRIPTION
The MERSI-2 reader could no longer read angles data due to that keyword 'calibration' was always expected.

The error message:
```
python3.6/site-packages/satpy/readers/mersi2_l1b.py", line 95, in get_dataset
    if dataset_id['calibration'] == 'counts':
KeyError: 'calibration'
```

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

