### PR TITLE
Fix satellite altitude being in kilometers in ABI L2 reader

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -41,6 +41,7 @@ The following people have made contributions to this project:
 - [Panu Lahtinen (pnuu)](https://github.com/pnuu)
 - [Thomas Leppelt (m4sth0)](https://github.com/m4sth0)
 - [Andrea Meraner (ameraner)](https://github.com/ameraner)
+- [Aronne Merrelli (aronnem)](https://github.com/aronnem)
 - [Lucas Meyer (LTMeyer)](https://github.com/LTMeyer)
 - [Ondrej Nedelcev (nedelceo)](https://github.com/nedelceo)
 - [Oana Nicola](https://github.com/)

--- a/satpy/readers/abi_l2_nc.py
+++ b/satpy/readers/abi_l2_nc.py
@@ -46,7 +46,7 @@ class NC_ABI_L2(NC_ABI_BASE):
                                'units': _units,
                                'satellite_latitude': float(self.nc['nominal_satellite_subpoint_lat']),
                                'satellite_longitude': float(self.nc['nominal_satellite_subpoint_lon']),
-                               'satellite_altitude': float(self.nc['nominal_satellite_height'])})
+                               'satellite_altitude': float(self.nc['nominal_satellite_height']) * 1000.})
 
         variable.attrs.update(key.to_dict())
 

--- a/satpy/tests/reader_tests/test_abi_l2_nc.py
+++ b/satpy/tests/reader_tests/test_abi_l2_nc.py
@@ -67,7 +67,7 @@ class Test_NC_ABI_L2_base(unittest.TestCase):
                 'HT': ht_da,
                 "nominal_satellite_subpoint_lat": np.array(0.0),
                 "nominal_satellite_subpoint_lon": np.array(-89.5),
-                "nominal_satellite_height": np.array(35786020.),
+                "nominal_satellite_height": np.array(35786.02),
                 "spatial_resolution": "10km at nadir",
 
             },


### PR DESCRIPTION
The attribute data assumes the satellite altitude is stored
in meters, while the ABI L2 data stores this value in km;
we simply need to insert factor of 1000 to convert the units.
This matches what happens in the ABI L1b reader.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->
