### PR TITLE
Add external image to composites docs

### DIFF
--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -407,6 +407,9 @@ image) for both of the static images::
           min_stretch: [0, 0, 0]
           max_stretch: [255, 255, 255]
 
+.. image:: https://user-images.githubusercontent.com/500246/106626015-8b72c400-6577-11eb-87b7-5bf32e45d5e1.png
+   :width: 600
+
 .. _enhancing-the-images:
 
 Enhancing the images


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

Add an external image to the composite documentation, directly linked from the Github PR where the code to generate the image was introduced.  It works locally, let's see if it works on RTD.

 - [ ] Closes #1527 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
