### PR TITLE
Fix enhance2dataset to support P-mode datasets

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -565,8 +565,7 @@ def enhance2dataset(dset, convert_p=False):
     If `convert_p` is True, enhancements generating a P mode will be converted to RGB or RGBA.
     """
     attrs = dset.attrs
-    img = get_enhanced_image(dset)
-    data = _get_data_from_image(img, convert_p)
+    data = _get_data_from_enhanced_image(dset, convert_p)
     data.attrs = attrs
     # remove 'mode' if it is specified since it may have been updated
     data.attrs.pop('mode', None)
@@ -575,18 +574,23 @@ def enhance2dataset(dset, convert_p=False):
     return data
 
 
-def _get_data_from_image(img, convert_p):
+def _get_data_from_enhanced_image(dset, convert_p):
+    img = get_enhanced_image(dset)
     if convert_p and img.mode == 'P':
-        if len(img.palette[0]) == 3:
-            img = img.convert('RGB')
-        elif len(img.palette[0]) == 4:
-            img = img.convert('RGBA')
+        img = _apply_palette_to_image(img)
     if img.mode != 'P':
-        # Clip image data to interval [0.0, 1.0]
         data = img.data.clip(0.0, 1.0)
     else:
         data = img.data
     return data
+
+
+def _apply_palette_to_image(img):
+    if len(img.palette[0]) == 3:
+        img = img.convert('RGB')
+    elif len(img.palette[0]) == 4:
+        img = img.convert('RGBA')
+    return img
 
 
 def add_bands(data, bands):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -782,9 +782,6 @@ class TestAddBands(unittest.TestCase):
     def test_add_bands_l_rgb(self):
         """Test adding bands."""
         from satpy.composites import add_bands
-        import dask.array as da
-        import numpy as np
-        import xarray as xr
 
         # L + RGB -> RGB
         data = xr.DataArray(da.ones((1, 3, 3)), dims=('bands', 'y', 'x'),
@@ -800,9 +797,7 @@ class TestAddBands(unittest.TestCase):
     def test_add_bands_l_rgba(self):
         """Test adding bands."""
         from satpy.composites import add_bands
-        import dask.array as da
-        import numpy as np
-        import xarray as xr
+
         # L + RGBA -> RGBA
         data = xr.DataArray(da.ones((1, 3, 3)), dims=('bands', 'y', 'x'),
                             coords={'bands': ['L']}, attrs={'mode': 'L'})
@@ -817,9 +812,6 @@ class TestAddBands(unittest.TestCase):
     def test_add_bands_la_rgb(self):
         """Test adding bands."""
         from satpy.composites import add_bands
-        import dask.array as da
-        import numpy as np
-        import xarray as xr
 
         # LA + RGB -> RGBA
         data = xr.DataArray(da.ones((2, 3, 3)), dims=('bands', 'y', 'x'),
@@ -835,9 +827,6 @@ class TestAddBands(unittest.TestCase):
     def test_add_bands_rgb_rbga(self):
         """Test adding bands."""
         from satpy.composites import add_bands
-        import dask.array as da
-        import numpy as np
-        import xarray as xr
 
         # RGB + RGBA -> RGBA
         data = xr.DataArray(da.ones((3, 3, 3)), dims=('bands', 'y', 'x'),
@@ -854,8 +843,6 @@ class TestAddBands(unittest.TestCase):
     def test_add_bands_p_l(self):
         """Test adding bands."""
         from satpy.composites import add_bands
-        import dask.array as da
-        import xarray as xr
 
         # P(RGBA) + L -> RGBA
         data = xr.DataArray(da.ones((1, 3, 3)), dims=('bands', 'y', 'x'),


### PR DESCRIPTION
Allows P-datasets to be converted to RGB during the BackgroundCompositor operations.

 - [x] Depends on #1430 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

