### PR TITLE
Add 'environment_prefix' to AWIPS tiled writer for flexible filenames

### DIFF
--- a/satpy/etc/writers/awips_tiled.yaml
+++ b/satpy/etc/writers/awips_tiled.yaml
@@ -777,7 +777,7 @@ templates:
   glm_l2_radc:
     single_variable: false
     # OR_GLM-L2-GLMF-M6_G16_T10_e20201105150300.nc
-    filename: 'OR_GLM-L2-GLM{scene_abbr}-{scan_mode}_{platform_shortname}_T{tile_number:02d}_{end_time:%Y%m%d%H%M%S}.nc'
+    filename: '{environment_prefix}_GLM-L2-GLM{scene_abbr}-{scan_mode}_{platform_shortname}_T{tile_number:02d}_{end_time:%Y%m%d%H%M%S}.nc'
     global_attributes:
       # FIXME: This should come from the reader's metadata
       dataset_name:
@@ -951,7 +951,7 @@ templates:
   glm_l2_radf:
     single_variable: false
     # OR_GLM-L2-GLMF-M6_G16_T10_e20201105150300.nc
-    filename: 'OR_GLM-L2-GLM{scene_abbr}-{scan_mode}_{platform_shortname}_T{tile_number:02d}_{end_time:%Y%m%d%H%M%S}.nc'
+    filename: '{environment_prefix}_GLM-L2-GLM{scene_abbr}-{scan_mode}_{platform_shortname}_T{tile_number:02d}_{end_time:%Y%m%d%H%M%S}.nc'
     global_attributes:
       # FIXME: This should come from the reader's metadata
       dataset_name:

--- a/satpy/tests/writer_tests/test_awips_tiled.py
+++ b/satpy/tests/writer_tests/test_awips_tiled.py
@@ -25,6 +25,18 @@ import dask.array as da
 import pytest
 
 
+def _check_production_location(ds):
+    if 'production_site' in ds.attrs:
+        prod_loc_name = 'production_site'
+    elif 'production_location' in ds.attrs:
+        prod_loc_name = 'producton_location'
+    else:
+        return
+
+    if prod_loc_name in ds.attrs:
+        assert len(ds.attrs[prod_loc_name]) == 31
+
+
 def check_required_common_attributes(ds):
     """Check common properties of the created AWIPS tiles for validity."""
     assert 'x' in ds.coords
@@ -50,6 +62,7 @@ def check_required_common_attributes(ds):
                       'number_product_tiles',
                       'product_rows', 'product_columns'):
         assert attr_name in ds.attrs
+    _check_production_location(ds)
 
     for data_arr in ds.data_vars.values():
         if data_arr.ndim == 0:
@@ -533,6 +546,8 @@ class TestAWIPSTiledWriter:
         from xarray import DataArray
         from pyresample.geometry import AreaDefinition
         from pyresample.utils import proj4_str_to_dict
+        import os
+        os.environ['ORGANIZATION'] = '1' * 50
         w = AWIPSTiledWriter(base_dir=self.base_dir, compress=True)
         area_def = AreaDefinition(
             'test',

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -216,6 +216,7 @@ lettered tile locations.
 import os
 import logging
 import string
+import warnings
 import sys
 from datetime import datetime, timedelta
 from collections import namedtuple
@@ -915,10 +916,20 @@ class AWIPSNetCDFTemplate(NetCDFTemplate):
         del input_metadata
         org = os.environ.get('ORGANIZATION', None)
         if org is not None:
-            return org
-        LOG.warning('environment ORGANIZATION not set for .production_location attribute, using hostname')
-        import socket
-        return socket.gethostname()  # FUTURE: something more correct but this will do for now
+            prod_location = org
+        else:
+            LOG.warning('environment ORGANIZATION not set for .production_location attribute, using hostname')
+            import socket
+            prod_location = socket.gethostname()  # FUTURE: something more correct but this will do for now
+
+        if len(prod_location) > 31:
+            warnings.warn("Production location attribute is longer than 31 "
+                          "characters (AWIPS limit). Set it to a smaller "
+                          "value with the 'ORGANIZATION' environment "
+                          "variable. Defaults to hostname and is currently "
+                          "set to '{}'.".format(prod_location))
+            prod_location = prod_location[:31]
+        return prod_location
 
     _global_production_site = _global_production_location
 

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -1397,6 +1397,7 @@ class AWIPSTiledWriter(Writer):
                 columns=area_def.width,
                 sector_id=sector_id,
                 tile_id=tile_info.tile_id,
+                tile_number=tile_info.tile_number,
                 **kwargs)
         except RuntimeError:
             # the user didn't provide a specific filename, use the template
@@ -1445,7 +1446,7 @@ class AWIPSTiledWriter(Writer):
                       lettered_grid=False, num_subtiles=None,
                       use_end_time=False, use_sector_reference=False,
                       template='polar', check_categories=True,
-                      extra_global_attrs=None,
+                      extra_global_attrs=None, environment_prefix='DR',
                       compute=True, **kwargs):
         """Write a series of DataArray objects to multiple NetCDF4 Tile files.
 
@@ -1464,6 +1465,12 @@ class AWIPSTiledWriter(Writer):
             source_name (str): Name of producer of these files (ex. "SSEC").
                 This name is used to create the output filename for some
                 templates.
+            environment_prefix (str): Prefix of filenames for some templates.
+                For operational real-time data this is usually "OR", "OT" for
+                test data, "IR" for test system real-time data, and "IT" for
+                test system test data. This defaults to "DR" for "Developer
+                Real-time" to avoid anyone accidentally producing files that
+                could be mistaken for the operational system.
             tile_count (tuple): For numbered tiles only, how many tile rows
                 and tile columns to produce. Default to ``(1, 1)``, a single
                 giant tile. Either ``tile_count``, ``tile_size``, or
@@ -1535,6 +1542,7 @@ class AWIPSTiledWriter(Writer):
                                                source_name)
             output_filename = self.get_filename(template, area_def,
                                                 tile_info, sector_id,
+                                                environment_prefix=environment_prefix,
                                                 **ds_info)
             self.check_tile_exists(output_filename)
             # TODO: Provide attribute caching for things that likely won't change (functools lrucache)


### PR DESCRIPTION
Different processing environments may want different prefixes for files that will go to AWIPS. This is semi-standard for AWIPS tiled files (OR, OT, etc). This PR adds a new `environment_prefix` kwarg to the writer to control this for the GLM templates and fixes an issue where `tile_number` wasn't being provided to the user provided custom filename format string.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

CC @rayg-ssec @nbearson