### PR TITLE
Add support for multiple values in the DecisionTree used for enhancements

### DIFF
--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -111,53 +111,12 @@ class TestEnhancer(unittest.TestCase):
             ValueError, Enhancer, enhancement_config_file="is_not_a_valid_filename_?.yaml")
 
 
-class TestEnhancerUserConfigs(unittest.TestCase):
-    """Test `Enhancer` functionality when user's custom configurations are present."""
+class _BaseCustomEnhancementConfigTests:
 
-    ENH_FN = 'test_sensor.yaml'
-    ENH_ENH_FN = os.path.join('enhancements', ENH_FN)
-    ENH_FN2 = 'test_sensor2.yaml'
-    ENH_ENH_FN2 = os.path.join('enhancements', ENH_FN2)
-    ENH_FN3 = 'test_empty.yaml'
-
-    TEST_CONFIGS = {
-        ENH_FN: """
-sensor_name: visir/test_sensor
-enhancements:
-  test1_default:
-    name: test1
-    operations:
-    - name: stretch
-      method: !!python/name:satpy.enhancements.stretch ''
-      kwargs: {stretch: linear, cutoffs: [0., 0.]}
-
-        """,
-        ENH_ENH_FN: """
-sensor_name: visir/test_sensor
-enhancements:
-  test1_kelvin:
-    name: test1
-    units: kelvin
-    operations:
-    - name: stretch
-      method: !!python/name:satpy.enhancements.stretch ''
-      kwargs: {stretch: crude, min_stretch: 0, max_stretch: 20}
-
-        """,
-        ENH_FN2: """
-sensor_name: visir/test_sensor2
-
-
-        """,
-        ENH_ENH_FN2: """
-sensor_name: visir/test_sensor2
-
-        """,
-        ENH_FN3: """""",
-    }
+    TEST_CONFIGS = {}
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         """Create fake user configurations."""
         for fn, content in cls.TEST_CONFIGS.items():
             base_dir = os.path.dirname(fn)
@@ -179,7 +138,7 @@ sensor_name: visir/test_sensor2
         cls.CustomImageWriter = CustomImageWriter
 
     @classmethod
-    def tearDownClass(cls):
+    def teardown_class(cls):
         """Remove fake user configurations."""
         for fn, _content in cls.TEST_CONFIGS.items():
             base_dir = os.path.dirname(fn)
@@ -187,6 +146,141 @@ sensor_name: visir/test_sensor2
                 shutil.rmtree(base_dir)
             elif os.path.isfile(fn):
                 os.remove(fn)
+
+
+class TestComplexSensorEnhancerConfigs(_BaseCustomEnhancementConfigTests):
+    """Test enhancement configs that use or expect multiple sensors."""
+
+    ENH_FN = 'test_sensor1.yaml'
+    ENH_FN2 = 'test_sensor2.yaml'
+
+    TEST_CONFIGS = {
+        ENH_FN: """
+sensor_name: visir/test_sensor1
+enhancements:
+  test1_sensor1_specific:
+    name: test1
+    sensor: test_sensor1
+    operations:
+    - name: stretch
+      method: !!python/name:satpy.enhancements.stretch
+      kwargs: {stretch: crude, min_stretch: 0, max_stretch: 200}
+
+        """,
+        ENH_FN2: """
+sensor_name: visir/test_sensor2
+enhancements:
+  default:
+    operations:
+    - name: stretch
+      method: !!python/name:satpy.enhancements.stretch
+      kwargs: {stretch: crude, min_stretch: 0, max_stretch: 100}
+  test1_sensor2_specific:
+    name: test1
+    sensor: test_sensor2
+    operations:
+    - name: stretch
+      method: !!python/name:satpy.enhancements.stretch
+      kwargs: {stretch: crude, min_stretch: 0, max_stretch: 50}
+  exact_multisensor_comp:
+    name: my_comp
+    sensor: [test_sensor1, test_sensor2]
+    operations:
+    - name: stretch
+      method: !!python/name:satpy.enhancements.stretch
+      kwargs: {stretch: crude, min_stretch: 0, max_stretch: 20}
+            """,
+    }
+
+    def test_multisensor_choice(self):
+        """Test that a DataArray with two sensors works."""
+        from satpy.writers import Enhancer, get_enhanced_image
+        from xarray import DataArray
+        ds = DataArray(np.arange(1, 11.).reshape((2, 5)),
+                       attrs={
+                           'name': 'test1',
+                           'sensor': {'test_sensor2', 'test_sensor1'},
+                           'mode': 'L'
+                       },
+                       dims=['y', 'x'])
+        e = Enhancer()
+        assert e.enhancement_tree is not None
+        img = get_enhanced_image(ds, enhance=e)
+        # make sure that both sensor configs were loaded
+        assert (set(e.sensor_enhancement_configs) ==
+                {os.path.abspath(self.ENH_FN),
+                 os.path.abspath(self.ENH_FN2)})
+        # test_sensor1 config should have been used because it is
+        # alphabetically first
+        np.testing.assert_allclose(img.data.values[0], ds.data / 200.0)
+
+    def test_multisensor_exact(self):
+        """Test that a DataArray with two sensors can match exactly."""
+        from satpy.writers import Enhancer, get_enhanced_image
+        from xarray import DataArray
+        ds = DataArray(np.arange(1, 11.).reshape((2, 5)),
+                       attrs={
+                           'name': 'my_comp',
+                           'sensor': {'test_sensor2', 'test_sensor1'},
+                           'mode': 'L'
+                       },
+                       dims=['y', 'x'])
+        e = Enhancer()
+        assert e.enhancement_tree is not None
+        img = get_enhanced_image(ds, enhance=e)
+        # make sure that both sensor configs were loaded
+        assert (set(e.sensor_enhancement_configs) ==
+                {os.path.abspath(self.ENH_FN),
+                 os.path.abspath(self.ENH_FN2)})
+        # test_sensor1 config should have been used because it is
+        # alphabetically first
+        np.testing.assert_allclose(img.data.values[0], ds.data / 20.0)
+
+
+class TestEnhancerUserConfigs(_BaseCustomEnhancementConfigTests):
+    """Test `Enhancer` functionality when user's custom configurations are present."""
+
+    ENH_FN = 'test_sensor.yaml'
+    ENH_ENH_FN = os.path.join('enhancements', ENH_FN)
+    ENH_FN2 = 'test_sensor2.yaml'
+    ENH_ENH_FN2 = os.path.join('enhancements', ENH_FN2)
+    ENH_FN3 = 'test_empty.yaml'
+
+    TEST_CONFIGS = {
+        ENH_FN: """
+sensor_name: visir/test_sensor
+enhancements:
+  test1_default:
+    name: test1
+    operations:
+    - name: stretch
+      method: !!python/name:satpy.enhancements.stretch
+      kwargs: {stretch: linear, cutoffs: [0., 0.]}
+
+        """,
+        ENH_ENH_FN: """
+sensor_name: visir/test_sensor
+enhancements:
+  test1_kelvin:
+    name: test1
+    units: kelvin
+    operations:
+    - name: stretch
+      method: !!python/name:satpy.enhancements.stretch
+      kwargs: {stretch: crude, min_stretch: 0, max_stretch: 20}
+
+        """,
+        ENH_FN2: """
+sensor_name: visir/test_sensor2
+
+
+        """,
+        ENH_ENH_FN2: """
+sensor_name: visir/test_sensor2
+
+        """,
+        ENH_FN3: """""",
+    }
 
     def test_enhance_empty_config(self):
         """Test Enhancer doesn't fail with empty enhancement file."""
@@ -196,10 +290,10 @@ sensor_name: visir/test_sensor2
                        attrs=dict(sensor='test_empty', mode='L'),
                        dims=['y', 'x'])
         e = Enhancer()
-        self.assertIsNotNone(e.enhancement_tree)
+        assert e.enhancement_tree is not None
         get_enhanced_image(ds, enhance=e)
-        self.assertSetEqual(set(e.sensor_enhancement_configs),
-                            {os.path.abspath(self.ENH_FN3)})
+        assert (set(e.sensor_enhancement_configs) ==
+                {os.path.abspath(self.ENH_FN3)})
 
     def test_enhance_with_sensor_no_entry(self):
         """Test enhancing an image that has no configuration sections."""
@@ -209,11 +303,11 @@ sensor_name: visir/test_sensor2
                        attrs=dict(sensor='test_sensor2', mode='L'),
                        dims=['y', 'x'])
         e = Enhancer()
-        self.assertIsNotNone(e.enhancement_tree)
+        assert e.enhancement_tree is not None
         get_enhanced_image(ds, enhance=e)
-        self.assertSetEqual(set(e.sensor_enhancement_configs),
-                            {os.path.abspath(self.ENH_FN2),
-                             os.path.abspath(self.ENH_ENH_FN2)})
+        assert (set(e.sensor_enhancement_configs) ==
+                {os.path.abspath(self.ENH_FN2),
+                 os.path.abspath(self.ENH_ENH_FN2)})
 
     def test_deprecated_enhance_with_file_specified(self):
         """Test enhancing an image when config file is specified."""
@@ -267,12 +361,11 @@ sensor_name: visir/test_sensor2
                        attrs=dict(name='test1', sensor='test_sensor', mode='L'),
                        dims=['y', 'x'])
         e = Enhancer()
-        self.assertIsNotNone(e.enhancement_tree)
+        assert e.enhancement_tree is not None
         img = get_enhanced_image(ds, enhance=e)
-        self.assertSetEqual(
-            set(e.sensor_enhancement_configs),
-            {os.path.abspath(self.ENH_FN),
-             os.path.abspath(self.ENH_ENH_FN)})
+        assert (set(e.sensor_enhancement_configs) ==
+                {os.path.abspath(self.ENH_FN),
+                 os.path.abspath(self.ENH_ENH_FN)})
         np.testing.assert_almost_equal(img.data.isel(bands=0).max().values,
                                        1.)
 
@@ -280,11 +373,11 @@ sensor_name: visir/test_sensor2
                        attrs=dict(name='test1', sensor='test_sensor', mode='L'),
                        dims=['y', 'x'])
         e = Enhancer()
-        self.assertIsNotNone(e.enhancement_tree)
+        assert e.enhancement_tree is not None
         img = get_enhanced_image(ds, enhance=e)
-        self.assertSetEqual(set(e.sensor_enhancement_configs),
-                            {os.path.abspath(self.ENH_FN),
-                             os.path.abspath(self.ENH_ENH_FN)})
+        assert (set(e.sensor_enhancement_configs) ==
+                {os.path.abspath(self.ENH_FN),
+                 os.path.abspath(self.ENH_ENH_FN)})
         np.testing.assert_almost_equal(img.data.isel(bands=0).max().values, 1.)
 
     def test_enhance_with_sensor_entry2(self):
@@ -296,11 +389,11 @@ sensor_name: visir/test_sensor2
                                   sensor='test_sensor', mode='L'),
                        dims=['y', 'x'])
         e = Enhancer()
-        self.assertIsNotNone(e.enhancement_tree)
+        assert e.enhancement_tree is not None
         img = get_enhanced_image(ds, enhance=e)
-        self.assertSetEqual(set(e.sensor_enhancement_configs),
-                            {os.path.abspath(self.ENH_FN),
-                             os.path.abspath(self.ENH_ENH_FN)})
+        assert (set(e.sensor_enhancement_configs) ==
+                {os.path.abspath(self.ENH_FN),
+                 os.path.abspath(self.ENH_ENH_FN)})
         np.testing.assert_almost_equal(img.data.isel(bands=0).max().values, 0.5)
 
 

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -17,7 +17,6 @@
 """Test generic writer functions."""
 
 import os
-import errno
 import shutil
 import unittest
 import warnings
@@ -26,23 +25,6 @@ import numpy as np
 import xarray as xr
 from trollimage.colormap import greys
 from unittest import mock
-
-
-def mkdir_p(path):
-    """Make directories."""
-    if not path or path == '.':
-        return
-
-    # Use for python 2.7 compatibility
-    # When python 2.7 support is dropped just use
-    # `os._makedirs(path, exist_ok=True)`
-    try:
-        os.makedirs(path)
-    except OSError as exc:  # Python >2.5
-        if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
 
 
 class TestWritersModule(unittest.TestCase):
@@ -179,7 +161,8 @@ sensor_name: visir/test_sensor2
         """Create fake user configurations."""
         for fn, content in cls.TEST_CONFIGS.items():
             base_dir = os.path.dirname(fn)
-            mkdir_p(base_dir)
+            if base_dir:
+                os.makedirs(base_dir, exist_ok=True)
             with open(fn, 'w') as f:
                 f.write(content)
 

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -876,7 +876,8 @@ class DecisionTree(object):
 
     Examples:
         Decision sections are provided as a dictionary of dictionaries.
-        Matches are returned
+        The returned match will be the first result found by searching
+        provided `match_keys` in order.
 
         decisions = {
             'first_section': {

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -859,14 +859,54 @@ class ImageWriter(Writer):
 
 
 class DecisionTree(object):
-    """The decision tree."""
+    """Structure to search for nearest match from a set of parameters.
+
+    This class is used to find the best configuration section by matching
+    a set of attributes. The provided dictionary contains a mapping of
+    "section name" to "decision" dictionaries. Each decision dictionary
+    contains the attributes that will be used for matching plus any
+    additional keys that could be useful when matched. This class will
+    search these decisions and return the one with the most matching
+    parameters to the attributes passed to the
+    :meth:`~satpy.writers.DecisionTree.find_match`` method.
+
+    Note that decision sections are provided as a dict instead of a list
+    so that they can be overwritten or updated by doing the equivalent
+    of a ``current_dicts.update(new_dicts)``.
+
+    Examples:
+        Decision sections are provided as a dictionary of dictionaries.
+        Matches are returned
+
+        decisions = {
+            'first_section': {
+                'a': 1,
+                'b': 2,
+                'useful_key': 'useful_value',
+            },
+            'second_section': {
+                'a': 5,
+                'useful_key': 'other_useful_value1',
+            },
+            'third_section': {
+                'b': 4,
+                'useful_key': 'other_useful_value2',
+            },
+        }
+        tree = DecisionTree(decisions, ('a', 'b'))
+        tree.find_match(a=5, b=2)  # second_section dict
+        tree.find_match(a=1, b=2)  # first_section dict
+        tree.find_match(a=5, b=4)  # second_section dict
+        tree.find_match(a=3, b=2)  # no match
+
+    """
 
     any_key = None
 
-    def __init__(self, decision_dicts, attrs, **kwargs):
+    def __init__(self, decision_dicts, match_keys):
         """Init the decision tree."""
-        self.attrs = attrs
-        self.tree = {}
+        self._match_keys = match_keys
+        self._tree = {}
         if not isinstance(decision_dicts, (list, tuple)):
             decision_dicts = [decision_dicts]
         self.add_config_to_tree(*decision_dicts)
@@ -879,52 +919,77 @@ class DecisionTree(object):
         self._build_tree(conf)
 
     def _build_tree(self, conf):
-        """Build the tree."""
-        for _section_name, attrs in conf.items():
-            # Set a path in the tree for each section in the configuration
-            # files
-            curr_level = self.tree
-            for attr in self.attrs:
+        """Build the tree.
+
+        Create a tree structure of dicts where each level represents the
+        possible matches for a specific ``match_key``. When finding matches
+        we will iterate through the tree matching each key that we know about.
+        The last dict in the "tree" will contain the configure section whose
+        match values led down that path in the tree.
+
+        See :meth:`DecisionTree.find_match` for more information.
+
+        """
+        for _section_name, sect_attrs in conf.items():
+            # Set a path in the tree for each section in the config files
+            curr_level = self._tree
+            for match_key in self._match_keys:
                 # or None is necessary if they have empty strings
-                this_attr = attrs.get(attr, self.any_key) or None
-                if attr == self.attrs[-1]:
+                this_attr_val = sect_attrs.get(match_key, self.any_key) or None
+                is_last_key = match_key == self._match_keys[-1]
+                level_needs_init = this_attr_val not in curr_level
+                if is_last_key:
                     # if we are at the last attribute, then assign the value
                     # set the dictionary of attributes because the config is
                     # not persistent
-                    curr_level[this_attr] = attrs
-                elif this_attr not in curr_level:
-                    curr_level[this_attr] = {}
-                curr_level = curr_level[this_attr]
+                    curr_level[this_attr_val] = sect_attrs
+                elif level_needs_init:
+                    curr_level[this_attr_val] = {}
+                curr_level = curr_level[this_attr_val]
 
-    def _find_match(self, curr_level, attrs, kwargs):
-        """Find a match."""
-        if len(attrs) == 0:
-            # we're at the bottom level, we must have found something
-            return curr_level
-
+    def _find_match_if_known(self, curr_level, remaining_match_keys, query_dict):
         match = None
+        curr_match_key = remaining_match_keys[0]
         try:
-            if attrs[0] in kwargs and kwargs[attrs[0]] in curr_level:
-                # we know what we're searching for, try to find a pattern
-                # that uses this attribute
-                match = self._find_match(curr_level[kwargs[attrs[0]]],
-                                         attrs[1:], kwargs)
+            if curr_match_key in query_dict and query_dict[curr_match_key] in curr_level:
+                # query has this parameter, let's search down that path
+                query_val = query_dict[curr_match_key]
+                match = self._find_match(curr_level[query_val],
+                                         remaining_match_keys[1:],
+                                         query_dict)
         except TypeError:
             # we don't handle multiple values (for example sensor) atm.
             LOG.debug("Strange stuff happening in decision tree for %s: %s",
-                      attrs[0], kwargs[attrs[0]])
+                      curr_match_key, query_dict[remaining_match_keys[0]])
+        return match
+
+    def _find_match(self, curr_level, remaining_match_keys, query_dict):
+        """Find a match."""
+        if len(remaining_match_keys) == 0:
+            # we're at the bottom level, we must have found something
+            return curr_level
+
+        match = self._find_match_if_known(
+            curr_level, remaining_match_keys, query_dict)
 
         if match is None and self.any_key in curr_level:
             # if we couldn't find it using the attribute then continue with
             # the other attributes down the 'any' path
-            match = self._find_match(curr_level[self.any_key], attrs[1:],
-                                     kwargs)
+            match = self._find_match(
+                curr_level[self.any_key],
+                remaining_match_keys[1:],
+                query_dict)
         return match
 
-    def find_match(self, **kwargs):
-        """Find a match."""
+    def find_match(self, **query_dict):
+        """Find a match.
+
+        Recursively search through the tree structure for a path that matches
+        the provided match parameters.
+
+        """
         try:
-            match = self._find_match(self.tree, self.attrs, kwargs)
+            match = self._find_match(self._tree, self._match_keys, query_dict)
         except (KeyError, IndexError, ValueError):
             LOG.debug("Match exception:", exc_info=True)
             LOG.error("Error when finding matching decision section")
@@ -932,7 +997,7 @@ class DecisionTree(object):
         if match is None:
             # only possible if no default section was provided
             raise KeyError("No decision section found for %s" %
-                           (kwargs.get("uid", None), ))
+                           (query_dict.get("uid", None),))
         return match
 
 
@@ -941,14 +1006,15 @@ class EnhancementDecisionTree(DecisionTree):
 
     def __init__(self, *decision_dicts, **kwargs):
         """Init the decision tree."""
-        attrs = kwargs.pop("attrs", ("name",
-                                     "platform_name",
-                                     "sensor",
-                                     "standard_name",
-                                     "units",))
+        match_keys = kwargs.pop("match_keys",
+                                ("name",
+                                 "platform_name",
+                                 "sensor",
+                                 "standard_name",
+                                 "units",))
         self.prefix = kwargs.pop("config_section", "enhancements")
         super(EnhancementDecisionTree, self).__init__(
-            decision_dicts, attrs, **kwargs)
+            decision_dicts, match_keys, **kwargs)
 
     def add_config_to_tree(self, *decision_dict):
         """Add configuration to tree."""
@@ -978,14 +1044,14 @@ class EnhancementDecisionTree(DecisionTree):
 
         self._build_tree(conf)
 
-    def find_match(self, **kwargs):
+    def find_match(self, **query_dict):
         """Find a match."""
         try:
-            return super(EnhancementDecisionTree, self).find_match(**kwargs)
+            return super(EnhancementDecisionTree, self).find_match(**query_dict)
         except KeyError:
             # give a more understandable error message
             raise KeyError("No enhancement configuration found for %s" %
-                           (kwargs.get("uid", None), ))
+                           (query_dict.get("uid", None),))
 
 
 class Enhancer(object):


### PR DESCRIPTION
The current `DecisionTree` class, which is used as the base class for the `EnhancementDecisionTree`, currently has issues when a DataArray has multiple sensors specified for `.attrs['sensor']`. It currently causes a `TypeError` with a semi-cryptic debug log message produced:

```
Strange stuff happening in decision tree for %s: %s
```

This is because the DecisionTree expects a single string value for the "sensor" value, but is getting a set (ex. `{'abi', 'glm'}`). What this means is that you can never actually configure an enhancement for a DataArray with multiple sensors as it will fail when trying to find the match. This PR is meant to allow for you to both configure an enhancement for `sensor: [abi, glm]` to match it exactly, or for the provided DataArray with `.attrs['sensor'] = {'abi', 'glm'}` to match either `sensor: abi` or `sensor: glm`.

My one concern about this is that specifying `sensor: [abi, glm]` in the YAML config will make people think that that matches either `abi` or `glm` when it will actually only match the exact pair `{'abi', 'glm'}`.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
