### PR TITLE
Add option to configure group_files behaviour on empty groups in case of multiple readers

### DIFF
--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -28,6 +28,7 @@ from satpy.dataset.dataid import WavelengthRange, ModifierTuple, DataID
 
 # clear the config dir environment variable so it doesn't interfere
 os.environ.pop("PPP_CONFIG_DIR", None)
+os.environ.pop("SATPY_CONFIG_PATH", None)
 
 local_id_keys_config = {'name': {
     'required': True,
@@ -845,6 +846,61 @@ class TestGroupFiles(unittest.TestCase):
                     reader=("abi_l1b", "viirs_sdr"),
                     group_keys=("start_time"),
                     time_threshold=10**9)
+
+    def test_multi_readers_empty_groups(self):
+        """Test behaviour on empty groups passing multiple readers."""
+        from satpy.readers import group_files
+        filenames = [
+            "OR_ABI-L1b-RadF-M6C14_G16_s19000010000000_e19000010005000_c20403662359590.nc",
+            "OR_ABI-L1b-RadF-M6C14_G16_s19000010010000_e19000010015000_c20403662359590.nc",
+            "OR_ABI-L1b-RadF-M6C14_G16_s19000010020000_e19000010025000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010000000_e19000010001000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010001000_e19000010002000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010002000_e19000010003000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010003000_e19000010004000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010004000_e19000010005000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010005000_e19000010006000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010006000_e19000010007000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010007000_e19000010008000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010008000_e19000010009000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010009000_e19000010010000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010010000_e19000010011000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010011000_e19000010012000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010012000_e19000010013000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010013000_e19000010014000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010014000_e19000010015000_c20403662359590.nc",
+            "OR_GLM-L2-GLMF-M3_G16_s19000010015000_e19000010016000_c20403662359590.nc"]
+        with pytest.raises(FileNotFoundError):
+            # make sure it raises an exception, for there will be groups
+            # containing GLM but not ABI
+            group_files(
+                filenames,
+                reader=["abi_l1b", "glm_l2"],
+                group_keys=("start_time",),
+                time_threshold=35,
+                missing="raise")
+        # verify that all groups lacking ABI are skipped, resulting in only
+        # three groups that are all non-empty for both instruments
+        groups = group_files(
+            filenames,
+            reader=["abi_l1b", "glm_l2"],
+            group_keys=("start_time",),
+            time_threshold=35,
+            missing="skip")
+        assert len(groups) == 3
+        for g in groups:
+            assert g["abi_l1b"]
+            assert g["glm_l2"]
+        # verify that all groups are there, resulting in some that are empty
+        groups = group_files(
+            filenames,
+            reader=["abi_l1b", "glm_l2"],
+            group_keys=("start_time",),
+            time_threshold=35,
+            missing="pass")
+        assert len(groups) == len(filenames)
+        assert not groups[1]["abi_l1b"]  # should be empty
+        assert groups[1]["glm_l2"]  # should not be empty
 
 
 def _generate_random_string():


### PR DESCRIPTION
In `satpy.readers.group_files`, when passing multiple readers, allow the user to configure the behaviour in case some groups have zero files corresponding to some readers.  The options are "pass" (pass the groups anyway, current and default behaviour), "skip" (skip those groups entirely, meaning some files are not assigned to any group), or "raise" (raise an exception as soon as for at least one group there is at least one reader with zero corresponding files).  This behaviour is useful for a multiscene to prevent a single missing file in a long (time) series from making a multi-reader composite impossible to load for the entire multiscene.

(Work in progress, so far only the test is there)

 - [ ] Closes #1742<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
