### PR TITLE
Make FSFile open in bytes mode

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -581,9 +581,9 @@ class FSFile(os.PathLike):
         This is read-only.
         """
         try:
-            return self._fs.open(self._file)
+            return self._fs.open(self._file, mode="rb")
         except AttributeError:
-            return open(self._file)
+            return open(self._file, mode="rb")
 
     def __lt__(self, other):
         """Implement ordering.

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -575,15 +575,15 @@ class FSFile(os.PathLike):
         """Representation of the object."""
         return '<FSFile "' + str(self._file) + '">'
 
-    def open(self):
+    def open(self, **kwargs):
         """Open the file.
 
         This is read-only.
         """
         try:
-            return self._fs.open(self._file, mode="rb")
+            return self._fs.open(self._file, **kwargs)
         except AttributeError:
-            return open(self._file, mode="rb")
+            return open(self._file, **kwargs)
 
     def __lt__(self, other):
         """Implement ordering.
@@ -626,7 +626,7 @@ class FSFile(os.PathLike):
 def open_file_or_filename(unknown_file_thing):
     """Try to open the *unknown_file_thing*, otherwise return the filename."""
     try:
-        f_obj = unknown_file_thing.open()
+        f_obj = unknown_file_thing.open(mode="rb")
     except AttributeError:
         f_obj = unknown_file_thing
     return f_obj

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -138,6 +138,20 @@ class TestScene:
         with pytest.raises(ValueError, match="No supported files found"):
             Scene(filenames=[fsf], reader=[])
 
+    def test_fsfile_bytes(self, tmp_path):
+        """Test that FSFile opens files in bytes mode."""
+        from satpy.readers import FSFile
+
+        name = tmp_path / "OR_ABI-L1b-RadF-M6C14_G16_s19000010000000_e19000010005000_c20403662359590.nc"
+        fsf = FSFile(name)
+        with pytest.raises(FileNotFoundError):
+            Scene(filenames=[fsf], reader=["abi_l1b"])
+        name.touch()
+        # Raises a ValueError if opened in bytes mode, a TypeError if opened in
+        # text mode.
+        with pytest.raises(ValueError, match="cannot guess the engine"):
+            Scene(filenames=[fsf], reader=["abi_l1b"])
+
     # TODO: Rewrite this test for the 'find_files_and_readers' function
     # def test_create_reader_instances_with_sensor(self):
     #     import satpy.scene

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -152,6 +152,13 @@ class TestScene:
         with pytest.raises(ValueError, match="cannot guess the engine"):
             Scene(filenames=[fsf], reader=["abi_l1b"])
 
+        # test that it's also true when passing a fs instance
+        from fsspec.implementations.local import LocalFileSystem
+        lfs = LocalFileSystem()
+        fsf = FSFile(name, fs=lfs)
+        with pytest.raises(ValueError, match="cannot guess the engine"):
+            Scene(filenames=[fsf], reader=["abi_l1b"])
+
     # TODO: Rewrite this test for the 'find_files_and_readers' function
     # def test_create_reader_instances_with_sensor(self):
     #     import satpy.scene


### PR DESCRIPTION
When FSFile opens a file, it should open it in bytes mode, not in text
mode.  Most of our data are binary.  If there are any readers that need
files opened in text mode we need to find a way to deal with that.

The unit test is not entirely desirable, because all it does is create
an empty file and see that the expected exception is raised.  I did not
succeed in suppressing the warning issued by pytest that another
exception is raised on destroying the object.  The catch_warnings
context manager couldn't help me here, because this destruction happens
after the unit test has already completed (I think).

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #1641 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
