### PR TITLE
Standardize vii dims

### DIFF
--- a/satpy/readers/vii_base_nc.py
+++ b/satpy/readers/vii_base_nc.py
@@ -103,7 +103,11 @@ class ViiNCBaseFileHandler(NetCDF4FileHandler):
 
         variable.attrs.update(dataset_info)
         variable.attrs.update(self._get_global_attributes())
-
+        try:
+            variable = variable.rename({'num_pixels': 'x', 'num_lines': 'y'})
+        except ValueError:
+            pass
+        variable.transpose('y', 'x')
         return variable
 
     @staticmethod

--- a/satpy/readers/vii_base_nc.py
+++ b/satpy/readers/vii_base_nc.py
@@ -107,7 +107,7 @@ class ViiNCBaseFileHandler(NetCDF4FileHandler):
             variable = variable.rename({'num_pixels': 'x', 'num_lines': 'y'})
         except ValueError:
             pass
-        variable.transpose('y', 'x')
+        variable = variable.transpose('y', 'x')
         return variable
 
     @staticmethod

--- a/satpy/readers/vii_base_nc.py
+++ b/satpy/readers/vii_base_nc.py
@@ -63,6 +63,14 @@ class ViiNCBaseFileHandler(NetCDF4FileHandler):
             logger.warning("Cached longitude and/or latitude datasets are not correctly defined in YAML file")
             self.longitude, self.latitude = None, None
 
+    def _standardize_dims(self, variable):
+        """Standardize dims to y, x."""
+        if 'num_pixels' in variable.dims:
+            variable = variable.rename({'num_pixels': 'x', 'num_lines': 'y'})
+        if variable.dims[0] == 'x':
+            variable = variable.transpose('y', 'x')
+        return variable
+
     def get_dataset(self, dataset_id, dataset_info):
         """Get dataset using file_key in dataset_info."""
         var_key = dataset_info['file_key']
@@ -103,11 +111,7 @@ class ViiNCBaseFileHandler(NetCDF4FileHandler):
 
         variable.attrs.update(dataset_info)
         variable.attrs.update(self._get_global_attributes())
-        try:
-            variable = variable.rename({'num_pixels': 'x', 'num_lines': 'y'})
-        except ValueError:
-            pass
-        variable = variable.transpose('y', 'x')
+        variable = self._standardize_dims(variable)
         return variable
 
     @staticmethod

--- a/satpy/tests/reader_tests/test_vii_base_nc.py
+++ b/satpy/tests/reader_tests/test_vii_base_nc.py
@@ -231,7 +231,7 @@ class TestViiNCBaseFileHandler(unittest.TestCase):
 
         # Checks that the _perform_interpolation function is correctly executed
         variable = xr.DataArray(
-            dims=('x', 'y'),
+            dims=('y', 'x'),
             name='test_name',
             attrs={
                 'key_1': 'value_1',
@@ -254,7 +254,7 @@ class TestViiNCBaseFileHandler(unittest.TestCase):
 
         # Checks that the _perform_geo_interpolation function is correctly executed
         variable_lon = xr.DataArray(
-            dims=('x', 'y'),
+            dims=('y', 'x'),
             name='test_lon',
             attrs={
                 'key_1': 'value_lon_1',
@@ -263,7 +263,7 @@ class TestViiNCBaseFileHandler(unittest.TestCase):
             data=np.zeros((10, 100))
         )
         variable_lat = xr.DataArray(
-            dims=('x', 'y'),
+            dims=('y', 'x'),
             name='test_lat',
             attrs={
                 'key_1': 'value_lat_1',
@@ -297,6 +297,22 @@ class TestViiNCBaseFileHandler(unittest.TestCase):
         self.assertEqual(return_lat.name, 'test_lat')
         self.assertEqual(return_lat.dims, ('num_pixels', 'num_lines'))
 
+    def test_standardize_dims(self):
+        """Test the standardize dims function."""
+        test_variable = xr.DataArray(
+            dims=('num_pixels', 'num_lines'),
+            name='test_data',
+            attrs={
+                'key_1': 'value_lat_1',
+                'key_2': 'value_lat_2'
+            },
+            data=np.ones((10, 100)) * 1.
+        )
+        out_variable = self.reader._standardize_dims(test_variable)
+        self.assertTrue(np.allclose(out_variable.values, np.ones((100, 10))))
+        self.assertEqual(out_variable.dims, ('y', 'x'))
+        self.assertEqual(out_variable.attrs['key_1'], 'value_lat_1')
+
     @mock.patch('satpy.readers.vii_base_nc.ViiNCBaseFileHandler._perform_calibration')
     @mock.patch('satpy.readers.vii_base_nc.ViiNCBaseFileHandler._perform_interpolation')
     @mock.patch('satpy.readers.vii_base_nc.ViiNCBaseFileHandler._perform_orthorectification')
@@ -309,8 +325,8 @@ class TestViiNCBaseFileHandler(unittest.TestCase):
         pi_.assert_not_called()
         po_.assert_not_called()
 
-        self.assertTrue(np.allclose(variable.values, np.ones((10, 100))))
-        self.assertEqual(variable.dims, ('num_pixels', 'num_lines'))
+        self.assertTrue(np.allclose(variable.values, np.ones((100, 10))))
+        self.assertEqual(variable.dims, ('y', 'x'))
         self.assertEqual(variable.attrs['test_attr'], 'attr')
         self.assertEqual(variable.attrs['units'], None)
 


### PR DESCRIPTION
Dimensions are normally named 'y', 'x' in satpy.
And 'y' should be the first dim.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->


