### PR TITLE
Add comprehensive calibration tests for SEVIRI readers

### DIFF
--- a/satpy/tests/reader_tests/test_seviri_l1b_nc.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_nc.py
@@ -22,9 +22,11 @@ from unittest import mock
 from datetime import datetime
 
 import numpy as np
+import pytest
 import xarray as xr
 
 from satpy.readers.seviri_l1b_nc import NCSEVIRIFileHandler
+from satpy.tests.reader_tests.test_seviri_base import TestCalibrationBase
 from satpy.tests.utils import make_dataid
 
 
@@ -71,3 +73,98 @@ class TestNCSEVIRIFileHandler(unittest.TestCase):
 
         strip_attrs = ["comment", "long_name", "nc_key", "scale_factor", "add_offset", "valid_min", "valid_max"]
         self.assertFalse(any([k in res.attrs.keys() for k in strip_attrs]))
+
+
+class TestCalibration(TestCalibrationBase):
+    """Unit tests for calibration."""
+
+    @pytest.fixture(name='file_handler')
+    def file_handler(self, counts):
+        """Create a mocked file handler."""
+        with mock.patch(
+            'satpy.readers.seviri_l1b_nc.NCSEVIRIFileHandler.__init__',
+            return_value=None
+        ):
+            # Create dataset and set calibration coefficients
+            ds = xr.Dataset(
+                {
+                    'VIS006': counts.copy(),
+                    'IR_108': counts.copy(),
+                    'planned_chan_processing': self.radiance_types,
+                },
+                attrs={
+                    'satellite_id': self.platform_id
+                }
+            )
+            ds['VIS006'].attrs.update({
+                'scale_factor': self.gains_nominal[0],
+                'add_offset': self.offsets_nominal[0]
+            })
+            ds['IR_108'].attrs.update({
+                'scale_factor': self.gains_nominal[8],
+                'add_offset': self.offsets_nominal[8],
+            })
+
+            # Add some attributes so that the reader can strip them
+            strip_attrs = {
+                'comment': None,
+                'long_name': None,
+                'valid_min': None,
+                'valid_max': None
+            }
+            for name in ['VIS006', 'IR_108']:
+                ds[name].attrs.update(strip_attrs)
+
+            # Create file handler
+            fh = NCSEVIRIFileHandler()
+            fh.nc = ds
+            fh.deltaSt = self.scan_time
+            fh.mda = {
+                'projection_parameters': {
+                    'ssp_longitude': 0,
+                    'h': 12345
+                }
+            }
+            return fh
+
+    @pytest.mark.parametrize(
+        ('channel', 'calibration', 'use_ext_coefs'),
+        [
+            # VIS channel, internal coefficients
+            ('VIS006', 'counts', False),
+            ('VIS006', 'radiance', False),
+            ('VIS006', 'reflectance', False),
+            # VIS channel, external coefficients
+            # ('VIS006', 'radiance', True),
+            # ('VIS006', 'reflectance', True),
+            # IR channel, internal coefficients
+            ('IR_108', 'counts', False),
+            ('IR_108', 'radiance', False),
+            ('IR_108', 'brightness_temperature', False),
+            # IR channel, external coefficients
+            # ('IR_108', 'radiance', True),
+            # ('IR_108', 'brightness_temperature', True),
+        ]
+    )
+    def test_calibrate(
+            self, file_handler, channel, calibration, use_ext_coefs
+    ):
+        """Test the calibration."""
+        external_coefs = self.external_coefs if use_ext_coefs else {}
+        expected = self._get_expected(
+            channel=channel,
+            calibration=calibration,
+            calib_mode='NOMINAL',
+            use_ext_coefs=use_ext_coefs
+        )
+        fh = file_handler
+        fh.ext_calib_coefs = external_coefs  # no effect ATM
+
+        dataset_info = {
+            'nc_key': channel
+        }
+        dataset_id = make_dataid(name=channel, calibration=calibration)
+
+        res = fh.get_dataset(dataset_id, dataset_info)
+        res = res.isel(y=slice(None, None, -1))  # compatibility with other readers
+        xr.testing.assert_allclose(res, expected)


### PR DESCRIPTION
This is a helper PR for #1457 which is a bigger refactoring. Updating the corresponding tests seems difficult, because they patch a lot of private methods. So the idea here is to first add comprehensive calibration tests that only use public methods. Then do the refactoring and see if they still pass.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
