### PR TITLE
Clarify usage of config 'config_path' option

### DIFF
--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -123,6 +123,8 @@ Note that this value must be a list. In Python, this could be set by doing:
 
 As mentioned above, if setting an environment variable then it must be a
 colon-separated string and must be set **before** calling/importing Satpy.
+If the environment variable is a single path it will be converted to a list
+when Satpy is imported.
 
 .. code-block:: bash
 

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -103,9 +103,14 @@ Component Configuration Path
 * **Default**: ``[]``
 
 Base directory, or directories, where Satpy component YAML configuration files
-are stored. Directories provided will typically include subdirectories for
-each component that is being configured (ex. ``readers``, ``writers``, etc).
-This option replaces the legacy ``PPP_CONFIG_DIR`` environment variable.
+are stored. Satpy expects configuration files for specific component types to
+be in appropriate subdirectories (ex. ``readers``, ``writers``, etc), but
+these subdirectories should not be included in the ``config_path``.
+For example, if you have custom composites configured in
+``/my/config/dir/etc/composites/visir.yaml``, then ``config_path`` should
+include ``/my/config/dir/etc`` for Satpy to find this configuration file
+when searching for composites. This option replaces the legacy
+``PPP_CONFIG_DIR`` environment variable.
 
 Note that this value must be a list. In Python, this could be set by doing:
 

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -107,21 +107,7 @@ are stored. Directories provided will typically include subdirectories for
 each component that is being configured (ex. `readers`, `writers`, etc).
 This option replaces the legacy ``PPP_CONFIG_DIR`` environment variable.
 
-Satpy will always include the builtin configuration files that it
-is distributed with regardless of this setting. When specified as an
-environment variable it must be a colon-separated series of paths. Otherwise,
-it should be specified as a list. When a component supports merging of
-configuration files, they are merged in reverse order. This means "base"
-configuration paths should be at the end of the list and custom/user paths
-should be at the beginning of the list.
-
-Note that this value must be a list. In Python, this could be set by doing:
-
-.. code-block:: python
-
-    satpy.config.set(config_path=['/path/custom1', '/path/custom2'])
-
-As mentioned above, if setting an environment variable then it must be a
+If setting an environment variable then it must be a
 colon-separated string and must be set **before** calling/importing Satpy.
 If the environment variable is a single path it will be converted to a list
 when Satpy is imported.
@@ -129,6 +115,18 @@ when Satpy is imported.
 .. code-block:: bash
 
     export SATPY_CONFIG_PATH="/path/custom1:/path/custom2"
+
+Satpy will always include the builtin configuration files that it
+is distributed with regardless of this setting. When a component supports
+merging of configuration files, they are merged in reverse order. This means
+"base" configuration paths should be at the end of the list and custom/user
+paths should be at the beginning of the list.
+
+Note that this value must be a list. In Python, this could be set by doing:
+
+.. code-block:: python
+
+    satpy.config.set(config_path=['/path/custom1', '/path/custom2'])
 
 Data Directory
 ^^^^^^^^^^^^^^

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -115,6 +115,19 @@ configuration files, they are merged in reverse order. This means "base"
 configuration paths should be at the end of the list and custom/user paths
 should be at the beginning of the list.
 
+Note that this value must be a list. In Python, this could be set by doing:
+
+.. code-block:: python
+
+    satpy.config.set(config_path=['/path/custom1', '/path/custom2'])
+
+As mentioned above, if setting an environment variable then it must be a
+colon-separated string and must be set **before** calling/importing Satpy.
+
+.. code-block:: bash
+
+    export SATPY_CONFIG_PATH="/path/custom1:/path/custom2"
+
 Data Directory
 ^^^^^^^^^^^^^^
 

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -104,8 +104,14 @@ Component Configuration Path
 
 Base directory, or directories, where Satpy component YAML configuration files
 are stored. Directories provided will typically include subdirectories for
-each component that is being configured (ex. `readers`, `writers`, etc).
+each component that is being configured (ex. ``readers``, ``writers``, etc).
 This option replaces the legacy ``PPP_CONFIG_DIR`` environment variable.
+
+Note that this value must be a list. In Python, this could be set by doing:
+
+.. code-block:: python
+
+    satpy.config.set(config_path=['/path/custom1', '/path/custom2'])
 
 If setting an environment variable then it must be a
 colon-separated string and must be set **before** calling/importing Satpy.
@@ -121,12 +127,6 @@ is distributed with regardless of this setting. When a component supports
 merging of configuration files, they are merged in reverse order. This means
 "base" configuration paths should be at the end of the list and custom/user
 paths should be at the beginning of the list.
-
-Note that this value must be a list. In Python, this could be set by doing:
-
-.. code-block:: python
-
-    satpy.config.set(config_path=['/path/custom1', '/path/custom2'])
 
 Data Directory
 ^^^^^^^^^^^^^^

--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -85,6 +85,15 @@ if _ancpath is not None and _data_dir is None:
 config = Config("satpy", defaults=[_CONFIG_DEFAULTS], paths=_CONFIG_PATHS)
 
 
+def get_config_path_safe():
+    """Get 'config_path' and check for proper 'list' type."""
+    config_path = config.get('config_path')
+    if not isinstance(config_path, list):
+        raise ValueError("Satpy config option 'config_path' must be a "
+                         "list, not '{}'".format(type(config_path)))
+    return config_path
+
+
 def get_entry_points_config_dirs(name, include_config_path=True):
     """Get the config directories for all entry points of given name."""
     dirs = []
@@ -101,7 +110,7 @@ def get_entry_points_config_dirs(name, include_config_path=True):
 def config_search_paths(filename, search_dirs=None, **kwargs):
     """Get series of configuration base paths where Satpy configs are located."""
     if search_dirs is None:
-        search_dirs = config.get('config_path')[::-1]
+        search_dirs = get_config_path_safe()[::-1]
 
     paths = [filename, os.path.basename(filename)]
     paths += [os.path.join(search_dir, filename) for search_dir in search_dirs]

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -20,6 +20,7 @@
 import os
 import unittest
 from unittest import mock
+import pytest
 
 
 class TestBuiltinAreas(unittest.TestCase):
@@ -159,3 +160,21 @@ class TestConfigObject:
             assert satpy.config.get('config_path') == ['/my/configs1',
                                                        '/my/configs2',
                                                        '/my/configs3']
+
+    def test_bad_str_config_path(self):
+        """Test that a str config path isn't allowed."""
+        from importlib import reload
+        import satpy
+        old_vars = {
+            'SATPY_CONFIG_PATH': '/my/configs1',
+        }
+
+        # single path from env var still works
+        with mock.patch.dict('os.environ', old_vars):
+            reload(satpy._config)
+            reload(satpy)
+            assert satpy.config.get('config_path') == ['/my/configs1']
+
+        # strings are not allowed, lists are
+        with satpy.config.set(config_path='/single/string/paths/are/bad'):
+            pytest.raises(ValueError, satpy._config.get_config_path_safe)


### PR DESCRIPTION
This addresses the confusion in #1530. I've added more documentation on setting the config_path and also added a "safe" get utility function which should 

 - [x] Closes #1530 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
