### PR TITLE
Update GRIB reader for greater flexibility.

### DIFF
--- a/satpy/readers/grib.py
+++ b/satpy/readers/grib.py
@@ -271,25 +271,33 @@ class GRIBFileHandler(BaseFileHandler):
             center_description = msg['centreDescription']
         except (RuntimeError, KeyError):
             center_description = None
+
+        key_dicts = {
+            'shortName': 'shortName',
+            'long_name': 'name',
+            'pressureUnits': 'pressureUnits',
+            'typeOfLevel': 'typeOfLevel',
+            'standard_name': 'cfName',
+            'units': 'units',
+            'modelName': 'modelName',
+            'valid_min': 'minimum',
+            'valid_max': 'maximum',
+            'sensor': 'modelName'}
+
         ds_info.update({
             'filename': self.filename,
-            'shortName': msg['shortName'],
-            'long_name': msg['name'],
-            'pressureUnits': msg['pressureUnits'],
-            'typeOfLevel': msg['typeOfLevel'],
-            'standard_name': msg['cfName'],
-            'units': msg['units'],
-            'modelName': msg['modelName'],
             'model_time': model_time,
             'centreDescription': center_description,
-            'valid_min': msg['minimum'],
-            'valid_max': msg['maximum'],
             'start_time': start_time,
             'end_time': end_time,
-            'sensor': msg['modelName'],
-            # National Weather Prediction
-            'platform_name': 'unknown',
-        })
+            'platform_name': 'unknown'})
+
+        for key in key_dicts:
+            if key_dicts[key] in msg.keys():
+                ds_info.update({key: msg[key_dicts[key]]})
+            else:
+                ds_info.update({key: 'unknown'})
+
         return ds_info
 
     def get_dataset(self, dataset_id, ds_info):

--- a/satpy/readers/grib.py
+++ b/satpy/readers/grib.py
@@ -294,9 +294,9 @@ class GRIBFileHandler(BaseFileHandler):
 
         for key in key_dicts:
             if key_dicts[key] in msg.keys():
-                ds_info.update({key: msg[key_dicts[key]]})
+                ds_info[key] = msg[key_dicts[key]]
             else:
-                ds_info.update({key: 'unknown'})
+                ds_info[key] = 'unknown'
 
         return ds_info
 

--- a/satpy/tests/reader_tests/test_grib.py
+++ b/satpy/tests/reader_tests/test_grib.py
@@ -43,6 +43,11 @@ TEST_PARAMS = (
 )
 
 
+def fake_gribdata():
+    """Return some faked data for use as grib values."""
+    return np.arange(25.).reshape((5, 5))
+
+
 def _round_trip_projection_lonlat_check(area):
     """Check that X/Y coordinates can be transformed multiple times.
 
@@ -77,6 +82,10 @@ class FakeMessage(object):
         self.projparams = proj_params
         self._latlons = latlons
 
+    def keys(self):
+        """Get message keys."""
+        return self.attrs.keys()
+
     def latlons(self):
         """Get coordinates."""
         return self._latlons
@@ -101,7 +110,7 @@ class FakeGRIB(object):
         else:
             self._messages = [
                 FakeMessage(
-                    values=np.arange(25.).reshape((5, 5)),
+                    values=fake_gribdata(),
                     name='TEST',
                     shortName='t',
                     level=100,
@@ -115,7 +124,7 @@ class FakeGRIB(object):
                     distinctLongitudes=np.arange(5.),
                     distinctLatitudes=np.arange(5.),
                     missingValue=9999,
-                    modelName='unknown',
+                    modelName='notknown',
                     minimum=100.,
                     maximum=200.,
                     typeOfLevel='isobaricInhPa',
@@ -124,7 +133,7 @@ class FakeGRIB(object):
                     latlons=latlons,
                 ),
                 FakeMessage(
-                    values=np.arange(25.).reshape((5, 5)),
+                    values=fake_gribdata(),
                     name='TEST',
                     shortName='t',
                     level=200,
@@ -138,16 +147,16 @@ class FakeGRIB(object):
                     distinctLongitudes=np.arange(5.),
                     distinctLatitudes=np.arange(5.),
                     missingValue=9999,
-                    modelName='unknown',
+                    modelName='notknown',
                     minimum=100.,
                     maximum=200.,
                     typeOfLevel='isobaricInhPa',
-                    jScansPositively=0,
+                    jScansPositively=1,
                     proj_params=proj_params,
                     latlons=latlons,
                 ),
                 FakeMessage(
-                    values=np.arange(25.).reshape((5, 5)),
+                    values=fake_gribdata(),
                     name='TEST',
                     shortName='t',
                     level=300,
@@ -161,7 +170,6 @@ class FakeGRIB(object):
                     distinctLongitudes=np.arange(5.),
                     distinctLatitudes=np.arange(5.),
                     missingValue=9999,
-                    modelName='unknown',
                     minimum=100.,
                     maximum=200.,
                     typeOfLevel='isobaricInhPa',
@@ -307,3 +315,30 @@ class TestGRIBReader:
         if not hasattr(area, 'crs'):
             pytest.skip("Can't test with pyproj < 2.0")
         _round_trip_projection_lonlat_check(area)
+
+    @pytest.mark.parametrize(TEST_ARGS, TEST_PARAMS)
+    def test_missing_attributes(self, proj_params, lon_corners, lat_corners):
+        """Check that the grib reader handles missing attributes in the grib file."""
+        fake_pygrib = self._get_fake_pygrib(proj_params, lon_corners, lat_corners)
+
+        # This has modelName
+        query_contains = DataQuery(name='t', level=100, modifiers=tuple())
+        # This does not have modelName
+        query_not_contains = DataQuery(name='t', level=300, modifiers=tuple())
+        dataset = self._get_test_datasets([query_contains, query_not_contains], fake_pygrib)
+        assert dataset[query_contains].attrs['modelName'] == 'notknown'
+        assert dataset[query_not_contains].attrs['modelName'] == 'unknown'
+
+    @pytest.mark.parametrize(TEST_ARGS, TEST_PARAMS)
+    def test_jscanspositively(self, proj_params, lon_corners, lat_corners):
+        """Check that data is flipped if the jScansPositively is present."""
+        fake_pygrib = self._get_fake_pygrib(proj_params, lon_corners, lat_corners)
+
+        # This has no jScansPositively
+        query_not_contains = DataQuery(name='t', level=100, modifiers=tuple())
+        # This contains jScansPositively
+        query_contains = DataQuery(name='t', level=200, modifiers=tuple())
+        dataset = self._get_test_datasets([query_contains, query_not_contains], fake_pygrib)
+
+        np.testing.assert_allclose(fake_gribdata(), dataset[query_not_contains].values)
+        np.testing.assert_allclose(fake_gribdata(),dataset[query_contains].values[::-1])

--- a/satpy/tests/reader_tests/test_grib.py
+++ b/satpy/tests/reader_tests/test_grib.py
@@ -341,4 +341,4 @@ class TestGRIBReader:
         dataset = self._get_test_datasets([query_contains, query_not_contains], fake_pygrib)
 
         np.testing.assert_allclose(fake_gribdata(), dataset[query_not_contains].values)
-        np.testing.assert_allclose(fake_gribdata(),dataset[query_contains].values[::-1])
+        np.testing.assert_allclose(fake_gribdata(), dataset[query_contains].values[::-1])


### PR DESCRIPTION
Currently, the grib reader expects certain keys to be present in the grib file, [for example](https://github.com/pytroll/satpy/blob/master/satpy/readers/grib.py#L236-L254):
```
ds_info.update({
            'filename': self.filename,
            'shortName': msg['shortName'],
            'long_name': msg['name'],
            'pressureUnits': msg['pressureUnits'],
            'typeOfLevel': msg['typeOfLevel'],
            'standard_name': msg['cfName'],
            'units': msg['units'],
            'modelName': msg['modelName'],
            'model_time': model_time,
            'centreDescription': center_description,
            'valid_min': msg['minimum'],
            'valid_max': msg['maximum'],
            'start_time': start_time,
            'end_time': end_time,
            'sensor': msg['modelName'],
            # National Weather Prediction
            'platform_name': 'unknown',
        })
```

For some grib files, such as those from the ERA5 and CAMS datasets, not all keys are present. `modelName` is not present in ERA5 single level datasets.

This PR adds some flexibility to the grib reader and will now set missing keys to `unknown` in `ds_info` rather than raising an error.
I have only tested this with ECMWF/ERA/GFS data but it seems to work well with those.

 - [ ] Tests passed
 - [ ] Passes ``flake8 satpy``