### PR TITLE
Bugfix NWC SAF GEO v2016 area definition

### DIFF
--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -267,7 +267,7 @@ class NcNWCSAF(BaseFileHandler):
 
         nlines, ncols = self.nc[dsid['name']].shape
 
-        area = self._fix_adef_units(
+        area = self._ensure_area_def_is_in_meters(
             get_area_def('some_area_name',
                          "On-the-fly area",
                          'geosmsg',
@@ -279,19 +279,20 @@ class NcNWCSAF(BaseFileHandler):
         return area
 
     @staticmethod
-    def _fix_adef_units(adef):
+    def _ensure_area_def_is_in_meters(area_definition):
         """Fix units in Earth shape, satellite altitude and 'units' attribute."""
-        if adef.proj_dict["units"] == "km":
-            proj_dict = adef.proj_dict.copy()
+        if area_definition.proj_dict["units"] == "km":
+            proj_dict = area_definition.proj_dict.copy()
             from pyresample.geometry import AreaDefinition
 
             proj_dict["units"] = "m"
             proj_dict["a"] *= 1000.
             proj_dict["h"] *= 1000.
-            area_extent = tuple([val * 1000. for val in adef.area_extent])
-            return AreaDefinition(adef.area_id, adef.description, adef.proj_id, proj_dict,
-                                  adef.width, adef.height, area_extent)
-        return adef
+            area_extent = tuple([val * 1000. for val in area_definition.area_extent])
+            return AreaDefinition(area_definition.area_id, area_definition.description,
+                                  area_definition.proj_id, proj_dict,
+                                  area_definition.width, area_definition.height, area_extent)
+        return area_definition
 
     def __del__(self):
         """Delete the instance."""

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -281,8 +281,8 @@ class NcNWCSAF(BaseFileHandler):
     @staticmethod
     def _fix_adef_units(adef):
         """Fix units in Earth shape, satellite altitude and 'units' attribute."""
-        proj_dict = adef.proj_dict.copy()
-        if proj_dict["units"] == "km":
+        if adef.proj_dict["units"] == "km":
+            proj_dict = adef.proj_dict.copy()
             from pyresample.geometry import AreaDefinition
 
             proj_dict["units"] = "m"

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -54,7 +54,7 @@ def np2str(value):
 
     """
     if hasattr(value, 'dtype') and \
-            issubclass(value.dtype.type, (np.string_, np.object_)) \
+            issubclass(value.dtype.type, (np.str_, np.string_, np.object_)) \
             and value.size == 1:
         value = value.item()
         if not isinstance(value, str):

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -152,9 +152,9 @@ class TestNcNWCSAF(unittest.TestCase):
         self.assertEqual(var.attrs['valid_range'][1], 25000.)
 
 
-def _check_area_def(adef):
-    assert adef.proj_dict['h'] > 100e3
-    assert adef.proj_dict['a'] > 10e3
-    assert adef.proj_dict['units'] == 'm'
-    assert min(adef.area_extent) < -100e3
-    assert max(adef.area_extent) > 100e3
+def _check_area_def(area_definition):
+    assert area_definition.proj_dict['h'] > 100e3
+    assert area_definition.proj_dict['a'] > 10e3
+    assert area_definition.proj_dict['units'] == 'm'
+    assert min(area_definition.area_extent) < -100e3
+    assert max(area_definition.area_extent) > 100e3

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -153,8 +153,13 @@ class TestNcNWCSAF(unittest.TestCase):
 
 
 def _check_area_def(area_definition):
-    assert area_definition.proj_dict['h'] > 100e3
-    assert area_definition.proj_dict['a'] > 10e3
+    correct_h = float(PROJ['gdal_projection'].split('+h=')[-1])
+    correct_a = float(PROJ['gdal_projection'].split('+a=')[-1].split()[0])
+    assert area_definition.proj_dict['h'] == correct_h
+    assert area_definition.proj_dict['a'] == correct_a
     assert area_definition.proj_dict['units'] == 'm'
-    assert min(area_definition.area_extent) < -100e3
-    assert max(area_definition.area_extent) > 100e3
+    correct_extent = (PROJ["gdal_xgeo_up_left"],
+                      PROJ["gdal_ygeo_low_right"],
+                      PROJ["gdal_xgeo_low_right"],
+                      PROJ["gdal_ygeo_up_left"])
+    assert area_definition.area_extent == correct_extent


### PR DESCRIPTION
The `nwcsaf-geo` reader returned a non-working area definition with Earth shape, satellite altitude and extents in kilometers for NWC SAF GEO v2016 files. This PR makes sure these values are correct.

The solution is a bit convoluted. The data are first parsed as previously to get the erroneous `AreaDefinition` and then fixing the values. This was the easiest way as now the `proj_string` parsing is done only once and the existing structure doesn't need larger changes.

I also replaced the existing test of a private method with a test that checks the public interface instead. This way we can later work on the above mentioned convoluted way the fix was implemented.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
