### PR TITLE
Fix combine_metadata not handling lists of different sizes

### DIFF
--- a/satpy/dataset/metadata.py
+++ b/satpy/dataset/metadata.py
@@ -177,5 +177,5 @@ def _all_list_of_arrays_equal(array_lists):
 def _all_values_equal(values):
     try:
         return _pairwise_all(nan_allclose, values)
-    except TypeError:
+    except (ValueError, TypeError):
         return _pairwise_all(eq, values)

--- a/satpy/tests/test_dataset.py
+++ b/satpy/tests/test_dataset.py
@@ -167,8 +167,25 @@ class TestCombineMetadata(unittest.TestCase):
               ]
         assert "quality" not in combine_metadata(*dts6)
 
+    def test_combine_lists(self):
+        """Test combine metadata with different types of lists."""
+        from satpy.dataset.metadata import combine_metadata
+        metadatas = [
+            {'prerequisites': [1, 2, 3, 4]},
+            {'prerequisites': [1, 2, 3, 4]},
+        ]
+        res = combine_metadata(*metadatas)
+        assert res['prerequisites'] == [1, 2, 3, 4]
+
+        metadatas = [
+            {'prerequisites': [1, 2, 3, 4]},
+            {'prerequisites': []},
+        ]
+        res = combine_metadata(*metadatas)
+        assert 'prerequisites' not in res
+
     def test_combine_identical_numpy_scalars(self):
-        """Test combining idendical fill values."""
+        """Test combining identical fill values."""
         from satpy.dataset.metadata import combine_metadata
         test_metadata = [{'_FillValue': np.uint16(42)}, {'_FillValue': np.uint16(42)}]
         assert combine_metadata(*test_metadata) == {'_FillValue': 42}

--- a/satpy/tests/test_dataset.py
+++ b/satpy/tests/test_dataset.py
@@ -167,8 +167,8 @@ class TestCombineMetadata(unittest.TestCase):
               ]
         assert "quality" not in combine_metadata(*dts6)
 
-    def test_combine_lists(self):
-        """Test combine metadata with different types of lists."""
+    def test_combine_lists_identical(self):
+        """Test combine metadata with identical lists."""
         from satpy.dataset.metadata import combine_metadata
         metadatas = [
             {'prerequisites': [1, 2, 3, 4]},
@@ -177,9 +177,29 @@ class TestCombineMetadata(unittest.TestCase):
         res = combine_metadata(*metadatas)
         assert res['prerequisites'] == [1, 2, 3, 4]
 
+    def test_combine_lists_same_size_diff_values(self):
+        """Test combine metadata with lists with different values."""
+        from satpy.dataset.metadata import combine_metadata
+        metadatas = [
+            {'prerequisites': [1, 2, 3, 4]},
+            {'prerequisites': [1, 2, 3, 5]},
+        ]
+        res = combine_metadata(*metadatas)
+        assert 'prerequisites' not in res
+
+    def test_combine_lists_different_size(self):
+        """Test combine metadata with different size lists."""
+        from satpy.dataset.metadata import combine_metadata
         metadatas = [
             {'prerequisites': [1, 2, 3, 4]},
             {'prerequisites': []},
+        ]
+        res = combine_metadata(*metadatas)
+        assert 'prerequisites' not in res
+
+        metadatas = [
+            {'prerequisites': [1, 2, 3, 4]},
+            {'prerequisites': [1, 2, 3]},
         ]
         res = combine_metadata(*metadatas)
         assert 'prerequisites' not in res


### PR DESCRIPTION
The `combine_metadata` utility function doesn't seem to handle lists of different sizes. Before this PR you'd get something like this:

```
~/repos/git/satpy/satpy/dataset/metadata.py in _all_values_equal(values)
    179 def _all_values_equal(values):
    180     try:
--> 181         return _pairwise_all(nan_allclose, values)
    182     except TypeError:
    183         return _pairwise_all(eq, values)

~/repos/git/satpy/satpy/dataset/metadata.py in _pairwise_all(func, values)
    144 def _pairwise_all(func, values):
    145     for value in values[1:]:
--> 146         if not func(values[0], value):
    147             return False
    148     return True

<__array_function__ internals> in allclose(*args, **kwargs)

~/miniconda3/envs/satpy_py37/lib/python3.7/site-packages/numpy/core/numeric.py in allclose(a, b, rtol, atol, equal_nan)
   2254 
   2255     """
-> 2256     res = all(isclose(a, b, rtol=rtol, atol=atol, equal_nan=equal_nan))
   2257     return bool(res)
   2258 

<__array_function__ internals> in isclose(*args, **kwargs)

~/miniconda3/envs/satpy_py37/lib/python3.7/site-packages/numpy/core/numeric.py in isclose(a, b, rtol, atol, equal_nan)
   2363     yfin = isfinite(y)
   2364     if all(xfin) and all(yfin):
-> 2365         return within_tol(x, y, atol, rtol)
   2366     else:
   2367         finite = xfin & yfin

~/miniconda3/envs/satpy_py37/lib/python3.7/site-packages/numpy/core/numeric.py in within_tol(x, y, atol, rtol)
   2344     def within_tol(x, y, atol, rtol):
   2345         with errstate(invalid='ignore'):
-> 2346             return less_equal(abs(x-y), atol + rtol * abs(y))
   2347 
   2348     x = asanyarray(a)

ValueError: operands could not be broadcast together with shapes (4,) (0,) 
```

This PR fixes this by catching this ValueError when trying to compare lists. I wanted to have a simple additional check like `if len(x) != len(y): return False`, but the function that is triggering this issue is meant to compare *any* value including those that may not have a `len` parameter.

 - [x] Closes #1632 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

