### PR TITLE
Fix missing VIIRS SDR DNB solar and lunar azimuth angle datasets

### DIFF
--- a/satpy/etc/readers/viirs_l1b.yaml
+++ b/satpy/etc/readers/viirs_l1b.yaml
@@ -465,6 +465,13 @@ datasets:
     coordinates: [dnb_lon, dnb_lat]
     file_type: vgeod
     file_key: geolocation_data/solar_zenith
+  DNB_SENZ:
+    name: dnb_satellite_zenith_angle
+    standard_name: sensor_zenith_angle
+    resolution: 743
+    coordinates: [dnb_lon, dnb_lat]
+    file_type: vgeod
+    file_key: geolocation_data/solar_zenith
   DNB_LZA:
     name: dnb_lunar_zenith_angle
     standard_name: lunar_zenith_angle
@@ -472,6 +479,27 @@ datasets:
     coordinates: [dnb_lon, dnb_lat]
     file_type: vgeod
     file_key: geolocation_data/lunar_zenith
+  DNB_SAA:
+    name: dnb_solar_azimuth_angle
+    standard_name: solar_azimuth_angle
+    resolution: 743
+    coordinates: [dnb_lon, dnb_lat]
+    file_type: vgeod
+    file_key: geolocation_data/solar_azimuth
+  DNB_SENA:
+    name: dnb_satellite_azimuth_angle
+    standard_name: sensor_azimuth_angle
+    resolution: 743
+    coordinates: [dnb_lon, dnb_lat]
+    file_type: vgeod
+    file_key: geolocation_data/sensor_azimuth
+  DNB_LAA:
+    name: dnb_lunar_azimuth_angle
+    standard_name: lunar_azimuth_angle
+    resolution: 743
+    coordinates: [dnb_lon, dnb_lat]
+    file_type: vgeod
+    file_key: geolocation_data/lunar_azimuth
   dnb_moon_illumination_fraction:
     name: dnb_moon_illumination_fraction
     resolution: 743

--- a/satpy/etc/readers/viirs_sdr.yaml
+++ b/satpy/etc/readers/viirs_sdr.yaml
@@ -496,6 +496,24 @@ datasets:
     file_type: generic_file
     dataset_groups: [GDNBO]
     file_key: 'All_Data/{dataset_group}_All/SatelliteZenithAngle'
+  DNB_SAA:
+    name: dnb_solar_azimuth_angle
+    standard_name: solar_azimuth_angle
+    resolution: 743
+    coordinates: [dnb_longitude, dnb_latitude]
+    file_units: degrees
+    file_type: generic_file
+    dataset_groups: [GDNBO]
+    file_key: 'All_Data/{dataset_group}_All/SolarAzimuthAngle'
+  DNB_LAA:
+    name: dnb_lunar_azimuth_angle
+    standard_name: lunar_azimuth_angle
+    resolution: 743
+    coordinates: [dnb_longitude, dnb_latitude]
+    file_units: degrees
+    file_type: generic_file
+    dataset_groups: [GDNBO]
+    file_key: 'All_Data/{dataset_group}_All/LunarAzimuthAngle'
   DNB_SENA:
     name: dnb_satellite_azimuth_angle
     standard_name: sensor_azimuth_angle

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -180,7 +180,8 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
 
     @staticmethod
     def _add_geolocation_info_to_file_content(file_content, filename, data_var_prefix):
-        if filename[:5] in ['GMODO', 'GIMGO']:
+        is_dnb = filename[:5] not in ['GMODO', 'GIMGO']
+        if not is_dnb:
             lon_data = np.linspace(15, 55, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
             lat_data = np.linspace(55, 75, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
         else:
@@ -197,7 +198,14 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
             file_content[k] = lon_data
             file_content[k] = np.repeat([file_content[k]], DEFAULT_FILE_SHAPE[0], axis=0)
             file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
-        for k in ["SolarZenithAngle"]:
+
+        angles = ['SolarZenithAngle',
+                  'SolarAzimuthAngle',
+                  'SatelliteZenithAngle',
+                  'SatelliteAzimuthAngle']
+        if is_dnb:
+            angles += ['LunarZenithAngle', 'LunarAzimuthAngle']
+        for k in angles:
             k = data_var_prefix + "/" + k
             file_content[k] = lon_data  # close enough to SZA
             file_content[k] = np.repeat([file_content[k]], DEFAULT_FILE_SHAPE[0], axis=0)
@@ -590,8 +598,13 @@ class TestVIIRSSDRReader(unittest.TestCase):
             'GDNBO_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
         ])
         r.create_filehandlers(loadables, {'include_factors': False})
-        ds = r.load(['dnb_solar_zenith_angle'])
-        self.assertEqual(len(ds), 1)
+        ds = r.load(['dnb_solar_zenith_angle',
+                     'dnb_solar_azimuth_angle',
+                     'dnb_satellite_zenith_angle',
+                     'dnb_satellite_azimuth_angle',
+                     'dnb_lunar_zenith_angle',
+                     'dnb_lunar_azimuth_angle'])
+        self.assertEqual(len(ds), 6)
         for d in ds.values():
             self.assertTrue(np.issubdtype(d.dtype, np.float32))
             self.assertEqual(d.attrs['units'], 'degrees')


### PR DESCRIPTION
I'd like to use these datasets but they weren't configured in the `viirs_sdr` and `viirs_l1b` readers.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
