### PR TITLE
Ensure FSFile objects compare equal when they should

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -588,6 +588,12 @@ class FSFile(os.PathLike):
         """Implement ordering."""
         return os.fspath(self) < os.fspath(other)
 
+    def __eq__(self, other):
+        """Implement equality comparisons."""
+        return (isinstance(other, FSFile) and
+                self._file == other._file and
+                self._fs == other._fs)
+
 
 def open_file_or_filename(unknown_file_thing):
     """Try to open the *unknown_file_thing*, otherwise return the filename."""

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -585,11 +585,19 @@ class FSFile(os.PathLike):
             return open(self._file)
 
     def __lt__(self, other):
-        """Implement ordering."""
+        """Implement ordering.
+
+        Ordering is defined by the string representation of the filename,
+        without considering the file system.
+        """
         return os.fspath(self) < os.fspath(other)
 
     def __eq__(self, other):
-        """Implement equality comparisons."""
+        """Implement equality comparisons.
+
+        Two FSFile instances are considered equal if they have the same
+        filename and the same file system.
+        """
         return (isinstance(other, FSFile) and
                 self._file == other._file and
                 self._fs == other._fs)

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -963,4 +963,4 @@ class TestFSFile(unittest.TestCase):
                 FSFile(self.local_filename, zip_fs))
         assert (FSFile(self.local_filename, zip_fs) !=
                 FSFile(self.local_filename))
-        assert FSFile(self.local_filaneme) != FSFile(self.local_filename2)
+        assert FSFile(self.local_filename) != FSFile(self.local_filename2)

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -952,3 +952,15 @@ class TestFSFile(unittest.TestCase):
         sorted_filenames = [os.fspath(file) for file in sorted([file1, file2, extra_file])]
         expected_filenames = sorted([extra_file, os.fspath(file1), os.fspath(file2)])
         assert sorted_filenames == expected_filenames
+
+    def test_equality(self):
+        """Test that FSFile compares equal when it should."""
+        from satpy.readers import FSFile
+        from fsspec.implementations.zip import ZipFileSystem
+        zip_fs = ZipFileSystem(self.zip_name)
+        assert FSFile(self.local_filename) == FSFile(self.local_filename)
+        assert (FSFile(self.local_filename, zip_fs) ==
+                FSFile(self.local_filename, zip_fs))
+        assert (FSFile(self.local_filename, zip_fs) !=
+                FSFile(self.local_filename))
+        assert FSFile(self.local_filaneme) != FSFile(self.local_filename2)


### PR DESCRIPTION
Ensure that FSFile objects compare equal when they refer to the same file on the same file system, and unequal otherwise.

 - [x] Closes #1581
 - [x] Tests added
 - [x] Fully documented
