### PR TITLE
FSFile support for avhrr l1b gaclac

### DIFF
--- a/satpy/readers/avhrr_l1b_gaclac.py
+++ b/satpy/readers/avhrr_l1b_gaclac.py
@@ -123,7 +123,11 @@ class GACLACFile(BaseFileHandler):
                 interpolate_coords=self.interpolate_coords,
                 creation_site=self.creation_site,
                 **self.reader_kwargs)
-            self.reader.read(self.filename)
+            if hasattr(self.filename, 'open'):
+                with self.filename.open() as fileobj:
+                    self.reader.read(str(self.filename), fileobj)
+            else:
+                self.reader.read(self.filename)
             if np.all(self.reader.mask):
                 raise ValueError('All data is masked out')
 

--- a/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
+++ b/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
@@ -160,8 +160,8 @@ class TestGACLACFile(ModulePatcher):
         import satpy
         from satpy.readers import FSFile
 
-        coords = np.arange(4).reshape((2,2))
-        channels = np.arange(4*6).reshape((2,2,6))
+        coords = np.arange(4).reshape((2, 2))
+        channels = np.arange(4*6).reshape((2, 2, 6))
         utcs = np.array(['2000-01-01', '2020-01-01'], dtype='datetime64')
         reader_mock = mock.MagicMock()
         reader_mock.get_lonlat.return_value = coords, coords

--- a/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
+++ b/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
@@ -17,6 +17,7 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Pygac interface."""
 
+import io
 from datetime import datetime
 from unittest import TestCase, mock
 
@@ -153,6 +154,36 @@ class TestGACLACFile(ModulePatcher):
                                 "Start time must precede end time.")
                 self.assertIs(fh.reader_class, reader_cls,
                               'Wrong reader class assigned to {}'.format(filename))
+
+    def test_fsfile(self):
+        """Test the use of FSFile filename"""
+        import satpy
+        from satpy.readers import FSFile
+
+        coords = np.arange(4).reshape((2,2))
+        channels = np.arange(4*6).reshape((2,2,6))
+        utcs = np.array(['2000-01-01', '2020-01-01'], dtype='datetime64')
+        reader_mock = mock.MagicMock()
+        reader_mock.get_lonlat.return_value = coords, coords
+        reader_mock.get_calibrated_channels.return_value = channels
+        reader_mock.mask = [True]
+        reader_mock.get_times.return_value = utcs
+        self.pygac.gac_klm.GACKLMReader.return_value = reader_mock
+
+        filepath = '/path/to/NSS.GHRR.NN.D16160.S0504.E0659.B5694748.WI'
+        fileobj = io.BytesIO()
+        filesystem = mock.MagicMock()
+        filesystem.open.return_value = fileobj
+        filename = FSFile(filepath, fs=filesystem)
+        reader = 'avhrr_l1b_gaclac'
+        reader_kwargs = {'tle_dir': './TLE/',
+                         'tle_name': 'TLE_%(satname)s.txt',
+                         'tle_thresh': 7}
+
+        scene = satpy.Scene(filenames=[filename], reader=reader,
+                            reader_kwargs=reader_kwargs)
+        scene.load(['1', '2'])
+        reader_mock.read.assert_called_once_with(filepath, fileobj)
 
     def test_read_raw_data(self):
         """Test raw data reading."""


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
This PR enables the use of `FSPath` objects for the `avhrr_l1b_gaclac` reader.
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #1299 (for my use case) <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already

Note:
------
Beside fsspec FileSystem paths, this PR allows any sort of `PathLike` objects as filenames.
This allows passing file objects by defining a `PathLike` class as follows:
```python
@total_ordering
class FileObjectPath(os.PathLike):
    def __init__(self, fileobj, filepath=None):
        self._fileobj = fileobj
        self._filepath = filepath or fileobj.name
    
    def __str__(self):
        return self._filepath
    
    def __fspath__(self):
        return self._filepath
    
    def __lt__(self, other):
        return os.fspath(self) < os.fspath(other)
    
    def open(self):
        return self._fileobj
```