### PR TITLE
Remove extra attributes tag and fix indentation

### DIFF
--- a/satpy/etc/writers/awips_tiled.yaml
+++ b/satpy/etc/writers/awips_tiled.yaml
@@ -124,9 +124,8 @@ templates:
         name: cloud_type
         var_name: data
         attributes:
-          attributes:
-            physical_element:
-              raw_value: CLAVR-x Cloud Type
+          physical_element:
+            raw_value: CLAVR-x Cloud Type
       clavrx_cld_temp_acha:
         reader: clavrx
         name: cld_temp_acha


### PR DESCRIPTION
The CLAVR-x cloud type attributes needed formatting changes.  This PR fixes just that (removes an extra attributes tag and fixes indentation.) 

No tests added.