### PR TITLE
Feature: add s3 support to viirs sdr reader

### DIFF
--- a/satpy/readers/hdf5_utils.py
+++ b/satpy/readers/hdf5_utils.py
@@ -23,6 +23,7 @@ import numpy as np
 import xarray as xr
 import dask.array as da
 
+from satpy.readers import open_file_or_filename
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.utils import np2str
 from satpy import CHUNK_SIZE
@@ -41,7 +42,7 @@ class HDF5FileHandler(BaseFileHandler):
         self._attrs_cache = {}
 
         try:
-            file_handle = h5py.File(self.filename, 'r')
+            file_handle = h5py.File(open_file_or_filename(self.filename), 'r')
         except IOError:
             LOG.exception(
                 'Failed reading file %s. Possibly corrupted file', self.filename)
@@ -71,7 +72,7 @@ class HDF5FileHandler(BaseFileHandler):
 
     def get_reference(self, name, key):
         """Get reference."""
-        with h5py.File(self.filename, 'r') as hf:
+        with h5py.File(open_file_or_filename(self.filename), 'r') as hf:
             return self._get_reference(hf, hf[name].attrs[key])
 
     def _get_reference(self, hf, ref):
@@ -95,7 +96,7 @@ class HDF5FileHandler(BaseFileHandler):
         val = self.file_content[key]
         if isinstance(val, h5py.Dataset):
             # these datasets are closed and inaccessible when the file is closed, need to reopen
-            dset = h5py.File(self.filename, 'r')[key]
+            dset = h5py.File(open_file_or_filename(self.filename), 'r')[key]
             dset_data = da.from_array(dset, chunks=CHUNK_SIZE)
             attrs = self._attrs_cache.get(key, dset.attrs)
             if dset.ndim == 2:


### PR DESCRIPTION
Add s3 reading support to viirs sdr reader

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
