### PR TITLE
Fix auxiliary download script not using provided data directory

### DIFF
--- a/satpy/aux_download.py
+++ b/satpy/aux_download.py
@@ -361,6 +361,6 @@ def retrieve_all_cmd():
     if args.data_dir is None:
         args.data_dir = satpy.config.get('data_dir')
 
-    with satpy.config.set(datA_dir=args.data_dir):
+    with satpy.config.set(data_dir=args.data_dir):
         retrieve_all(readers=args.readers, writers=args.writers,
                      composite_sensors=args.composite_sensors)

--- a/satpy/aux_download.py
+++ b/satpy/aux_download.py
@@ -333,7 +333,7 @@ class DataDownloadMixin:
                              known_hash=known_hash)
 
 
-def retrieve_all_cmd():
+def retrieve_all_cmd(argv=None):
     """Call 'retrieve_all' function from console script 'satpy_retrieve_all'."""
     import argparse
     parser = argparse.ArgumentParser(description="Download auxiliary data files used by Satpy.")
@@ -354,7 +354,7 @@ def retrieve_all_cmd():
                         help="Limit searching to these writers. If specified "
                              "with no arguments, no writer files will be "
                              "downloaded.")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     logging.basicConfig(level=logging.INFO)
 

--- a/satpy/tests/test_data_download.py
+++ b/satpy/tests/test_data_download.py
@@ -229,3 +229,20 @@ class TestDataDownload:
             # offline downloading should still be allowed
             with satpy.config.set(download_aux=False):
                 retrieve(cache_key)
+
+    def test_download_script(self):
+        """Test basic functionality of the download script."""
+        from satpy.aux_download import retrieve_all_cmd
+        import satpy
+        file_registry = {}
+        file_urls = {}
+        with satpy.config.set(config_path=[self.tmpdir]), \
+             mock.patch('satpy.aux_download._FILE_REGISTRY', file_registry), \
+             mock.patch('satpy.aux_download._FILE_URLS', file_urls), \
+             mock.patch('satpy.aux_download.find_registerable_files'):
+            comp_file = 'composites/README.rst'
+            file_registry[comp_file] = None
+            file_urls[comp_file] = README_URL
+            assert not self.tmpdir.join(comp_file).exists()
+            retrieve_all_cmd(argv=["--data-dir", str(self.tmpdir)])
+            assert self.tmpdir.join(comp_file).exists()


### PR DESCRIPTION
Small typo that stopped the auxiliary download script from customizing the location of data to download. This script was supposed to be so simple it didn't need testing... :facepalm: 

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

