### PR TITLE
Fix reference to sector_id global key in 'awips_tiled' writer YAML

### DIFF
--- a/satpy/etc/writers/awips_tiled.yaml
+++ b/satpy/etc/writers/awips_tiled.yaml
@@ -118,7 +118,7 @@ templates:
         var_name: data
         attributes:
           physical_element:
-            raw_value: 'CLAVR-x {name}'
+            value: 'CLAVR-x {name}'
       clavrx_cloud_type:
         reader: clavrx
         name: cloud_type

--- a/satpy/etc/writers/awips_tiled.yaml
+++ b/satpy/etc/writers/awips_tiled.yaml
@@ -66,7 +66,7 @@ templates:
 #        value: "${ORGANIZATION}"
       awips_id: {}
 #        value: "{awips_id}"  # special variable created by awips_tiled.py
-      creating_entity:
+      satellite_id:
         value: "{platform_name!u}-{sensor!u}"
       sector_id: {}  # special handler in awips_tiled.py
     coordinates:

--- a/satpy/tests/writer_tests/test_awips_tiled.py
+++ b/satpy/tests/writer_tests/test_awips_tiled.py
@@ -187,6 +187,7 @@ class TestAWIPSTiledWriter:
             ds = xr.open_dataset(fn, mask_and_scale=False)
             check_required_common_attributes(ds)
             assert ds.attrs['my_global'] == 'TEST'
+            assert ds.attrs['sector_id'] == 'TEST'
             stime = input_data_arr.attrs['start_time']
             assert ds.attrs['start_date_time'] == stime.strftime('%Y-%m-%dT%H:%M:%S')
 

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -1060,7 +1060,7 @@ class AWIPSNetCDFTemplate(NetCDFTemplate):
         return new_ds
 
     def _add_sector_id_global(self, new_ds, sector_id):
-        if not self._template_dict.get('apply_sector_id_global'):
+        if not self._template_dict.get('add_sector_id_global'):
             return
 
         if sector_id is None:


### PR DESCRIPTION
This edits one line in awips_tiled.py so that the key "add_sector_id_global" is used for applying the sector_id to the global attributes.  This key is chosen since it matches the key defined in the awips_tiled.yaml file 
https://github.com/pytroll/satpy/blob/88938ab8e0eb2b2f6ae89665733b7e2281720fce/satpy/etc/writers/awips_tiled.yaml#L58
