### PR TITLE
Ensure that orbital parameters are in a dict

### DIFF
--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -18,7 +18,6 @@
 """Interface for BaseFileHandlers."""
 
 from abc import ABCMeta
-import json
 
 import numpy as np
 from pyresample.geometry import SwathDefinition
@@ -64,7 +63,6 @@ class BaseFileHandler(metaclass=ABCMeta):
     @staticmethod
     def _combine(infos, func, *keys):
         res = {}
-        infos = [_str2dict(i) for i in infos]
         for key in keys:
             if key in infos[0]:
                 res[key] = func([i[key] for i in infos])
@@ -110,7 +108,7 @@ class BaseFileHandler(metaclass=ABCMeta):
             # Collect all available keys
             orb_params_comb = {}
             for d in orb_params:
-                orb_params_comb.update(_str2dict(d))
+                orb_params_comb.update(d)
 
             # Average known keys
             keys = ['projection_longitude', 'projection_latitude', 'projection_altitude',
@@ -257,10 +255,3 @@ class BaseFileHandler(metaclass=ABCMeta):
                 yield is_avail, ds_info
                 continue
             yield self.file_type_matches(ds_info['file_type']), ds_info
-
-
-def _str2dict(val):
-    """Convert string to dictionary."""
-    if isinstance(val, str):
-        val = json.loads(val)
-    return val

--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -18,6 +18,7 @@
 """Interface for BaseFileHandlers."""
 
 from abc import ABCMeta
+import json
 
 import numpy as np
 from pyresample.geometry import SwathDefinition
@@ -63,9 +64,11 @@ class BaseFileHandler(metaclass=ABCMeta):
     @staticmethod
     def _combine(infos, func, *keys):
         res = {}
+        infos = [_str2dict(i) for i in infos]
         for key in keys:
             if key in infos[0]:
                 res[key] = func([i[key] for i in infos])
+
         return res
 
     def combine_info(self, all_infos):
@@ -107,7 +110,7 @@ class BaseFileHandler(metaclass=ABCMeta):
             # Collect all available keys
             orb_params_comb = {}
             for d in orb_params:
-                orb_params_comb.update(d)
+                orb_params_comb.update(_str2dict(d))
 
             # Average known keys
             keys = ['projection_longitude', 'projection_latitude', 'projection_altitude',
@@ -254,3 +257,10 @@ class BaseFileHandler(metaclass=ABCMeta):
                 yield is_avail, ds_info
                 continue
             yield self.file_type_matches(ds_info['file_type']), ds_info
+
+
+def _str2dict(val):
+    """Convert string to dictionary."""
+    if isinstance(val, str):
+        val = json.loads(val)
+    return val

--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -180,6 +180,7 @@ Output:
 """
 import itertools
 import logging
+import json
 
 import xarray as xr
 
@@ -291,4 +292,13 @@ class SatpyCFFileHandler(BaseFileHandler):
         if name != ds_id['name']:
             data = data.rename(ds_id['name'])
         data.attrs.update(nc.attrs)  # For now add global attributes to all datasets
+        if "orbital_parameters" in data.attrs:
+            data.attrs["orbital_parameters"] = _str2dict(data.attrs["orbital_parameters"])
         return data
+
+
+def _str2dict(val):
+    """Convert string to dictionary."""
+    if isinstance(val, str):
+        val = json.loads(val)
+    return val

--- a/satpy/tests/reader_tests/test_fci_l2_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l2_nc.py
@@ -21,18 +21,13 @@
 import datetime
 import os
 import unittest
+import uuid
 from contextlib import suppress
 from unittest import mock
 
 import numpy as np
 from netCDF4 import Dataset
-
 from satpy.readers.fci_l2_nc import FciL2NCFileHandler, FciL2NCSegmentFileHandler, PRODUCT_DATA_DURATION_MINUTES
-
-TEST_FILE = 'test_file_fci_l2_nc.nc'
-SEG_TEST_FILE = 'test_seg_file_fci_l2_nc.nc'
-TEST_ERROR_FILE = 'test_error_file_fci_l2_nc.nc'
-TEST_BYTE_FILE = 'test_byte_file_fci_l2_nc.nc'
 
 
 class TestFciL2NCFileHandler(unittest.TestCase):
@@ -41,7 +36,9 @@ class TestFciL2NCFileHandler(unittest.TestCase):
     def setUp(self):
         """Set up the test by creating a test file and opening it with the reader."""
         # Easiest way to test the reader is to create a test netCDF file on the fly
-        with Dataset(TEST_FILE, 'w') as nc:
+        # Create unique filenames to prevent race conditions when tests are run in parallel
+        self.test_file = str(uuid.uuid4()) + ".nc"
+        with Dataset(self.test_file, 'w') as nc:
             # Create dimensions
             nc.createDimension('number_of_columns', 10)
             nc.createDimension('number_of_rows', 100)
@@ -82,7 +79,7 @@ class TestFciL2NCFileHandler(unittest.TestCase):
             mtg_geos_projection.perspective_point_height = 35786400.
 
         self.reader = FciL2NCFileHandler(
-            filename=TEST_FILE,
+            filename=self.test_file,
             filename_info={
                 'creation_time':  datetime.datetime(year=2017, month=9, day=20,
                                                     hour=12, minute=30, second=30),
@@ -94,9 +91,9 @@ class TestFciL2NCFileHandler(unittest.TestCase):
         """Remove the previously created test file."""
         # First delete the reader, forcing the file to be closed if still open
         del self.reader
-        # Then can safely remove it from the system
+        # Then we can safely remove the file from the system
         with suppress(OSError):
-            os.remove(TEST_FILE)
+            os.remove(self.test_file)
 
     def test_all_basic(self):
         """Test all basic functionalities."""
@@ -116,7 +113,7 @@ class TestFciL2NCFileHandler(unittest.TestCase):
 
         global_attributes = self.reader._get_global_attributes()
         expected_global_attributes = {
-            'filename': TEST_FILE,
+            'filename': self.test_file,
             'start_time': datetime.datetime(year=2017, month=9, day=20,
                                             hour=17, minute=30, second=40),
             'end_time': datetime.datetime(year=2017, month=9, day=20,
@@ -201,7 +198,8 @@ class TestFciL2NCSegmentFileHandler(unittest.TestCase):
     def setUp(self):
         """Set up the test by creating a test file and opening it with the reader."""
         # Easiest way to test the reader is to create a test netCDF file on the fly
-        with Dataset(SEG_TEST_FILE, 'w') as nc:
+        self.seg_test_file = str(uuid.uuid4()) + ".nc"
+        with Dataset(self.seg_test_file, 'w') as nc:
             # Create dimensions
             nc.createDimension('number_of_FoR_cols', 10)
             nc.createDimension('number_of_FoR_rows', 100)
@@ -239,7 +237,7 @@ class TestFciL2NCSegmentFileHandler(unittest.TestCase):
             test_dataset.units = 'test_units'
 
         self.segment_reader = FciL2NCSegmentFileHandler(
-            filename=SEG_TEST_FILE,
+            filename=self.seg_test_file,
             filename_info={
                 'creation_time':  datetime.datetime(year=2017, month=9, day=20,
                                                     hour=12, minute=30, second=30),
@@ -253,7 +251,7 @@ class TestFciL2NCSegmentFileHandler(unittest.TestCase):
         del self.segment_reader
         # Then can safely remove it from the system
         with suppress(OSError):
-            os.remove(SEG_TEST_FILE)
+            os.remove(self.seg_test_file)
 
     def test_all_basic(self):
         """Test all basic functionalities."""
@@ -274,7 +272,7 @@ class TestFciL2NCSegmentFileHandler(unittest.TestCase):
         global_attributes = self.segment_reader._get_global_attributes()
 
         expected_global_attributes = {
-            'filename': SEG_TEST_FILE,
+            'filename': self.seg_test_file,
             'start_time': datetime.datetime(year=2017, month=9, day=20,
                                             hour=17, minute=30, second=40),
             'end_time': datetime.datetime(year=2017, month=9, day=20,
@@ -313,8 +311,8 @@ class TestFciL2NCErrorFileHandler(unittest.TestCase):
     def setUp(self):
         """Set up the test by creating a test file and opening it with the reader."""
         # Easiest way to test the reader is to create a test netCDF file on the fly
-
-        with Dataset(TEST_ERROR_FILE, 'w') as nc_err:
+        self.test_error_file = str(uuid.uuid4()) + ".nc"
+        with Dataset(self.test_error_file, 'w') as nc_err:
             # Create dimensions
             nc_err.createDimension('number_of_FoR_cols', 10)
             nc_err.createDimension('number_of_FoR_rows', 100)
@@ -351,7 +349,7 @@ class TestFciL2NCErrorFileHandler(unittest.TestCase):
             test_dataset.units = 'test_units'
 
         self.error_reader = FciL2NCSegmentFileHandler(
-            filename=TEST_ERROR_FILE,
+            filename=self.test_error_file,
             filename_info={
                 'creation_time': datetime.datetime(year=2017, month=9, day=20,
                                                    hour=12, minute=30, second=30),
@@ -365,7 +363,7 @@ class TestFciL2NCErrorFileHandler(unittest.TestCase):
         del self.error_reader
         # Then can safely remove it from the system
         with suppress(OSError):
-            os.remove(TEST_ERROR_FILE)
+            os.remove(self.test_error_file)
 
     def test_errors(self):
         """Test that certain properties cause errors."""
@@ -388,8 +386,8 @@ class TestFciL2NCReadingByteData(unittest.TestCase):
     def setUp(self):
         """Set up the test by creating a test file and opening it with the reader."""
         # Easiest way to test the reader is to create a test netCDF file on the fly
-
-        with Dataset(TEST_BYTE_FILE, 'w') as nc_byte:
+        self.test_byte_file = str(uuid.uuid4()) + ".nc"
+        with Dataset(self.test_byte_file, 'w') as nc_byte:
             # Create dimensions
             nc_byte.createDimension('number_of_columns', 1)
             nc_byte.createDimension('number_of_rows', 1)
@@ -416,7 +414,7 @@ class TestFciL2NCReadingByteData(unittest.TestCase):
             test_dataset[:] = 4544767
 
         self.byte_reader = FciL2NCFileHandler(
-            filename=TEST_BYTE_FILE,
+            filename=self.test_byte_file,
             filename_info={
                 'creation_time': datetime.datetime(year=2017, month=9, day=20,
                                                    hour=12, minute=30, second=30),
@@ -430,7 +428,7 @@ class TestFciL2NCReadingByteData(unittest.TestCase):
         del self.byte_reader
         # Then can safely remove it from the system
         with suppress(OSError):
-            os.remove(TEST_BYTE_FILE)
+            os.remove(self.test_byte_file)
 
     def test_byte_extraction(self):
         """Test the execution of the get_dataset function."""

--- a/satpy/tests/test_file_handlers.py
+++ b/satpy/tests/test_file_handlers.py
@@ -17,8 +17,10 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """test file handler baseclass."""
 
+import json
 import unittest
 from unittest import mock
+
 import numpy as np
 
 from satpy.readers.file_handlers import BaseFileHandler
@@ -131,6 +133,12 @@ class TestBaseFileHandler(unittest.TestCase):
                                       'nadir_latitude': 1.5,
                                       'only_in_1': False,
                                       'only_in_2': True}}
+        res = self.fh.combine_info([info1, info2])
+        self.assertDictEqual(res, exp)
+
+        # As a string, like from satpy_nc_cf reader
+        info1['orbital_parameters'] = json.dumps(info1['orbital_parameters'])
+        info2['orbital_parameters'] = json.dumps(info2['orbital_parameters'])
         res = self.fh.combine_info([info1, info2])
         self.assertDictEqual(res, exp)
 

--- a/satpy/tests/test_file_handlers.py
+++ b/satpy/tests/test_file_handlers.py
@@ -17,7 +17,6 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """test file handler baseclass."""
 
-import json
 import unittest
 from unittest import mock
 
@@ -133,12 +132,6 @@ class TestBaseFileHandler(unittest.TestCase):
                                       'nadir_latitude': 1.5,
                                       'only_in_1': False,
                                       'only_in_2': True}}
-        res = self.fh.combine_info([info1, info2])
-        self.assertDictEqual(res, exp)
-
-        # As a string, like from satpy_nc_cf reader
-        info1['orbital_parameters'] = json.dumps(info1['orbital_parameters'])
-        info2['orbital_parameters'] = json.dumps(info2['orbital_parameters'])
         res = self.fh.combine_info([info1, info2])
         self.assertDictEqual(res, exp)
 


### PR DESCRIPTION
The `'cf'` writer converts orbital parameter dictionaries to dicts using `json.dumps()`. When reading this data back, the string representation isn't converted back to a dictionary. This PR adds the conversion to `file_handlers.py` where the orbital data are handled.

I guess the more correct place for this fix is in the `satpy_cf_nc` reader, but that would complicate both the implementation and testing significantly.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
