### PR TITLE
Ignore raw metadata when combining metadata

### DIFF
--- a/satpy/dataset/metadata.py
+++ b/satpy/dataset/metadata.py
@@ -33,7 +33,8 @@ def combine_metadata(*metadata_objects, average_times=True):
     in them and consisting of datetime objects will be averaged. This
     is to handle cases where data were observed at almost the same time
     but not exactly.  In the interest of time, lazy arrays are compared by
-    object identity rather than by their contents.
+    object identity rather than by their contents. Raw dataset metadata
+    are excluded as well.
 
     Args:
         *metadata_objects: MetadataObject or dict objects to combine
@@ -49,6 +50,10 @@ def combine_metadata(*metadata_objects, average_times=True):
         return info_dicts[0].copy()
 
     shared_keys = _shared_keys(info_dicts)
+    try:
+        shared_keys.remove('raw_metadata')
+    except KeyError:
+        pass
 
     return _combine_shared_info(shared_keys, info_dicts, average_times)
 

--- a/satpy/dataset/metadata.py
+++ b/satpy/dataset/metadata.py
@@ -34,7 +34,7 @@ def combine_metadata(*metadata_objects, average_times=True):
     is to handle cases where data were observed at almost the same time
     but not exactly.  In the interest of time, lazy arrays are compared by
     object identity rather than by their contents. Raw dataset metadata
-    are excluded as well.
+    (`raw_metadata` attribute) are excluded as well.
 
     Args:
         *metadata_objects: MetadataObject or dict objects to combine

--- a/satpy/dataset/metadata.py
+++ b/satpy/dataset/metadata.py
@@ -50,10 +50,7 @@ def combine_metadata(*metadata_objects, average_times=True):
         return info_dicts[0].copy()
 
     shared_keys = _shared_keys(info_dicts)
-    try:
-        shared_keys.remove('raw_metadata')
-    except KeyError:
-        pass
+    shared_keys.discard('raw_metadata')
 
     return _combine_shared_info(shared_keys, info_dicts, average_times)
 

--- a/satpy/tests/test_dataset.py
+++ b/satpy/tests/test_dataset.py
@@ -250,7 +250,8 @@ class TestCombineMetadata(unittest.TestCase):
                                                 'cpp_reff_pal',
                                                 '-'],
                         'platform_name': 'NOAA-20',
-                        'sensor': {'viirs'}},
+                        'sensor': {'viirs'},
+                        'raw_metadata': {'foo': np.array([1, 2, 3])}},
                        {'_FillValue': np.nan,
                         'valid_range': np.array([0., 0.00032], dtype=np.float32),
                         'ancillary_variables': ['cpp_status_flag',
@@ -259,7 +260,8 @@ class TestCombineMetadata(unittest.TestCase):
                                                 'cpp_reff_pal',
                                                 '-'],
                         'platform_name': 'NOAA-20',
-                        'sensor': {'viirs'}})
+                        'sensor': {'viirs'},
+                        'raw_metadata': {'foo': np.array([2, 3, 4])}})
 
         expected = {'_FillValue': np.nan,
                     'valid_range': np.array([0., 0.00032], dtype=np.float32),


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
When combining metadata from multiple datasets, ignore the `raw_metadata` attribute. Usually these are nested dictionaries containing numpy arrays. You could compare them using `np.testing.assert_equal`, but

- raw metadata from another time/sensor will be different anyway
- this would slow down the code a little bit, because the raw metadata can be quite large
- we probably shouldn't use the numpy test module outside the unit tests

So I'd say it's not worth the effort.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Closes #1656  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [X] Tests added <!-- for all bug fixes or enhancements -->
