### PR TITLE
Cleanup usage of deprecated pyresample proj_str/proj_dict property

### DIFF
--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -286,8 +286,12 @@ class NcNWCSAF(BaseFileHandler):
         proj_dict = proj4_str_to_dict(proj_str)
         if proj_dict.get('units') == 'km':
             proj_dict["units"] = "m"
-            proj_dict["a"] *= 1000.
-            proj_dict["b"] *= 1000.
+            if "a" in proj_dict:
+                proj_dict["a"] *= 1000.
+            if "b" in proj_dict:
+                proj_dict["b"] *= 1000.
+            if "R" in proj_dict:
+                proj_dict["R"] *= 1000.
             proj_dict["h"] *= 1000.
             area_extent = tuple([val * 1000. for val in area_extent])
         return CRS(proj_dict), area_extent

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -30,6 +30,7 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
+from pyresample.geometry import AreaDefinition
 from pyresample.utils import get_area_def
 from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
@@ -281,10 +282,8 @@ class NcNWCSAF(BaseFileHandler):
     @staticmethod
     def _ensure_area_def_is_in_meters(area_definition):
         """Fix units in Earth shape, satellite altitude and 'units' attribute."""
-        if area_definition.proj_dict["units"] == "km":
-            proj_dict = area_definition.proj_dict.copy()
-            from pyresample.geometry import AreaDefinition
-
+        proj_dict = area_definition.proj_dict.copy()
+        if proj_dict["units"] == "km":
             proj_dict["units"] = "m"
             proj_dict["a"] *= 1000.
             proj_dict["h"] *= 1000.

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -66,7 +66,7 @@ def np2str(value):
         raise ValueError("Array is not a string type or is larger than 1")
 
 
-def _get_geostationary_h(geos_area):
+def _get_geostationary_height(geos_area):
     try:
         crs = geos_area.crs
         params = crs.coordinate_operation.params
@@ -76,7 +76,7 @@ def _get_geostationary_h(geos_area):
         return geos_area.proj_dict['h']
 
 
-def _get_geostationary_ab(geos_area):
+def _get_geostationary_semi_axes(geos_area):
     try:
         crs = geos_area.crs
         a = crs.ellipsoid.semi_major_metre
@@ -96,8 +96,8 @@ def _get_geostationary_ab(geos_area):
 def get_geostationary_angle_extent(geos_area):
     """Get the max earth (vs space) viewing angles in x and y."""
     # TODO: take into account sweep_axis_angle parameter
-    a, b = _get_geostationary_ab(geos_area)
-    h = _get_geostationary_h(geos_area)
+    a, b = _get_geostationary_semi_axes(geos_area)
+    h = _get_geostationary_height(geos_area)
     req = float(a) / 1000
     rp = float(b) / 1000
     h = float(h) / 1000 + req
@@ -125,7 +125,7 @@ def get_geostationary_mask(area):
 
     """
     # Compute projection coordinates at the earth's limb
-    h = _get_geostationary_h(area)
+    h = _get_geostationary_height(area)
     xmax, ymax = get_geostationary_angle_extent(area)
     xmax *= h
     ymax *= h
@@ -139,8 +139,8 @@ def get_geostationary_mask(area):
 
 def _lonlat_from_geos_angle(x, y, geos_area):
     """Get lons and lats from x, y in projection coordinates."""
-    a, b = _get_geostationary_ab(geos_area)
-    h = _get_geostationary_h(geos_area)
+    a, b = _get_geostationary_semi_axes(geos_area)
+    h = _get_geostationary_height(geos_area)
     h__ = float(h + a) / 1000
     b__ = (a / float(b)) ** 2
 
@@ -170,7 +170,7 @@ def get_geostationary_bounding_box(geos_area, nb_points=50):
 
     """
     xmax, ymax = get_geostationary_angle_extent(geos_area)
-    h = _get_geostationary_h(geos_area)
+    h = _get_geostationary_height(geos_area)
 
     # generate points around the north hemisphere in satellite projection
     # make it a bit smaller so that we stay inside the valid area

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -66,11 +66,17 @@ def np2str(value):
         raise ValueError("Array is not a string type or is larger than 1")
 
 
-def get_geostationary_angle_extent(geos_area):
-    """Get the max earth (vs space) viewing angles in x and y."""
-    # TODO: take into account sweep_axis_angle parameter
+def _get_geostationary_h(geos_area):
+    try:
+        crs = geos_area.crs
+        params = crs.coordinate_operation.params
+        h_param = [p for p in params if 'satellite height' in p.name.lower()][0]
+        return h_param.value
+    except AttributeError:
+        return geos_area.proj_dict['h']
 
-    # get some projection parameters
+
+def _get_geostationary_ab(geos_area):
     try:
         crs = geos_area.crs
         a = crs.ellipsoid.semi_major_metre
@@ -82,11 +88,19 @@ def get_geostationary_angle_extent(geos_area):
     except AttributeError:
         # older versions of pyproj don't have CRS objects
         from pyresample.utils import proj4_radius_parameters
-        a, b = proj4_radius_parameters(geos_area.proj_dict)
+        proj_dict = geos_area.proj_dict
+        a, b = proj4_radius_parameters(proj_dict)
+    return a, b
 
+
+def get_geostationary_angle_extent(geos_area):
+    """Get the max earth (vs space) viewing angles in x and y."""
+    # TODO: take into account sweep_axis_angle parameter
+    a, b = _get_geostationary_ab(geos_area)
+    h = _get_geostationary_h(geos_area)
     req = float(a) / 1000
     rp = float(b) / 1000
-    h = float(geos_area.proj_dict['h']) / 1000 + req
+    h = float(h) / 1000 + req
 
     # compute some constants
     aeq = 1 - req**2 / (h ** 2)
@@ -111,7 +125,7 @@ def get_geostationary_mask(area):
 
     """
     # Compute projection coordinates at the earth's limb
-    h = area.proj_dict['h']
+    h = _get_geostationary_h(area)
     xmax, ymax = get_geostationary_angle_extent(area)
     xmax *= h
     ymax *= h
@@ -125,16 +139,18 @@ def get_geostationary_mask(area):
 
 def _lonlat_from_geos_angle(x, y, geos_area):
     """Get lons and lats from x, y in projection coordinates."""
-    h = float(geos_area.proj_dict['h'] + geos_area.proj_dict['a']) / 1000
-    b__ = (geos_area.proj_dict['a'] / float(geos_area.proj_dict['b'])) ** 2
+    a, b = _get_geostationary_ab(geos_area)
+    h = _get_geostationary_h(geos_area)
+    h__ = float(h + a) / 1000
+    b__ = (a / float(b)) ** 2
 
-    sd = np.sqrt((h * np.cos(x) * np.cos(y)) ** 2 -
+    sd = np.sqrt((h__ * np.cos(x) * np.cos(y)) ** 2 -
                  (np.cos(y)**2 + b__ * np.sin(y)**2) *
-                 (h**2 - (float(geos_area.proj_dict['a']) / 1000)**2))
+                 (h__**2 - (float(a) / 1000)**2))
     # sd = 0
 
-    sn = (h * np.cos(x) * np.cos(y) - sd) / (np.cos(y)**2 + b__ * np.sin(y)**2)
-    s1 = h - sn * np.cos(x) * np.cos(y)
+    sn = (h__ * np.cos(x) * np.cos(y) - sd) / (np.cos(y)**2 + b__ * np.sin(y)**2)
+    s1 = h__ - sn * np.cos(x) * np.cos(y)
     s2 = sn * np.sin(x) * np.cos(y)
     s3 = -sn * np.sin(y)
     sxy = np.sqrt(s1**2 + s2**2)
@@ -154,6 +170,7 @@ def get_geostationary_bounding_box(geos_area, nb_points=50):
 
     """
     xmax, ymax = get_geostationary_angle_extent(geos_area)
+    h = _get_geostationary_h(geos_area)
 
     # generate points around the north hemisphere in satellite projection
     # make it a bit smaller so that we stay inside the valid area
@@ -162,7 +179,7 @@ def get_geostationary_bounding_box(geos_area, nb_points=50):
 
     # clip the projection coordinates to fit the area extent of geos_area
     ll_x, ll_y, ur_x, ur_y = (np.array(geos_area.area_extent) /
-                              float(geos_area.proj_dict['h']))
+                              float(h))
 
     x = np.clip(np.concatenate([x, x[::-1]]), min(ll_x, ur_x), max(ll_x, ur_x))
     y = np.clip(np.concatenate([y, -y]), min(ll_y, ur_y), max(ll_y, ur_y))
@@ -181,8 +198,9 @@ def get_sub_area(area, xslice, yslice):
                        (area.pixel_upper_left[1] -
                         (yslice.start - 0.5) * area.pixel_size_y))
 
+    crs = area.crs if hasattr(area, 'crs') else area.proj_dict
     return AreaDefinition(area.area_id, area.name,
-                          area.proj_id, area.proj_dict,
+                          area.proj_id, crs,
                           xslice.stop - xslice.start,
                           yslice.stop - yslice.start,
                           new_area_extent)

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -1276,7 +1276,7 @@ def _pad_earlier_segments_area(file_handlers, dsid, area_defs):
                           fh in file_handlers]
     area = file_handlers[0].get_area_def(dsid)
     seg_size = area.shape
-    proj_dict = area.proj_dict
+    crs = area.crs if hasattr(area, 'crs') else area.proj_dict
     padding_fci_scene = file_handlers[0].filetype_info.get('file_type') == 'fci_l1c_fdhsi'
 
     for segment in range(available_segments[0] - 1, 0, -1):
@@ -1289,7 +1289,7 @@ def _pad_earlier_segments_area(file_handlers, dsid, area_defs):
         fill_extent = (area.area_extent[0], new_ll_y,
                        area.area_extent[2], new_ur_y)
         area = AreaDefinition('fill', 'fill', 'fill',
-                              proj_dict,
+                              crs,
                               seg_size[1], new_height_px,
                               fill_extent)
         area_defs[segment] = area

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -1260,7 +1260,7 @@ def _pad_later_segments_area(file_handlers, dsid):
             new_ur_y = area.area_extent[1]
             fill_extent = (area.area_extent[0], new_ll_y,
                            area.area_extent[2], new_ur_y)
-            area = AreaDefinition('fill', 'fill', 'fill', area.proj_dict,
+            area = AreaDefinition('fill', 'fill', 'fill', area.crs,
                                   seg_size[1], new_height_px,
                                   fill_extent)
 
@@ -1276,7 +1276,6 @@ def _pad_earlier_segments_area(file_handlers, dsid, area_defs):
                           fh in file_handlers]
     area = file_handlers[0].get_area_def(dsid)
     seg_size = area.shape
-    crs = area.crs if hasattr(area, 'crs') else area.proj_dict
     padding_fci_scene = file_handlers[0].filetype_info.get('file_type') == 'fci_l1c_fdhsi'
 
     for segment in range(available_segments[0] - 1, 0, -1):
@@ -1289,7 +1288,7 @@ def _pad_earlier_segments_area(file_handlers, dsid, area_defs):
         fill_extent = (area.area_extent[0], new_ll_y,
                        area.area_extent[2], new_ur_y)
         area = AreaDefinition('fill', 'fill', 'fill',
-                              crs,
+                              area.crs,
                               seg_size[1], new_height_px,
                               fill_extent)
         area_defs[segment] = area

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -207,8 +207,8 @@ class Scene:
                    for x in areas[1:]):
             raise ValueError("Can't compare areas of different types")
         elif isinstance(areas[0], AreaDefinition):
-            first_pstr = areas[0].proj_str
-            if not all(ad.proj_str == first_pstr for ad in areas[1:]):
+            first_pstr = self._crs_or_proj(areas[0])
+            if not all(self._crs_or_proj(ad) == first_pstr for ad in areas[1:]):
                 raise ValueError("Can't compare areas with different "
                                  "projections.")
 
@@ -417,12 +417,18 @@ class Scene:
         all_areas = [x for x in all_areas if x is not None]
         return all(all_areas[0] == x for x in all_areas[1:])
 
+    @staticmethod
+    def _crs_or_proj(area_def):
+        if hasattr(area_def, 'crs'):
+            return area_def.crs
+        return area_def.proj_str
+
     @property
     def all_same_proj(self):
         """All contained data array are in the same projection."""
         all_areas = [x.attrs.get('area', None) for x in self.values()]
         all_areas = [x for x in all_areas if x is not None]
-        return all(all_areas[0].proj_str == x.proj_str for x in all_areas[1:])
+        return all(self._crs_or_proj(all_areas[0]) == self._crs_or_proj(x) for x in all_areas[1:])
 
     @staticmethod
     def _slice_area_from_bbox(src_area, dst_area, ll_bbox=None,

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -207,8 +207,8 @@ class Scene:
                    for x in areas[1:]):
             raise ValueError("Can't compare areas of different types")
         elif isinstance(areas[0], AreaDefinition):
-            first_pstr = self._crs_or_proj(areas[0])
-            if not all(self._crs_or_proj(ad) == first_pstr for ad in areas[1:]):
+            first_crs = areas[0].crs
+            if not all(ad.crs == first_crs for ad in areas[1:]):
                 raise ValueError("Can't compare areas with different "
                                  "projections.")
 
@@ -417,18 +417,12 @@ class Scene:
         all_areas = [x for x in all_areas if x is not None]
         return all(all_areas[0] == x for x in all_areas[1:])
 
-    @staticmethod
-    def _crs_or_proj(area_def):
-        if hasattr(area_def, 'crs'):
-            return area_def.crs
-        return area_def.proj_str
-
     @property
     def all_same_proj(self):
         """All contained data array are in the same projection."""
         all_areas = [x.attrs.get('area', None) for x in self.values()]
         all_areas = [x for x in all_areas if x is not None]
-        return all(self._crs_or_proj(all_areas[0]) == self._crs_or_proj(x) for x in all_areas[1:])
+        return all(all_areas[0].crs == x.crs for x in all_areas[1:])
 
     @staticmethod
     def _slice_area_from_bbox(src_area, dst_area, ll_bbox=None,
@@ -439,10 +433,9 @@ class Scene:
                 'crop_area', 'crop_area', 'crop_latlong',
                 {'proj': 'latlong'}, 100, 100, ll_bbox)
         elif xy_bbox is not None:
-            crs = src_area.crs if hasattr(src_area, 'crs') else src_area.proj_dict
             dst_area = AreaDefinition(
                 'crop_area', 'crop_area', 'crop_xy',
-                crs, src_area.width, src_area.height,
+                src_area.crs, src_area.width, src_area.height,
                 xy_bbox)
         x_slice, y_slice = src_area.get_area_slices(dst_area)
         return src_area[y_slice, x_slice], y_slice, x_slice

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -35,18 +35,18 @@ class TestHelpers(unittest.TestCase):
 
     def test_lonlat_from_geos(self):
         """Get lonlats from geos."""
+        import pyproj
         geos_area = mock.MagicMock()
+        del geos_area.crs
         lon_0 = 0
         h = 35785831.00
         geos_area.proj_dict = {'a': 6378169.00,
                                'b': 6356583.80,
                                'h': h,
-                               'lon_0': lon_0}
+                               'lon_0': lon_0,
+                               'proj': 'geos'}
 
-        expected = np.array((lon_0, 0))
-
-        import pyproj
-        proj = pyproj.Proj(proj='geos', **geos_area.proj_dict)
+        proj = pyproj.Proj(geos_area.proj_dict)
 
         expected = proj(0, 0, inverse=True)
 
@@ -192,11 +192,11 @@ class TestHelpers(unittest.TestCase):
         area.area_id = 'fakeid'
         area.name = 'fake name'
         area.proj_id = 'fakeproj'
-        area.proj_dict = {'fake': 'dict'}
+        area.crs = 'some_crs'
 
         hf.get_sub_area(area, slice(1, 4), slice(0, 3))
         adef.assert_called_once_with('fakeid', 'fake name', 'fakeproj',
-                                     {'fake': 'dict'},
+                                     'some_crs',
                                      3, 3,
                                      (0.75, -3.75, 5.25, 0.75))
 

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -27,10 +27,7 @@ try:
 except ImportError:
     LegacyDaskEWAResampler = None
 
-try:
-    from pyproj import CRS
-except ImportError:
-    CRS = None
+from pyproj import CRS
 
 
 def get_test_data(input_shape=(100, 50), output_shape=(200, 100), output_proj=None,
@@ -73,9 +70,8 @@ def get_test_data(input_shape=(100, 50), output_shape=(200, 100), output_proj=No
         input_shape[0],  # height
         (-1000., -1500., 1000., 1500.))
     ds1.attrs['area'] = source
-    if CRS is not None:
-        crs = CRS.from_string(input_proj_str)
-        ds1 = ds1.assign_coords(crs=crs)
+    crs = CRS.from_string(input_proj_str)
+    ds1 = ds1.assign_coords(crs=crs)
 
     ds2 = ds1.copy()
     input_area_shape = tuple(ds1.sizes[dim] for dim in ds1.dims
@@ -87,9 +83,8 @@ def get_test_data(input_shape=(100, 50), output_shape=(200, 100), output_proj=No
         DataArray(lons, dims=geo_dims),
         DataArray(lats, dims=geo_dims))
     ds2.attrs['area'] = swath_def
-    if CRS is not None:
-        crs = CRS.from_string('+proj=latlong +datum=WGS84 +ellps=WGS84')
-        ds2 = ds2.assign_coords(crs=crs)
+    crs = CRS.from_string('+proj=latlong +datum=WGS84 +ellps=WGS84')
+    ds2 = ds2.assign_coords(crs=crs)
 
     # set up target definition
     output_proj_str = ('+proj=lcc +datum=WGS84 +ellps=WGS84 '
@@ -303,14 +298,12 @@ class TestEWAResampler(unittest.TestCase):
         self.assertEqual(get_lonlats.call_count, lonlat_calls)
         self.assertIn('y', new_data.coords)
         self.assertIn('x', new_data.coords)
-        if CRS is not None:
-            self.assertIn('crs', new_data.coords)
-            self.assertIsInstance(new_data.coords['crs'].item(), CRS)
-            self.assertIn('lcc', new_data.coords['crs'].item().to_proj4())
-            self.assertEqual(new_data.coords['y'].attrs['units'], 'meter')
-            self.assertEqual(new_data.coords['x'].attrs['units'], 'meter')
-            if hasattr(target_area, 'crs'):
-                self.assertIs(target_area.crs, new_data.coords['crs'].item())
+        self.assertIn('crs', new_data.coords)
+        self.assertIsInstance(new_data.coords['crs'].item(), CRS)
+        self.assertIn('lcc', new_data.coords['crs'].item().to_proj4())
+        self.assertEqual(new_data.coords['y'].attrs['units'], 'meter')
+        self.assertEqual(new_data.coords['x'].attrs['units'], 'meter')
+        self.assertEqual(target_area.crs, new_data.coords['crs'].item())
 
     @mock.patch('satpy.resample.fornav')
     @mock.patch('satpy.resample.ll2cr')
@@ -355,16 +348,14 @@ class TestEWAResampler(unittest.TestCase):
         self.assertIn('y', new_data.coords)
         self.assertIn('x', new_data.coords)
         self.assertIn('bands', new_data.coords)
-        if CRS is not None:
-            self.assertIn('crs', new_data.coords)
-            self.assertIsInstance(new_data.coords['crs'].item(), CRS)
-            self.assertIn('lcc', new_data.coords['crs'].item().to_proj4())
-            self.assertEqual(new_data.coords['y'].attrs['units'], 'meter')
-            self.assertEqual(new_data.coords['x'].attrs['units'], 'meter')
-            np.testing.assert_equal(new_data.coords['bands'].values,
-                                    ['R', 'G', 'B'])
-            if hasattr(target_area, 'crs'):
-                self.assertIs(target_area.crs, new_data.coords['crs'].item())
+        self.assertIn('crs', new_data.coords)
+        self.assertIsInstance(new_data.coords['crs'].item(), CRS)
+        self.assertIn('lcc', new_data.coords['crs'].item().to_proj4())
+        self.assertEqual(new_data.coords['y'].attrs['units'], 'meter')
+        self.assertEqual(new_data.coords['x'].attrs['units'], 'meter')
+        np.testing.assert_equal(new_data.coords['bands'].values,
+                                ['R', 'G', 'B'])
+        self.assertEqual(target_area.crs, new_data.coords['crs'].item())
 
 
 class TestNativeResampler(unittest.TestCase):
@@ -407,14 +398,12 @@ class TestNativeResampler(unittest.TestCase):
         self.assertTrue(np.all(new_data == new_data2))
         self.assertIn('y', new_data.coords)
         self.assertIn('x', new_data.coords)
-        if CRS is not None:
-            self.assertIn('crs', new_data.coords)
-            self.assertIsInstance(new_data.coords['crs'].item(), CRS)
-            self.assertIn('lcc', new_data.coords['crs'].item().to_proj4())
-            self.assertEqual(new_data.coords['y'].attrs['units'], 'meter')
-            self.assertEqual(new_data.coords['x'].attrs['units'], 'meter')
-            if hasattr(target_area, 'crs'):
-                self.assertIs(target_area.crs, new_data.coords['crs'].item())
+        self.assertIn('crs', new_data.coords)
+        self.assertIsInstance(new_data.coords['crs'].item(), CRS)
+        self.assertIn('lcc', new_data.coords['crs'].item().to_proj4())
+        self.assertEqual(new_data.coords['y'].attrs['units'], 'meter')
+        self.assertEqual(new_data.coords['x'].attrs['units'], 'meter')
+        self.assertEqual(target_area.crs, new_data.coords['crs'].item())
 
     def test_expand_dims_3d(self):
         """Test expanding native resampling with 3D data."""
@@ -433,14 +422,12 @@ class TestNativeResampler(unittest.TestCase):
         self.assertIn('bands', new_data.coords)
         np.testing.assert_equal(new_data.coords['bands'].values,
                                 ['R', 'G', 'B'])
-        if CRS is not None:
-            self.assertIn('crs', new_data.coords)
-            self.assertIsInstance(new_data.coords['crs'].item(), CRS)
-            self.assertIn('lcc', new_data.coords['crs'].item().to_proj4())
-            self.assertEqual(new_data.coords['y'].attrs['units'], 'meter')
-            self.assertEqual(new_data.coords['x'].attrs['units'], 'meter')
-            if hasattr(target_area, 'crs'):
-                self.assertIs(target_area.crs, new_data.coords['crs'].item())
+        self.assertIn('crs', new_data.coords)
+        self.assertIsInstance(new_data.coords['crs'].item(), CRS)
+        self.assertIn('lcc', new_data.coords['crs'].item().to_proj4())
+        self.assertEqual(new_data.coords['y'].attrs['units'], 'meter')
+        self.assertEqual(new_data.coords['x'].attrs['units'], 'meter')
+        self.assertEqual(target_area.crs, new_data.coords['crs'].item())
 
     def test_expand_without_dims(self):
         """Test expanding native resampling with no dimensions specified."""
@@ -453,12 +440,10 @@ class TestNativeResampler(unittest.TestCase):
         self.assertEqual(new_data.shape, (200, 100))
         new_data2 = resampler.resample(ds1.compute())
         self.assertTrue(np.all(new_data == new_data2))
-        if CRS is not None:
-            self.assertIn('crs', new_data.coords)
-            self.assertIsInstance(new_data.coords['crs'].item(), CRS)
-            self.assertIn('lcc', new_data.coords['crs'].item().to_proj4())
-            if hasattr(target_area, 'crs'):
-                self.assertIs(target_area.crs, new_data.coords['crs'].item())
+        self.assertIn('crs', new_data.coords)
+        self.assertIsInstance(new_data.coords['crs'].item(), CRS)
+        self.assertIn('lcc', new_data.coords['crs'].item().to_proj4())
+        self.assertEqual(target_area.crs, new_data.coords['crs'].item())
 
     def test_expand_without_dims_4D(self):
         """Test expanding native resampling with 4D data with no dimensions specified."""
@@ -502,14 +487,12 @@ class TestBilinearResampler(unittest.TestCase):
             data, fill_value=fill_value, output_shape=target_area.shape)
         self.assertIn('y', new_data.coords)
         self.assertIn('x', new_data.coords)
-        if CRS is not None:
-            self.assertIn('crs', new_data.coords)
-            self.assertIsInstance(new_data.coords['crs'].item(), CRS)
-            self.assertIn('lcc', new_data.coords['crs'].item().to_proj4())
-            self.assertEqual(new_data.coords['y'].attrs['units'], 'meter')
-            self.assertEqual(new_data.coords['x'].attrs['units'], 'meter')
-            if hasattr(target_area, 'crs'):
-                self.assertIs(target_area.crs, new_data.coords['crs'].item())
+        self.assertIn('crs', new_data.coords)
+        self.assertIsInstance(new_data.coords['crs'].item(), CRS)
+        self.assertIn('lcc', new_data.coords['crs'].item().to_proj4())
+        self.assertEqual(new_data.coords['y'].attrs['units'], 'meter')
+        self.assertEqual(new_data.coords['x'].attrs['units'], 'meter')
+        self.assertEqual(target_area.crs, new_data.coords['crs'].item())
 
         # Test that the resampling info is tried to read from the disk
         resampler = BilinearResampler(source_swath, target_area)
@@ -601,17 +584,15 @@ class TestCoordinateHelpers(unittest.TestCase):
         self.assertIn('y', new_data_arr.coords)
         self.assertIn('x', new_data_arr.coords)
 
-        if CRS is not None:
-            self.assertIn('units', new_data_arr.coords['y'].attrs)
-            self.assertEqual(
-                new_data_arr.coords['y'].attrs['units'], 'meter')
-            self.assertIn('units', new_data_arr.coords['x'].attrs)
-            self.assertEqual(
-                new_data_arr.coords['x'].attrs['units'], 'meter')
-            self.assertIn('crs', new_data_arr.coords)
-            self.assertIsInstance(new_data_arr.coords['crs'].item(), CRS)
-            if hasattr(area_def, 'crs'):
-                self.assertIs(area_def.crs, new_data_arr.coords['crs'].item())
+        self.assertIn('units', new_data_arr.coords['y'].attrs)
+        self.assertEqual(
+            new_data_arr.coords['y'].attrs['units'], 'meter')
+        self.assertIn('units', new_data_arr.coords['x'].attrs)
+        self.assertEqual(
+            new_data_arr.coords['x'].attrs['units'], 'meter')
+        self.assertIn('crs', new_data_arr.coords)
+        self.assertIsInstance(new_data_arr.coords['crs'].item(), CRS)
+        self.assertEqual(area_def.crs, new_data_arr.coords['crs'].item())
 
         # already has coords
         data_arr = xr.DataArray(
@@ -627,11 +608,9 @@ class TestCoordinateHelpers(unittest.TestCase):
         self.assertNotIn('units', new_data_arr.coords['x'].attrs)
         np.testing.assert_equal(new_data_arr.coords['y'], np.arange(2, 202))
 
-        if CRS is not None:
-            self.assertIn('crs', new_data_arr.coords)
-            self.assertIsInstance(new_data_arr.coords['crs'].item(), CRS)
-            if hasattr(area_def, 'crs'):
-                self.assertIs(area_def.crs, new_data_arr.coords['crs'].item())
+        self.assertIn('crs', new_data_arr.coords)
+        self.assertIsInstance(new_data_arr.coords['crs'].item(), CRS)
+        self.assertEqual(area_def.crs, new_data_arr.coords['crs'].item())
 
         # lat/lon area
         area_def = AreaDefinition(
@@ -647,17 +626,15 @@ class TestCoordinateHelpers(unittest.TestCase):
         self.assertIn('y', new_data_arr.coords)
         self.assertIn('x', new_data_arr.coords)
 
-        if CRS is not None:
-            self.assertIn('units', new_data_arr.coords['y'].attrs)
-            self.assertEqual(
-                new_data_arr.coords['y'].attrs['units'], 'degrees_north')
-            self.assertIn('units', new_data_arr.coords['x'].attrs)
-            self.assertEqual(
-                new_data_arr.coords['x'].attrs['units'], 'degrees_east')
-            self.assertIn('crs', new_data_arr.coords)
-            self.assertIsInstance(new_data_arr.coords['crs'].item(), CRS)
-            if hasattr(area_def, 'crs'):
-                self.assertIs(area_def.crs, new_data_arr.coords['crs'].item())
+        self.assertIn('units', new_data_arr.coords['y'].attrs)
+        self.assertEqual(
+            new_data_arr.coords['y'].attrs['units'], 'degrees_north')
+        self.assertIn('units', new_data_arr.coords['x'].attrs)
+        self.assertEqual(
+            new_data_arr.coords['x'].attrs['units'], 'degrees_east')
+        self.assertIn('crs', new_data_arr.coords)
+        self.assertIsInstance(new_data_arr.coords['crs'].item(), CRS)
+        self.assertEqual(area_def.crs, new_data_arr.coords['crs'].item())
 
     def test_swath_def_coordinates(self):
         """Test coordinates being added with an SwathDefinition."""
@@ -690,12 +667,11 @@ class TestCoordinateHelpers(unittest.TestCase):
         #     new_data_arr.coords['latitude'].attrs['units'], 'degrees_north')
         # self.assertIsInstance(new_data_arr.coords['latitude'].data, da.Array)
 
-        if CRS is not None:
-            self.assertIn('crs', new_data_arr.coords)
-            crs = new_data_arr.coords['crs'].item()
-            self.assertIsInstance(crs, CRS)
-            self.assertIn('longlat', crs.to_proj4())
-            self.assertIsInstance(new_data_arr.coords['crs'].item(), CRS)
+        self.assertIn('crs', new_data_arr.coords)
+        crs = new_data_arr.coords['crs'].item()
+        self.assertIsInstance(crs, CRS)
+        self.assertIn('longlat', crs.to_proj4())
+        self.assertIsInstance(new_data_arr.coords['crs'].item(), CRS)
 
 
 class TestBucketAvg(unittest.TestCase):

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -1063,7 +1063,7 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         from satpy.readers.yaml_reader import _pad_earlier_segments_area as pesa
 
         seg2_area = MagicMock()
-        seg2_area.proj_dict = 'proj_dict'
+        seg2_area.crs = 'proj_dict'
         seg2_area.area_extent = [0, 1000, 200, 500]
         seg2_area.shape = [200, 500]
         get_area_def = MagicMock()
@@ -1090,7 +1090,7 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         from satpy.readers.yaml_reader import _pad_earlier_segments_area as pesa
 
         seg2_area = MagicMock()
-        seg2_area.proj_dict = 'proj_dict'
+        seg2_area.crs = 'proj_dict'
         seg2_area.area_extent = [0, 1000, 200, 500]
         seg2_area.shape = [278, 5568]
         get_area_def = MagicMock()

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -1006,7 +1006,7 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         from satpy.readers.yaml_reader import _pad_later_segments_area as plsa
 
         seg1_area = MagicMock()
-        seg1_area.proj_dict = 'proj_dict'
+        seg1_area.crs = 'some_crs'
         seg1_area.area_extent = [0, 1000, 200, 500]
         seg1_area.shape = [200, 500]
         get_area_def = MagicMock()
@@ -1022,7 +1022,7 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         res = plsa(file_handlers, dataid)
         self.assertEqual(len(res), 2)
         seg2_extent = (0, 1500, 200, 1000)
-        expected_call = ('fill', 'fill', 'fill', 'proj_dict', 500, 200,
+        expected_call = ('fill', 'fill', 'fill', 'some_crs', 500, 200,
                          seg2_extent)
         AreaDefinition.assert_called_once_with(*expected_call)
 
@@ -1032,7 +1032,7 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         from satpy.readers.yaml_reader import _pad_later_segments_area as plsa
 
         seg1_area = MagicMock()
-        seg1_area.proj_dict = 'proj_dict'
+        seg1_area.crs = 'some_crs'
         seg1_area.area_extent = [0, 1000, 200, 500]
         seg1_area.shape = [556, 11136]
         get_area_def = MagicMock()
@@ -1053,7 +1053,7 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         # therefore, the new vertical area extent should be half of the previous size (1000-500)/2=250.
         # The new area extent lower-left row is therefore 1000+250=1250
         seg2_extent = (0, 1250, 200, 1000)
-        expected_call = ('fill', 'fill', 'fill', 'proj_dict', 11136, 278,
+        expected_call = ('fill', 'fill', 'fill', 'some_crs', 11136, 278,
                          seg2_extent)
         AreaDefinition.assert_called_once_with(*expected_call)
 
@@ -1063,7 +1063,7 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         from satpy.readers.yaml_reader import _pad_earlier_segments_area as pesa
 
         seg2_area = MagicMock()
-        seg2_area.crs = 'proj_dict'
+        seg2_area.crs = 'some_crs'
         seg2_area.area_extent = [0, 1000, 200, 500]
         seg2_area.shape = [200, 500]
         get_area_def = MagicMock()
@@ -1080,7 +1080,7 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         res = pesa(file_handlers, dataid, area_defs)
         self.assertEqual(len(res), 2)
         seg1_extent = (0, 500, 200, 0)
-        expected_call = ('fill', 'fill', 'fill', 'proj_dict', 500, 200,
+        expected_call = ('fill', 'fill', 'fill', 'some_crs', 500, 200,
                          seg1_extent)
         AreaDefinition.assert_called_once_with(*expected_call)
 
@@ -1090,7 +1090,7 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         from satpy.readers.yaml_reader import _pad_earlier_segments_area as pesa
 
         seg2_area = MagicMock()
-        seg2_area.crs = 'proj_dict'
+        seg2_area.crs = 'some_crs'
         seg2_area.area_extent = [0, 1000, 200, 500]
         seg2_area.shape = [278, 5568]
         get_area_def = MagicMock()
@@ -1112,7 +1112,7 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         # therefore, the new vertical area extent should be half of the previous size (1000-500)/2=250.
         # The new area extent lower-left row is therefore 500-250=250
         seg1_extent = (0, 500, 200, 250)
-        expected_call = ('fill', 'fill', 'fill', 'proj_dict', 5568, 139,
+        expected_call = ('fill', 'fill', 'fill', 'some_crs', 5568, 139,
                          seg1_extent)
         AreaDefinition.assert_called_once_with(*expected_call)
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ except ImportError:
 
 requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.11.0', 'trollsift',
             'trollimage >1.10.1', 'pykdtree', 'pyyaml', 'xarray >=0.10.1, !=0.13.0',
-            'dask[array] >=0.17.1', 'pyproj', 'zarr', 'donfig', 'appdirs',
+            'dask[array] >=0.17.1', 'pyproj>=2.2', 'zarr', 'donfig', 'appdirs',
             'pooch']
 
 test_requires = ['behave', 'h5py', 'netCDF4', 'pyhdf', 'imageio', 'libtiff',


### PR DESCRIPTION
Using PROJ strings and dictionaries is moving towards deprecation in pyresample. The PROJ/pyproj library no longer prefer them. This PR tries to replaces the various usages of these properties of the AreaDefinition class where possible.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
