### PR TITLE
Allow to pass pathlike-objects to FSFile

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -546,10 +546,14 @@ class FSFile(os.PathLike):
     def __init__(self, file, fs=None):
         """Initialise the FSFile instance.
 
-        *file* can be string, an object implementing the PathLike protocol, or
-            an fsspec.OpenFile instance. In the latter case, the follow argument
-            *fs* has no effect.
-        *fs* can be None or a fsspec filesystem instance.
+        Args:
+            file (str, Pathlike, or OpenFile):
+                String, object implementing the `os.PathLike` protocol, or
+                an `fsspec.OpenFile` instance.  If passed an instance of
+                `fsspec.OpenFile`, the following argument ``fs`` has no
+                effect.
+            fs (fsspec filesystem, optional)
+                Object implementing the fsspec filesystem protocol.
         """
         try:
             self._file = file.path

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -546,7 +546,9 @@ class FSFile(os.PathLike):
     def __init__(self, file, fs=None):
         """Initialise the FSFile instance.
 
-        *file* can be string or an fsspec.OpenFile instance. In the latter case, the follow argument *fs* has no effect.
+        *file* can be string, an object implementing the PathLike protocol, or
+            an fsspec.OpenFile instance. In the latter case, the follow argument
+            *fs* has no effect.
         *fs* can be None or a fsspec filesystem instance.
         """
         try:
@@ -558,11 +560,11 @@ class FSFile(os.PathLike):
 
     def __str__(self):
         """Return the string version of the filename."""
-        return self._file
+        return os.fspath(self._file)
 
     def __fspath__(self):
         """Comply with PathLike."""
-        return self._file
+        return os.fspath(self._file)
 
     def __repr__(self):
         """Representation of the object."""

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -896,6 +896,12 @@ class TestFSFile(unittest.TestCase):
         from satpy.readers import FSFile
         assert os.fspath(FSFile(self.random_string, fs=None)) == self.random_string
 
+    def test_fsfile_with_pathlike(self):
+        from satpy.readers import FSFile
+        from pathlib import Path
+        f = FSFile(Path(self.local_filename))
+        assert str(f) == os.fspath(f) == self.local_filename
+
     def test_fsfile_with_fs_open_file_abides_pathlike(self):
         """Test that FSFile abides PathLike for fsspec OpenFile instances."""
         from satpy.readers import FSFile


### PR DESCRIPTION
When constructing an FSFile object, allow to pass not only strings, but
any object meeting the os.PathLike protocol.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1516 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
