### PR TITLE
Fix tests where xarray was unable to guess backend engine

### DIFF
--- a/satpy/tests/reader_tests/test_vii_base_nc.py
+++ b/satpy/tests/reader_tests/test_vii_base_nc.py
@@ -46,7 +46,7 @@ class TestViiNCBaseFileHandler(unittest.TestCase):
         """Set up the test."""
         # Easiest way to test the reader is to create a test netCDF file on the fly
         # uses a UUID to avoid permission conflicts during execution of tests in parallel
-        self.test_file_name = TEST_FILE + str(uuid.uuid1())
+        self.test_file_name = TEST_FILE + str(uuid.uuid1()) + ".nc"
 
         with Dataset(self.test_file_name, 'w') as nc:
             # Add global attributes

--- a/satpy/tests/reader_tests/test_vii_l1b_nc.py
+++ b/satpy/tests/reader_tests/test_vii_l1b_nc.py
@@ -42,7 +42,7 @@ class TestViiL1bNCFileHandler(unittest.TestCase):
         """Set up the test."""
         # Easiest way to test the reader is to create a test netCDF file on the fly
         # uses a UUID to avoid permission conflicts during execution of tests in parallel
-        self.test_file_name = TEST_FILE + str(uuid.uuid1())
+        self.test_file_name = TEST_FILE + str(uuid.uuid1()) + ".nc"
 
         with Dataset(self.test_file_name, 'w') as nc:
             # Create data group

--- a/satpy/tests/reader_tests/test_vii_l2_nc.py
+++ b/satpy/tests/reader_tests/test_vii_l2_nc.py
@@ -41,7 +41,7 @@ class TestViiL2NCFileHandler(unittest.TestCase):
         """Set up the test."""
         # Easiest way to test the reader is to create a test netCDF file on the fly
         # uses a UUID to avoid permission conflicts during execution of tests in parallel
-        self.test_file_name = TEST_FILE + str(uuid.uuid1())
+        self.test_file_name = TEST_FILE + str(uuid.uuid1()) + ".nc"
 
         with Dataset(self.test_file_name, 'w') as nc:
             # Create data group

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -36,13 +36,14 @@ except ImportError:
 class TempFile(object):
     """A temporary filename class."""
 
-    def __init__(self):
+    def __init__(self, suffix=".nc"):
         """Initialize."""
         self.filename = None
+        self.suffix = suffix
 
     def __enter__(self):
         """Enter."""
-        self.handle, self.filename = tempfile.mkstemp()
+        self.handle, self.filename = tempfile.mkstemp(suffix=self.suffix)
         os.close(self.handle)
         return self.filename
 


### PR DESCRIPTION
Our unstable CI tests started failing because https://github.com/pydata/xarray/pull/4989 was merged. Xarray was no longer able to guess the backend engine for our tests that weren't using the `.nc` suffix even though the tests were created/using netcdf files. This PR fixes these tests.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
