### PR TITLE
add file_patterns in file_types with resolution type for satpy_cf_nc reader

### DIFF
--- a/satpy/etc/readers/satpy_cf_nc.yaml
+++ b/satpy/etc/readers/satpy_cf_nc.yaml
@@ -11,4 +11,5 @@ file_types:
     graphic:
         file_reader: !!python/name:satpy.readers.satpy_cf_nc.SatpyCFFileHandler
         file_patterns:
+         - '{platform_name}-{sensor}-{resolution_type}-{start_time:%Y%m%d%H%M%S}-{end_time:%Y%m%d%H%M%S}.nc'
          - '{platform_name}-{sensor}-{start_time:%Y%m%d%H%M%S}-{end_time:%Y%m%d%H%M%S}.nc'


### PR DESCRIPTION
If a instrument provide different spatial resolution, like viirs with M, I and DN Bands this can be stored in one file per resolution type.
This PR adds a file_pattern to match this.