### PR TITLE
Fix compression not being applied in awips_tiled writer

### DIFF
--- a/satpy/tests/writer_tests/test_awips_tiled.py
+++ b/satpy/tests/writer_tests/test_awips_tiled.py
@@ -56,6 +56,7 @@ def check_required_common_attributes(ds):
             # grid mapping variable
             assert 'grid_mapping_name' in data_arr.attrs
             continue
+        assert data_arr.encoding.get('zlib', False)
         assert 'grid_mapping' in data_arr.attrs
         assert data_arr.attrs['grid_mapping'] in ds
 

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -1545,6 +1545,8 @@ class AWIPSTiledWriter(Writer):
                                      extra_global_attrs=extra_global_attrs)
             if self.compress:
                 new_ds.encoding['zlib'] = True
+                for var in new_ds.variables.values():
+                    var.encoding['zlib'] = True
 
             datasets_to_save.append(new_ds)
             output_filenames.append(output_filename)


### PR DESCRIPTION
User discovered that the files weren't being compressed. I had assumed setting the global encoding of `zlib=True` was good enough, but it needs to actually be set on every variable.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Passes ``flake8 satpy`` <!-- remove if you did not edit any Python files -->
