### PR TITLE
`time_bnds` for multiple time steps

### DIFF
--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -59,12 +59,14 @@ def timeseries(datasets):
         if 'time' not in ds.dims:
             tmp = ds.expand_dims("time")
             tmp.coords["time"] = pd.DatetimeIndex([ds.attrs["start_time"]])
+            tmp.coords['start_time'] = ('time', [ds.attrs["start_time"]])
+            tmp.coords['end_time'] = ('time', [ds.attrs["end_time"]])
         else:
             tmp = ds
         expanded_ds.append(tmp)
 
     res = xr.concat(expanded_ds, dim="time")
-    res.attrs = combine_metadata(*[x.attrs for x in expanded_ds])
+    res.attrs = combine_metadata(*[x.attrs for x in expanded_ds], average_times=False)
     return res
 
 


### PR DESCRIPTION
1. Fix the different length of dimension 'time' when using `save_datasets` with Scene blended by time.
2. Instead of average `start_time` and `end_time`, `start_time` and `end_time` are available at each timestamp.

 - [ ] Closes #1242, #1174, and #1675
 - [ ] Tests added 
 - [ ] Fully documented