### PR TITLE
read goes-r data from https aws, gcp or azure (it uses h5netcdf)

### DIFF
--- a/satpy/readers/abi_base.py
+++ b/satpy/readers/abi_base.py
@@ -22,6 +22,8 @@ from datetime import datetime
 
 import numpy as np
 import xarray as xr
+import requests
+import io
 
 from pyresample import geometry
 from satpy.readers.file_handlers import BaseFileHandler
@@ -42,13 +44,19 @@ class NC_ABI_BASE(BaseFileHandler):
         """Open the NetCDF file with xarray and prepare the Dataset for reading."""
         super(NC_ABI_BASE, self).__init__(filename, filename_info, filetype_info)
         # xarray's default netcdf4 engine
+        url = self.filename
+        if 'googleapis' in url or 'amazonaws' in url or 'core.windows' in url:
+            resp = requests.get(url)
+            store = io.BytesIO(resp.content)
+        else:
+            store = url
         try:
-            self.nc = xr.open_dataset(self.filename,
+            self.nc = xr.open_dataset(store,
                                       decode_cf=True,
                                       mask_and_scale=False,
                                       chunks={'x': CHUNK_SIZE, 'y': CHUNK_SIZE}, )
         except ValueError:
-            self.nc = xr.open_dataset(self.filename,
+            self.nc = xr.open_dataset(store,
                                       decode_cf=True,
                                       mask_and_scale=False,
                                       chunks={'lon': CHUNK_SIZE, 'lat': CHUNK_SIZE}, )


### PR DESCRIPTION
This second method @djhoese, it uses h5netcdf, I think is a best option, but it has some error, I've tried to track it but can't find it
is adapted of this: https://github.com/pydata/xarray/issues/1075
When I load directly from https using xarray it works fine, but in satpy "abi_base.py" it gets stuck.
the advantage of this method, is that you can read direct from S3 using boto3: https://github.com/pydata/xarray/issues/1075#issuecomment-635415386
```
netcdf_bytes = s3_object['Body'].read()
netcdf_bytes_io = io.BytesIO(netcdf_bytes)
ds = xr.open_dataset(netcdf_bytes_io)
```
and from google storage
```
bucket = storage_client.bucket('gcp-public-data-goes-16')
objt = 'ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C13_G16_s20202822056149_e20202822058534_c20202822059042.nc'
blob = bucket.get_blob(objt)
netcdf_bytes_io = io.BytesIO(blob.download_as_string())
ds = xr.open_dataset(netcdf_bytes_io)
```
the latter I tried it in google colab and it worked

---------------------------------------------
I did the test with this data in my local machine

```
from satpy import Scene
from satpy.utils import debug_on
debug_on()

list_files = ['https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C01_G16_s20202822031149_e20202822033522_c20202822033567.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C02_G16_s20202822031149_e20202822033522_c20202822033556.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C03_G16_s20202822031149_e20202822033522_c20202822033572.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C04_G16_s20202822031149_e20202822033522_c20202822034046.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C05_G16_s20202822031149_e20202822033522_c20202822034051.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C06_G16_s20202822031149_e20202822033528_c20202822034065.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C07_G16_s20202822031149_e20202822033534_c20202822033585.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C08_G16_s20202822031149_e20202822033522_c20202822034031.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C09_G16_s20202822031149_e20202822033528_c20202822034008.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C10_G16_s20202822031149_e20202822033534_c20202822033595.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C11_G16_s20202822031149_e20202822033522_c20202822033577.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C12_G16_s20202822031149_e20202822033528_c20202822034057.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C13_G16_s20202822031149_e20202822033534_c20202822034038.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C14_G16_s20202822031149_e20202822033522_c20202822034014.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C15_G16_s20202822031149_e20202822033528_c20202822034022.nc',
 'https://gcp-public-data-goes-16.storage.googleapis.com/ABI-L1b-RadC/2020/282/20/OR_ABI-L1b-RadC-M6C16_G16_s20202822031149_e20202822033534_c20202822034001.nc']

gscn = Scene(reader="abi_l1b", filenames=list_files,)
gscn.load(['C{:02d}'.format(13)])
```
and this is the error when I read the data

```
/home/jhbravo/Software/miniconda3/envs/pytroll/lib/python3.8/site-packages/pyproj/crs/crs.py:543: UserWarning: You will likely lose important projection information when converting to a PROJ string from another format. See: https://proj.org/faq.html#what-is-the-best-format-for-describing-coordinate-reference-systems
proj_string = self.to_proj4()
[DEBUG: 2020-11-04 20:04:51 : satpy.readers.abi_l1b] Reading in get_dataset C13.
[DEBUG: 2020-11-04 20:04:51 : satpy.readers.abi_l1b] Calibrating to brightness temperatures
[ERROR: 2020-11-04 20:04:51 : satpy.readers.yaml_reader] Could not load dataset 'DataID(name='C13', wavelength=WavelengthRange(min=10.1, central=10.35, max=10.6, unit='µm'), resolution=2000, calibration=<calibration.brightness_temperature>, modifiers=())': dimensions () must have the same length as the number of data dimensions, ndim=1
Traceback (most recent call last):
File "/home/jhbravo/Software/miniconda3/envs/pytroll/lib/python3.8/site-packages/satpy/readers/yaml_reader.py", line 828, in _load_dataset_with_area
ds = self._load_dataset_data(file_handlers, dsid, **kwargs)
File "/home/jhbravo/Software/miniconda3/envs/pytroll/lib/python3.8/site-packages/satpy/readers/yaml_reader.py", line 711, in _load_dataset_data
proj = self._load_dataset(dsid, ds_info, file_handlers, **kwargs)
File "/home/jhbravo/Software/miniconda3/envs/pytroll/lib/python3.8/site-packages/satpy/readers/yaml_reader.py", line 687, in _load_dataset
projectable = fh.get_dataset(dsid, ds_info)
File "/home/jhbravo/Software/miniconda3/envs/pytroll/lib/python3.8/site-packages/satpy/readers/abi_l1b.py", line 48, in get_dataset
res = self._ir_calibrate(radiances)
File "/home/jhbravo/Software/miniconda3/envs/pytroll/lib/python3.8/site-packages/satpy/readers/abi_l1b.py", line 112, in _ir_calibrate
fk1 = float(self["planck_fk1"])
File "/home/jhbravo/Software/miniconda3/envs/pytroll/lib/python3.8/site-packages/satpy/readers/abi_base.py", line 117, in __getitem__
data = data.where(data != fill, new_fill)
File "/home/jhbravo/Software/miniconda3/envs/pytroll/lib/python3.8/site-packages/xarray/core/dataarray.py", line 2765, in func
f(self.variable, other_variable)
File "/home/jhbravo/Software/miniconda3/envs/pytroll/lib/python3.8/site-packages/xarray/core/nputils.py", line 79, in array_ne
return _ensure_bool_is_ndarray(self != other, self, other)
File "/home/jhbravo/Software/miniconda3/envs/pytroll/lib/python3.8/site-packages/xarray/core/variable.py", line 2134, in func
result = Variable(dims, new_data, attrs=attrs)
File "/home/jhbravo/Software/miniconda3/envs/pytroll/lib/python3.8/site-packages/xarray/core/variable.py", line 327, in __init__
self._dims = self._parse_dimensions(dims)
File "/home/jhbravo/Software/miniconda3/envs/pytroll/lib/python3.8/site-packages/xarray/core/variable.py", line 559, in _parse_dimensions
raise ValueError(
ValueError: dimensions () must have the same length as the number of data dimensions, ndim=1
[WARNING: 2020-11-04 20:04:51 : satpy.scene] The following datasets were not created and may require resampling to be generated: DataID(name='C13', wavelength=WavelengthRange(min=10.1, central=10.35, max=10.6, unit='µm'), resolution=2000, calibration=<calibration.brightness_temperature>, modifiers=())
```


<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
