### PR TITLE
Fix Scene.copy not preserving wishlist properly

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -421,11 +421,7 @@ class Scene:
             # NOTE: Must use `._datasets` or side effects of `__setitem__`
             #       could hurt us with regards to the wishlist
             new_scn._datasets[ds_id] = self[ds_id]
-
-        if not datasets:
-            new_scn._wishlist = self._wishlist.copy()
-        else:
-            new_scn._wishlist = set(ds_id for ds_id in new_scn.keys())
+        new_scn._wishlist = self._wishlist.copy()
 
     def copy(self, datasets=None):
         """Create a copy of the Scene including dependency information.
@@ -810,14 +806,9 @@ class Scene:
                 arguments.
 
         """
-        to_resample_ids = [dsid for (dsid, dataset) in self._datasets.items()
-                           if (not datasets) or dsid in datasets]
-
         if destination is None:
-            destination = self.finest_area(to_resample_ids)
-        new_scn = self.copy(datasets=to_resample_ids)
-        # we may have some datasets we asked for but don't exist yet
-        new_scn._wishlist = self._wishlist.copy()
+            destination = self.finest_area(datasets)
+        new_scn = self.copy(datasets=datasets)
         self._resampled_scene(new_scn, destination, resampler=resampler,
                               reduce_data=reduce_data, **resample_kwargs)
 

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1378,7 +1378,11 @@ class TestSceneResampling:
         )
 
     @mock.patch('satpy.scene.resample_dataset')
-    def test_resample_scene_copy(self, rs):
+    @pytest.mark.parametrize('datasets', [
+        None,
+        ('comp13', 'ds5', 'ds2'),
+    ])
+    def test_resample_scene_copy(self, rs, datasets):
         """Test that the Scene is properly copied during resampling.
 
         The Scene that is created as a copy of the original Scene should not
@@ -1395,7 +1399,7 @@ class TestSceneResampling:
         scene = Scene(filenames=['fake1_1.txt', 'fake1_highres_1.txt'], reader='fake1')
 
         scene.load(['comp19'])
-        new_scene = scene.resample(area_def)
+        new_scene = scene.resample(area_def, datasets=datasets)
         new_scene['new_ds'] = new_scene['comp19'].copy()
 
         scene.load(['ds1'])


### PR DESCRIPTION
As mentioned in #1562, the `Scene.copy` method would replace the `.wishlist` of the new Scene with a list of the selected datasets (those provided as `datasets=`). This causes issues when you want to generate a composite later (like after resampling) because the composite is no longer in the wishlist so the Scene has no idea that you want to generate it.

A longer term or better solution would be to look at the dependency tree and if `datasets=` includes a composite that hasn't been generated, then make sure to include its dependencies. I may look into doing this in a future PR, but no promises.

Lastly, doing these changes and updating the tests made me realize that the resample code could be simpler (and was actually broken). So those changes are included here also.

 - [x] Closes #1562  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

