### PR TITLE
Full disk padding feature for SEVIRI Native data

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -82,7 +82,7 @@ the base Satpy installation.
       - Nominal
     * - MSG (Meteosat 8 to 11) SEVIRI data in native format
       - `seviri_l1b_native`
-      - HRV full disk data cannot be remapped.
+      - Nominal.
     * - MSG (Meteosat 8 to 11) SEVIRI data in netCDF format
       - `seviri_l1b_nc`
       - | HRV channel not supported, incomplete metadata

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -432,6 +432,15 @@ def calculate_area_extent(area_dict):
     return tuple(aex)
 
 
+def get_service_mode(ssp_lon):
+    """Get information about whether we're dealing with data from the FES, RSS or IODC service mode."""
+    seviri_service_modes = {'0.0': {'name': 'FES', 'desc': 'Full Earth scanning service'},
+                            '9.5': {'name': 'RSS', 'desc': 'Rapid scanning service'},
+                            '41.5': {'name': 'IODC', 'desc': 'Indian Ocean data coverage service'}}
+
+    return seviri_service_modes['%.1f' % ssp_lon]
+
+
 def get_padding_area(shape, dtype):
     """Create a padding area filled with no data."""
     if np.issubdtype(dtype, np.floating):

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -168,8 +168,8 @@ from satpy.readers.hrit_base import (HRITFileHandler, ancillary_text,
                                      image_data_function)
 from satpy.readers.seviri_base import (CALIB, CHANNEL_NAMES, SATNUM,
                                        VIS_CHANNELS, SEVIRICalibrationHandler,
-                                       chebyshev, get_cds_time,  HRV_NUM_COLUMNS,
-                                       pad_data_ew)
+                                       chebyshev, get_cds_time, HRV_NUM_COLUMNS,
+                                       pad_data_horizontally)
 from satpy.readers.seviri_l1b_native_hdr import (hrit_epilogue, hrit_prologue,
                                                  impf_configuration)
 from satpy.readers._geos_area import get_area_extent, get_area_definition
@@ -735,18 +735,18 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
         data_list = list()
         if upper_south_line > 0:
             # we have some of the lower window
-            data_lower = pad_data_ew(res[:upper_south_line, :].data,
-                                     (upper_south_line, HRV_NUM_COLUMNS),
-                                     bounds['LowerEastColumnActual'],
-                                     bounds['LowerWestColumnActual'])
+            data_lower = pad_data_horizontally(res[:upper_south_line, :].data,
+                                               (upper_south_line, HRV_NUM_COLUMNS),
+                                               bounds['LowerEastColumnActual'],
+                                               bounds['LowerWestColumnActual'])
             data_list.append(data_lower)
 
         if upper_south_line < nlines:
             # we have some of the upper window
-            data_upper = pad_data_ew(res[upper_south_line:, :].data,
-                                     (nlines - upper_south_line, HRV_NUM_COLUMNS),
-                                     bounds['UpperEastColumnActual'],
-                                     bounds['UpperWestColumnActual'])
+            data_upper = pad_data_horizontally(res[upper_south_line:, :].data,
+                                               (nlines - upper_south_line, HRV_NUM_COLUMNS),
+                                               bounds['UpperEastColumnActual'],
+                                               bounds['UpperWestColumnActual'])
             data_list.append(data_upper)
         return xr.DataArray(da.vstack(data_list), dims=('y', 'x'))
 

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -689,9 +689,7 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
         res = super(HRITMSGFileHandler, self).get_dataset(key, info)
         res = self.calibrate(res, key['calibration'])
         if key['name'] == 'HRV' and self.fill_hrv:
-            attrs = res.attrs
             res = self.pad_hrv_data(res)
-            res.attrs = attrs
 
         res.attrs['units'] = info['units']
         res.attrs['wavelength'] = info['wavelength']
@@ -748,7 +746,7 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
                                                bounds['UpperEastColumnActual'],
                                                bounds['UpperWestColumnActual'])
             data_list.append(data_upper)
-        return xr.DataArray(da.vstack(data_list), dims=('y', 'x'))
+        return xr.DataArray(da.vstack(data_list), dims=('y', 'x'), attrs=res.attrs.copy())
 
     def calibrate(self, data, calibration):
         """Calibrate the data."""

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -162,14 +162,14 @@ import xarray as xr
 
 import satpy.readers.utils as utils
 from pyresample import geometry
-from satpy import CHUNK_SIZE
 from satpy.readers.eum_base import recarray2dict, time_cds_short
 from satpy.readers.hrit_base import (HRITFileHandler, ancillary_text,
                                      annotation_header, base_hdr_map,
                                      image_data_function)
 from satpy.readers.seviri_base import (CALIB, CHANNEL_NAMES, SATNUM,
                                        VIS_CHANNELS, SEVIRICalibrationHandler,
-                                       chebyshev, get_cds_time)
+                                       chebyshev, get_cds_time,  HRV_NUM_COLUMNS,
+                                       pad_data_ew)
 from satpy.readers.seviri_l1b_native_hdr import (hrit_epilogue, hrit_prologue,
                                                  impf_configuration)
 from satpy.readers._geos_area import get_area_extent, get_area_definition
@@ -652,10 +652,10 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
         bounds = self.epilogue['ImageProductionStats']['ActualL15CoverageHRV'].copy()
         if self.fill_hrv:
             bounds['UpperEastColumnActual'] = 1
-            bounds['UpperWestColumnActual'] = 11136
+            bounds['UpperWestColumnActual'] = HRV_NUM_COLUMNS
             bounds['LowerEastColumnActual'] = 1
-            bounds['LowerWestColumnActual'] = 11136
-            pdict['ncols'] = 11136
+            bounds['LowerWestColumnActual'] = HRV_NUM_COLUMNS
+            pdict['ncols'] = HRV_NUM_COLUMNS
 
         upper_south_line = bounds[
             'LowerNorthLineActual'] - current_first_line - 1
@@ -689,7 +689,9 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
         res = super(HRITMSGFileHandler, self).get_dataset(key, info)
         res = self.calibrate(res, key['calibration'])
         if key['name'] == 'HRV' and self.fill_hrv:
+            attrs = res.attrs
             res = self.pad_hrv_data(res)
+            res.attrs = attrs
 
         res.attrs['units'] = info['units']
         res.attrs['wavelength'] = info['wavelength']
@@ -733,18 +735,18 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
         data_list = list()
         if upper_south_line > 0:
             # we have some of the lower window
-            data_lower = pad_data(res[:upper_south_line, :].data,
-                                  (upper_south_line, 11136),
-                                  bounds['LowerEastColumnActual'],
-                                  bounds['LowerWestColumnActual'])
+            data_lower = pad_data_ew(res[:upper_south_line, :].data,
+                                     (upper_south_line, HRV_NUM_COLUMNS),
+                                     bounds['LowerEastColumnActual'],
+                                     bounds['LowerWestColumnActual'])
             data_list.append(data_lower)
 
         if upper_south_line < nlines:
             # we have some of the upper window
-            data_upper = pad_data(res[upper_south_line:, :].data,
-                                  (nlines - upper_south_line, 11136),
-                                  bounds['UpperEastColumnActual'],
-                                  bounds['UpperWestColumnActual'])
+            data_upper = pad_data_ew(res[upper_south_line:, :].data,
+                                     (nlines - upper_south_line, HRV_NUM_COLUMNS),
+                                     bounds['UpperEastColumnActual'],
+                                     bounds['UpperWestColumnActual'])
             data_list.append(data_upper)
         return xr.DataArray(da.vstack(data_list), dims=('y', 'x'))
 
@@ -811,18 +813,3 @@ class HRITMSGFileHandler(HRITFileHandler, SEVIRICalibrationHandler):
         """Read scanline timestamps from the segment header."""
         tline = self.mda['image_segment_line_quality']['line_mean_acquisition']
         return get_cds_time(days=tline['days'], msecs=tline['milliseconds'])
-
-
-def pad_data(data, final_size, east_bound, west_bound):
-    """Pad the data given east and west bounds and the desired size."""
-    nlines = final_size[0]
-    if west_bound - east_bound != data.shape[1] - 1:
-        raise IndexError('East and west bounds do not match data shape')
-    padding_east = da.zeros((nlines, east_bound - 1),
-                            dtype=data.dtype, chunks=CHUNK_SIZE)
-    padding_west = da.zeros((nlines, (final_size[1] - west_bound)),
-                            dtype=data.dtype, chunks=CHUNK_SIZE)
-    if np.issubdtype(data.dtype, np.floating):
-        padding_east = padding_east * np.nan
-        padding_west = padding_west * np.nan
-    return np.hstack((padding_east, data, padding_west))

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -58,7 +58,7 @@ from satpy.readers.seviri_base import (SEVIRICalibrationHandler,
                                        CHANNEL_NAMES, CALIB, SATNUM,
                                        dec10216, VISIR_NUM_COLUMNS,
                                        VISIR_NUM_LINES, HRV_NUM_COLUMNS, HRV_NUM_LINES,
-                                       VIS_CHANNELS, pad_data_horizontally, pad_data_vertically)
+                                       VIS_CHANNELS, get_service_mode, pad_data_horizontally, pad_data_vertically)
 from satpy.readers.seviri_l1b_native_hdr import (GSDTRecords, native_header,
                                                  native_trailer)
 from satpy.readers._geos_area import get_area_definition
@@ -288,13 +288,15 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
         pdict['ssp_lon'] = self.mda['projection_parameters']['ssp_longitude']
 
         if dataset_id['name'] == 'HRV':
-            pdict['a_name'] = 'geos_seviri_hrv'
-            pdict['a_desc'] = 'SEVIRI high resolution channel area'
+            res = 1.0
             pdict['p_id'] = 'seviri_hrv'
         else:
-            pdict['a_name'] = 'geos_seviri_visir'
-            pdict['a_desc'] = 'SEVIRI low resolution channel area'
+            res = 3.0
             pdict['p_id'] = 'seviri_visir'
+
+        service_mode = get_service_mode(pdict['ssp_lon'])
+        pdict['a_name'] = 'msg_seviri_%s_%.0fkm' % (service_mode['name'], res)
+        pdict['a_desc'] = 'SEVIRI %s area definition with %.0f km resolution' % (service_mode['desc'], res)
 
         area_extent = self.get_area_extent(dataset_id)
         areas = list()

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -611,8 +611,11 @@ class Padder:
         """Pad data to full disk with empty pixels."""
         logger.debug('Padding data to full disk')
 
+        south_bounds, north_bounds, east_bouds, west_bounds = self._img_bounds.values()
+
         data_list = []
-        for south_bound, north_bound, east_bound, west_bound in zip(*self._img_bounds.values()):
+        for south_bound, north_bound, east_bound, west_bound in zip(south_bounds, north_bounds,
+                                                                    east_bouds, west_bounds):
             nlines = north_bound - south_bound + 1
             data = self._extract_data_to_pad(dataset, south_bound, north_bound)
             padded_data = pad_data_horizontally(data, (nlines, self._final_shape[1]), east_bound, west_bound)

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -499,8 +499,8 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
             dataset = None
         else:
             dataset = self.calibrate(xarr, dataset_id)
-            attrs = dataset.attrs
             if dataset_id['name'] == 'HRV' and self.fill_hrv:
+                attrs = dataset.attrs
                 dataset = self.pad_hrv_data(dataset)
                 dataset.attrs = attrs
             dataset.attrs['units'] = dataset_info['units']

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -443,12 +443,18 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
             return area_extent, nlines, ncolumns, window
 
         # If we're dealing with VISIR data we use the selected navigation parameters from the
-        # secondary header information
+        # secondary header information. If the number of columns in the file is not divisible by 4,
+        # UMARF will add extra columns to the file (towards west). This will not be captured by the
+        # selected navigation parameters from the secondary header information. Hence we use the
+        # south/north parameters in combination with the number of lines/columns to identify the area
+        # extent boundaries.
         else:
-            north = coeff * int(sec15hd['NorthLineSelectedRectangle']['Value'])
-            east = coeff * int(sec15hd['EastColumnSelectedRectangle']['Value'])
-            west = coeff * int(sec15hd['WestColumnSelectedRectangle']['Value'])
+            nlines = self.mda['number_of_lines']
+            ncolumns = self.mda['number_of_columns']
             south = coeff * int(sec15hd['SouthLineSelectedRectangle']['Value'])
+            east = coeff * int(sec15hd['EastColumnSelectedRectangle']['Value'])
+            west = east + ncolumns - 1
+            north = south + nlines - 1
 
             area_extent = self._calculate_area_extent(
                 center_point, north, east,

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -67,75 +67,6 @@ from satpy.readers._geos_area import get_area_definition
 logger = logging.getLogger('native_msg')
 
 
-class Padder:
-    """Padding of HRV, RSS and ROI to full disk."""
-
-    def __init__(self, boundary, is_full_disk):
-        """Initialize the padder."""
-        self._boundary = boundary
-        self._is_full_disk = is_full_disk
-
-    def pad_data(self, dataset_id, dataset):
-        """Pad data to full disk with empty pixels."""
-        logger.debug('Padding data to full disk')
-
-        if dataset_id['name'] == 'HRV' and self._is_full_disk:
-            padded_data = self._pad_fes_hrv_data(dataset)
-        else:
-            padded_data = self._pad_rss_roi_data(dataset_id, dataset)
-
-        return padded_data
-
-    def _pad_fes_hrv_data(self, dataset):
-        """Pad FES HRV data to full disk with empty pixels."""
-        data_shape = dataset.shape
-        final_shape = (HRV_NUM_LINES, HRV_NUM_COLUMNS)
-
-        # The HRV channel in FES mode consists of data from two windows ('Lower' and 'Upper') covering
-        # all 11136 lines. Data from these two windows are read, padded (in east-west) and finally
-        # staked to form a full disk array.
-        data_list = list()
-        for south, north, east, west in zip(self._boundary['south'], self._boundary['north'],
-                                            self._boundary['east'], self._boundary['west']):
-            nlines = north - south + 1
-            line_start = south - final_shape[0] + data_shape[0]
-            line_end = line_start + nlines - 1
-
-            # Pad data in east-west direction
-            data_window = pad_data_ew(dataset[line_start - 1:line_end, :].data,
-                                      (nlines, final_shape[1]),
-                                      east, west)
-
-            data_list.append(data_window)
-
-        padded_data = da.vstack(data_list)
-
-        return xr.DataArray(padded_data, dims=('y', 'x'))
-
-    def _pad_rss_roi_data(self, dataset_id, dataset):
-        """Pad RSS and ROI data to full disk with empty pixels."""
-        data_shape = dataset.shape
-
-        if dataset_id['name'] == 'HRV':
-            final_shape = (HRV_NUM_LINES, HRV_NUM_COLUMNS)
-        else:
-            final_shape = (VISIR_NUM_LINES, VISIR_NUM_COLUMNS)
-
-        # The HRV channel in RSS mode consists of data from one window ('Lower'). If we're dealing with
-        # such data, we need to use the actual navigation parameters in order to pad the data correctly.
-        # Otherwise, we use the selected navigation parameters.
-
-        # Pad data in east-west direction
-        east, west = self._boundary['east'][0], self._boundary['west'][0]
-        padded_data = pad_data_ew(dataset.data, (data_shape[0], final_shape[1]), east, west)
-
-        # Pad data in south-north direction
-        south, north = self._boundary['south'][0], self._boundary['north'][0]
-        padded_data = pad_data_sn(padded_data, final_shape, south, north)
-
-        return xr.DataArray(padded_data, dims=('y', 'x'))
-
-
 class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
     """SEVIRI native format reader.
 
@@ -442,7 +373,8 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
             raise NotImplementedError(msg)
 
         area_extent = {'area_extent': [], 'nlines': [], 'ncolumns': []}
-        img_bounds = self._get_image_bounds(dataset_id)
+        navigator = Navigator(self.header, self.trailer, self.mda)
+        img_bounds = navigator.get_image_bounds(dataset_id, self.is_roi())
         for south, north, east, west in zip(img_bounds['south'], img_bounds['north'],
                                             img_bounds['east'], img_bounds['west']):
 
@@ -509,9 +441,11 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
             dataset = None
         else:
             dataset = self.calibrate(xarr, dataset_id)
+
             if self.fill_disk and not (dataset_id['name'] != 'HRV' and self.mda['is_full_disk']):
                 attrs = dataset.attrs
-                img_bounds = self._get_image_bounds(dataset_id)
+                navigator = Navigator(self.header, self.trailer, self.mda)
+                img_bounds = navigator.get_image_bounds(dataset_id, self.is_roi())
                 padder = Padder(img_bounds, self.mda['is_full_disk'])
                 dataset = padder.pad_data(dataset_id, dataset)
                 dataset.attrs = attrs
@@ -541,54 +475,6 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
         is_top3segments = (ncolumns == VISIR_NUM_COLUMNS and nlines == 1392 and north == VISIR_NUM_LINES)
 
         return not self.mda['is_full_disk'] and not (is_rapid_scan and is_top3segments)
-
-    def _get_image_bounds(self, dataset_id):
-
-        if dataset_id['name'] == 'HRV' and not self.is_roi():
-            south, north, east, west = self._get_hrv_actual_image_bounds()
-        else:
-            south, north, east, west = self._get_selected_image_bounds(dataset_id)
-
-        return {'south': south, 'north': north, 'east': east, 'west': west}
-
-    def _get_hrv_actual_image_bounds(self):
-        """Get the actual HRV image line and column boundaries for a given HRV window."""
-        hrv_bounds = self.trailer['15TRAILER']['ImageProductionStats']['ActualL15CoverageHRV']
-
-        south, north, east, west = [], [], [], []
-        for hrv_window in ['Lower', 'Upper']:
-            south.append(hrv_bounds['%sSouthLineActual' % hrv_window])
-            north.append(hrv_bounds['%sNorthLineActual' % hrv_window])
-            east.append(hrv_bounds['%sEastColumnActual' % hrv_window])
-            west.append(hrv_bounds['%sWestColumnActual' % hrv_window])
-
-            # Data from the upper hrv window are only available in FES mode
-            if not self.mda['is_full_disk']:
-                break
-
-        return south, north, east, west
-
-    def _get_selected_image_bounds(self, dataset_id):
-        """Get the selected image line and column boundaries."""
-        if dataset_id['name'] == 'HRV':
-            nlines = int(self.mda['hrv_number_of_lines'])
-            ncolumns = int(self.mda['hrv_number_of_columns'])
-            coeff = 3
-            offset = 2
-        else:
-            nlines = int(self.mda['number_of_lines'])
-            ncolumns = int(self.mda['number_of_columns'])
-            coeff = 1
-            offset = 0
-
-        sec15hd = self.header['15_SECONDARY_PRODUCT_HEADER']
-        south = coeff * int(sec15hd['SouthLineSelectedRectangle']['Value']) - offset
-        east = coeff * int(sec15hd['EastColumnSelectedRectangle']['Value']) - offset
-
-        north = south + nlines - 1
-        west = east + ncolumns - 1
-
-        return [south], [north], [east], [west]
 
     def calibrate(self, data, dataset_id):
         """Calibrate the data."""
@@ -638,6 +524,142 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
 
         logger.debug("Calibration time " + str(datetime.now() - tic))
         return res
+
+
+class Navigator:
+    """Collect image navigation information."""
+
+    def __init__(self, header, trailer, mda):
+        """Initialize the Navigator."""
+        self._header = header
+        self._trailer = trailer
+        self._mda = mda
+
+    def get_image_bounds(self, dataset_id, is_roi):
+        """Get image line and column boundaries."""
+        if dataset_id['name'] == 'HRV':
+            if not is_roi:
+                south, north, east, west = self._get_hrv_actual_image_bounds()
+            else:
+                south, north, east, west = self._get_hrv_selected_image_bounds()
+        else:
+            south, north, east, west = self._get_visir_selected_image_bounds()
+
+        return {'south': south, 'north': north, 'east': east, 'west': west}
+
+    def _get_hrv_actual_image_bounds(self):
+        """Get the actual HRV image line and column boundaries for a given HRV window."""
+        hrv_bounds = self._trailer['15TRAILER']['ImageProductionStats']['ActualL15CoverageHRV']
+
+        south, north, east, west = [], [], [], []
+        for hrv_window in ['Lower', 'Upper']:
+            south.append(hrv_bounds['%sSouthLineActual' % hrv_window])
+            north.append(hrv_bounds['%sNorthLineActual' % hrv_window])
+            east.append(hrv_bounds['%sEastColumnActual' % hrv_window])
+            west.append(hrv_bounds['%sWestColumnActual' % hrv_window])
+
+            # Data from the upper hrv window are only available in FES mode
+            if not self._mda['is_full_disk']:
+                break
+
+        return south, north, east, west
+
+    def _get_hrv_selected_image_bounds(self):
+        """Get the selected image line and column boundaries for hrv roi data."""
+        nlines = int(self._mda['hrv_number_of_lines'])
+        ncolumns = int(self._mda['hrv_number_of_columns'])
+
+        sec15hd = self._header['15_SECONDARY_PRODUCT_HEADER']
+        south = 3 * int(sec15hd['SouthLineSelectedRectangle']['Value']) - 2
+        east = 3 * int(sec15hd['EastColumnSelectedRectangle']['Value']) - 2
+
+        north = south + nlines - 1
+        west = east + ncolumns - 1
+
+        return [south], [north], [east], [west]
+
+    def _get_visir_selected_image_bounds(self):
+        """Get the selected image line and column boundaries for visir data."""
+        nlines = int(self._mda['number_of_lines'])
+        ncolumns = int(self._mda['number_of_columns'])
+
+        sec15hd = self._header['15_SECONDARY_PRODUCT_HEADER']
+        south = int(sec15hd['SouthLineSelectedRectangle']['Value'])
+        east = int(sec15hd['EastColumnSelectedRectangle']['Value'])
+
+        north = south + nlines - 1
+        west = east + ncolumns - 1
+
+        return [south], [north], [east], [west]
+
+
+class Padder:
+    """Padding of HRV, RSS and ROI to full disk."""
+
+    def __init__(self, boundary, is_full_disk):
+        """Initialize the padder."""
+        self._boundary = boundary
+        self._is_full_disk = is_full_disk
+
+    def pad_data(self, dataset_id, dataset):
+        """Pad data to full disk with empty pixels."""
+        logger.debug('Padding data to full disk')
+
+        if dataset_id['name'] == 'HRV' and self._is_full_disk:
+            padded_data = self._pad_fes_hrv_data(dataset)
+        else:
+            padded_data = self._pad_rss_roi_data(dataset_id, dataset)
+
+        return padded_data
+
+    def _pad_fes_hrv_data(self, dataset):
+        """Pad FES HRV data to full disk with empty pixels."""
+        data_shape = dataset.shape
+        final_shape = (HRV_NUM_LINES, HRV_NUM_COLUMNS)
+
+        # The HRV channel in FES mode consists of data from two windows ('Lower' and 'Upper') covering
+        # all 11136 lines. Data from these two windows are read, padded (in east-west) and finally
+        # staked to form a full disk array.
+        data_list = list()
+        for south, north, east, west in zip(self._boundary['south'], self._boundary['north'],
+                                            self._boundary['east'], self._boundary['west']):
+            nlines = north - south + 1
+            line_start = south - final_shape[0] + data_shape[0]
+            line_end = line_start + nlines - 1
+
+            # Pad data in east-west direction
+            data_window = pad_data_ew(dataset[line_start - 1:line_end, :].data,
+                                      (nlines, final_shape[1]),
+                                      east, west)
+
+            data_list.append(data_window)
+
+        padded_data = da.vstack(data_list)
+
+        return xr.DataArray(padded_data, dims=('y', 'x'))
+
+    def _pad_rss_roi_data(self, dataset_id, dataset):
+        """Pad RSS and ROI data to full disk with empty pixels."""
+        data_shape = dataset.shape
+
+        if dataset_id['name'] == 'HRV':
+            final_shape = (HRV_NUM_LINES, HRV_NUM_COLUMNS)
+        else:
+            final_shape = (VISIR_NUM_LINES, VISIR_NUM_COLUMNS)
+
+        # The HRV channel in RSS mode consists of data from one window ('Lower'). If we're dealing with
+        # such data, we need to use the actual navigation parameters in order to pad the data correctly.
+        # Otherwise, we use the selected navigation parameters.
+
+        # Pad data in east-west direction
+        east, west = self._boundary['east'][0], self._boundary['west'][0]
+        padded_data = pad_data_ew(dataset.data, (data_shape[0], final_shape[1]), east, west)
+
+        # Pad data in south-north direction
+        south, north = self._boundary['south'][0], self._boundary['north'][0]
+        padded_data = pad_data_sn(padded_data, final_shape, south, north)
+
+        return xr.DataArray(padded_data, dims=('y', 'x'))
 
 
 def get_available_channels(header):

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -609,8 +609,6 @@ class ImageBoundaries:
         if not (same_lengths and no_empty):
             raise ValueError('Invalid image boundaries')
 
-        return
-
 
 class Padder:
     """Padding of HRV, RSS and ROI data to full disk."""

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -33,12 +33,11 @@ References:
     - `Conversion from radiances to reflectances for SEVIRI warm channels`_
 
 .. _MSG Level 1.5 Native Format File Definition
-    https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_FG15_MSG-NATIVE-FORMAT-15&RevisionSelectionMethod=LatestReleased&Rendition=Web
+    https://www-cdn.eumetsat.int/files/2020-04/pdf_fg15_msg-native-format-15.pdf
 .. _MSG Level 1.5 Image Data Format Description
-    https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_TEN_05105_MSG_IMG_DATA&RevisionSelectionMethod=LatestReleased&Rendition=Web
+    https://www-cdn.eumetsat.int/files/2020-05/pdf_ten_05105_msg_img_data.pdf
 .. _Conversion from radiances to reflectances for SEVIRI warm channels:
-    https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_MSG_SEVIRI_RAD2REFL&
-    RevisionSelectionMethod=LatestReleased&Rendition=Web
+    https://www-cdn.eumetsat.int/files/2020-04/pdf_msg_seviri_rad2refl.pdf
 
 """
 

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -435,12 +435,10 @@ class NativeMSGFileHandler(BaseFileHandler, SEVIRICalibrationHandler):
             'projection_altitude': self.mda['projection_parameters']['h']}
 
         if self.fill_disk and not (dataset_id['name'] != 'HRV' and self.mda['is_full_disk']):
-            attrs = dataset.attrs
             padder = Padder(dataset_id,
                             self.image_boundaries.get_img_bounds(dataset_id, self.is_roi()),
                             self.mda['is_full_disk'])
             dataset = padder.pad_data(dataset)
-            dataset.attrs = attrs
 
         return dataset
 
@@ -640,7 +638,7 @@ class Padder:
         if not self._is_full_disk:
             padded_data = pad_data_vertically(padded_data, self._final_shape, south_bound, north_bound)
 
-        return xr.DataArray(padded_data, dims=('y', 'x'))
+        return xr.DataArray(padded_data, dims=('y', 'x'), attrs=dataset.attrs.copy())
 
     def _extract_data_to_pad(self, dataset, south_bound, north_bound):
         """Extract the data that shall be padded.

--- a/satpy/tests/reader_tests/test_seviri_base.py
+++ b/satpy/tests/reader_tests/test_seviri_base.py
@@ -20,7 +20,7 @@
 import unittest
 import numpy as np
 import xarray as xr
-from satpy.readers.seviri_base import dec10216, chebyshev, get_cds_time, pad_data_ew, pad_data_sn
+from satpy.readers.seviri_base import dec10216, chebyshev, get_cds_time, pad_data_horizontally, pad_data_vertically
 
 
 def chebyshev4(c, x, domain):
@@ -70,31 +70,31 @@ class SeviriBaseTest(unittest.TestCase):
         expected = np.datetime64('2016-03-03 12:00:00.000')
         np.testing.assert_equal(get_cds_time(days=days, msecs=msecs), expected)
 
-    def test_pad_data_ew(self):
+    def test_pad_data_horizontally(self):
         """Test the hrv padding in east-west direction."""
         data = xr.DataArray(data=np.zeros((1, 10)), dims=('y', 'x'))
         east_bound = 4
         west_bound = 13
         final_size = (1, 20)
-        res = pad_data_ew(data, final_size, east_bound, west_bound)
+        res = pad_data_horizontally(data, final_size, east_bound, west_bound)
         expected = np.array([[np.nan, np.nan, np.nan,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,
                               np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]])
         np.testing.assert_allclose(res, expected)
 
         east_bound = 3
-        self.assertRaises(IndexError, pad_data_ew, data, final_size, east_bound, west_bound)
+        self.assertRaises(IndexError, pad_data_horizontally, data, final_size, east_bound, west_bound)
 
-    def test_pad_data_sn(self):
+    def test_pad_data_vertically(self):
         """Test the hrv padding in south-north direction."""
         data = xr.DataArray(data=np.zeros((10, 1)), dims=('y', 'x'))
         south_bound = 4
         north_bound = 13
         final_size = (20, 1)
-        res = pad_data_sn(data, final_size, south_bound, north_bound)
+        res = pad_data_vertically(data, final_size, south_bound, north_bound)
         expected = np.zeros(final_size)
         expected[:] = np.nan
         expected[south_bound-1:north_bound] = 0.
         np.testing.assert_allclose(res, expected)
 
         south_bound = 3
-        self.assertRaises(IndexError, pad_data_sn, data, final_size, south_bound, north_bound)
+        self.assertRaises(IndexError, pad_data_vertically, data, final_size, south_bound, north_bound)

--- a/satpy/tests/reader_tests/test_seviri_base.py
+++ b/satpy/tests/reader_tests/test_seviri_base.py
@@ -79,10 +79,7 @@ class SeviriBaseTest(unittest.TestCase):
         res = pad_data_horizontally(data, final_size, east_bound, west_bound)
         expected = np.array([[np.nan, np.nan, np.nan,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,
                               np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]])
-        np.testing.assert_allclose(res, expected)
-
-        east_bound = 3
-        self.assertRaises(IndexError, pad_data_horizontally, data, final_size, east_bound, west_bound)
+        np.testing.assert_equal(res, expected)
 
     def test_pad_data_vertically(self):
         """Test the hrv padding in south-north direction."""
@@ -94,7 +91,4 @@ class SeviriBaseTest(unittest.TestCase):
         expected = np.zeros(final_size)
         expected[:] = np.nan
         expected[south_bound-1:north_bound] = 0.
-        np.testing.assert_allclose(res, expected)
-
-        south_bound = 3
-        self.assertRaises(IndexError, pad_data_vertically, data, final_size, south_bound, north_bound)
+        np.testing.assert_equal(res, expected)

--- a/satpy/tests/reader_tests/test_seviri_base.py
+++ b/satpy/tests/reader_tests/test_seviri_base.py
@@ -17,9 +17,9 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Test the MSG common (native and hrit format) functionionalities."""
 
-import xarray as xr
 import unittest
 import numpy as np
+import xarray as xr
 from satpy.readers.seviri_base import dec10216, chebyshev, get_cds_time, pad_data_ew, pad_data_sn
 
 

--- a/satpy/tests/reader_tests/test_seviri_base.py
+++ b/satpy/tests/reader_tests/test_seviri_base.py
@@ -23,7 +23,7 @@ import xarray as xr
 import dask.array as da
 
 from satpy.readers.seviri_base import dec10216, chebyshev, get_cds_time,\
-    get_padding_area, pad_data_horizontally, pad_data_vertically
+    get_service_mode, get_padding_area, pad_data_horizontally, pad_data_vertically
 from satpy import CHUNK_SIZE
 
 
@@ -134,3 +134,33 @@ class SeviriBaseTest(unittest.TestCase):
         res = get_padding_area(shape, dtype)
         expected = da.full(shape, 0, dtype=dtype, chunks=CHUNK_SIZE)
         np.testing.assert_array_equal(res, expected)
+
+    @staticmethod
+    def test_get_service_mode_fes():
+        """Test fetching of SEVIRI service mode information for FES."""
+        ssp_lon = 0.0
+        name = 'FES'
+        desc = 'Full Earth scanning service'
+        res = get_service_mode(ssp_lon)
+        np.testing.assert_equal(res['name'], name)
+        np.testing.assert_equal(res['desc'], desc)
+
+    @staticmethod
+    def test_get_service_mode_rss():
+        """Test fetching of SEVIRI service mode information for RSS."""
+        ssp_lon = 9.5
+        name = 'RSS'
+        desc = 'Rapid scanning service'
+        res = get_service_mode(ssp_lon)
+        np.testing.assert_equal(res['name'], name)
+        np.testing.assert_equal(res['desc'], desc)
+
+    @staticmethod
+    def test_get_service_mode_iodc():
+        """Test fetching of SEVIRI service mode information for IODC."""
+        ssp_lon = 41.5
+        name = 'IODC'
+        desc = 'Indian Ocean data coverage service'
+        res = get_service_mode(ssp_lon)
+        np.testing.assert_equal(res['name'], name)
+        np.testing.assert_equal(res['desc'], desc)

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -25,11 +25,12 @@ import numpy as np
 import xarray as xr
 
 from satpy.readers.seviri_l1b_hrit import (HRITMSGFileHandler, HRITMSGPrologueFileHandler, HRITMSGEpilogueFileHandler,
-                                           NoValidOrbitParams, pad_data)
+                                           NoValidOrbitParams)
 from satpy.readers.seviri_base import CHANNEL_NAMES, VIS_CHANNELS
 from satpy.tests.utils import make_dataid
 
 from numpy import testing as npt
+
 
 def new_get_hd(instance, hdr_info):
     """Generate some metadata."""
@@ -117,8 +118,8 @@ class TestHRITMSGFileHandlerHRV(unittest.TestCase):
                     self.reader.mda['planned_start_segment_number'] = 1
 
                     tline = np.zeros(nlines, dtype=[('days', '>u2'), ('milliseconds', '>u4')])
-                    tline['days'][1:-1] = 21246 * np.ones(nlines-2)  # 2016-03-03
-                    tline['milliseconds'][1:-1] = np.arange(nlines-2)
+                    tline['days'][1:-1] = 21246 * np.ones(nlines - 2)  # 2016-03-03
+                    tline['milliseconds'][1:-1] = np.arange(nlines - 2)
                     self.reader.mda['image_segment_line_quality'] = {'line_mean_acquisition': tline}
 
     @mock.patch('satpy.readers.hrit_base.np.memmap')
@@ -224,20 +225,6 @@ class TestHRITMSGFileHandlerHRV(unittest.TestCase):
         self.assertTrue(np.all(res['acq_time'] == timestamps))
         self.assertEqual(res['acq_time'].attrs['long_name'], 'Mean scanline acquisition time')
 
-    def test_pad_data(self):
-        """Test the hrv padding."""
-        data = xr.DataArray(data=np.zeros((1, 10)), dims=('y', 'x'))
-        east_bound = 4
-        west_bound = 13
-        final_size = (1, 20)
-        res = pad_data(data, final_size, east_bound, west_bound)
-        expected = np.array([[np.nan, np.nan, np.nan,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,
-                              np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]])
-        np.testing.assert_allclose(res, expected)
-
-        east_bound = 3
-        self.assertRaises(IndexError, pad_data, data, final_size, east_bound, west_bound)
-
     def test_get_area_def(self):
         """Test getting the area def."""
         from pyresample.utils import proj4_radius_parameters
@@ -319,8 +306,8 @@ class TestHRITMSGFileHandler(unittest.TestCase):
                     self.reader.mda['orbital_parameters']['satellite_actual_altitude'] = 35783328
 
                     tline = np.zeros(nlines, dtype=[('days', '>u2'), ('milliseconds', '>u4')])
-                    tline['days'][1:-1] = 21246 * np.ones(nlines-2)  # 2016-03-03
-                    tline['milliseconds'][1:-1] = np.arange(nlines-2)
+                    tline['days'][1:-1] = 21246 * np.ones(nlines - 2)  # 2016-03-03
+                    tline['milliseconds'][1:-1] = np.arange(nlines - 2)
                     self.reader.mda['image_segment_line_quality'] = {'line_mean_acquisition': tline}
 
     def test_get_area_def(self):
@@ -580,8 +567,10 @@ class TestHRITMSGPrologueFileHandler(unittest.TestCase):
     @mock.patch('satpy.readers.hrit_base.HRITFileHandler.__init__', autospec=True)
     def test_extra_kwargs(self, init, *mocks):
         """Test whether the prologue file handler accepts extra keyword arguments."""
+
         def init_patched(self, *args, **kwargs):
             self.mda = {}
+
         init.side_effect = init_patched
 
         HRITMSGPrologueFileHandler(filename=None,
@@ -707,6 +696,7 @@ class TestHRITMSGEpilogueFileHandler(unittest.TestCase):
     @mock.patch('satpy.readers.hrit_base.HRITFileHandler.__init__', autospec=True)
     def setUp(self, init, *mocks):
         """Set up the test case."""
+
         def init_patched(self, *args, **kwargs):
             self.mda = {}
 
@@ -721,6 +711,7 @@ class TestHRITMSGEpilogueFileHandler(unittest.TestCase):
     @mock.patch('satpy.readers.hrit_base.HRITFileHandler.__init__', autospec=True)
     def test_extra_kwargs(self, init, *mocks):
         """Test whether the epilogue file handler accepts extra keyword arguments."""
+
         def init_patched(self, *args, **kwargs):
             self.mda = {}
 

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -56,6 +56,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_FULLDISK = {
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
+    'fill_hrv': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -74,6 +75,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI = {
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
+    'fill_hrv': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -92,9 +94,10 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
+    'fill_hrv': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI low resolution channel area',
+        'Description': 'SEVIRI high resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -106,21 +109,60 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK = {
     }
 }
 
+TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK_FILL = {
+    'earth_model': 1,
+    'dataset_id': make_dataid(name='HRV'),
+    'is_full_disk': True,
+    'is_rapid_scan': 0,
+    'fill_hrv': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_hrv',
+        'Description': 'SEVIRI high resolution channel area',
+        'Projection ID': 'seviri_hrv',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 11136,
+        'Number of rows': 11136,
+        'Area extent': (5567747.920155525, 5569748.188853264, -5569748.188853264, -5567747.920155525)
+    }
+}
+
 TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN = {
     'earth_model': 1,
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 1,
+    'fill_hrv': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI low resolution channel area',
+        'Description': 'SEVIRI high resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 5568,
         'Number of rows': 4176,
-        'Area extent': (5567747.920155525, 2625352.665781975, -1000.1343488693237, -5567747.920155525)
+        'Area extent': (2889388.1338834763, 5569748.188853264, -2679359.9206209183, 1393187.147974968)
+    }
+}
+
+TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN_FILL = {
+    'earth_model': 1,
+    'dataset_id': make_dataid(name='HRV'),
+    'is_full_disk': False,
+    'is_rapid_scan': 1,
+    'fill_hrv': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_hrv',
+        'Description': 'SEVIRI high resolution channel area',
+        'Projection ID': 'seviri_hrv',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 11136,
+        'Number of rows': 11136,
+        'Area extent': (5567747.920155525, 5569748.188853264, -5569748.188853264, -5567747.920155525)
     }
 }
 
@@ -129,6 +171,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
+    'fill_hrv': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -147,6 +190,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_FULLDISK = {
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
+    'fill_hrv': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -165,9 +209,10 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
+    'fill_hrv': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI low resolution channel area',
+        'Description': 'SEVIRI high resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -179,21 +224,60 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK = {
     }
 }
 
+TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK_FILL = {
+    'earth_model': 2,
+    'dataset_id': make_dataid(name='HRV'),
+    'is_full_disk': True,
+    'is_rapid_scan': 0,
+    'fill_hrv': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_hrv',
+        'Description': 'SEVIRI high resolution channel area',
+        'Projection ID': 'seviri_hrv',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 11136,
+        'Number of rows': 11136,
+        'Area extent': (5566247.718632221, 5571248.390376568, -5571248.390376568, -5566247.718632221)
+    }
+}
+
 TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN = {
     'earth_model': 2,
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 1,
+    'fill_hrv': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI low resolution channel area',
+        'Description': 'SEVIRI high resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 5568,
         'Number of rows': 4176,
-        'Area extent': (5566247.718632221, 2626852.867305279, -2500.3358721733093, -5566247.718632221)
+        'Area extent': (2887887.9323601723, 5571248.390376568, -2680860.1221442223, 1394687.349498272)
+    }
+}
+
+TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN_FILL = {
+    'earth_model': 2,
+    'dataset_id': make_dataid(name='HRV'),
+    'is_full_disk': False,
+    'is_rapid_scan': 1,
+    'fill_hrv': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_hrv',
+        'Description': 'SEVIRI high resolution channel area',
+        'Projection ID': 'seviri_hrv',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 11136,
+        'Number of rows': 11136,
+        'Area extent': (5566247.718632221, 5571248.390376568, -5571248.390376568, -5566247.718632221)
     }
 }
 
@@ -202,6 +286,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI = {
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
+    'fill_hrv': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -220,6 +305,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
+    'fill_hrv': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -379,25 +465,46 @@ class TestNativeMSGArea(unittest.TestCase):
         Mocked Trailer with sufficient attributes for
         NativeMSGFileHandler.get_area_extent to be able to execute.
         """
-        trailer = {
-            '15TRAILER': {
-                'ImageProductionStats': {
-                    'ActualL15CoverageHRV': {
-                        'UpperNorthLineActual': 11136,
-                        'UpperWestColumnActual': 7533,
-                        'UpperSouthLineActual': 8193,
-                        'UpperEastColumnActual': 1966,
-                        'LowerNorthLineActual': 8192,
-                        'LowerWestColumnActual': 5568,
-                        'LowerSouthLineActual': 1,
-                        'LowerEastColumnActual': 1
-                    },
-                    'ActualScanningSummary': {
-                        'ReducedScan': is_rapid_scan
+        if not is_rapid_scan:
+            trailer = {
+                '15TRAILER': {
+                    'ImageProductionStats': {
+                        'ActualL15CoverageHRV': {
+                            'UpperNorthLineActual': 11136,
+                            'UpperWestColumnActual': 7533,
+                            'UpperSouthLineActual': 8193,
+                            'UpperEastColumnActual': 1966,
+                            'LowerNorthLineActual': 8192,
+                            'LowerWestColumnActual': 5568,
+                            'LowerSouthLineActual': 1,
+                            'LowerEastColumnActual': 1
+                        },
+                        'ActualScanningSummary': {
+                            'ReducedScan': is_rapid_scan
+                        }
                     }
                 }
             }
-        }
+        else:
+            trailer = {
+                '15TRAILER': {
+                    'ImageProductionStats': {
+                        'ActualL15CoverageHRV': {
+                            'UpperNorthLineActual': 0,
+                            'UpperWestColumnActual': 0,
+                            'UpperSouthLineActual': 0,
+                            'UpperEastColumnActual': 0,
+                            'LowerNorthLineActual': 11136,
+                            'LowerWestColumnActual': 8246,
+                            'LowerSouthLineActual': 6961,
+                            'LowerEastColumnActual': 2679
+                        },
+                        'ActualScanningSummary': {
+                            'ReducedScan': is_rapid_scan
+                        }
+                    }
+                }
+            }
 
         return trailer
 
@@ -410,6 +517,7 @@ class TestNativeMSGArea(unittest.TestCase):
         header = self.create_test_header(earth_model, dataset_id, is_full_disk, is_rapid_scan)
         trailer = self.create_test_trailer(is_rapid_scan)
         expected_area_def = test_dict['expected_area_def']
+        fill_hrv = test_dict['fill_hrv']
 
         with mock.patch('satpy.readers.seviri_l1b_native.np.fromfile') as fromfile:
             fromfile.return_value = header
@@ -420,6 +528,7 @@ class TestNativeMSGArea(unittest.TestCase):
                     with mock.patch('satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer'):
 
                         fh = NativeMSGFileHandler(None, {}, None)
+                        fh.fill_hrv = fill_hrv
                         fh.header = header
                         fh.trailer = trailer
                         calc_area_def = fh.get_area_def(dataset_id)
@@ -453,10 +562,35 @@ class TestNativeMSGArea(unittest.TestCase):
         self.assertEqual(calculated.defs[0].proj_id, expected['Projection ID'])
         self.assertEqual(calculated.defs[1].proj_id, expected['Projection ID'])
 
+    def test_earthmodel1_hrv_fulldisk_fill(self):
+        """Test the HRV Fulldisk with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK_FILL
+        )
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
     def test_earthmodel1_hrv_rapidscan(self):
         """Test the HRV Fulldisk with the EarthModel 1."""
         calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN
+        )
+
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
+    def test_earthmodel1_hrv_rapidscan_fill(self):
+        """Test the HRV Fulldisk with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN_FILL
         )
 
         assertNumpyArraysEqual(np.array(calculated.area_extent),
@@ -513,6 +647,17 @@ class TestNativeMSGArea(unittest.TestCase):
         self.assertEqual(calculated.defs[0].proj_id,  expected['Projection ID'])
         self.assertEqual(calculated.defs[1].proj_id,  expected['Projection ID'])
 
+    def test_earthmodel2_hrv_fulldisk_fill(self):
+        """Test the HRV Fulldisk with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK_FILL
+        )
+        assertNumpyArraysEqual(np.array(calculated.area_extent), np.array(expected['Area extent']))
+
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
     def test_earthmodel2_hrv_rapidscan(self):
         """Test the HRV Fulldisk with the EarthModel 1."""
         calculated, expected = self.prepare_area_defs(
@@ -520,6 +665,18 @@ class TestNativeMSGArea(unittest.TestCase):
         )
         assertNumpyArraysEqual(np.array(calculated.area_extent),
                                np.array(expected['Area extent']))
+
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
+    def test_earthmodel2_hrv_rapidscan_fill(self):
+        """Test the HRV Fulldisk with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN_FILL
+        )
+
+        assertNumpyArraysEqual(np.array(calculated.area_extent), np.array(expected['Area extent']))
 
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -23,7 +23,7 @@ import numpy as np
 import xarray as xr
 
 from satpy.readers.seviri_l1b_native import (
-    NativeMSGFileHandler,
+    NativeMSGFileHandler, ImageBoundaries,
     get_available_channels,
 )
 
@@ -83,7 +83,8 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI = {
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 2516,
         'Number of rows': 1829,
-        'Area extent': (5337717.232, 5154692.6389, -2205296.3269, -333044.7514)
+        'Area extent': (5337717.232, 5154692.6389, -2211297.1332, -333044.7514)
+
     }
 }
 
@@ -119,7 +120,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN = {
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 5568,
-        'Number of rows': 4176,
+        'Number of rows': 8192,
         'Area extent': (5567747.920155525, 2625352.665781975, -1000.1343488693237, -5567747.920155525)
     }
 }
@@ -136,9 +137,9 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI = {
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
-        'Number of columns': 11136,
-        'Number of rows': 11136,
-        'Area extent': (5334716.616868973, 5155692.568421364, -2206296.373605728, -330044.33512687683)
+        'Number of columns': 7548,
+        'Number of rows': 5487,
+        'Area extent': (5336716.885566711, 5155692.568421364, -2212297.179698944, -332044.6038246155)
     }
 }
 
@@ -192,7 +193,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN = {
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 5568,
-        'Number of rows': 4176,
+        'Number of rows': 8192,
         'Area extent': (5566247.718632221, 2626852.867305279, -2500.3358721733093, -5566247.718632221)
     }
 }
@@ -211,7 +212,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI = {
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 2516,
         'Number of rows': 1829,
-        'Area extent': (5336217.0304, 5156192.8405, -2206796.5285, -331544.5498)
+        'Area extent': (5336217.0304, 5156192.8405, -2212797.3348, -331544.5498)
     }
 }
 
@@ -227,9 +228,9 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI = {
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
-        'Number of columns': 11136,
-        'Number of rows': 11136,
-        'Area extent': (5333216.415345669, 5157192.769944668, -2207796.575129032, -328544.13360357285)
+        'Number of columns': 7548,
+        'Number of rows': 5487,
+        'Area extent': (5335216.684043407, 5157192.769944668, -2213797.381222248, -330544.4023013115)
     }
 }
 
@@ -312,6 +313,7 @@ class TestNativeMSGArea(unittest.TestCase):
             south = 1
             n_visir_cols = 3712
             n_visir_lines = 3712
+            n_hrv_cols = 11136
             n_hrv_lines = 11136
         elif is_rapid_scan:
             north = 3712
@@ -320,6 +322,7 @@ class TestNativeMSGArea(unittest.TestCase):
             south = 2321
             n_visir_cols = 3712
             n_visir_lines = 1392
+            n_hrv_cols = 11136
             n_hrv_lines = 4176
         else:
             north = 3574
@@ -328,7 +331,8 @@ class TestNativeMSGArea(unittest.TestCase):
             south = 1746
             n_visir_cols = 2516
             n_visir_lines = north - south + 1
-            n_hrv_lines = 11136
+            n_hrv_cols = n_visir_cols * 3
+            n_hrv_lines = n_visir_lines * 3
 
         header = {
             '15_DATA_HEADER': {
@@ -364,7 +368,7 @@ class TestNativeMSGArea(unittest.TestCase):
                 'SelectedBandIDs': {'Value': 'xxxxxxxxxxxx'},
                 'NumberColumnsVISIR': {'Value': n_visir_cols},
                 'NumberLinesVISIR': {'Value': n_visir_lines},
-                'NumberColumnsHRV': {'Value': 11136},
+                'NumberColumnsHRV': {'Value': n_hrv_cols},
                 'NumberLinesHRV': {'Value': n_hrv_lines},
             }
 
@@ -422,6 +426,7 @@ class TestNativeMSGArea(unittest.TestCase):
                         fh = NativeMSGFileHandler(None, {}, None)
                         fh.header = header
                         fh.trailer = trailer
+                        fh.image_boundaries = ImageBoundaries(header, trailer, fh.mda)
                         calc_area_def = fh.get_area_def(dataset_id)
 
         return (calc_area_def, expected_area_def)

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -505,7 +505,7 @@ TEST_CALIBRATION_MODE = {
 TEST_PADDER_RSS_ROI = {
     'img_bounds': {'south': [2], 'north': [4], 'east': [2], 'west': [3]},
     'is_full_disk': False,
-    'dataset_id': make_dataid(name='HRV'),
+    'dataset_id': make_dataid(name='VIS006'),
     'dataset': xr.DataArray(np.ones((3, 2)), dims=['y', 'x']).astype(np.float32),
     'final_shape': (5, 5),
     'expected_padded_data': xr.DataArray(np.array([[np.nan, np.nan, np.nan, np.nan, np.nan],

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -85,7 +85,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI = {
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 2516,
         'Number of rows': 1829,
-        'Area extent': (5337717.232, 5154692.6389, -2205296.3269, -333044.7514)
+        'Area extent': (5343718.038, 5154692.6389, -2205296.3269, -333044.7514)
     }
 }
 
@@ -179,9 +179,28 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI = {
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 7548,
+        'Number of rows': 5487,
+        'Area extent': (5342717.691659927, 5155692.568421364, -2206296.373605728, -332044.6038246155)
+    }
+}
+
+TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI_FILL = {
+    'earth_model': 1,
+    'dataset_id': make_dataid(name='HRV'),
+    'is_full_disk': False,
+    'is_rapid_scan': 0,
+    'fill_hrv': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_hrv',
+        'Description': 'SEVIRI high resolution channel area',
+        'Projection ID': 'seviri_hrv',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 11136,
         'Number of rows': 11136,
-        'Area extent': (5334716.616868973, 5155692.568421364, -2206296.373605728, -330044.33512687683)
+        'Area extent': (5567747.920155525, 5569748.188853264, -5569748.188853264, -5567747.920155525)
     }
 }
 
@@ -296,7 +315,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI = {
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 2516,
         'Number of rows': 1829,
-        'Area extent': (5336217.0304, 5156192.8405, -2206796.5285, -331544.5498)
+        'Area extent': (5342217.8367, 5156192.8405, -2206796.5285, -331544.5498)
     }
 }
 
@@ -313,9 +332,29 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI = {
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 7548,
+        'Number of rows': 5487,
+        'Area extent': (5341217.49013662, 5157192.76994467, -2207796.57512903, -330544.40230131)
+    }
+}
+
+TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI_FILL = {
+    'earth_model': 2,
+    'dataset_id': make_dataid(name='HRV'),
+    'is_full_disk': False,
+    'is_rapid_scan': 0,
+    'fill_hrv': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_hrv',
+        'Description': 'SEVIRI high resolution channel area',
+        'Projection ID': 'seviri_hrv',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 11136,
         'Number of rows': 11136,
-        'Area extent': (5333216.415345669, 5157192.769944668, -2207796.575129032, -328544.13360357285)
+        'Area extent': (5566247.718632221, 5571248.390376568, -5571248.390376568, -5566247.718632221)
+
     }
 }
 
@@ -399,6 +438,7 @@ class TestNativeMSGArea(unittest.TestCase):
             n_visir_cols = 3712
             n_visir_lines = 3712
             n_hrv_lines = 11136
+            n_hrv_cols = 11136
         elif is_rapid_scan:
             north = 3712
             east = 1
@@ -407,14 +447,16 @@ class TestNativeMSGArea(unittest.TestCase):
             n_visir_cols = 3712
             n_visir_lines = 1392
             n_hrv_lines = 4176
+            n_hrv_cols = 11136
         else:
             north = 3574
-            east = 78
+            east = 76
             west = 2591
             south = 1746
-            n_visir_cols = 2516
+            n_visir_cols = west - east + 1
             n_visir_lines = north - south + 1
-            n_hrv_lines = 11136
+            n_hrv_lines = n_visir_lines * 3
+            n_hrv_cols = n_visir_cols * 3
 
         header = {
             '15_DATA_HEADER': {
@@ -450,7 +492,7 @@ class TestNativeMSGArea(unittest.TestCase):
                 'SelectedBandIDs': {'Value': 'xxxxxxxxxxxx'},
                 'NumberColumnsVISIR': {'Value': n_visir_cols},
                 'NumberLinesVISIR': {'Value': n_visir_lines},
-                'NumberColumnsHRV': {'Value': 11136},
+                'NumberColumnsHRV': {'Value': n_hrv_cols},
                 'NumberLinesHRV': {'Value': n_hrv_lines},
             }
 
@@ -622,6 +664,17 @@ class TestNativeMSGArea(unittest.TestCase):
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.proj_id,  expected['Projection ID'])
 
+    def test_earthmodel1_hrv_roi_fill(self):
+        """Test the HRV ROI with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI_FILL
+        )
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+
     # Earth model 2 tests
     def test_earthmodel2_visir_fulldisk(self):
         """Test the VISIR Fulldisk with the EarthModel 2."""
@@ -704,6 +757,17 @@ class TestNativeMSGArea(unittest.TestCase):
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.proj_id,  expected['Projection ID'])
 
+    def test_earthmodel2_hrv_roi_fill(self):
+        """Test the HRV ROI with the EarthModel 2."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI_FILL
+        )
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+
 
 class TestNativeMSGCalibrationMode(unittest.TestCase):
     """Test NativeMSGFileHandler.get_area_extent.
@@ -736,6 +800,7 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
             n_visir_cols = 3712
             n_visir_lines = 3712
             n_hrv_lines = 11136
+            n_hrv_cols = 11136
         elif is_rapid_scan:
             north = 3712
             east = 1
@@ -744,14 +809,16 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
             n_visir_cols = 3712
             n_visir_lines = 1392
             n_hrv_lines = 4176
+            n_hrv_cols = 11136
         else:
             north = 3574
-            east = 78
+            east = 76
             west = 2591
             south = 1746
-            n_visir_cols = 2516
+            n_visir_cols = west - east + 1
             n_visir_lines = north - south + 1
-            n_hrv_lines = 11136
+            n_hrv_lines = n_visir_lines * 3
+            n_hrv_cols = n_visir_cols * 3
 
         header = {
             '15_DATA_HEADER': {
@@ -800,7 +867,7 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
                 'SelectedBandIDs': {'Value': 'xxxxxxxxxxxx'},
                 'NumberColumnsVISIR': {'Value': n_visir_cols},
                 'NumberLinesVISIR': {'Value': n_visir_lines},
-                'NumberColumnsHRV': {'Value': 11136},
+                'NumberColumnsHRV': {'Value': n_hrv_cols},
                 'NumberLinesHRV': {'Value': n_hrv_lines},
             }
 

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -27,7 +27,9 @@ from satpy.readers.seviri_l1b_native import (
     get_available_channels,
 )
 
+
 from satpy.tests.utils import make_dataid
+
 
 CHANNEL_INDEX_LIST = ['VIS006', 'VIS008', 'IR_016', 'IR_039',
                       'WV_062', 'WV_073', 'IR_087', 'IR_097',
@@ -35,6 +37,7 @@ CHANNEL_INDEX_LIST = ['VIS006', 'VIS008', 'IR_016', 'IR_039',
 AVAILABLE_CHANNELS = {}
 for item in CHANNEL_INDEX_LIST:
     AVAILABLE_CHANNELS[item] = True
+
 
 SEC15HDR = '15_SECONDARY_PRODUCT_HEADER'
 IDS = 'SelectedBandIDs'
@@ -53,7 +56,6 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_FULLDISK = {
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
-    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -72,7 +74,6 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI = {
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
-    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -82,7 +83,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI = {
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 2516,
         'Number of rows': 1829,
-        'Area extent': (5343718.038, 5154692.6389, -2205296.3269, -333044.7514)
+        'Area extent': (5337717.232, 5154692.6389, -2205296.3269, -333044.7514)
     }
 }
 
@@ -91,10 +92,9 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
-    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI high resolution channel area',
+        'Description': 'SEVIRI low resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -106,60 +106,21 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK = {
     }
 }
 
-TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK_FILL = {
-    'earth_model': 1,
-    'dataset_id': make_dataid(name='HRV'),
-    'is_full_disk': True,
-    'is_rapid_scan': 0,
-    'fill_disk': True,
-    'expected_area_def': {
-        'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI high resolution channel area',
-        'Projection ID': 'seviri_hrv',
-        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
-                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
-                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
-        'Number of columns': 11136,
-        'Number of rows': 11136,
-        'Area extent': (5567747.920155525, 5569748.188853264, -5569748.188853264, -5567747.920155525)
-    }
-}
-
 TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN = {
     'earth_model': 1,
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 1,
-    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI high resolution channel area',
+        'Description': 'SEVIRI low resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 5568,
         'Number of rows': 4176,
-        'Area extent': (2889388.1338834763, 5569748.188853264, -2679359.9206209183, 1393187.147974968)
-    }
-}
-
-TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN_FILL = {
-    'earth_model': 1,
-    'dataset_id': make_dataid(name='HRV'),
-    'is_full_disk': False,
-    'is_rapid_scan': 1,
-    'fill_disk': True,
-    'expected_area_def': {
-        'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI high resolution channel area',
-        'Projection ID': 'seviri_hrv',
-        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
-                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
-                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
-        'Number of columns': 11136,
-        'Number of rows': 11136,
-        'Area extent': (5567747.920155525, 5569748.188853264, -5569748.188853264, -5567747.920155525)
+        'Area extent': (5567747.920155525, 2625352.665781975, -1000.1343488693237, -5567747.920155525)
     }
 }
 
@@ -168,26 +129,6 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
-    'fill_disk': False,
-    'expected_area_def': {
-        'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI high resolution channel area',
-        'Projection ID': 'seviri_hrv',
-        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
-                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
-                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
-        'Number of columns': 7548,
-        'Number of rows': 5487,
-        'Area extent': (5342717.691659927, 5155692.568421364, -2206296.373605728, -332044.6038246155)
-    }
-}
-
-TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI_FILL = {
-    'earth_model': 1,
-    'dataset_id': make_dataid(name='HRV'),
-    'is_full_disk': False,
-    'is_rapid_scan': 0,
-    'fill_disk': True,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -197,7 +138,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI_FILL = {
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 11136,
         'Number of rows': 11136,
-        'Area extent': (5567747.920155525, 5569748.188853264, -5569748.188853264, -5567747.920155525)
+        'Area extent': (5334716.616868973, 5155692.568421364, -2206296.373605728, -330044.33512687683)
     }
 }
 
@@ -206,7 +147,6 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_FULLDISK = {
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
-    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -225,10 +165,9 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
-    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI high resolution channel area',
+        'Description': 'SEVIRI low resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -240,60 +179,21 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK = {
     }
 }
 
-TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK_FILL = {
-    'earth_model': 2,
-    'dataset_id': make_dataid(name='HRV'),
-    'is_full_disk': True,
-    'is_rapid_scan': 0,
-    'fill_disk': True,
-    'expected_area_def': {
-        'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI high resolution channel area',
-        'Projection ID': 'seviri_hrv',
-        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
-                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
-                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
-        'Number of columns': 11136,
-        'Number of rows': 11136,
-        'Area extent': (5566247.718632221, 5571248.390376568, -5571248.390376568, -5566247.718632221)
-    }
-}
-
 TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN = {
     'earth_model': 2,
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 1,
-    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI high resolution channel area',
+        'Description': 'SEVIRI low resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 5568,
         'Number of rows': 4176,
-        'Area extent': (2887887.9323601723, 5571248.390376568, -2680860.1221442223, 1394687.349498272)
-    }
-}
-
-TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN_FILL = {
-    'earth_model': 2,
-    'dataset_id': make_dataid(name='HRV'),
-    'is_full_disk': False,
-    'is_rapid_scan': 1,
-    'fill_disk': True,
-    'expected_area_def': {
-        'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI high resolution channel area',
-        'Projection ID': 'seviri_hrv',
-        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
-                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
-                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
-        'Number of columns': 11136,
-        'Number of rows': 11136,
-        'Area extent': (5566247.718632221, 5571248.390376568, -5571248.390376568, -5566247.718632221)
+        'Area extent': (5566247.718632221, 2626852.867305279, -2500.3358721733093, -5566247.718632221)
     }
 }
 
@@ -302,7 +202,6 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI = {
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
-    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -312,7 +211,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI = {
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 2516,
         'Number of rows': 1829,
-        'Area extent': (5342217.8367, 5156192.8405, -2206796.5285, -331544.5498)
+        'Area extent': (5336217.0304, 5156192.8405, -2206796.5285, -331544.5498)
     }
 }
 
@@ -321,26 +220,6 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
-    'fill_disk': False,
-    'expected_area_def': {
-        'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI high resolution channel area',
-        'Projection ID': 'seviri_hrv',
-        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
-                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
-                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
-        'Number of columns': 7548,
-        'Number of rows': 5487,
-        'Area extent': (5341217.49013662, 5157192.76994467, -2207796.57512903, -330544.40230131)
-    }
-}
-
-TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI_FILL = {
-    'earth_model': 2,
-    'dataset_id': make_dataid(name='HRV'),
-    'is_full_disk': False,
-    'is_rapid_scan': 0,
-    'fill_disk': True,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -350,8 +229,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI_FILL = {
                        'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
         'Number of columns': 11136,
         'Number of rows': 11136,
-        'Area extent': (5566247.718632221, 5571248.390376568, -5571248.390376568, -5566247.718632221)
-
+        'Area extent': (5333216.415345669, 5157192.769944668, -2207796.575129032, -328544.13360357285)
     }
 }
 
@@ -366,7 +244,6 @@ TEST_CALIBRATION_MODE = {
     'GSICSCalCoeff': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.96, 0.97],
     'GSICSOffsetCount': [-51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0]
 }
-
 
 # This should preferably be put in a helper-module
 # Fixme!
@@ -436,7 +313,6 @@ class TestNativeMSGArea(unittest.TestCase):
             n_visir_cols = 3712
             n_visir_lines = 3712
             n_hrv_lines = 11136
-            n_hrv_cols = 11136
         elif is_rapid_scan:
             north = 3712
             east = 1
@@ -445,16 +321,14 @@ class TestNativeMSGArea(unittest.TestCase):
             n_visir_cols = 3712
             n_visir_lines = 1392
             n_hrv_lines = 4176
-            n_hrv_cols = 11136
         else:
             north = 3574
-            east = 76
+            east = 78
             west = 2591
             south = 1746
-            n_visir_cols = west - east + 1
+            n_visir_cols = 2516
             n_visir_lines = north - south + 1
-            n_hrv_lines = n_visir_lines * 3
-            n_hrv_cols = n_visir_cols * 3
+            n_hrv_lines = 11136
 
         header = {
             '15_DATA_HEADER': {
@@ -490,7 +364,7 @@ class TestNativeMSGArea(unittest.TestCase):
                 'SelectedBandIDs': {'Value': 'xxxxxxxxxxxx'},
                 'NumberColumnsVISIR': {'Value': n_visir_cols},
                 'NumberLinesVISIR': {'Value': n_visir_lines},
-                'NumberColumnsHRV': {'Value': n_hrv_cols},
+                'NumberColumnsHRV': {'Value': 11136},
                 'NumberLinesHRV': {'Value': n_hrv_lines},
             }
 
@@ -505,46 +379,25 @@ class TestNativeMSGArea(unittest.TestCase):
         Mocked Trailer with sufficient attributes for
         NativeMSGFileHandler.get_area_extent to be able to execute.
         """
-        if not is_rapid_scan:
-            trailer = {
-                '15TRAILER': {
-                    'ImageProductionStats': {
-                        'ActualL15CoverageHRV': {
-                            'UpperNorthLineActual': 11136,
-                            'UpperWestColumnActual': 7533,
-                            'UpperSouthLineActual': 8193,
-                            'UpperEastColumnActual': 1966,
-                            'LowerNorthLineActual': 8192,
-                            'LowerWestColumnActual': 5568,
-                            'LowerSouthLineActual': 1,
-                            'LowerEastColumnActual': 1
-                        },
-                        'ActualScanningSummary': {
-                            'ReducedScan': is_rapid_scan
-                        }
+        trailer = {
+            '15TRAILER': {
+                'ImageProductionStats': {
+                    'ActualL15CoverageHRV': {
+                        'UpperNorthLineActual': 11136,
+                        'UpperWestColumnActual': 7533,
+                        'UpperSouthLineActual': 8193,
+                        'UpperEastColumnActual': 1966,
+                        'LowerNorthLineActual': 8192,
+                        'LowerWestColumnActual': 5568,
+                        'LowerSouthLineActual': 1,
+                        'LowerEastColumnActual': 1
+                    },
+                    'ActualScanningSummary': {
+                        'ReducedScan': is_rapid_scan
                     }
                 }
             }
-        else:
-            trailer = {
-                '15TRAILER': {
-                    'ImageProductionStats': {
-                        'ActualL15CoverageHRV': {
-                            'UpperNorthLineActual': 0,
-                            'UpperWestColumnActual': 0,
-                            'UpperSouthLineActual': 0,
-                            'UpperEastColumnActual': 0,
-                            'LowerNorthLineActual': 11136,
-                            'LowerWestColumnActual': 8246,
-                            'LowerSouthLineActual': 6961,
-                            'LowerEastColumnActual': 2679
-                        },
-                        'ActualScanningSummary': {
-                            'ReducedScan': is_rapid_scan
-                        }
-                    }
-                }
-            }
+        }
 
         return trailer
 
@@ -557,7 +410,6 @@ class TestNativeMSGArea(unittest.TestCase):
         header = self.create_test_header(earth_model, dataset_id, is_full_disk, is_rapid_scan)
         trailer = self.create_test_trailer(is_rapid_scan)
         expected_area_def = test_dict['expected_area_def']
-        fill_disk = test_dict['fill_disk']
 
         with mock.patch('satpy.readers.seviri_l1b_native.np.fromfile') as fromfile:
             fromfile.return_value = header
@@ -566,8 +418,8 @@ class TestNativeMSGArea(unittest.TestCase):
                 with mock.patch('satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_memmap') as _get_memmap:
                     _get_memmap.return_value = np.arange(3)
                     with mock.patch('satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer'):
+
                         fh = NativeMSGFileHandler(None, {}, None)
-                        fh.fill_disk = fill_disk
                         fh.header = header
                         fh.trailer = trailer
                         calc_area_def = fh.get_area_def(dataset_id)
@@ -584,7 +436,7 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
 
     def test_earthmodel1_hrv_fulldisk(self):
         """Test the HRV Fulldisk with the EarthModel 1."""
@@ -601,35 +453,10 @@ class TestNativeMSGArea(unittest.TestCase):
         self.assertEqual(calculated.defs[0].proj_id, expected['Projection ID'])
         self.assertEqual(calculated.defs[1].proj_id, expected['Projection ID'])
 
-    def test_earthmodel1_hrv_fulldisk_fill(self):
-        """Test the HRV Fulldisk with the EarthModel 1."""
-        calculated, expected = self.prepare_area_defs(
-            TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK_FILL
-        )
-        assertNumpyArraysEqual(np.array(calculated.area_extent),
-                               np.array(expected['Area extent']))
-
-        self.assertEqual(calculated.width, expected['Number of columns'])
-        self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id, expected['Projection ID'])
-
     def test_earthmodel1_hrv_rapidscan(self):
         """Test the HRV Fulldisk with the EarthModel 1."""
         calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN
-        )
-
-        assertNumpyArraysEqual(np.array(calculated.area_extent),
-                               np.array(expected['Area extent']))
-
-        self.assertEqual(calculated.width, expected['Number of columns'])
-        self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id, expected['Projection ID'])
-
-    def test_earthmodel1_hrv_rapidscan_fill(self):
-        """Test the HRV Fulldisk with the EarthModel 1."""
-        calculated, expected = self.prepare_area_defs(
-            TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN_FILL
         )
 
         assertNumpyArraysEqual(np.array(calculated.area_extent),
@@ -648,7 +475,7 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
 
     def test_earthmodel1_hrv_roi(self):
         """Test the HRV ROI with the EarthModel 1."""
@@ -659,18 +486,7 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id, expected['Projection ID'])
-
-    def test_earthmodel1_hrv_roi_fill(self):
-        """Test the HRV ROI with the EarthModel 1."""
-        calculated, expected = self.prepare_area_defs(
-            TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI_FILL
-        )
-        assertNumpyArraysEqual(np.array(calculated.area_extent),
-                               np.array(expected['Area extent']))
-        self.assertEqual(calculated.width, expected['Number of columns'])
-        self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
 
     # Earth model 2 tests
     def test_earthmodel2_visir_fulldisk(self):
@@ -682,7 +498,7 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
 
     def test_earthmodel2_hrv_fulldisk(self):
         """Test the HRV Fulldisk with the EarthModel 2."""
@@ -694,19 +510,8 @@ class TestNativeMSGArea(unittest.TestCase):
 
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.defs[0].proj_id, expected['Projection ID'])
-        self.assertEqual(calculated.defs[1].proj_id, expected['Projection ID'])
-
-    def test_earthmodel2_hrv_fulldisk_fill(self):
-        """Test the HRV Fulldisk with the EarthModel 1."""
-        calculated, expected = self.prepare_area_defs(
-            TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK_FILL
-        )
-        assertNumpyArraysEqual(np.array(calculated.area_extent), np.array(expected['Area extent']))
-
-        self.assertEqual(calculated.width, expected['Number of columns'])
-        self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+        self.assertEqual(calculated.defs[0].proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.defs[1].proj_id,  expected['Projection ID'])
 
     def test_earthmodel2_hrv_rapidscan(self):
         """Test the HRV Fulldisk with the EarthModel 1."""
@@ -715,18 +520,6 @@ class TestNativeMSGArea(unittest.TestCase):
         )
         assertNumpyArraysEqual(np.array(calculated.area_extent),
                                np.array(expected['Area extent']))
-
-        self.assertEqual(calculated.width, expected['Number of columns'])
-        self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id, expected['Projection ID'])
-
-    def test_earthmodel2_hrv_rapidscan_fill(self):
-        """Test the HRV Fulldisk with the EarthModel 1."""
-        calculated, expected = self.prepare_area_defs(
-            TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN_FILL
-        )
-
-        assertNumpyArraysEqual(np.array(calculated.area_extent), np.array(expected['Area extent']))
 
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
@@ -741,7 +534,7 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
 
     def test_earthmodel2_hrv_roi(self):
         """Test the HRV ROI with the EarthModel 2."""
@@ -752,18 +545,7 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id, expected['Projection ID'])
-
-    def test_earthmodel2_hrv_roi_fill(self):
-        """Test the HRV ROI with the EarthModel 2."""
-        calculated, expected = self.prepare_area_defs(
-            TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI_FILL
-        )
-        assertNumpyArraysEqual(np.array(calculated.area_extent),
-                               np.array(expected['Area extent']))
-        self.assertEqual(calculated.width, expected['Number of columns'])
-        self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
 
 
 class TestNativeMSGCalibrationMode(unittest.TestCase):
@@ -797,7 +579,6 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
             n_visir_cols = 3712
             n_visir_lines = 3712
             n_hrv_lines = 11136
-            n_hrv_cols = 11136
         elif is_rapid_scan:
             north = 3712
             east = 1
@@ -806,16 +587,14 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
             n_visir_cols = 3712
             n_visir_lines = 1392
             n_hrv_lines = 4176
-            n_hrv_cols = 11136
         else:
             north = 3574
-            east = 76
+            east = 78
             west = 2591
             south = 1746
-            n_visir_cols = west - east + 1
+            n_visir_cols = 2516
             n_visir_lines = north - south + 1
-            n_hrv_lines = n_visir_lines * 3
-            n_hrv_cols = n_visir_cols * 3
+            n_hrv_lines = 11136
 
         header = {
             '15_DATA_HEADER': {
@@ -864,7 +643,7 @@ class TestNativeMSGCalibrationMode(unittest.TestCase):
                 'SelectedBandIDs': {'Value': 'xxxxxxxxxxxx'},
                 'NumberColumnsVISIR': {'Value': n_visir_cols},
                 'NumberLinesVISIR': {'Value': n_visir_lines},
-                'NumberColumnsHRV': {'Value': n_hrv_cols},
+                'NumberColumnsHRV': {'Value': 11136},
                 'NumberLinesHRV': {'Value': n_hrv_lines},
             }
 

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -53,7 +53,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_FULLDISK = {
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
-    'fill_hrv': False,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -72,7 +72,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI = {
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
-    'fill_hrv': False,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -91,7 +91,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
-    'fill_hrv': False,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -111,7 +111,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK_FILL = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
-    'fill_hrv': True,
+    'fill_disk': True,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -130,7 +130,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 1,
-    'fill_hrv': False,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -149,7 +149,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN_FILL = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 1,
-    'fill_hrv': True,
+    'fill_disk': True,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -168,7 +168,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
-    'fill_hrv': False,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -187,7 +187,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI_FILL = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
-    'fill_hrv': True,
+    'fill_disk': True,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -206,7 +206,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_FULLDISK = {
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
-    'fill_hrv': False,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -225,7 +225,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
-    'fill_hrv': False,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -245,7 +245,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK_FILL = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
-    'fill_hrv': True,
+    'fill_disk': True,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -264,7 +264,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 1,
-    'fill_hrv': False,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -283,7 +283,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN_FILL = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 1,
-    'fill_hrv': True,
+    'fill_disk': True,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -302,7 +302,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI = {
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
-    'fill_hrv': False,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -321,7 +321,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
-    'fill_hrv': False,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -340,7 +340,7 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI_FILL = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
-    'fill_hrv': True,
+    'fill_disk': True,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -557,7 +557,7 @@ class TestNativeMSGArea(unittest.TestCase):
         header = self.create_test_header(earth_model, dataset_id, is_full_disk, is_rapid_scan)
         trailer = self.create_test_trailer(is_rapid_scan)
         expected_area_def = test_dict['expected_area_def']
-        fill_hrv = test_dict['fill_hrv']
+        fill_disk = test_dict['fill_disk']
 
         with mock.patch('satpy.readers.seviri_l1b_native.np.fromfile') as fromfile:
             fromfile.return_value = header
@@ -567,7 +567,7 @@ class TestNativeMSGArea(unittest.TestCase):
                     _get_memmap.return_value = np.arange(3)
                     with mock.patch('satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer'):
                         fh = NativeMSGFileHandler(None, {}, None)
-                        fh.fill_hrv = fill_hrv
+                        fh.fill_disk = fill_disk
                         fh.header = header
                         fh.trailer = trailer
                         calc_area_def = fh.get_area_def(dataset_id)

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -27,9 +27,7 @@ from satpy.readers.seviri_l1b_native import (
     get_available_channels,
 )
 
-
 from satpy.tests.utils import make_dataid
-
 
 CHANNEL_INDEX_LIST = ['VIS006', 'VIS008', 'IR_016', 'IR_039',
                       'WV_062', 'WV_073', 'IR_087', 'IR_097',
@@ -37,7 +35,6 @@ CHANNEL_INDEX_LIST = ['VIS006', 'VIS008', 'IR_016', 'IR_039',
 AVAILABLE_CHANNELS = {}
 for item in CHANNEL_INDEX_LIST:
     AVAILABLE_CHANNELS[item] = True
-
 
 SEC15HDR = '15_SECONDARY_PRODUCT_HEADER'
 IDS = 'SelectedBandIDs'
@@ -370,6 +367,7 @@ TEST_CALIBRATION_MODE = {
     'GSICSOffsetCount': [-51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0]
 }
 
+
 # This should preferably be put in a helper-module
 # Fixme!
 
@@ -568,7 +566,6 @@ class TestNativeMSGArea(unittest.TestCase):
                 with mock.patch('satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_memmap') as _get_memmap:
                     _get_memmap.return_value = np.arange(3)
                     with mock.patch('satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer'):
-
                         fh = NativeMSGFileHandler(None, {}, None)
                         fh.fill_hrv = fill_hrv
                         fh.header = header
@@ -587,7 +584,7 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
     def test_earthmodel1_hrv_fulldisk(self):
         """Test the HRV Fulldisk with the EarthModel 1."""
@@ -651,7 +648,7 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
     def test_earthmodel1_hrv_roi(self):
         """Test the HRV ROI with the EarthModel 1."""
@@ -662,7 +659,7 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
     def test_earthmodel1_hrv_roi_fill(self):
         """Test the HRV ROI with the EarthModel 1."""
@@ -673,7 +670,7 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
     # Earth model 2 tests
     def test_earthmodel2_visir_fulldisk(self):
@@ -685,7 +682,7 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
     def test_earthmodel2_hrv_fulldisk(self):
         """Test the HRV Fulldisk with the EarthModel 2."""
@@ -697,8 +694,8 @@ class TestNativeMSGArea(unittest.TestCase):
 
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.defs[0].proj_id,  expected['Projection ID'])
-        self.assertEqual(calculated.defs[1].proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.defs[0].proj_id, expected['Projection ID'])
+        self.assertEqual(calculated.defs[1].proj_id, expected['Projection ID'])
 
     def test_earthmodel2_hrv_fulldisk_fill(self):
         """Test the HRV Fulldisk with the EarthModel 1."""
@@ -744,7 +741,7 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
     def test_earthmodel2_hrv_roi(self):
         """Test the HRV ROI with the EarthModel 2."""
@@ -755,7 +752,7 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
     def test_earthmodel2_hrv_roi_fill(self):
         """Test the HRV ROI with the EarthModel 2."""
@@ -766,7 +763,7 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
 
 class TestNativeMSGCalibrationMode(unittest.TestCase):

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -27,9 +27,7 @@ from satpy.readers.seviri_l1b_native import (
     get_available_channels,
 )
 
-
 from satpy.tests.utils import make_dataid
-
 
 CHANNEL_INDEX_LIST = ['VIS006', 'VIS008', 'IR_016', 'IR_039',
                       'WV_062', 'WV_073', 'IR_087', 'IR_097',
@@ -37,7 +35,6 @@ CHANNEL_INDEX_LIST = ['VIS006', 'VIS008', 'IR_016', 'IR_039',
 AVAILABLE_CHANNELS = {}
 for item in CHANNEL_INDEX_LIST:
     AVAILABLE_CHANNELS[item] = True
-
 
 SEC15HDR = '15_SECONDARY_PRODUCT_HEADER'
 IDS = 'SelectedBandIDs'
@@ -56,6 +53,45 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_FULLDISK = {
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
+    'fill_disk': False,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_visir',
+        'Description': 'SEVIRI low resolution channel area',
+        'Projection ID': 'seviri_visir',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 3712,
+        'Number of rows': 3712,
+        'Area extent': (5568748.2758, 5568748.2758, -5568748.2758, -5568748.2758)
+    }
+}
+
+TEST_AREA_EXTENT_EARTHMODEL1_VISIR_RAPIDSCAN = {
+    'earth_model': 1,
+    'dataset_id': make_dataid(name='VIS006'),
+    'is_full_disk': False,
+    'is_rapid_scan': 1,
+    'fill_disk': False,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_visir',
+        'Description': 'SEVIRI low resolution channel area',
+        'Projection ID': 'seviri_visir',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 3712,
+        'Number of rows': 1392,
+        'Area extent': (5568748.275756836, 5568748.275756836, -5568748.275756836, 1392187.068939209)
+    }
+}
+
+TEST_AREA_EXTENT_EARTHMODEL1_VISIR_RAPIDSCAN_FILL = {
+    'earth_model': 1,
+    'dataset_id': make_dataid(name='VIS006'),
+    'is_full_disk': False,
+    'is_rapid_scan': 1,
+    'fill_disk': True,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -74,6 +110,7 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI = {
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -88,14 +125,35 @@ TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI = {
     }
 }
 
+TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI_FILL = {
+    'earth_model': 1,
+    'dataset_id': make_dataid(name='VIS006'),
+    'is_full_disk': False,
+    'is_rapid_scan': 0,
+    'fill_disk': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_visir',
+        'Description': 'SEVIRI low resolution channel area',
+        'Projection ID': 'seviri_visir',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 3712,
+        'Number of rows': 3712,
+        'Area extent': (5568748.2758, 5568748.2758, -5568748.2758, -5568748.2758)
+
+    }
+}
+
 TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK = {
     'earth_model': 1,
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI low resolution channel area',
+        'Description': 'SEVIRI high resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -107,14 +165,34 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK = {
     }
 }
 
+TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK_FILL = {
+    'earth_model': 1,
+    'dataset_id': make_dataid(name='HRV'),
+    'is_full_disk': True,
+    'is_rapid_scan': 0,
+    'fill_disk': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_hrv',
+        'Description': 'SEVIRI high resolution channel area',
+        'Projection ID': 'seviri_hrv',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 11136,
+        'Number of rows': 11136,
+        'Area extent': (5567747.920155525, 5569748.188853264, -5569748.188853264, -5567747.920155525)
+    }
+}
+
 TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN = {
     'earth_model': 1,
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 1,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI low resolution channel area',
+        'Description': 'SEVIRI high resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -125,11 +203,31 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN = {
     }
 }
 
+TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN_FILL = {
+    'earth_model': 1,
+    'dataset_id': make_dataid(name='HRV'),
+    'is_full_disk': False,
+    'is_rapid_scan': 1,
+    'fill_disk': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_hrv',
+        'Description': 'SEVIRI high resolution channel area',
+        'Projection ID': 'seviri_hrv',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 11136,
+        'Number of rows': 11136,
+        'Area extent': (5567747.920155525, 5569748.188853264, -5569748.188853264, -5567747.920155525)
+    }
+}
+
 TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI = {
     'earth_model': 1,
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -143,11 +241,31 @@ TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI = {
     }
 }
 
+TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI_FILL = {
+    'earth_model': 1,
+    'dataset_id': make_dataid(name='HRV'),
+    'is_full_disk': False,
+    'is_rapid_scan': 0,
+    'fill_disk': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_hrv',
+        'Description': 'SEVIRI high resolution channel area',
+        'Projection ID': 'seviri_hrv',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 11136,
+        'Number of rows': 11136,
+        'Area extent': (5567747.920155525, 5569748.188853264, -5569748.188853264, -5567747.920155525)
+    }
+}
+
 TEST_AREA_EXTENT_EARTHMODEL2_VISIR_FULLDISK = {
     'earth_model': 2,
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -166,9 +284,10 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK = {
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': True,
     'is_rapid_scan': 0,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI low resolution channel area',
+        'Description': 'SEVIRI high resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -180,14 +299,74 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK = {
     }
 }
 
+TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK_FILL = {
+    'earth_model': 2,
+    'dataset_id': make_dataid(name='HRV'),
+    'is_full_disk': True,
+    'is_rapid_scan': 0,
+    'fill_disk': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_hrv',
+        'Description': 'SEVIRI high resolution channel area',
+        'Projection ID': 'seviri_hrv',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 11136,
+        'Number of rows': 11136,
+        'Area extent': (5566247.718632221, 5571248.390376568, -5571248.390376568, -5566247.718632221)
+    }
+}
+
+TEST_AREA_EXTENT_EARTHMODEL2_VISIR_RAPIDSCAN = {
+    'earth_model': 2,
+    'dataset_id': make_dataid(name='VIS006'),
+    'is_full_disk': False,
+    'is_rapid_scan': 1,
+    'fill_disk': False,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_visir',
+        'Description': 'SEVIRI low resolution channel area',
+        'Projection ID': 'seviri_visir',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 3712,
+        'Number of rows': 1392,
+        'Area extent': (5567248.074173927, 5570248.477339745, -5570248.477339745, 1393687.2705221176)
+
+    }
+}
+
+TEST_AREA_EXTENT_EARTHMODEL2_VISIR_RAPIDSCAN_FILL = {
+    'earth_model': 2,
+    'dataset_id': make_dataid(name='VIS006'),
+    'is_full_disk': False,
+    'is_rapid_scan': 1,
+    'fill_disk': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_visir',
+        'Description': 'SEVIRI low resolution channel area',
+        'Projection ID': 'seviri_visir',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 3712,
+        'Number of rows': 3712,
+        'Area extent': (5567248.0742, 5570248.4773, -5570248.4773, -5567248.0742)
+
+    }
+}
+
 TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN = {
     'earth_model': 2,
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 1,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
-        'Description': 'SEVIRI low resolution channel area',
+        'Description': 'SEVIRI high resolution channel area',
         'Projection ID': 'seviri_hrv',
         'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
                        'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
@@ -198,11 +377,31 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN = {
     }
 }
 
+TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN_FILL = {
+    'earth_model': 2,
+    'dataset_id': make_dataid(name='HRV'),
+    'is_full_disk': False,
+    'is_rapid_scan': 1,
+    'fill_disk': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_hrv',
+        'Description': 'SEVIRI high resolution channel area',
+        'Projection ID': 'seviri_hrv',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 11136,
+        'Number of rows': 11136,
+        'Area extent': (5566247.718632221, 5571248.390376568, -5571248.390376568, -5566247.718632221)
+    }
+}
+
 TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI = {
     'earth_model': 2,
     'dataset_id': make_dataid(name='VIS006'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_visir',
         'Description': 'SEVIRI low resolution channel area',
@@ -216,11 +415,31 @@ TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI = {
     }
 }
 
+TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI_FILL = {
+    'earth_model': 2,
+    'dataset_id': make_dataid(name='VIS006'),
+    'is_full_disk': False,
+    'is_rapid_scan': 0,
+    'fill_disk': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_visir',
+        'Description': 'SEVIRI low resolution channel area',
+        'Projection ID': 'seviri_visir',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 3712,
+        'Number of rows': 3712,
+        'Area extent': (5567248.0742, 5570248.4773, -5570248.4773, -5567248.0742)
+    }
+}
+
 TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI = {
     'earth_model': 2,
     'dataset_id': make_dataid(name='HRV'),
     'is_full_disk': False,
     'is_rapid_scan': 0,
+    'fill_disk': False,
     'expected_area_def': {
         'Area ID': 'geos_seviri_hrv',
         'Description': 'SEVIRI high resolution channel area',
@@ -231,6 +450,25 @@ TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI = {
         'Number of columns': 7548,
         'Number of rows': 5487,
         'Area extent': (5335216.684043407, 5157192.769944668, -2213797.381222248, -330544.4023013115)
+    }
+}
+
+TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI_FILL = {
+    'earth_model': 2,
+    'dataset_id': make_dataid(name='HRV'),
+    'is_full_disk': False,
+    'is_rapid_scan': 0,
+    'fill_disk': True,
+    'expected_area_def': {
+        'Area ID': 'geos_seviri_hrv',
+        'Description': 'SEVIRI high resolution channel area',
+        'Projection ID': 'seviri_hrv',
+        'Projection': {'a': '6378169000', 'b': '6356583800', 'h': '35785831',
+                       'lon_0': '0', 'no_defs': 'None', 'proj': 'geos',
+                       'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'},
+        'Number of columns': 11136,
+        'Number of rows': 11136,
+        'Area extent': (5566247.718632221, 5571248.390376568, -5571248.390376568, -5566247.718632221)
     }
 }
 
@@ -245,6 +483,7 @@ TEST_CALIBRATION_MODE = {
     'GSICSCalCoeff': [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 0.95, 0.96, 0.97],
     'GSICSOffsetCount': [-51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0, -51.0]
 }
+
 
 # This should preferably be put in a helper-module
 # Fixme!
@@ -411,6 +650,7 @@ class TestNativeMSGArea(unittest.TestCase):
         dataset_id = test_dict['dataset_id']
         is_full_disk = test_dict['is_full_disk']
         is_rapid_scan = test_dict['is_rapid_scan']
+        fill_disk = test_dict['fill_disk']
         header = self.create_test_header(earth_model, dataset_id, is_full_disk, is_rapid_scan)
         trailer = self.create_test_trailer(is_rapid_scan)
         expected_area_def = test_dict['expected_area_def']
@@ -422,8 +662,8 @@ class TestNativeMSGArea(unittest.TestCase):
                 with mock.patch('satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_memmap') as _get_memmap:
                     _get_memmap.return_value = np.arange(3)
                     with mock.patch('satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer'):
-
                         fh = NativeMSGFileHandler(None, {}, None)
+                        fh.fill_disk = fill_disk
                         fh.header = header
                         fh.trailer = trailer
                         fh.image_boundaries = ImageBoundaries(header, trailer, fh.mda)
@@ -433,7 +673,7 @@ class TestNativeMSGArea(unittest.TestCase):
 
     # Earth model 1 tests
     def test_earthmodel1_visir_fulldisk(self):
-        """Test the VISIR Fulldisk with the EarthModel 1."""
+        """Test the VISIR FES with the EarthModel 1."""
         calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL1_VISIR_FULLDISK
         )
@@ -441,10 +681,10 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
     def test_earthmodel1_hrv_fulldisk(self):
-        """Test the HRV Fulldisk with the EarthModel 1."""
+        """Test the HRV FES with the EarthModel 1."""
         calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK
         )
@@ -458,10 +698,60 @@ class TestNativeMSGArea(unittest.TestCase):
         self.assertEqual(calculated.defs[0].proj_id, expected['Projection ID'])
         self.assertEqual(calculated.defs[1].proj_id, expected['Projection ID'])
 
+    def test_earthmodel1_hrv_fulldisk_fill(self):
+        """Test the HRV FES padded to fulldisk with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL1_HRV_FULLDISK_FILL
+        )
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
+    def test_earthmodel1_visir_rapidscan(self):
+        """Test the VISIR RSS with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL1_VISIR_RAPIDSCAN
+        )
+
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
+    def test_earthmodel1_visir_rapidscan_fill(self):
+        """Test the VISIR RSS padded to fulldisk with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL1_VISIR_RAPIDSCAN_FILL
+        )
+
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
     def test_earthmodel1_hrv_rapidscan(self):
-        """Test the HRV Fulldisk with the EarthModel 1."""
+        """Test the HRV RSS with the EarthModel 1."""
         calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN
+        )
+
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
+    def test_earthmodel1_hrv_rapidscan_fill(self):
+        """Test the HRV RSS padded to fulldisk with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN_FILL
         )
 
         assertNumpyArraysEqual(np.array(calculated.area_extent),
@@ -480,7 +770,18 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
+    def test_earthmodel1_visir_roi_fill(self):
+        """Test the VISIR ROI padded to fulldisk with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL1_VISIR_ROI_FILL
+        )
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
     def test_earthmodel1_hrv_roi(self):
         """Test the HRV ROI with the EarthModel 1."""
@@ -491,11 +792,22 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
+    def test_earthmodel1_hrv_roi_fill(self):
+        """Test the HRV ROI padded to fulldisk with the EarthModel 1."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL1_HRV_ROI_FILL
+        )
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
     # Earth model 2 tests
     def test_earthmodel2_visir_fulldisk(self):
-        """Test the VISIR Fulldisk with the EarthModel 2."""
+        """Test the VISIR FES with the EarthModel 2."""
         calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL2_VISIR_FULLDISK
         )
@@ -503,10 +815,10 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
     def test_earthmodel2_hrv_fulldisk(self):
-        """Test the HRV Fulldisk with the EarthModel 2."""
+        """Test the HRV FES with the EarthModel 2."""
         calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK
         )
@@ -515,13 +827,60 @@ class TestNativeMSGArea(unittest.TestCase):
 
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.defs[0].proj_id,  expected['Projection ID'])
-        self.assertEqual(calculated.defs[1].proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.defs[0].proj_id, expected['Projection ID'])
+        self.assertEqual(calculated.defs[1].proj_id, expected['Projection ID'])
+
+    def test_earthmodel2_hrv_fulldisk_fill(self):
+        """Test the HRV FES padded to fulldisk with the EarthModel 2."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL2_HRV_FULLDISK_FILL
+        )
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
+    def test_earthmodel2_visir_rapidscan(self):
+        """Test the VISIR RSS with the EarthModel 2."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL2_VISIR_RAPIDSCAN
+        )
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
+    def test_earthmodel2_visir_rapidscan_fill(self):
+        """Test the VISIR RSS padded to fulldisk with the EarthModel 2."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL2_VISIR_RAPIDSCAN_FILL
+        )
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
     def test_earthmodel2_hrv_rapidscan(self):
-        """Test the HRV Fulldisk with the EarthModel 1."""
+        """Test the HRV RSS with the EarthModel 2."""
         calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN
+        )
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
+    def test_earthmodel2_hrv_rapidscan_fill(self):
+        """Test the HRV RSS padded to fulldisk with the EarthModel 2."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL2_HRV_RAPIDSCAN_FILL
         )
         assertNumpyArraysEqual(np.array(calculated.area_extent),
                                np.array(expected['Area extent']))
@@ -539,7 +898,18 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
+    def test_earthmodel2_visir_roi_fill(self):
+        """Test the VISIR ROI padded to fulldisk with the EarthModel 2."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL2_VISIR_ROI_FILL
+        )
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
     def test_earthmodel2_hrv_roi(self):
         """Test the HRV ROI with the EarthModel 2."""
@@ -550,7 +920,18 @@ class TestNativeMSGArea(unittest.TestCase):
                                np.array(expected['Area extent']))
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
-        self.assertEqual(calculated.proj_id,  expected['Projection ID'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
+
+    def test_earthmodel2_hrv_roi_fill(self):
+        """Test the HRV ROI padded to fulldisk with the EarthModel 2."""
+        calculated, expected = self.prepare_area_defs(
+            TEST_AREA_EXTENT_EARTHMODEL2_HRV_ROI_FILL
+        )
+        assertNumpyArraysEqual(np.array(calculated.area_extent),
+                               np.array(expected['Area extent']))
+        self.assertEqual(calculated.width, expected['Number of columns'])
+        self.assertEqual(calculated.height, expected['Number of rows'])
+        self.assertEqual(calculated.proj_id, expected['Projection ID'])
 
 
 class TestNativeMSGCalibrationMode(unittest.TestCase):


### PR DESCRIPTION
This PR adds the possibility to load any native SEVIRI data as a full-disk array, padded with no-data where necessary, by providing the `fill_disk` as True in the `reader_kwargs` . This is especially useful for the HRV channel in FES (full Earth Scanning) mode, as it contains data from two different windows, but can also be used for VISIR and HRV RSS (Rapid Scanning Service) and ROI (Region of Interest) data. By default the original, unpadded, data are loaded (fill_disk=False).

The PR also includes the harmonization of the area id.

Wrt. the documentation I updated the status of the reader to "Nominal", but as far as I could see there is no specific documentation to update for the native reader.

 - [x] Closes #1440 
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
