### PR TITLE
Fix AHI HSD reader not having access to the AreaDefinition on load

### DIFF
--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -422,7 +422,7 @@ class AHIHSDFileHandler(BaseFileHandler):
 
     def _check_fpos(self, fp_, fpos, offset, block):
         """Check file position matches blocksize."""
-        if (fp_.tell() + offset != fpos):
+        if fp_.tell() + offset != fpos:
             warnings.warn("Actual "+block+" header size does not match expected")
         return
 

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -48,6 +48,7 @@ from satpy.readers.utils import unzip_file, get_geostationary_mask, \
                                 get_user_calibration_factors, \
                                 apply_rad_correction
 from satpy.readers._geos_area import get_area_extent, get_area_definition
+from satpy._compat import cached_property
 
 AHI_CHANNEL_NAMES = ("1", "2", "3", "4", "5",
                      "6", "7", "8", "9", "10",
@@ -321,7 +322,6 @@ class AHIHSDFileHandler(BaseFileHandler):
 
         self._data = dict([(i, None) for i in AHI_CHANNEL_NAMES])
         self._header = dict([(i, None) for i in AHI_CHANNEL_NAMES])
-        self._area = None
         self.lons = None
         self.lats = None
         self.segment_number = filename_info['segment']
@@ -384,12 +384,10 @@ class AHIHSDFileHandler(BaseFileHandler):
         """Get the dataset."""
         return self.read_band(key, info)
 
-    @property
+    @cached_property
     def area(self):
         """Get AreaDefinition representing this file's data."""
-        if self._area is None:
-            self._area = self._get_area_def()
-        return self._area
+        return self._get_area_def()
 
     def get_area_def(self, dsid):
         """Get the area definition."""

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -321,6 +321,7 @@ class AHIHSDFileHandler(BaseFileHandler):
 
         self._data = dict([(i, None) for i in AHI_CHANNEL_NAMES])
         self._header = dict([(i, None) for i in AHI_CHANNEL_NAMES])
+        self._area = None
         self.lons = None
         self.lats = None
         self.segment_number = filename_info['segment']
@@ -354,7 +355,7 @@ class AHIHSDFileHandler(BaseFileHandler):
 
     def __del__(self):
         """Delete the object."""
-        if (self.is_zipped and os.path.exists(self.filename)):
+        if self.is_zipped and os.path.exists(self.filename):
             os.remove(self.filename)
 
     @property
@@ -383,10 +384,19 @@ class AHIHSDFileHandler(BaseFileHandler):
         """Get the dataset."""
         return self.read_band(key, info)
 
+    @property
+    def area(self):
+        """Get AreaDefinition representing this file's data."""
+        if self._area is None:
+            self._area = self._get_area_def()
+        return self._area
+
     def get_area_def(self, dsid):
         """Get the area definition."""
         del dsid
+        return self.area
 
+    def _get_area_def(self):
         pdict = {}
         pdict['cfac'] = np.uint32(self.proj_info['CFAC'])
         pdict['lfac'] = np.uint32(self.proj_info['LFAC'])
@@ -408,10 +418,7 @@ class AHIHSDFileHandler(BaseFileHandler):
         pdict['a_desc'] = "AHI {} area".format(self.observation_area)
         pdict['p_id'] = 'geosh8'
 
-        area = get_area_definition(pdict, aex)
-
-        self.area = area
-        return area
+        return get_area_definition(pdict, aex)
 
     def _check_fpos(self, fp_, fpos, offset, block):
         """Check file position matches blocksize."""


### PR DESCRIPTION
I think this has been broken since #1541, but due to the heavy amount of mocking and lack of high level tests (from the Reader-level or above) this wasn't caught. The AHI HSD reader needs the AreaDefinition in order to mask space pixels. This was previously dependent on `get_area_def` being called before `get_dataset` but #1541 swapped their call order. This PR fixes the access to the area.

 - [x] Tests added <!-- for all bug fixes or enhancements -->

Note: I know there is a lot of mocking, but I'm not sure how to fix that without completely rewriting the tests and/or the file handler class.