### PR TITLE
Replace doc references to PPP_CONFIG_DIR

### DIFF
--- a/satpy/plugin_base.py
+++ b/satpy/plugin_base.py
@@ -44,7 +44,7 @@ class Plugin(object):
             default_config_filename (str): Configuration filename to use if
                 no other files have been specified with `config_files`.
             config_files (list or str): Configuration files to load instead
-                of those automatically found in `ppp_config_dir` and other
+                of those automatically found in `SATPY_CONFIG_PATH` and other
                 default configuration locations.
             kwargs (dict): Unused keyword arguments.
 

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -205,7 +205,7 @@ def get_area_file():
 def get_area_def(area_name):
     """Get the definition of *area_name* from file.
 
-    The file is defined to use is to be placed in the $PPP_CONFIG_DIR
+    The file is defined to use is to be placed in the $SATPY_CONFIG_PATH
     directory, and its name is defined in satpy's configuration file.
     """
     try:


### PR DESCRIPTION
Replace documentation references to PPP_CONFIG_DIR to refer to
SATPY_CONFIG_PATH instead, except where the context refers to the former
being out of date.

 - [x] Closes #1724 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
