### PR TITLE
Fix geotiff writer FAQ link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ doc/source/_build/*
 # this should be generated automatically when installed
 satpy/version.py
 doc/api/*.rst
+doc/source/api/*.rst

--- a/.gitignore
+++ b/.gitignore
@@ -73,5 +73,4 @@ doc/source/_build/*
 # setuptools_scm files
 # this should be generated automatically when installed
 satpy/version.py
-doc/api/*.rst
 doc/source/api/*.rst

--- a/doc/source/api/.gitignore
+++ b/doc/source/api/.gitignore
@@ -1,2 +1,0 @@
-modules.rst
-satpy*.rst

--- a/doc/source/api/.gitignore
+++ b/doc/source/api/.gitignore
@@ -1,0 +1,2 @@
+modules.rst
+satpy*.rst

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -44,7 +44,7 @@ class GeoTIFFWriter(ImageWriter):
         ...                  tags={'offset': 291.8, 'scale': -0.35})
 
     For performance tips on creating geotiffs quickly and making them smaller
-    see the :doc:`faq`.
+    see the :ref:`faq`.
 
     """
 


### PR DESCRIPTION
Fix geotiff writer FAQ link to point to Satpy FAQ rather than to xarray
FAQ.

Add a gitignore for automatically generated RST sources by sphinx-apidoc.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
