### PR TITLE
Fix dependency tree CompositorNode not retaining properties on copy

### DIFF
--- a/satpy/dependency_tree.py
+++ b/satpy/dependency_tree.py
@@ -181,6 +181,14 @@ class DependencyTree(Tree):
             new_tree.add_child(new_tree._root, c)
         return new_tree
 
+    def update_node_name(self, node, new_name):
+        """Update 'name' property of a node and any related metadata."""
+        old_name = node.name
+        assert old_name in self._all_nodes
+        node.update_name(new_name)
+        self._all_nodes[new_name] = node
+        del self._all_nodes[old_name]
+
     def populate_with_keys(self, dataset_keys: set, query=None):
         """Populate the dependency tree.
 

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -49,6 +49,10 @@ class Node:
         self.children = []
         self.parents = []
 
+    def update_name(self, new_name):
+        """Update 'name' property."""
+        self.name = new_name
+
     @property
     def is_leaf(self):
         """Check if the node is a leaf."""
@@ -134,7 +138,7 @@ class Node:
 
     def trunk(self, unique=True):
         """Get the trunk of the tree starting at this root."""
-        # uniqueness is not correct in `trunk` yet
+        # FIXME: uniqueness is not correct in `trunk` yet
         unique = False
         res = []
         if self.children and self.name is not EMPTY_LEAF_NAME:
@@ -153,6 +157,12 @@ class CompositorNode(Node):
     def __init__(self, compositor):
         """Set up the node."""
         super().__init__(compositor.id, data=(compositor, [], []))
+
+    def update_name(self, new_name):
+        """Update 'name' property and related compositor metadata."""
+        super().update_name(new_name)
+        self.compositor.attrs.update(new_name)
+        self.compositor.attrs['_satpy_id'] = new_name
 
     def add_required_nodes(self, children):
         """Add nodes to the required field."""

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1269,7 +1269,7 @@ class Scene:
             if comp_node.name in self._wishlist:
                 self._wishlist.remove(comp_node.name)
                 self._wishlist.add(cid)
-            comp_node.name = cid
+            self._dependency_tree.update_node_name(comp_node, cid)
         except IncompatibleAreas:
             LOG.debug("Delaying generation of %s because of incompatible areas", str(compositor.id))
             preservable_datasets = set(self._datasets.keys())


### PR DESCRIPTION
This pull request tries to address some inconsistencies in the state and metadata held within the Scene's `Tree` (dependency tree) object. While debugging some composite loading issues, I've found some unexpected behavior in the dependency tree. Here are the things I've noticed and tried to fix:

1. The `CompositorNode` does not properly handle the `DataID` properties being updated when the composite is generated. We currently do a `comp_node.name = new_data_id`, but this does not modify the `comp_node.compositor` dictionary of metadata originally taken from the YAML configuration. This isn't an issue by itself, but the `_copy_name_and_data` method which is called to copy the Node (for example, when resampling copies the Scene) creates its DataID/name from this metadata. This means that the copied dependency tree is now inconsistent from the original dependency tree.
2. The `_all_nodes` dictionary in the dependency tree does not get updated with the new `DataID` when a composite is created. Since the `_all_nodes` dictionary is used in various internal operations it would be best to keep this in sync.
3. The Scene's composite generation analyzes and attempts to generate composites that it doesn't need to. This is more common the more levels of compositors there are (ex. comp1 -> comp2 -> comp3 -> reader_data[modifier]). The Scene's `_generate_composites_from_loaded_datasets` method asks the dependency tree for the `trunk` nodes and then removes any that are already present in the Scene. Since there is no order to how these composites are checked, this means that the Scene tries to generate sub-composites/modifiers that may not be needed any more because the dependent composite was already created. Taking the example above, if comp2 was generated before resampling, but comp1 needs resampling, then the trunk nodes will consist of comp2, comp3, and the modified reader data. We only need to check for comp2.
4. There was a comment about how `unique` wasn't implemented completely for Node. I turned this into a FIXME so we can catch it easier in the future.

## Remaining Questions

1. Should `update_name` just be a property setter? `@name.setter`.

## TODO

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
