### PR TITLE
Delete unnecessary coordinates in tropomi reader

### DIFF
--- a/satpy/etc/readers/tropomi_l2.yaml
+++ b/satpy/etc/readers/tropomi_l2.yaml
@@ -16,13 +16,11 @@ datasets:
         name: 'latitude'
         file_type: tropomi_l2
         file_key: 'PRODUCT/latitude'
-        coordinates: [longitude, latitude]
         standard_name: latitude
     longitude:
         name: 'longitude'
         file_type: tropomi_l2
         file_key: 'PRODUCT/longitude'
-        coordinates: [longitude, latitude]
         standard_name: longitude
     latitude_bounds:
         name: 'latitude_bounds'


### PR DESCRIPTION
The coordinates of `longitude` and `latitude` shouldn't be linked to themselves again.

And this PR can fix this error of `scn.save_datasets()` when loading `longitude` or `latitude`:

```
  File "test_save.py", line 77, in <module>
    scn.save_datasets(filename='./output/test.nc')
  File "/public/home/zhangxin/new/miniconda3/envs/s5p_tobac/lib/python3.8/site-packages/satpy/scene.py", line 1065, in save_datasets
    return writer.save_datasets(dataarrays, compute=compute, **save_kwargs)
  File "/public/home/zhangxin/new/miniconda3/envs/s5p_tobac/lib/python3.8/site-packages/satpy/writers/cf_writer.py", line 721, in save_datasets
    res = dataset.to_netcdf(filename, engine=engine, group=group_name, mode='a', encoding=encoding,
  File "/public/home/zhangxin/new/miniconda3/envs/s5p_tobac/lib/python3.8/site-packages/xarray/core/dataset.py", line 1689, in to_netcdf
    return to_netcdf(
  File "/public/home/zhangxin/new/miniconda3/envs/s5p_tobac/lib/python3.8/site-packages/xarray/backends/api.py", line 1107, in to_netcdf
    dump_to_store(
  File "/public/home/zhangxin/new/miniconda3/envs/s5p_tobac/lib/python3.8/site-packages/xarray/backends/api.py", line 1142, in dump_to_store
    variables, attrs = conventions.encode_dataset_coordinates(dataset)
  File "/public/home/zhangxin/new/miniconda3/envs/s5p_tobac/lib/python3.8/site-packages/xarray/conventions.py", line 806, in encode_dataset_coordinates
    return _encode_coordinates(
  File "/public/home/zhangxin/new/miniconda3/envs/s5p_tobac/lib/python3.8/site-packages/xarray/conventions.py", line 765, in _encode_coordinates
    written_coords.update(attrs["coordinates"].split())
AttributeError: 'list' object has no attribute 'split'
```