### PR TITLE
Rewrite installation instructions to make conda use clearer

### DIFF
--- a/doc/source/dev_guide/index.rst
+++ b/doc/source/dev_guide/index.rst
@@ -30,6 +30,8 @@ Satpy is now Python 3 only and it is no longer needed to support Python 2.
 Check ``setup.py`` for the current Python versions any new code needs
 to support.
 
+.. _devinstall:
+
 Development installation
 ========================
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -23,20 +23,41 @@ to always use conda-forge by running:
 
     $ conda config --add channels conda-forge
 
-We recommend creating a separate environment for your work with Satpy. If
-you haven't created and activated one already, you can by running:
+In a new conda environment
+--------------------------
+
+We recommend creating a separate environment for your work with Satpy. To
+create a new environment and install Satpy all in one command you can
+run:
+
 
 .. code-block:: bash
 
-    $ conda create -c conda-forge -n my_satpy_env python
+    $ conda create -c conda-forge -n my_satpy_env python satpy
+
+You must then activate the environment so any future python or
+conda commands will use this environment.
+
+.. code-block::
+
     $ conda activate my_satpy_env
 
-The above will create a new environment with the latest version of Python
-installed along with Satpy and all of its dependencies. The second command
-will activate the environment so all future conda or python commands will
-use this new environment.
+This method of creating an environment with Satpy (and optionally other
+packages) installed can generally be created faster than creating an
+environment and then later installing Satpy and other packages (see the
+section below).
 
-Next to install Satpy into an existing activated environment run:
+In an existing environment
+--------------------------
+
+.. note::
+
+    It is recommended that when first exploring Satpy, you create a new
+    environment specifically for this rather than modifying one used for
+    other work.
+
+If you already have a conda environment, it is activated, and would like to
+install Satpy into it, run the following:
 
 .. code-block:: bash
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -67,7 +67,9 @@ install Satpy into it, run the following:
 
     Satpy only automatically installs the dependencies needed to process the
     most common use cases. Additional dependencies may need to be installed
-    with conda or pip if import errors are encountered.
+    with conda or pip if import errors are encountered. To check your
+    installation use the ``check_satpy`` function discussed
+    :ref:`here <troubleshooting>`.
 
 Pip-based Installation
 ======================

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -2,6 +2,52 @@
 Installation Instructions
 =========================
 
+Satpy is available from conda-forge (via conda), PyPI (via pip), or from
+source (via pip+git). The below instructions show how to install stable
+versions of Satpy. For a development/unstable version see :ref:`devinstall`.
+
+Conda-based Installation
+========================
+
+Satpy can be installed into a conda environment by installing the package
+from the conda-forge channel. If you do not already have access to a conda
+installation, we recommend installing
+`miniconda <https://docs.conda.io/en/latest/miniconda.html>`_ for the smallest
+and easiest installation.
+
+The commands below will use ``-c conda-forge`` to make sure packages are
+downloaded from the conda-forge channel. Alternatively, you can tell conda
+to always use conda-forge by running:
+
+.. code-block:: bash
+
+    $ conda config --add channels conda-forge
+
+We recommend creating a separate environment for your work with Satpy. If
+you haven't created and activated one already, you can by running:
+
+.. code-block:: bash
+
+    $ conda create -c conda-forge -n my_satpy_env python
+    $ conda activate my_satpy_env
+
+The above will create a new environment with the latest version of Python
+installed along with Satpy and all of its dependencies. The second command
+will activate the environment so all future conda or python commands will
+use this new environment.
+
+Next to install Satpy into an existing activated environment run:
+
+.. code-block:: bash
+
+    $ conda install -c conda-forge satpy
+
+.. note::
+
+    Satpy only automatically installs the dependencies needed to process the
+    most common use cases. Additional dependencies may need to be installed
+    with conda or pip if import errors are encountered.
+
 Pip-based Installation
 ======================
 
@@ -30,42 +76,6 @@ dependencies:
 .. code-block:: bash
 
     $ pip install "satpy[all]"
-
-Conda-based Installation
-========================
-
-Satpy is available from the conda-forge channel. If
-you have not configured your conda environment to search conda-forge already
-then do:
-
-.. code-block:: bash
-
-    $ conda config --add channels conda-forge
-
-We recommend creating a separate environment for your work with Satpy. If
-you haven't created and activated one already, you can by running:
-
-.. code-block:: bash
-
-    $ conda create -n my_satpy_env python
-    $ conda activate my_satpy_env
-
-The above will create a new environment with the latest version of Python
-installed along with Satpy and all of its dependencies. The second command
-will activate the environment so all future conda or python commands will
-use this new environment.
-
-Next to install Satpy into an existing activated environment run:
-
-.. code-block:: bash
-
-    $ conda install satpy
-
-.. note::
-
-    Satpy only automatically installs the dependencies needed to process the
-    most common use cases. Additional dependencies may need to be installed
-    with conda or pip if import errors are encountered.
 
 Ubuntu System Python Installation
 =================================

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -281,6 +281,7 @@ To subset multi-resolution data consistently, use the :meth:`~satpy.scene.Scene.
   >>> vis006_llbox_lon, vis006_llbox_lat = vis006_llbox.attrs['area'].get_lonlats()
 
 
+.. _troubleshooting:
 
 Troubleshooting
 ===============


### PR DESCRIPTION
We generally tell new users to use conda for installing Satpy. This PR rearranges the installation instructions so conda comes before pip and also adds information about miniconda.

 - [x] Closes #1060 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
