### PR TITLE
Add parallax-corrected file patterns to the nwcsaf-geo reader

### DIFF
--- a/satpy/etc/readers/nwcsaf-geo.yaml
+++ b/satpy/etc/readers/nwcsaf-geo.yaml
@@ -8,23 +8,28 @@ reader:
 file_types:
     nc_nwcsaf_cma:
         file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
-        file_patterns: ['S_NWC_CMA_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc']
+        file_patterns: ['S_NWC_CMA_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc',
+                        'S_NWC_CMA_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z_PLAX.nc']
 
     nc_nwcsaf_ct:
         file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
-        file_patterns: ['S_NWC_CT_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc']
+        file_patterns: ['S_NWC_CT_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc',
+                        'S_NWC_CT_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z_PLAX.nc']
 
     nc_nwcsaf_ctth:
         file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
-        file_patterns: ['S_NWC_CTTH_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc']
+        file_patterns: ['S_NWC_CTTH_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc',
+                        'S_NWC_CTTH_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z_PLAX.nc']
 
     nc_nwcsaf_cmic:
         file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
-        file_patterns: ['S_NWC_CMIC_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc']
+        file_patterns: ['S_NWC_CMIC_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc',
+                        'S_NWC_CMIC_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z_PLAX.nc']
 
     nc_nwcsaf_pc:
         file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
-        file_patterns: ['S_NWC_PC_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc']
+        file_patterns: ['S_NWC_PC_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc',
+                        'S_NWC_PC_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z_PLAX.nc']
 
     nc_nwcsaf_crr:
         file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF


### PR DESCRIPTION
The nwcsaf-geo package is capable of producing parallax-corrected products. This PR adds the possibilitity to read these.

