### PR TITLE
Improve exception when dependencies misses area attribute

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -191,8 +191,9 @@ class CompositeBase:
         areas = [ds.attrs.get('area') for ds in data_arrays]
         if all(a is None for a in areas):
             return
-        elif any(a is None for a in areas):
-            raise ValueError("Missing 'area' attribute")
+        for ds in data_arrays:
+            if "area" not in ds.attrs:
+                raise AttributeError(f"Dataset {ds.name!s} missing 'area' attribute")
 
         if not all(areas[0] == x for x in areas[1:]):
             LOG.debug("Not all areas are the same in "

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -32,7 +32,7 @@ import xarray as xr
 class TestMatchDataArrays(unittest.TestCase):
     """Test the utility method 'match_data_arrays'."""
 
-    def _get_test_ds(self, shape=(50, 100), dims=('y', 'x')):
+    def _get_test_ds(self, shape=(50, 100), dims=('y', 'x'), name="test"):
         """Get a fake DataArray."""
         from pyresample.geometry import AreaDefinition
         data = da.random.random(shape, chunks=25)
@@ -43,7 +43,7 @@ class TestMatchDataArrays(unittest.TestCase):
             shape[dims.index('x')], shape[dims.index('y')],
             (-20037508.34, -10018754.17, 20037508.34, 10018754.17))
         attrs = {'area': area}
-        return xr.DataArray(data, dims=dims, attrs=attrs)
+        return xr.DataArray(data, dims=dims, attrs=attrs, name=name)
 
     def test_single_ds(self):
         """Test a single dataset is returned unharmed."""
@@ -66,11 +66,12 @@ class TestMatchDataArrays(unittest.TestCase):
     def test_mult_ds_no_area(self):
         """Test that all datasets must have an area attribute."""
         from satpy.composites import CompositeBase
-        ds1 = self._get_test_ds()
-        ds2 = self._get_test_ds()
+        ds1 = self._get_test_ds(name="seaweed")
+        ds2 = self._get_test_ds(name="tumbleweed")
         del ds2.attrs['area']
         comp = CompositeBase('test_comp')
-        self.assertRaises(ValueError, comp.match_data_arrays, (ds1, ds2))
+        with pytest.raises(AttributeError, match="tumbleweed"):
+            comp.match_data_arrays((ds1, ds2))
 
     def test_mult_ds_diff_area(self):
         """Test that datasets with different areas fail."""


### PR DESCRIPTION
When a composite is checking that all data arrays have the area
attribute, and a composite is missing this, raise an AttributeError
rather than a ValueError.  Include the name of the offending dataset in
the associated error message.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
