### PR TITLE
Add low resolution file patterns for AHI HSD reader

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,6 +29,7 @@ The following people have made contributions to this project:
 - [Blanka Gvozdikova (gvozdikb)](https://github.com/gvozdikb)
 - [Nina Håkansson (ninahakansson)](https://github.com/ninahakansson)
 - [Ulrich Hamann](https://github.com/)
+- [Mitch Herbertson (mherbertson)](https://github.com/mherbertson)
 - [Gerrit Holl (gerritholl)](https://github.com/gerritholl)
 - [David Hoese (djhoese)](https://github.com/djhoese)
 - [Marc Honnorat (honnorat)](https://github.com/honnorat)

--- a/satpy/etc/readers/ahi_hsd.yaml
+++ b/satpy/etc/readers/ahi_hsd.yaml
@@ -289,64 +289,80 @@ file_types:
   hsd_b01:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B01_{area}_R10_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B01_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B01_{area}_R10_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b02:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B02_{area}_R10_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B02_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B02_{area}_R10_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b03:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B03_{area}_R05_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B03_{area}_R10_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B03_{area}_R05_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b04:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B04_{area}_R10_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B04_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B04_{area}_R10_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b05:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B05_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B05_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B05_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b06:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B06_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B06_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B06_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b07:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B07_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B07_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B07_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b08:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B08_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B08_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B08_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b09:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B09_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B09_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B09_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b10:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B10_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B10_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B10_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b11:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B11_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B11_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B11_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b12:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B12_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B12_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B12_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b13:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B13_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B13_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B13_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b14:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B14_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B14_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B14_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b15:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B15_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B15_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B15_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b16:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
     file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B16_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B16_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B16_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']

--- a/satpy/etc/readers/ahi_hsd.yaml
+++ b/satpy/etc/readers/ahi_hsd.yaml
@@ -288,81 +288,65 @@ datasets:
 file_types:
   hsd_b01:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B01_{area}_R10_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B01_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B01_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B01_{area}_R10_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b02:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B02_{area}_R10_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B02_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B02_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B02_{area}_R10_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b03:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B03_{area}_R05_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B03_{area}_R10_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B03_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B03_{area}_R05_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b04:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B04_{area}_R10_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B04_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B04_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B04_{area}_R10_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b05:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B05_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B05_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B05_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B05_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b06:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B06_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B06_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B06_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B06_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b07:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B07_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B07_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B07_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B07_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b08:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B08_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B08_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B08_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B08_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b09:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B09_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B09_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B09_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B09_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b10:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B10_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B10_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B10_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B10_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b11:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B11_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B11_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B11_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B11_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b12:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B12_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B12_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B12_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B12_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b13:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B13_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B13_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B13_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B13_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b14:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B14_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B14_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B14_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B14_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b15:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B15_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B15_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B15_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B15_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']
   hsd_b16:
     file_reader: !!python/name:satpy.readers.ahi_hsd.AHIHSDFileHandler
-    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B16_{area}_R20_S{segment:2d}{total_segments:2d}.DAT',
-                    'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B16_{area}_R40_S{segment:2d}{total_segments:2d}.DAT',
+    file_patterns: ['HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B16_{area}_R{res_id:d}_S{segment:2d}{total_segments:2d}.DAT',
                     'HS_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B16_{area}_R20_S{segment:2d}{total_segments:2d}.DAT.bz2']


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

This PR adds ability to read low resolution AHI HSD file format created by a sample JMA utility.  As this utility requires the .DAT file, a bz2 format shouldn't be required.

https://www.data.jma.go.jp/mscweb/en/himawari89/space_segment/spsg_sample.html
