### PR TITLE
Add feature CategoricalDataCompositor

### DIFF
--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -224,6 +224,19 @@ BackgroundCompositor
     >>> background = local_scene['overview']
     >>> composite = compositor([clouds, background])
 
+CategoricalDataCompositor
+-------------------------
+
+    :class:`CategoricalDataCompositor` can be used to recategorize categorical data. This is for example useful to
+    combine comparable categories into a common category. Below is an example on how to create a binary clear-sky/cloud
+    mask from a pseodu cloud type product with six categories representing clear sky (cat1/cat5), cloudy features
+    (cat2-cat4) and missing/undefined data (cat0).
+
+    >>> cloud_type = local_scene['cloud_type']  # 0 - cat0, 1 - cat1, 2 - cat2, 3 - cat3, 4 - cat4, 5 - cat5,
+    >>> lut = [np.nan, 0, 1, 1, 1, 0]
+    >>> compositor = CategoricalDataCompositor('binary_cloud_mask', lut=lut)
+    >>> composite = compositor([cloud_type])  # 0 - cat1/cat5, 1 - cat2/cat3/cat4, nan - cat0
+
 Creating composite configuration files
 ======================================
 

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -234,6 +234,7 @@ using a look-up-table (`lut`)::
                  [[lut[data[1,0]], lut[data[1,1]], lut[data[1,Nj]],
                  [[lut[data[Ni,0]], lut[data[Ni,1]], lut[data[Ni,Nj]]]
 
+Hence, `lut` must have a length that is greater than the maximum value in `data` in orer to avoid an `IndexError`.
 Below is an example on how to create a binary clear-sky/cloud mask from a pseodu cloud type product with six
 categories representing clear sky (cat1/cat5), cloudy features (cat2-cat4) and missing/undefined data (cat0)::
 

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -9,7 +9,6 @@ Composites are generated in satpy using Compositor classes. The attributes of th
 resulting composites are usually a combination of the prerequisites' attributes and
 the key/values of the DataID used to identify it.
 
-
 Built-in Compositors
 ====================
 
@@ -227,15 +226,23 @@ BackgroundCompositor
 CategoricalDataCompositor
 -------------------------
 
-    :class:`CategoricalDataCompositor` can be used to recategorize categorical data. This is for example useful to
-    combine comparable categories into a common category. Below is an example on how to create a binary clear-sky/cloud
-    mask from a pseodu cloud type product with six categories representing clear sky (cat1/cat5), cloudy features
-    (cat2-cat4) and missing/undefined data (cat0).
+:class:`CategoricalDataCompositor` can be used to recategorize categorical data. This is for example useful to
+combine comparable categories into a common category. The category remapping from `data` to `composite` is done
+using a look-up-table (`lut`)::
+
+    composite = [[lut[data[0,0]], lut[data[0,1]], lut[data[0,Nj]]],
+                 [[lut[data[1,0]], lut[data[1,1]], lut[data[1,Nj]],
+                 [[lut[data[Ni,0]], lut[data[Ni,1]], lut[data[Ni,Nj]]]
+
+Below is an example on how to create a binary clear-sky/cloud mask from a pseodu cloud type product with six
+categories representing clear sky (cat1/cat5), cloudy features (cat2-cat4) and missing/undefined data (cat0)::
 
     >>> cloud_type = local_scene['cloud_type']  # 0 - cat0, 1 - cat1, 2 - cat2, 3 - cat3, 4 - cat4, 5 - cat5,
+    # categories: 0    1  2  3  4  5
     >>> lut = [np.nan, 0, 1, 1, 1, 0]
     >>> compositor = CategoricalDataCompositor('binary_cloud_mask', lut=lut)
     >>> composite = compositor([cloud_type])  # 0 - cat1/cat5, 1 - cat2/cat3/cat4, nan - cat0
+
 
 Creating composite configuration files
 ======================================

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -268,8 +268,8 @@ class CategoricalDataCompositor(CompositeBase):
         """Get look-up-table used to recategorize data.
 
         Args:
-            lut (list): a list of new categories. The lenght must be greather than or equal to
-                        the maximum value in the data array that should be recategorized.
+            lut (list): a list of new categories. The lenght must be greater than the
+                        maximum value in the data array that should be recategorized.
         """
         self.lut = np.array(lut)
         super(CategoricalDataCompositor, self).__init__(name, **kwargs)
@@ -287,9 +287,9 @@ class CategoricalDataCompositor(CompositeBase):
         data = data.astype(int)
 
         maxval = data.data.max().compute()
-        if len(self.lut) < maxval:
-            raise ValueError("The LUT length (={}) must be greater than or equal to the"
-                             "maximum value in data array (={})".format(len(self.lut), maxval))
+        if len(self.lut) <= maxval:
+            raise ValueError("The LUT length (={}) must be greater than the maximum value "
+                             "in the data array (={})".format(len(self.lut), maxval))
 
         res = data.data.map_blocks(self._getitem, self.lut, dtype=self.lut.dtype)
 

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -289,11 +289,6 @@ class CategoricalDataCompositor(CompositeBase):
             raise ValueError("Can't have more than one dataset for a categorical data composite")
 
         data = projectables[0].astype(int)
-        maxval = data.data.max().compute()
-        if len(self.lut) <= maxval:
-            raise ValueError("The LUT length (={}) must be greater than the maximum value "
-                             "in the data array (={})".format(len(self.lut), maxval))
-
         res = data.data.map_blocks(self._getitem, self.lut, dtype=self.lut.dtype)
 
         new_attrs = data.attrs.copy()

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -274,13 +274,8 @@ class CategoricalDataCompositor(CompositeBase):
         self.lut = np.array(lut)
         super(CategoricalDataCompositor, self).__init__(name, **kwargs)
 
-    def _update_attrs(self, existing_attrs, new_attrs):
-        """Transfer attributes from **attrs, modify name and add LUT."""
-        for key, val in existing_attrs.items():
-            if key not in new_attrs and val is not None:
-                new_attrs[key] = val
-
-        # Modify name and add the LUT used to create the composite
+    def _update_attrs(self, new_attrs):
+        """Modify name and add LUT."""
         new_attrs['name'] = self.attrs['name']
         new_attrs['composite_lut'] = list(self.lut)
 
@@ -288,7 +283,7 @@ class CategoricalDataCompositor(CompositeBase):
     def _getitem(block, lut):
         return lut[block]
 
-    def __call__(self, projectables, **attrs):
+    def __call__(self, projectables, **kwargs):
         """Recategorize the data."""
         if len(projectables) != 1:
             raise ValueError("Can't have more than one dataset for a categorical data composite")
@@ -301,9 +296,8 @@ class CategoricalDataCompositor(CompositeBase):
 
         res = data.data.map_blocks(self._getitem, self.lut, dtype=self.lut.dtype)
 
-        # Update attributes
         new_attrs = data.attrs.copy()
-        self._update_attrs(attrs, new_attrs)
+        self._update_attrs(new_attrs)
 
         return xr.DataArray(res, dims=data.dims, attrs=new_attrs, coords=data.coords)
 

--- a/satpy/etc/composites/fci.yaml
+++ b/satpy/etc/composites/fci.yaml
@@ -1,1 +1,13 @@
 sensor_name: visir/fci
+
+
+composites:
+
+  binary_cloud_mask:
+    # This will set all clear pixels to '0', all pixles with cloudy features (meteorological/dust/ash clouds) to '1' and
+    # missing/undefined pixels to 'nan'. This can be used for the the official EUMETSAT cloud mask product (CLM).
+    compositor: !!python/name:satpy.composites.CategoricalDataCompositor
+    prerequisites:
+      - name: 'cloud_state'
+    lut: [.nan, 0, 1, 1, 1, 1, 1, 1, 0, .nan]
+    standard_name: binary_cloud_mask

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -726,8 +726,15 @@ class TestCategoricalDataCompositor(unittest.TestCase):
         np.testing.assert_equal(res.attrs['name'], name)
         np.testing.assert_equal(res.attrs['composite_lut'], lut)
 
+    def test_too_many_datasets(self):
+        """Test that ValueError is raised if more than one dataset is provided."""
+        from satpy.composites import CategoricalDataCompositor
+        lut = [np.nan, 0, 1]
+        comp = CategoricalDataCompositor(name='foo', lut=lut)
+        np.testing.assert_raises(ValueError, comp, [self.data, self.data])
+
     def test_bad_lut(self):
-        """Test that ValueError is raised if the LU is not sufficiently long."""
+        """Test that ValueError is raised if the LUT is not sufficiently long."""
         from satpy.composites import CategoricalDataCompositor
         lut = [np.nan, 0, 1]
         comp = CategoricalDataCompositor(name='foo', lut=lut)

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -702,6 +702,38 @@ class TestSingleBandCompositor(unittest.TestCase):
         self.assertEqual(res.attrs['resolution'], 333)
 
 
+class TestCategoricalDataCompositor(unittest.TestCase):
+    """Test composiotor for recategorization of categorical data."""
+
+    def setUp(self):
+        """Create test data."""
+        attrs = {'name': 'foo'}
+        data = xr.DataArray(da.from_array([[2., 1.], [3., 0.]]), attrs=attrs,
+                            dims=('y', 'x'), coords={'y': [0, 1], 'x': [0, 1]})
+
+        self.data = data
+
+    def test_basic_recategorization(self):
+        """Test general functionality of compositor incl. attributes."""
+        from satpy.composites import CategoricalDataCompositor
+        lut = [np.nan, 0, 1, 1]
+        name = 'bar'
+        comp = CategoricalDataCompositor(name=name, lut=lut)
+        res = comp([self.data])
+        res = res.compute()
+        expected = np.array([[1., 0.], [1., np.nan]])
+        np.testing.assert_equal(res.values, expected)
+        np.testing.assert_equal(res.attrs['name'], name)
+        np.testing.assert_equal(res.attrs['composite_lut'], lut)
+
+    def test_bad_lut(self):
+        """Test that ValueError is raised if the LU is not sufficiently long."""
+        from satpy.composites import CategoricalDataCompositor
+        lut = [np.nan, 0, 1]
+        comp = CategoricalDataCompositor(name='foo', lut=lut)
+        np.testing.assert_raises(ValueError, comp, [self.data])
+
+
 class TestGenericCompositor(unittest.TestCase):
     """Test generic compositor."""
 

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -729,16 +729,9 @@ class TestCategoricalDataCompositor(unittest.TestCase):
     def test_too_many_datasets(self):
         """Test that ValueError is raised if more than one dataset is provided."""
         from satpy.composites import CategoricalDataCompositor
-        lut = [np.nan, 0, 1]
+        lut = [np.nan, 0, 1, 1]
         comp = CategoricalDataCompositor(name='foo', lut=lut)
         np.testing.assert_raises(ValueError, comp, [self.data, self.data])
-
-    def test_bad_lut(self):
-        """Test that ValueError is raised if the LUT is not sufficiently long."""
-        from satpy.composites import CategoricalDataCompositor
-        lut = [np.nan, 0, 1]
-        comp = CategoricalDataCompositor(name='foo', lut=lut)
-        np.testing.assert_raises(ValueError, comp, [self.data])
 
 
 class TestGenericCompositor(unittest.TestCase):


### PR DESCRIPTION
This PR adds a CategoricalDataCompositor class that allows for the recategorization of categorical data. This is for example useful to combine comparable categories into a common category. The main reason is to be able to load a binary FCI cloud mask derived from the official EUMETSAT FCI cloud mask (CLM) product which contains ten different categories with information about clear sky, meteorological clouds, dust, volcanic ash, scene opacity and missing data. A composite recipe for this has been added to `satpy/etc/composites/fci.yaml`.

A look-up-table (LUT) containing the flags of the new categories must be provided as input when the class in initialized.. The values in the categorical data array that shall be recategorized will then be used as indices to extract the new category flag from the LUT.  Below is an example on how to create a binary clear-sky/cloud  mask from a pseodu cloud type product with six categories representing clear sky (cat1/cat5), cloudy features (cat2-cat4) and missing/undefined data (cat0).

```
cloud_type = local_scene['cloud_type']  # 0 - cat0, 1 - cat1, 2 - cat2, 3 - cat3, 4 - cat4, 5 - cat5,
lut = [np.nan, 0, 1, 1, 1, 0]
compositor = CategoricalDataCompositor('binary_cloud_mask', lut=lut)
composite = compositor([cloud_type])  # 0 - cat1/cat5, 1 - cat2/cat3/cat4, nan - cat0
```

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->