### PR TITLE
Cleanup optional dependencies in setup.py

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -120,7 +120,7 @@ jobs:
       - name: Run unit tests
         shell: bash -l {0}
         run: |
-          pytest --cov=satpy satpy/tests --cov-report=xml
+          pytest --cov=satpy satpy/tests --cov-report=xml --cov-report=
 
       - name: Upload unittest coverage to Codecov
         uses: codecov/codecov-action@v1
@@ -128,6 +128,13 @@ jobs:
           flags: unittests
           file: ./coverage.xml
           env_vars: OS,PYTHON_VERSION,UNSTABLE
+
+      - name: Coveralls Parallel
+        uses: AndreMiras/coveralls-python-action@develop
+        with:
+          flag-name: run-${{ matrix.test_number }}
+          parallel: true
+        if: runner.os == 'Linux'
 
       - name: Run behaviour tests
         shell: bash -l {0}
@@ -141,3 +148,13 @@ jobs:
           flags: behaviourtests
           file: ./coverage.xml
           env_vars: OS,PYTHON_VERSION,UNSTABLE
+
+  coveralls:
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Coveralls Finished
+        uses: AndreMiras/coveralls-python-action@develop
+        with:
+          parallel-finished: true
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,3 +18,8 @@ exclude =
     satpy/readers/scatsat1_l2b.py
     satpy/version.py
     satpy/tests/features
+
+[coverage:run]
+relative_files = True
+omit =
+    satpy/version.py

--- a/setup.py
+++ b/setup.py
@@ -51,10 +51,8 @@ extras_require = {
     'omps_edr': ['h5py >= 2.7.0'],
     'amsr2_l1b': ['h5py >= 2.7.0'],
     'hrpt': ['pyorbital >= 1.3.1', 'pygac', 'python-geotiepoints >= 1.1.7'],
-    'proj': ['pyresample'],
-    'pyspectral': ['pyspectral >= 0.10.1'],
-    'pyorbital': ['pyorbital >= 1.3.1'],
     'hrit_msg': ['pytroll-schedule'],
+    'msi_safe': ['glymur'],
     'nc_nwcsaf_msg': ['netCDF4 >= 1.1.8'],
     'sar_c': ['python-geotiepoints >= 1.1.7', 'rasterio', 'rioxarray'],
     'abi_l1b': ['h5netcdf'],
@@ -67,12 +65,16 @@ extras_require = {
     'geotiff': ['rasterio', 'trollimage[geotiff]'],
     'mitiff': ['libtiff'],
     'ninjo': ['pyninjotiff', 'pint'],
+    # Composites/Modifiers:
+    'rayleigh': ['pyspectral >= 0.10.1'],
+    'angles': ['pyorbital >= 1.3.1'],
     # MultiScene:
     'animations': ['imageio'],
     # Documentation:
     'doc': ['sphinx', 'sphinx_rtd_theme', 'sphinxcontrib-apidoc'],
     # Other
     'geoviews': ['geoviews'],
+    'overlays': ['pycoast', 'pydecorate'],
 }
 all_extras = []
 for extra_deps in extras_require.values():


### PR DESCRIPTION
Some of the unique optional dependencies for parts of Satpy are missing from the setup.py. By unique I mean dependencies that aren't needed by a lot of readers, only a select few. See #562 for some of the discussion on this.

I also rearranged some of the existing dependencies so they make a little more sense. One odd one I noticed is that abi_l1b is currently listed as needed h5netcdf which isn't actually true (netcdf4-python is fine). Thoughts on this @mraspaud?

 - [x] Closes #562 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
