### PR TITLE
Fix: bucket resampler changing dtype

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -1105,7 +1105,7 @@ class BucketResamplerBase(BaseResampler):
             attrs['calibration'] = ''
             attrs['standard_name'] = 'number_of_observations'
 
-        result = xr.DataArray(result, dims=dims, coords=coords,
+        result = xr.DataArray(result.astype(data.dtype.type), dims=dims, coords=coords,
                               attrs=attrs)
 
         return update_resampled_coords(data, result, self.target_geo_def)


### PR DESCRIPTION
Fixes the dtype of the data returned from bucket resampler being different from the input data dtype.

The `get_sum`, `get_average` and `get_fractions` called in the `compute` method of the resampler use `dask.array.where` which does not preserve dtype.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
