### PR TITLE
Fix offline aux download not working for modifiers

### DIFF
--- a/satpy/aux_download.py
+++ b/satpy/aux_download.py
@@ -198,6 +198,13 @@ def _find_registerable_files_compositors(sensors=None):
         sensors = composite_loader.all_composite_sensors()
     if sensors:
         composite_loader.load_compositors(sensors)
+    _register_modifier_files(composite_loader)
+
+
+def _register_modifier_files(composite_loader):
+    for mod_sensor_dict in composite_loader.modifiers.values():
+        for mod_cls, mod_props in mod_sensor_dict.values():
+            mod_cls(**mod_props)
 
 
 def _find_registerable_files_readers(readers=None):
@@ -296,6 +303,8 @@ class DataDownloadMixin:
         'reader': 'readers',
         'writer': 'writers',
         'composit': 'composites',
+        'modifi': 'modifiers',
+        'corr': 'modifiers',
     }
 
     @property

--- a/satpy/aux_download.py
+++ b/satpy/aux_download.py
@@ -203,8 +203,12 @@ def _find_registerable_files_compositors(sensors=None):
 
 def _register_modifier_files(composite_loader):
     for mod_sensor_dict in composite_loader.modifiers.values():
-        for mod_cls, mod_props in mod_sensor_dict.values():
-            mod_cls(**mod_props)
+        for mod_name, (mod_cls, mod_props) in mod_sensor_dict.items():
+            try:
+                mod_cls(**mod_props)
+            except (ValueError, RuntimeError):
+                logger.error("Could not initialize modifier '%s' for "
+                             "auxiliary download registration.", mod_name)
 
 
 def _find_registerable_files_readers(readers=None):

--- a/satpy/tests/test_data_download.py
+++ b/satpy/tests/test_data_download.py
@@ -29,10 +29,18 @@ README_URL = "https://raw.githubusercontent.com/pytroll/satpy/master/README.rst"
 
 def _setup_custom_composite_config(base_dir):
     from satpy.composites import StaticImageCompositor
+    from satpy.modifiers.atmosphere import ReflectanceCorrector
     composite_config = base_dir.mkdir("composites").join("visir.yaml")
     with open(composite_config, 'w') as comp_file:
         yaml.dump({
             "sensor_name": "visir",
+            "modifiers": {
+                "test_modifier": {
+                    "modifier": ReflectanceCorrector,
+                    "url": README_URL,
+                    "known_hash": None,
+                },
+            },
             "composites": {
                 "test_static": {
                     "compositor": StaticImageCompositor,
@@ -103,6 +111,13 @@ def _get_comp_find_conditions(comp_sensors, found_files):
     return comp_cond
 
 
+def _get_mod_find_conditions(comp_sensors, found_files):
+    mod_cond = 'modifiers/README.rst' in found_files
+    if comp_sensors is not None and not comp_sensors:
+        mod_cond = not mod_cond
+    return mod_cond
+
+
 class TestDataDownload:
     """Test basic data downloading functionality."""
 
@@ -135,6 +150,8 @@ class TestDataDownload:
             assert w_cond2
             comp_cond = _get_comp_find_conditions(comp_sensors, found_files)
             assert comp_cond
+            mod_cond = _get_mod_find_conditions(comp_sensors, found_files)
+            assert mod_cond
 
     def test_limited_find_registerable(self):
         """Test that find_registerable doesn't find anything when limited."""

--- a/satpy/tests/test_data_download.py
+++ b/satpy/tests/test_data_download.py
@@ -86,36 +86,32 @@ writer:
 """.format(README_URL, README_URL))
 
 
-def _get_reader_find_conditions(readers, found_files):
+def _assert_reader_files_downloaded(readers, found_files):
     r_cond1 = 'readers/README.rst' in found_files
     r_cond2 = 'readers/README2.rst' in found_files
     if readers is not None and not readers:
-        r_cond1 = not r_cond1
-        r_cond2 = not r_cond2
-    return r_cond1, r_cond2
+        assert not r_cond1
+        assert not r_cond2
 
 
-def _get_writer_find_conditions(writers, found_files):
+def _assert_writer_files_downloaded(writers, found_files):
     w_cond1 = 'writers/README.rst' in found_files
     w_cond2 = 'writers/README2.rst' in found_files
     if writers is not None and not writers:
-        w_cond1 = not w_cond1
-        w_cond2 = not w_cond2
-    return w_cond1, w_cond2
+        assert not w_cond1
+        assert not w_cond2
 
 
-def _get_comp_find_conditions(comp_sensors, found_files):
+def _assert_comp_files_downloaded(comp_sensors, found_files):
     comp_cond = 'composites/README.rst' in found_files
     if comp_sensors is not None and not comp_sensors:
-        comp_cond = not comp_cond
-    return comp_cond
+        assert not comp_cond
 
 
-def _get_mod_find_conditions(comp_sensors, found_files):
+def _assert_mod_files_downloaded(comp_sensors, found_files):
     mod_cond = 'modifiers/README.rst' in found_files
     if comp_sensors is not None and not comp_sensors:
-        mod_cond = not mod_cond
-    return mod_cond
+        assert not mod_cond
 
 
 class TestDataDownload:
@@ -142,16 +138,10 @@ class TestDataDownload:
                 composite_sensors=comp_sensors,
             )
 
-            r_cond1, r_cond2 = _get_reader_find_conditions(readers, found_files)
-            assert r_cond1
-            assert r_cond2
-            w_cond1, w_cond2 = _get_writer_find_conditions(writers, found_files)
-            assert w_cond1
-            assert w_cond2
-            comp_cond = _get_comp_find_conditions(comp_sensors, found_files)
-            assert comp_cond
-            mod_cond = _get_mod_find_conditions(comp_sensors, found_files)
-            assert mod_cond
+            _assert_reader_files_downloaded(readers, found_files)
+            _assert_writer_files_downloaded(writers, found_files)
+            _assert_comp_files_downloaded(comp_sensors, found_files)
+            _assert_mod_files_downloaded(comp_sensors, found_files)
 
     def test_limited_find_registerable(self):
         """Test that find_registerable doesn't find anything when limited."""


### PR DESCRIPTION
See #1633 for details. This adds an extra step to the offline registration so that all modifier classes are created (without any dependent information since we don't have it yet). This should work in 99% of cases, but may fail if the `__init__` of the modifier is actually using the name/DataID of the dataset it is going to modify.

 - [x] Closes #1633 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
