### PR TITLE
Add pending deprecation reader names check

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -39,8 +39,8 @@ LOG = logging.getLogger(__name__)
 
 
 # Old Name -> New Name
-OLD_READER_NAMES = {
-}
+PENDING_OLD_READER_NAMES = {}
+OLD_READER_NAMES = {}
 
 
 def group_files(files_to_sort, reader=None, time_threshold=10,
@@ -254,20 +254,8 @@ def configs_for_reader(reader=None):
     if reader is not None:
         if not isinstance(reader, (list, tuple)):
             reader = [reader]
-        # check for old reader names
-        new_readers = []
-        for reader_name in reader:
-            if reader_name.endswith('.yaml') or reader_name not in OLD_READER_NAMES:
-                new_readers.append(reader_name)
-                continue
 
-            new_name = OLD_READER_NAMES[reader_name]
-            # Satpy 0.11 only displays a warning
-            # Satpy 0.13 will raise an exception
-            raise ValueError("Reader name '{}' has been deprecated, use '{}' instead.".format(reader_name, new_name))
-            # Satpy 0.15 or 1.0, remove exception and mapping
-
-        reader = new_readers
+        reader = get_valid_reader_names(reader)
         # given a config filename or reader name
         config_files = [r if r.endswith('.yaml') else r + '.yaml' for r in reader]
     else:
@@ -286,6 +274,28 @@ def configs_for_reader(reader=None):
             raise ValueError("No reader named: {}".format(reader_name))
 
         yield reader_configs
+
+
+def get_valid_reader_names(reader):
+    """Check for old reader names or readers pending deprecation."""
+    new_readers = []
+    for reader_name in reader:
+        if reader_name in OLD_READER_NAMES:
+            raise ValueError(
+                "Reader name '{}' has been deprecated, "
+                "use '{}' instead.".format(reader_name,
+                                           OLD_READER_NAMES[reader_name]))
+
+        if reader_name in PENDING_OLD_READER_NAMES:
+            new_name = PENDING_OLD_READER_NAMES[reader_name]
+            warnings.warn("Reader name '{}' is being deprecated and will be removed soon."
+                          "Please use '{}' instead.".format(reader_name, new_name),
+                          FutureWarning)
+            new_readers.append(new_name)
+        else:
+            new_readers.append(reader_name)
+
+    return new_readers
 
 
 def available_readers(as_dict=False):

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -593,7 +593,8 @@ class TestFindFilesAndReaders(unittest.TestCase):
                                  "no pending deprecated readers.")
         test_reader = sorted(PENDING_OLD_READER_NAMES.keys())[0]
         with self.assertWarns(FutureWarning):
-            get_valid_reader_names([test_reader])
+            valid_reader_names = get_valid_reader_names([test_reader])
+        self.assertEqual(valid_reader_names[0], PENDING_OLD_READER_NAMES[test_reader])
 
     def test_old_reader_name_mapping(self):
         """Test that requesting old reader names raises a warning."""

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -585,14 +585,25 @@ class TestFindFilesAndReaders(unittest.TestCase):
             load.side_effect = yaml.YAMLError("Import problems")
             self.assertRaises(yaml.YAMLError, find_files_and_readers, reader='viirs_sdr')
 
+    def test_pending_old_reader_name_mapping(self):
+        """Test that requesting pending old reader names raises a warning."""
+        from satpy.readers import get_valid_reader_names, PENDING_OLD_READER_NAMES
+        if not PENDING_OLD_READER_NAMES:
+            return unittest.skip("Skipping pending deprecated reader tests because "
+                                 "no pending deprecated readers.")
+        test_reader = sorted(PENDING_OLD_READER_NAMES.keys())[0]
+        with self.assertWarns(FutureWarning):
+            get_valid_reader_names([test_reader])
+
     def test_old_reader_name_mapping(self):
         """Test that requesting old reader names raises a warning."""
-        from satpy.readers import configs_for_reader, OLD_READER_NAMES
+        from satpy.readers import get_valid_reader_names, OLD_READER_NAMES
         if not OLD_READER_NAMES:
             return unittest.skip("Skipping deprecated reader tests because "
                                  "no deprecated readers.")
         test_reader = sorted(OLD_READER_NAMES.keys())[0]
-        self.assertRaises(ValueError, list, configs_for_reader(test_reader))
+        with self.assertRaises(ValueError):
+            get_valid_reader_names([test_reader])
 
 
 class TestYAMLFiles(unittest.TestCase):


### PR DESCRIPTION
This PR adds a mechanism to warn the user that a reader name is being deprecated and will not work soon.
This can be used when a reader has been renamed, and we want to give some time to users to adapt the code.

Moving the reader from PENDING_OLD_READER_NAMES to OLD_READER_NAMES will raise an error instead of just a warning.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
