### PR TITLE
Add new piecewise_linear_stretch enhancement method

### DIFF
--- a/doc/source/enhancements.rst
+++ b/doc/source/enhancements.rst
@@ -63,11 +63,13 @@ invert
 crefl_scaling
 -------------
 
-interp_scaling
---------------
+Deprecated. Use 'piecewise_linear_stretch' instead.
+
+piecewise_linear_stretch
+------------------------
 
 Use :func:`numpy.interp` to linearly interpolate data to a new range. See
-:func:`satpy.enhancements.interp_scaling` for more information and examples.
+:func:`satpy.enhancements.piecewise_linear_stretch` for more information and examples.
 
 cira_stretch
 ------------

--- a/doc/source/enhancements.rst
+++ b/doc/source/enhancements.rst
@@ -63,6 +63,12 @@ invert
 crefl_scaling
 -------------
 
+interp_scaling
+--------------
+
+Use :func:`numpy.interp` to linearly interpolate data to a new range. See
+:func:`satpy.enhancements.interp_scaling` for more information and examples.
+
 cira_stretch
 ------------
 

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -121,7 +121,7 @@ def piecewise_linear_stretch(
         xp: ArrayLike,
         fp: ArrayLike,
         coordinate_divisor: Number = None,
-        **kwargs):
+        **kwargs) -> xr.DataArray:
     """Apply 1D linear interpolation.
 
     This uses :func:`numpy.interp` mapped over the provided dask array chunks.

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -113,14 +113,14 @@ def crefl_scaling(img, **kwargs):
     LOG.debug("Applying the crefl_scaling")
     warnings.warn("'crefl_scaling' is deprecated, use 'piecewise_linear_stretch' instead.", DeprecationWarning)
     img.data.data = img.data.data / 100
-    return piecewise_linear_stretch(img, xp=kwargs['idx'], fp=kwargs['sc'], reference_divisor=255)
+    return piecewise_linear_stretch(img, xp=kwargs['idx'], fp=kwargs['sc'], reference_scale_factor=255)
 
 
 def piecewise_linear_stretch(
         img: XRImage,
         xp: ArrayLike,
         fp: ArrayLike,
-        reference_divisor: Number = None,
+        reference_scale_factor: Number = None,
         **kwargs) -> xr.DataArray:
     """Apply 1D linear interpolation.
 
@@ -133,7 +133,7 @@ def piecewise_linear_stretch(
             interpolation. This is passed directly to :func:`numpy.interp`.
         fp: Target reference values of the output image data points used for
             interpolation. This is passed directly to :func:`numpy.interp`.
-        reference_divisor: Divide ``xp`` and ``fp`` by this value before
+        reference_scale_factor: Divide ``xp`` and ``fp`` by this value before
             passing using for interpolation. This is a convenience to make
             matching normalized image data to interp coordinates or to avoid
             floating point precision errors in YAML configuration files.
@@ -156,13 +156,13 @@ def piecewise_linear_stretch(
                   kwargs:
                    xp: [0., 25., 55., 100., 255.]
                    fp: [0., 90., 140., 175., 255.]
-                   reference_divisor: 255
+                   reference_scale_factor: 255
 
     """
     LOG.debug("Applying the piecewise_linear_stretch")
-    if reference_divisor is not None:
-        xp = np.asarray(xp) / reference_divisor
-        fp = np.asarray(fp) / reference_divisor
+    if reference_scale_factor is not None:
+        xp = np.asarray(xp) / reference_scale_factor
+        fp = np.asarray(fp) / reference_scale_factor
 
     def func(band_data, xp, fp, index=None):
         # Interpolate band on [0,1] using "lazy" arrays (put calculations off until the end).

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -111,12 +111,12 @@ def apply_enhancement(data, func, exclude=None, separate=False,
 def crefl_scaling(img, **kwargs):
     """Apply non-linear stretch used by CREFL-based RGBs."""
     LOG.debug("Applying the crefl_scaling")
-    warnings.warn("'crefl_scaling' is deprecated, use 'interp_scaling' instead.", DeprecationWarning)
+    warnings.warn("'crefl_scaling' is deprecated, use 'piecewise_linear_stretch' instead.", DeprecationWarning)
     img.data.data = img.data.data / 100
-    return interp_scaling(img, xp=kwargs['idx'], fp=kwargs['sc'], coordinate_divisor=255)
+    return piecewise_linear_stretch(img, xp=kwargs['idx'], fp=kwargs['sc'], coordinate_divisor=255)
 
 
-def interp_scaling(
+def piecewise_linear_stretch(
         img: XRImage,
         xp: ArrayLike,
         fp: ArrayLike,
@@ -129,9 +129,9 @@ def interp_scaling(
     Args:
         img: Image data to be scaled. It is assumed the data is already
             normalized between 0 and 1.
-        xp: Input values of the image data points used for interpolation.
-            This is passed directly to :func:`numpy.interp`.
-        fp: Target values of the output image data points used for
+        xp: Input reference values of the image data points used for
+            interpolation. This is passed directly to :func:`numpy.interp`.
+        fp: Target reference values of the output image data points used for
             interpolation. This is passed directly to :func:`numpy.interp`.
         coordinate_divisor: Divide ``xp`` and ``fp`` by this value before
             passing using for interpolation. This is a convenience to make
@@ -152,14 +152,14 @@ def interp_scaling(
                   method: !!python/name:satpy.enhancements.stretch
                   kwargs: {stretch: 'crude', min_stretch: 0., max_stretch: 100.}
                 - name: Linear interpolation
-                  method: !!python/name:satpy.enhancements.interp_scaling
+                  method: !!python/name:satpy.enhancements.piecewise_linear_stretch
                   kwargs:
                    xp: [0., 25., 55., 100., 255.]
                    fp: [0., 90., 140., 175., 255.]
                    coordinate_divisor: 255
 
     """
-    LOG.debug("Applying the interp_scaling")
+    LOG.debug("Applying the piecewise_linear_stretch")
     if coordinate_divisor is not None:
         xp = np.asarray(xp) / coordinate_divisor
         fp = np.asarray(fp) / coordinate_divisor

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -134,7 +134,7 @@ def piecewise_linear_stretch(
         fp: Target reference values of the output image data points used for
             interpolation. This is passed directly to :func:`numpy.interp`.
         reference_scale_factor: Divide ``xp`` and ``fp`` by this value before
-            passing using for interpolation. This is a convenience to make
+            using them for interpolation. This is a convenience to make
             matching normalized image data to interp coordinates or to avoid
             floating point precision errors in YAML configuration files.
             If not provided, ``xp`` and ``fp`` will not be modified.

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -140,7 +140,8 @@ def piecewise_linear_stretch(
             If not provided, ``xp`` and ``fp`` will not be modified.
 
     Examples:
-        YAML example:
+        This example YAML uses a 'crude' stretch to pre-scale the RGB data
+        and then uses reference points in a 0-255 range.
 
         .. code-block:: yaml
 
@@ -157,6 +158,22 @@ def piecewise_linear_stretch(
                    xp: [0., 25., 55., 100., 255.]
                    fp: [0., 90., 140., 175., 255.]
                    reference_scale_factor: 255
+
+        This example YAML does the same as the above on the C02 channel, but
+        the interpolation reference points are already adjusted for the input
+        reflectance (%) data and the output range (0 to 1).
+
+        .. code-block:: yaml
+
+              c02_linear_interpolation:
+                sensor: abi
+                standard_name: C02
+                operations:
+                - name: Linear interpolation
+                  method: !!python/name:satpy.enhancements.piecewise_linear_stretch
+                  kwargs:
+                   xp: [0., 9.8039, 21.5686, 39.2157, 100.]
+                   fp: [0., 0.3529, 0.5490, 0.6863, 1.0]
 
     """
     LOG.debug("Applying the piecewise_linear_stretch")

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -113,14 +113,14 @@ def crefl_scaling(img, **kwargs):
     LOG.debug("Applying the crefl_scaling")
     warnings.warn("'crefl_scaling' is deprecated, use 'piecewise_linear_stretch' instead.", DeprecationWarning)
     img.data.data = img.data.data / 100
-    return piecewise_linear_stretch(img, xp=kwargs['idx'], fp=kwargs['sc'], coordinate_divisor=255)
+    return piecewise_linear_stretch(img, xp=kwargs['idx'], fp=kwargs['sc'], reference_divisor=255)
 
 
 def piecewise_linear_stretch(
         img: XRImage,
         xp: ArrayLike,
         fp: ArrayLike,
-        coordinate_divisor: Number = None,
+        reference_divisor: Number = None,
         **kwargs) -> xr.DataArray:
     """Apply 1D linear interpolation.
 
@@ -133,7 +133,7 @@ def piecewise_linear_stretch(
             interpolation. This is passed directly to :func:`numpy.interp`.
         fp: Target reference values of the output image data points used for
             interpolation. This is passed directly to :func:`numpy.interp`.
-        coordinate_divisor: Divide ``xp`` and ``fp`` by this value before
+        reference_divisor: Divide ``xp`` and ``fp`` by this value before
             passing using for interpolation. This is a convenience to make
             matching normalized image data to interp coordinates or to avoid
             floating point precision errors in YAML configuration files.
@@ -156,13 +156,13 @@ def piecewise_linear_stretch(
                   kwargs:
                    xp: [0., 25., 55., 100., 255.]
                    fp: [0., 90., 140., 175., 255.]
-                   coordinate_divisor: 255
+                   reference_divisor: 255
 
     """
     LOG.debug("Applying the piecewise_linear_stretch")
-    if coordinate_divisor is not None:
-        xp = np.asarray(xp) / coordinate_divisor
-        fp = np.asarray(fp) / coordinate_divisor
+    if reference_divisor is not None:
+        xp = np.asarray(xp) / reference_divisor
+        fp = np.asarray(fp) / reference_divisor
 
     def func(band_data, xp, fp, index=None):
         # Interpolate band on [0,1] using "lazy" arrays (put calculations off until the end).

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -24,18 +24,16 @@ enhancements:
     name: true_color_crefl
     standard_name: true_color
     operations:
-    - name: crefl_scaling
-      method: !!python/name:satpy.enhancements.crefl_scaling
-      kwargs:
-#      Polar2Grid's scaling: "Preferred".
-       idx: [0., 25., 55., 100., 255.]
-       sc: [0., 90., 140., 175., 255.]
-#       Ralph's new scaling: Looks darker.
-#       idx: [0., 30., 60., 120., 190., 255.]
-#       sc: [0., 100., 128., 188., 223., 255.]
-#       Ralph's old scaling: Looks lighter.
-#       idx: [0., 30., 60., 120., 190., 255.]
-#       sc: [0, 110, 160, 210, 240, 255]
+      - name: reflectance_range
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs: {stretch: 'crude', min_stretch: 0., max_stretch: 100.}
+      - name: linear interpolation
+        method: !!python/name:satpy.enhancements.interp_scaling
+        kwargs:
+        # Polar2Grid's "Preferred" scaling
+         xp: [0., 25., 55., 100., 255.]
+         fp: [0., 90., 140., 175., 255.]
+         coordinate_divisor: 255
   overview_default:
     standard_name: overview
     operations:

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -33,7 +33,7 @@ enhancements:
         # Polar2Grid's "Preferred" scaling
          xp: [0., 25., 55., 100., 255.]
          fp: [0., 90., 140., 175., 255.]
-         coordinate_divisor: 255
+         reference_divisor: 255
   overview_default:
     standard_name: overview
     operations:

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -28,7 +28,7 @@ enhancements:
         method: !!python/name:satpy.enhancements.stretch
         kwargs: {stretch: 'crude', min_stretch: 0., max_stretch: 100.}
       - name: linear interpolation
-        method: !!python/name:satpy.enhancements.interp_scaling
+        method: !!python/name:satpy.enhancements.piecewise_linear_stretch
         kwargs:
         # Polar2Grid's "Preferred" scaling
          xp: [0., 25., 55., 100., 255.]

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -33,7 +33,7 @@ enhancements:
         # Polar2Grid's "Preferred" scaling
          xp: [0., 25., 55., 100., 255.]
          fp: [0., 90., 140., 175., 255.]
-         reference_divisor: 255
+         reference_scale_factor: 255
   overview_default:
     standard_name: overview
     operations:

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -142,12 +142,12 @@ class TestEnhancementStretch(unittest.TestCase):
                                sc=[0., 90., 140., 175., 255.])
 
     def test_interp_scaling(self):
-        """Test the interp_scaling enhancement function."""
-        from satpy.enhancements import interp_scaling
+        """Test the piecewise_linear_stretch enhancement function."""
+        from satpy.enhancements import piecewise_linear_stretch
         expected = np.array([[
             [np.nan, 0., 0., 0.44378, 0.631734],
             [0.737562, 0.825041, 0.912521, 1., 1.]]])
-        self._test_enhancement(interp_scaling,
+        self._test_enhancement(piecewise_linear_stretch,
                                self.ch2 / 100.0,
                                expected,
                                xp=[0., 25., 55., 100., 255.],

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -152,7 +152,7 @@ class TestEnhancementStretch(unittest.TestCase):
                                expected,
                                xp=[0., 25., 55., 100., 255.],
                                fp=[0., 90., 140., 175., 255.],
-                               coordinate_divisor=255,
+                               reference_divisor=255,
                                )
 
     def test_btemp_threshold(self):

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -141,6 +141,20 @@ class TestEnhancementStretch(unittest.TestCase):
         self._test_enhancement(crefl_scaling, self.ch2, expected, idx=[0., 25., 55., 100., 255.],
                                sc=[0., 90., 140., 175., 255.])
 
+    def test_interp_scaling(self):
+        """Test the interp_scaling enhancement function."""
+        from satpy.enhancements import interp_scaling
+        expected = np.array([[
+            [np.nan, 0., 0., 0.44378, 0.631734],
+            [0.737562, 0.825041, 0.912521, 1., 1.]]])
+        self._test_enhancement(interp_scaling,
+                               self.ch2 / 100.0,
+                               expected,
+                               xp=[0., 25., 55., 100., 255.],
+                               fp=[0., 90., 140., 175., 255.],
+                               coordinate_divisor=255,
+                               )
+
     def test_btemp_threshold(self):
         """Test applying the cira_stretch."""
         from satpy.enhancements import btemp_threshold

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -141,7 +141,7 @@ class TestEnhancementStretch(unittest.TestCase):
         self._test_enhancement(crefl_scaling, self.ch2, expected, idx=[0., 25., 55., 100., 255.],
                                sc=[0., 90., 140., 175., 255.])
 
-    def test_interp_scaling(self):
+    def test_piecewise_linear_stretch(self):
         """Test the piecewise_linear_stretch enhancement function."""
         from satpy.enhancements import piecewise_linear_stretch
         expected = np.array([[

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -152,7 +152,7 @@ class TestEnhancementStretch(unittest.TestCase):
                                expected,
                                xp=[0., 25., 55., 100., 255.],
                                fp=[0., 90., 140., 175., 255.],
-                               reference_divisor=255,
+                               reference_scale_factor=255,
                                )
 
     def test_btemp_threshold(self):


### PR DESCRIPTION
This is an improvement to the existing `crefl_scaling` enhancement function that was added in a hurry to replace functionality used by the CSPP Polar2Grid project. This new function `interp_scaling` is more flexible and doesn't assume anything about the input data (where as `crefl_scaling` always divided by 100 to convert % to albedo).

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
