### PR TITLE
Fix error when calling to_xarray_dataset on an empty scene

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -905,6 +905,9 @@ class Scene:
         """
         dataarrays = self._get_dataarrays_from_identifiers(datasets)
 
+        if len(dataarrays) == 0:
+            return xr.Dataset()
+
         ds_dict = {i.attrs['name']: i.rename(i.attrs['name']) for i in dataarrays if i.attrs.get('area') is not None}
         mdata = combine_metadata(*tuple(i.attrs for i in dataarrays))
         if mdata.get('area') is None or not isinstance(mdata['area'], SwathDefinition):

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1745,6 +1745,16 @@ class TestSceneSaving(unittest.TestCase):
 class TestSceneConversions(unittest.TestCase):
     """Test Scene conversion to geoviews, xarray, etc."""
 
+    def test_to_xarray_dataset_with_empty_scene(self):
+        """Test converting empty Scene to xarray dataset."""
+        from satpy import Scene
+        from xarray import Dataset
+        scn = Scene()
+        xrds = scn.to_xarray_dataset()
+        assert isinstance(xrds, Dataset)
+        assert len(xrds.variables) == 0
+        assert len(xrds.coords) == 0
+
     def test_geoviews_basic_with_area(self):
         """Test converting a Scene to geoviews with an AreaDefinition."""
         from satpy import Scene


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
If `to_xarray_dataset` is called on an empty Scene instead of an error an empty xarray dataset is now returned.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1584 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
