### PR TITLE
Fix deprecated sphinx html_context usage in conf.py

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,13 +43,13 @@ jobs:
           environment-file: continuous_integration/environment.yaml
           activate-environment: test-environment
 
-      - name: Install satpy
+      - name: Install Satpy
         shell: bash -l {0}
         run: |
           pip install sphinx sphinx_rtd_theme sphinxcontrib-apidoc; \
           pip install --no-deps -e .
 
-      - name: Run unit tests
+      - name: Run Sphinx Build
         shell: bash -l {0}
         run: |
           cd doc; \

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -180,11 +180,9 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-        ],
-     }
+html_css_files = [
+    'theme_overrides.css',  # override wide tables in RTD theme
+]
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.


### PR DESCRIPTION
We were using the old `html_context` which has been deprecated for a while. This PR switches to `html_css_files` instead. See https://github.com/sphinx-doc/sphinx/issues/8885 for more information.
