### PR TITLE
Remove valid_range from attributes in VIRR L1b reader

### DIFF
--- a/satpy/readers/virr_l1b.py
+++ b/satpy/readers/virr_l1b.py
@@ -92,10 +92,11 @@ class VIRR_L1B(HDF5FileHandler):
             file_key = file_key.replace('Data/', '')
         data = self[file_key]
         band_index = ds_info.get('band_index')
+        valid_range = data.attrs.pop('valid_range', None)
         if band_index is not None:
             data = data[band_index]
-            data = data.where((data >= self[file_key + '/attr/valid_range'][0]) &
-                              (data <= self[file_key + '/attr/valid_range'][1]))
+            data = data.where((data >= valid_range[0]) &
+                              (data <= valid_range[1]))
             if 'Emissive' in file_key:
                 slope = self._correct_slope(self[self.l1b_prefix + 'Emissive_Radiance_Scales'].
                                             data[:, band_index][:, np.newaxis])
@@ -121,8 +122,9 @@ class VIRR_L1B(HDF5FileHandler):
         else:
             slope = self._correct_slope(self[file_key + '/attr/Slope'])
             intercept = self[file_key + '/attr/Intercept']
-            data = data.where((data >= self[file_key + '/attr/valid_range'][0]) &
-                              (data <= self[file_key + '/attr/valid_range'][1]))
+
+            data = data.where((data >= valid_range[0]) &
+                              (data <= valid_range[1]))
             data = data * slope + intercept
         new_dims = {old: new for old, new in zip(data.dims, ('y', 'x'))}
         data = data.rename(new_dims)

--- a/satpy/readers/virr_l1b.py
+++ b/satpy/readers/virr_l1b.py
@@ -95,8 +95,9 @@ class VIRR_L1B(HDF5FileHandler):
         valid_range = data.attrs.pop('valid_range', None)
         if band_index is not None:
             data = data[band_index]
-            data = data.where((data >= valid_range[0]) &
-                              (data <= valid_range[1]))
+            if valid_range:
+                data = data.where((data >= valid_range[0]) &
+                                  (data <= valid_range[1]))
             if 'Emissive' in file_key:
                 slope = self._correct_slope(self[self.l1b_prefix + 'Emissive_Radiance_Scales'].
                                             data[:, band_index][:, np.newaxis])
@@ -123,8 +124,9 @@ class VIRR_L1B(HDF5FileHandler):
             slope = self._correct_slope(self[file_key + '/attr/Slope'])
             intercept = self[file_key + '/attr/Intercept']
 
-            data = data.where((data >= valid_range[0]) &
-                              (data <= valid_range[1]))
+            if valid_range:
+                data = data.where((data >= valid_range[0]) &
+                                  (data <= valid_range[1]))
             data = data * slope + intercept
         new_dims = {old: new for old, new in zip(data.dims, ('y', 'x'))}
         data = data.rename(new_dims)

--- a/satpy/tests/reader_tests/test_virr_l1b.py
+++ b/satpy/tests/reader_tests/test_virr_l1b.py
@@ -160,6 +160,7 @@ class TestVIRRL1BReader(unittest.TestCase):
                 self.assertEqual(('longitude', 'latitude'), attributes['coordinates'])
             self.assertEqual(band_values[dataset['name']],
                              round(float(np.array(ds[ds.shape[0] // 2][ds.shape[1] // 2])), 6))
+            assert "valid_range" not in ds.attrs
 
     def test_fy3b_file(self):
         """Test that FY3B files are recognized."""


### PR DESCRIPTION
The valid_range is removed from the attributes after it is a applied to the data.  The format as a numpy array was not working with another writer.  This was chosen over the alternative approach to make the valid_range a list.  The valid_range was in the attributes but not scaled to match the final data output and so it didn't seem to have much relevant meaning.  

Test has been added to make sure that valid_range is not in the final dataset attributes.  
