### PR TITLE
Add auxiliary data download API

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -39,6 +39,7 @@ dependencies:
   - fsspec
   - pylibtiff
   - python-geotiepoints
+  - pooch
   - pip
   - pip:
     - trollsift

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - graphviz
   - numpy
   - pillow
+  - pooch
   - pyresample
   - setuptools
   - setuptools_scm

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -268,4 +268,5 @@ intersphinx_mapping = {
     'xarray': ('https://xarray.pydata.org/en/stable', None),
     'rasterio': ('https://rasterio.readthedocs.io/en/latest', None),
     'donfig': ('https://donfig.readthedocs.io/en/latest', None),
+    'pooch': ('https://www.fatiando.org/pooch/latest/', None),
 }

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -130,6 +130,21 @@ defaults to a different path depending on your operating system following the
 `appdirs <https://github.com/ActiveState/appdirs#some-example-output>`_
 "user data dir".
 
+.. _download_aux_setting:
+
+Download Auxiliary Data
+^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Environment variable**: ``SATPY_DOWNLOAD_AUX``
+* **YAML/Config Key**: ``download_aux``
+* **Default**: True
+
+Whether to allow downloading of auxiliary files for certain Satpy operations.
+See :doc:`dev_guide/aux_data` for more information. If ``True`` then Satpy
+will download and cache any necessary data files to :ref:`data_dir_setting`
+when needed. If ``False`` then pre-downloaded files will be used, but any
+other files will not be downloaded or checked for validity.
+
 .. _component_configuration:
 
 Component Configuration

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -115,6 +115,8 @@ configuration files, they are merged in reverse order. This means "base"
 configuration paths should be at the end of the list and custom/user paths
 should be at the beginning of the list.
 
+.. _data_dir_setting:
+
 Data Directory
 ^^^^^^^^^^^^^^
 

--- a/doc/source/dev_guide/aux_data.rst
+++ b/doc/source/dev_guide/aux_data.rst
@@ -1,0 +1,109 @@
+Auxiliary Data Download
+=======================
+
+Sometimes Satpy components need some extra data files to get their work
+done properly. These include files like Look Up Tables (LUTs), coefficients,
+or Earth model data (ex. elevations). This includes any file that would be too
+large to be included in the Satpy python package; anything bigger than a small
+text file. To help with this, Satpy includes utilities for downloading and
+caching these files only when your component is used. This saves the user from
+wasting time and disk space downloading files they may never use.
+This functionality is made possible thanks to the
+`Pooch library <https://www.fatiando.org/pooch/latest/>`_.
+
+Downloaded files are stored in the directory configured by
+:ref:`data_dir_setting`.
+
+Adding download functionality
+-----------------------------
+
+The utility functions for data downloading include a two step process:
+
+1. **Registering**: Tell Satpy what files might need to be downloaded and used
+   later.
+2. **Retrieving**: Ask Satpy to download and store the files locally.
+
+Registering
+^^^^^^^^^^^
+
+Registering a file for downloading tells Satpy the remote URL for the file,
+and an optional hash. The hash is used to verify a successful download.
+Registering can also include a ``filename`` to tell Satpy what to name the
+file when it is downloaded. If not provided it will be determined from the URL.
+Once registered, Satpy can be told to retrieve the file (see below) by using a
+"cache key". Cache keys follow the general scheme of
+``<component_type>/<filename>`` (ex. ``readers/README.rst``).
+
+Satpy includes a low-level function and a high-level Mixin class for
+registering files. The higher level class is recommended for any Satpy
+component like readers, writers, and compositors. The lower-level
+:func:`~satpy.data_download.register_file` function can be used for any other
+use case.
+
+The :class:`~satpy.data_download.DataMixIn` class is automatically included
+in the :class:`~satpy.readers.yaml_reader.FileYAMLReader` and
+:class:`~satpy.writers.Writer` base classes. For any other component (like
+a compositor) you should include it as another parent class:
+
+.. code-block:: python
+
+    from satpy.data_download import DataDownloadMixin
+    from satpy.composites import GenericCompositor
+
+    class MyCompositor(GenericCompositor, DataDownloadMixin):
+        """Compositor that uses downloaded files."""
+
+        def __init__(self, name, url=None, known_hash=None, **kwargs):
+            super().__init__(name, **kwargs)
+            data_files = [{'url': url, 'known_hash': known_hash}]
+            self.register_data_files(data_files)
+
+However your code registers files, to be consistent it must do it during
+initialization so that the :func:`~satpy.data_download.find_registerable_files`.
+If your component isn't a reader, writer, or compositor then this function
+will need to be updated to find and load your registered files. See
+:ref:`offline_aux_downloads` below for more information.
+
+As mentioned, the mixin class is included in the base reader and writer class.
+To register files in these cases, include a ``data_files`` section in your
+YAML configuration file. For readers this would go under the ``reader``
+section and for writers the ``writer`` section. This parameter is a list
+of dictionaries including a ``url``, ``known_hash``, and optional
+``filename``. For example::
+
+    reader:
+        name: abi_l1b
+        short_name: ABI L1b
+        long_name: GOES-R ABI Level 1b
+        ... other metadata ...
+        data_files:
+          - url: "https://example.com/my_data_file.dat"
+          - url: "https://raw.githubusercontent.com/pytroll/satpy/master/README.rst"
+            known_hash: "sha256:5891286b63e7745de08c4b0ac204ad44cfdb9ab770309debaba90308305fa759"
+          - url: "https://raw.githubusercontent.com/pytroll/satpy/master/RELEASING.md"
+            filename: "satpy_releasing.md"
+            known_hash: null
+
+See the :class:`~satpy.data_download.DataDownloadMixin` for more information.
+
+Retrieving
+^^^^^^^^^^
+
+Files that have been registered (see above) can be retrieved by calling the
+:func:`~satpy.data_download.retrieve` function. This function expects a single
+argument: the cache key. Cache keys are returned by registering functions, but
+can also be pre-determined by following the scheme
+``<component_type>/<filename>`` (ex. ``readers/README.rst``).
+Retrieving a file will download it to local disk if needed and then return
+the local pathname. Data is stored locally in the :ref:`data_dir_setting`.
+It is up to the caller to then open the file.
+
+.. _offline_aux_downloads:
+
+Offline Downloads
+-----------------
+
+To assist with operational environments, Satpy includes a
+:func:`~satpy.data_download.retrieve_all` function that will try to find all
+files that Satpy components may need to download in the future and download
+them to the current directory specified by :ref:`data_dir_setting`.

--- a/doc/source/dev_guide/aux_data.rst
+++ b/doc/source/dev_guide/aux_data.rst
@@ -37,17 +37,17 @@ Once registered, Satpy can be told to retrieve the file (see below) by using a
 Satpy includes a low-level function and a high-level Mixin class for
 registering files. The higher level class is recommended for any Satpy
 component like readers, writers, and compositors. The lower-level
-:func:`~satpy.data_download.register_file` function can be used for any other
+:func:`~satpy.aux_download.register_file` function can be used for any other
 use case.
 
-The :class:`~satpy.data_download.DataMixIn` class is automatically included
+The :class:`~satpy.aux_download.DataMixIn` class is automatically included
 in the :class:`~satpy.readers.yaml_reader.FileYAMLReader` and
 :class:`~satpy.writers.Writer` base classes. For any other component (like
 a compositor) you should include it as another parent class:
 
 .. code-block:: python
 
-    from satpy.data_download import DataDownloadMixin
+    from satpy.aux_download import DataDownloadMixin
     from satpy.composites import GenericCompositor
 
     class MyCompositor(GenericCompositor, DataDownloadMixin):
@@ -59,7 +59,7 @@ a compositor) you should include it as another parent class:
             self.register_data_files(data_files)
 
 However your code registers files, to be consistent it must do it during
-initialization so that the :func:`~satpy.data_download.find_registerable_files`.
+initialization so that the :func:`~satpy.aux_download.find_registerable_files`.
 If your component isn't a reader, writer, or compositor then this function
 will need to be updated to find and load your registered files. See
 :ref:`offline_aux_downloads` below for more information.
@@ -84,13 +84,13 @@ of dictionaries including a ``url``, ``known_hash``, and optional
             filename: "satpy_releasing.md"
             known_hash: null
 
-See the :class:`~satpy.data_download.DataDownloadMixin` for more information.
+See the :class:`~satpy.aux_download.DataDownloadMixin` for more information.
 
 Retrieving
 ^^^^^^^^^^
 
 Files that have been registered (see above) can be retrieved by calling the
-:func:`~satpy.data_download.retrieve` function. This function expects a single
+:func:`~satpy.aux_download.retrieve` function. This function expects a single
 argument: the cache key. Cache keys are returned by registering functions, but
 can also be pre-determined by following the scheme
 ``<component_type>/<filename>`` (ex. ``readers/README.rst``).
@@ -104,7 +104,7 @@ Offline Downloads
 -----------------
 
 To assist with operational environments, Satpy includes a
-:func:`~satpy.data_download.retrieve_all` function that will try to find all
+:func:`~satpy.aux_download.retrieve_all` function that will try to find all
 files that Satpy components may need to download in the future and download
 them to the current directory specified by :ref:`data_dir_setting`.
 This function allows you to specify a list of ``readers``, ``writers``, or

--- a/doc/source/dev_guide/aux_data.rst
+++ b/doc/source/dev_guide/aux_data.rst
@@ -112,11 +112,11 @@ This function allows you to specify a list of ``readers``, ``writers``, or
 download.
 
 The ``retrieve_all`` function is also available through a command line script
-called ``satpy_retrieve_all``. Run the following for usage information.
+called ``satpy_retrieve_all_aux_data``. Run the following for usage information.
 
 .. code-block:: bash
 
-    satpy_retrieve_all --help
+    satpy_retrieve_all_aux_data --help
 
 To make sure that no additional files are downloaded when running Satpy see
 :ref:`download_aux_setting`.

--- a/doc/source/dev_guide/aux_data.rst
+++ b/doc/source/dev_guide/aux_data.rst
@@ -107,3 +107,13 @@ To assist with operational environments, Satpy includes a
 :func:`~satpy.data_download.retrieve_all` function that will try to find all
 files that Satpy components may need to download in the future and download
 them to the current directory specified by :ref:`data_dir_setting`.
+This function allows you to specify a list of ``readers``, ``writers``, or
+``composite_sensors`` to limit what components are checked for files to
+download.
+
+The ``retrieve_all`` function is also available through a command line script
+called ``satpy_retrieve_all``. Run the following for usage information.
+
+.. code-block:: bash
+
+    satpy_retrieve_all --help

--- a/doc/source/dev_guide/aux_data.rst
+++ b/doc/source/dev_guide/aux_data.rst
@@ -117,3 +117,6 @@ called ``satpy_retrieve_all``. Run the following for usage information.
 .. code-block:: bash
 
     satpy_retrieve_all --help
+
+To make sure that no additional files are downloaded when running Satpy see
+:ref:`download_aux_setting`.

--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -572,3 +572,11 @@ One way of implementing a file handler is shown below:
 
 If you have any questions, please contact the
 :ref:`Satpy developers <dev_help>`.
+
+Auxiliary File Download
+-----------------------
+
+If your reader needs additional data files to do calibrations, corrections,
+or anything else see the :doc:`aux_data` document for more information on
+how to download and cache these files without including them in the Satpy
+python package.

--- a/doc/source/dev_guide/index.rst
+++ b/doc/source/dev_guide/index.rst
@@ -16,6 +16,7 @@ at the pages listed below.
     custom_reader
     plugins
     satpy_internals
+    aux_data
 
 Coding guidelines
 =================

--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -38,6 +38,7 @@ _CONFIG_DEFAULTS = {
     'cache_dir': _satpy_dirs.user_cache_dir,
     'data_dir': _satpy_dirs.user_data_dir,
     'config_path': [],
+    'download_aux': True,
 }
 
 # Satpy main configuration object

--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -116,13 +116,14 @@ def config_search_paths(filename, search_dirs=None, **kwargs):
     return paths[::-1]
 
 
-def glob_config(pattern):
+def glob_config(pattern, search_dirs=None):
     """Return glob results for all possible configuration locations.
 
     Note: This method does not check the configuration "base" directory if the pattern includes a subdirectory.
           This is done for performance since this is usually used to find *all* configs for a certain component.
     """
-    patterns = config_search_paths(pattern, check_exists=False)
+    patterns = config_search_paths(pattern, search_dirs=search_dirs,
+                                   check_exists=False)
     for pattern_fn in patterns:
         for path in glob.iglob(pattern_fn):
             yield path

--- a/satpy/aux_download.py
+++ b/satpy/aux_download.py
@@ -34,7 +34,7 @@ def register_file(url, filename, component_type=None, known_hash=None):
 
     This function only prepares Satpy to be able to download and cache the
     provided file. It will not download the file. See
-    :func:`satpy.data_download.retrieve` for more information.
+    :func:`satpy.aux_download.retrieve` for more information.
 
     Args:
         url (str): URL where remote file can be downloaded.
@@ -51,7 +51,7 @@ def register_file(url, filename, component_type=None, known_hash=None):
     Returns:
         Cache key that can be used to retrieve the file later. The cache key
         consists of the ``component_type`` and provided ``filename``. This
-        should be passed to :func:`satpy.data_download_retrieve` when the
+        should be passed to :func:`satpy.aux_download_retrieve` when the
         file will be used.
 
     """
@@ -89,7 +89,7 @@ def retrieve(cache_key, pooch_kwargs=None):
 
     Args:
         cache_key (str): Cache key returned by
-            :func:`~satpy.data_download.register_file`.
+            :func:`~satpy.aux_download.register_file`.
         pooch_kwargs (dict or None): Extra keyword arguments to pass to
             :meth:`pooch.Pooch.fetch`.
 
@@ -232,7 +232,7 @@ class DataDownloadMixin:
     The below code is shown as an example::
 
         from satpy.readers.yaml_reader import AbstractYAMLReader
-        from satpy.data_download import DataDownloadMixin
+        from satpy.aux_download import DataDownloadMixin
 
         class MyReader(AbstractYAMLReader, DataDownloadMixin):
             def __init__(self, *args, **kwargs):
@@ -261,22 +261,22 @@ class DataDownloadMixin:
     In this example we register two files that might be downloaded.
     If ``known_hash`` is not provided or None (null in YAML) then the data
     file will not be checked for validity when downloaded. See
-    :func:`~satpy.data_download.register_file` for more information. You can
+    :func:`~satpy.aux_download.register_file` for more information. You can
     optionally specify ``filename`` to define the in-cache name when this file
     is downloaded. This can be useful in cases when the filename can not be
     easily determined from the URL.
 
     When it comes time to needing the file, you can retrieve the local path
-    by calling ``~satpy.data_download.retrieve(cache_key)`` with the
+    by calling ``~satpy.aux_download.retrieve(cache_key)`` with the
     "cache key" generated during registration. These keys will be in the
     format: ``<component_type>/<filename>``. For a
     reader this would be ``readers/satpy_release.md``.
 
     This Mixin is not the only way to register and download files for a
     Satpy component, but is the most generic and flexible. Feel free to
-    use the :func:`~satpy.data_download.register_file` and
-    :func:`~satpy.data_download.retrieve` functions directly.
-    However, :meth:`~satpy.data_download.find_registerable_files` must also
+    use the :func:`~satpy.aux_download.register_file` and
+    :func:`~satpy.aux_download.retrieve` functions directly.
+    However, :meth:`~satpy.aux_download.find_registerable_files` must also
     be updated to support your component (if files are not register during
     initialization).
 
@@ -299,7 +299,7 @@ class DataDownloadMixin:
     def register_data_files(self, data_files=None):
         """Register a series of files that may be downloaded later.
 
-        See :class:`~satpy.data_download.DataDownloadMixin` for more
+        See :class:`~satpy.aux_download.DataDownloadMixin` for more
         information on the assumptions and structure of the data file
         configuration dictionary.
 

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -27,7 +27,7 @@ import xarray as xr
 
 from satpy.dataset import DataID, combine_metadata
 from satpy.dataset.dataid import minimal_default_keys_config
-from satpy.data_download import DataDownloadMixin
+from satpy.aux_download import DataDownloadMixin
 from satpy.writers import get_enhanced_image
 
 
@@ -1040,7 +1040,7 @@ class StaticImageCompositor(GenericCompositor, DataDownloadMixin):
         }])
 
     def _retrieve_data_file(self):
-        from satpy.data_download import retrieve
+        from satpy.aux_download import retrieve
         if os.path.isabs(self._cache_filename):
             return self._cache_filename
         return retrieve(self._cache_key)

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -995,7 +995,6 @@ class StaticImageCompositor(GenericCompositor):
             raise ValueError("No image configured for static image compositor")
         self.file_uri = os.path.expandvars(filename)
         self._cache_filename = os.path.basename(self.file_uri)
-        self._cache_key = None  # initialized later
         self._known_hash = known_hash
         self.area = None
         if area is not None:
@@ -1003,7 +1002,7 @@ class StaticImageCompositor(GenericCompositor):
             self.area = get_area_def(area)
 
         super(StaticImageCompositor, self).__init__(name, **kwargs)
-        self.register_data_files()
+        self._cache_key = self.register_data_files()[0]
 
     def register_data_files(self):
         """Tell Satpy about files we may want to download."""
@@ -1012,7 +1011,7 @@ class StaticImageCompositor(GenericCompositor):
                                   component_type='composites',
                                   component_name=self.__class__.__name__,
                                   known_hash=self._known_hash)
-        self._cache_key = cache_key
+        return [cache_key]
 
     def __call__(self, *args, **kwargs):
         """Call the compositor."""

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1025,7 +1025,7 @@ class StaticImageCompositor(GenericCompositor):
             url = os.path.expandvars(url)
             if filename is None:
                 filename = os.path.basename(url)
-        if url is None and not os.path.isabs(filename):
+        if url is None and (filename is None or not os.path.isabs(filename)):
             raise ValueError("StaticImageCompositor needs a remote 'url' "
                              "or absolute path to 'filename'.")
         return filename, url

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -974,11 +974,8 @@ class NaturalEnh(GenericCompositor):
 class StaticImageCompositor(GenericCompositor, DataDownloadMixin):
     """A compositor that loads a static image from disk.
 
-    If the filename passed to this compositor is not valid then
-    the SATPY_ANCPATH environment variable will be checked to see
-    if the image is located there
+    Environment variables in the filename are automatically expanded.
 
-    Environment variables in the filename are automatically expanded
     """
 
     def __init__(self, name, filename=None, url=None, known_hash=None, area=None,

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -997,7 +997,7 @@ class StaticImageCompositor(GenericCompositor, DataDownloadMixin):
                 Environment variables are expanded.
             known_hash (str or None): Hash of the remote file used to verify
                 a successful download. If not provided then the download will
-                not be verified. See :func:`satpy.data_download.register_file`
+                not be verified. See :func:`satpy.aux_download.register_file`
                 for more information.
             area (str): Name of area definition for the image.  Optional
                 for images with built-in area definitions (geotiff).

--- a/satpy/composites/config_loader.py
+++ b/satpy/composites/config_loader.py
@@ -207,6 +207,11 @@ class CompositorLoader:
                 continue
         raise KeyError("Could not find modifier '{}'".format(key))
 
+    def load_all_sensors(self):
+        """Load compositors for all sensors."""
+        # TODO
+        pass
+
     def load_compositors(self, sensor_names):
         """Load all compositor configs for the provided sensors.
 

--- a/satpy/composites/config_loader.py
+++ b/satpy/composites/config_loader.py
@@ -24,7 +24,8 @@ import yaml
 from yaml import UnsafeLoader
 
 from satpy import DatasetDict, DataQuery, DataID
-from satpy._config import get_entry_points_config_dirs, config_search_paths
+from satpy._config import (get_entry_points_config_dirs, config_search_paths,
+                           glob_config)
 from satpy.utils import recursive_dict_update
 from satpy.dataset.dataid import minimal_default_keys_config
 
@@ -175,6 +176,19 @@ class CompositorLoader:
         # sensor -> { dict of DataID key information }
         self._sensor_dataid_keys = {}
 
+    @classmethod
+    def all_composite_sensors(cls):
+        """Get all sensor names from available composite configs."""
+        paths = get_entry_points_config_dirs('satpy.composites')
+        composite_configs = glob_config(
+            os.path.join("composites", "*.yaml"),
+            search_dirs=paths)
+        yaml_names = set([os.path.splitext(os.path.basename(fn))[0]
+                          for fn in composite_configs])
+        non_sensor_yamls = ('visir',)
+        sensor_names = [x for x in yaml_names if x not in non_sensor_yamls]
+        return sensor_names
+
     def load_sensor_composites(self, sensor_name):
         """Load all compositor configs for the provided sensor."""
         config_filename = sensor_name + ".yaml"
@@ -206,11 +220,6 @@ class CompositorLoader:
             except KeyError:
                 continue
         raise KeyError("Could not find modifier '{}'".format(key))
-
-    def load_all_sensors(self):
-        """Load compositors for all sensors."""
-        # TODO
-        pass
 
     def load_compositors(self, sensor_names):
         """Load all compositor configs for the provided sensors.

--- a/satpy/data_download.py
+++ b/satpy/data_download.py
@@ -165,7 +165,10 @@ def _find_registerable_files_writers():
     """Load all writers so that files are registered."""
     from satpy.writers import configs_for_writer, load_writer_configs
     for writer_configs in configs_for_writer():
-        load_writer_configs(writer_configs)
+        try:
+            load_writer_configs(writer_configs)
+        except ValueError:
+            continue
 
 
 class DataDownloadMixin:

--- a/satpy/data_download.py
+++ b/satpy/data_download.py
@@ -144,7 +144,7 @@ def _find_registerable_files_compositors():
     """
     from satpy.composites.config_loader import CompositorLoader
     composite_loader = CompositorLoader()
-    all_sensor_names = ['viirs', 'seviri']  # FIXME: Find a way to actually get these
+    all_sensor_names = composite_loader.all_composite_sensors()
     composite_loader.load_compositors(all_sensor_names)
 
 # TODO: Add MixIn class that can be used by readers and writers

--- a/satpy/data_download.py
+++ b/satpy/data_download.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Functions and utilities for downloading ancillary data.
+
+TODO: Put examples here or on a new sphinx page?
+
+"""
+
+import logging
+import satpy
+import unittest.mock
+
+try:
+    import pooch
+except ImportError:
+    # TODO: Implement DumpPooch for local files only
+    pooch = None
+
+logger = logging.getLogger(__name__)
+
+FILE_REGISTRY = {}
+FILE_URLS = {}
+
+
+def register_file(url, filename, component_type=None, component_name=None, known_hash=None):
+    """Register file for future retrieval.
+
+    This function only prepares Satpy to be able to download and cache the
+    provided file. It will not download the file. See
+    :func:`satpy.data_download.retrieve` for more information.
+
+    Args:
+        url (str): URL where remote file can be downloaded.
+        filename (str): Filename used to identify and store the downloaded
+            file as.
+        component_type (str or None): Name of the type of Satpy component that
+            will use this file. Typically "readers", "composites", "writers",
+            or "enhancements" for consistency. This will be prepended to the
+            filename when storing the data in the cache.
+        component_name (str or None): Name of the Satpy component that will
+            use this file. In most cases this will be the name of the Python
+            class instead of the name of the instance
+            (ex. StaticImageCompositor versus '_night_background'). This will be
+            prepended to the filename when storing the data in the cache.
+        known_hash (str): Hash used to verify the file is downloaded correctly.
+            See https://www.fatiando.org/pooch/v1.3.0/beginner.html#hashes
+            for more information. If not provided then the file is not checked.
+
+    Returns:
+        Cache key that can be used to retrieve the file later. The cache key
+        consists of the ``component_type``, ``component_name``, and provided
+        ``filename``. This should be passed to
+        :func:`satpy.data_download_retrieve` when the file will be used.
+
+    """
+    if known_hash is None:
+        # https://www.fatiando.org/pooch/v1.3.0/advanced.html#bypassing-the-hash-check
+        known_hash = unittest.mock.ANY
+    fname = _generate_filename(filename, component_type, component_name)
+
+    global FILE_REGISTRY
+    global FILE_URLS
+    FILE_REGISTRY[fname] = known_hash
+    FILE_URLS[fname] = url
+    return fname
+
+
+def _generate_filename(filename, component_type, component_name):
+    if filename is None:
+        return None
+    path = filename
+    if component_name:
+        path = '/'.join([component_name, path])
+    if component_type:
+        path = '/'.join([component_type, path])
+    return path
+
+
+# def retrieve(url, filename=None, component_type=None, component_name=None,
+#              known_hash=None, pooch_kwargs=None):
+#     if pooch is None:
+#         raise ImportError("Extra dependency library 'pooch' is required to "
+#                           "download data files.")
+#     pooch_kwargs = pooch_kwargs or {}
+#
+#     path = satpy.config.get('data_dir')
+#     fname = register_file(url, filename, component_type, component_name,
+#                           known_hash)
+#     return pooch.retrieve(url, known_hash, fname=fname, path=path,
+#                           **pooch_kwargs)
+
+
+def retrieve(cache_key, pooch_kwargs=None):
+    """Download and cache the file associated with the provided ``cache_key``.
+
+    Cache location is controlled by the config ``data_dir`` key. See
+    :ref:`data_dir_setting` for more information.
+
+    Args:
+        cache_key (str): Cache key returned by
+            :func:`~satpy.data_download.register_file`.
+        pooch_kwargs (dict or None): Extra keyword arguments to pass to
+            :meth:`pooch.Pooch.fetch`.
+
+    Returns:
+        Local path of the cached file.
+
+
+    """
+    if pooch is None:
+        raise ImportError("Extra dependency library 'pooch' is required to "
+                          "download data files.")
+    pooch_kwargs = pooch_kwargs or {}
+
+    path = satpy.config.get('data_dir')
+    # reuse data directory as the default URL where files can be downloaded from
+    pooch_obj = pooch.create(path, path, registry=FILE_REGISTRY,
+                             urls=FILE_URLS)
+    return pooch_obj.fetch(cache_key, **pooch_kwargs)
+
+
+def retrieve_all(pooch_kwargs=None):
+    """Find cache-able data files for Satpy and download them.
+
+    The typical use case for this function is to download all ancillary files
+    before going to an environment/system that does not have internet access.
+
+    """
+    if pooch is None:
+        raise ImportError("Extra dependency library 'pooch' is required to "
+                          "download data files.")
+    if pooch_kwargs is None:
+        pooch_kwargs = {}
+
+    _find_registerable_files()
+    path = satpy.config.get('data_dir')
+    pooch_obj = pooch.create(path, path, registry=FILE_REGISTRY,
+                             urls=FILE_URLS)
+    for fname in FILE_REGISTRY:
+        logger.info("Downloading extra data file '%s'...", fname)
+        pooch_obj.fetch(fname, **pooch_kwargs)
+    logger.info("Done downloading all extra files.")
+
+
+def _find_registerable_files():
+    """Load all Satpy components so they can be downloaded."""
+    _find_registerable_files_compositors()
+    # TODO: Readers, writers
+
+
+def _find_registerable_files_compositors():
+    """Load all compositor configs so that files are registered.
+
+    Compositor objects should register files when they are initialized.
+
+    """
+    from satpy.composites.config_loader import CompositorLoader
+    composite_loader = CompositorLoader()
+    all_sensor_names = ['viirs', 'seviri']  # FIXME: Find a way to actually get these
+    composite_loader.load_compositors(all_sensor_names)

--- a/satpy/data_download.py
+++ b/satpy/data_download.py
@@ -24,11 +24,7 @@ TODO: Put examples here or on a new sphinx page?
 import logging
 import satpy
 
-try:
-    import pooch
-except ImportError:
-    # TODO: Implement DumpPooch for local files only
-    pooch = None
+import pooch
 
 logger = logging.getLogger(__name__)
 
@@ -104,9 +100,6 @@ def retrieve(cache_key, pooch_kwargs=None):
 
 
     """
-    if pooch is None:
-        raise ImportError("Extra dependency library 'pooch' is required to "
-                          "download data files.")
     pooch_kwargs = pooch_kwargs or {}
 
     path = satpy.config.get('data_dir')
@@ -123,9 +116,6 @@ def retrieve_all(pooch_kwargs=None):
     before going to an environment/system that does not have internet access.
 
     """
-    if pooch is None:
-        raise ImportError("Extra dependency library 'pooch' is required to "
-                          "download data files.")
     if pooch_kwargs is None:
         pooch_kwargs = {}
 

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -419,11 +419,11 @@ composites:
   _night_background:
     compositor: !!python/name:satpy.composites.StaticImageCompositor
     standard_name: night_background
-    filename: "https://neo.sci.gsfc.nasa.gov/archive/blackmarble/2016/global/BlackMarble_2016_01deg_geo.tif"
+    url: "https://neo.sci.gsfc.nasa.gov/archive/blackmarble/2016/global/BlackMarble_2016_01deg_geo.tif"
     known_hash: "sha256:146c116962677ae113d9233374715686737ff97141a77cc5da69a9451315a685"  # optional
 
   _night_background_hires:
     compositor: !!python/name:satpy.composites.StaticImageCompositor
     standard_name: night_background_hires
-    filename: "https://neo.sci.gsfc.nasa.gov/archive/blackmarble/2016/global/BlackMarble_2016_3km_geo.tif"
+    url: "https://neo.sci.gsfc.nasa.gov/archive/blackmarble/2016/global/BlackMarble_2016_3km_geo.tif"
     known_hash: "sha256:e915ef2a20d84e2a59e1547d3ad564463ad4bcf22bfa02e0e0b8ed1cd722e9c0"  # optional

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -419,9 +419,11 @@ composites:
   _night_background:
     compositor: !!python/name:satpy.composites.StaticImageCompositor
     standard_name: night_background
-    filename: BlackMarble_2016_01deg_geo.tif
+    filename: "https://neo.sci.gsfc.nasa.gov/archive/blackmarble/2016/global/BlackMarble_2016_01deg_geo.tif"
+    known_hash: "sha256:146c116962677ae113d9233374715686737ff97141a77cc5da69a9451315a685"  # optional
 
   _night_background_hires:
     compositor: !!python/name:satpy.composites.StaticImageCompositor
     standard_name: night_background_hires
-    filename: BlackMarble_2016_3km_geo.tif
+    filename: "https://neo.sci.gsfc.nasa.gov/archive/blackmarble/2016/global/BlackMarble_2016_3km_geo.tif"
+    known_hash: "sha256:e915ef2a20d84e2a59e1547d3ad564463ad4bcf22bfa02e0e0b8ed1cd722e9c0"  # optional

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -42,6 +42,7 @@ from satpy.resample import get_area_def
 from satpy.utils import recursive_dict_update
 from satpy.dataset import DataQuery, DataID, get_key
 from satpy.dataset.dataid import get_keys_from_config, default_id_keys_config, default_co_keys_config
+from satpy.data_download import DataDownloadMixin
 from satpy import DatasetDict
 from satpy.resample import add_crs_xy_coords
 from trollsift.parser import globify, parse
@@ -329,7 +330,7 @@ class AbstractYAMLReader(metaclass=ABCMeta):
         return ids
 
 
-class FileYAMLReader(AbstractYAMLReader):
+class FileYAMLReader(AbstractYAMLReader, DataDownloadMixin):
     """Primary reader base class that is configured by a YAML file.
 
     This class uses the idea of per-file "file handler" objects to read file
@@ -354,6 +355,7 @@ class FileYAMLReader(AbstractYAMLReader):
         self.filter_filenames = self.info.get('filter_filenames', filter_filenames)
         self.filter_parameters = filter_parameters or {}
         self.coords_cache = WeakValueDictionary()
+        self.register_data_files()
 
     @property
     def sensor_names(self):

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -42,7 +42,7 @@ from satpy.resample import get_area_def
 from satpy.utils import recursive_dict_update
 from satpy.dataset import DataQuery, DataID, get_key
 from satpy.dataset.dataid import get_keys_from_config, default_id_keys_config, default_co_keys_config
-from satpy.data_download import DataDownloadMixin
+from satpy.aux_download import DataDownloadMixin
 from satpy import DatasetDict
 from satpy.resample import add_crs_xy_coords
 from trollsift.parser import globify, parse

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -902,8 +902,10 @@ class TestStaticImageCompositor(unittest.TestCase):
         self.assertEqual(comp.area, "bar")
         get_area_def.assert_called_once_with("euro4")
 
+    @mock.patch('satpy.data_download.retrieve')
+    @mock.patch('satpy.data_download.register_file')
     @mock.patch('satpy.Scene')
-    def test_call(self, Scene):  # noqa
+    def test_call(self, Scene, register, retrieve):  # noqa
         """Test the static compositing."""
         from satpy.composites import StaticImageCompositor
 
@@ -916,6 +918,8 @@ class TestStaticImageCompositor(unittest.TestCase):
         scn = MockScene()
         scn['image'] = img
         Scene.return_value = scn
+        register.return_value = "foo.tif"
+        retrieve.return_value = "foo.tif"
         comp = StaticImageCompositor("name", filename="foo.tif", area="euro4")
         res = comp()
         Scene.assert_called_once_with(reader='generic_image',

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -892,13 +892,13 @@ class TestStaticImageCompositor(unittest.TestCase):
 
         # No area defined
         comp = StaticImageCompositor("name", filename="foo.tif")
-        self.assertEqual(comp.filename, "foo.tif")
+        self.assertEqual(comp.file_uri, "foo.tif")
         self.assertIsNone(comp.area)
 
         # Area defined
         get_area_def.return_value = "bar"
         comp = StaticImageCompositor("name", filename="foo.tif", area="euro4")
-        self.assertEqual(comp.filename, "foo.tif")
+        self.assertEqual(comp.file_uri, "foo.tif")
         self.assertEqual(comp.area, "bar")
         get_area_def.assert_called_once_with("euro4")
 
@@ -919,7 +919,7 @@ class TestStaticImageCompositor(unittest.TestCase):
         comp = StaticImageCompositor("name", filename="foo.tif", area="euro4")
         res = comp()
         Scene.assert_called_once_with(reader='generic_image',
-                                      filenames=[comp.filename])
+                                      filenames=[comp.file_uri])
         self.assertTrue("start_time" in res.attrs)
         self.assertTrue("end_time" in res.attrs)
         self.assertIsNone(res.attrs['sensor'])
@@ -940,7 +940,7 @@ class TestStaticImageCompositor(unittest.TestCase):
         # Filename contains environment variable
         os.environ["TEST_IMAGE_PATH"] = "/path/to/image"
         comp = StaticImageCompositor("name", filename="${TEST_IMAGE_PATH}/foo.tif", area='euro4')
-        self.assertEqual(comp.filename, "/path/to/image/foo.tif")
+        self.assertEqual(comp.file_uri, "/path/to/image/foo.tif")
 
 
 def _enhance2dataset(dataset, convert_p=False):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -906,8 +906,8 @@ class TestStaticImageCompositor(unittest.TestCase):
         self.assertEqual(comp.area, "bar")
         get_area_def.assert_called_once_with("euro4")
 
-    @mock.patch('satpy.data_download.retrieve')
-    @mock.patch('satpy.data_download.register_file')
+    @mock.patch('satpy.aux_download.retrieve')
+    @mock.patch('satpy.aux_download.register_file')
     @mock.patch('satpy.Scene')
     def test_call(self, Scene, register, retrieve):  # noqa
         """Test the static compositing."""

--- a/satpy/tests/test_data_download.py
+++ b/satpy/tests/test_data_download.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Test for ancillary data downloading."""
+
+from unittest import mock
+import pytest
+import yaml
+
+pooch = pytest.importorskip("pooch")
+
+README_URL = "https://raw.githubusercontent.com/pytroll/satpy/master/README.rst"
+
+
+def _setup_custom_composite_config(base_dir):
+    from satpy.composites import StaticImageCompositor
+    composite_config = base_dir.mkdir("composites").join("visir.yaml")
+    with open(composite_config, 'w') as comp_file:
+        yaml.dump({
+            "sensor_name": "visir",
+            "composites": {
+                "test_static": {
+                    "compositor": StaticImageCompositor,
+                    "filename": README_URL,
+                    "known_hash": None,
+                },
+            },
+        }, comp_file)
+
+
+def _setup_custom_configs(base_dir):
+    # TODO: Readers and Writers
+    _setup_custom_composite_config(base_dir)
+
+
+class TestDataDownload:
+    """Test basic data downloading functionality."""
+
+    def test_find_registerable(self, tmpdir):
+        """Test that find_registerable finds some things."""
+        import satpy
+        from satpy.data_download import find_registerable_files
+        _setup_custom_configs(tmpdir)
+        file_registry = {}
+        with satpy.config.set(config_path=[tmpdir]), \
+             mock.patch('satpy.data_download._FILE_REGISTRY', file_registry):
+            found_files = find_registerable_files()
+            assert 'composites/StaticImageCompositor/README.rst' in found_files
+
+    def test_retrieve(self, tmpdir):
+        """Test retrieving a single file."""
+        import satpy
+        from satpy.data_download import find_registerable_files, retrieve
+        _setup_custom_configs(tmpdir)
+        file_registry = {}
+        with satpy.config.set(config_path=[tmpdir], data_dir=str(tmpdir)), \
+             mock.patch('satpy.data_download._FILE_REGISTRY', file_registry):
+            comp_file = 'composites/StaticImageCompositor/README.rst'
+            found_files = find_registerable_files()
+            assert comp_file in found_files
+            assert not tmpdir.join(comp_file).exists()
+            retrieve(comp_file)
+            assert tmpdir.join(comp_file).exists()
+
+    def test_retrieve_all(self, tmpdir):
+        """Test registering and retrieving all files."""
+        import satpy
+        from satpy.data_download import retrieve_all
+        _setup_custom_configs(tmpdir)
+        file_registry = {}
+        file_urls = {}
+        with satpy.config.set(config_path=[tmpdir], data_dir=str(tmpdir)), \
+             mock.patch('satpy.data_download._FILE_REGISTRY', file_registry), \
+             mock.patch('satpy.data_download._FILE_URLS', file_urls), \
+             mock.patch('satpy.data_download.find_registerable_files'):
+            comp_file = 'composites/StaticImageCompositor/README.rst'
+            file_registry[comp_file] = None
+            file_urls[comp_file] = README_URL
+            assert not tmpdir.join(comp_file).exists()
+            retrieve_all()
+            assert tmpdir.join(comp_file).exists()

--- a/satpy/tests/test_data_download.py
+++ b/satpy/tests/test_data_download.py
@@ -35,7 +35,7 @@ def _setup_custom_composite_config(base_dir):
             "composites": {
                 "test_static": {
                     "compositor": StaticImageCompositor,
-                    "filename": README_URL,
+                    "url": README_URL,
                     "known_hash": None,
                 },
             },

--- a/satpy/tests/test_data_download.py
+++ b/satpy/tests/test_data_download.py
@@ -119,9 +119,9 @@ class TestDataDownload:
     def test_find_registerable(self, readers, writers, comp_sensors):
         """Test that find_registerable finds some things."""
         import satpy
-        from satpy.data_download import find_registerable_files
+        from satpy.aux_download import find_registerable_files
         with satpy.config.set(config_path=[self.tmpdir]), \
-             mock.patch('satpy.data_download._FILE_REGISTRY', {}):
+             mock.patch('satpy.aux_download._FILE_REGISTRY', {}):
             found_files = find_registerable_files(
                 readers=readers, writers=writers,
                 composite_sensors=comp_sensors,
@@ -139,10 +139,10 @@ class TestDataDownload:
     def test_limited_find_registerable(self):
         """Test that find_registerable doesn't find anything when limited."""
         import satpy
-        from satpy.data_download import find_registerable_files
+        from satpy.aux_download import find_registerable_files
         file_registry = {}
         with satpy.config.set(config_path=[self.tmpdir]), \
-             mock.patch('satpy.data_download._FILE_REGISTRY', file_registry):
+             mock.patch('satpy.aux_download._FILE_REGISTRY', file_registry):
             found_files = find_registerable_files(
                 readers=[], writers=[], composite_sensors=[],
             )
@@ -151,10 +151,10 @@ class TestDataDownload:
     def test_retrieve(self):
         """Test retrieving a single file."""
         import satpy
-        from satpy.data_download import find_registerable_files, retrieve
+        from satpy.aux_download import find_registerable_files, retrieve
         file_registry = {}
         with satpy.config.set(config_path=[self.tmpdir], data_dir=str(self.tmpdir)), \
-             mock.patch('satpy.data_download._FILE_REGISTRY', file_registry):
+             mock.patch('satpy.aux_download._FILE_REGISTRY', file_registry):
             comp_file = 'composites/README.rst'
             found_files = find_registerable_files()
             assert comp_file in found_files
@@ -165,10 +165,10 @@ class TestDataDownload:
     def test_offline_retrieve(self):
         """Test retrieving a single file when offline."""
         import satpy
-        from satpy.data_download import find_registerable_files, retrieve
+        from satpy.aux_download import find_registerable_files, retrieve
         file_registry = {}
         with satpy.config.set(config_path=[self.tmpdir], data_dir=str(self.tmpdir), download_aux=True), \
-             mock.patch('satpy.data_download._FILE_REGISTRY', file_registry):
+             mock.patch('satpy.aux_download._FILE_REGISTRY', file_registry):
             comp_file = 'composites/README.rst'
             found_files = find_registerable_files()
             assert comp_file in found_files
@@ -190,20 +190,20 @@ class TestDataDownload:
     def test_offline_retrieve_all(self):
         """Test registering and retrieving all files fails when offline."""
         import satpy
-        from satpy.data_download import retrieve_all
+        from satpy.aux_download import retrieve_all
         with satpy.config.set(config_path=[self.tmpdir], data_dir=str(self.tmpdir), download_aux=False):
             pytest.raises(RuntimeError, retrieve_all)
 
     def test_retrieve_all(self):
         """Test registering and retrieving all files."""
         import satpy
-        from satpy.data_download import retrieve_all
+        from satpy.aux_download import retrieve_all
         file_registry = {}
         file_urls = {}
         with satpy.config.set(config_path=[self.tmpdir], data_dir=str(self.tmpdir)), \
-             mock.patch('satpy.data_download._FILE_REGISTRY', file_registry), \
-             mock.patch('satpy.data_download._FILE_URLS', file_urls), \
-             mock.patch('satpy.data_download.find_registerable_files'):
+             mock.patch('satpy.aux_download._FILE_REGISTRY', file_registry), \
+             mock.patch('satpy.aux_download._FILE_URLS', file_urls), \
+             mock.patch('satpy.aux_download.find_registerable_files'):
             comp_file = 'composites/README.rst'
             file_registry[comp_file] = None
             file_urls[comp_file] = README_URL

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -39,6 +39,7 @@ from satpy.utils import recursive_dict_update
 from satpy import CHUNK_SIZE
 from satpy.plugin_base import Plugin
 from satpy.resample import get_area_def
+from satpy.data_download import DataDownloadMixin
 
 from trollsift import parser
 
@@ -543,7 +544,7 @@ def compute_writer_results(results):
                 target.close()
 
 
-class Writer(Plugin):
+class Writer(Plugin, DataDownloadMixin):
     """Base Writer class for all other writers.
 
     A minimal writer subclass should implement the `save_dataset` method.
@@ -595,6 +596,7 @@ class Writer(Plugin):
             raise ValueError("Writer 'name' not provided")
 
         self.filename_parser = self.create_filename_parser(base_dir)
+        self.register_data_files()
 
     @classmethod
     def separate_init_kwargs(cls, kwargs):

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -39,7 +39,7 @@ from satpy.utils import recursive_dict_update
 from satpy import CHUNK_SIZE
 from satpy.plugin_base import Plugin
 from satpy.resample import get_area_def
-from satpy.data_download import DataDownloadMixin
+from satpy.aux_download import DataDownloadMixin
 
 from trollsift import parser
 

--- a/setup.py
+++ b/setup.py
@@ -103,6 +103,13 @@ def _config_data_files(base_dirs, extensions=(".cfg", )):
     return data_files
 
 
+entry_points = {
+    'console_scripts': [
+        'satpy_retrieve_all=satpy.data_download:retrieve_all_cmd',
+    ],
+}
+
+
 NAME = 'satpy'
 with open('README.rst', 'r') as readme:
     README = readme.read()
@@ -139,4 +146,5 @@ setup(name=NAME,
       tests_require=test_requires,
       python_requires='>=3.6',
       extras_require=extras_require,
+      entry_points=entry_points,
       )

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ except ImportError:
 
 requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.11.0', 'trollsift',
             'trollimage >1.10.1', 'pykdtree', 'pyyaml', 'xarray >=0.10.1, !=0.13.0',
-            'dask[array] >=0.17.1', 'pyproj', 'zarr', 'donfig', 'appdirs']
+            'dask[array] >=0.17.1', 'pyproj', 'zarr', 'donfig', 'appdirs',
+            'pooch']
 
 test_requires = ['behave', 'h5py', 'netCDF4', 'pyhdf', 'imageio', 'libtiff',
                  'rasterio', 'geoviews', 'trollimage', 'fsspec']

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ def _config_data_files(base_dirs, extensions=(".cfg", )):
 
 entry_points = {
     'console_scripts': [
-        'satpy_retrieve_all=satpy.data_download:retrieve_all_cmd',
+        'satpy_retrieve_all_aux_data=satpy.data_download:retrieve_all_cmd',
     ],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ def _config_data_files(base_dirs, extensions=(".cfg", )):
 
 entry_points = {
     'console_scripts': [
-        'satpy_retrieve_all_aux_data=satpy.data_download:retrieve_all_cmd',
+        'satpy_retrieve_all_aux_data=satpy.aux_download:retrieve_all_cmd',
     ],
 }
 


### PR DESCRIPTION
## The Problem

There are a couple cases in Satpy where additional files are needed to completely function. Examples include the StaticImageCompositor, "crefl" rayleigh correction which uses data files for elevation values, or the MiRS reader in #1511 that needs LUTs to properly perform some limb correction. It is a pain for users to have to download these files and set an environment variable (previously SATPY_ANCPATH) just to use something that is builtin to Satpy. This should be automatic.

## The Solution

This pull request utilizes the [pooch library](https://www.fatiando.org/pooch/latest/beginner.html) to allow Satpy components to download the files that they need to operate. Pooch allows us to cache the files and check hashes. It has some versioning support but we aren't using it. It also has some typical use cases that we aren't using because of the dynamic nature of Satpy's components (ex. a user customizing things in YAML).

There are a lot of TODOS left for this PR, but the general idea is sketched out here and I'm looking for feedback.

### Example 1 - Satpy Component retrieves data file

```
from satpy.data_download import register_file, retrieve

cache_key = register_file('http://example.com/some_file.txt', 'some_file.txt', component_type='composites', component_name='StaticImageCompositor', known_hash="sha256:abcdefghij")
# ... later on ...
local_filename = retrieve(cache_key)
# use local_filename...

```

### Example 2 - User wants to download all files for offline use

```
from satpy.data_download import retrieve_all
retrieve_all()
```

### Example 3 - User wants to customize data location

```
import satpy

scn = satpy.Scene(...)
with satpy.config.set(data_dir='/tmp'):
    scn.load(['_night_background'])
```

 - [x] Closes #1362 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
