### PR TITLE
Point out get_area_def in resample documentation

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -127,7 +127,15 @@ and loaded using pyresample's utility methods
     >>> from pyresample import load_area
     >>> my_area = load_area('my_areas.yaml', 'my_area')
 
-Examples coming soon...
+Or using :func:`satpy.resample.get_area_def`, which will search through all
+``areas.yaml`` files in your ``SATPY_CONFIG_PATH``::
+
+    >>> from satpy.resample import get_area_def
+    >>> area_eurol = get_area_def("eurol")
+
+For examples of area definitions, see the file ``etc/areas.yaml`` that is
+included with Satpy and where all the area definitions shipped with Satpy are
+defined.
 
 """
 import hashlib


### PR DESCRIPTION
In the main resample documentation, mention the nice satpy utility
function get_area_def.

 - [x] Closes #1726<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
