### PR TITLE
Add the reinhard enhancements

### DIFF
--- a/doc/source/enhancements.rst
+++ b/doc/source/enhancements.rst
@@ -66,14 +66,14 @@ crefl_scaling
 cira_stretch
 ------------
 
-Logarithmic stretch base on a cira recipe.
+Logarithmic stretch based on a cira recipe.
 
 reinhard_to_srgb
 ----------------
 
 Stretch method based on the Reinhard algorithm, using luminance.
 
-The function include conversion to sRGB colorspace.
+The function includes conversion to sRGB colorspace.
 
     Reinhard, Erik & Stark, Michael & Shirley, Peter & Ferwerda, James. (2002).
     Photographic Tone Reproduction For Digital Images. ACM Transactions on Graphics.

--- a/doc/source/enhancements.rst
+++ b/doc/source/enhancements.rst
@@ -66,6 +66,19 @@ crefl_scaling
 cira_stretch
 ------------
 
+Logarithmic stretch base on a cira recipe.
+
+reinhard_to_srgb
+----------------
+
+Stretch method based on the Reinhard algorithm, using luminance.
+
+The function include conversion to sRGB colorspace.
+
+    Reinhard, Erik & Stark, Michael & Shirley, Peter & Ferwerda, James. (2002).
+    Photographic Tone Reproduction For Digital Images. ACM Transactions on Graphics.
+    :doi: `21. 10.1145/566654.566575`
+
 lookup
 ------
 

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -156,7 +156,7 @@ def reinhard(img, saturation=1.25, luminosity=1, **kwargs):
         gain = 1.5
         res = res * gain
         # saturate
-        luma = res.sel(bands='R').data * 0.2126 + res.sel(bands='G').data * 0.7152 + res.sel(bands='B').data * 0.722
+        luma = res.sel(bands='R').data * 0.2126 + res.sel(bands='G').data * 0.7152 + res.sel(bands='B').data * 0.0722
         res = (luma + (res - luma) * saturation).clip(0)
 
         # reinhard
@@ -186,7 +186,7 @@ def luma_reinhard(img, saturation=1.25, **kwargs):
         gain = 1.5
         res = res * gain
         # saturate
-        luma = res.sel(bands='R').data * 0.2126 + res.sel(bands='G').data * 0.7152 + res.sel(bands='B').data * 0.722
+        luma = res.sel(bands='R').data * 0.2126 + res.sel(bands='G').data * 0.7152 + res.sel(bands='B').data * 0.0722
         saturation = 1.25
         res = (luma + (res - luma) * saturation).clip(0)
 

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -146,6 +146,9 @@ def reinhard(img, saturation=1.25, luminosity=1, **kwargs):
     Luminosity has default value 1. Less is darker.
     Saturation has default value 1.25. Less is grayer.
 
+    Reinhard, Erik, Michael Stark, Peter Shirley, and James Ferwerda:
+    ‘Photographic Tone Reproduction for Digital Images’, n.d., 10.
+
     Credits Gregory Ivanov
     https://github.com/sentinel-hub/custom-scripts/tree/master/sentinel-2/tonemapped_natural_color
     """
@@ -175,6 +178,9 @@ def luma_reinhard(img, saturation=1.25, **kwargs):
     """Stretch method based on the Reinhard algorithm, using luminance only.
 
     Saturation has default value 1.25. Less is grayer.
+
+    Reinhard, Erik, Michael Stark, Peter Shirley, and James Ferwerda:
+    ‘Photographic Tone Reproduction for Digital Images’, n.d., 10.
 
     Credits Gregory Ivanov
     https://github.com/sentinel-hub/custom-scripts/tree/master/sentinel-2/tonemapped_natural_color

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -161,7 +161,7 @@ def reinhard(img, saturation=1.25, luminosity=1, **kwargs):
 
         # reinhard
         white = 2.4
-        default_luminosity = (1 + 1 / white)
+        default_luminosity = (1 + luma / (white ** 2))
         res = res / (1 + res) * default_luminosity * luminosity
 
         # srgb gamma

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -68,30 +68,16 @@ class TestEnhancementStretch(unittest.TestCase):
 
     def test_reinhard(self):
         """Test the reinhard algorithm."""
-        from satpy.enhancements import reinhard
-        expected = np.array([[[np.nan, 0., 0., 0.87470856, 0.99428697],
-                              [1.04370489, 1.07085066, 1.08803526, 1.09989758, 1.10858066]],
+        from satpy.enhancements import reinhard_to_srgb
+        expected = np.array([[[np.nan, 0., 0., 0.93333793, 1.29432402],
+                              [1.55428709, 1.76572249, 1.94738635, 2.10848544, 2.25432809]],
 
-                             [[np.nan, 0., 0., 0.87124838, 0.99180807],
-                              [1.04180364, 1.06931363, 1.08674673, 1.0987889, 1.10760799]],
+                             [[np.nan, 0., 0., 0.93333793, 1.29432402],
+                              [1.55428709, 1.76572249, 1.94738635, 2.10848544, 2.25432809]],
 
-                             [[np.nan, 0., 0., 0.86073148, 0.98420293],
-                              [1.03594516, 1.06456543, 1.08275961, 1.09535428, 1.10459215]]])
-        self._test_enhancement(reinhard, self.rgb, expected)
-
-    def test_luma_reinhard(self):
-        """Test the reinhard algorithm for luminance."""
-        from satpy.enhancements import luma_reinhard
-        expected = np.array([[[np.nan, -0., 0., 0.71725512, 0.8695631],
-                              [0.97627342, 1.06477928, 1.14258941, 1.21299763, 1.27782253]],
-
-                             [[np.nan, -0., 0., 0.7112939, 0.86242619],
-                              [0.96831278, 1.05613545, 1.13334494, 1.20320966, 1.26753417]],
-
-                             [[np.nan, -0., 0., 0.69365932, 0.84131363],
-
-                              [0.94476347, 1.03056509, 1.10599778, 1.17425472, 1.23709894]]])
-        self._test_enhancement(luma_reinhard, self.rgb, expected)
+                             [[np.nan, 0., 0., 0.93333793, 1.29432402],
+                              [1.55428709, 1.76572249, 1.94738635, 2.10848544, 2.25432809]]])
+        self._test_enhancement(reinhard_to_srgb, self.rgb, expected)
 
     def test_lookup(self):
         """Test the lookup enhancement function."""

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -66,6 +66,33 @@ class TestEnhancementStretch(unittest.TestCase):
             [1.05181359, 1.11651012, 1.16635571, 1.20691137, 1.24110186]]])
         self._test_enhancement(cira_stretch, self.ch1, expected)
 
+    def test_reinhard(self):
+        """Test the reinhard algorithm."""
+        from satpy.enhancements import reinhard
+        expected = np.array([[[np.nan, 0., 0., 0.87470856, 0.99428697],
+                              [1.04370489, 1.07085066, 1.08803526, 1.09989758, 1.10858066]],
+
+                             [[np.nan, 0., 0., 0.87124838, 0.99180807],
+                              [1.04180364, 1.06931363, 1.08674673, 1.0987889, 1.10760799]],
+
+                             [[np.nan, 0., 0., 0.86073148, 0.98420293],
+                              [1.03594516, 1.06456543, 1.08275961, 1.09535428, 1.10459215]]])
+        self._test_enhancement(reinhard, self.rgb, expected)
+
+    def test_luma_reinhard(self):
+        """Test the reinhard algorithm for luminance."""
+        from satpy.enhancements import luma_reinhard
+        expected = np.array([[[np.nan, -0., 0., 0.71725512, 0.8695631],
+                              [0.97627342, 1.06477928, 1.14258941, 1.21299763, 1.27782253]],
+
+                             [[np.nan, -0., 0., 0.7112939, 0.86242619],
+                              [0.96831278, 1.05613545, 1.13334494, 1.20320966, 1.26753417]],
+
+                             [[np.nan, -0., 0., 0.69365932, 0.84131363],
+
+                              [0.94476347, 1.03056509, 1.10599778, 1.17425472, 1.23709894]]])
+        self._test_enhancement(luma_reinhard, self.rgb, expected)
+
     def test_lookup(self):
         """Test the lookup enhancement function."""
         from satpy.enhancements import lookup


### PR DESCRIPTION
This PR adds a reinhard-based tonemapping enhancement.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

An example on an Himawari 8 True Color image

Reinhard:
![h8_reinhard](https://user-images.githubusercontent.com/167802/112816933-312b4680-9082-11eb-803b-863723adfdec.jpg)

Cira stretch
![h8_cira](https://user-images.githubusercontent.com/167802/112696379-007ebd80-8e86-11eb-8a73-a9c724c8c649.jpg)
