### PR TITLE
Fix builtin coords swath

### DIFF
--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -257,7 +257,7 @@ class SatpyCFFileHandler(BaseFileHandler):
             yield True, ds_info
 
     def _coordinate_datasets(self, configured_datasets=None):
-        """Add information of coordiante datasets."""
+        """Add information of coordinate datasets."""
         nc = xr.open_dataset(self.filename, engine=self.engine)
         for var_name, val in nc.coords.items():
             ds_info = dict(val.attrs)

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -844,7 +844,7 @@ class FileYAMLReader(AbstractYAMLReader):
         if not coords:
             coords = []
             for coord in ds.coords.values():
-                if coord.attrs['standard_name'] in ['longitude', 'latitude']:
+                if coord.attrs.get('standard_name') in ['longitude', 'latitude']:
                     coords.append(coord)
         return coords
 

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -775,7 +775,7 @@ class FileYAMLReader(AbstractYAMLReader):
     def _make_area_from_coords(self, coords):
         """Create an appropriate area with the given *coords*."""
         if len(coords) == 2:
-            lats, lons = self._get_lons_lats_from_coords(coords)
+            lons, lats = self._get_lons_lats_from_coords(coords)
 
             sdef = self._make_swath_definition_from_lons_lats(lons, lats)
             return sdef
@@ -793,7 +793,7 @@ class FileYAMLReader(AbstractYAMLReader):
                 lats = coord
         if lons is None or lats is None:
             raise ValueError('Missing longitude or latitude coordinate: ' + str(coords))
-        return lats, lons
+        return lons, lats
 
     def _make_swath_definition_from_lons_lats(self, lons, lats):
         """Make a swath definition instance from lons and lats."""
@@ -841,7 +841,7 @@ class FileYAMLReader(AbstractYAMLReader):
             logger.exception("Could not load dataset '%s': %s", dsid, str(err))
             return None
 
-        coords = self._assign_builtin_coords(coords, ds)
+        coords = self._assign_coords_from_dataarray(coords, ds)
 
         area = self._load_dataset_area(dsid, file_handlers, coords, **kwargs)
 
@@ -851,8 +851,8 @@ class FileYAMLReader(AbstractYAMLReader):
         return ds
 
     @staticmethod
-    def _assign_builtin_coords(coords, ds):
-        """Assign builtin coords if needed."""
+    def _assign_coords_from_dataarray(coords, ds):
+        """Assign coords from the *ds* dataarray if needed."""
         if not coords:
             coords = []
             for coord in ds.coords.values():

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -528,8 +528,8 @@ class TestFileYAMLReaderLoading(unittest.TestCase):
                 return lons
             elif dsid['name'] == 'latitude':
                 return lats
-            else:
-                return data
+
+            return data
 
         fake_fh.get_dataset.side_effect = _assign_array
         self.reader.file_handlers = {'ftype1': [fake_fh]}

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -481,6 +481,66 @@ class TestFileFileYAMLReader(unittest.TestCase):
         self.assertIs(proj, xarray.concat.return_value)
 
 
+class TestFileYAMLReaderLoading(unittest.TestCase):
+    """Tests for FileYAMLReader.load."""
+
+    def setUp(self):
+        """Prepare a reader instance with a fake config."""
+        patterns = ['a{something:3s}.bla']
+        res_dict = {'reader': {'name': 'fake',
+                               'sensors': ['canon']},
+                    'file_types': {'ftype1': {'name': 'ft1',
+                                              'file_reader': BaseFileHandler,
+                                              'file_patterns': patterns}},
+                    'datasets': {'ch1': {'name': 'ch01',
+                                         'wavelength': [0.5, 0.6, 0.7],
+                                         'calibration': 'reflectance',
+                                         'file_type': 'ftype1'},
+                                 }}
+
+        self.config = res_dict
+        self.reader = yr.FileYAMLReader(res_dict,
+                                        filter_parameters={
+                                            'start_time': datetime(2000, 1, 1),
+                                            'end_time': datetime(2000, 1, 2),
+                                        })
+
+    def test_load_dataset_with_builtin_coords(self):
+        """Test loading a dataset with builtin coordinates."""
+        fake_fh = FakeFH(None, None)
+        import xarray as xr
+        import numpy as np
+        lons = xr.DataArray(np.ones((2, 2)) * 2,
+                            dims=['y', 'x'],
+                            attrs={'standard_name': 'longitude',
+                                   'name': 'longitude'})
+        lats = xr.DataArray(np.ones((2, 2)) * 2,
+                            dims=['y', 'x'],
+                            attrs={'standard_name': 'latitude',
+                                   'name': 'latitude'})
+        data = xr.DataArray(np.ones((2, 2)),
+                            coords={'longitude': lons,
+                            'latitude': lats},
+                            dims=['y', 'x'])
+
+        def _assign_array(dsid, *_args, **_kwargs):
+            if dsid['name'] == 'longitude':
+                return lons
+            elif dsid['name'] == 'latitude':
+                return lats
+            else:
+                return data
+
+        fake_fh.get_dataset.side_effect = _assign_array
+        self.reader.file_handlers = {'ftype1': [fake_fh]}
+
+        res = self.reader.load(['ch01'])
+
+        assert 'area' in res['ch01'].attrs
+        np.testing.assert_array_equal(res['ch01'].attrs['area'].lons, lons)
+        np.testing.assert_array_equal(res['ch01'].attrs['area'].lats, lats)
+
+
 class TestFileFileYAMLReaderMultipleFileTypes(unittest.TestCase):
     """Test units from FileYAMLReader with multiple file types."""
 


### PR DESCRIPTION
This PR allows satpy to use longitudes and latitudes provided as coordinates to other dataarrays to create the dataarrays' `area` attribute.

Consider for example:
```
<xarray.DataArray '2' (y: 5400, x: 2048)>
dask.array<open_dataset-d4a5694130e597fc2b6cbc2df91fdec72, shape=(5400, 2048), dtype=float64, chunksize=(4096, 2048), chunktype=numpy.ndarray>
Coordinates:
    longitude  (y, x) float64 dask.array<chunksize=(4096, 2048), meta=np.ndarray>
    latitude   (y, x) float64 dask.array<chunksize=(4096, 2048), meta=np.ndarray>
Dimensions without coordinates: y, x
Attributes:
    calibration:    reflectance
    end_time:       2020-01-08 08:34:49.556000
    modifiers:      []
    platform_name:  Metop-C
    resolution:     1050
    sensor:         avhrr-3
    standard_name:  toa_bidirectional_reflectance
    start_time:     2020-01-08 08:19:49.890000
    units:          %
    wavelength:     ['0.725', '0.8625', '1.0', 'µm']
```

This dataarray contains already populated longitude and latitude coordinates (it is being read from a well-constructed netcdf file), but satpy fails to create the necessary `area` attribute from it.
This PR fixes it in a manner that uses the builtin coordinates if no other coordinates are provided from eg the dataset definitions  of the reader's yaml file.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
