### PR TITLE
Fix wavelength range print out to use regular nbsp

### DIFF
--- a/satpy/dataset/dataid.py
+++ b/satpy/dataset/dataid.py
@@ -127,7 +127,7 @@ class WavelengthRange(wlklass):
 
     def __str__(self):
         """Format for print out."""
-        return "{0.central} {0.unit} ({0.min}-{0.max} {0.unit})".format(self)
+        return "{0.central} {0.unit} ({0.min}-{0.max} {0.unit})".format(self)
 
     def __contains__(self, other):
         """Check if this range contains *other*."""

--- a/satpy/tests/test_dataset.py
+++ b/satpy/tests/test_dataset.py
@@ -536,5 +536,5 @@ def test_wavelength_range():
         wr2 in wr
 
     # Check __str__
-    assert str(wr) == "2 µm (1-3 µm)"
-    assert str(wr2) == "2 nm (1-3 nm)"
+    assert str(wr) == "2 µm (1-3 µm)"
+    assert str(wr2) == "2 nm (1-3 nm)"


### PR DESCRIPTION
The International System of Units page on wikipedia says:

 > The value of a quantity is written as a number followed by a space (representing a multiplication sign) and a unit symbol; e.g., 2.21 kg, 7.3×102 m2, 22 K. This rule explicitly includes the percent sign (%)[28]:134 and the symbol for degrees Celsius (°C).[28]:133 Exceptions are the symbols for plane angular degrees, minutes, and seconds (°, ′, and ″, respectively), which are placed immediately after the number with no intervening space.

(https://en.wikipedia.org/wiki/International_System_of_Units#General_rules)

so a regular (not narrow) space is now used when displaying wavelength ranges.

 - [x] Closes #1449 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

