### PR TITLE
Remove unnecessary use of numpy masked arrays in awips_tiled writer

### DIFF
--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -572,8 +572,8 @@ class LetteredTileGenerator(NumberedTileGenerator):
                 # theoretically we can precompute the X/Y now
                 # instead of taking the x/y data and mapping it
                 # to the tile
-                tmp_x = np.ma.arange(x_left + cw / 2., x_right, cw)
-                tmp_y = np.ma.arange(y_top - ch / 2., y_bot, -ch)
+                tmp_x = np.arange(x_left + cw / 2., x_right, cw)
+                tmp_y = np.arange(y_top - ch / 2., y_bot, -ch)
                 data_x_idx_min = np.nonzero(np.isclose(tmp_x, x[x_slice.start]))[0][0]
                 data_x_idx_max = np.nonzero(np.isclose(tmp_x, x[x_slice.stop - 1]))[0][0]
                 # I have a half pixel error some where


### PR DESCRIPTION
This is a small wasteful piece of code I found when debugging something in my own software. The old version of the `awips_tiled` writer used numpy masked arrays, but I removed all usage of that when I switched to dask and xarray. At least I don't intend to be benefiting from it. This PR removes the small usage I had of `np.ma.*`.