### PR TITLE
Set specific start and end times for channels 3A and 3B.

### DIFF
--- a/satpy/readers/aapp_l1b.py
+++ b/satpy/readers/aapp_l1b.py
@@ -113,19 +113,21 @@ class AVHRRAAPPL1BFile(BaseFileHandler):
             activated[channel_name] = bool(status >> bit & 1)
         return activated
 
+    def _get_time_for_idx(self, idx):
+        """Get the time for the observation at scanline(s) idx."""
+        return datetime(self._data['scnlinyr'][idx], 1, 1) + timedelta(
+            days=int(self._data['scnlindy'][idx]) - 1,
+            milliseconds=int(self._data['scnlintime'][idx]))
+
     @property
     def start_time(self):
         """Get the time of the first observation."""
-        return datetime(self._data['scnlinyr'][0], 1, 1) + timedelta(
-            days=int(self._data['scnlindy'][0]) - 1,
-            milliseconds=int(self._data['scnlintime'][0]))
+        return self._get_time_for_idx(0)
 
     @property
     def end_time(self):
         """Get the time of the final observation."""
-        return datetime(self._data['scnlinyr'][-1], 1, 1) + timedelta(
-            days=int(self._data['scnlindy'][-1]) - 1,
-            milliseconds=int(self._data['scnlintime'][-1]))
+        return self._get_time_for_idx(-1)
 
     def get_dataset(self, key, info):
         """Get a dataset from the file."""

--- a/satpy/tests/reader_tests/test_aapp_l1b.py
+++ b/satpy/tests/reader_tests/test_aapp_l1b.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2020 Satpy developers
+# Copyright (c) 2020-2021 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -152,6 +152,19 @@ class TestAAPPL1BAllChannelsPresent(unittest.TestCase):
             key = make_dataid(name='latitude')
             res = fh.get_dataset(key, info)
             assert(np.all(res == 0))
+
+    def test_times(self):
+        """Test start time and end time are as expected."""
+        with tempfile.TemporaryFile() as tmpfile:
+            self._header.tofile(tmpfile)
+            tmpfile.seek(22016, 0)
+            self._data.tofile(tmpfile)
+
+            fh = AVHRRAAPPL1BFile(tmpfile, self.filename_info, self.filetype_info)
+            assert fh.start_time == datetime.datetime(
+                    2020, 1, 8, 8, 23, 15, 225000)
+            assert fh.end_time == datetime.datetime(
+                    2020, 1, 8, 8, 23, 15, 556000)
 
 
 class TestAAPPL1BChannel3AMissing(unittest.TestCase):


### PR DESCRIPTION
Set specific start and end times for channels 3A and 3B.

(Work in progress.)

 - [ ] Closes #1652<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
