### PR TITLE
Add reader for FIDUCEO MVIRI FCDR data

### DIFF
--- a/doc/source/api/satpy.readers.rst
+++ b/doc/source/api/satpy.readers.rst
@@ -365,7 +365,7 @@ satpy.readers.msi\_safe module
    :show-inheritance:
 
 satpy.readers.mviri\_l1b\_fiduceo\_nc module
-------------------------------
+--------------------------------------------
 
 .. automodule:: satpy.readers.mviri_l1b_fiduceo_nc
    :members:

--- a/doc/source/api/satpy.readers.rst
+++ b/doc/source/api/satpy.readers.rst
@@ -364,6 +364,14 @@ satpy.readers.msi\_safe module
    :undoc-members:
    :show-inheritance:
 
+satpy.readers.mviri\_l1b\_fiduceo\_nc module
+------------------------------
+
+.. automodule:: satpy.readers.mviri_l1b_fiduceo_nc
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 satpy.readers.netcdf\_utils module
 ----------------------------------
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -93,6 +93,9 @@ the base Satpy installation.
     * - MSG (Meteosat 8 to 11) L2 products in GRIB2 format
       - `seviri_l2_grib`
       - In development, CLM, OCA and FIR products supported
+    * - MFG (Meteosat 2 to 7) MVIRI data in netCDF format (FIDUCEO FCDR)
+      - `mviri_l1b_fiduceo_nc`
+      - Beta
     * - Himawari 8 and 9 AHI data in HSD format
       - `ahi_hsd`
       - Nominal

--- a/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
+++ b/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
@@ -20,11 +20,13 @@ file_types:
         file_reader: !!python/name:satpy.readers.mviri_l1b_fiduceo_nc.FiduceoMviriEasyFcdrFileHandler
         file_patterns: [
           'FIDUCEO_FCDR_{level}_{sensor}_{platform}-{projection_longitude}_{start_time:%Y%m%d%H%M}_{end_time:%Y%m%d%H%M}_EASY_{processor_version}_{format_version}.nc'
+          # Example: FIDUCEO_FCDR_L15_MVIRI_MET7-57.0_201701201000_201701201030_EASY_v2.6_fv3.1.nc
         ]
     nc_full:
         file_reader: !!python/name:satpy.readers.mviri_l1b_fiduceo_nc.FiduceoMviriFullFcdrFileHandler
         file_patterns: [
           'FIDUCEO_FCDR_{level}_{sensor}_{platform}-{projection_longitude}_{start_time:%Y%m%d%H%M}_{end_time:%Y%m%d%H%M}_FULL_{processor_version}_{format_version}.nc'
+          # Example: FIDUCEO_FCDR_L15_MVIRI_MET7-57.0_201701201000_201701201030_FULL_v2.6_fv3.1.nc
         ]
 
 datasets:

--- a/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
+++ b/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
@@ -1,0 +1,101 @@
+# References:
+#    - MFG User Handbook
+#    - FIDUCEO MVIRI FCDR Product User Guide
+
+reader:
+  name: mviri_l1b_fiduceo_nc
+  short_name: FIDUCEO MVIRI FCDR
+  long_name: >
+    Fundamental Climate Data Record of re-calibrated Level 1.5 Infrared, Water Vapour, and Visible radiances
+    from the Meteosat Visible Infra-Red Imager (MVIRI) instrument onboard the Meteosat First Generation satellites
+  description: >
+    Reader for FIDUCEO MVIRI FCDR data in netCDF format. For documentation see
+    http://doi.org/10.15770/EUM_SEC_CLM_0009 .
+  sensors: [mviri]
+  default_channels: [VIS, WV, IR]
+  reader: !!python/name:satpy.readers.yaml_reader.GEOFlippableFileYAMLReader
+
+file_types:
+    nc_easy:
+        file_reader: !!python/name:satpy.readers.mviri_l1b_fiduceo_nc.FiduceoMviriEasyFcdrFileHandler
+        file_patterns: [
+          'FIDUCEO_FCDR_{level}_{sensor}_{platform}-{projection_longitude}_{start_time:%Y%m%d%H%M}_{end_time:%Y%m%d%H%M}_EASY_{processor_version}_{format_version}.nc'
+        ]
+    nc_full:
+        file_reader: !!python/name:satpy.readers.mviri_l1b_fiduceo_nc.FiduceoMviriFullFcdrFileHandler
+        file_patterns: [
+          'FIDUCEO_FCDR_{level}_{sensor}_{platform}-{projection_longitude}_{start_time:%Y%m%d%H%M}_{end_time:%Y%m%d%H%M}_FULL_{processor_version}_{format_version}.nc'
+        ]
+
+datasets:
+  VIS:
+    name: VIS
+    resolution: 2250
+    wavelength: [0.5, 0.7, 0.9]
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        # standard_name: TODO
+        units: W m-2 sr-1  # TODO: Per unit wave number/length
+      counts:
+        standard_name: counts
+        units: count
+    file_type: [nc_easy, nc_full]
+
+  WV:
+    name: WV
+    resolution: 4500
+    wavelength: [5.7, 6.4, 7.1]
+    calibration:
+      brightness_temperature:
+        standard_name: toa_brightness_temperature
+        units: K
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: mW m-2 sr-1 (cm-1)-1
+      counts:
+        standard_name: counts
+        units: count
+    file_type: [nc_easy, nc_full]
+
+  IR:
+    name: IR
+    resolution: 4500
+    wavelength: [10.5, 11.5, 12.5]
+    calibration:
+      brightness_temperature:
+        standard_name: toa_brightness_temperature
+        units: K
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: mW m-2 sr-1 (cm-1)-1
+      counts:
+        standard_name: counts
+        units: count
+    file_type: [nc_easy, nc_full]
+
+  quality_pixel_bitmask:
+    name: quality_pixel_bitmask
+    resolution: 2250
+    file_type: [nc_easy, nc_full]
+
+  data_quality_bitmask:
+    name: data_quality_bitmask
+    resolution: 2250
+    file_type: [nc_easy, nc_full]
+
+  u_independent_toa_bidirectional_reflectance:
+    name: u_independent_toa_bidirectional_reflectance
+    long_name: "independent uncertainty per pixel"
+    units: "%"
+    resolution: 2250
+    file_type: [nc_easy]
+
+  u_structured_toa_bidirectional_reflectance:
+    name: u_structured_toa_bidirectional_reflectance
+    long_name: "structured uncertainty per pixel"
+    units: "%"
+    resolution: 2250
+    file_type: [nc_easy]

--- a/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
+++ b/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
@@ -102,66 +102,34 @@ datasets:
     resolution: 2250
     file_type: [nc_easy]
 
-  solar_zenith_angle_vis:
-    name: solar_zenith_angle_vis
+  solar_zenith_angle:
+    name: solar_zenith_angle
     standard_name: solar_zenith_angle
-    long_name: "Solar zenith angle VIS channel"
+    long_name: "Solar zenith angle"
     units: degree
-    resolution: 2250
+    resolution: [2250, 4500]
     file_type: [nc_easy, nc_full]
 
-  solar_azimuth_angle_vis:
-    name: solar_azimuth_angle_vis
+  solar_azimuth_angle:
+    name: solar_azimuth_angle
     standard_name: solar_azimuth_angle
-    long_name: "Solar azimuth angle VIS channel"
+    long_name: "Solar azimuth angle"
     units: degree
-    resolution: 2250
+    resolution: [2250, 4500]
     file_type: [nc_easy, nc_full]
 
-  satellite_zenith_angle_vis:
-    name: satellite_zenith_angle_vis
+  satellite_zenith_angle:
+    name: satellite_zenith_angle
     standard_name: sensor_zenith_angle
-    long_name: "Satellite zenith angle VIS channel"
+    long_name: "Satellite zenith angle"
     units: degree
-    resolution: 2250
+    resolution: [2250, 4500]
     file_type: [nc_easy, nc_full]
 
-  satellite_azimuth_angle_vis:
-    name: satellite_azimuth_angle_vis
+  satellite_azimuth_angle:
+    name: satellite_azimuth_angle
     standard_name: sensor_azimuth_angle
-    long_name: "Satellite azimuth angle VIS channel"
+    long_name: "Satellite azimuth angle"
     units: degree
-    resolution: 2250
-    file_type: [nc_easy, nc_full]
-
-  solar_zenith_angle_ir_wv:
-    name: solar_zenith_angle_ir_wv
-    standard_name: solar_zenith_angle
-    long_name: "Solar zenith angle IR/WV channels"
-    units: degree
-    resolution: 4500
-    file_type: [nc_easy, nc_full]
-
-  solar_azimuth_angle_ir_wv:
-    name: solar_azimuth_angle_ir_wv
-    standard_name: solar_azimuth_angle
-    long_name: "Solar azimuth angle IR/WV channels"
-    units: degree
-    resolution: 4500
-    file_type: [nc_easy, nc_full]
-
-  satellite_zenith_angle_ir_wv:
-    name: satellite_zenith_angle_ir_wv
-    standard_name: sensor_zenith_angle
-    long_name: "Satellite zenith angle IR/WV channels"
-    units: degree
-    resolution: 4500
-    file_type: [nc_easy, nc_full]
-
-  satellite_azimuth_angle_ir_wv:
-    name: satellite_azimuth_angle_ir_wv
-    standard_name: sensor_azimuth_angle
-    long_name: "Satellite azimuth angle IR/WV channels"
-    units: degree
-    resolution: 4500
+    resolution: [2250, 4500]
     file_type: [nc_easy, nc_full]

--- a/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
+++ b/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
@@ -139,7 +139,7 @@ datasets:
     standard_name: solar_zenith_angle
     long_name: "Solar zenith angle IR/WV channels"
     units: degree
-    resolution: 2250
+    resolution: 4500
     file_type: [nc_easy, nc_full]
 
   solar_azimuth_angle_ir_wv:
@@ -147,7 +147,7 @@ datasets:
     standard_name: solar_azimuth_angle
     long_name: "Solar azimuth angle IR/WV channels"
     units: degree
-    resolution: 2250
+    resolution: 4500
     file_type: [nc_easy, nc_full]
 
   satellite_zenith_angle_ir_wv:
@@ -155,7 +155,7 @@ datasets:
     standard_name: sensor_zenith_angle
     long_name: "Satellite zenith angle IR/WV channels"
     units: degree
-    resolution: 2250
+    resolution: 4500
     file_type: [nc_easy, nc_full]
 
   satellite_azimuth_angle_ir_wv:
@@ -163,5 +163,5 @@ datasets:
     standard_name: sensor_azimuth_angle
     long_name: "Satellite azimuth angle IR/WV channels"
     units: degree
-    resolution: 2250
+    resolution: 4500
     file_type: [nc_easy, nc_full]

--- a/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
+++ b/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
@@ -19,13 +19,13 @@ file_types:
     nc_easy:
         file_reader: !!python/name:satpy.readers.mviri_l1b_fiduceo_nc.FiduceoMviriEasyFcdrFileHandler
         file_patterns: [
-          'FIDUCEO_FCDR_{level}_{sensor}_{platform}-{projection_longitude}_{start_time:%Y%m%d%H%M}_{end_time:%Y%m%d%H%M}_EASY_{processor_version}_{format_version}.nc'
+          'FIDUCEO_FCDR_{level}_{sensor}_{platform}-{projection_longitude:f}_{start_time:%Y%m%d%H%M}_{end_time:%Y%m%d%H%M}_EASY_{processor_version}_{format_version}.nc'
           # Example: FIDUCEO_FCDR_L15_MVIRI_MET7-57.0_201701201000_201701201030_EASY_v2.6_fv3.1.nc
         ]
     nc_full:
         file_reader: !!python/name:satpy.readers.mviri_l1b_fiduceo_nc.FiduceoMviriFullFcdrFileHandler
         file_patterns: [
-          'FIDUCEO_FCDR_{level}_{sensor}_{platform}-{projection_longitude}_{start_time:%Y%m%d%H%M}_{end_time:%Y%m%d%H%M}_FULL_{processor_version}_{format_version}.nc'
+          'FIDUCEO_FCDR_{level}_{sensor}_{platform}-{projection_longitude:f}_{start_time:%Y%m%d%H%M}_{end_time:%Y%m%d%H%M}_FULL_{processor_version}_{format_version}.nc'
           # Example: FIDUCEO_FCDR_L15_MVIRI_MET7-57.0_201701201000_201701201030_FULL_v2.6_fv3.1.nc
         ]
 

--- a/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
+++ b/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
@@ -39,8 +39,8 @@ datasets:
         standard_name: toa_bidirectional_reflectance
         units: "%"
       radiance:
-        # standard_name: TODO
-        units: W m-2 sr-1  # TODO: Per unit wave number/length
+        # Confirmed by EUM: No (1/wavenumber) here. Hence no standard name.
+        units: W m-2 sr-1
       counts:
         standard_name: counts
         units: count
@@ -55,7 +55,7 @@ datasets:
         standard_name: toa_brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
         units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
@@ -71,7 +71,7 @@ datasets:
         standard_name: toa_brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
         units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
@@ -104,56 +104,64 @@ datasets:
 
   solar_zenith_angle_vis:
     name: solar_zenith_angle_vis
+    standard_name: solar_zenith_angle
     long_name: "Solar zenith angle VIS channel"
-    units: "degrees"
+    units: degree
     resolution: 2250
     file_type: [nc_easy, nc_full]
 
   solar_azimuth_angle_vis:
     name: solar_azimuth_angle_vis
+    standard_name: solar_azimuth_angle
     long_name: "Solar azimuth angle VIS channel"
-    units: "degrees"
+    units: degree
     resolution: 2250
     file_type: [nc_easy, nc_full]
 
   satellite_zenith_angle_vis:
     name: satellite_zenith_angle_vis
+    standard_name: sensor_zenith_angle
     long_name: "Satellite zenith angle VIS channel"
-    units: "degrees"
+    units: degree
     resolution: 2250
     file_type: [nc_easy, nc_full]
 
   satellite_azimuth_angle_vis:
     name: satellite_azimuth_angle_vis
+    standard_name: sensor_azimuth_angle
     long_name: "Satellite azimuth angle VIS channel"
-    units: "degrees"
+    units: degree
     resolution: 2250
     file_type: [nc_easy, nc_full]
 
   solar_zenith_angle_ir_wv:
     name: solar_zenith_angle_ir_wv
+    standard_name: solar_zenith_angle
     long_name: "Solar zenith angle IR/WV channels"
-    units: "degrees"
+    units: degree
     resolution: 2250
     file_type: [nc_easy, nc_full]
 
   solar_azimuth_angle_ir_wv:
     name: solar_azimuth_angle_ir_wv
+    standard_name: solar_azimuth_angle
     long_name: "Solar azimuth angle IR/WV channels"
-    units: "degrees"
+    units: degree
     resolution: 2250
     file_type: [nc_easy, nc_full]
 
   satellite_zenith_angle_ir_wv:
     name: satellite_zenith_angle_ir_wv
+    standard_name: sensor_zenith_angle
     long_name: "Satellite zenith angle IR/WV channels"
-    units: "degrees"
+    units: degree
     resolution: 2250
     file_type: [nc_easy, nc_full]
 
   satellite_azimuth_angle_ir_wv:
     name: satellite_azimuth_angle_ir_wv
+    standard_name: sensor_azimuth_angle
     long_name: "Satellite azimuth angle IR/WV channels"
-    units: "degrees"
+    units: degree
     resolution: 2250
     file_type: [nc_easy, nc_full]

--- a/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
+++ b/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
@@ -101,3 +101,59 @@ datasets:
     units: "%"
     resolution: 2250
     file_type: [nc_easy]
+
+  solar_zenith_angle_vis:
+    name: solar_zenith_angle_vis
+    long_name: "Solar zenith angle VIS channel"
+    units: "degrees"
+    resolution: 2250
+    file_type: [nc_easy, nc_full]
+
+  solar_azimuth_angle_vis:
+    name: solar_azimuth_angle_vis
+    long_name: "Solar azimuth angle VIS channel"
+    units: "degrees"
+    resolution: 2250
+    file_type: [nc_easy, nc_full]
+
+  satellite_zenith_angle_vis:
+    name: satellite_zenith_angle_vis
+    long_name: "Satellite zenith angle VIS channel"
+    units: "degrees"
+    resolution: 2250
+    file_type: [nc_easy, nc_full]
+
+  satellite_azimuth_angle_vis:
+    name: satellite_azimuth_angle_vis
+    long_name: "Satellite azimuth angle VIS channel"
+    units: "degrees"
+    resolution: 2250
+    file_type: [nc_easy, nc_full]
+
+  solar_zenith_angle_ir_wv:
+    name: solar_zenith_angle_ir_wv
+    long_name: "Solar zenith angle IR/WV channels"
+    units: "degrees"
+    resolution: 2250
+    file_type: [nc_easy, nc_full]
+
+  solar_azimuth_angle_ir_wv:
+    name: solar_azimuth_angle_ir_wv
+    long_name: "Solar azimuth angle IR/WV channels"
+    units: "degrees"
+    resolution: 2250
+    file_type: [nc_easy, nc_full]
+
+  satellite_zenith_angle_ir_wv:
+    name: satellite_zenith_angle_ir_wv
+    long_name: "Satellite zenith angle IR/WV channels"
+    units: "degrees"
+    resolution: 2250
+    file_type: [nc_easy, nc_full]
+
+  satellite_azimuth_angle_ir_wv:
+    name: satellite_azimuth_angle_ir_wv
+    long_name: "Satellite azimuth angle IR/WV channels"
+    units: "degrees"
+    resolution: 2250
+    file_type: [nc_easy, nc_full]

--- a/satpy/readers/_geos_area.py
+++ b/satpy/readers/_geos_area.py
@@ -145,3 +145,24 @@ def get_area_definition(pdict, a_ext):
         a_ext)
 
     return a_def
+
+
+def ang2fac(ang):
+    """Convert angular sampling to line/column scaling factor (aka LFAC/CFAC).
+
+    Reference: `MSG Ground Segment LRIT HRIT Mission Specific Implementation`_,
+    Appendix E.2.
+
+
+    .. _MSG Ground Segment LRIT HRIT Mission Specific Implementation: http://www.eumetsat.int/\
+website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_TEN_05057_SPE_MSG_LRIT_HRI\
+&RevisionSelectionMethod=LatestReleased&Rendition=Web
+
+    Args:
+        ang: float
+            Angular sampling (rad)
+
+    Returns:
+        Line/column scaling factor (deg-1)
+    """
+    return 2.0 ** 16 / np.rad2deg(ang)

--- a/satpy/readers/_geos_area.py
+++ b/satpy/readers/_geos_area.py
@@ -147,7 +147,7 @@ def get_area_definition(pdict, a_ext):
     return a_def
 
 
-def ang2fac(ang):
+def sampling_to_lfac_cfac(sampling):
     """Convert angular sampling to line/column scaling factor (aka LFAC/CFAC).
 
     Reference: `MSG Ground Segment LRIT HRIT Mission Specific Implementation`_,
@@ -159,10 +159,10 @@ website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_TEN_05057_SPE_MSG_LRIT_H
 &RevisionSelectionMethod=LatestReleased&Rendition=Web
 
     Args:
-        ang: float
+        sampling: float
             Angular sampling (rad)
 
     Returns:
         Line/column scaling factor (deg-1)
     """
-    return 2.0 ** 16 / np.rad2deg(ang)
+    return 2.0 ** 16 / np.rad2deg(sampling)

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -61,6 +61,17 @@ In the above example pixels considered bad quality are masked, see
 netCDF attributes are available in the ``raw_metadata`` attribute of
 each loaded dataset.
 
+
+Image Orientation
+-----------------
+The images are stored in MVIRI scanning direction, that means South is up and
+East is right. This can be changed as follows:
+
+.. code-block:: python
+
+    scn.load(['VIS'], upper_right_corner='NE')
+
+
 Geolocation
 -----------
 In addition to the image data, FIDUCEO also provides so called *static FCDRs*
@@ -79,7 +90,8 @@ are small differences. The mean difference is < 1E3 degrees for all channels
 and projection longitudes.
 
 
-References:
+References
+----------
     - `[Handbook]`_ MFG User Handbook
     - `[PUG]`_ FIDUCEO MVIRI FCDR Product User Guide
 

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -295,6 +295,8 @@ class FiduceoMviriBase(BaseFileHandler):
                 return rad
             bt = self._ir_wv_radiance_to_brightness_temperature(rad, channel)
             return bt
+        else:
+            raise KeyError('Invalid calibration: {}'.format(calibration.name))
 
     def _ir_wv_counts_to_radiance(self, counts, channel):
         """Convert IR/WV counts to radiance.

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -309,7 +309,10 @@ class FiduceoMviriBase(BaseFileHandler):
         return rad.where(rad > 0)
 
     def _ir_wv_radiance_to_brightness_temperature(self, rad, channel):
-        """Convert IR/WV radiance to brightness temperature."""
+        """Convert IR/WV radiance to brightness temperature.
+
+        Reference: [PUG], equations (5.1) and (5.2).
+        """
         if channel == 'WV':
             a, b = self.nc['bt_a_wv'], self.nc['bt_b_wv']
         else:

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -1,0 +1,523 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""FIDUCEO MVIRI FCDR Reader.
+
+Introduction
+------------
+The FIDUCEO MVIRI FCDR is a Fundamental Climate Data Record (FCDR) of
+re-calibrated Level 1.5 Infrared, Water Vapour, and Visible radiances from
+the Meteosat Visible Infra-Red Imager (MVIRI) instrument onboard the
+Meteosat First Generation satellites. There are two variants of the dataset:
+The *full FCDR* and a simplified version called *easy FCDR*. Some datasets are
+only available in one of the two variants, see the corresponding YAML
+definition in ``satpy/etc/readers/``.
+
+Dataset Names
+-------------
+The FIDUCEO MVIRI readers use names ``VIS``, ``WV`` and ``IR`` for the visible,
+water vapor and infrared channels, respectively. These are different from
+the original netCDF variable names for the following reasons:
+
+- VIS channel is named differently in full FCDR (``counts_vis``) and easy FCDR
+  (``toa_bidirectional_reflectance_vis``)
+- netCDF variable names contain the calibration level (e.g. ``counts_...``),
+  which might be confusing for satpy users if a different calibration level
+  is chosen.
+
+Remaining datasets (such as quality flags and uncertainties) have the same
+name in the reader as in the netCDF file.
+
+
+Example
+-------
+This is how to read FIDUCEO MVIRI FCDR data in satpy:
+
+.. code-block:: python
+
+    from satpy import Scene
+
+    scn = Scene(filenames=['FIDUCEO_FCDR_L15_MVIRI_MET7-57.0...'],
+                reader='mviri_l1b_fiduceo_nc',
+                reader_kwargs={'mask_bad_quality': True)
+    scn.load(['VIS', 'WV', 'IR'])
+
+In the above example pixels considered bad quality are masked, see
+:class:`FiduceoMviriBase` for a keyword argument description. Global
+netCDF attributes are available in the ``raw_metadata`` attribute of
+each loaded dataset.
+
+Geolocation
+-----------
+In addition to the image data, FIDUCEO also provides so called *static FCDRs*
+containing latitude and longitude coordinates. In order to simplify their
+usage, the FIDUCEO MVIRI readers do not make use of these static files, but
+instead provide an area definition that can be used to compute longitude and
+latitude coordinates on demand.
+
+.. code-block:: python
+
+    area = scn['VIS'].attrs['area']
+    lons, lats = area.get_lonlats()
+
+Those were compared to the static FCDR and they agree very well, however there
+are small differences. The mean difference is < 1E3 degrees for all channels
+and projection longitudes.
+
+
+References:
+    - `[Handbook]`_ MFG User Handbook
+    - `[PUG]`_ FIDUCEO MVIRI FCDR Product User Guide
+
+.. _[Handbook]: http://www.eumetsat.int/\
+website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_TD06_MARF&\
+RevisionSelectionMethod=LatestReleased&Rendition=Web
+.. _[PUG]: http://doi.org/10.15770/EUM_SEC_CLM_0009
+"""
+
+import abc
+import functools
+import numpy as np
+import xarray as xr
+
+
+from satpy import CHUNK_SIZE
+from satpy.readers.file_handlers import BaseFileHandler
+from satpy.readers._geos_area import (ang2fac, get_area_definition,
+                                      get_area_extent)
+
+
+EQUATOR_RADIUS = 6378140.0
+POLE_RADIUS = 6356755.0
+ALTITUDE = 42164000.0 - EQUATOR_RADIUS
+"""[Handbook] section 5.2.1."""
+
+MVIRI_FIELD_OF_VIEW = 18.0
+"""[Handbook] section 5.3.2.1."""
+
+CHANNELS = ['VIS', 'WV', 'IR']
+OTHER_REFLECTANCES = [
+    'u_independent_toa_bidirectional_reflectance',
+    'u_structured_toa_bidirectional_reflectance'
+]
+
+
+class shape_cache:
+    """Cache function call based on image shape.
+
+    Shape can be used to maintain separate caches for low resolution
+    (WV/IR) and high resolution (VIS) channels.
+    """
+
+    def __init__(self, func):
+        """Create the cache.
+
+        Args:
+            func:
+                Function to me cached.
+        """
+        self.func = func
+        self.cache = {}
+
+    def __call__(self, *args):
+        """Call the decorated function.
+
+        Dataset is expected to be the last argument. If an instance method is
+        decorated, it is preceded by a filehandler instance.
+        """
+        ds = args[-1]
+        shape = ds.coords['y'].shape
+        if shape not in self.cache:
+            self.cache[shape] = self.func(*args)
+        return self.cache[shape]
+
+    def __get__(self, obj, objtype):
+        """To support instance methods."""
+        return functools.partial(self.__call__, obj)
+
+
+class FiduceoMviriBase(BaseFileHandler):
+    """Baseclass for FIDUCEO MVIRI file handlers."""
+
+    def __init__(self, filename, filename_info, filetype_info,
+                 mask_bad_quality=False):
+        """Initialize the file handler.
+
+        Args:
+             mask_bad_quality: Mask pixels with bad quality, that means
+                 everything else than "ok" or "use with caution". If you need
+                 more control, use the ``quality_pixel_bitmask`` and
+                 ``data_quality_bitmask`` datasets.
+        """
+        super(FiduceoMviriBase, self).__init__(
+            filename, filename_info, filetype_info)
+        self.mask_bad_quality = mask_bad_quality
+        self.nc = xr.open_dataset(filename, chunks=CHUNK_SIZE)
+
+        # Projection longitude is not provided in the file, read it from the
+        # filename.
+        self.projection_longitude = filename_info['projection_longitude']
+
+    @abc.abstractproperty
+    def nc_keys(self):
+        """Map satpy dataset names to netCDF variables."""
+        raise NotImplementedError
+
+    def get_dataset(self, dataset_id, info):
+        """Get the dataset."""
+        name = dataset_id['name']
+        ds = self._read_dataset(name)
+        if dataset_id['name'] in CHANNELS:
+            ds = self.calibrate(ds, channel=name,
+                                calibration=dataset_id['calibration'])
+            if self.mask_bad_quality:
+                ds = self._mask(ds)
+            ds['acq_time'] = ('y', self._get_acq_time(ds))
+        elif dataset_id['name'] in OTHER_REFLECTANCES:
+            ds = ds * 100  # conversion to percent
+        self._update_attrs(ds)
+        ds.attrs['orbital_parameters'] = self._get_orbital_parameters()
+        return ds
+
+    def _get_nc_key(self, name):
+        """Get netCDF key corresponding to the given dataset name."""
+        return
+
+    def _read_dataset(self, name):
+        """Read a dataset from the file."""
+        nc_key = self.nc_keys.get(name, name)
+        ds = self.nc[nc_key]
+        if 'y_ir_wv' in ds.dims:
+            ds = ds.rename({'y_ir_wv': 'y', 'x_ir_wv': 'x'})
+        return ds
+
+    def _update_attrs(self, ds):
+        """Update dataset attributes."""
+        ds.attrs.update({'platform': self.filename_info['platform'],
+                         'sensor': self.filename_info['sensor']})
+        ds.attrs['raw_metadata'] = self.nc.attrs
+
+    def get_area_def(self, dataset_id):
+        """Get area definition of the given dataset."""
+        ds = self._read_dataset(dataset_id['name'])
+        im_size = ds.coords['y'].size
+
+        # Determine line/column offsets and scaling factors. For offsets
+        # see variables "asamp" and "aline" of subroutine "refgeo" in
+        # [Handbook] and in
+        # https://github.com/FIDUCEO/FCDR_MVIRI/blob/master/lib/nrCrunch/cruncher.f
+        loff = coff = im_size / 2 + 0.5
+        lfac = cfac = ang2fac(np.deg2rad(MVIRI_FIELD_OF_VIEW) / im_size)
+
+        pdict = {
+            'ssp_lon': self.projection_longitude,
+            'a': EQUATOR_RADIUS,
+            'b': POLE_RADIUS,
+            'h': ALTITUDE,
+            'units': 'm',
+            'loff': loff - im_size,
+            'coff': coff,
+            'lfac': -lfac,
+            'cfac': -cfac,
+            'nlines': im_size,
+            'ncols': im_size,
+            'scandir': 'S2N',  # Reference: [PUG] section 2.
+            'p_id': 'geos_mviri',
+            'a_name': 'geos_mviri',
+            'a_desc': 'MVIRI Geostationary Projection'
+        }
+        extent = get_area_extent(pdict)
+        area_def = get_area_definition(pdict, extent)
+        return area_def
+
+    def calibrate(self, ds, channel, calibration):
+        """Calibrate the given dataset."""
+        if channel == 'VIS':
+            return self._calibrate_vis(ds, calibration)
+        elif channel in ['WV', 'IR']:
+            return self._calibrate_ir_wv(ds, channel, calibration)
+        else:
+            raise KeyError('Don\'t know how to calibrate channel {}'.format(
+                channel))
+
+    @abc.abstractmethod
+    def _calibrate_vis(self, ds, calibration):
+        """Calibrate VIS channel. To be implemented by subclasses."""
+        raise NotImplementedError
+
+    def _update_refl_attrs(self, refl):
+        """Update attributes of reflectance datasets."""
+        refl.attrs['sun_earth_distance_correction_applied'] = True
+        refl.attrs['sun_earth_distance_correction_factor'] = self.nc[
+            'distance_sun_earth'].values
+        return refl
+
+    def _calibrate_ir_wv(self, ds, channel, calibration):
+        """Calibrate IR and WV channel."""
+        if calibration == 'counts':
+            return ds
+        elif calibration in ('radiance', 'brightness_temperature'):
+            rad = self._ir_wv_counts_to_radiance(ds, channel)
+            if calibration == 'radiance':
+                return rad
+            bt = self._ir_wv_radiance_to_brightness_temperature(rad, channel)
+            return bt
+
+    def _ir_wv_counts_to_radiance(self, counts, channel):
+        """Convert IR/WV counts to radiance.
+
+        Reference: [PUG], equations (4.1) and (4.2).
+        """
+        if channel == 'WV':
+            a, b = self.nc['a_wv'], self.nc['b_wv']
+        else:
+            a, b = self.nc['a_ir'], self.nc['b_ir']
+        rad = a + b * counts
+        return rad.where(rad > 0)
+
+    def _ir_wv_radiance_to_brightness_temperature(self, rad, channel):
+        """Convert IR/WV radiance to brightness temperature."""
+        if channel == 'WV':
+            a, b = self.nc['bt_a_wv'], self.nc['bt_b_wv']
+        else:
+            a, b = self.nc['bt_a_ir'], self.nc['bt_b_ir']
+        bt = b / (np.log(rad) - a)
+        return bt.where(bt > 0)
+
+    def _mask(self, ds):
+        """Mask pixels with bad quality.
+
+        Pixels are considered bad quality if the "quality_pixel_bitmask" is
+        everything else than 0 (no flag set) or 2 ("use_with_caution" and no
+        other flag set).
+        """
+        mask = self._get_mask(ds)
+        return ds.where(np.logical_or(mask == 0, mask == 2))
+
+    @shape_cache
+    def _get_mask(self, ds):
+        """Get quality bitmask for the given dataset."""
+        mask = self.nc['quality_pixel_bitmask']
+
+        # Mask has high (VIS) resolution. Downsample to low (IR/WV) resolution
+        # if required.
+        if mask.coords['y'].size > ds.coords['y'].size:
+            mask = mask.isel(y=slice(None, None, 2),
+                             x=slice(None, None, 2))
+            mask = mask.assign_coords(y=ds.coords['y'].values,
+                                      x=ds.coords['x'].values)
+        return mask
+
+    @shape_cache
+    def _get_acq_time(self, ds):
+        """Get scanline acquisition time.
+
+        The files provide timestamps per pixel for the low resolution
+        channels (IR/WV) only.
+
+        1) Average values in each line to obtain one timestamp per line.
+        2) For the VIS channel duplicate values in y-direction (as
+           advised by [PUG]).
+
+        Note that the timestamps do not increase monotonically with the
+        line number in some cases.
+
+        Returns:
+            Mean scanline acquisition timestamps
+        """
+        # Variable is sometimes named "time" and sometimes "time_ir_wv".
+        try:
+            time_lores = self.nc['time_ir_wv']
+        except KeyError:
+            time_lores = self.nc['time']
+
+        # Compute mean timestamp per scanline
+        time_lores = time_lores.mean(dim='x_ir_wv').rename({'y_ir_wv': 'y'})
+
+        # If required, repeat timestamps in y-direction to obtain higher
+        # resolution
+        y_lores = time_lores.coords['y'].values
+        y_target = ds.coords['y'].values
+        if y_lores.size < y_target.size:
+            reps = y_target.size // y_lores.size
+            y_lores_rep = np.repeat(y_lores, reps)
+            time_hires = time_lores.reindex(y=y_lores_rep)
+            time_hires = time_hires.assign_coords(y=y_target)
+            return time_hires
+
+        return time_lores
+
+    def _get_orbital_parameters(self):
+        """Get the orbital parameters."""
+        ssp_lon, ssp_lat = self._get_ssp_lonlat()
+        orbital_parameters = {
+            'projection_longitude': self.projection_longitude,
+            'projection_latitude': 0.0,
+            'projection_altitude': ALTITUDE
+        }
+        if not np.isnan(ssp_lon) and not np.isnan(ssp_lat):
+            orbital_parameters.update({
+                'satellite_actual_longitude': ssp_lon,
+                'satellite_actual_latitude': ssp_lat,
+                # altitude not available
+            })
+
+    def _get_ssp_lonlat(self):
+        """Get longitude and latitude at the subsatellite point.
+
+        Easy FCDR files provide satellite position at the beginning and
+        end of the scan. This method computes the mean of those two values.
+        In the full FCDR the information seems to be missing.
+
+        Returns:
+            Subsatellite longitude and latitude
+        """
+        ssp_lon = self._get_ssp('longitude')
+        ssp_lat = self._get_ssp('latitude')
+        return ssp_lon, ssp_lat
+
+    def _get_ssp(self, coord):
+        key_start = 'sub_satellite_{}_start'.format(coord)
+        key_end = 'sub_satellite_{}_end'.format(coord)
+        try:
+            sub_lonlat = np.nanmean(
+                [self.nc[key_start].values,
+                 self.nc[key_end].values]
+            )
+        except KeyError:
+            # Variables seem to be missing in full FCDR
+            sub_lonlat = np.nan
+        return sub_lonlat
+
+    @shape_cache
+    def _get_solar_zenith_angle(self, ds):
+        """Get solar zenith angle for the given dataset.
+
+        Files provide solar zenith angle, but at a coarser resolution.
+        Interpolate to the resolution of the given dataset.
+        """
+        return self._interp_tiepoints(self.nc['solar_zenith_angle'],
+                                      ds.coords['x'],
+                                      ds.coords['y'])
+
+    def _interp_tiepoints(self, ds, target_x, target_y):
+        """Interpolate dataset between tiepoints.
+
+        Uses linear interpolation.
+
+        FUTURE: [PUG] recommends cubic spline interpolation.
+
+        Args:
+            ds:
+                Dataset to be interpolated
+            target_x:
+                Target x coordinates
+            target_y:
+                Target y coordinates
+        """
+        if 'x_tie' not in ds.dims:
+            raise ValueError('Dataset has no tiepoints to be interpolated.')
+
+        # No tiepoint coordinates specified in the files. Use dimensions
+        # to calculate tiepoint sampling and assign tiepoint coordinates
+        # accordingly.
+        sampling = target_x.size // ds.coords['x_tie'].size
+        ds = ds.assign_coords(x_tie=target_x.values[::sampling],
+                              y_tie=target_y.values[::sampling])
+
+        ds_interp = ds.interp(x_tie=target_x, y_tie=target_y)
+        return ds_interp.rename({'x_tie': 'x', 'y_tie': 'y'})
+
+
+class FiduceoMviriEasyFcdrFileHandler(FiduceoMviriBase):
+    """File handler for FIDUCEO MVIRI Easy FCDR."""
+
+    nc_keys = {
+        'VIS': 'toa_bidirectional_reflectance_vis',
+        'WV': 'count_wv',
+        'IR': 'count_ir'
+    }
+
+    def _calibrate_vis(self, ds, calibration):
+        """Calibrate VIS channel.
+
+        Easy FCDR provides reflectance only, no counts or radiance.
+        """
+        if calibration == 'reflectance':
+            refl = 100 * ds  # conversion to percent
+            refl = self._update_refl_attrs(refl)
+            return refl
+        elif calibration in ('counts', 'radiance'):
+            raise ValueError('Cannot calibrate to {}. Easy FCDR provides '
+                             'reflectance only.'.format(calibration.name))
+        else:
+            raise KeyError('Invalid calibration: {}'.format(calibration.name))
+
+
+class FiduceoMviriFullFcdrFileHandler(FiduceoMviriBase):
+    """File handler for FIDUCEO MVIRI Full FCDR."""
+
+    nc_keys = {
+        'VIS': 'count_vis',
+        'WV': 'count_wv',
+        'IR': 'count_ir'
+    }
+
+    def _calibrate_vis(self, ds, calibration):
+        """Calibrate VIS channel.
+
+        All calibration levels are available here.
+        """
+        if calibration == 'counts':
+            return ds
+        elif calibration in ('radiance', 'reflectance'):
+            rad = self._vis_counts_to_radiance(ds)
+            if calibration == 'radiance':
+                return rad
+            refl = self._vis_radiance_to_reflectance(rad)
+            refl = self._update_refl_attrs(refl)
+            return refl
+        else:
+            raise KeyError('Invalid calibration: {}'.format(calibration.name))
+
+    def _vis_counts_to_radiance(self, counts):
+        """Convert VIS counts to radiance.
+
+        Reference: [PUG], equations (7) and (8).
+        """
+        years_since_launch = self.nc['years_since_launch']
+        a_cf = (self.nc['a0_vis'] +
+                self.nc['a1_vis'] * years_since_launch +
+                self.nc['a2_vis'] * years_since_launch ** 2)
+
+        rad = (counts - self.nc['mean_count_space_vis']) * a_cf
+        return rad.where(rad > 0)
+
+    def _vis_radiance_to_reflectance(self, rad):
+        """Convert VIS radiance to reflectance factor.
+
+        Reference: [PUG], equation (6).
+        """
+        sza = self._get_solar_zenith_angle(rad)
+        cos_sza = np.cos(np.deg2rad(sza))
+        refl = (
+           (np.pi * self.nc['distance_sun_earth'] ** 2) /
+           (self.nc['solar_irradiance_vis'] * cos_sza) *
+           rad
+        )
+        refl = refl * 100  # conversion to percent
+        return refl.where(refl > 0)

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -173,6 +173,30 @@ class shape_cache:
 class FiduceoMviriBase(BaseFileHandler):
     """Baseclass for FIDUCEO MVIRI file handlers."""
 
+    nc_keys = {'WV': 'count_wv', 'IR': 'count_ir'}
+    nc_keys_coefs = {
+        'WV': {
+            'radiance': {
+                'a': 'a_wv',
+                'b': 'b_wv'
+            },
+            'brightness_temperature': {
+                'a': 'bt_a_wv',
+                'b': 'bt_b_wv'
+            }
+        },
+        'IR': {
+            'radiance': {
+                'a': 'a_ir',
+                'b': 'b_ir'
+            },
+            'brightness_temperature': {
+                'a': 'bt_a_ir',
+                'b': 'bt_b_ir'
+            }
+        },
+    }
+
     def __init__(self, filename, filename_info, filetype_info,
                  mask_bad_quality=False):
         """Initialize the file handler.
@@ -475,11 +499,8 @@ class FiduceoMviriBase(BaseFileHandler):
 class FiduceoMviriEasyFcdrFileHandler(FiduceoMviriBase):
     """File handler for FIDUCEO MVIRI Easy FCDR."""
 
-    nc_keys = {
-        'VIS': 'toa_bidirectional_reflectance_vis',
-        'WV': 'count_wv',
-        'IR': 'count_ir'
-    }
+    nc_keys = FiduceoMviriBase.nc_keys.copy()
+    nc_keys['VIS'] = 'toa_bidirectional_reflectance_vis'
 
     def _calibrate_vis(self, ds, calibration):
         """Calibrate VIS channel.
@@ -500,11 +521,8 @@ class FiduceoMviriEasyFcdrFileHandler(FiduceoMviriBase):
 class FiduceoMviriFullFcdrFileHandler(FiduceoMviriBase):
     """File handler for FIDUCEO MVIRI Full FCDR."""
 
-    nc_keys = {
-        'VIS': 'count_vis',
-        'WV': 'count_wv',
-        'IR': 'count_ir'
-    }
+    nc_keys = FiduceoMviriBase.nc_keys.copy()
+    nc_keys['VIS'] = 'count_vis'
 
     def _calibrate_vis(self, ds, calibration):
         """Calibrate VIS channel.

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -300,7 +300,7 @@ class FiduceoMviriBase(BaseFileHandler):
             ds = ds.rename({'y_ir_wv': 'y', 'x_ir_wv': 'x'})
         elif 'y_tie' in ds.dims:
             ds = ds.rename({'y_tie': 'y', 'x_tie': 'x'})
-        elif 'y' in ds.dims:
+        elif 'y' in ds.dims and 'y' not in ds.coords:
             # For some reason xarray doesn't assign coordinates to all
             # high resolution data variables.
             ds = ds.assign_coords({'y': self.nc.coords['y'],

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -421,7 +421,13 @@ class FiduceoMviriBase(BaseFileHandler):
         the VIS channel.
         """
         mask = self.nc['quality_pixel_bitmask']
-        return ds.where(np.logical_or(mask == 0, mask == 2),
+        if 'y' not in mask.coords:
+            # For some reason xarray doesn't assign coordinates to the
+            # masks. Maybe because of the 'coordinates' attribute which
+            # points to non-existent latitude and longitude.
+            mask = mask.assign_coords({'y': ds.coords['y'],
+                                       'x': ds.coords['x']})
+        return ds.where(da.logical_or(mask == 0, mask == 2),
                         np.float32(np.nan))
 
     def _get_acq_time(self, ds):

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -467,7 +467,8 @@ class FiduceoMviriBase(BaseFileHandler):
         ds = ds.assign_coords(x_tie=target_x.values[::sampling],
                               y_tie=target_y.values[::sampling])
 
-        ds_interp = ds.interp(x_tie=target_x, y_tie=target_y)
+        ds_interp = ds.interp(x_tie=target_x.values,
+                              y_tie=target_y.values)
         return ds_interp.rename({'x_tie': 'x', 'y_tie': 'y'})
 
 

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -349,6 +349,7 @@ class FiduceoMviriBase(BaseFileHandler):
 
     def calibrate(self, ds, channel, calibration):
         """Calibrate the given dataset."""
+        ds.attrs.pop('ancillary_variables', None)  # to avoid satpy warnings
         if channel == 'VIS':
             return self._calibrate_vis(ds, calibration)
         elif channel in ['WV', 'IR']:

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -285,7 +285,7 @@ class FiduceoMviriBase(BaseFileHandler):
         """Update attributes of reflectance datasets."""
         refl.attrs['sun_earth_distance_correction_applied'] = True
         refl.attrs['sun_earth_distance_correction_factor'] = self.nc[
-            'distance_sun_earth'].values
+            'distance_sun_earth'].item()
         return refl
 
     def _calibrate_ir_wv(self, ds, channel, calibration):

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -102,6 +102,7 @@ masking bad quality pixels is to set the ``mask_bad_quality`` keyword argument
 to ``True``:
 
 .. code-block:: python
+
     scn = Scene(filenames=['FIDUCEO_FCDR_L15_MVIRI_MET7-57.0...'],
                 reader='mviri_l1b_fiduceo_nc',
                 reader_kwargs={'mask_bad_quality': True})

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -163,8 +163,11 @@ import numpy as np
 import xarray as xr
 
 from satpy import CHUNK_SIZE
-from satpy.readers._geos_area import (ang2fac, get_area_definition,
-                                      get_area_extent)
+from satpy.readers._geos_area import (
+    sampling_to_lfac_cfac,
+    get_area_definition,
+    get_area_extent
+)
 from satpy.readers.file_handlers import BaseFileHandler
 
 EQUATOR_RADIUS = 6378140.0
@@ -306,7 +309,9 @@ class FiduceoMviriBase(BaseFileHandler):
         # [Handbook] and in
         # https://github.com/FIDUCEO/FCDR_MVIRI/blob/master/lib/nrCrunch/cruncher.f
         loff = coff = im_size / 2 + 0.5
-        lfac = cfac = ang2fac(np.deg2rad(MVIRI_FIELD_OF_VIEW) / im_size)
+        lfac = cfac = sampling_to_lfac_cfac(
+            np.deg2rad(MVIRI_FIELD_OF_VIEW) / im_size
+        )
 
         pdict = {
             'ssp_lon': self.projection_longitude,

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -208,21 +208,24 @@ class IRWVCalibrator:
         if calibration == 'counts':
             return counts
         elif calibration in ('radiance', 'brightness_temperature'):
-            rad = self._counts_to_radiance(counts)
-            if calibration == 'radiance':
-                return rad
-            bt = self._radiance_to_brightness_temperature(rad)
-            return bt
+            return self._calibrate_rad_bt(counts, calibration)
         else:
             raise KeyError('Invalid calibration: {}'.format(calibration.name))
+
+    def _calibrate_rad_bt(self, counts, calibration):
+        """Calibrate counts to radiance or brightness temperature."""
+        rad = self._counts_to_radiance(counts)
+        if calibration == 'radiance':
+            return rad
+        bt = self._radiance_to_brightness_temperature(rad)
+        return bt
 
     def _counts_to_radiance(self, counts):
         """Convert IR/WV counts to radiance.
 
         Reference: [PUG], equations (4.1) and (4.2).
         """
-        a, b = self.coefs['radiance']
-        rad = a + b * counts
+        rad = self.coefs['a'] + self.coefs['b'] * counts
         return rad.where(rad > 0, np.float32(np.nan))
 
     def _radiance_to_brightness_temperature(self, rad):
@@ -230,8 +233,7 @@ class IRWVCalibrator:
 
         Reference: [PUG], equations (5.1) and (5.2).
         """
-        a, b = self.coefs['brightness_temperature']
-        bt = b / (np.log(rad) - a)
+        bt = self.coefs['bt_b'] / (np.log(rad) - self.coefs['bt_a'])
         return bt.where(bt > 0, np.float32(np.nan))
 
 
@@ -256,26 +258,29 @@ class VISCalibrator:
         if calibration == 'counts':
             return counts
         elif calibration in ('radiance', 'reflectance'):
-            rad = self._counts_to_radiance(counts)
-            if calibration == 'radiance':
-                return rad
-            refl = self._radiance_to_reflectance(rad)
-            refl = self.update_refl_attrs(refl)
-            return refl
+            return self._calibrate_rad_refl(counts, calibration)
         else:
             raise KeyError('Invalid calibration: {}'.format(calibration.name))
+
+    def _calibrate_rad_refl(self, counts, calibration):
+        """Calibrate counts to radiance or reflectance."""
+        rad = self._counts_to_radiance(counts)
+        if calibration == 'radiance':
+            return rad
+        refl = self._radiance_to_reflectance(rad)
+        refl = self.update_refl_attrs(refl)
+        return refl
 
     def _counts_to_radiance(self, counts):
         """Convert VIS counts to radiance.
 
         Reference: [PUG], equations (7) and (8).
         """
-        coefs = self.coefs['radiance']
-        years_since_launch = coefs['years_since_launch']
-        a_cf = (coefs['a0_vis'] +
-                coefs['a1_vis'] * years_since_launch +
-                coefs['a2_vis'] * years_since_launch ** 2)
-        mean_count_space_vis = coefs['mean_count_space_vis']
+        years_since_launch = self.coefs['years_since_launch']
+        a_cf = (self.coefs['a0'] +
+                self.coefs['a1'] * years_since_launch +
+                self.coefs['a2'] * years_since_launch ** 2)
+        mean_count_space_vis = self.coefs['mean_count_space']
         rad = (counts - mean_count_space_vis) * a_cf
         return rad.where(rad > 0, np.float32(np.nan))
 
@@ -288,16 +293,14 @@ class VISCalibrator:
 
         Reference: [PUG], equation (6).
         """
-        coefs = self.coefs['reflectance']
-        sza = self.solar_zenith_angle
-        sza = sza.where(da.fabs(sza) < 90,
-                        np.float32(np.nan))  # direct illumination only
+        sza = self.solar_zenith_angle.where(
+            da.fabs(self.solar_zenith_angle) < 90,
+            np.float32(np.nan)
+        )  # direct illumination only
         cos_sza = np.cos(np.deg2rad(sza))
-        distance_sun_earth2 = coefs['distance_sun_earth'] ** 2
-        solar_irradiance_vis = coefs['solar_irradiance_vis']
         refl = (
-           (np.pi * distance_sun_earth2) /
-           (solar_irradiance_vis * cos_sza) *
+           (np.pi * self.coefs['distance_sun_earth'] ** 2) /
+           (self.coefs['solar_irradiance'] * cos_sza) *
            rad
         )
         return self.refl_factor_to_percent(refl)
@@ -306,7 +309,7 @@ class VISCalibrator:
         """Update attributes of reflectance datasets."""
         refl.attrs['sun_earth_distance_correction_applied'] = True
         refl.attrs['sun_earth_distance_correction_factor'] = self.coefs[
-            'reflectance']['distance_sun_earth'].item()
+            'distance_sun_earth'].item()
         return refl
 
     @staticmethod
@@ -315,60 +318,133 @@ class VISCalibrator:
         return refl * 100
 
 
-def interp_tiepoints(ds, target_x, target_y):
-    """Interpolate dataset between tiepoints.
+class Navigator:
+    """Navigate MVIRI images."""
 
-    Uses linear interpolation.
+    def get_area_def(self, im_size, projection_longitude):
+        """Create MVIRI area definition."""
+        proj_params = self._get_proj_params(im_size, projection_longitude)
+        extent = get_area_extent(proj_params)
+        return get_area_definition(proj_params, extent)
 
-    FUTURE: [PUG] recommends cubic spline interpolation.
+    def _get_proj_params(self, im_size, projection_longitude):
+        """Get projection parameters for the given settings."""
+        area_name = 'geos_mviri_{0}x{0}'.format(im_size)
+        lfac, cfac, loff, coff = self._get_factors_offsets(im_size)
+        return {
+            'ssp_lon': projection_longitude,
+            'a': EQUATOR_RADIUS,
+            'b': POLE_RADIUS,
+            'h': ALTITUDE,
+            'units': 'm',
+            'loff': loff - im_size,
+            'coff': coff,
+            'lfac': -lfac,
+            'cfac': -cfac,
+            'nlines': im_size,
+            'ncols': im_size,
+            'scandir': 'S2N',  # Reference: [PUG] section 2.
+            'p_id': area_name,
+            'a_name': area_name,
+            'a_desc': 'MVIRI Geostationary Projection'
+        }
 
-    Args:
-        ds:
-            Dataset to be interpolated
-        target_x:
-            Target x coordinates
-        target_y:
-            Target y coordinates
-    """
-    # No tiepoint coordinates specified in the files. Use dimensions
-    # to calculate tiepoint sampling and assign tiepoint coordinates
-    # accordingly.
-    sampling = target_x.size // ds.coords['x'].size
-    ds = ds.assign_coords(x=target_x.values[::sampling],
-                          y=target_y.values[::sampling])
-
-    return ds.interp(x=target_x.values, y=target_y.values)
+    def _get_factors_offsets(self, im_size):
+        """Determine line/column offsets and scaling factors."""
+        # For offsets see variables "asamp" and "aline" of subroutine
+        # "refgeo" in [Handbook] and in
+        # https://github.com/FIDUCEO/FCDR_MVIRI/blob/master/lib/nrCrunch/cruncher.f
+        loff = coff = im_size / 2 + 0.5
+        lfac = cfac = sampling_to_lfac_cfac(
+            np.deg2rad(MVIRI_FIELD_OF_VIEW) / im_size
+        )
+        return lfac, cfac, loff, coff
 
 
-def interp_acq_time(time2d, target_y):
-    """Interpolate scanline acquisition time to the given coordinates.
+class Interpolator:
+    """Interpolate datasets to another resolution."""
 
-    The files provide timestamps per pixel for the low resolution
-    channels (IR/WV) only.
+    @staticmethod
+    def interp_tiepoints(ds, target_x, target_y):
+        """Interpolate dataset between tiepoints.
 
-    1) Average values in each line to obtain one timestamp per line.
-    2) For the VIS channel duplicate values in y-direction (as
-       advised by [PUG]).
+        Uses linear interpolation.
 
-    Note that the timestamps do not increase monotonically with the
-    line number in some cases.
+        FUTURE: [PUG] recommends cubic spline interpolation.
 
-    Returns:
-        Mean scanline acquisition timestamps
-    """
-    # Compute mean timestamp per scanline
-    time = time2d.mean(dim='x_ir_wv').rename({'y_ir_wv': 'y'})
+        Args:
+            ds:
+                Dataset to be interpolated
+            target_x:
+                Target x coordinates
+            target_y:
+                Target y coordinates
+        """
+        # No tiepoint coordinates specified in the files. Use dimensions
+        # to calculate tiepoint sampling and assign tiepoint coordinates
+        # accordingly.
+        sampling = target_x.size // ds.coords['x'].size
+        ds = ds.assign_coords(x=target_x.values[::sampling],
+                              y=target_y.values[::sampling])
 
-    # If required, repeat timestamps in y-direction to obtain higher
-    # resolution
-    y = time.coords['y'].values
-    if y.size < target_y.size:
-        reps = target_y.size // y.size
-        y_rep = np.repeat(y, reps)
-        time_hires = time.reindex(y=y_rep)
-        time_hires = time_hires.assign_coords(y=target_y)
-        return time_hires
-    return time
+        return ds.interp(x=target_x.values, y=target_y.values)
+
+    @staticmethod
+    def interp_acq_time(time2d, target_y):
+        """Interpolate scanline acquisition time to the given coordinates.
+
+        The files provide timestamps per pixel for the low resolution
+        channels (IR/WV) only.
+
+        1) Average values in each line to obtain one timestamp per line.
+        2) For the VIS channel duplicate values in y-direction (as
+           advised by [PUG]).
+
+        Note that the timestamps do not increase monotonically with the
+        line number in some cases.
+
+        Returns:
+            Mean scanline acquisition timestamps
+        """
+        # Compute mean timestamp per scanline
+        time = time2d.mean(dim='x_ir_wv').rename({'y_ir_wv': 'y'})
+
+        # If required, repeat timestamps in y-direction to obtain higher
+        # resolution
+        y = time.coords['y'].values
+        if y.size < target_y.size:
+            reps = target_y.size // y.size
+            y_rep = np.repeat(y, reps)
+            time_hires = time.reindex(y=y_rep)
+            time_hires = time_hires.assign_coords(y=target_y)
+            return time_hires
+        return time
+
+
+class VisQualityControl:
+    """Simple quality control for VIS channel."""
+
+    def __init__(self, mask):
+        """Initialize the quality control."""
+        self._mask = mask
+
+    def check(self):
+        """Check VIS channel quality and issue a warning if it's bad."""
+        use_with_caution = da.bitwise_and(self._mask, 2)
+        if use_with_caution.all():
+            warnings.warn(
+                'All pixels of the VIS channel are flagged as "use with '
+                'caution". Use datasets "quality_pixel_bitmask" and '
+                '"data_quality_bitmask" to find out why.'
+            )
+
+    def mask(self, ds):
+        """Mask VIS pixels with bad quality.
+
+        Pixels are considered bad quality if the "quality_pixel_bitmask" is
+        everything else than 0 (no flag set).
+        """
+        return ds.where(self._mask == 0, np.float32(np.nan))
 
 
 def is_high_resol(resolution):
@@ -382,28 +458,6 @@ class FiduceoMviriBase(BaseFileHandler):
     nc_keys = {
         'WV': 'count_wv',
         'IR': 'count_ir'
-    }
-    nc_keys_coefs = {
-        'WV': {
-            'radiance': {
-                'a': 'a_wv',
-                'b': 'b_wv'
-            },
-            'brightness_temperature': {
-                'a': 'bt_a_wv',
-                'b': 'bt_b_wv'
-            }
-        },
-        'IR': {
-            'radiance': {
-                'a': 'a_ir',
-                'b': 'b_ir'
-            },
-            'brightness_temperature': {
-                'a': 'bt_a_ir',
-                'b': 'bt_b_ir'
-            }
-        },
     }
 
     def __init__(self, filename, filename_info, filetype_info,
@@ -430,6 +484,7 @@ class FiduceoMviriBase(BaseFileHandler):
         # Projection longitude is not provided in the file, read it from the
         # filename.
         self.projection_longitude = float(filename_info['projection_longitude'])
+        self.calib_coefs = self._get_calib_coefs()
 
     def get_dataset(self, dataset_id, dataset_info):
         """Get the dataset."""
@@ -448,40 +503,13 @@ class FiduceoMviriBase(BaseFileHandler):
         """Get area definition of the given dataset."""
         if is_high_resol(dataset_id['resolution']):
             im_size = self.nc.coords['y'].size
-            area_name = 'geos_mviri_vis'
         else:
             im_size = self.nc.coords['y_ir_wv'].size
-            area_name = 'geos_mviri_ir_wv'
-
-        # Determine line/column offsets and scaling factors. For offsets
-        # see variables "asamp" and "aline" of subroutine "refgeo" in
-        # [Handbook] and in
-        # https://github.com/FIDUCEO/FCDR_MVIRI/blob/master/lib/nrCrunch/cruncher.f
-        loff = coff = im_size / 2 + 0.5
-        lfac = cfac = sampling_to_lfac_cfac(
-            np.deg2rad(MVIRI_FIELD_OF_VIEW) / im_size
+        nav = Navigator()
+        return nav.get_area_def(
+            im_size=im_size,
+            projection_longitude=self.projection_longitude
         )
-
-        pdict = {
-            'ssp_lon': self.projection_longitude,
-            'a': EQUATOR_RADIUS,
-            'b': POLE_RADIUS,
-            'h': ALTITUDE,
-            'units': 'm',
-            'loff': loff - im_size,
-            'coff': coff,
-            'lfac': -lfac,
-            'cfac': -cfac,
-            'nlines': im_size,
-            'ncols': im_size,
-            'scandir': 'S2N',  # Reference: [PUG] section 2.
-            'p_id': area_name,
-            'a_name': area_name,
-            'a_desc': 'MVIRI Geostationary Projection'
-        }
-        extent = get_area_extent(pdict)
-        area_def = get_area_definition(pdict, extent)
-        return area_def
 
     def _get_channel(self, name, resolution, calibration):
         """Get and calibrate channel data."""
@@ -492,10 +520,11 @@ class FiduceoMviriBase(BaseFileHandler):
             calibration=calibration
         )
         if name == 'VIS':
+            qc = VisQualityControl(self._read_dataset('quality_pixel_bitmask'))
             if self.mask_bad_quality:
-                ds = self._mask_vis(ds)
+                ds = qc.mask(ds)
             else:
-                self._check_vis_quality()
+                qc.check()
         ds['acq_time'] = ('y', self._get_acq_time(resolution))
         return ds
 
@@ -513,7 +542,7 @@ class FiduceoMviriBase(BaseFileHandler):
         else:
             target_x = self.nc.coords['x_ir_wv']
             target_y = self.nc.coords['y_ir_wv']
-        return interp_tiepoints(
+        return Interpolator.interp_tiepoints(
             angles,
             target_x=target_x,
             target_y=target_y
@@ -526,13 +555,9 @@ class FiduceoMviriBase(BaseFileHandler):
             ds = VISCalibrator.refl_factor_to_percent(ds)
         return ds
 
-    def _get_nc_key(self, ds_name):
-        """Get netCDF variable name for the given dataset."""
-        return self.nc_keys.get(ds_name, ds_name)
-
     def _read_dataset(self, name):
         """Read a dataset from the file."""
-        nc_key = self._get_nc_key(name)
+        nc_key = self.nc_keys.get(name, name)
         ds = self.nc[nc_key]
         if 'y_ir_wv' in ds.dims:
             ds = ds.rename({'y_ir_wv': 'y', 'x_ir_wv': 'x'})
@@ -543,6 +568,7 @@ class FiduceoMviriBase(BaseFileHandler):
             # high resolution data variables.
             ds = ds.assign_coords({'y': self.nc.coords['y'],
                                    'x': self.nc.coords['x']})
+        ds.attrs.pop('ancillary_variables', None)  # to avoid satpy warnings
         return ds
 
     def _update_attrs(self, ds, info):
@@ -555,70 +581,48 @@ class FiduceoMviriBase(BaseFileHandler):
 
     def _calibrate(self, ds, channel, calibration):
         """Calibrate the given dataset."""
-        ds.attrs.pop('ancillary_variables', None)  # to avoid satpy warnings
         if channel == 'VIS':
-            return self._calibrate_vis(ds, calibration)
-        elif channel in ['WV', 'IR']:
-            return self._calibrate_ir_wv(ds, channel, calibration)
+            return self._calibrate_vis(ds, channel, calibration)
         else:
-            raise KeyError('Don\'t know how to calibrate channel {}'.format(
-                channel))
+            calib = IRWVCalibrator(self.calib_coefs[channel])
+            return calib.calibrate(ds, calibration)
 
     @abc.abstractmethod
-    def _calibrate_vis(self, ds, calibration):
+    def _calibrate_vis(self, ds, channel, calibration):
         """Calibrate VIS channel. To be implemented by subclasses."""
         raise NotImplementedError
 
-    def _calibrate_ir_wv(self, ds, channel, calibration):
-        """Calibrate IR and WV channel."""
-        coefs = self._get_coefs_ir_wv(channel)
-        cal = IRWVCalibrator(coefs)
-        return cal.calibrate(ds, calibration)
+    def _get_calib_coefs(self):
+        """Get calibration coefficients for all channels.
 
-    def _get_coefs_ir_wv(self, channel):
-        """Get calibration coefficients for IR/WV channels."""
-        coefs = {}
-        for calibration in ('radiance', 'brightness_temperature'):
-            nc_key_a = self.nc_keys_coefs[channel][calibration]['a']
-            nc_key_b = self.nc_keys_coefs[channel][calibration]['b']
-            a = np.float32(self.nc[nc_key_a])
-            b = np.float32(self.nc[nc_key_b])
-            coefs[calibration] = (a, b)
-        return coefs
-
-    def _get_coefs_vis(self):
-        """Get VIS calibration coefs present in both file types."""
-        return {
-            'reflectance': {
-                'distance_sun_earth': np.float32(
-                    self.nc['distance_sun_earth']
-                ),
-                'solar_irradiance_vis': np.float32(
-                    self.nc['solar_irradiance_vis']
-                )
-            }
+        Note: Only coefficients present in both file types.
+        """
+        coefs = {
+            'VIS': {
+                'distance_sun_earth': self.nc['distance_sun_earth'],
+                'solar_irradiance': self.nc['solar_irradiance_vis']
+            },
+            'IR': {
+                'a': self.nc['a_ir'],
+                'b': self.nc['b_ir'],
+                'bt_a': self.nc['bt_a_ir'],
+                'bt_b': self.nc['bt_b_ir']
+            },
+            'WV': {
+                'a': self.nc['a_wv'],
+                'b': self.nc['b_wv'],
+                'bt_a': self.nc['bt_a_wv'],
+                'bt_b': self.nc['bt_b_wv']
+            },
         }
 
-    def _check_vis_quality(self):
-        """Check VIS channel quality and issue a warning if it's bad."""
-        mask = self._read_dataset('quality_pixel_bitmask')
-        use_with_caution = da.bitwise_and(mask, 2)
-        if use_with_caution.all():
-            warnings.warn(
-                'All pixels of the VIS channel are flagged as "use with '
-                'caution". Use datasets "quality_pixel_bitmask" and '
-                '"data_quality_bitmask" to find out why.'
-            )
+        # Convert coefficients to 32bit float to reduce memory footprint
+        # of calibrated data.
+        for ch in coefs:
+            for name in coefs[ch]:
+                coefs[ch][name] = np.float32(coefs[ch][name])
 
-    def _mask_vis(self, ds):
-        """Mask VIS pixels with bad quality.
-
-        Pixels are considered bad quality if the "quality_pixel_bitmask" is
-        everything else than 0 (no flag set).
-        """
-        mask = self._read_dataset('quality_pixel_bitmask')
-        return ds.where(mask == 0,
-                        np.float32(np.nan))
+        return coefs
 
     @lru_cache(maxsize=3)  # Three channels
     def _get_acq_time(self, resolution):
@@ -636,7 +640,7 @@ class FiduceoMviriBase(BaseFileHandler):
             target_y = self.nc.coords['x']
         else:
             target_y = self.nc.coords['x_ir_wv']
-        return interp_acq_time(time2d, target_y=target_y.values)
+        return Interpolator.interp_acq_time(time2d, target_y=target_y.values)
 
     def _get_orbital_parameters(self):
         """Get the orbital parameters."""
@@ -688,13 +692,13 @@ class FiduceoMviriEasyFcdrFileHandler(FiduceoMviriBase):
     nc_keys = FiduceoMviriBase.nc_keys.copy()
     nc_keys['VIS'] = 'toa_bidirectional_reflectance_vis'
 
-    def _calibrate_vis(self, ds, calibration):
+    def _calibrate_vis(self, ds, channel, calibration):
         """Calibrate VIS channel.
 
         Easy FCDR provides reflectance only, no counts or radiance.
         """
         if calibration == 'reflectance':
-            coefs = self._get_coefs_vis()
+            coefs = self.calib_coefs[channel]
             cal = VISCalibrator(coefs)
             refl = cal.refl_factor_to_percent(ds)
             refl = cal.update_refl_attrs(refl)
@@ -712,26 +716,24 @@ class FiduceoMviriFullFcdrFileHandler(FiduceoMviriBase):
     nc_keys = FiduceoMviriBase.nc_keys.copy()
     nc_keys['VIS'] = 'count_vis'
 
-    def _get_coefs_vis(self):
-        """Get full set of calibration coefficients for VIS channel."""
-        coefs = super()._get_coefs_vis()
-        coefs.update({
-            'radiance': {
-                'years_since_launch': np.float32(self.nc['years_since_launch']),
-                'a0_vis': np.float32(self.nc['a0_vis']),
-                'a1_vis': np.float32(self.nc['a1_vis']),
-                'a2_vis': np.float32(self.nc['a2_vis']),
-                'mean_count_space_vis': np.float32(
-                    self.nc['mean_count_space_vis']
-                )
-            },
+    def _get_calib_coefs(self):
+        """Add additional VIS coefficients only present in full FCDR."""
+        coefs = super()._get_calib_coefs()
+        coefs['VIS'].update({
+            'years_since_launch': np.float32(self.nc['years_since_launch']),
+            'a0': np.float32(self.nc['a0_vis']),
+            'a1': np.float32(self.nc['a1_vis']),
+            'a2': np.float32(self.nc['a2_vis']),
+            'mean_count_space': np.float32(
+                self.nc['mean_count_space_vis']
+            )
         })
         return coefs
 
-    def _calibrate_vis(self, ds, calibration):
-        coefs = self._get_coefs_vis()
+    def _calibrate_vis(self, ds, channel, calibration):
+        """Calibrate VIS channel."""
         sza = None
         if calibration == 'reflectance':
             sza = self._get_angles('solar_zenith_angle', HIGH_RESOL)
-        cal = VISCalibrator(coefs, sza)
+        cal = VISCalibrator(self.calib_coefs[channel], sza)
         return cal.calibrate(ds, calibration)

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -368,12 +368,10 @@ class FiduceoMviriBase(BaseFileHandler):
 
         Reference: [PUG], equations (4.1) and (4.2).
         """
-        if channel == 'WV':
-            a, b = self.nc['a_wv'], self.nc['b_wv']
-        else:
-            a, b = self.nc['a_ir'], self.nc['b_ir']
-        a = np.float32(a)
-        b = np.float32(b)
+        nc_key_a = self.nc_keys_coefs[channel]['radiance']['a']
+        nc_key_b = self.nc_keys_coefs[channel]['radiance']['b']
+        a = np.float32(self.nc[nc_key_a])
+        b = np.float32(self.nc[nc_key_b])
         rad = a + b * counts
         return rad.where(rad > 0, np.float32(np.nan))
 
@@ -382,12 +380,10 @@ class FiduceoMviriBase(BaseFileHandler):
 
         Reference: [PUG], equations (5.1) and (5.2).
         """
-        if channel == 'WV':
-            a, b = self.nc['bt_a_wv'], self.nc['bt_b_wv']
-        else:
-            a, b = self.nc['bt_a_ir'], self.nc['bt_b_ir']
-        a = np.float32(a)
-        b = np.float32(b)
+        nc_key_a = self.nc_keys_coefs[channel]['brightness_temperature']['a']
+        nc_key_b = self.nc_keys_coefs[channel]['brightness_temperature']['b']
+        a = np.float32(self.nc[nc_key_a])
+        b = np.float32(self.nc[nc_key_b])
         bt = b / (np.log(rad) - a)
         return bt.where(bt > 0, np.float32(np.nan))
 

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -648,7 +648,7 @@ class FiduceoMviriBase(BaseFileHandler):
         return calib.calibrate(ds, calibration)
 
     @abc.abstractmethod
-    def _calibrate_vis(self, ds, channel, calibration):
+    def _calibrate_vis(self, ds, channel, calibration):  # pragma: no cover
         """Calibrate VIS channel. To be implemented by subclasses."""
         raise NotImplementedError
 

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -196,12 +196,7 @@ class FiduceoMviriBase(BaseFileHandler):
 
         # Projection longitude is not provided in the file, read it from the
         # filename.
-        self.projection_longitude = filename_info['projection_longitude']
-
-    @abc.abstractproperty
-    def nc_keys(self):
-        """Map satpy dataset names to netCDF variables."""
-        raise NotImplementedError
+        self.projection_longitude = float(filename_info['projection_longitude'])
 
     def get_dataset(self, dataset_id, info):
         """Get the dataset."""

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -110,17 +110,17 @@ RevisionSelectionMethod=LatestReleased&Rendition=Web
 """
 
 import abc
-import dask.array as da
 import functools
+
+import dask.array as da
 import numpy as np
 import xarray as xr
 
 from satpy import CHUNK_SIZE
-from satpy.readers.file_handlers import BaseFileHandler
+from satpy.dataset.dataid import DataQuery
 from satpy.readers._geos_area import (ang2fac, get_area_definition,
                                       get_area_extent)
-from satpy.dataset.dataid import DataQuery
-
+from satpy.readers.file_handlers import BaseFileHandler
 
 EQUATOR_RADIUS = 6378140.0
 POLE_RADIUS = 6356755.0
@@ -269,10 +269,6 @@ class FiduceoMviriBase(BaseFileHandler):
             ds = self._interp_angles(ds, dataset_id)
         self._update_attrs(ds, dataset_info)
         return ds
-
-    def _get_nc_key(self, name):
-        """Get netCDF key corresponding to the given dataset name."""
-        return
 
     def _read_dataset(self, name):
         """Read a dataset from the file."""

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -210,7 +210,9 @@ class IRWVCalibrator:
         elif calibration in ('radiance', 'brightness_temperature'):
             return self._calibrate_rad_bt(counts, calibration)
         else:
-            raise KeyError('Invalid calibration: {}'.format(calibration.name))
+            raise KeyError(
+                'Invalid IR/WV calibration: {}'.format(calibration.name)
+            )
 
     def _calibrate_rad_bt(self, counts, calibration):
         """Calibrate counts to radiance or brightness temperature."""
@@ -260,7 +262,9 @@ class VISCalibrator:
         elif calibration in ('radiance', 'reflectance'):
             return self._calibrate_rad_refl(counts, calibration)
         else:
-            raise KeyError('Invalid calibration: {}'.format(calibration.name))
+            raise KeyError(
+                'Invalid VIS calibration: {}'.format(calibration.name)
+            )
 
     def _calibrate_rad_refl(self, counts, calibration):
         """Calibrate counts to radiance or reflectance."""

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -114,11 +114,11 @@ If you need the angles in both resolutions, use data queries:
 
     from satpy import DataQuery
 
-    q_vis = DataQuery(
+    query_vis = DataQuery(
         name='solar_zenith_angle',
         resolution=2250
     )
-    q_ir = DataQuery(
+    query_ir = DataQuery(
         name='solar_zenith_angle',
         resolution=4500
     )

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -583,9 +583,8 @@ class FiduceoMviriBase(BaseFileHandler):
         """Calibrate the given dataset."""
         if channel == 'VIS':
             return self._calibrate_vis(ds, channel, calibration)
-        else:
-            calib = IRWVCalibrator(self.calib_coefs[channel])
-            return calib.calibrate(ds, calibration)
+        calib = IRWVCalibrator(self.calib_coefs[channel])
+        return calib.calibrate(ds, calibration)
 
     @abc.abstractmethod
     def _calibrate_vis(self, ds, channel, calibration):

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -390,18 +390,19 @@ class FiduceoMviriBase(BaseFileHandler):
 
     def _get_orbital_parameters(self):
         """Get the orbital parameters."""
-        ssp_lon, ssp_lat = self._get_ssp_lonlat()
         orbital_parameters = {
             'projection_longitude': self.projection_longitude,
             'projection_latitude': 0.0,
             'projection_altitude': ALTITUDE
         }
+        ssp_lon, ssp_lat = self._get_ssp_lonlat()
         if not np.isnan(ssp_lon) and not np.isnan(ssp_lat):
             orbital_parameters.update({
                 'satellite_actual_longitude': ssp_lon,
                 'satellite_actual_latitude': ssp_lat,
                 # altitude not available
             })
+        return orbital_parameters
 
     def _get_ssp_lonlat(self):
         """Get longitude and latitude at the subsatellite point.

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -528,20 +528,20 @@ class FiduceoMviriBase(BaseFileHandler):
             target_y = self.nc.coords['y_ir_wv']
         return self._interp_angles_cached(
             angles=angles,
-            nc_key=self._get_nc_key(dataset_id['name']),
+            name=dataset_id['name'],
             target_x=target_x,
             target_y=target_y
         )
 
     @interp_cache(
-        keys=('nc_key', 'target_x', 'target_y'),
+        keys=('name', 'target_x', 'target_y'),
         hash_funcs={
-            'nc_key': lambda nc_key: nc_key,
+            'name': lambda name: name,
             'target_x': lambda x: x.size,
             'target_y': lambda y: y.size
         }
     )
-    def _interp_angles_cached(self, angles, nc_key, target_x, target_y):
+    def _interp_angles_cached(self, angles, name, target_x, target_y):
         """Interpolate angles to the given resolution."""
         return self._interp_tiepoints(angles,
                                       target_x,

--- a/satpy/tests/reader_tests/test_geos_area.py
+++ b/satpy/tests/reader_tests/test_geos_area.py
@@ -21,7 +21,7 @@ import unittest
 from satpy.readers._geos_area import (get_xy_from_linecol,
                                       get_area_extent,
                                       get_area_definition,
-                                      ang2fac)
+                                      sampling_to_lfac_cfac)
 
 import numpy as np
 
@@ -147,8 +147,8 @@ class TestGEOSProjectionUtil(unittest.TestCase):
         self.assertEqual(b, 6356583.8)
         self.assertEqual(a_def.proj_dict['h'], 35785831)
 
-    def test_ang2fac(self):
+    def test_sampling_to_lfac_cfac(self):
         """Test conversion from angular sampling to line/column offset."""
         lfac = 13642337  # SEVIRI LFAC
         sampling = np.deg2rad(2 ** 16 / lfac)
-        np.testing.assert_allclose(ang2fac(sampling), lfac)
+        np.testing.assert_allclose(sampling_to_lfac_cfac(sampling), lfac)

--- a/satpy/tests/reader_tests/test_geos_area.py
+++ b/satpy/tests/reader_tests/test_geos_area.py
@@ -20,7 +20,8 @@
 import unittest
 from satpy.readers._geos_area import (get_xy_from_linecol,
                                       get_area_extent,
-                                      get_area_definition)
+                                      get_area_definition,
+                                      ang2fac)
 
 import numpy as np
 
@@ -145,3 +146,9 @@ class TestGEOSProjectionUtil(unittest.TestCase):
         self.assertEqual(a, 6378169)
         self.assertEqual(b, 6356583.8)
         self.assertEqual(a_def.proj_dict['h'], 35785831)
+
+    def test_ang2fac(self):
+        """Test conversion from angular sampling to line/column offset."""
+        lfac = 13642337  # SEVIRI LFAC
+        sampling = np.deg2rad(2 ** 16 / lfac)
+        np.testing.assert_allclose(ang2fac(sampling), lfac)

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -208,7 +208,7 @@ ir_bt_exp = xr.DataArray(
 )
 quality_pixel_bitmask_exp = xr.DataArray(
     np.array(
-        [[2, 0, 0, 0],
+        [[0, 0, 0, 0],
          [0, 0, 0, 0],
          [0, 0, 1, 0],
          [0, 0, 0, 0]],
@@ -287,7 +287,7 @@ def fake_dataset():
     )
     mask = da.from_array(
         np.array(
-            [[2, 0, 0, 0],  # 2 = "use with caution"
+            [[0, 0, 0, 0],
              [0, 0, 0, 0],
              [0, 0, 1, 0],  # 1 = "invalid"
              [0, 0, 0, 0]],

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -260,15 +260,15 @@ area_vis_exp = AreaDefinition(
         'a': EQUATOR_RADIUS,
         'b': POLE_RADIUS
     },
-    width=5000,
-    height=5000,
+    width=4,
+    height=4,
     area_extent=[5621229.74392, 5621229.74392, -5621229.74392, -5621229.74392]
 )
 area_ir_wv_exp = area_vis_exp.copy(
     area_id='geos_mviri_ir_wv',
     proj_id='geos_mviri_ir_wv',
-    width=2500,
-    height=2500
+    width=2,
+    height=2
 )
 
 
@@ -379,8 +379,8 @@ class TestFiduceoMviriFileHandlers:
             ('IR', 'radiance', 4500, ir_rad_exp),
             ('IR', 'brightness_temperature', 4500, ir_bt_exp),
             ('quality_pixel_bitmask', None, 2250, quality_pixel_bitmask_exp),
-            ('solar_zenith_angle_vis', None, 2250, sza_vis_exp),
-            ('solar_zenith_angle_ir_wv', None, 4500, sza_ir_wv_exp),
+            ('solar_zenith_angle', None, 2250, sza_vis_exp),
+            ('solar_zenith_angle', None, 4500, sza_ir_wv_exp),
             ('u_independent_toa_bidirectional_reflectance', None, 4500, u_vis_refl_exp)
         ]
     )
@@ -472,9 +472,9 @@ class TestFiduceoMviriFileHandlers:
             ('VIS', 2250, area_vis_exp),
             ('WV', 4500, area_ir_wv_exp),
             ('IR', 4500, area_ir_wv_exp),
-            ('quality_pixel_bitmask', 4500, area_vis_exp),
-            ('solar_zenith_angle_vis', 4500, area_vis_exp),
-            ('solar_zenith_angle_ir_wv', 2250, area_ir_wv_exp)
+            ('quality_pixel_bitmask', 2250, area_vis_exp),
+            ('solar_zenith_angle', 2250, area_vis_exp),
+            ('solar_zenith_angle', 4500, area_ir_wv_exp)
         ]
     )
     def test_get_area_definition(self, file_handler, name, resolution,
@@ -486,6 +486,8 @@ class TestFiduceoMviriFileHandlers:
         a_exp, b_exp = proj4_radius_parameters(area_exp.proj_dict)
         assert a == a_exp
         assert b == b_exp
+        assert area.width == area_exp.width
+        assert area.height == area_exp.height
         for key in ['h', 'lon_0', 'proj', 'units']:
             assert area.proj_dict[key] == area_exp.proj_dict[key]
         np.testing.assert_allclose(area.area_extent, area_exp.area_extent)

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -430,10 +430,10 @@ class TestFiduceoMviriFileHandlers:
     def test_get_dataset_corrupt(self, file_handler):
         """Test getting datasets with known corruptions."""
         # Time may have different names and satellite position might be missing
-        file_handler.nc = file_handler.nc.rename(
+        file_handler.nc.nc = file_handler.nc.nc.rename(
             {'time_ir_wv': 'time'}
         )
-        file_handler.nc = file_handler.nc.drop_vars(
+        file_handler.nc.nc = file_handler.nc.nc.drop_vars(
             ['sub_satellite_longitude_start']
         )
 
@@ -564,7 +564,7 @@ class TestFiduceoMviriFileHandlers:
     @pytest.mark.file_handler_data(mask_bad_quality=False)
     def test_bad_quality_warning(self, file_handler):
         """Test warning about bad VIS quality."""
-        file_handler.nc['quality_pixel_bitmask'] = 2
+        file_handler.nc.nc['quality_pixel_bitmask'] = 2
         vis = make_dataid(name='VIS', resolution=2250,
                           calibration='reflectance')
         with pytest.warns(UserWarning):

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -58,10 +58,13 @@ acq_time_vis_exp = [np.datetime64('1970-01-01 00:30'),
                     np.datetime64('1970-01-01 02:30'),
                     np.datetime64('1970-01-01 02:30')]
 vis_counts_exp = xr.DataArray(
-    [[0., 17., 34., 51.],
-     [68., 85., 102., 119.],
-     [136., 153., np.nan, 187.],
-     [204., 221., 238., 255]],
+    np.array(
+        [[0., 17., 34., 51.],
+         [68., 85., 102., 119.],
+         [136., 153., np.nan, 187.],
+         [204., 221., 238., 255]],
+        dtype=np.float32
+    ),
     dims=('y', 'x'),
     coords={
         'y': [1, 2, 3, 4],
@@ -71,10 +74,13 @@ vis_counts_exp = xr.DataArray(
     attrs=attrs_exp
 )
 vis_rad_exp = xr.DataArray(
-    [[np.nan, 18.56, 38.28, 58.],
-     [77.72, 97.44, 117.16, 136.88],
-     [156.6, 176.32, np.nan, 215.76],
-     [235.48, 255.2, 274.92, 294.64]],
+    np.array(
+        [[np.nan, 18.56, 38.28, 58.],
+         [77.72, 97.44, 117.16, 136.88],
+         [156.6, 176.32, np.nan, 215.76],
+         [235.48, 255.2, 274.92, 294.64]],
+        dtype=np.float32
+    ),
     dims=('y', 'x'),
     coords={
         'y': [1, 2, 3, 4],
@@ -84,10 +90,13 @@ vis_rad_exp = xr.DataArray(
     attrs=attrs_exp
 )
 vis_refl_exp = xr.DataArray(
-    [[np.nan, 23.440929, np.nan, np.nan],
-     [40.658744, 66.602233, 147.970867, np.nan],
-     [75.688217, 92.240733, np.nan, np.nan],
-     [np.nan, np.nan, np.nan, np.nan]],
+    np.array(
+        [[np.nan, 23.440929, np.nan, np.nan],
+         [40.658744, 66.602233, 147.970867, np.nan],
+         [75.688217, 92.240733, np.nan, np.nan],
+         [np.nan, np.nan, np.nan, np.nan]],
+        dtype=np.float32
+    ),
     # (0, 0) and (2, 2) are NaN because radiance is NaN
     # (0, 2) is NaN because SZA >= 90 degrees
     # Last row/col is NaN due to SZA interpolation
@@ -102,8 +111,11 @@ vis_refl_exp = xr.DataArray(
 acq_time_ir_wv_exp = [np.datetime64('1970-01-01 00:30'),
                       np.datetime64('1970-01-01 02:30')]
 wv_counts_exp = xr.DataArray(
-    [[0, 85],
-     [170, 255]],
+    np.array(
+        [[0, 85],
+         [170, 255]],
+        dtype=np.uint8
+    ),
     dims=('y', 'x'),
     coords={
         'y': [1, 2],
@@ -113,8 +125,11 @@ wv_counts_exp = xr.DataArray(
     attrs=attrs_exp
 )
 wv_rad_exp = xr.DataArray(
-    [[np.nan, 3.75],
-     [8, 12.25]],
+    np.array(
+        [[np.nan, 3.75],
+         [8, 12.25]],
+        dtype=np.float32
+    ),
     dims=('y', 'x'),
     coords={
         'y': [1, 2],
@@ -124,8 +139,11 @@ wv_rad_exp = xr.DataArray(
     attrs=attrs_exp
 )
 wv_bt_exp = xr.DataArray(
-    [[np.nan, 230.461366],
-     [252.507448, 266.863289]],
+    np.array(
+        [[np.nan, 230.461366],
+         [252.507448, 266.863289]],
+        dtype=np.float32
+    ),
     dims=('y', 'x'),
     coords={
         'y': [1, 2],
@@ -135,8 +153,11 @@ wv_bt_exp = xr.DataArray(
     attrs=attrs_exp
 )
 ir_counts_exp = xr.DataArray(
-    [[0, 85],
-     [170, 255]],
+    np.array(
+        [[0, 85],
+         [170, 255]],
+        dtype=np.uint8
+    ),
     dims=('y', 'x'),
     coords={
         'y': [1, 2],
@@ -146,8 +167,11 @@ ir_counts_exp = xr.DataArray(
     attrs=attrs_exp
 )
 ir_rad_exp = xr.DataArray(
-    [[np.nan, 80],
-     [165, 250]],
+    np.array(
+        [[np.nan, 80],
+         [165, 250]],
+        dtype=np.float32
+    ),
     dims=('y', 'x'),
     coords={
         'y': [1, 2],
@@ -157,8 +181,11 @@ ir_rad_exp = xr.DataArray(
     attrs=attrs_exp
 )
 ir_bt_exp = xr.DataArray(
-    [[np.nan, 178.00013189],
-     [204.32955838, 223.28709913]],
+    np.array(
+        [[np.nan, 178.00013189],
+         [204.32955838, 223.28709913]],
+        dtype=np.float32
+    ),
     dims=('y', 'x'),
     coords={
         'y': [1, 2],
@@ -168,10 +195,13 @@ ir_bt_exp = xr.DataArray(
     attrs=attrs_exp
 )
 quality_pixel_bitmask_exp = xr.DataArray(
-    [[2, 0, 0, 0],
-     [0, 0, 0, 0],
-     [0, 0, 1, 0],
-     [0, 0, 0, 0]],
+    np.array(
+        [[2, 0, 0, 0],
+         [0, 0, 0, 0],
+         [0, 0, 1, 0],
+         [0, 0, 0, 0]],
+        dtype=np.uint8
+    ),
     dims=('y', 'x'),
     coords={
         'y': [1, 2, 3, 4],
@@ -180,10 +210,13 @@ quality_pixel_bitmask_exp = xr.DataArray(
     attrs=attrs_exp
 )
 sza_vis_exp = xr.DataArray(
-    [[45., 67.5, 90., np.nan],
-     [22.5, 45., 67.5, np.nan],
-     [0., 22.5, 45., np.nan],
-     [np.nan, np.nan, np.nan, np.nan]],
+    np.array(
+        [[45., 67.5, 90., np.nan],
+         [22.5, 45., 67.5, np.nan],
+         [0., 22.5, 45., np.nan],
+         [np.nan, np.nan, np.nan, np.nan]],
+        dtype=np.float32
+    ),
     dims=('y', 'x'),
     coords={
         'y': [1, 2, 3, 4],
@@ -192,8 +225,11 @@ sza_vis_exp = xr.DataArray(
     attrs=attrs_exp
 )
 sza_ir_wv_exp = xr.DataArray(
-    [[45, 90],
-     [0, 45]],
+    np.array(
+        [[45, 90],
+         [0, 45]],
+        dtype=np.float32
+    ),
     dims=('y', 'x'),
     coords={
         'y': [1, 2],
@@ -227,18 +263,24 @@ area_ir_wv_exp = area_vis_exp.copy(
 @pytest.fixture()
 def fake_dataset():
     """Create fake dataset."""
-    count_ir = da.linspace(0, 255, 4, dtype=np.float32).reshape(2, 2)
-    count_wv = da.linspace(0, 255, 4, dtype=np.float32).reshape(2, 2)
-    count_vis = da.linspace(0, 255, 16, dtype=np.float32).reshape(4, 4)
+    count_ir = da.linspace(0, 255, 4, dtype=np.uint8).reshape(2, 2)
+    count_wv = da.linspace(0, 255, 4, dtype=np.uint8).reshape(2, 2)
+    count_vis = da.linspace(0, 255, 16, dtype=np.uint8).reshape(4, 4)
     sza = da.from_array(
-        [[45, 90],
-         [0, 45]]
-    ).astype(np.float32)
+        np.array(
+            [[45, 90],
+             [0, 45]],
+            dtype=np.float32
+        )
+    )
     mask = da.from_array(
-        [[2, 0, 0, 0],  # 2 = "use with caution"
-         [0, 0, 0, 0],
-         [0, 0, 1, 0],  # 1 = "invalid"
-         [0, 0, 0, 0]]
+        np.array(
+            [[2, 0, 0, 0],  # 2 = "use with caution"
+             [0, 0, 0, 0],
+             [0, 0, 1, 0],  # 1 = "invalid"
+             [0, 0, 0, 0]],
+            dtype=np.uint8
+        )
     )
     time = np.arange(4).astype('datetime64[h]').reshape(2, 2)
     ds = xr.Dataset(
@@ -356,6 +398,7 @@ class TestFiduceoMviriFileHandlers:
         else:
             ds = file_handler.get_dataset(dataset_id, dataset_info)
             xr.testing.assert_allclose(ds, expected)
+            assert ds.dtype == expected.dtype
             assert ds.attrs == expected.attrs
 
     def test_time_cache(self, file_handler):

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -431,7 +431,7 @@ class TestFiduceoMviriFileHandlers:
 
     def test_angle_cache(self, file_handler):
         """Test caching of angle datasets."""
-        nc_key = 'mykey'
+        name = 'my_angles'
         x1 = y1 = xr.DataArray([1, 2, 3, 4])
         sza_coarse = xr.DataArray(
             [[45, 90],
@@ -440,7 +440,7 @@ class TestFiduceoMviriFileHandlers:
         )
         sza1 = file_handler._interp_angles_cached(
             angles=sza_coarse,
-            nc_key=nc_key,
+            name=name,
             target_x=x1,
             target_y=y1
         )
@@ -449,7 +449,7 @@ class TestFiduceoMviriFileHandlers:
         # should not interpolate them again.
         sza2 = file_handler._interp_angles_cached(
             angles=sza_coarse - 10,
-            nc_key=nc_key,
+            name=name,
             target_x=x1,
             target_y=y1
         )
@@ -459,7 +459,7 @@ class TestFiduceoMviriFileHandlers:
         x2 = y2 = xr.DataArray([1, 2])
         sza3 = file_handler._interp_angles_cached(
             angles=sza_coarse,
-            nc_key=nc_key,
+            name=name,
             target_x=x2,
             target_y=y2
         )

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -513,16 +513,21 @@ class TestFiduceoMviriFileHandlers:
 
     def test_calib_exceptions(self, file_handler):
         """Test calibration exceptions."""
-        ds = xr.Dataset()
         with pytest.raises(KeyError):
-            file_handler.calibrate(ds, 'solar_zenith_angle', None)
-
-        calib = mock.MagicMock()
-        calib.configure_mock(name='invalid_calib')
+            file_handler.get_dataset(
+                make_dataid(name='solar_zenith_angle', calibration='counts'),
+                {}
+            )
         with pytest.raises(KeyError):
-            file_handler.calibrate(ds, 'VIS', calib)
+            file_handler.get_dataset(
+                {'name': 'VIS', 'calibration': 'invalid'},
+                {}
+            )
         with pytest.raises(KeyError):
-            file_handler.calibrate(ds, 'IR', calib)
+            file_handler.get_dataset(
+                {'name': 'IR', 'calibration': 'invalid'},
+                {}
+            )
 
     @pytest.mark.file_handler_data(mask_bad_quality=False)
     def test_bad_quality_warning(self, file_handler):

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -427,9 +427,7 @@ class TestFiduceoMviriFileHandlers:
             assert ds.dtype == expected.dtype
             assert ds.attrs == expected.attrs
 
-    @mock.patch(
-        'satpy.readers.mviri_l1b_fiduceo_nc.FiduceoMviriBase._interp_acq_time'
-    )
+    @mock.patch('satpy.readers.mviri_l1b_fiduceo_nc.interp_acq_time')
     def test_time_cache(self, interp_acq_time, file_handler):
         """Test caching of acquisition times."""
         dataset_id = make_dataid(
@@ -460,9 +458,7 @@ class TestFiduceoMviriFileHandlers:
         file_handler.get_dataset(another_id, info)
         interp_acq_time.assert_called()
 
-    @mock.patch(
-        'satpy.readers.mviri_l1b_fiduceo_nc.FiduceoMviriBase._interp_tiepoints'
-    )
+    @mock.patch('satpy.readers.mviri_l1b_fiduceo_nc.interp_tiepoints')
     def test_angle_cache(self, interp_tiepoints, file_handler):
         """Test caching of angle datasets."""
         dataset_id = make_dataid(name='solar_zenith_angle',

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for the FIDUCEO MVIRI FCDR Reader."""
+
+import dask.array as da
+import numpy as np
+import pytest
+from unittest import mock
+import xarray as xr
+
+from satpy.tests.utils import make_dataid
+from satpy.readers.mviri_l1b_fiduceo_nc import (
+    FiduceoMviriEasyFcdrFileHandler,
+    FiduceoMviriFullFcdrFileHandler
+)
+
+
+attrs_exp = {
+    'platform': 'MET7',
+    'raw_metadata': {'foo': 'bar'},
+    'sensor': 'MVIRI',
+    'orbital_parameters': {
+        'projection_longitude': 57.0,
+        'projection_latitude': 0.0,
+        'projection_altitude': 35785860.0,
+        'satellite_actual_longitude': 57.1,
+        'satellite_actual_latitude': 0.1,
+    }
+
+}
+attrs_refl_exp = attrs_exp.copy()
+attrs_refl_exp.update(
+    {'sun_earth_distance_correction_applied': True,
+     'sun_earth_distance_correction_factor': 1.}
+)
+acq_time_hires_exp = [np.datetime64('1970-01-01 00:30'),
+                      np.datetime64('1970-01-01 00:30'),
+                      np.datetime64('1970-01-01 02:30'),
+                      np.datetime64('1970-01-01 02:30')]
+vis_counts_exp = xr.DataArray(
+    [[0., 17., 34., 51.],
+     [68., 85., 102., 119.],
+     [136., 153., np.nan, 187.],
+     [204., 221., 238., 255]],
+    dims=('y', 'x'),
+    coords={
+        'y': [1, 2, 3, 4],
+        'x': [1, 2, 3, 4],
+        'acq_time': ('y', acq_time_hires_exp),
+    },
+    attrs=attrs_exp
+)
+vis_rad_exp = xr.DataArray(
+    [[np.nan, 18.56, 38.28, 58.],
+     [77.72, 97.44, 117.16, 136.88],
+     [156.6, 176.32, np.nan, 215.76],
+     [235.48, 255.2, 274.92, 294.64]],
+    dims=('y', 'x'),
+    coords={
+        'y': [1, 2, 3, 4],
+        'x': [1, 2, 3, 4],
+        'acq_time': ('y', acq_time_hires_exp),
+    },
+    attrs=attrs_exp
+)
+vis_refl_exp = xr.DataArray(
+    [[np.nan, 23.440929, np.nan, np.nan],
+     [40.658744, 66.602233, 147.970867, np.nan],
+     [75.688217, 92.240733, np.nan, np.nan],
+     [np.nan, np.nan, np.nan, np.nan]],
+    # (0, 0) and (2, 2) are NaN because radiance is NaN
+    # (0, 2) is NaN because SZA >= 90 degrees
+    # Last row/col is NaN due to SZA interpolation
+    dims=('y', 'x'),
+    coords={
+        'y': [1, 2, 3, 4],
+        'x': [1, 2, 3, 4],
+        'acq_time': ('y', acq_time_hires_exp),
+    },
+    attrs=attrs_refl_exp
+)
+acq_time_lores_exp = [np.datetime64('1970-01-01 00:30'),
+                      np.datetime64('1970-01-01 02:30')]
+wv_counts_exp = xr.DataArray(
+    [[0, 85],
+     [170, 255]],
+    dims=('y', 'x'),
+    coords={
+        'y': [1, 2],
+        'x': [1, 2],
+        'acq_time': ('y', acq_time_lores_exp),
+    },
+    attrs=attrs_exp
+)
+wv_rad_exp = xr.DataArray(
+    [[np.nan, 3.75],
+     [8, 12.25]],
+    dims=('y', 'x'),
+    coords={
+        'y': [1, 2],
+        'x': [1, 2],
+        'acq_time': ('y', acq_time_lores_exp),
+    },
+    attrs=attrs_exp
+)
+wv_bt_exp = xr.DataArray(
+    [[np.nan, 230.461366],
+     [252.507448, 266.863289]],
+    dims=('y', 'x'),
+    coords={
+        'y': [1, 2],
+        'x': [1, 2],
+        'acq_time': ('y', acq_time_lores_exp),
+    },
+    attrs=attrs_exp
+)
+ir_counts_exp = xr.DataArray(
+    [[0, 85],
+     [170, 255]],
+    dims=('y', 'x'),
+    coords={
+        'y': [1, 2],
+        'x': [1, 2],
+        'acq_time': ('y', acq_time_lores_exp),
+    },
+    attrs=attrs_exp
+)
+ir_rad_exp = xr.DataArray(
+    [[np.nan, 80],
+     [165, 250]],
+    dims=('y', 'x'),
+    coords={
+        'y': [1, 2],
+        'x': [1, 2],
+        'acq_time': ('y', acq_time_lores_exp),
+    },
+    attrs=attrs_exp
+)
+ir_bt_exp = xr.DataArray(
+    [[np.nan, 178.00013189],
+     [204.32955838, 223.28709913]],
+    dims=('y', 'x'),
+    coords={
+        'y': [1, 2],
+        'x': [1, 2],
+        'acq_time': ('y', acq_time_lores_exp),
+    },
+    attrs=attrs_exp
+)
+quality_pixel_bitmask_exp = xr.DataArray(
+    [[2, 0, 0, 0],
+     [0, 0, 0, 0],
+     [0, 0, 1, 0],
+     [0, 0, 0, 0]],
+    dims=('y', 'x'),
+    coords={
+        'y': [1, 2, 3, 4],
+        'x': [1, 2, 3, 4],
+    },
+    attrs=attrs_exp
+)
+sza_vis_exp = xr.DataArray(
+    [[45., 67.5, 90., np.nan],
+     [22.5, 45., 67.5, np.nan],
+     [0., 22.5, 45., np.nan],
+     [np.nan, np.nan, np.nan, np.nan]],
+    dims=('y', 'x'),
+    coords={
+        'y': [1, 2, 3, 4],
+        'x': [1, 2, 3, 4],
+    },
+    attrs=attrs_exp
+)
+sza_ir_wv_exp = xr.DataArray(
+    [[45, 90],
+     [0, 45]],
+    dims=('y', 'x'),
+    coords={
+        'y': [1, 2],
+        'x': [1, 2],
+    },
+    attrs=attrs_exp
+)
+
+
+@pytest.fixture()
+def fake_dataset():
+    """Create fake dataset."""
+    count_ir = da.linspace(0, 255, 4, dtype=np.float32).reshape(2, 2)
+    count_wv = da.linspace(0, 255, 4, dtype=np.float32).reshape(2, 2)
+    count_vis = da.linspace(0, 255, 16, dtype=np.float32).reshape(4, 4)
+    sza = da.from_array(
+        [[45, 90],
+         [0, 45]]
+    ).astype(np.float32)
+    mask = da.from_array(
+        [[2, 0, 0, 0],  # 2 = "use with caution"
+         [0, 0, 0, 0],
+         [0, 0, 1, 0],  # 1 = "invalid"
+         [0, 0, 0, 0]]
+    )
+    time = np.arange(4).astype('datetime64[h]').reshape(2, 2)
+    ds = xr.Dataset(
+        data_vars={
+            'count_vis': (('y', 'x'), count_vis),
+            'count_wv': (('y_ir_wv', 'x_ir_wv'), count_wv),
+            'count_ir': (('y_ir_wv', 'x_ir_wv'), count_ir),
+            'toa_bidirectional_reflectance_vis': (
+                ('y', 'x'), vis_refl_exp / 100),
+            'quality_pixel_bitmask': (('y', 'x'), mask),
+            'solar_zenith_angle': (('y_tie', 'x_tie'), sza),
+            'time_ir_wv': (('y_ir_wv', 'x_ir_wv'), time),
+            'a_ir': -5.0,
+            'b_ir': 1.0,
+            'bt_a_ir': 10.0,
+            'bt_b_ir': -1000.0,
+            'a_wv': -0.5,
+            'b_wv': 0.05,
+            'bt_a_wv': 10.0,
+            'bt_b_wv': -2000.0,
+            'years_since_launch': 20.0,
+            'a0_vis': 1.0,
+            'a1_vis': 0.01,
+            'a2_vis': -0.0001,
+            'mean_count_space_vis': 1.0,
+            'distance_sun_earth': 1.0,
+            'solar_irradiance_vis': 650.0,
+            'sub_satellite_longitude_start': 57.1,
+            'sub_satellite_longitude_end': np.nan,
+            'sub_satellite_latitude_start': np.nan,
+            'sub_satellite_latitude_end': 0.1,
+        },
+        coords={
+            'y': [1, 2, 3, 4],
+            'x': [1, 2, 3, 4],
+            'y_ir_wv': [1, 2],
+            'x_ir_wv': [1, 2],
+            'y_tie': [1, 2],
+            'x_tie': [1, 2]
+
+        },
+        attrs={'foo': 'bar'}
+    )
+    return ds
+
+
+@pytest.fixture(params=[FiduceoMviriEasyFcdrFileHandler,
+                        FiduceoMviriFullFcdrFileHandler])
+def file_handler(fake_dataset, request):
+    """Create mocked file handler."""
+    fh_class = request.param
+    with mock.patch('satpy.readers.mviri_l1b_fiduceo_nc.xr.open_dataset') as open_dataset:
+        open_dataset.return_value = fake_dataset
+        return fh_class(
+            filename='filename',
+            filename_info={'platform': 'MET7',
+                           'sensor': 'MVIRI',
+                           'projection_longitude': '57.0'},
+            filetype_info={'foo': 'bar'},
+            mask_bad_quality=True
+        )
+
+
+
+
+
+# TODO: Test file patterns
+
+
+
+
+
+
+class TestFiduceoMviriFileHandlers:
+    """Unit tests for FIDUCEO MVIRI file handlers."""
+
+    def test_init(self, file_handler):
+        """Test file handler initialization."""
+        assert file_handler.projection_longitude == 57.0
+        assert file_handler.mask_bad_quality is True
+
+    @pytest.mark.parametrize(
+        ('name', 'calibration', 'expected'),
+        [
+            ('VIS', 'counts', vis_counts_exp),
+            ('VIS', 'radiance', vis_rad_exp),
+            ('VIS', 'reflectance', vis_refl_exp),
+            ('WV', 'counts', wv_counts_exp),
+            ('WV', 'radiance', wv_rad_exp),
+            ('WV', 'brightness_temperature', wv_bt_exp),
+            ('IR', 'counts', ir_counts_exp),
+            ('IR', 'radiance', ir_rad_exp),
+            ('IR', 'brightness_temperature', ir_bt_exp),
+            ('quality_pixel_bitmask', None, quality_pixel_bitmask_exp),
+            ('solar_zenith_angle_vis', None, sza_vis_exp),
+            ('solar_zenith_angle_ir_wv', None, sza_ir_wv_exp)
+        ]
+    )
+    def test_get_dataset(self, file_handler, name, calibration, expected):
+        """Test getting datasets."""
+        id_keys = {'name': name}
+        if calibration:
+            id_keys['calibration'] = calibration
+        data_id = make_dataid(**id_keys)
+        info = {'platform': 'MET7'}
+
+        is_easy = isinstance(file_handler, FiduceoMviriEasyFcdrFileHandler)
+        is_vis = name == 'VIS'
+        is_refl = calibration == 'reflectance'
+        if is_easy and is_vis and not is_refl:
+            # VIS counts/radiance not available in easy FCDR
+            with pytest.raises(ValueError):
+                file_handler.get_dataset(data_id, info)
+        else:
+            ds = file_handler.get_dataset(data_id, info)
+            xr.testing.assert_allclose(ds, expected)
+            assert ds.attrs == expected.attrs
+
+    def test_time_cache(self, file_handler):
+        """Test caching of acquisition times."""
+        time2d = xr.DataArray(
+            np.array([[1, 2],
+                      [3, 4]],
+                     dtype='datetime64[h]'),
+            dims=('y_ir_wv', 'x_ir_wv')
+        )
+        y1 = xr.DataArray([1, 2, 3, 4])
+        t1 = file_handler._get_acq_time_cached(time2d, target_y=y1)
+
+        # Change 2d timestamps. If the cache works correctly, the second call
+        # should not average/interpolate them again.
+        t2 = file_handler._get_acq_time_cached(
+            time2d + np.timedelta64(1, 'h'), target_y=y1)
+        xr.testing.assert_equal(t2, t1)
+
+        # With new target coordinates we shouldn't hit the cache
+        y2 = xr.DataArray([1, 2])
+        t3 = file_handler._get_acq_time_cached(target_y=y2)
+        with pytest.raises(AssertionError):
+            xr.testing.assert_equal(t3, t1)
+
+    def test_angle_cache(self, file_handler):
+        """Test caching of angle datasets."""
+        nc_key = 'mykey'
+        x1 = y1 = xr.DataArray([1, 2, 3, 4])
+        sza_coarse = xr.DataArray(
+            [[45, 90],
+             [0, 45]],
+            dims=('y', 'x')
+        )
+        sza1 = file_handler._interp_angles_cached(
+            angles=sza_coarse,
+            nc_key=nc_key,
+            target_x=x1,
+            target_y=y1
+        )
+
+        # Change coarse angles. If the cache works correctly, the second call
+        # should not interpolate them again.
+        sza2 = file_handler._interp_angles_cached(
+            angles=sza_coarse - 10,
+            nc_key=nc_key,
+            target_x=x1,
+            target_y=y1
+        )
+        xr.testing.assert_equal(sza2, sza1)
+
+        # With new target coordinates we shouldn't hit the cache
+        x2 = y2 = xr.DataArray([1, 2])
+        sza3 = file_handler._interp_angles_cached(
+            angles=sza_coarse,
+            nc_key=nc_key,
+            target_x=x2,
+            target_y=y2
+        )
+        with pytest.raises(AssertionError):
+            xr.testing.assert_equal(sza3, sza1)

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -250,8 +250,8 @@ sza_ir_wv_exp = xr.DataArray(
     attrs=attrs_exp
 )
 area_vis_exp = AreaDefinition(
-    area_id='geos_mviri_vis',
-    proj_id='geos_mviri_vis',
+    area_id='geos_mviri_4x4',
+    proj_id='geos_mviri_4x4',
     description='MVIRI Geostationary Projection',
     projection={
         'proj': 'geos',
@@ -265,8 +265,8 @@ area_vis_exp = AreaDefinition(
     area_extent=[5621229.74392, 5621229.74392, -5621229.74392, -5621229.74392]
 )
 area_ir_wv_exp = area_vis_exp.copy(
-    area_id='geos_mviri_ir_wv',
-    proj_id='geos_mviri_ir_wv',
+    area_id='geos_mviri_2x2',
+    proj_id='geos_mviri_2x2',
     width=2,
     height=2
 )
@@ -427,7 +427,9 @@ class TestFiduceoMviriFileHandlers:
             assert ds.dtype == expected.dtype
             assert ds.attrs == expected.attrs
 
-    @mock.patch('satpy.readers.mviri_l1b_fiduceo_nc.interp_acq_time')
+    @mock.patch(
+        'satpy.readers.mviri_l1b_fiduceo_nc.Interpolator.interp_acq_time'
+    )
     def test_time_cache(self, interp_acq_time, file_handler):
         """Test caching of acquisition times."""
         dataset_id = make_dataid(
@@ -458,7 +460,9 @@ class TestFiduceoMviriFileHandlers:
         file_handler.get_dataset(another_id, info)
         interp_acq_time.assert_called()
 
-    @mock.patch('satpy.readers.mviri_l1b_fiduceo_nc.interp_tiepoints')
+    @mock.patch(
+        'satpy.readers.mviri_l1b_fiduceo_nc.Interpolator.interp_tiepoints'
+    )
     def test_angle_cache(self, interp_tiepoints, file_handler):
         """Test caching of angle datasets."""
         dataset_id = make_dataid(name='solar_zenith_angle',

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -272,8 +272,8 @@ area_ir_wv_exp = area_vis_exp.copy(
 )
 
 
-@pytest.fixture()
-def fake_dataset():
+@pytest.fixture(name='fake_dataset')
+def fixture_fake_dataset():
     """Create fake dataset."""
     count_ir = da.linspace(0, 255, 4, dtype=np.uint8).reshape(2, 2)
     count_wv = da.linspace(0, 255, 4, dtype=np.uint8).reshape(2, 2)
@@ -343,9 +343,12 @@ def fake_dataset():
     return ds
 
 
-@pytest.fixture(params=[FiduceoMviriEasyFcdrFileHandler,
-                        FiduceoMviriFullFcdrFileHandler])
-def file_handler(fake_dataset, request):
+@pytest.fixture(
+    name='file_handler',
+    params=[FiduceoMviriEasyFcdrFileHandler,
+            FiduceoMviriFullFcdrFileHandler]
+)
+def fixture_file_handler(fake_dataset, request):
     """Create mocked file handler."""
     marker = request.node.get_closest_marker("file_handler_data")
     mask_bad_quality = True
@@ -364,8 +367,8 @@ def file_handler(fake_dataset, request):
         )
 
 
-@pytest.fixture
-def reader():
+@pytest.fixture(name='reader')
+def fixture_reader():
     """Return MVIRI FIDUCEO FCDR reader."""
     from satpy.config import config_search_paths
     from satpy.readers import load_reader

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -338,6 +338,8 @@ def fake_dataset():
         },
         attrs={'foo': 'bar'}
     )
+    ds['count_ir'].attrs['ancillary_variables'] = 'a_ir b_ir'
+    ds['count_wv'].attrs['ancillary_variables'] = 'a_wv b_wv'
     return ds
 
 
@@ -494,15 +496,16 @@ class TestFiduceoMviriFileHandlers:
 
     def test_calib_exceptions(self, file_handler):
         """Test calibration exceptions."""
+        ds = xr.Dataset()
         with pytest.raises(KeyError):
-            file_handler.calibrate(None, 'solar_zenith_angle', None)
+            file_handler.calibrate(ds, 'solar_zenith_angle', None)
 
         calib = mock.MagicMock()
         calib.configure_mock(name='invalid_calib')
         with pytest.raises(KeyError):
-            file_handler.calibrate(None, 'VIS', calib)
+            file_handler.calibrate(ds, 'VIS', calib)
         with pytest.raises(KeyError):
-            file_handler.calibrate(None, 'IR', calib)
+            file_handler.calibrate(ds, 'IR', calib)
 
 
 @pytest.fixture

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -19,6 +19,7 @@
 
 import dask.array as da
 import numpy as np
+import os
 import pytest
 from unittest import mock
 import xarray as xr
@@ -344,16 +345,6 @@ def file_handler(fake_dataset, request):
         )
 
 
-
-
-
-# TODO: Test file patterns
-
-
-
-
-
-
 class TestFiduceoMviriFileHandlers:
     """Unit tests for FIDUCEO MVIRI file handlers."""
 
@@ -484,3 +475,29 @@ class TestFiduceoMviriFileHandlers:
         for key in ['h', 'lon_0', 'proj', 'units']:
             assert area.proj_dict[key] == area_exp.proj_dict[key]
         np.testing.assert_allclose(area.area_extent, area_exp.area_extent)
+
+
+@pytest.fixture
+def reader():
+    """Return MVIRI FIDUCEO FCDR reader."""
+    from satpy.config import config_search_paths
+    from satpy.readers import load_reader
+
+    reader_configs = config_search_paths(
+        os.path.join("readers", "mviri_l1b_fiduceo_nc.yaml"))
+    reader = load_reader(reader_configs)
+    return reader
+
+
+def test_file_pattern(reader):
+    """Test file pattern matching."""
+    filenames = [
+        "FIDUCEO_FCDR_L15_MVIRI_MET7-57.0_201701201000_201701201030_FULL_v2.6_fv3.1.nc",
+        "FIDUCEO_FCDR_L15_MVIRI_MET7-57.0_201701201000_201701201030_EASY_v2.6_fv3.1.nc",
+        "FIDUCEO_FCDR_L15_MVIRI_MET7-00.0_201701201000_201701201030_EASY_v2.6_fv3.1.nc",
+        "abcde",
+    ]
+
+    files = reader.select_files_from_pathnames(filenames)
+    # only 3 out of 4 above should match
+    assert len(files) == 3


### PR DESCRIPTION
Add a reader for FIDUCEO MVIRI FCDR data in netCDF format. Both full and easy FCDR are supported. 

---

Example usage:

```python
from satpy import Scene

scn = Scene(filenames=['FIDUCEO_FCDR_L15_MVIRI_MET7-57.0...'],
            reader='mviri_l1b_fiduceo_nc',
            reader_kwargs={'mask_bad_quality': False})
scn.load(['VIS', 'WV', 'IR'], upper_right_corner='NE')
```

---

Example images (with `upper_right_corner='native'`):

![fiduceo_mviri_fcdr_VIS](https://user-images.githubusercontent.com/1991007/98391447-f4b96880-2056-11eb-8dc8-c03da329954a.png)
![fiduceo_mviri_fcdr_WV](https://user-images.githubusercontent.com/1991007/98391443-f420d200-2056-11eb-9e24-fb8c4a20e0da.png)
![fiduceo_mviri_fcdr_IR](https://user-images.githubusercontent.com/1991007/98391449-f551ff00-2056-11eb-8dd0-1cb36def45f5.png)

---

Difference between lon/lat from area definition and "static FCDR"

![lon_diff_VIS_57_deg](https://user-images.githubusercontent.com/1991007/98551716-e7da8600-229d-11eb-9076-9ccc09175c0a.png)
![lat_diff_VIS_57_deg](https://user-images.githubusercontent.com/1991007/98551719-e8731c80-229d-11eb-81eb-6edb6989932e.png)





 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [X] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->