### PR TITLE
Add id for GOMS3/Electro-l n3

### DIFF
--- a/satpy/readers/electrol_hrit.py
+++ b/satpy/readers/electrol_hrit.py
@@ -243,8 +243,12 @@ class HRITGOMSEpilogueFileHandler(HRITFileHandler):
 C1 = 1.19104273e-5
 C2 = 1.43877523
 
+
+# Defined in MSG Level 1.5 Image Data Format Description
+# https://www-cdn.eumetsat.int/files/2020-05/pdf_ten_05105_msg_img_data.pdf
 SPACECRAFTS = {19001: "Electro-L N1",
-               19002: "Electro-L N2"}
+               19002: "Electro-L N2",
+               19003: "Electro-L N3"}
 
 
 class HRITGOMSFileHandler(HRITFileHandler):


### PR DESCRIPTION
This adds the Electro l n3 ID to the reader.

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
