### PR TITLE
Enable showing DeprecationWarning in debug_on and add unit test

### DIFF
--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -338,6 +338,9 @@ def test_debug_on(caplog):
     debug_off()  # other tests assume debugging is off
     # test that filters were reset
     assert warnings.filters == filts_before
+    with debug():
+        assert warnings.filters != filts_before
+    assert warnings.filters == filts_before
 
 
 def test_logging_on_and_off(caplog):

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -316,7 +316,7 @@ class TestCheckSatpy(unittest.TestCase):
 
 def test_debug_on(caplog):
     """Test that debug_on is working as expected."""
-    from satpy.utils import debug_on
+    from satpy.utils import debug_on, debug_off, debug
 
     def depwarn():
         logger = logging.getLogger("satpy.silly")
@@ -335,3 +335,22 @@ def test_debug_on(caplog):
     with pytest.warns(DeprecationWarning):
         depwarn()
     assert warnings.filters != filts_before
+    debug_off()  # other tests assume debugging is off
+    # test that filters were reset
+    assert warnings.filters == filts_before
+
+
+def test_logging_on_and_off(caplog):
+    """Test that switching logging on and off works."""
+    from satpy.utils import logging_on, logging_off
+    logger = logging.getLogger("satpy.silly")
+    logging_on()
+    with caplog.at_level(logging.WARNING):
+        logger.debug("I'd like to leave the army please, sir.")
+        logger.warning("Stop that!  It's SILLY.")
+    assert "Stop that!  It's SILLY" in caplog.text
+    assert "I'd like to leave the army please, sir." not in caplog.text
+    logging_off()
+    with caplog.at_level(logging.DEBUG):
+        logger.warning("You've got a nice army base here, Colonel.")
+    assert "You've got a nice army base here, Colonel." not in caplog.text

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -44,7 +44,7 @@ def ensure_dir(filename):
         os.makedirs(directory)
 
 
-def debug_on(dep_warnings=True):
+def debug_on(deprecation_warnings=True):
     """Turn debugging logging on.
 
     Sets up a StreamHandler to to `sys.stderr` at debug level for all
@@ -56,15 +56,15 @@ def debug_on(dep_warnings=True):
     value.
 
     Args:
-        dep_warnings (Optional[bool]): Switch on deprecation warnings.
+        deprecation_warnings (Optional[bool]): Switch on deprecation warnings.
             Defaults to True.
 
     Returns:
         None
     """
     logging_on(logging.DEBUG)
-    if dep_warnings:
-        dep_warnings_on()
+    if deprecation_warnings:
+        deprecation_warnings_on()
 
 
 def debug_off():
@@ -74,11 +74,11 @@ def debug_off():
     deprecation warnings.
     """
     logging_off()
-    dep_warnings_off()
+    deprecation_warnings_off()
 
 
 @contextlib.contextmanager
-def debug(dep_warnings=True):
+def debug(deprecation_warnings=True):
     """Context manager to temporarily set debugging on.
 
     Example::
@@ -87,10 +87,10 @@ def debug(dep_warnings=True):
         ...     code_here()
 
     Args:
-        dep_warnings (Optional[bool]): Switch on deprecation warnings.
+        deprecation_warnings (Optional[bool]): Switch on deprecation warnings.
             Defaults to True.
     """
-    debug_on()
+    debug_on(deprecation_warnings=deprecation_warnings)
     yield
     debug_off()
 
@@ -109,13 +109,13 @@ class _WarningManager:
 _warning_manager = _WarningManager()
 
 
-def dep_warnings_on():
+def deprecation_warnings_on():
     """Switch on deprecation warnings."""
     warnings.filterwarnings("default", category=DeprecationWarning)
     _warning_manager.filt = warnings.filters[0]
 
 
-def dep_warnings_off():
+def deprecation_warnings_off():
     """Switch off deprecation warnings."""
     if _warning_manager.filt in warnings.filters:
         warnings.filters.remove(_warning_manager.filt)

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -74,7 +74,7 @@ def trace_on():
 def dep_warnings_on():
     """Switch on deprecation warnings.
     """
-    logging.filterwarnings("default", DeprecationWarning)
+    warnings.filterwarnings("default", category=DeprecationWarning)
 
 
 def logging_on(level=logging.WARNING):

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -81,10 +81,10 @@ def debug_off():
 def debug(dep_warnings=True):
     """Context manager to temporarily set debugging on.
 
-    Example:
+    Example::
 
-    >>> with satpy.utils.debug():
-    ...     code_here()
+        >>> with satpy.utils.debug():
+        ...     code_here()
 
     Args:
         dep_warnings (Optional[bool]): Switch on deprecation warnings.
@@ -102,6 +102,7 @@ def trace_on():
 
 class _WarningManager:
     """Class to handle switching warnings on and off."""
+
     filt = None
 
 

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -66,6 +66,7 @@ def debug_on(dep_warnings=True):
     if dep_warnings:
         dep_warnings_on()
 
+
 def debug_off():
     """Turn debugging logging off.
 
@@ -102,6 +103,8 @@ def trace_on():
 class _WarningManager:
     """Class to handle switching warnings on and off."""
     filt = None
+
+
 _warning_manager = _WarningManager()
 
 

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -43,14 +43,38 @@ def ensure_dir(filename):
         os.makedirs(directory)
 
 
-def debug_on():
-    """Turn debugging logging on."""
+def debug_on(dep_warnings=True):
+    """Turn debugging logging on.
+
+    Sets up a StreamHandler to to `sys.stderr` at debug level for all
+    loggers, such that all debug messages (and log messages with higher
+    severity) are logged to the standard error stream.
+
+    By default, since Satpy 0.26, this also enables the global visibility
+    of deprecation warnings.  This can be suppressed by passing a false
+    value.
+
+    Args:
+        dep_warnings (Optional[bool]): Switch on deprecation warnings.
+            Defaults to True.
+
+    Returns:
+        None
+    """
     logging_on(logging.DEBUG)
+    if dep_warnings:
+        dep_warnings_on()
 
 
 def trace_on():
     """Turn trace logging on."""
     logging_on(TRACE_LEVEL)
+
+
+def dep_warnings_on():
+    """Switch on deprecation warnings.
+    """
+    logging.filterwarnings("default", DeprecationWarning)
 
 
 def logging_on(level=logging.WARNING):

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -72,8 +72,7 @@ def trace_on():
 
 
 def dep_warnings_on():
-    """Switch on deprecation warnings.
-    """
+    """Switch on deprecation warnings."""
     warnings.filterwarnings("default", category=DeprecationWarning)
 
 


### PR DESCRIPTION
Extend the functionality of `debug_on` to switch on the visibility of `DeprecationWarning` using the `default` filter (as opposed to only showing them in `__main__`, which is the default Python behaviour in current and recent Python versions).  Also add a unit test for `debug_on`.

 - [x] Closes #1554<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
