### PR TITLE
Allow 'glm_l2' reader to accept arbitrary filename prefixes

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -34,7 +34,7 @@ dependencies:
   - zarr
   - python-eccodes
   # 2.19.1 seems to cause library linking issues
-  - eccodes!=2.19
+  - eccodes>=2.20
   - geoviews
   - pytest
   - pytest-cov

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -33,6 +33,8 @@ dependencies:
   - geoviews
   - zarr
   - python-eccodes
+  # 2.19.1 seems to cause library linking issues
+  - eccodes!=2.19
   - geoviews
   - pytest
   - pytest-cov

--- a/satpy/etc/readers/glm_l2.yaml
+++ b/satpy/etc/readers/glm_l2.yaml
@@ -19,7 +19,7 @@ reader:
 file_types:
   glm_l2_imagery:
     file_reader: !!python/name:satpy.readers.glm_l2.NCGriddedGLML2
-    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-GLM{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_patterns: ['{system_environment:s}_{mission_id:3s}-L2-GLM{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
 # glm_l2_lcfa - add this with glmtools
 
 datasets:

--- a/satpy/tests/reader_tests/test_glm_l2.py
+++ b/satpy/tests/reader_tests/test_glm_l2.py
@@ -216,8 +216,9 @@ class TestGLML2Reader(unittest.TestCase):
         r = load_reader(self.reader_configs)
         loadables = r.select_files_from_pathnames([
             'OR_GLM-L2-GLMC-M3_G16_s20192862159000_e20192862200000_c20192862200350.nc',
+            'CSPP_CG_GLM-L2-GLMC-M3_G16_s20192862159000_e20192862200000_c20192862200350.nc',
         ])
-        self.assertEqual(len(loadables), 1)
+        self.assertEqual(len(loadables), 2)
         r.create_filehandlers(loadables)
         self.reader = r
 


### PR DESCRIPTION
Plans are coming down the pipe that will make it more common for arbitrary filename prefixes in PUG-like files. Specifically the CSPP Geo Gridded GLM package will default to a `CSPP_CG` prefix instead of the operational realtime prefix `OR`.

 - [x] Tests added <!-- for all bug fixes or enhancements -->