### PR TITLE
Add reader support for VIIRS Land Surface Reflectance

### DIFF
--- a/satpy/etc/readers/viirs_l2_lsr.yaml
+++ b/satpy/etc/readers/viirs_l2_lsr.yaml
@@ -9,7 +9,7 @@ file_types:
         file_reader: !!python/name:satpy.readers.viirs_l2_lsr.VIIRSLandSurfaceReflectanceFileHandler
         variable_prefix: ""
         file_patterns: 
-            - 'SurfRefl_v1r1_{platform_shortname:3s}_s{start_time:%Y%m%d%H%M%S%f}_e{end_time:%Y%m%d%H%M%S%f}_c{creation_time:%Y%m%d%H%M%S%f}.nc'
+            - 'SurfRefl_v{version:1d}r{revision:1d}_{platform_shortname:3s}_s{start_time:%Y%m%d%H%M%S%f}_e{end_time:%Y%m%d%H%M%S%f}_c{creation_time:%Y%m%d%H%M%S%f}.nc'
 
 navigations:
     vgeoi:

--- a/satpy/etc/readers/viirs_l2_lsr.yaml
+++ b/satpy/etc/readers/viirs_l2_lsr.yaml
@@ -1,0 +1,187 @@
+reader:
+    description: VIIRS Land Surface Reflectance Reader
+    name: viirs_l2_lsr
+    reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
+    sensors: [viirs]
+
+file_types:
+    lsr_netcdf:
+        file_reader: !!python/name:satpy.readers.viirs_l2_lsr.VIIRSLandSurfaceReflectanceFileHandler
+        variable_prefix: ""
+        file_patterns: 
+            - 'SurfRefl_v1r1_{platform_shortname:3s}_s{start_time:%Y%m%d%H%M%S%f}_e{end_time:%Y%m%d%H%M%S%f}_c{creation_time:%Y%m%d%H%M%S%f}.nc'
+
+navigations:
+    vgeoi:
+        description: VIIRS L1B I-band Navigation
+        file_type: vgeoi
+        latitude_key: Latitude_at_375m_resolution
+        longitude_key: Longitude_at_375m_resolution
+        nadir_resolution: [371]
+        rows_per_scan: 32
+    vgeom:
+        description: VIIRS L1B M-band Navigation
+        file_type: vgeom
+        latitude_key: Latitude_at_750m_resolution
+        longitude_key: Longitude_at_750m_resolution
+        nadir_resolution: [742]
+        rows_per_scan: 16
+
+datasets:
+    i1:
+        name: i1
+        standard_name: i1
+        file_type: [lsr_netcdf]
+        file_key: "375m Surface Reflectance Band I1"
+        coordinates: [i_lon, i_lat]
+        units: '1'
+        _FillValue: -9999
+    srf_i1:
+        name: srf_i1
+        standard_name: surface_reflectance
+        file_type: [lsr_netcdf]
+        file_key: "375m Surface Reflectance Band I1"
+        coordinates: [i_lon, i_lat]
+        units: '1'
+        _FillValue: -9999
+    srf_i2:
+        name: srf_i2
+        standard_name: surface_reflectance
+        file_type: [lsr_netcdf]
+        file_key: "375m Surface Reflectance Band I2"
+        coordinates: [i_lon, i_lat]
+        units: '1'
+        _FillValue: -9999
+    srf_i3:
+        name: srf_i3
+        standard_name: surface_reflectance
+        file_type: [lsr_netcdf]
+        file_key: "375m Surface Reflectance Band I3"
+        coordinates: [i_lon, i_lat]
+        units: '1'
+        _FillValue: -9999
+
+
+    srf_m1:
+        name: srf_m1
+        standard_name: surface_reflectance
+        file_type: [lsr_netcdf]
+        file_key: "750m Surface Reflectance Band M1"
+        coordinates: [m_lon, m_lat]
+        units: '1'
+        _FillValue: -9999
+    srf_m2:
+        name: srf_m2
+        standard_name: surface_reflectance
+        file_type: [lsr_netcdf]
+        file_key: "750m Surface Reflectance Band M2"
+        coordinates: [m_lon, m_lat]
+        units: '1'
+        _FillValue: -9999
+    srf_m3:
+        name: srf_m3
+        standard_name: surface_reflectance
+        file_type: [lsr_netcdf]
+        file_key: "750m Surface Reflectance Band M3"
+        coordinates: [m_lon, m_lat]
+        units: '1'
+        _FillValue: -9999
+    srf_m4:
+        name: srf_m4
+        standard_name: surface_reflectance
+        file_type: [lsr_netcdf]
+        file_key: "750m Surface Reflectance Band M4"
+        coordinates: [m_lon, m_lat]
+        units: '1'
+        _FillValue: -9999
+    srf_m5:
+        name: srf_m5
+        standard_name: surface_reflectance
+        file_type: [lsr_netcdf]
+        file_key: "750m Surface Reflectance Band M5"
+        coordinates: [m_lon, m_lat]
+        units: '1'
+        _FillValue: -9999
+# m6 is not valid
+    srf_m7:
+        name: srf_m7
+        standard_name: surface_reflectance
+        file_type: [lsr_netcdf]
+        file_key: "750m Surface Reflectance Band M7"
+        coordinates: [m_lon, m_lat]
+        units: '1'
+        _FillValue: -9999
+    srf_m8:
+        name: srf_m8
+        standard_name: surface_reflectance
+        file_type: [lsr_netcdf]
+        file_key: "750m Surface Reflectance Band M8"
+        coordinates: [m_lon, m_lat]
+        units: '1'
+        _FillValue: -9999
+# m9 is not valid
+    srf_m10:
+        name: srf_m10
+        standard_name: surface_reflectance
+        file_type: [lsr_netcdf]
+        file_key: "750m Surface Reflectance Band M10"
+        coordinates: [m_lon, m_lat]
+        units: '1'
+        _FillValue: -9999
+    srf_m11:
+        name: srf_m11
+        standard_name: surface_reflectance
+        file_type: [lsr_netcdf]
+        file_key: "750m Surface Reflectance Band M11"
+        coordinates: [m_lon, m_lat]
+        units: '1'
+        _FillValue: -9999
+
+    m_lon:
+        name: m_lon
+        resolution: 742
+        standard_name: longitude
+        file_type: [lsr_netcdf]
+        file_key: "Longitude_at_750m_resolution"
+        units: 'degrees_east'
+        _FillValue: -999.9
+    m_lat:
+        name: m_lat
+        resolution: 742
+        standard_name: latitude
+        file_type: [lsr_netcdf]
+        file_key: "Latitude_at_750m_resolution"
+        units: 'degrees_north'
+        _FillValue: -999.9
+    i_lon:
+        name: i_lon
+        resolution: 371
+        standard_name: longitude
+        file_type: [lsr_netcdf]
+        file_key: "Longitude_at_375m_resolution"
+        units: 'degrees_east'
+        _FillValue: -999.9
+    i_lat:
+        name: i_lat
+        resolution: 371
+        standard_name: latitude
+        file_type: [lsr_netcdf]
+        file_key: "Latitude_at_375m_resolution"
+        units: 'degrees_north'
+        _FillValue: -999.9
+
+
+    ndvi: # only in the CSPP product
+        name: ndvi
+        standard_name: ndvi
+        file_type: [lsr_netcdf]
+        file_key: "NDVI"
+        coordinates: [i_lon, i_lat]
+        units: '1'
+    evi: # only in the CSPP product
+        name: evi
+        standard_name: evi
+        file_type: [lsr_netcdf]
+        file_key: "EVI"
+        coordinates: [i_lon, i_lat]
+        units: '1'

--- a/satpy/readers/viirs_l2_lsr.py
+++ b/satpy/readers/viirs_l2_lsr.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 20 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""VIIRS Land Surface Reflectance reader.
+
+This module implements readers for VIIRS Land Surface Reflectance NetCDF
+files, with additions for CSPP LEO NDVI & EVI products.
+"""
+
+from satpy.readers.netcdf_utils import NetCDF4FileHandler
+from satpy.readers.file_handlers import BaseFileHandler
+import dask.dataframe as dd
+import xarray as xr
+import numpy as np
+
+# map platform attributes to Oscar standard name
+PLATFORM_MAP = {
+    "NPP": "Suomi-NPP",
+    "J01": "NOAA-20",
+    "J02": "NOAA-21"
+}
+
+
+class VIIRSLandSurfaceReflectanceFileHandler(NetCDF4FileHandler):
+    """NetCDF4 reader for VIIRS Land Surface Reflectance."""
+
+    def __init__(self, filename, filename_info, filetype_info,
+                 auto_maskandscale=False, xarray_kwargs=None):
+        """Open and perform initial investigation of NetCDF file."""
+        super(VIIRSLandSurfaceReflectanceFileHandler, self).__init__(
+            filename, filename_info, filetype_info,
+            auto_maskandscale=auto_maskandscale, xarray_kwargs=xarray_kwargs)
+        self.prefix = filetype_info.get('variable_prefix')
+
+    def get_dataset(self, dsid, dsinfo):
+        """Get requested data as DataArray.
+
+        Args:
+            dsid: Dataset ID
+            param2: Dataset Information
+
+        Returns:
+            Dask DataArray: Data
+
+        """
+        key = dsinfo.get('file_key', dsid['name']).format(variable_prefix=self.prefix)
+        data = self[key]
+        # rename "phoney dims"
+        data = data.rename(dict(zip(data.dims, ['y', 'x'])))
+
+        # handle attributes from YAML
+        for key in ('units', 'standard_name', 'flag_meanings', 'flag_values', '_FillValue'):
+            # we only want to add information that isn't present already
+            if key in dsinfo and key not in data.attrs:
+                data.attrs[key] = dsinfo[key]
+        if isinstance(data.attrs.get('flag_meanings'), str):
+            data.attrs['flag_meanings'] = data.attrs['flag_meanings'].split(' ')
+
+        # use more common CF standard units
+        if data.attrs.get('units') == 'kelvins':
+            data.attrs['units'] = 'K'
+
+        data.attrs["platform_name"] = PLATFORM_MAP.get(self.filename_info['platform_shortname'].upper(), "unknown")
+        data.attrs["sensor"] = "VIIRS"
+
+        if dsid['name'] == "ndvi" or dsid['name'] == "evi":
+            data = data.where(data <= 1.0, np.float32(np.nan))
+            data = data.where(data >= -1.0, np.float32(np.nan))
+
+        return data
+
+    @property
+    def start_time(self):
+        """Get first date/time when observations were recorded."""
+        return self.filename_info['start_time']
+
+    @property
+    def end_time(self):
+        """Get last date/time when observations were recorded."""
+        return self.filename_info.get('end_time', self.start_time)
+
+    @property
+    def sensor_name(self):
+        """Name of sensor for this file."""
+        return self["sensor"]
+
+    @property
+    def platform_name(self):
+        """Name of platform/satellite for this file."""
+        return self["platform_name"]


### PR DESCRIPTION
This PR adds a reader for the VIIRS Land Surface Reflectance product, with additional NDVI/EVI fields provided by the (upcoming) CSPP VIIRS LSR release.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
