### PR TITLE
Fix combination of raw metadata (again)

### DIFF
--- a/satpy/dataset/metadata.py
+++ b/satpy/dataset/metadata.py
@@ -157,7 +157,7 @@ def _dict_equal(d1, d2):
     """
     if not (isinstance(d1, dict) and isinstance(d2, dict)):
         return False
-    if not d1.keys() == d2.keys():
+    if d1.keys() != d2.keys():
         return False
     for key in d1.keys():
         if isinstance(d1[key], dict) and isinstance(d2[key], dict):

--- a/satpy/dataset/metadata.py
+++ b/satpy/dataset/metadata.py
@@ -151,11 +151,20 @@ def _all_arrays_equal(arrays):
 
 
 def _all_values_equal(values):
-    return _all_close(values) or _all_equal(values)
+    try:
+        return _all_close(values)
+    except (ValueError, TypeError):
+        # In case of object type arrays (e.g. datetime) _all_close fails,
+        # but _all_equal succeeds.
+        return _all_equal(values)
 
 
 def _all_dicts_equal(dicts):
-    return _pairwise_all(_dict_equal, dicts)
+    try:
+        return _pairwise_all(_dict_equal, dicts)
+    except AttributeError:
+        # There is something else than a dictionary in the list
+        return False
 
 
 def _dict_equal(d1, d2):
@@ -186,13 +195,6 @@ def _pairwise_all(func, values):
 
 
 def _is_equal(a, b, comp_func):
-    try:
-        return _array_or_object_equal(a, b, comp_func)
-    except (ValueError, AttributeError, TypeError):
-        return False
-
-
-def _array_or_object_equal(a, b, comp_func):
     res = comp_func(a, b)
     if _is_array(res):
         return res.all()

--- a/satpy/dataset/metadata.py
+++ b/satpy/dataset/metadata.py
@@ -105,7 +105,11 @@ def _are_values_combinable(values):
     """Check if the *values* can be combined."""
     if _contain_dicts(values):
         return _all_dicts_equal(values)
-    elif _contain_arrays(values):
+    return _all_non_dicts_equal(values)
+
+
+def _all_non_dicts_equal(values):
+    if _contain_arrays(values):
         return _all_arrays_equal(values)
     elif _contain_collections_of_arrays(values):
         # in the real world, the `ancillary_variables` attribute may be
@@ -163,9 +167,7 @@ def _dict_equal(d1, d2):
         if isinstance(d1[key], dict) and isinstance(d2[key], dict):
             return _dict_equal(d1[key], d2[key])
         value_pair = [d1[key], d2[key]]
-        if _contain_arrays(value_pair):
-            return _all_arrays_equal(value_pair)
-        return _all_values_equal(value_pair)
+        return _all_non_dicts_equal(value_pair)
 
 
 def _pairwise_all(func, values):

--- a/satpy/tests/test_dataset.py
+++ b/satpy/tests/test_dataset.py
@@ -240,6 +240,52 @@ class TestCombineMetadata(unittest.TestCase):
         result = combine_metadata(*test_metadata)
         assert 'valid_range' not in result
 
+    def test_combine_dicts_close(self):
+        """Test combination of dictionaries whose values are close."""
+        from satpy.dataset.metadata import combine_metadata
+        raw_mda = {
+            'a': 1,
+            'b': 'foo',
+            'c': [1, 2, 3],
+            'd': {
+                'e': np.str('bar'),
+                'f': datetime(2020, 1, 1, 12, 15, 30),
+                'g': np.array([1, 2, 3])
+            }
+        }
+        raw_mda_close = {
+            'a': 1 + 1E-12,
+            'b': 'foo',
+            'c': np.array([1, 2, 3]) + 1E-12,
+            'd': {
+                'e': np.str('bar'),
+                'f': datetime(2020, 1, 1, 12, 15, 30),
+                'g': np.array([1, 2, 3]) + 1E-12
+            }
+        }
+
+        test_metadata = [raw_mda, raw_mda_close]
+        result = combine_metadata(*test_metadata)
+        assert result == raw_mda
+
+    def test_combine_dicts_different(self):
+        """Test combination of dictionaries differing in various ways."""
+        from satpy.dataset.metadata import combine_metadata
+        raw_mda = {'a': {'b': np.array([1, 2, 3]), 'c': 1.0}, 'd': 'foo'}
+        a_diff = {'a': np.array([1, 2, 3]), 'd': 123}
+        b_diff = {'a': {'b': np.array([4, 5, 6]), 'c': 1.0}, 'd': 'foo'}
+        c_diff = {'a': {'b': np.array([1, 2, 3]), 'c': 2.0}, 'd': 'foo'}
+        d_diff = {'a': {'b': np.array([1, 2, 3]), 'c': 1.0}, 'd': 'bar'}
+        type_diff = np.array([1, 2, 3])
+        b_type_diff = {'a': {'b': 'baz', 'c': 1.0}, 'd': 'foo'}
+        c_type_diff = {'a': {'b': np.array([1, 2, 3]), 'c': 'baz'}, 'd': 'foo'}
+        d_type_diff = {'a': {'b': np.array([1, 2, 3]), 'c': 1.0}, 'd': 1.0}
+
+        test_metadata = [raw_mda, a_diff, b_diff, c_diff, d_diff, type_diff,
+                         b_type_diff, c_type_diff, d_type_diff]
+        result = combine_metadata(*test_metadata)
+        assert not result
+
     def test_combine_real_world_mda(self):
         """Test with real data."""
         mda_objects = ({'_FillValue': np.nan,
@@ -251,7 +297,7 @@ class TestCombineMetadata(unittest.TestCase):
                                                 '-'],
                         'platform_name': 'NOAA-20',
                         'sensor': {'viirs'},
-                        'raw_metadata': {'foo': np.array([1, 2, 3])}},
+                        'raw_metadata': {'foo': {'bar': np.array([1, 2, 3])}}},
                        {'_FillValue': np.nan,
                         'valid_range': np.array([0., 0.00032], dtype=np.float32),
                         'ancillary_variables': ['cpp_status_flag',
@@ -261,7 +307,7 @@ class TestCombineMetadata(unittest.TestCase):
                                                 '-'],
                         'platform_name': 'NOAA-20',
                         'sensor': {'viirs'},
-                        'raw_metadata': {'foo': np.array([2, 3, 4])}})
+                        'raw_metadata': {'foo': {'bar': np.array([1, 2, 3])}}})
 
         expected = {'_FillValue': np.nan,
                     'valid_range': np.array([0., 0.00032], dtype=np.float32),
@@ -271,12 +317,15 @@ class TestCombineMetadata(unittest.TestCase):
                                             'cpp_reff_pal',
                                             '-'],
                     'platform_name': 'NOAA-20',
-                    'sensor': {'viirs'}}
+                    'sensor': {'viirs'},
+                    'raw_metadata': {'foo': {'bar': np.array([1, 2, 3])}}}
 
         from satpy.dataset.metadata import combine_metadata
         result = combine_metadata(*mda_objects)
         assert np.allclose(result.pop('_FillValue'), expected.pop('_FillValue'), equal_nan=True)
         assert np.allclose(result.pop('valid_range'), expected.pop('valid_range'))
+        np.testing.assert_equal(result.pop('raw_metadata'),
+                                expected.pop('raw_metadata'))
         assert result == expected
 
     def test_combine_one_metadata_object(self):

--- a/satpy/tests/test_dataset.py
+++ b/satpy/tests/test_dataset.py
@@ -322,8 +322,9 @@ def test_combine_dicts_close():
             'd': {
                 'e': np.str('bar'),
                 'f': datetime(2020, 1, 1, 12, 15, 30),
-                'g': np.array([1, 2, 3])
-            }
+                'g': np.array([1, 2, 3]),
+            },
+            'h': np.array([datetime(2020, 1, 1), datetime(2020, 1, 1)])
         }
     }
     attrs_close = {
@@ -335,7 +336,8 @@ def test_combine_dicts_close():
                 'e': np.str('bar'),
                 'f': datetime(2020, 1, 1, 12, 15, 30),
                 'g': np.array([1, 2, 3]) + 1E-12
-            }
+            },
+            'h': np.array([datetime(2020, 1, 1), datetime(2020, 1, 1)])
         }
     }
     test_metadata = [attrs, attrs_close]
@@ -346,10 +348,12 @@ def test_combine_dicts_close():
 @pytest.mark.parametrize(
     "test_mda",
     [
+        # a/b/c/d different
         {'a': np.array([1, 2, 3]), 'd': 123},
         {'a': {'b': np.array([4, 5, 6]), 'c': 1.0}, 'd': 'foo'},
         {'a': {'b': np.array([1, 2, 3]), 'c': 2.0}, 'd': 'foo'},
         {'a': {'b': np.array([1, 2, 3]), 'c': 1.0}, 'd': 'bar'},
+        # a/b/c/d type different
         np.array([1, 2, 3]),
         {'a': {'b': 'baz', 'c': 1.0}, 'd': 'foo'},
         {'a': {'b': np.array([1, 2, 3]), 'c': 'baz'}, 'd': 'foo'},


### PR DESCRIPTION
In my recent attempt to fix the combination of raw metadata I updated `satpy.dataset.metadata.combine_metadata` to drop the `raw_metadata` attribute. This works fine with single-file datasets (e.g. SEVIRI Native), but for multi-file datasets (e.g. SEVIRI HRIT) the attribute is dropped even if only a single dataset has been loaded. This is of course not desired.

This PR enables `combine_metadata` to compare (nested) dictionaries, so that the removal of the `raw_metadata` attribute is not necessary anymore. In the end it wasn't as complicated as I thought.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Tests added <!-- for all bug fixes or enhancements -->

