### PR TITLE
Fix SLSTR composites for oblique view

### DIFF
--- a/satpy/etc/composites/slstr.yaml
+++ b/satpy/etc/composites/slstr.yaml
@@ -8,6 +8,7 @@ composite_identification_keys:
     enum:
     - nadir
     - oblique
+    transitive: true
   stripe:
     enum:
       - a


### PR DESCRIPTION
This makes the view id key transitive for composites too.

 - [x] Closes #1532 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->

