### PR TITLE
Fix infer_mode not using the band coordinate

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -25,11 +25,6 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-try:
-    from yaml import UnsafeLoader
-except ImportError:
-    from yaml import Loader as UnsafeLoader
-
 from satpy.config import get_environ_ancpath
 from satpy.dataset import DataID, combine_metadata
 from satpy.dataset.dataid import minimal_default_keys_config
@@ -275,7 +270,7 @@ class GenericCompositor(CompositeBase):
             return data_arr.attrs['mode']
         if 'bands' not in data_arr.dims:
             return cls.modes[1]
-        if 'bands' in data_arr.coords and isinstance(data_arr.coords['bands'][0], str):
+        if 'bands' in data_arr.coords and isinstance(data_arr.coords['bands'][0].item(), str):
             return ''.join(data_arr.coords['bands'].values)
         return cls.modes[data_arr.sizes['bands']]
 
@@ -1025,7 +1020,6 @@ class BackgroundCompositor(GenericCompositor):
     def __call__(self, projectables, *args, **kwargs):
         """Call the compositor."""
         projectables = self.match_data_arrays(projectables)
-
         # Get enhanced datasets
         foreground = enhance2dataset(projectables[0])
         background = enhance2dataset(projectables[1])

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -1240,3 +1240,34 @@ class TestNaturalEnhCompositor(unittest.TestCase):
         self.assertEqual(res[0], correct)
         self.assertEqual(res[1], projectables[1])
         self.assertEqual(res[2], projectables[2])
+
+
+class TestInferMode(unittest.TestCase):
+    """Test the infer_mode utility."""
+
+    def test_bands_coords_is_used(self):
+        """Test that the `bands` coord is used."""
+        from satpy.composites import GenericCompositor
+        arr = xr.DataArray(np.ones((1, 5, 5)), dims=('bands', 'x', 'y'), coords={'bands': ['P']})
+        assert GenericCompositor.infer_mode(arr) == 'P'
+
+        arr = xr.DataArray(np.ones((3, 5, 5)), dims=('bands', 'x', 'y'), coords={'bands': ['Y', 'Cb', 'Cr']})
+        assert GenericCompositor.infer_mode(arr) == 'YCbCr'
+
+    def test_mode_is_used(self):
+        """Test that the `mode` attribute is used."""
+        from satpy.composites import GenericCompositor
+        arr = xr.DataArray(np.ones((1, 5, 5)), dims=('bands', 'x', 'y'), attrs={'mode': 'P'})
+        assert GenericCompositor.infer_mode(arr) == 'P'
+
+    def test_band_size_is_used(self):
+        """Test that the band size is used."""
+        from satpy.composites import GenericCompositor
+        arr = xr.DataArray(np.ones((2, 5, 5)), dims=('bands', 'x', 'y'))
+        assert GenericCompositor.infer_mode(arr) == 'LA'
+
+    def test_no_bands_is_l(self):
+        """Test that default (no band) is L."""
+        from satpy.composites import GenericCompositor
+        arr = xr.DataArray(np.ones((5, 5)), dims=('x', 'y'))
+        assert GenericCompositor.infer_mode(arr) == 'L'


### PR DESCRIPTION
The `infer_mode` utility classmethod is now taking care of bands coordinates being an array.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

