### PR TITLE
Fix NUCAPS reader having incorrect _FillValue attribute

### DIFF
--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -221,6 +221,9 @@ class NUCAPSFileHandler(NetCDF4FileHandler):
             data = data.where((data <= valid_max))  # | (data >= valid_min))
         if fill_value is not None:
             data = data.where(data != fill_value)
+            # this _FillValue is no longer valid
+            metadata.pop('_FillValue', None)
+            data.attrs.pop('_FillValue', None)
 
         data.attrs.update(metadata)
         # Older format

--- a/satpy/tests/reader_tests/test_nucaps.py
+++ b/satpy/tests/reader_tests/test_nucaps.py
@@ -249,6 +249,8 @@ class TestNUCAPSReader(unittest.TestCase):
         for v in datasets.values():
             # self.assertNotEqual(v.info['resolution'], 0)
             self.assertEqual(v.ndim, 2)
+            if np.issubdtype(v.dtype, np.floating):
+                assert '_FillValue' not in v.attrs
 
     def test_load_individual_pressure_levels_true(self):
         """Test loading Temperature with individual pressure datasets."""


### PR DESCRIPTION
The `_FillValue` attribute was being returned in NUCAPS DataArrays even after they had been masked out and replaced with NaNs. This PR makes sure the attribute is removed.

CC @tommyjasmin and @joleenf who were the most recent people to modify this reader.

 - [x] Closes #1104 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->