### PR TITLE
Remove x/y coordinates in mviri_l1b_fiduceo_nc

### DIFF
--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -581,6 +581,7 @@ class FiduceoMviriBase(BaseFileHandler):
             ds = self._get_channel(name, resolution, dataset_id['calibration'])
         else:
             ds = self._get_other_dataset(name)
+        ds = self._cleanup_coords(ds)
         self._update_attrs(ds, dataset_info)
         return ds
 
@@ -639,6 +640,16 @@ class FiduceoMviriBase(BaseFileHandler):
                          'sensor': self.filename_info['sensor']})
         ds.attrs['raw_metadata'] = self.nc.attrs
         ds.attrs['orbital_parameters'] = self._get_orbital_parameters()
+
+    def _cleanup_coords(self, ds):
+        """Cleanup dataset coordinates.
+
+        Y/x coordinates have been useful for interpolation so far, but they
+        only contain row/column numbers. Drop these coordinates so that Satpy
+        can assign projection coordinates upstream (based on the area
+        definition).
+        """
+        return ds.drop_vars(['y', 'x'])
 
     def _calibrate(self, ds, channel, calibration):
         """Calibrate the given dataset."""

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -65,8 +65,6 @@ vis_counts_exp = xr.DataArray(
     ),
     dims=('y', 'x'),
     coords={
-        'y': [1, 2, 3, 4],
-        'x': [1, 2, 3, 4],
         'acq_time': ('y', acq_time_vis_exp),
     },
     attrs=attrs_exp
@@ -81,8 +79,6 @@ vis_rad_exp = xr.DataArray(
     ),
     dims=('y', 'x'),
     coords={
-        'y': [1, 2, 3, 4],
-        'x': [1, 2, 3, 4],
         'acq_time': ('y', acq_time_vis_exp),
     },
     attrs=attrs_exp
@@ -100,8 +96,6 @@ vis_refl_exp = xr.DataArray(
     # Last row/col is NaN due to SZA interpolation
     dims=('y', 'x'),
     coords={
-        'y': [1, 2, 3, 4],
-        'x': [1, 2, 3, 4],
         'acq_time': ('y', acq_time_vis_exp),
     },
     attrs=attrs_refl_exp
@@ -115,10 +109,6 @@ u_vis_refl_exp = xr.DataArray(
         dtype=np.float32
     ),
     dims=('y', 'x'),
-    coords={
-        'y': [1, 2, 3, 4],
-        'x': [1, 2, 3, 4],
-    },
     attrs=attrs_exp
 )
 acq_time_ir_wv_exp = [np.datetime64('1970-01-01 00:30'),
@@ -131,8 +121,6 @@ wv_counts_exp = xr.DataArray(
     ),
     dims=('y', 'x'),
     coords={
-        'y': [1, 2],
-        'x': [1, 2],
         'acq_time': ('y', acq_time_ir_wv_exp),
     },
     attrs=attrs_exp
@@ -145,8 +133,6 @@ wv_rad_exp = xr.DataArray(
     ),
     dims=('y', 'x'),
     coords={
-        'y': [1, 2],
-        'x': [1, 2],
         'acq_time': ('y', acq_time_ir_wv_exp),
     },
     attrs=attrs_exp
@@ -159,8 +145,6 @@ wv_bt_exp = xr.DataArray(
     ),
     dims=('y', 'x'),
     coords={
-        'y': [1, 2],
-        'x': [1, 2],
         'acq_time': ('y', acq_time_ir_wv_exp),
     },
     attrs=attrs_exp
@@ -173,8 +157,6 @@ ir_counts_exp = xr.DataArray(
     ),
     dims=('y', 'x'),
     coords={
-        'y': [1, 2],
-        'x': [1, 2],
         'acq_time': ('y', acq_time_ir_wv_exp),
     },
     attrs=attrs_exp
@@ -187,8 +169,6 @@ ir_rad_exp = xr.DataArray(
     ),
     dims=('y', 'x'),
     coords={
-        'y': [1, 2],
-        'x': [1, 2],
         'acq_time': ('y', acq_time_ir_wv_exp),
     },
     attrs=attrs_exp
@@ -201,8 +181,6 @@ ir_bt_exp = xr.DataArray(
     ),
     dims=('y', 'x'),
     coords={
-        'y': [1, 2],
-        'x': [1, 2],
         'acq_time': ('y', acq_time_ir_wv_exp),
     },
     attrs=attrs_exp
@@ -216,10 +194,6 @@ quality_pixel_bitmask_exp = xr.DataArray(
         dtype=np.uint8
     ),
     dims=('y', 'x'),
-    coords={
-        'y': [1, 2, 3, 4],
-        'x': [1, 2, 3, 4],
-    },
     attrs=attrs_exp
 )
 sza_vis_exp = xr.DataArray(
@@ -231,10 +205,6 @@ sza_vis_exp = xr.DataArray(
         dtype=np.float32
     ),
     dims=('y', 'x'),
-    coords={
-        'y': [1, 2, 3, 4],
-        'x': [1, 2, 3, 4],
-    },
     attrs=attrs_exp
 )
 sza_ir_wv_exp = xr.DataArray(
@@ -244,10 +214,6 @@ sza_ir_wv_exp = xr.DataArray(
         dtype=np.float32
     ),
     dims=('y', 'x'),
-    coords={
-        'y': [1, 2],
-        'x': [1, 2],
-    },
     attrs=attrs_exp
 )
 area_vis_exp = AreaDefinition(


### PR DESCRIPTION
Remove x/y coordinates from `mviri_l1b_fiduceo_nc` datasets as they only contain image rows/columns and prevent satpy from adding projection coordinates (based on the area definition).

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
