### PR TITLE
Fix DifferenceCompositor ignoring YAML metadata

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -208,13 +208,14 @@ class CompositeBase:
 class DifferenceCompositor(CompositeBase):
     """Make the difference of two data arrays."""
 
-    def __call__(self, projectables, nonprojectables=None, **info):
+    def __call__(self, projectables, nonprojectables=None, **attrs):
         """Generate the composite."""
         if len(projectables) != 2:
             raise ValueError("Expected 2 datasets, got %d" % (len(projectables),))
         projectables = self.match_data_arrays(projectables)
         info = combine_metadata(*projectables)
         info['name'] = self.attrs['name']
+        info.update(attrs)
 
         proj = projectables[0] - projectables[1]
         proj.attrs = info

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -267,8 +267,9 @@ class TestDifferenceCompositor(unittest.TestCase):
         """Test that a basic difference composite works."""
         from satpy.composites import DifferenceCompositor
         comp = DifferenceCompositor(name='diff')
-        res = comp((self.ds1, self.ds2))
+        res = comp((self.ds1, self.ds2), standard_name='temperature_difference')
         np.testing.assert_allclose(res.values, -2)
+        assert res.attrs.get('standard_name') == 'temperature_difference'
 
     def test_bad_areas_diff(self):
         """Test that a difference where resolutions are different fails."""


### PR DESCRIPTION
I needed to be able to set a `standard_name` for my difference and noticed that it was being ignored. This pull request fixes that.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
