### PR TITLE
Fix and improve unit conversion when writing NinJoTIFF

### DIFF
--- a/satpy/tests/writer_tests/test_ninjotiff.py
+++ b/satpy/tests/writer_tests/test_ninjotiff.py
@@ -21,6 +21,7 @@ import sys
 import unittest
 from unittest import mock
 
+import numpy as np
 import xarray as xr
 
 
@@ -82,3 +83,16 @@ class TestNinjoTIFFWriter(unittest.TestCase):
         assert(nt.save.mock_calls[0][2]['ch_min_measurement_unit']
                < nt.save.mock_calls[0][2]['ch_max_measurement_unit'])
         assert(ret == nt.save.return_value)
+
+    def test_convert_units(self):
+        """Test that unit conversions work as expected."""
+        from ..utils import make_fake_scene
+        from satpy.writers.ninjotiff import convert_units
+        # ensure that converting from % to itself does not change the data
+        sc = make_fake_scene(
+                {"VIS006": np.arange(25).reshape(5, 5)},
+                common_attrs={"units": "%"})
+        ds_in = sc["VIS006"]
+        ds_out = convert_units(ds_in, "%", "%")
+        np.testing.assert_array_equal(ds_in, ds_out)
+        assert ds_in.attrs == ds_out.attrs

--- a/satpy/tests/writer_tests/test_ninjotiff.py
+++ b/satpy/tests/writer_tests/test_ninjotiff.py
@@ -85,8 +85,8 @@ class TestNinjoTIFFWriter(unittest.TestCase):
                < nt.save.mock_calls[0][2]['ch_max_measurement_unit'])
         assert(ret == nt.save.return_value)
 
-    def test_convert_units(self):
-        """Test that unit conversions work as expected."""
+    def test_convert_units_self(self):
+        """Test that unit conversion to themselves do nothing."""
         from ..utils import make_fake_scene
         from satpy.writers.ninjotiff import convert_units
         # ensure that converting from % to itself does not change the data
@@ -98,7 +98,11 @@ class TestNinjoTIFFWriter(unittest.TestCase):
         np.testing.assert_array_equal(ds_in, ds_out)
         assert ds_in.attrs == ds_out.attrs
 
+    def test_convert_units_temp(self):
+        """Test that temperature unit conversions works as expected."""
         # test converting between °C and K
+        from ..utils import make_fake_scene
+        from satpy.writers.ninjotiff import convert_units
         sc = make_fake_scene(
                 {"IR108": np.arange(25, dtype="f4").reshape(5, 5)},
                 common_attrs={"units": "K"})
@@ -109,11 +113,15 @@ class TestNinjoTIFFWriter(unittest.TestCase):
             assert ds_in.attrs != ds_out.attrs
             assert ds_out.attrs["units"] == out_unit
 
+    def test_convert_units_other(self):
+        """Test that other unit conversions are not implemented."""
         # test arbitrary different conversion
+        from ..utils import make_fake_scene
+        from satpy.writers.ninjotiff import convert_units
         sc = make_fake_scene(
                 {"rain_rate": np.arange(25, dtype="f8").reshape(5, 5)},
                 common_attrs={"units": "millimeter/hour"})
 
         ds_in = sc["rain_rate"]
-        with pytest.raises(ValueError):
+        with pytest.raises(NotImplementedError):
             convert_units(ds_in, "millimeter/hour", "m/s")

--- a/satpy/tests/writer_tests/test_ninjotiff.py
+++ b/satpy/tests/writer_tests/test_ninjotiff.py
@@ -56,15 +56,15 @@ class TestNinjoTIFFWriter(unittest.TestCase):
         self.assertDictEqual(ntw.tags, ninjo_tags)
 
     @mock.patch('satpy.writers.ninjotiff.ImageWriter.save_dataset')
-    @mock.patch('satpy.writers.ninjotiff.convert_units')
     @mock.patch('satpy.writers.ninjotiff.nt', pyninjotiff_mock.ninjotiff)
-    def test_dataset(self, uconv, iwsd):
+    def test_dataset(self, iwsd):
         """Test saving a dataset."""
         from satpy.writers.ninjotiff import NinjoTIFFWriter
         ntw = NinjoTIFFWriter()
         dataset = xr.DataArray([1, 2, 3], attrs={'units': 'K'})
-        ntw.save_dataset(dataset, physic_unit='CELSIUS')
-        uconv.assert_called_once_with(dataset, 'K', 'CELSIUS')
+        with mock.patch('satpy.writers.ninjotiff.convert_units') as uconv:
+            ntw.save_dataset(dataset, physic_unit='CELSIUS')
+            uconv.assert_called_once_with(dataset, 'K', 'CELSIUS')
         self.assertEqual(iwsd.call_count, 1)
 
     @mock.patch('satpy.writers.ninjotiff.NinjoTIFFWriter.save_dataset')

--- a/satpy/writers/ninjotiff.py
+++ b/satpy/writers/ninjotiff.py
@@ -94,10 +94,10 @@ def convert_units(dataset, in_unit, out_unit):
 
     Convert dataset units for the benefit of writing NinJoTIFF.  The main
     background here is that NinJoTIFF would like brightness temperatures in °C,
-    but satellinge data files are in K.  For simplicity of implementation, this
-    function can only convert from °C to K.
+    but satellite data files are in K.  For simplicity of implementation, this
+    function can only convert from K to °C.
 
-    This function will convert input data from °C to K and write the new unit
+    This function will convert input data from K to °C and write the new unit
     in the ``"units"`` attribute.  When output and input units are equal, it
     returns the input dataset.
 
@@ -120,12 +120,10 @@ def convert_units(dataset, in_unit, out_unit):
         new_dataset.attrs["units"] = out_unit
         return new_dataset
 
-    # Other cases not implemented.  Creating a quantity from a pint array
-    # doesn't work (TypeError: Quantity cannot wrap upcast type
-    # xarray.DataArray).  Working on the values may cause further bugs and
-    # dask-compatibility.  I don't know if anyone is using this function to
-    # convert between non-temperature units.
-    raise ValueError(
+    # Other units not implemented.  Before Satpy 0.16.1 there was a
+    # non-working implementation based on pint here.
+
+    raise NotImplementedError(
             "NinJoTIFF unit conversion only implemented between K and C, not "
             f"between {in_unit!s} and {out_unit!s}")
 


### PR DESCRIPTION
Refactor, fix, improve the unit conversion that happens in the Satpy NinJoTIFF writer when writing a NinJoTIFF file.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1614 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
