### PR TITLE
Fix composite metadata overwriting and 'sensor' filename formatting

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -227,6 +227,12 @@ class SingleBandCompositor(CompositeBase):
     This preserves all the attributes of the dataset it is derived from.
     """
 
+    @staticmethod
+    def _update_missing_metadata(existing_attrs, new_attrs):
+        for key, val in new_attrs.items():
+            if key not in existing_attrs and val is not None:
+                existing_attrs[key] = val
+
     def __call__(self, projectables, nonprojectables=None, **attrs):
         """Build the composite."""
         if len(projectables) != 1:
@@ -234,10 +240,7 @@ class SingleBandCompositor(CompositeBase):
 
         data = projectables[0]
         new_attrs = data.attrs.copy()
-
-        new_attrs.update({key: val
-                          for (key, val) in attrs.items()
-                          if val is not None})
+        self._update_missing_metadata(new_attrs, attrs)
         resolution = new_attrs.get('resolution', None)
         new_attrs.update(self.attrs)
         if resolution is not None:

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1261,8 +1261,7 @@ class Scene:
 
         try:
             composite = compositor(prereq_datasets,
-                                   optional_datasets=optional_datasets,
-                                   **self.attrs)
+                                   optional_datasets=optional_datasets)
             cid = DataID.new_id_from_dataarray(composite)
             self._datasets[cid] = composite
 

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -663,10 +663,16 @@ class TestSingleBandCompositor(unittest.TestCase):
         # Dataset with extra attributes
         all_valid = self.all_valid
         all_valid.attrs['sensor'] = 'foo'
-        attrs = {'foo': 'bar', 'resolution': 333, 'units': 'K',
-                 'calibration': 'BT', 'wavelength': 10.8}
+        attrs = {
+            'foo': 'bar',
+            'resolution': 333,
+            'units': 'K',
+            'sensor': {'fake1', 'fake2'},
+            'calibration': 'BT',
+            'wavelength': 10.8
+        }
         self.comp.attrs['resolution'] = None
-        res = self.comp([self.all_valid], **attrs)
+        res = self.comp([all_valid], **attrs)
         # Verify attributes
         self.assertEqual(res.attrs.get('sensor'), 'foo')
         self.assertTrue('foo' in res.attrs)

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -667,7 +667,7 @@ class TestSingleBandCompositor(unittest.TestCase):
             'foo': 'bar',
             'resolution': 333,
             'units': 'K',
-            'sensor': {'fake1', 'fake2'},
+            'sensor': {'fake_sensor1', 'fake_sensor2'},
             'calibration': 'BT',
             'wavelength': 10.8
         }

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -577,11 +577,11 @@ class TestBaseWriter:
             attrs={
                 'name': 'test',
                 'start_time': datetime(2018, 1, 1, 0, 0, 0),
-                'sensor': 'fake',
+                'sensor': 'fake_sensor',
             }
         )
         ds2 = ds1.copy()
-        ds2.attrs['sensor'] = {'fake1', 'fake2'}
+        ds2.attrs['sensor'] = {'fake_sensor1', 'fake_sensor2'}
         self.scn = Scene()
         self.scn['test'] = ds1
         self.scn['test2'] = ds2
@@ -607,7 +607,7 @@ class TestBaseWriter:
             ('geotiff_{name}_{start_time:%Y%m%d_%H%M%S}.tif',
              ['geotiff_test_20180101_000000.tif', 'geotiff_test2_20180101_000000.tif']),
             ('geotiff_{name}_{sensor}.tif',
-             ['geotiff_test_fake.tif', 'geotiff_test2_fake1-fake2.tif']),
+             ['geotiff_test_fake_sensor.tif', 'geotiff_test2_fake_sensor1-fake_sensor2.tif']),
         ]
     )
     def test_save_dataset_dynamic_filename(self, fmt_fn, exp_fns):

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -635,7 +635,7 @@ class Writer(Plugin, DataDownloadMixin):
     @staticmethod
     def _prepare_metadata_for_filename_formatting(attrs):
         if isinstance(attrs.get('sensor'), set):
-            attrs['sensor'] = '-'.join(attrs['sensor'])
+            attrs['sensor'] = '-'.join(sorted(attrs['sensor']))
 
     def get_filename(self, **kwargs):
         """Create a filename where output data will be saved.

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -632,6 +632,11 @@ class Writer(Plugin, DataDownloadMixin):
             file_pattern = self.file_pattern
         return parser.Parser(file_pattern) if file_pattern else None
 
+    @staticmethod
+    def _prepare_metadata_for_filename_formatting(attrs):
+        if isinstance(attrs.get('sensor'), set):
+            attrs['sensor'] = '-'.join(attrs['sensor'])
+
     def get_filename(self, **kwargs):
         """Create a filename where output data will be saved.
 
@@ -642,6 +647,7 @@ class Writer(Plugin, DataDownloadMixin):
         """
         if self.filename_parser is None:
             raise RuntimeError("No filename pattern or specific filename provided")
+        self._prepare_metadata_for_filename_formatting(kwargs)
         output_filename = self.filename_parser.compose(kwargs)
         dirname = os.path.dirname(output_filename)
         if dirname and not os.path.isdir(dirname):


### PR DESCRIPTION
See #1550 for details.

This PR does three main things:

1. Stops the `Scene` from passing its own metadata to the compositors. I think this was left over from some of @mraspaud's work trying to get resolutions to be respected in composites, but it doesn't seem to be used and definitely isn't tested.
2. Stops the SingleBandCompositor from overwriting metadata that already exists in the prereq metadata.
3. Formats `'sensor'` if it is a set just before creating a filename so that `{'abi', 'glm'}` becomes `'abi-glm'`. Not the best solution, but it is a start.

Feedback welcome.

 - [x] Closes #1550 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
