### PR TITLE
Fix DeprecationWarning usage in `min_area` `max_area` deprecation

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -245,7 +245,7 @@ class Scene:
 
         """
         warnings.warn("'max_area' is deprecated, use 'finest_area' instead.",
-                      warnings.DeprecationWarning)
+                      DeprecationWarning)
         return self.finest_area(datasets=datasets)
 
     def coarsest_area(self, datasets=None):
@@ -271,7 +271,7 @@ class Scene:
 
         """
         warnings.warn("'min_area' is deprecated, use 'coarsest_area' instead.",
-                      warnings.DeprecationWarning)
+                      DeprecationWarning)
         return self.coarsest_area(datasets=datasets)
 
     def available_dataset_ids(self, reader_name=None, composites=False):


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Fix problem of Satpy crashing with `warnings.DeprecationWarning` wrong usage in `min_area` `max_area` deprecation

 - [x] Closes #1573  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
