### PR TITLE
Fix config test when user environment variables are set

### DIFF
--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -102,9 +102,12 @@ class TestPluginsConfigs(unittest.TestCase):
         ep.dist.module_path = os.path.join(os.path.sep + 'bla', 'bla')
         iter_entry_points.return_value = [ep]
 
+        import satpy
         from satpy._config import get_entry_points_config_dirs
-        dirs = get_entry_points_config_dirs('satpy.composites')
-        self.assertListEqual(dirs, [os.path.join(ep.dist.module_path, 'satpy_cpe', 'etc')])
+        # don't let user env vars effect results
+        with satpy.config.set(config_path=[]):
+            dirs = get_entry_points_config_dirs('satpy.composites')
+            self.assertListEqual(dirs, [os.path.join(ep.dist.module_path, 'satpy_cpe', 'etc')])
 
 
 class TestConfigObject:

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -104,7 +104,7 @@ class TestPluginsConfigs(unittest.TestCase):
 
         import satpy
         from satpy._config import get_entry_points_config_dirs
-        # don't let user env vars effect results
+        # don't let user env vars affect results
         with satpy.config.set(config_path=[]):
             dirs = get_entry_points_config_dirs('satpy.composites')
             self.assertListEqual(dirs, [os.path.join(ep.dist.module_path, 'satpy_cpe', 'etc')])


### PR DESCRIPTION
Fixes a simple test in the case when a user has environment variables set that effect the results.

 - [x] Closes #1520  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 