### PR TITLE
Add static scale_factor/add_offset/_FillValue to awips_tiled GLM config

### DIFF
--- a/satpy/etc/writers/awips_tiled.yaml
+++ b/satpy/etc/writers/awips_tiled.yaml
@@ -1024,6 +1024,9 @@ templates:
         encoding:
           dtype: int16
           _Unsigned: "true"
+          scale_factor: 1.0000001
+          add_offset: 0.0
+          _FillValue: -1
       flash_extent_density_window:
         name: "flash_extent_density_window"
         var_name: "Flash_extent_density_w5u1"


### PR DESCRIPTION
This is purely a configuration change to the configuration file used by the `awips_tiled` writer. This change is specific to the GLM "Full Disk" file scheme used by AWIPS and only effects the "Flash_extent_density" variable. The reason for this change is an apparent bug in AWIPS where for **only** the FED variable, the scale_factor/add_offset/_FillValue are ignored. In the best case we would use a scale_factor of 1.0 and add_offset of 0.0, but AWIPS, for some reason, does not allow "identity" scalings so 1.0 is not allowed. The change in this PR makes the scale_factor as close to 1.0 as possible for a 32-bit float so that the values in the file should nearly represent the original values.

The AWIPS bug is still being investigated, but in the mean time this workaround should be backwards compatible and allow us to continue our work.
