### PR TITLE
Improve FCI geolocation computation, harmonize area_id, add geolocation tests

### DIFF
--- a/satpy/etc/areas.yaml
+++ b/satpy/etc/areas.yaml
@@ -433,8 +433,8 @@ met07globe:
   area_extent:
     lower_left_xy: [-5621225.237846375, -5621225.237846375]
     upper_right_xy: [5621225.237846375, 5621225.237846375]
-fci_0deg_1km:
-  description: Full disk FCI view, 1 km (based on pre-launch test data)
+mtg_fci_fdss_1km:
+  description: FCI Full-Disk Scanning Service area definition with 1 km resolution
   projection:
     proj: geos
     lon_0: 0
@@ -447,11 +447,11 @@ fci_0deg_1km:
     height: 11136
     width: 11136
   area_extent:
-    lower_left_xy: [-5567999.998527619, -5567999.998577303]
-    upper_right_xy: [5567999.998577303,  5567999.998527619]
+    lower_left_xy: [-5567999.998577303, -5567999.998577303]
+    upper_right_xy: [5567999.998527619,  5567999.998527619]
     units: m
-fci_0deg_2km:
-  description: Full disk FCI view, 2 km (based on pre-launch test data)
+mtg_fci_fdss_2km:
+  description: FCI Full-Disk Scanning Service area definition with 2 km resolution
   projection:
     proj: geos
     lon_0: 0
@@ -464,8 +464,8 @@ fci_0deg_2km:
     height: 5568
     width: 5568
   area_extent:
-    lower_left_xy: [-5567999.994206558, -5567999.994200589]
-    upper_right_xy: [5567999.994200589,  5567999.994206558]
+    lower_left_xy: [-5567999.994200589, -5567999.994200589]
+    upper_right_xy: [5567999.994206558,  5567999.994206558]
     units: m
 spain:
   description: Spain

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -21,27 +21,29 @@ This module defines the :class:`FCIFDHSIFileHandler` file handler, to
 be used for reading Meteosat Third Generation (MTG) Flexible Combined
 Imager (FCI) Full Disk High Spectral Imagery (FDHSI) data.  FCI will fly
 on the MTG Imager (MTG-I) series of satellites, scheduled to be launched
-in 2021 by the earliest.  For more information about FCI, see `EUMETSAT`_.
+in 2022 by the earliest.  For more information about FCI, see `EUMETSAT`_.
+
+For simulated test data to be used with this reader, see `test data release`_.
+For the Product User Guide (PUG) of the FCI L1c data, see `PUG`_.
+
 
 Geolocation is based on information from the data files.  It uses:
 
     * From the shape of the data variable ``data/<channel>/measured/effective_radiance``,
       start and end line columns of current swath.
     * From the data variable ``data/<channel>/measured/x``, the x-coordinates
-      for the grid, in radians
+      for the grid, in radians (azimuth angle positive towards West).
     * From the data variable ``data/<channel>/measured/y``, the y-coordinates
-      for the grid, in radians
+      for the grid, in radians (elevation angle positive towards North).
     * From the attribute ``semi_major_axis`` on the data variable
       ``data/mtg_geos_projection``, the Earth equatorial radius
-    * From the attribute ``semi_minor_axis`` on the same, the Earth polar
-      radius
-    * From the attribute ``perspective_point_height`` on the same data
-      variable, the geostationary altitude in the normalised geostationary
-      projection (see `PUG`_ §5.2)
-    * From the attribute ``longitude_of_projection_origin`` on the same
-      data variable, the longitude of the projection origin
     * From the attribute ``inverse_flattening`` on the same data variable, the
       (inverse) flattening of the ellipsoid
+    * From the attribute ``perspective_point_height`` on the same data
+      variable, the geostationary altitude in the normalised geostationary
+      projection
+    * From the attribute ``longitude_of_projection_origin`` on the same
+      data variable, the longitude of the projection origin
     * From the attribute ``sweep_angle_axis`` on the same, the sweep angle
       axis, see https://proj.org/operations/projections/geos.html
 
@@ -53,8 +55,8 @@ geostationary altitude, and longitude of projection origin, are passed on to
 ``pyresample.geometry.AreaDefinition``, which then uses proj4 for the actual
 geolocation calculations.
 
-The brightness temperature calculation is based on the formulas indicated in
-`PUG`_ and `RADTOBR`_.
+The brightness temperature and reflectance calculation is based on the formulas indicated in
+`PUG`_.
 
 The reading routine supports channel data in counts, radiances, and (depending
 on channel) brightness temperatures or reflectances.  For each channel, it also
@@ -68,9 +70,9 @@ supports the pixel quality, obtained by prepending the channel name such as
     ``pixel_quality`` and disambiguated by a to-be-decided property in the
     `DataID`.
 
-.. _RADTOBR: https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_EFFECT_RAD_TO_BRIGHTNESS&RevisionSelectionMethod=LatestReleased&Rendition=Web
-.. _PUG: http://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_DMT_719113&RevisionSelectionMethod=LatestReleased&Rendition=Web
-.. _EUMETSAT: https://www.eumetsat.int/website/home/Satellites/FutureSatellites/MeteosatThirdGeneration/MTGDesign/index.html#fci  # noqa: E501
+.. _PUG: https://www-cdn.eumetsat.int/files/2020-07/pdf_mtg_fci_l1_pug.pdf
+.. _EUMETSAT: https://www.eumetsat.int/mtg-flexible-combined-imager  # noqa: E501
+.. _test data release: https://www.eumetsat.int/simulated-mtg-fci-l1c-enhanced-non-nominal-datasets
 """
 
 from __future__ import (division, absolute_import, print_function,
@@ -262,33 +264,38 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         # Calculate full globe line extent
         h = float(self["data/mtg_geos_projection/attr/perspective_point_height"])
 
-        ext = {}
-        for c in "xy":
-            c_radian = self["data/{:s}/measured/{:s}".format(lab, c)]
-            c_radian_num = c_radian[:] * c_radian.scale_factor + c_radian.add_offset
+        extents = {}
+        for coord in "xy":
+            coord_radian = self["data/{:s}/measured/{:s}".format(lab, coord)]
+            coord_radian_num = coord_radian[:] * coord_radian.scale_factor + coord_radian.add_offset
 
-            # FCI defines pixels by centroids (Example Products for Pytroll
-            # Workshop, §B.4.2)
+            # FCI defines pixels by centroids (see PUG)
             #
             # pyresample defines corners as lower left corner of lower left pixel,
             # upper right corner of upper right pixel (Martin Raspaud, personal
-            # communication).
+            # communication). Therefore, half a pixel needs to be added in each direction.
+
+            # SW corner
+            first_coord_radian = coord_radian_num[0] - coord_radian.scale_factor/2
+            # NE corner
+            last_coord_radian = coord_radian_num[-1] + coord_radian.scale_factor/2
+
+            # convert to arc length in m
+            first_coord = first_coord_radian * h  # arc length in m
+            last_coord = last_coord_radian * h
 
             # the .item() call is needed with the h5netcdf backend, see
             # https://github.com/pytroll/satpy/issues/972#issuecomment-558191583
             # but we need to compute it first if this is dask
-            min_c_radian = c_radian_num[0] - c_radian.scale_factor/2
-            max_c_radian = c_radian_num[-1] + c_radian.scale_factor/2
-            min_c = min_c_radian * h  # arc length in m
-            max_c = max_c_radian * h
             try:
-                min_c = min_c.compute()
-                max_c = max_c.compute()
+                first_coord = first_coord.compute()
+                last_coord = last_coord.compute()
             except AttributeError:  # not a dask.array
                 pass
-            ext[c] = (min_c.item(), max_c.item())
+            extents[coord] = (first_coord.item(), last_coord.item())
 
-        area_extent = (ext["x"][1], ext["y"][1], ext["x"][0], ext["y"][0])
+        area_extent = (extents["x"][1], extents["y"][1], extents["x"][0], extents["y"][0])
+        # area_extent = (-ext["x"][0], ext["y"][1], -ext["x"][1], ext["y"][0])
         return area_extent, nlines, ncols
 
     def get_area_def(self, key, info=None):
@@ -379,9 +386,10 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
 
     def calibrate_rad_to_bt(self, radiance, key):
         """IR channel calibration."""
+        # using the method from PUG section Converting from Effective Radiance to Brightness Temperature for IR Channels
+
         measured = self.get_channel_measured_group_path(key['name'])
 
-        # using the method from RADTOBR and PUG
         vc = self[measured + "/radiance_to_bt_conversion_coefficient_wavenumber"]
 
         a = self[measured + "/radiance_to_bt_conversion_coefficient_a"]

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -323,7 +323,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
         rf = float(self["data/mtg_geos_projection/attr/inverse_flattening"])
         lon_0 = float(self["data/mtg_geos_projection/attr/longitude_of_projection_origin"])
         sweep = str(self["data/mtg_geos_projection"].sweep_angle_axis)
-        # Channel dependent swath resolution
+
         area_extent, nlines, ncols = self.calc_area_extent(key)
         logger.debug('Calculated area extent: {}'
                      .format(''.join(str(area_extent))))
@@ -337,10 +337,14 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
                      'units': 'm',
                      "sweep": sweep}
 
+        area_id_name = 'mtg_fci_fdss_{:.0f}km'.format(key['resolution']/1000)
+        area_id_description = 'FCI Full-Disk Scanning Service area definition with {:.0f} km resolution' \
+                              ''.format(key['resolution']/1000)
+
         area = geometry.AreaDefinition(
-            'some_area_name',
-            "On-the-fly area",
-            'geosfci',
+            area_id_name,
+            area_id_description,
+            "FCI Full-Disk Scanning Service geostationary projection",
             proj_dict,
             ncols,
             nlines,

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -337,6 +337,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
                      'units': 'm',
                      "sweep": sweep}
 
+        # follow the format <platform>_<instrument>_<service>_<resolution>
         area_id_name = 'mtg_fci_fdss_{:.0f}km'.format(key['resolution']/1000)
         area_id_description = 'FCI Full-Disk Scanning Service area definition with {:.0f} km resolution' \
                               ''.format(key['resolution']/1000)

--- a/satpy/readers/fci_l1c_fdhsi.py
+++ b/satpy/readers/fci_l1c_fdhsi.py
@@ -274,7 +274,7 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
             # (see https://pyresample.readthedocs.io/en/latest/geo_def.html).
             # Therefore, half a pixel (i.e. half scale factor) needs to be added in each direction.
 
-            # The grid origin is in the SW corner.
+            # The grid origin is in the South-West corner.
             # Note that the azimuth angle (x) is defined as positive towards West (see PUG - Level 1c Reference Grid)
             # The elevation angle (y) is defined as positive towards North as per usual convention. Therefore:
             # The values of x go from positive (West) to negative (East) and the scale factor of x is negative.
@@ -301,12 +301,12 @@ class FCIFDHSIFileHandler(NetCDF4FileHandler):
             extents[coord] = (first_coord.item(), last_coord.item())
 
         # For the final extents, take into account that the image is upside down (lower line is North), and that
-        # East is defined as positive azimuth in Proj so we need to multiply by -1 the azimuth extents.
+        # East is defined as positive azimuth in Proj, so we need to multiply by -1 the azimuth extents.
 
-        # lower left column: west-ward extent: first coord of x, multiplied by -1 to account for azimuth orientation
-        # lower left line: north-ward extent: last coord of y
-        # upper right column: east-ward extent: last coord of x, multiplied by -1 to account for azimuth orientation
-        # upper right line: south-ward extent: first coord of y
+        # lower left x: west-ward extent: first coord of x, multiplied by -1 to account for azimuth orientation
+        # lower left y: north-ward extent: last coord of y
+        # upper right x: east-ward extent: last coord of x, multiplied by -1 to account for azimuth orientation
+        # upper right y: south-ward extent: first coord of y
         area_extent = (-extents["x"][0], extents["y"][1], -extents["x"][1], extents["y"][0])
 
         return area_extent, nlines, ncols

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -492,14 +492,19 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
         assert res['vis_06'].attrs['area'].area_id == 'mtg_fci_fdss_1km'
         assert res['ir_105'].attrs['area'].area_id == 'mtg_fci_fdss_2km'
 
+        area_def = res['ir_105'].attrs['area']
         # test area extents computation
-        np.testing.assert_array_almost_equal(np.array(res['ir_105'].attrs['area'].area_extent),
+        np.testing.assert_array_almost_equal(np.array(area_def.area_extent),
                                              np.array([-5568062.23065902, 5168057.7600648,
                                                        16704186.692027, 5568062.23065902]))
 
-        # check the projection string
-        expected_proj_str = '+ellps=WGS84 +h=35786400 +lon_0=0 +no_defs +proj=geos +type=crs +units=m +x_0=0 +y_0=0'
-        assert res['ir_105'].attrs['area'].proj_str == expected_proj_str
+        # check that the projection is read in properly
+        assert area_def.crs.coordinate_operation.method_name == 'Geostationary Satellite (Sweep Y)'
+        assert area_def.crs.coordinate_operation.params[0].value == 0.0  # projection origin longitude
+        assert area_def.crs.coordinate_operation.params[1].value == 35786400.0  # projection height
+        assert area_def.crs.ellipsoid.semi_major_metre == 6378137.0
+        assert area_def.crs.ellipsoid.inverse_flattening == 298.257223563
+        assert area_def.crs.ellipsoid.is_semi_minor_computed
 
 
 class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -493,9 +493,9 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
         assert res['ir_105'].attrs['area'].area_id == 'mtg_fci_fdss_2km'
 
         # test area extents computation
-        np.testing.assert_array_equal(np.array(res['ir_105'].attrs['area'].area_extent),
-                                      np.array([-5568062.23065902, 5168057.7600648,
-                                                16704186.692027, 5568062.23065902]))
+        np.testing.assert_array_almost_equal(np.array(res['ir_105'].attrs['area'].area_extent),
+                                             np.array([-5568062.23065902, 5168057.7600648,
+                                                       16704186.692027, 5568062.23065902]))
 
         # check the projection string
         expected_proj_str = '+ellps=WGS84 +h=35786400 +lon_0=0 +no_defs +proj=geos +type=crs +units=m +x_0=0 +y_0=0'

--- a/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_fdhsi.py
@@ -149,21 +149,14 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
 
     def _get_test_content_areadef(self):
         data = {}
-        proc = "state/processor"
-        for (lb, no) in (
-                ("earth_equatorial_radius", 6378137),
-                ("earth_polar_radius", 6356752),
-                ("reference_altitude", 35786000),
-                ("projection_origin_longitude", 0)):
-            data[proc + "/" + lb] = xr.DataArray(no)
+
         proj = "data/mtg_geos_projection"
 
         attrs = {
-                "sweep_angle_axis": "x",
-                "perspective_point_height": "35786400",
-                "semi_major_axis": "6378137",
-                "semi_minor_axis": "6356752",
-                "longitude_of_projection_origin": "0",
+                "sweep_angle_axis": "y",
+                "perspective_point_height": "35786400.0",
+                "semi_major_axis": "6378137.0",
+                "longitude_of_projection_origin": "0.0",
                 "inverse_flattening": "298.257223563",
                 "units": "m"}
         data[proj] = xr.DataArray(
@@ -255,9 +248,6 @@ class TestFCIL1CFDHSIReader:
 
 class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
     """Test FCI L1C FDHSI reader."""
-
-    # TODO:
-    # - test geolocation
 
     _alt_handler = FakeNetCDF4FileHandler2
 
@@ -482,6 +472,34 @@ class TestFCIL1CFDHSIReaderGoodData(TestFCIL1CFDHSIReader):
             fhs["fci_l1c_fdhsi"][0].get_dataset(
                     make_dataid(name="ir_123", calibration="unknown"),
                     {"units": "unknown"})
+
+    def test_area_definition_computation(self, reader_configs):
+        """Test that the geolocation computation is correct."""
+        from satpy.readers import load_reader
+
+        filenames = [
+            "W_XX-EUMETSAT-Darmstadt,IMG+SAT,MTI1+FCI-1C-RRAD-FDHSI-FD--"
+            "CHK-BODY--L2P-NC4E_C_EUMT_20170410114434_GTT_DEV_"
+            "20170410113925_20170410113934_N__C_0070_0067.nc",
+        ]
+
+        reader = load_reader(reader_configs)
+        loadables = reader.select_files_from_pathnames(filenames)
+        reader.create_filehandlers(loadables)
+        res = reader.load(['ir_105', 'vis_06'], pad_data=False)
+
+        # test that area_ids are harmonisation-conform <platform>_<instrument>_<service>_<resolution>
+        assert res['vis_06'].attrs['area'].area_id == 'mtg_fci_fdss_1km'
+        assert res['ir_105'].attrs['area'].area_id == 'mtg_fci_fdss_2km'
+
+        # test area extents computation
+        np.testing.assert_array_equal(np.array(res['ir_105'].attrs['area'].area_extent),
+                                      np.array([-5568062.23065902, 5168057.7600648,
+                                                16704186.692027, 5568062.23065902]))
+
+        # check the projection string
+        expected_proj_str = '+ellps=WGS84 +h=35786400 +lon_0=0 +no_defs +proj=geos +type=crs +units=m +x_0=0 +y_0=0'
+        assert res['ir_105'].attrs['area'].proj_str == expected_proj_str
 
 
 class TestFCIL1CFDHSIReaderBadData(TestFCIL1CFDHSIReader):


### PR DESCRIPTION
This PR does a few changes to the geolocation part of the `fci_l1_fdhsi` reader.

- changes slightly how the area extents are computed (multiply by -1 the azimuth array instead of flipping it, see comments)
- changes slightly how the proj dict is composed (remove `semi_minor_axis` and use inverse flattening instead)
          - fixes bug in proj dictionary: inverse flattening parameter is called `rf` and not `if` (see 
                  https://en.wikibooks.org/wiki/PROJ.4#Parameters)
- harmonises the area_id names according to https://github.com/pytroll/satpy/issues/1248
- updates the areas.yaml accordingly
- adds tests for the geolocation
- updates the links to references after EUM website update

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
