### PR TITLE
Fix handling of modifiers in satpy-cf reader

### DIFF
--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -263,6 +263,7 @@ class SatpyCFFileHandler(BaseFileHandler):
             ds_info = dict(val.attrs)
             ds_info['file_type'] = self.filetype_info['file_type']
             ds_info['name'] = var_name
+            self.fix_modifier_attr(ds_info)
             yield True, ds_info
 
     def get_dataset(self, ds_id, ds_info):

--- a/satpy/tests/reader_tests/test_satpy_cf_nc.py
+++ b/satpy/tests/reader_tests/test_satpy_cf_nc.py
@@ -64,12 +64,14 @@ class TestCFReader(unittest.TestCase):
                            dims=('y', 'x'),
                            coords={'y': y_visir, 'x': x_visir},
                            attrs={'name': 'lat',
-                                  'standard_name': 'latitude'})
+                                  'standard_name': 'latitude',
+                                  'modifiers': np.array([])})
         lon = xr.DataArray(lon,
                            dims=('y', 'x'),
                            coords={'y': y_visir, 'x': x_visir},
                            attrs={'name': 'lon',
-                                  'standard_name': 'longitude'})
+                                  'standard_name': 'longitude',
+                                  'modifiers': np.array([])})
         self.scene = Scene()
         self.scene.attrs['sensor'] = ['avhrr-1', 'avhrr-2', 'avhrr-3']
         scene_dict = {'image0': vis006,


### PR DESCRIPTION
Coordinates can have a `modifiers` attribute, too.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->

