### PR TITLE
Fix geotiff writer ignoring dtype argument

### DIFF
--- a/satpy/tests/writer_tests/test_geotiff.py
+++ b/satpy/tests/writer_tests/test_geotiff.py
@@ -111,7 +111,7 @@ class TestGeoTIFFWriter(unittest.TestCase):
         w.save_datasets(datasets)
 
     def test_dtype_for_enhance_false(self):
-        """Test that dtype of dataset is used if enhance=False."""
+        """Test that dtype of dataset is used if parameters enhance=False and dtype=None."""
         from satpy.writers.geotiff import GeoTIFFWriter
         datasets = self._get_test_datasets()
         w = GeoTIFFWriter(base_dir=self.base_dir, enhance=False)
@@ -119,6 +119,16 @@ class TestGeoTIFFWriter(unittest.TestCase):
             save_method.return_value = None
             w.save_datasets(datasets, compute=False)
             self.assertEqual(save_method.call_args[1]['dtype'], np.float64)
+
+    def test_dtype_for_enhance_false_and_given_dtype(self):
+        """Test that dtype of dataset is used if enhance=False and dtype=uint8."""
+        from satpy.writers.geotiff import GeoTIFFWriter
+        datasets = self._get_test_datasets()
+        w = GeoTIFFWriter(base_dir=self.base_dir, enhance=False, dtype=np.uint8)
+        with mock.patch('satpy.writers.XRImage.save') as save_method:
+            save_method.return_value = None
+            w.save_datasets(datasets, compute=False)
+            self.assertEqual(save_method.call_args[1]['dtype'], np.uint8)
 
     def test_fill_value_from_config(self):
         """Test fill_value coming from the writer config."""

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -196,7 +196,7 @@ class GeoTIFFWriter(ImageWriter):
         dtype = dtype if dtype is not None else self.dtype
         if dtype is None and self.enhancer is not False:
             dtype = np.uint8
-        else:
+        elif dtype is None:
             dtype = img.data.dtype.type
 
         if "alpha" in kwargs:


### PR DESCRIPTION
This fixes #1730
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1730 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->