### PR TITLE
Update Code of Conduct contact email to groups.io address

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at <pytroll-conduct@lists.wisc.edu>. All
+reported by contacting the project team at <pytroll-conduct@groups.io>. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
The current Code of Conduct uses a WiscList email; email group created under the University of Wisconsin WiscList service. This service is being deprecated. As a replacement we've decided to use groups.io instead. This PR updates the code of conduct to use this new email address.
