### PR TITLE
Use encoding for compressing cf datasets

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -1223,10 +1223,11 @@ class EncodingUpdateTest(unittest.TestCase):
                                '2': {'dtype': 'float32'}},
                   'other': 'kwargs'}
         enc, other_kwargs = update_encoding(ds, kwargs, numeric_name_prefix='CHANNEL_')
-        self.assertDictEqual(enc, {'y': {'_FillValue': None},
-                                   'x': {'_FillValue': None},
-                                   'CHANNEL_1': {'dtype': 'float32'},
-                                   'CHANNEL_2': {'dtype': 'float32'}})
+        self.assertDictEqual(enc, {'y': {'_FillValue': None, "zlib": True},
+                                   'x': {'_FillValue': None, "zlib": True},
+                                   'lon': {'zlib': True},
+                                   'CHANNEL_1': {'dtype': 'float32', "zlib": True},
+                                   'CHANNEL_2': {'dtype': 'float32', "zlib": True}})
         self.assertDictEqual(other_kwargs, {'other': 'kwargs'})
 
     def test_without_time(self):
@@ -1238,22 +1239,22 @@ class EncodingUpdateTest(unittest.TestCase):
         kwargs = {'encoding': {'bar': {'chunksizes': (1, 1)}},
                   'other': 'kwargs'}
         enc, other_kwargs = update_encoding(ds, kwargs)
-        self.assertDictEqual(enc, {'y': {'_FillValue': None},
-                                   'x': {'_FillValue': None},
-                                   'lon': {'chunksizes': (2, 2)},
-                                   'foo': {'chunksizes': (2, 2)},
-                                   'bar': {'chunksizes': (1, 1)}})
+        self.assertDictEqual(enc, {'y': {'_FillValue': None, "zlib": True},
+                                   'x': {'_FillValue': None, "zlib": True},
+                                   'lon': {'chunksizes': (2, 2), "zlib": True},
+                                   'foo': {'chunksizes': (2, 2), "zlib": True},
+                                   'bar': {'chunksizes': (1, 1), "zlib": True}})
         self.assertDictEqual(other_kwargs, {'other': 'kwargs'})
 
         # Chunksize may not exceed shape
         ds = self.ds.chunk(8)
         kwargs = {'encoding': {}, 'other': 'kwargs'}
         enc, other_kwargs = update_encoding(ds, kwargs)
-        self.assertDictEqual(enc, {'y': {'_FillValue': None},
-                                   'x': {'_FillValue': None},
-                                   'lon': {'chunksizes': (2, 2)},
-                                   'foo': {'chunksizes': (2, 2)},
-                                   'bar': {'chunksizes': (2, 2)}})
+        self.assertDictEqual(enc, {'y': {'_FillValue': None, "zlib": True},
+                                   'x': {'_FillValue': None, "zlib": True},
+                                   'lon': {'chunksizes': (2, 2), "zlib": True},
+                                   'foo': {'chunksizes': (2, 2), "zlib": True},
+                                   'bar': {'chunksizes': (2, 2), "zlib": True}})
 
     def test_with_time(self):
         """Test data with a time dimension."""
@@ -1264,17 +1265,18 @@ class EncodingUpdateTest(unittest.TestCase):
         kwargs = {'encoding': {'bar': {'chunksizes': (1, 1, 1)}},
                   'other': 'kwargs'}
         enc, other_kwargs = update_encoding(ds, kwargs)
-        self.assertDictEqual(enc, {'y': {'_FillValue': None},
-                                   'x': {'_FillValue': None},
-                                   'lon': {'chunksizes': (2, 2)},
-                                   'foo': {'chunksizes': (1, 2, 2)},
-                                   'bar': {'chunksizes': (1, 1, 1)},
+        self.assertDictEqual(enc, {'y': {'_FillValue': None, "zlib": True},
+                                   'x': {'_FillValue': None, "zlib": True},
+                                   'lon': {'chunksizes': (2, 2), "zlib": True},
+                                   'foo': {'chunksizes': (1, 2, 2), "zlib": True},
+                                   'bar': {'chunksizes': (1, 1, 1), "zlib": True},
                                    'time': {'_FillValue': None,
                                             'calendar': 'proleptic_gregorian',
-                                            'units': 'days since 2009-07-01 12:15:00'},
+                                            'units': 'days since 2009-07-01 12:15:00',
+                                            "zlib": True},
                                    'time_bnds': {'_FillValue': None,
                                                  'calendar': 'proleptic_gregorian',
                                                  'units': 'days since 2009-07-01 12:15:00'}})
 
         # User-defined encoding may not be altered
-        self.assertDictEqual(kwargs['encoding'], {'bar': {'chunksizes': (1, 1, 1)}})
+        self.assertDictEqual(kwargs['encoding'], {'bar': {'chunksizes': (1, 1, 1), "zlib": True}})

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -33,9 +33,9 @@ format:
 
 * You can select the netCDF backend using the ``engine`` keyword argument. Default is ``h5netcdf``.
 * For datasets with area definition you can exclude lat/lon coordinates by setting ``include_lonlats=False``.
-* By default the dataset name is prepended to non-dimensional coordinates such as scanline timestamps. This ensures
-  maximum consistency, i.e. the netCDF variable names are independent of the number/set of datasets to be written.
-  If a non-dimensional coordinate is identical for
+* By default non-dimensional coordinates (such as scanline timestamps) are prefixed with the corresponding
+  dataset name. This is because they are likely to be different for each dataset. If a non-dimensional
+  coordinate is identical for all datasets, the prefix can be removed by setting ``pretty=True``.
 * Some dataset names start with a digit, like AVHRR channels 1, 2, 3a, 3b, 4 and 5. This doesn't comply with CF
   https://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/build/ch02s03.html. These channels are prefixed
   with `CHANNEL_` by default. This can be controlled with the variable `numeric_name_prefix` to `save_datasets`.
@@ -54,6 +54,36 @@ datasets with common grids in separate netCDF groups as follows:
                           groups={'visir': ['VIS006', 'IR_108'], 'hrv': ['HRV']})
 
 Note that the resulting file will not be fully CF compliant.
+
+
+Dataset Encoding
+~~~~~~~~~~~~~~~~
+
+Dataset encoding can be specified in two ways:
+
+1) Via the ``encoding`` keyword argument of ``save_datasets``:
+
+    >>> my_encoding = {
+    ...    'my_dataset_1': {
+    ...        'zlib': True,
+    ...        'complevel': 9,
+    ...        'scale_factor': 0.01,
+    ...        'add_offset': 100,
+    ...        'dtype': np.int16
+    ...     },
+    ...    'my_dataset_2': {
+    ...        'zlib': False
+    ...     }
+    ... }
+    >>> scn.save_datasets(writer='cf', filename='encoding_test.nc', encoding=my_encoding)
+
+
+2) Via the ``encoding`` attribute of the datasets in a scene. For example
+
+    >>> scn['my_dataset'].encoding = {'zlib': False}
+    >>> scn.save_datasets(writer='cf', filename='encoding_test.nc')
+
+See the `xarray encoding documentation`_ for all encoding options.
 
 
 Attribute Encoding
@@ -99,6 +129,8 @@ This is what the corresponding ``ncdump`` output would look like in this case:
 
 
 .. _CF-compliant: http://cfconventions.org/
+.. _xarray encoding documentation:
+    http://xarray.pydata.org/en/stable/user-guide/io.html?highlight=encoding#writing-encoded-data
 """
 
 import copy


### PR DESCRIPTION
This remove the `compression` keyword from cf saving, letting the user rely on the `encoding` attribute instead.

 - [ ] Closes #1699 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

@BENR0 tell me what you think!
