### PR TITLE
Fix, correct usage of data returned by pyspectral AtmosphericalCorrection

### DIFF
--- a/satpy/modifiers/atmosphere.py
+++ b/satpy/modifiers/atmosphere.py
@@ -22,6 +22,7 @@ from weakref import WeakValueDictionary
 
 import numpy as np
 import dask.array as da
+import xarray as xr
 
 from satpy.modifiers import ModifierBase
 from satpy.utils import get_satpos
@@ -149,8 +150,8 @@ class PSPAtmosphericalCorrection(ModifierBase):
                                             band.attrs['sensor'])
 
         atm_corr = corrector.get_correction(satz, band.attrs['name'], band)
-        proj = band - atm_corr
-        proj.attrs = band.attrs
+        proj = xr.DataArray(atm_corr, attrs=band.attrs,
+                            dims=band.dims, coords=band.coords)
         self.apply_modifier_info(band, proj)
 
         return proj

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -370,7 +370,7 @@ class TestPSPAtmosphericalCorrection(unittest.TestCase):
                                      'start_time': 'start_time',
                                      'name': 'name',
                                      'platform_name': 'platform',
-                                     'sensor': 'sensor'})
+                                     'sensor': 'sensor'}, dims=['y'])
 
         # Perform atmospherical correction
         psp = PSPAtmosphericalCorrection(name='dummy')


### PR DESCRIPTION
The change in https://github.com/pytroll/satpy/commit/581388d8e8214b6b36a6974518c0681fe6355340 doesn't work. The data returned by the pyspectral routine is the aleady corrected version, not a diffence/offset that has to be substracted from the input data. This PR should fix this.

It was tested with pyspectral that includes the merged PR https://github.com/pytroll/pyspectral/pull/128.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Tests adopted
 
