### PR TITLE
Add raw 'counts' calibration to 'abi_l1b' reader

### DIFF
--- a/satpy/etc/readers/abi_l1b.yaml
+++ b/satpy/etc/readers/abi_l1b.yaml
@@ -102,6 +102,9 @@ datasets:
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c01
 
   C02:
@@ -115,6 +118,9 @@ datasets:
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c02
 
   C03:
@@ -128,6 +134,9 @@ datasets:
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c03
 
   C04:
@@ -141,6 +150,9 @@ datasets:
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c04
 
   C05:
@@ -154,6 +166,9 @@ datasets:
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c05
 
   C06:
@@ -167,6 +182,9 @@ datasets:
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c06
 
   C07:
@@ -180,6 +198,9 @@ datasets:
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c07
 
   C08:
@@ -193,6 +214,9 @@ datasets:
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c08
 
   C09:
@@ -206,6 +230,9 @@ datasets:
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c09
 
   C10:
@@ -219,6 +246,9 @@ datasets:
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c10
 
   C11:
@@ -232,6 +262,9 @@ datasets:
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c11
 
   C12:
@@ -245,6 +278,9 @@ datasets:
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c12
 
   C13:
@@ -258,6 +294,9 @@ datasets:
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c13
 
   C14:
@@ -271,6 +310,9 @@ datasets:
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c14
 
   C15:
@@ -284,6 +326,9 @@ datasets:
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c15
 
   C16:
@@ -297,4 +342,7 @@ datasets:
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: K
+      counts:
+        standard_name: raw_counts
+        units: "1"
     file_type: c16

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -46,6 +46,9 @@ class NC_ABI_L1B(NC_ABI_BASE):
         elif key['calibration'] == 'brightness_temperature':
             logger.debug("Calibrating to brightness temperatures")
             res = self._ir_calibrate(radiances)
+        elif key['calibration'] == 'counts':
+            logger.debug("Calibrating to raw counts")
+            res = self.nc['Rad'].copy()
         elif key['calibration'] != 'radiance':
             raise ValueError("Unknown calibration '{}'".format(key['calibration']))
         else:


### PR DESCRIPTION
<!-- This change is requested to support use of Satpy readers in the new Python implementation of [ADDE](https://www.researchgate.net/figure/Abstract-Data-Distribution-Environment-ADDE-Data-flow-from-satellite-signal-to-client_fig1_259119801), a remote sensing data access protocol developed at SSEC. "Raw" calibration is needed since some core ADDE capabilities require a copy of the raw satellite measurements.  ABI L1B is the server chosen as proof-of-concept for developing an API allowing development of Python-based ADDE servers. -->

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
