### PR TITLE
Bugfix of link_coords

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -621,11 +621,14 @@ class TestCFWriter(unittest.TestCase):
 
         data = [[1, 2], [3, 4]]
         lon = np.zeros((2, 2))
+        lon2 = np.zeros((1, 2, 2))
         lat = np.ones((2, 2))
         datasets = {
             'var1': xr.DataArray(data=data, dims=('y', 'x'), attrs={'coordinates': 'lon lat'}),
             'var2': xr.DataArray(data=data, dims=('y', 'x')),
+            'var3': xr.DataArray(data=data, dims=('y', 'x'), attrs={'coordinates': 'lon2 lat'}),
             'lon': xr.DataArray(data=lon, dims=('y', 'x')),
+            'lon2': xr.DataArray(data=lon2, dims=('time', 'y', 'x')),
             'lat': xr.DataArray(data=lat, dims=('y', 'x'))
         }
 
@@ -641,6 +644,9 @@ class TestCFWriter(unittest.TestCase):
         # There should be no link if there was no 'coordinate' attribute
         self.assertNotIn('lon', datasets['var2'].coords)
         self.assertNotIn('lat', datasets['var2'].coords)
+
+        # The time dimension should be dropped
+        self.assertNotIn('time', datasets['var3'].coords)
 
     def test_make_alt_coords_unique(self):
         """Test that created coordinate variables are unique."""

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -646,7 +646,7 @@ class TestCFWriter(unittest.TestCase):
         self.assertNotIn('lon', datasets['var2'].coords)
         self.assertNotIn('lat', datasets['var2'].coords)
 
-        # The not existed dimension or coordinate should be dropped
+        # The non-existant dimension or coordinate should be dropped
         self.assertNotIn('time', datasets['var3'].coords)
         self.assertNotIn('not_exist', datasets['var4'].coords)
 

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -627,6 +627,7 @@ class TestCFWriter(unittest.TestCase):
             'var1': xr.DataArray(data=data, dims=('y', 'x'), attrs={'coordinates': 'lon lat'}),
             'var2': xr.DataArray(data=data, dims=('y', 'x')),
             'var3': xr.DataArray(data=data, dims=('y', 'x'), attrs={'coordinates': 'lon2 lat'}),
+            'var4': xr.DataArray(data=data, dims=('y', 'x'), attrs={'coordinates': 'not_exist lon lat'}),
             'lon': xr.DataArray(data=lon, dims=('y', 'x')),
             'lon2': xr.DataArray(data=lon2, dims=('time', 'y', 'x')),
             'lat': xr.DataArray(data=lat, dims=('y', 'x'))
@@ -645,8 +646,9 @@ class TestCFWriter(unittest.TestCase):
         self.assertNotIn('lon', datasets['var2'].coords)
         self.assertNotIn('lat', datasets['var2'].coords)
 
-        # The time dimension should be dropped
+        # The not existed dimension or coordinate should be dropped
         self.assertNotIn('time', datasets['var3'].coords)
+        self.assertNotIn('not_exist', datasets['var4'].coords)
 
     def test_make_alt_coords_unique(self):
         """Test that created coordinate variables are unique."""

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -244,16 +244,14 @@ def link_coords(datas):
 
     """
     for da_name, data in datas.items():
-        coords = data.attrs.get('coordinates', [])
-        if isinstance(coords, str):
-            coords = coords.split(' ')
-        for coord in coords:
+        declared_coordinates = data.attrs.get('coordinates', [])
+        if isinstance(declared_coordinates, str):
+            declared_coordinates = declared_coordinates.split(' ')
+        for coord in declared_coordinates:
             if coord not in data.coords:
                 try:
-                    # drop dimension not existed in data
-                    drop_dims = list(set(datas[coord].dims) - set(data.dims))
-                    # assign coordinates
-                    data[coord] = datas[coord].squeeze(drop_dims).drop_vars(drop_dims)
+                    dimensions_not_in_data = list(set(datas[coord].dims) - set(data.dims))
+                    data[coord] = datas[coord].squeeze(dimensions_not_in_data, drop=True)
                 except KeyError:
                     warnings.warn('Coordinate "{}" referenced by dataarray {} does not exist, dropping reference.'
                                   .format(coord, da_name))

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -260,7 +260,7 @@ def link_coords(datas):
                     continue
 
         # Drop 'coordinates' attribute in any case to avoid conflicts in xr.Dataset.to_netcdf()
-        dataset.attrs.pop('coordinates', None)
+        data.attrs.pop('coordinates', None)
 
 
 def dataset_is_projection_coords(dataset):

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -255,8 +255,8 @@ def link_coords(datas):
                     # assign coordinates
                     data[coord] = datas[coord].squeeze(drop_dims).drop_vars(drop_dims)
                 except KeyError:
-                    warnings.warn('Coordinate "{}" referenced by dataarray {} does not exist, dropping reference.'.format(
-                        coord, da_name))
+                    warnings.warn('Coordinate "{}" referenced by dataarray {} does not exist, dropping reference.'
+                                  .format(coord, da_name))
                     continue
 
         # Drop 'coordinates' attribute in any case to avoid conflicts in xr.Dataset.to_netcdf()


### PR DESCRIPTION
- Rename dataset to data
- Drop linked coordinates's dimension which does not exist in dataarray

 - [ ] Closes #1493 
 - [x] Tests added