### PR TITLE
Fix SATPY_CONFIG_PATH being unusable when imported in a subprocess

### DIFF
--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -26,6 +26,7 @@ from collections import OrderedDict
 import pkg_resources
 from donfig import Config
 import appdirs
+import ast
 
 LOG = logging.getLogger(__name__)
 
@@ -64,15 +65,21 @@ _CONFIG_PATHS = [
 
 _ppp_config_dir = os.getenv('PPP_CONFIG_DIR', None)
 _satpy_config_path = os.getenv('SATPY_CONFIG_PATH', None)
-if _ppp_config_dir is not None:
+
+if _ppp_config_dir is not None and _satpy_config_path is None:
     LOG.warning("'PPP_CONFIG_DIR' is deprecated. Please use 'SATPY_CONFIG_PATH' instead.")
     _satpy_config_path = _ppp_config_dir
-    os.environ['SATPY_CONFIG_PATH'] = _satpy_config_path
 
 if _satpy_config_path is not None:
-    # colon-separated are ordered by custom -> builtins
-    # i.e. last-applied/highest priority to first-applied/lowest priority
-    _satpy_config_path = _satpy_config_path.split(':')
+    if _satpy_config_path.startswith("["):
+        # 'SATPY_CONFIG_PATH' is set by previous satpy config as a reprsentation of a 'list'
+        # need to use 'ast.literal_eval' to parse the string back to a list
+        _satpy_config_path = ast.literal_eval(_satpy_config_path)
+    else:
+        # colon-separated are ordered by custom -> builtins
+        # i.e. last-applied/highest priority to first-applied/lowest priority
+        _satpy_config_path = _satpy_config_path.split(':')
+
     os.environ['SATPY_CONFIG_PATH'] = repr(_satpy_config_path)
     for config_dir in _satpy_config_path:
         _CONFIG_PATHS.append(os.path.join(config_dir, 'satpy.yaml'))

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -166,6 +166,7 @@ class TestConfigObject:
 
     def test_config_path_multiple_load(self):
         """Test that config paths from subprocesses load properly.
+
         Satpy modifies the config path environment variable when it is imported.
         If Satpy is imported again from a subprocess then it should be able to parse this
         modified variable.

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -165,8 +165,9 @@ class TestConfigObject:
                                                        '/my/configs3']
 
     def test_config_path_multiple_load(self):
-        """Test that config paths are parsed properly after multiple load of satpy configs,
-           for example a subprocess call from a python script."""
+        """Test that config paths are parsed properly after multiple load of
+           satpy configs, for example a subprocess call from a python script.
+        """
         from importlib import reload
         import satpy
         old_vars = {

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -165,8 +165,11 @@ class TestConfigObject:
                                                        '/my/configs3']
 
     def test_config_path_multiple_load(self):
-        """Test that config paths are parsed properly after multiple load of
-           satpy configs, for example a subprocess call from a python script.
+        """Test that config paths from subprocesses load properly.
+        
+        Satpy modifies the config path environment variable when it is imported.
+        If Satpy is imported again from a subprocess then it should be able to parse this
+        modified variable.
         """
         from importlib import reload
         import satpy

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -164,7 +164,6 @@ class TestConfigObject:
                                                        '/my/configs2',
                                                        '/my/configs3']
 
-
     def test_config_path_multiple_load(self):
         """Test that config paths are parsed properly after multiple load of satpy configs,
            for example a subprocess call from a python script."""

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -166,7 +166,6 @@ class TestConfigObject:
 
     def test_config_path_multiple_load(self):
         """Test that config paths from subprocesses load properly.
-        
         Satpy modifies the config path environment variable when it is imported.
         If Satpy is imported again from a subprocess then it should be able to parse this
         modified variable.

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -185,7 +185,6 @@ class TestConfigObject:
                                                        '/my/configs2',
                                                        '/my/configs3']
 
-
     def test_bad_str_config_path(self):
         """Test that a str config path isn't allowed."""
         from importlib import reload

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -164,6 +164,29 @@ class TestConfigObject:
                                                        '/my/configs2',
                                                        '/my/configs3']
 
+
+    def test_config_path_multiple_load(self):
+        """Test that config paths are parsed properly after multiple load of satpy configs,
+           for example a subprocess call from a python script."""
+        from importlib import reload
+        import satpy
+        old_vars = {
+            'SATPY_CONFIG_PATH': '/my/configs1:/my/configs2:/my/configs3',
+        }
+
+        with mock.patch.dict('os.environ', old_vars):
+            # these reloads will update env variable "SATPY_CONFIG_PATH"
+            reload(satpy._config)
+            reload(satpy)
+
+            # load the updated env variable and parse it again.
+            reload(satpy._config)
+            reload(satpy)
+            assert satpy.config.get('config_path') == ['/my/configs1',
+                                                       '/my/configs2',
+                                                       '/my/configs3']
+
+
     def test_bad_str_config_path(self):
         """Test that a str config path isn't allowed."""
         from importlib import reload


### PR DESCRIPTION
This PR try to add back the feature to support to call another script which also uses satpy in a python subprocess call. See Issue #1676 for detail of the bug. 
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1676 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->


