### PR TITLE
Make FSFile hashable again

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -617,7 +617,7 @@ class FSFile(os.PathLike):
         """
         try:
             fshash = hash(self._fs.to_json())
-        except AttributeError:
+        except (AttributeError, NotImplementedError):
             fshash = hash(self._fs)
         return hash(self._file) ^ fshash
 

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -602,6 +602,22 @@ class FSFile(os.PathLike):
                 self._file == other._file and
                 self._fs == other._fs)
 
+    def __hash__(self):
+        """Implement hashing.
+
+        Make FSFile objects hashable, so that they can be used in sets.  Some
+        parts of satpy and perhaps others use sets of filenames (strings or
+        pathlib.Path), or maybe use them as dictionary keys.  This requires
+        them to be hashable.  To ensure FSFile can work as a drop-in
+        replacement for strings of Path objects to represent the location of
+        blob of data, FSFile should be hashable too.
+
+        Returns the hash, computed from the hash of the filename and the hash
+        of the filesystem.
+        """
+
+        return hash(self._file) ^ hash(self._fs)
+
 
 def open_file_or_filename(unknown_file_thing):
     """Try to open the *unknown_file_thing*, otherwise return the filename."""

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -22,6 +22,7 @@ import os
 import warnings
 from datetime import datetime, timedelta
 from functools import total_ordering
+import pickle
 
 import yaml
 
@@ -616,9 +617,9 @@ class FSFile(os.PathLike):
         of the filesystem.
         """
         try:
-            fshash = hash(self._fs.to_json())
-        except (AttributeError, NotImplementedError, TypeError):
             fshash = hash(self._fs)
+        except TypeError:  # fsspec < 0.8.8
+            fshash = hash(pickle.dumps(self._fs))
         return hash(self._file) ^ fshash
 
 

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -615,7 +615,6 @@ class FSFile(os.PathLike):
         Returns the hash, computed from the hash of the filename and the hash
         of the filesystem.
         """
-
         return hash(self._file) ^ hash(self._fs)
 
 

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -615,7 +615,11 @@ class FSFile(os.PathLike):
         Returns the hash, computed from the hash of the filename and the hash
         of the filesystem.
         """
-        return hash(self._file) ^ hash(self._fs)
+        try:
+            fshash = hash(self._fs.to_json())
+        except AttributeError:
+            fshash = hash(self._fs)
+        return hash(self._file) ^ fshash
 
 
 def open_file_or_filename(unknown_file_thing):

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -617,7 +617,7 @@ class FSFile(os.PathLike):
         """
         try:
             fshash = hash(self._fs.to_json())
-        except (AttributeError, NotImplementedError):
+        except (AttributeError, NotImplementedError, TypeError):
             fshash = hash(self._fs)
         return hash(self._file) ^ fshash
 

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -618,7 +618,7 @@ class FSFile(os.PathLike):
         """
         try:
             fshash = hash(self._fs)
-        except TypeError:  # fsspec < 0.8.8
+        except TypeError:  # fsspec < 0.8.8 for CachingFileSystem
             fshash = hash(pickle.dumps(self._fs))
         return hash(self._file) ^ fshash
 

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -964,3 +964,18 @@ class TestFSFile(unittest.TestCase):
         assert (FSFile(self.local_filename, zip_fs) !=
                 FSFile(self.local_filename))
         assert FSFile(self.local_filename) != FSFile(self.local_filename2)
+
+    def test_hash(self):
+        """Test that FSFile hashing behaves sanely."""
+        from satpy.readers import FSFile
+        from fsspec.implementations.zip import ZipFileSystem
+        from fsspec.implementations.local import LocalFileSystem
+        from fsspec.implementations.cached import CachingFileSystem
+
+        lfs = LocalFileSystem()
+        zfs = ZipFileSystem(self.zip_name)
+        cfs = CachingFileSystem(fs=lfs)
+        # make sure each name/fs-combi has its own hash
+        assert len({hash(FSFile(fn, fs))
+                    for fn in {self.local_filename, self.local_filename2}
+                    for fs in {None, lfs, zfs, cfs}}) == 2*4

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -978,4 +978,4 @@ class TestFSFile(unittest.TestCase):
         # make sure each name/fs-combi has its own hash
         assert len({hash(FSFile(fn, fs))
                     for fn in {self.local_filename, self.local_filename2}
-                    for fs in {None, lfs, zfs, cfs}}) == 2*4
+                    for fs in [None, lfs, zfs, cfs]}) == 2*4

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -127,11 +127,11 @@ class TestScene:
         # We should not mock _create_reader_instances here, because in
         # https://github.com/pytroll/satpy/issues/1605 satpy fails with
         # TypeError within that method if passed an FSFile instance.
-        # Instead rely on the ValueError # that satpy raises if no readers
+        # Instead rely on the ValueError that satpy raises if no readers
         # are found.
 
         fsf = FSFile("dummy")
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="No supported files found"):
             Scene(filenames=[fsf], reader=[])
 
     # TODO: Rewrite this test for the 'find_files_and_readers' function

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -120,6 +120,20 @@ class TestScene:
         filenames = []
         Scene(filenames=filenames)
 
+    def test_init_with_fsfile(self):
+        """Test initialisation with FSFile objects."""
+        from satpy.readers import FSFile
+
+        # We should not mock _create_reader_instances here, because in
+        # https://github.com/pytroll/satpy/issues/1605 satpy fails with
+        # TypeError within that method if passed an FSFile instance.
+        # Instead rely on the ValueError # that satpy raises if no readers
+        # are found.
+
+        fsf = FSFile("dummy")
+        with pytest.raises(ValueError):
+            Scene(filenames=[fsf], reader=[])
+
     # TODO: Rewrite this test for the 'find_files_and_readers' function
     # def test_create_reader_instances_with_sensor(self):
     #     import satpy.scene

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -20,6 +20,8 @@
 import os
 import unittest
 from unittest import mock
+import string
+import random
 
 import satpy
 from satpy import Scene
@@ -130,7 +132,9 @@ class TestScene:
         # Instead rely on the ValueError that satpy raises if no readers
         # are found.
 
-        fsf = FSFile("dummy")
+        # Choose random filename that doesn't exist.  Not using tempfile here,
+        # because tempfile creates files and we don't want that here.
+        fsf = FSFile("".join(random.choices(string.printable, k=50)))
         with pytest.raises(ValueError, match="No supported files found"):
             Scene(filenames=[fsf], reader=[])
 


### PR DESCRIPTION
FSFile objects had been inadvertently made unhashable by
https://github.com/pytroll/satpy/pull/1582 .  Make FSFile objects
hashable again by implementing a __hash__ method.

 - [x] Closes #1604 
 - [x] Closes #1605<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
