### PR TITLE
Update SLSTR reader to choose correct file for interpolated angles

### DIFF
--- a/satpy/readers/slstr_l1b.py
+++ b/satpy/readers/slstr_l1b.py
@@ -78,6 +78,7 @@ class NCSLSTRGeo(BaseFileHandler):
     def get_dataset(self, key, info):
         """Load a dataset."""
         logger.debug('Reading %s.', key['name'])
+        print(key['view'])
         file_key = info['file_key'].format(view=key['view'].name[0],
                                            stripe=key['stripe'].name)
         try:
@@ -246,7 +247,8 @@ class NCSLSTRAngles(BaseFileHandler):
         self.platform_name = PLATFORM_NAMES[filename_info['mission_id']]
         self.sensor = 'slstr'
 
-        self.view = filename_info['view']
+        views = {'n': 'nadir', 'o': 'oblique', 'x': 'meteo'}
+        self.view = views[filename_info['view']]
         self._start_time = filename_info['start_time']
         self._end_time = filename_info['end_time']
 
@@ -276,6 +278,8 @@ class NCSLSTRAngles(BaseFileHandler):
 
     def get_dataset(self, key, info):
         """Load a dataset."""
+        print("ANGLES")
+        print(info['view'], self.view)
         if not info['view'].name.startswith(self.view):
             return
         logger.debug('Reading %s.', key['name'])

--- a/satpy/readers/slstr_l1b.py
+++ b/satpy/readers/slstr_l1b.py
@@ -250,13 +250,22 @@ class NCSLSTRAngles(BaseFileHandler):
         self._start_time = filename_info['start_time']
         self._end_time = filename_info['end_time']
 
-        cart_file = os.path.join(
+        carta_file = os.path.join(
+            os.path.dirname(self.filename), 'cartesian_a{}.nc'.format(self.view[0]))
+        self.carta = xr.open_dataset(carta_file,
+                                     decode_cf=True,
+                                     mask_and_scale=True,
+                                     chunks={'columns': CHUNK_SIZE,
+                                             'rows': CHUNK_SIZE})
+
+        carti_file = os.path.join(
             os.path.dirname(self.filename), 'cartesian_i{}.nc'.format(self.view[0]))
-        self.cart = xr.open_dataset(cart_file,
-                                    decode_cf=True,
-                                    mask_and_scale=True,
-                                    chunks={'columns': CHUNK_SIZE,
-                                            'rows': CHUNK_SIZE})
+        self.carti = xr.open_dataset(carti_file,
+                                     decode_cf=True,
+                                     mask_and_scale=True,
+                                     chunks={'columns': CHUNK_SIZE,
+                                             'rows': CHUNK_SIZE})
+
         cartx_file = os.path.join(
             os.path.dirname(self.filename), 'cartesian_tx.nc')
         self.cartx = xr.open_dataset(cartx_file,
@@ -288,8 +297,12 @@ class NCSLSTRAngles(BaseFileHandler):
             # possible
             tie_x = self.cartx['x_tx'].data[0, :][::-1]
             tie_y = self.cartx['y_tx'].data[:, 0]
-            full_x = self.cart['x_i' + self.view[0]].data
-            full_y = self.cart['y_i' + self.view[0]].data
+            if key.get('resolution', 1000) == 500:
+                full_x = self.carta['x_a' + self.view[0]].data
+                full_y = self.carta['y_a' + self.view[0]].data
+            else:
+                full_x = self.carti['x_i' + self.view[0]].data
+                full_y = self.carti['y_i' + self.view[0]].data
 
             variable = variable.fillna(0)
 

--- a/satpy/readers/slstr_l1b.py
+++ b/satpy/readers/slstr_l1b.py
@@ -286,7 +286,6 @@ class NCSLSTRAngles(BaseFileHandler):
 
         if c_step != 1 or l_step != 1:
             logger.debug('Interpolating %s.', key['name'])
-
             # TODO: do it in cartesian coordinates ! pbs at date line and
             # possible
             tie_x = self.cartx['x_tx'].data[0, :][::-1]
@@ -299,6 +298,7 @@ class NCSLSTRAngles(BaseFileHandler):
                 full_y = self.carti['y_i' + self.view[0]].data
 
             variable = variable.fillna(0)
+            variable.attrs['resolution'] = key.get('resolution', 1000)
 
             from scipy.interpolate import RectBivariateSpline
             spl = RectBivariateSpline(

--- a/satpy/readers/slstr_l1b.py
+++ b/satpy/readers/slstr_l1b.py
@@ -78,7 +78,6 @@ class NCSLSTRGeo(BaseFileHandler):
     def get_dataset(self, key, info):
         """Load a dataset."""
         logger.debug('Reading %s.', key['name'])
-        print(key['view'])
         file_key = info['file_key'].format(view=key['view'].name[0],
                                            stripe=key['stripe'].name)
         try:
@@ -246,9 +245,7 @@ class NCSLSTRAngles(BaseFileHandler):
         # TODO: get metadata from the manifest file (xfdumanifest.xml)
         self.platform_name = PLATFORM_NAMES[filename_info['mission_id']]
         self.sensor = 'slstr'
-
-        views = {'n': 'nadir', 'o': 'oblique', 'x': 'meteo'}
-        self.view = views[filename_info['view']]
+        self.view = filename_info['view']
         self._start_time = filename_info['start_time']
         self._end_time = filename_info['end_time']
 
@@ -278,9 +275,7 @@ class NCSLSTRAngles(BaseFileHandler):
 
     def get_dataset(self, key, info):
         """Load a dataset."""
-        print("ANGLES")
-        print(info['view'], self.view)
-        if not info['view'].name.startswith(self.view):
+        if not key['view'].name.startswith(self.view[0]):
             return
         logger.debug('Reading %s.', key['name'])
         # Check if file_key is specified in the yaml

--- a/satpy/readers/slstr_l1b.py
+++ b/satpy/readers/slstr_l1b.py
@@ -231,6 +231,15 @@ class NCSLSTR1B(BaseFileHandler):
 class NCSLSTRAngles(BaseFileHandler):
     """Filehandler for angles."""
 
+    def _loadcart(self, fname):
+        """Load a cartesian file of appropriate type."""
+        cartf = xr.open_dataset(fname,
+                                decode_cf=True,
+                                mask_and_scale=True,
+                                chunks={'columns': CHUNK_SIZE,
+                                        'rows': CHUNK_SIZE})
+        return cartf
+
     def __init__(self, filename, filename_info, filetype_info):
         """Initialize the angles reader."""
         super(NCSLSTRAngles, self).__init__(filename, filename_info,
@@ -251,27 +260,13 @@ class NCSLSTRAngles(BaseFileHandler):
 
         carta_file = os.path.join(
             os.path.dirname(self.filename), 'cartesian_a{}.nc'.format(self.view[0]))
-        self.carta = xr.open_dataset(carta_file,
-                                     decode_cf=True,
-                                     mask_and_scale=True,
-                                     chunks={'columns': CHUNK_SIZE,
-                                             'rows': CHUNK_SIZE})
-
         carti_file = os.path.join(
             os.path.dirname(self.filename), 'cartesian_i{}.nc'.format(self.view[0]))
-        self.carti = xr.open_dataset(carti_file,
-                                     decode_cf=True,
-                                     mask_and_scale=True,
-                                     chunks={'columns': CHUNK_SIZE,
-                                             'rows': CHUNK_SIZE})
-
         cartx_file = os.path.join(
             os.path.dirname(self.filename), 'cartesian_tx.nc')
-        self.cartx = xr.open_dataset(cartx_file,
-                                     decode_cf=True,
-                                     mask_and_scale=True,
-                                     chunks={'columns': CHUNK_SIZE,
-                                             'rows': CHUNK_SIZE})
+        self.carta = self._loadcart(carta_file)
+        self.carti = self._loadcart(carti_file)
+        self.cartx = self._loadcart(cartx_file)
 
     def get_dataset(self, key, info):
         """Load a dataset."""

--- a/satpy/tests/reader_tests/test_slstr_l1b.py
+++ b/satpy/tests/reader_tests/test_slstr_l1b.py
@@ -141,6 +141,8 @@ class TestSLSTRReader(TestSLSTRL1B):
 
         ds_id = make_dataid(name='foo', calibration='radiance',
                             stripe='a', view='nadir')
+        ds_id_500 = make_dataid(name='foo', calibration='radiance',
+                                stripe='a', view='nadir', resolution=500)
         filename_info = {'mission_id': 'S3A', 'dataset_name': 'foo',
                          'start_time': 0, 'end_time': 0,
                          'stripe': 'a', 'view': 'n'}
@@ -184,13 +186,13 @@ class TestSLSTRReader(TestSLSTRL1B):
         xr_.open_dataset.assert_called()
         xr_.open_dataset.reset_mock()
 
-        filename_info['resolution'] = 1000
         test = NCSLSTRAngles('somedir/S1_radiance_an.nc', filename_info, 'c')
         test.get_dataset(ds_id, dict(filename_info, **{'file_key': 'geometry_t{view:1s}'}))
         self.assertEqual(test.start_time, good_start)
         self.assertEqual(test.end_time, good_end)
         xr_.open_dataset.assert_called()
         xr_.open_dataset.reset_mock()
+        test.get_dataset(ds_id_500, dict(filename_info, **{'file_key': 'geometry_t{view:1s}'}))
 
 
 class TestSLSTRCalibration(TestSLSTRL1B):

--- a/satpy/tests/reader_tests/test_slstr_l1b.py
+++ b/satpy/tests/reader_tests/test_slstr_l1b.py
@@ -121,9 +121,10 @@ class TestSLSTRReader(TestSLSTRL1B):
 
     class FakeSpl:
         """Fake return function for SPL interpolation."""
+
         @staticmethod
         def ev(foo_x, foo_y):
-            """"Fake function to return interpolated data."""
+            """Fake function to return interpolated data."""
             return np.zeros((3, 2))
 
     @mock.patch('satpy.readers.slstr_l1b.xr')

--- a/satpy/tests/reader_tests/test_slstr_l1b.py
+++ b/satpy/tests/reader_tests/test_slstr_l1b.py
@@ -93,6 +93,7 @@ class TestSLSTRL1B(unittest.TestCase):
                 'S9_BT_ao': self.rad,
                 'foo_radiance_an': self.rad,
                 'S5_solar_irradiances': self.rad,
+                'latitude_an': self.rad,
                 'detector_an': det,
             },
             attrs={
@@ -149,8 +150,9 @@ class TestSLSTRReader(TestSLSTRL1B):
         filename_info = {'mission_id': 'S3A', 'dataset_name': 'foo',
                          'start_time': 0, 'end_time': 0,
                          'stripe': 'a', 'view': 'n'}
-        test = NCSLSTRGeo('somedir/S1_radiance_an.nc', filename_info, 'c')
-        test.get_dataset(ds_id, dict(filename_info, **{'file_key': 'foo'}))
+        test = NCSLSTRGeo('somedir/geometry_an.nc', filename_info, 'c')
+        print(filename_info)
+        test.get_dataset(ds_id, dict(filename_info, **{'file_key': 'latitude_{stripe:1s}{view:1s}'}))
         self.assertEqual(test.start_time, good_start)
         self.assertEqual(test.end_time, good_end)
         xr_.open_dataset.assert_called()
@@ -158,7 +160,8 @@ class TestSLSTRReader(TestSLSTRL1B):
 
         test = NCSLSTRAngles('somedir/S1_radiance_an.nc', filename_info, 'c')
         # TODO: Make this test work
-        # test.get_dataset(ds_id, filename_info)
+        print(filename_info)
+        test.get_dataset(ds_id, dict(filename_info, **{'file_key': 'geometry_{stripe:1s}{view:1s}'}))
         self.assertEqual(test.start_time, good_start)
         self.assertEqual(test.end_time, good_end)
         xr_.open_dataset.assert_called()

--- a/satpy/tests/reader_tests/test_slstr_l1b.py
+++ b/satpy/tests/reader_tests/test_slstr_l1b.py
@@ -118,10 +118,12 @@ def make_dataid(**items):
 
 class TestSLSTRReader(TestSLSTRL1B):
     """Test various nc_slstr file handlers."""
+
     class FakeSpl:
         """Fake return function for SPL interpolation."""
         @staticmethod
         def ev(foo_x, foo_y):
+            """"Fake function to return interpolated data."""
             return np.zeros((3, 2))
 
     @mock.patch('satpy.readers.slstr_l1b.xr')


### PR DESCRIPTION
At present, the SLSTR reader does not choose the correct file for interpolated angle datasets. It needs the cartesian coordinate file and chooses `in` by default, which is the IR (1km) resolution file.
This PR allows the reader to select the `an` file, which is at VIS resolution of 500m pixel size when required. This will enable angles to be correctly interpolated onto the SLSTR grid.

This partially addresses #1702 but does *not* allow angles to be interpolated correctly onto the IR grid as (I think) the 500m lat/lon grid is always selected.

 - [x] Tests added 
