### PR TITLE
Fix SandwichCompositor modifying input data

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -948,7 +948,7 @@ class SandwichCompositor(GenericCompositor):
         """Generate the composite."""
         projectables = self.match_data_arrays(projectables)
         luminance = projectables[0]
-        luminance /= 100.
+        luminance = luminance / 100.
         # Limit between min(luminance) ... 1.0
         luminance = luminance.clip(max=1.)
 
@@ -1142,6 +1142,8 @@ class BackgroundCompositor(GenericCompositor):
         # L/RGB -> RGB/RGB
         # LA/RGB -> RGBA/RGBA
         # RGB/RGBA -> RGBA/RGBA
+        print(foreground.shape, background.shape)
+        print(foreground['bands'], background['bands'])
         foreground = add_bands(foreground, background['bands'])
         background = add_bands(background, foreground['bands'])
 

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1142,8 +1142,6 @@ class BackgroundCompositor(GenericCompositor):
         # L/RGB -> RGB/RGB
         # LA/RGB -> RGBA/RGBA
         # RGB/RGBA -> RGBA/RGBA
-        print(foreground.shape, background.shape)
-        print(foreground['bands'], background['bands'])
         foreground = add_bands(foreground, background['bands'])
         background = add_bands(background, foreground['bands'])
 

--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -194,7 +194,7 @@ composites:
         modifiers: [sunz_corrected, rayleigh_corrected]
       - name: C03
         modifiers: [sunz_corrected]
-    standard_name: toa_bidirection_reflectance
+    standard_name: toa_bidirectional_reflectance
 
   cimss_green_sunz:
     compositor: !!python/name:satpy.composites.abi.SimulatedGreen
@@ -207,7 +207,7 @@ composites:
         modifiers: [sunz_corrected]
       - name: C03
         modifiers: [sunz_corrected]
-    standard_name: toa_bidirection_reflectance
+    standard_name: toa_bidirectional_reflectance
 
   cimss_green:
     compositor: !!python/name:satpy.composites.abi.SimulatedGreen
@@ -217,7 +217,7 @@ composites:
       - name: C01
       - name: C02
       - name: C03
-    standard_name: toa_bidirection_reflectance
+    standard_name: toa_bidirectional_reflectance
 
   cimss_true_color_sunz_rayleigh:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -431,6 +431,8 @@ class TestSandwichCompositor(unittest.TestCase):
         for i in range(3):
             np.testing.assert_allclose(res.data[i, :, :],
                                        rgb_arr[i, :, :] * lum_arr / 100.)
+        # make sure the compositor doesn't modify the input data
+        np.testing.assert_allclose(lum.values, lum_arr.compute())
 
 
 class TestInlineComposites(unittest.TestCase):


### PR DESCRIPTION
In issue #1689 we realized that generating a true color composite while also generating a sandwich composite of that same true color produced an all black image. With this PR the SandwichCompositor no longer does an inplace operation.

One could argue that the utility methods used by the composites should always pass copies, but I think this is unnecessary in most cases and I'm scared it would hurt performance in the worst cases. This is the first time we've run into something like this...I think.

 - [x] Closes #1689 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

