### PR TITLE
Fix requiring newer numpy just for typing annotations

### DIFF
--- a/satpy/_compat.py
+++ b/satpy/_compat.py
@@ -26,3 +26,10 @@ except ImportError:
     def cached_property(func):
         """Port back functools.cached_property."""
         return property(lru_cache(maxsize=None)(func))
+
+
+try:
+    from numpy.typing import ArrayLike  # noqa
+except ImportError:
+    # numpy <1.20
+    from numpy import ndarray as ArrayLike  # noqa

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -25,12 +25,7 @@ from numbers import Number
 import logging
 import warnings
 from functools import partial
-
-try:
-    from numpy.typing import ArrayLike
-except ImportError:
-    # numpy <1.20
-    ArrayLike = np.ndarray
+from satpy._compat import ArrayLike
 
 LOG = logging.getLogger(__name__)
 

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -17,7 +17,6 @@
 """Enhancements."""
 
 import numpy as np
-from numpy.typing import ArrayLike
 import xarray as xr
 import dask
 import dask.array as da
@@ -26,6 +25,12 @@ from numbers import Number
 import logging
 import warnings
 from functools import partial
+
+try:
+    from numpy.typing import ArrayLike
+except ImportError:
+    # numpy <1.20
+    ArrayLike = np.ndarray
 
 LOG = logging.getLogger(__name__)
 


### PR DESCRIPTION
The `numpy.typing` subpackage was added in numpy 1.20 it seems. Satpy should still be able to support older versions of numpy. This PR adds a try/except around the `numpy.typing` that I added in #1646 for these older versions.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
