### PR TITLE
Fix bug in finest_area and coarsest_area logic for originally flipped SEVIRI data

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -214,7 +214,7 @@ class Scene:
                                  "projections.")
 
             def key_func(ds):
-                return 1. / ds.pixel_size_x
+                return 1. / abs(ds.pixel_size_x)
         else:
             def key_func(ds):
                 return ds.shape

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -595,6 +595,16 @@ class TestScene:
         assert scene.finest_area() is area_def2
         assert scene.coarsest_area(['2', '3']) is area_def2
 
+        # test logic for flipped areas
+        area_def1_flipped = area_def1.copy(area_extent=tuple([-1*ae for ae in area_def1.area_extent]))
+        area_def2_flipped = area_def2.copy(area_extent=tuple([-1*ae for ae in area_def2.area_extent]))
+        ds1.attrs['area'] = area_def1_flipped
+        ds2.attrs['area'] = area_def2_flipped
+        ds3.attrs['area'] = area_def2_flipped
+        assert scene.coarsest_area() is area_def1_flipped
+        assert scene.finest_area() is area_def2_flipped
+        assert scene.coarsest_area(['2', '3']) is area_def2_flipped
+
     def test_all_datasets_no_readers(self):
         """Test all datasets with no reader."""
         from satpy import Scene


### PR DESCRIPTION
There is a bug in the in the coarsest_area() finest_area() mechanism: the coarsest/finest area is found by comparing the pixel sizes; however, SEVIRI data is loaded by default upside-down and left-right flipped, hence has negative pixel size values. This wrongfully reverts the finest/coarsest assignment between HRV and VISIR channels.

See:
```python
scn = Scene(reader="seviri_l1b_native", filenames=[test_image], reader_kwargs={'fill_disk': True})
scn.load(['realistic_colors])
print(scn.finest_area())
print(scn.coarsest_area())
```
Before this PR:
```
Area ID: msg_seviri_fes_3km
Description: MSG SEVIRI Full Earth Scanning service area definition with 3 km resolution
Projection: {'a': '6378169', 'h': '35785831', 'lon_0': '0', 'no_defs': 'None', 'proj': 'geos', 'rf': '295.488065897014', 'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'}
Number of columns: 3712
Number of rows: 3712
Area extent: (5567248.0742, 5570248.4773, -5570248.4773, -5567248.0742)

Area ID: msg_seviri_fes_1km
Description: MSG SEVIRI Full Earth Scanning service area definition with 1 km resolution
Projection: {'a': '6378169', 'h': '35785831', 'lon_0': '0', 'no_defs': 'None', 'proj': 'geos', 'rf': '295.488065897014', 'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'}
Number of columns: 11136
Number of rows: 11136
Area extent: (5566247.7186, 5571248.3904, -5571248.3904, -5566247.7186)
```
after this PR the areas are the other way around (finest being the 1km grid).

 - [x] Tests added
