### PR TITLE
Rename min_area() and max_area() methods

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -72,13 +72,13 @@ when generating composites between bands of different resolutions.
     >>> new_scn = scn.resample(resampler='native')
 
 By default this resamples to the
-:meth:`highest resolution area <satpy.scene.Scene.max_area>` (smallest footprint per
-pixel) shared between the loaded datasets. You can easily specify the lower
+:meth:`highest resolution area <satpy.scene.Scene.finest_area>` (smallest footprint per
+pixel) shared between the loaded datasets. You can easily specify the lowest
 resolution area:
 
 .. code-block:: python
 
-    >>> new_scn = scn.resample(scn.min_area(), resampler='native')
+    >>> new_scn = scn.resample(scn.coarsest_area(), resampler='native')
 
 Providing an area that is neither the minimum or maximum resolution area
 may work, but behavior is currently undefined.

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -244,7 +244,8 @@ class Scene:
                                  current Scene. Defaults to all datasets.
 
         """
-        warnings.warn("'max_area' is deprecated, use 'finest_area' instead.")
+        warnings.warn("'max_area' is deprecated, use 'finest_area' instead.",
+                      warnings.DeprecationWarning)
         return self.finest_area(datasets=datasets)
 
     def coarsest_area(self, datasets=None):
@@ -269,7 +270,8 @@ class Scene:
                                  current Scene. Defaults to all datasets.
 
         """
-        warnings.warn("'min_area' is deprecated, use 'coarsest_area' instead.")
+        warnings.warn("'min_area' is deprecated, use 'coarsest_area' instead.",
+                      warnings.DeprecationWarning)
         return self.coarsest_area(datasets=datasets)
 
     def available_dataset_ids(self, reader_name=None, composites=False):

--- a/satpy/tests/test_regressions.py
+++ b/satpy/tests/test_regressions.py
@@ -179,7 +179,7 @@ def test_1258(fake_open_dataset):
 
     scene = Scene(abi_file_list, reader='abi_l1b')
     scene.load(['true_color_nocorr', 'C04'], calibration='radiance')
-    resampled_scene = scene.resample(scene.min_area(), resampler='native')
+    resampled_scene = scene.resample(scene.coarsest_area(), resampler='native')
     assert len(resampled_scene.keys()) == 2
 
 

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -575,8 +575,8 @@ class TestScene(unittest.TestCase):
         self.assertEqual(len(scene._datasets.keys()), 0)
         self.assertRaises(KeyError, scene.__delitem__, 0.2)
 
-    def test_min_max_area(self):
-        """Test 'min_area' and 'max_area' methods."""
+    def test_coarsest_finest_area(self):
+        """Test 'coarsest_area' and 'finest_area' methods."""
         from satpy import Scene
         from xarray import DataArray
         from pyresample.geometry import AreaDefinition
@@ -612,9 +612,9 @@ class TestScene(unittest.TestCase):
         ds1.attrs['area'] = area_def1
         ds2.attrs['area'] = area_def2
         ds3.attrs['area'] = area_def2
-        self.assertIs(scene.min_area(), area_def1)
-        self.assertIs(scene.max_area(), area_def2)
-        self.assertIs(scene.min_area(['2', '3']), area_def2)
+        self.assertIs(scene.coarsest_area(), area_def1)
+        self.assertIs(scene.finest_area(), area_def2)
+        self.assertIs(scene.coarsest_area(['2', '3']), area_def2)
 
     def test_all_datasets_no_readers(self):
         """Test all datasets with no reader."""


### PR DESCRIPTION
To clarify naming, this PR renames the `Scene.min_area()` and `Scene.max_area()` to `.coarsest_area()` and `.finest_area()`, respectively. The original naming was causing confusion what was meant: is `min_area()` the "geographically smallest area in the scene", "area with smallest pixels (highest resolution)" or "area of the data with smallest resolution (highest resolution)"? The new naming introduced in this PR got consensus in Slack, so lets use these. Warnings about the naming changes have been added.

 - [x] Tests adjusted <!-- for all bug fixes or enhancements -->
