### PR TITLE
Fix '::' erroneous for dicts syntax in docstrings

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -14,6 +14,7 @@ The following people have made contributions to this project:
 - [Jorge Bravo (jhbravo)](https://github.com/jhbravo)
 - [Andrew Brooks (howff)](https://github.com/howff)
 - Guido della Bruna - meteoswiss
+- [Pierre de Buyl (pdebuyl)](https://github.com/pdebuyl)
 - [Eric Bruning (deeplycloudy)](https://github.com/deeplycloudy)
 - [Lorenzo Clementi (loreclem)](https://github.com/loreclem)
 - [Colin Duff (ColinDuff)](https://github.com/ColinDuff)

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -240,7 +240,7 @@ class AHIHSDFileHandler(BaseFileHandler):
         filenames = glob.glob('*FLDK*.dat')
         scene = satpy.Scene(filenames,
                             reader='ahi_hsd',
-                            reader_kwargs={'mask_space':: False})
+                            reader_kwargs={'mask_space': False})
         scene.load([0.6])
 
     The AHI HSD data files contain multiple VIS channel calibration
@@ -254,7 +254,7 @@ class AHIHSDFileHandler(BaseFileHandler):
         filenames = glob.glob('*FLDK*.dat')
         scene = satpy.Scene(filenames,
                             reader='ahi_hsd',
-                            reader_kwargs={'calib_mode':: 'update'})
+                            reader_kwargs={'calib_mode': 'update'})
         scene.load([0.6])
 
     Alternative AHI calibrations are also available, such as GSICS
@@ -276,7 +276,7 @@ class AHIHSDFileHandler(BaseFileHandler):
         filenames = glob.glob('*FLDK*.dat')
         scene = satpy.Scene(filenames,
                             reader='ahi_hsd',
-                            reader_kwargs={'user_calibration':: calib_dict)
+                            reader_kwargs={'user_calibration': calib_dict)
         # B15 will not have custom radiance correction applied.
         scene.load(['B07', 'B14', 'B15'])
 

--- a/satpy/readers/ami_l1b.py
+++ b/satpy/readers/ami_l1b.py
@@ -51,7 +51,7 @@ class AMIL1bNetCDF(BaseFileHandler):
         filenames = glob.glob('*FLDK*.dat')
         scene = satpy.Scene(filenames,
                             reader='ahi_hsd',
-                            reader_kwargs={'calib_mode':: 'gsics'})
+                            reader_kwargs={'calib_mode': 'gsics'})
         scene.load(['B13'])
 
     In addition, the GSICS website (and other sources) also supply radiance
@@ -74,8 +74,8 @@ class AMIL1bNetCDF(BaseFileHandler):
         filenames = glob.glob('*.nc')
         scene = satpy.Scene(filenames,
                             reader='ami_l1b',
-                            reader_kwargs={'user_calibration':: calib_dict,
-                                           'calib_mode':: 'file')
+                            reader_kwargs={'user_calibration': calib_dict,
+                                           'calib_mode': 'file')
         # IR133 will not have radiance correction applied.
         scene.load(['WV063', 'IR087', 'IR133'])
 

--- a/satpy/readers/slstr_l1b.py
+++ b/satpy/readers/slstr_l1b.py
@@ -116,7 +116,7 @@ class NCSLSTR1B(BaseFileHandler):
     calib_dict = {'S1_nadir': 1.12}
     scene = satpy.Scene(filenames,
                         reader='slstr-l1b',
-                        reader_kwargs={'user_calib':: calib_dict})
+                        reader_kwargs={'user_calib': calib_dict})
 
     Will multiply S1 nadir radiances by 1.12.
     """


### PR DESCRIPTION
fix #1453

This PR fixes the syntax error in some readers docstrings.

 - [x] Closes #1453
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Add your name to `AUTHORS.md` if not there already

