### PR TITLE
Disallow tests from downloading files while running tests

### DIFF
--- a/satpy/conftest.py
+++ b/satpy/conftest.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Pytest configuration and setup functions."""
+
+
+def pytest_configure(config):
+    """Set test configuration."""
+    from satpy import aux_download
+    aux_download.RUNNING_TESTS = True
+
+
+def pytest_unconfigure(config):
+    """Undo previous configurations."""
+    from satpy import aux_download
+    aux_download.RUNNING_TESTS = False


### PR DESCRIPTION
See #1587. Basically, developers should be writing tests that mock the necessary functions so actual data downloads don't happen while tests are being run. This PR adds a check to see if we are running tests and if the file being downloaded is a README file. The auxiliary download tests themselves use a README file as the only file to actually test downloading. If we're running tests and a download is requested then a RuntimeError is raised. Offline downloads are still allowed but must also be explicitly requested (with the configuration value).

 - [x] Closes #1587 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

CC @joleenf who had fears about this in her own PR. 