### PR TITLE
Add the SAR Ice Log composite

### DIFF
--- a/satpy/composites/sar.py
+++ b/satpy/composites/sar.py
@@ -38,6 +38,16 @@ def overlay(top, bottom, maxval=None):
     return res.clip(min=0)
 
 
+def soft_light(top, bottom, maxval):
+    """Apply soft light.
+
+    http://www.pegtop.net/delphi/articles/blendmodes/softlight.htm
+    """
+    a = top / maxval
+    b = bottom / maxval
+    return (2*a*b + a*a * (1 - 2*b)) * maxval
+
+
 class SARIce(GenericCompositor):
     """The SAR Ice composite."""
 
@@ -77,6 +87,20 @@ class SARIceLegacy(GenericCompositor):
         green.attrs = combine_metadata(mhh, mhv)
 
         return super(SARIceLegacy, self).__call__((mhv, green, mhh), *args, **kwargs)
+
+
+class SARIceLog(GenericCompositor):
+    """The SAR Ice composite, using log-scale data."""
+
+    def __call__(self, projectables, *args, **kwargs):
+        """Create the SAR Ice Log composite."""
+        mhh, mhv = projectables
+        mhh.data = mhh.data.clip(-22)
+        mhv.data = mhv.data.clip(-30)
+        green = green = soft_light(mhh + 100, mhv + 100, 100) - 100
+        green.attrs = combine_metadata(mhh, mhv)
+
+        return super().__call__((mhv, green, mhh), *args, **kwargs)
 
 
 class SARRGB(GenericCompositor):

--- a/satpy/composites/sar.py
+++ b/satpy/composites/sar.py
@@ -95,8 +95,8 @@ class SARIceLog(GenericCompositor):
     def __call__(self, projectables, *args, **kwargs):
         """Create the SAR Ice Log composite."""
         mhh, mhv = projectables
-        mhh = mhh.clip(-22)
-        mhv = mhv.clip(-30)
+        mhh = mhh.clip(-40)
+        mhv = mhv.clip(-38)
         green = green = soft_light(mhh + 100, mhv + 100, 100) - 100
         green.attrs = combine_metadata(mhh, mhv)
 

--- a/satpy/composites/sar.py
+++ b/satpy/composites/sar.py
@@ -95,8 +95,8 @@ class SARIceLog(GenericCompositor):
     def __call__(self, projectables, *args, **kwargs):
         """Create the SAR Ice Log composite."""
         mhh, mhv = projectables
-        mhh.data = mhh.data.clip(-22)
-        mhv.data = mhv.data.clip(-30)
+        mhh = mhh.clip(-22)
+        mhv = mhv.clip(-30)
         green = green = soft_light(mhh + 100, mhv + 100, 100) - 100
         green.attrs = combine_metadata(mhh, mhv)
 

--- a/satpy/composites/sar.py
+++ b/satpy/composites/sar.py
@@ -97,7 +97,7 @@ class SARIceLog(GenericCompositor):
         mhh, mhv = projectables
         mhh = mhh.clip(-40)
         mhv = mhv.clip(-38)
-        green = green = soft_light(mhh + 100, mhv + 100, 100) - 100
+        green = soft_light(mhh + 100, mhv + 100, 100) - 100
         green.attrs = combine_metadata(mhh, mhv)
 
         return super().__call__((mhv, green, mhh), *args, **kwargs)

--- a/satpy/etc/composites/sar.yaml
+++ b/satpy/etc/composites/sar.yaml
@@ -58,3 +58,38 @@ composites:
     - name: measurement
       polarization: hv
     standard_name: sar-land
+
+  sar-land-iw:
+    compositor: !!python/name:satpy.composites.sar.SARIce
+    prerequisites:
+    - name: measurement
+      polarization: vv
+    - name: measurement
+      polarization: vh
+    standard_name: sar-land
+
+  sar-ice-log:
+    compositor: !!python/name:satpy.composites.sar.SARIceLog
+    prerequisites:
+    - name: measurement
+      polarization: hh
+      calibration: gamma
+      quantity: dB
+    - name: measurement
+      polarization: hv
+      calibration: gamma
+      quantity: dB
+    standard_name: sar-ice-log
+
+  sar-ice-log-iw:
+    compositor: !!python/name:satpy.composites.sar.SARIceLog
+    prerequisites:
+    - name: measurement
+      polarization: vv
+      calibration: gamma
+      quantity: dB
+    - name: measurement
+      polarization: vh
+      calibration: gamma
+      quantity: dB
+    standard_name: sar-ice-log

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -279,6 +279,21 @@ enhancements:
       kwargs:
         gamma: [2, 3, 2]
 
+  sar-ice-log:
+    standard_name: sar-ice-log
+    operations:
+    - name: stretch
+      method: !!python/name:satpy.enhancements.stretch
+      kwargs:
+        stretch: crude
+        min_stretch: [-30, -13, -22]
+        max_stretch: [-10, 0, 0 ]
+
+    - name: gamma
+      method: !!python/name:satpy.enhancements.gamma
+      kwargs:
+        gamma: [2, 1.2, 1.5]
+
   sar-ice-legacy:
     standard_name: sar-ice-legacy
     operations:

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -286,13 +286,13 @@ enhancements:
       method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: crude
-        min_stretch: [-30, -13, -22]
-        max_stretch: [-10, 0, 0 ]
+        min_stretch: [-38, -32, -40]
+        max_stretch: [-15, 0, 0 ]
 
     - name: gamma
       method: !!python/name:satpy.enhancements.gamma
       kwargs:
-        gamma: [2, 1.2, 1.5]
+        gamma: [1, 0.5, 1]
 
   sar-ice-legacy:
     standard_name: sar-ice-legacy
@@ -919,3 +919,14 @@ enhancements:
         stretch: crude
         min_stretch: [26.2,  27.4, 243.9]
         max_stretch: [ 0.6, -26.2, 208.5]
+
+  ctth_bw:
+    standard_name: ctth_bw
+    operations:
+    - name: stretch
+      method: !!python/name:satpy.enhancements.stretch
+      kwargs:
+        stretch: crude
+        min_stretch: [0]
+        max_stretch: [15000]
+

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -287,12 +287,12 @@ enhancements:
       kwargs:
         stretch: crude
         min_stretch: [-38, -32, -40]
-        max_stretch: [-15, 0, 0 ]
+        max_stretch: [-10, 0, 0 ]
 
     - name: gamma
       method: !!python/name:satpy.enhancements.gamma
       kwargs:
-        gamma: [1, 0.5, 1]
+        gamma: [1.2, 0.42, 0.75]
 
   sar-ice-legacy:
     standard_name: sar-ice-legacy

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -919,14 +919,3 @@ enhancements:
         stretch: crude
         min_stretch: [26.2,  27.4, 243.9]
         max_stretch: [ 0.6, -26.2, 208.5]
-
-  ctth_bw:
-    standard_name: ctth_bw
-    operations:
-    - name: stretch
-      method: !!python/name:satpy.enhancements.stretch
-      kwargs:
-        stretch: crude
-        min_stretch: [0]
-        max_stretch: [15000]
-

--- a/satpy/tests/compositor_tests/test_sar.py
+++ b/satpy/tests/compositor_tests/test_sar.py
@@ -51,3 +51,32 @@ class TestSARComposites(unittest.TestCase):
         np.testing.assert_allclose(data.sel(bands='R'), 31.58280822)
         np.testing.assert_allclose(data.sel(bands='G'), 159869.56789876)
         np.testing.assert_allclose(data.sel(bands='B'), 44.68138191)
+
+    def test_sar_ice_log(self):
+        """Test creating a the sar_ice_log composite."""
+        import xarray as xr
+        import dask.array as da
+        import numpy as np
+        from satpy.composites.sar import SARIceLog
+
+        rows = 2
+        cols = 2
+        comp = SARIceLog('sar_ice_log', prerequisites=('hh', 'hv'),
+                         standard_name='sar-ice-log')
+        hh = xr.DataArray(da.zeros((rows, cols), chunks=25) - 10,
+                          dims=('y', 'x'),
+                          attrs={'name': 'hh'})
+        hv = xr.DataArray(da.zeros((rows, cols), chunks=25) - 20,
+                          dims=('y', 'x'),
+                          attrs={'name': 'hv'})
+
+        res = comp((hh, hv))
+        self.assertIsInstance(res, xr.DataArray)
+        self.assertIsInstance(res.data, da.Array)
+        self.assertEqual(res.attrs['name'], 'sar_ice_log')
+        self.assertEqual(res.attrs['standard_name'],
+                         'sar-ice-log')
+        data = res.compute()
+        np.testing.assert_allclose(data.sel(bands='R'), -20)
+        np.testing.assert_allclose(data.sel(bands='G'), -4.6)
+        np.testing.assert_allclose(data.sel(bands='B'), -10)


### PR DESCRIPTION
This PR ass the SAR Ice Log composite.

The composite is using gamma-calibrated measurements, expressed in dB scale instead of linear scale as in the SAR Ice composite, giving smoother contrast while preserving the visibility of sea-ice features. The green channel is also modified to use the soft-light channel combination instead of overlay.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

Example for Sentinel 1B 2020-03-15 05:04:28, GRDH data, EW mode (HH and HV polarizations)
![sar-ice-log-jpeg-noalpha-bilinear](https://user-images.githubusercontent.com/167802/109296737-1f5f4500-7831-11eb-908f-ab07e2cf1cfc.jpg)


(Previous iteration, too dark for Sea Ice Charting)
![sar-ice-log-jpeg-noalpha-bilinear](https://user-images.githubusercontent.com/167802/109224095-c4d7d180-77bb-11eb-928c-5f0a50a6a322.jpg)

 