### PR TITLE
Fix VIRR reader handling valid_range when it is a numpy array

### DIFF
--- a/satpy/readers/virr_l1b.py
+++ b/satpy/readers/virr_l1b.py
@@ -93,6 +93,8 @@ class VIRR_L1B(HDF5FileHandler):
         data = self[file_key]
         band_index = ds_info.get('band_index')
         valid_range = data.attrs.pop('valid_range', None)
+        if isinstance(valid_range, np.ndarray):
+            valid_range = valid_range.tolist()
         if band_index is not None:
             data = data[band_index]
             if valid_range:


### PR DESCRIPTION
The valid_range can be an ndarray when it is read, making the boolean `if valid_range:` the incorrect choice for the data type.  Since valid_range can either be an ndarray or None, convert the ndarray to a list so that later boolean checks don't fail.