### PR TITLE
Fix package dependencies for the `msi_safe` reader

### DIFF
--- a/satpy/readers/msi_safe.py
+++ b/satpy/readers/msi_safe.py
@@ -114,6 +114,9 @@ class SAFEMSIMDXML(BaseFileHandler):
         self.tile = filename_info['gtile_number']
         self.platform_name = PLATFORMS[filename_info['fmission_id']]
 
+        import geotiepoints  # noqa
+        import bottleneck  # noqa
+
     @property
     def start_time(self):
         """Get start time."""

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ extras_require = {
     'amsr2_l1b': ['h5py >= 2.7.0'],
     'hrpt': ['pyorbital >= 1.3.1', 'pygac', 'python-geotiepoints >= 1.1.7'],
     'hrit_msg': ['pytroll-schedule'],
-    'msi_safe': ['glymur'],
+    'msi_safe': ['glymur', "bottleneck", "python-geotiepoints"],
     'nc_nwcsaf_msg': ['netCDF4 >= 1.1.8'],
     'sar_c': ['python-geotiepoints >= 1.1.7', 'rasterio', 'rioxarray'],
     'abi_l1b': ['h5netcdf'],


### PR DESCRIPTION
This PR add the required `bottleneck` and `python-geotiepoints` in the `msi_safe` reader. 

 - [x] Closes #1722 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->

