### PR TITLE
Updates to CLAVR-x reader and awips_tiled.yaml for CLAVR-x

### DIFF
--- a/satpy/etc/readers/clavrx.yaml
+++ b/satpy/etc/readers/clavrx.yaml
@@ -21,6 +21,7 @@ file_types:
     file_patterns:
       - 'clavrx_OR_{sensor}-L1b-Rad{sector}-{mode}C{channel_number}_{platform_shortname}_s{start_time:%Y%j%H%M%S%f}.level2.nc'
       - 'clavrx_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B{channel_number}_{sector}_R.level2.nc'
+      - 'clavrx_{platform_shortname}_{start_time:%Y%m%d_%H%M}_B{channel_number}_{sector}_DK_R10_S0110.DAT.level2.nc'
 
 #datasets:
 #  longitude:

--- a/satpy/etc/writers/awips_tiled.yaml
+++ b/satpy/etc/writers/awips_tiled.yaml
@@ -66,9 +66,12 @@ templates:
 #        value: "${ORGANIZATION}"
       awips_id: {}
 #        value: "{awips_id}"  # special variable created by awips_tiled.py
+      physical_element: {}
+#        value: "{physical_element}"   #special variable created by awips_tiled.py
       satellite_id:
         value: "{platform_name!u}-{sensor!u}"
       sector_id: {}  # special handler in awips_tiled.py
+
     coordinates:
       x:
         attributes:
@@ -123,6 +126,8 @@ templates:
         reader: clavrx
         name: cloud_type
         var_name: data
+        encoding:
+          dtype: "int16"
         attributes:
           physical_element:
             raw_value: CLAVR-x Cloud Type
@@ -130,6 +135,8 @@ templates:
         reader: clavrx
         name: cld_temp_acha
         var_name: data
+        encoding:
+          dtype: "int16"
         attributes:
           physical_element:
             raw_value: CLAVR-x Cloud Top Temperature (ACHA)
@@ -193,6 +200,8 @@ templates:
         reader: clavrx
         name: rain_rate
         var_name: data
+        encoding:
+          dtype: "int16"
         attributes:
           physical_element:
             raw_value: CLAVR-x Rain Rate

--- a/satpy/etc/writers/awips_tiled.yaml
+++ b/satpy/etc/writers/awips_tiled.yaml
@@ -127,8 +127,6 @@ templates:
         reader: clavrx
         name: cloud_type
         var_name: data
-        encoding:
-          dtype: "int16"
         attributes:
           physical_element:
             raw_value: CLAVR-x Cloud Type
@@ -137,8 +135,6 @@ templates:
         reader: clavrx
         name: cld_temp_acha
         var_name: data
-        encoding:
-          dtype: "int16"
         attributes:
           units: {}
           physical_element:
@@ -211,8 +207,6 @@ templates:
         reader: clavrx
         name: rain_rate
         var_name: data
-        encoding:
-          dtype: "int16"
         attributes:
           units: {}
           physical_element:

--- a/satpy/etc/writers/awips_tiled.yaml
+++ b/satpy/etc/writers/awips_tiled.yaml
@@ -80,7 +80,7 @@ templates:
             value: '{standard_name}'
         encoding:
           dtype: "int16"
-          _Unsigned: "true"
+          #_Unsigned: "true"
       y:
         attributes:
           units: {}
@@ -88,7 +88,7 @@ templates:
             value: '{standard_name}'
         encoding:
           dtype: "int16"
-          _Unsigned: "true"
+          #_Unsigned: "true"
 
     # XXX: Variable attributes *CAN NOT* be tile-specific.
     variables:
@@ -120,6 +120,7 @@ templates:
         reader: clavrx
         var_name: data
         attributes:
+          units: {}
           physical_element:
             value: 'CLAVR-x {name}'
       clavrx_cloud_type:
@@ -131,6 +132,7 @@ templates:
         attributes:
           physical_element:
             raw_value: CLAVR-x Cloud Type
+          units: {}
       clavrx_cld_temp_acha:
         reader: clavrx
         name: cld_temp_acha
@@ -138,6 +140,7 @@ templates:
         encoding:
           dtype: "int16"
         attributes:
+          units: {}
           physical_element:
             raw_value: CLAVR-x Cloud Top Temperature (ACHA)
       clavrx_cld_height_acha:
@@ -145,6 +148,7 @@ templates:
         name: cld_height_acha
         var_name: data
         attributes:
+          units: {}
           physical_element:
             raw_value: CLAVR-x Cloud Top Height (ACHA)
       clavrx_cloud_phase:
@@ -152,6 +156,7 @@ templates:
         name: cloud_phase
         var_name: data
         attributes:
+          units: {}
           physical_element:
             raw_value: CLAVR-x Cloud Phase
       clavrx_cld_opd_dcomp:
@@ -159,6 +164,7 @@ templates:
         name: cld_opd_dcomp
         var_name: data
         attributes:
+          units: {}
           physical_element:
             raw_value: CLAVR-x Cloud Optical Depth (dcomp)
       clavrx_clld_opd_nlcomp:
@@ -166,6 +172,7 @@ templates:
         name: cloud_opd_nlcomp
         var_name: data
         attributes:
+          units: {}
           physical_element:
             raw_value: CLAVR-x Cloud Optical Depth (nlcomp)
       clavrx_cld_reff_dcomp:
@@ -173,6 +180,7 @@ templates:
         name: cld_reff_dcomp
         var_name: data
         attributes:
+          units: {}
           physical_element:
             raw_value: CLAVR-x Cloud Effective Radius (dcomp)
       clavrx_cld_reff_nlcomp:
@@ -180,6 +188,7 @@ templates:
         name: cld_reff_nlcomp
         var_name: data
         attributes:
+          units: {}
           physical_element:
             raw_value: CLAVR-x Cloud Effective Radius (nlcomp)
       clavrx_cld_emiss_acha:
@@ -187,6 +196,7 @@ templates:
         name: cld_emiss_acha
         var_name: data
         attributes:
+          units: {}
           physical_element:
             raw_value: CLAVR-x Cloud Emissivity (ACHA)
       clavrx_refl_lunar_dnb_nom:
@@ -194,6 +204,7 @@ templates:
         name: refl_lunar_dnb_nom
         var_name: data
         attributes:
+          units: {}
           physical_element:
             raw_value: CLAVR-x Cloud Lunar Reflectance
       clavrx_rain_rate:
@@ -203,6 +214,7 @@ templates:
         encoding:
           dtype: "int16"
         attributes:
+          units: {}
           physical_element:
             raw_value: CLAVR-x Rain Rate
 

--- a/satpy/readers/clavrx.py
+++ b/satpy/readers/clavrx.py
@@ -62,7 +62,7 @@ NADIR_RESOLUTION = {
     'modis': 1000,
     'avhrr': 1050,
     'ahi': 2000,
-    'abi': 2000,
+    'abi': 2004,
 }
 
 

--- a/satpy/readers/clavrx.py
+++ b/satpy/readers/clavrx.py
@@ -129,12 +129,15 @@ class _CLAVRxHelper:
         if not flags:
             data = data.where(data != fill)
             data = _CLAVRxHelper._scale_data(data, factor, offset)
+            # don't need _FillValue if it has been applied.
+            attrs.pop('_FillValue', None)
+            fill = _CLAVRxHelper._scale_data(fill, factor, offset)
 
-        if all(valid_range) and not flags:
+        if all(valid_range):
             valid_min = _CLAVRxHelper._scale_data(valid_range[0], factor, offset)
             valid_max = _CLAVRxHelper._scale_data(valid_range[1], factor, offset)
             data = data.where((data >= valid_min) & (data <= valid_max))
-            data.attrs['valid_range'] = [valid_min, valid_max]
+            attrs['valid_range'] = [valid_min, valid_max]
 
         data.attrs = _CLAVRxHelper._remove_attributes(attrs)
 

--- a/satpy/readers/clavrx.py
+++ b/satpy/readers/clavrx.py
@@ -274,8 +274,8 @@ class CLAVRXHDF4FileHandler(HDF4FileHandler, _CLAVRxHelper):
         if u in CF_UNITS:
             # CF compliance
             i['units'] = CF_UNITS[u]
-        if u.lower() == "none":
-            i['units'] = 1
+            if u.lower() == "none":
+                i['units'] = "1"
 
         i['sensor'] = self.sensor
         i['platform'] = i['platform_name'] = self.platform
@@ -472,8 +472,8 @@ class CLAVRXNetCDFFileHandler(_CLAVRxHelper, BaseFileHandler):
         if u in CF_UNITS:
             # CF compliance
             i['units'] = CF_UNITS[u]
-        if u.lower() == "none":
-            i['units'] = 1
+            if u.lower() == "none":
+                i['units'] = 1
 
         i['sensor'] = self.sensor
         i['platform'] = i['platform_name'] = self.platform

--- a/satpy/readers/clavrx.py
+++ b/satpy/readers/clavrx.py
@@ -118,8 +118,8 @@ class _CLAVRxHelper:
 
         attrs = data.attrs.copy()
         fill = attrs.pop('_FillValue', None)
-        factor = attrs.pop('scale_factor', 1.0)
-        offset = attrs.pop('add_offset', 0.0)
+        factor = attrs.pop('scale_factor', 1)
+        offset = attrs.pop('add_offset', 0)
         valid_range = attrs.pop('valid_range', None)
 
         data = data.where(data != fill)
@@ -380,8 +380,7 @@ class CLAVRXNetCDFFileHandler(_CLAVRxHelper, BaseFileHandler):
                                   decode_cf=True,
                                   mask_and_scale=False,
                                   decode_coords=True,
-                                  chunks={'pixel_elements_along_scan_direction': CHUNK_SIZE,
-                                          'scan_lines_along_track_direction': CHUNK_SIZE})
+                                  chunks=CHUNK_SIZE)
         # y,x is used in satpy, bands rather than channel using in xrimage
         self.nc = self.nc.rename_dims({'scan_lines_along_track_direction': "y",
                                        'pixel_elements_along_scan_direction': "x"})

--- a/satpy/readers/clavrx.py
+++ b/satpy/readers/clavrx.py
@@ -121,6 +121,8 @@ class _CLAVRxHelper:
         factor = attrs.pop('scale_factor', 1.0)
         offset = attrs.pop('add_offset', 0.0)
         valid_range = attrs.get('valid_range', [None])
+        if isinstance(valid_range, np.ndarray):
+            attrs["valid_range"] = valid_range.tolist()
 
         flags = not data.attrs.get("SCALED", 1) and any(data.attrs.get("flag_values", [None]))
 
@@ -132,7 +134,7 @@ class _CLAVRxHelper:
             valid_min = _CLAVRxHelper._scale_data(valid_range[0], factor, offset)
             valid_max = _CLAVRxHelper._scale_data(valid_range[1], factor, offset)
             data = data.where((data >= valid_min) & (data <= valid_max))
-            data.attrs['valid_range'] = valid_min, valid_max
+            data.attrs['valid_range'] = [valid_min, valid_max]
 
         data.attrs = _CLAVRxHelper._remove_attributes(attrs)
 

--- a/satpy/readers/clavrx.py
+++ b/satpy/readers/clavrx.py
@@ -111,7 +111,7 @@ class _CLAVRxHelper:
         return data_arr
 
     @staticmethod
-    def _get_data(data: xr.DataArray, dataset_id: dict, ds_info: dict) -> xr.DataArray:
+    def _get_data(data: xr.DataArray, dataset_id: dict) -> xr.DataArray:
         """Get a dataset."""
         if dataset_id.get('resolution'):
             data.attrs['resolution'] = dataset_id['resolution']
@@ -295,7 +295,7 @@ class CLAVRXHDF4FileHandler(HDF4FileHandler, _CLAVRxHelper):
         """Get a dataset."""
         var_name = ds_info.get('file_key', dataset_id['name'])
         data = self[var_name]
-        data = _CLAVRxHelper._get_data(data, dataset_id, ds_info)
+        data = _CLAVRxHelper._get_data(data, dataset_id)
         data.attrs = _CLAVRxHelper.get_metadata(self.sensor, self.platform,
                                                 data.attrs, ds_info)
         return data
@@ -389,7 +389,7 @@ class CLAVRXNetCDFFileHandler(_CLAVRxHelper, BaseFileHandler):
 
         self.nc = xr.open_dataset(filename,
                                   decode_cf=True,
-                                  mask_and_scale=False,
+                                  mask_and_scale=True,
                                   decode_coords=True,
                                   chunks=CHUNK_SIZE)
         # y,x is used in satpy, bands rather than channel using in xrimage
@@ -404,7 +404,6 @@ class CLAVRXNetCDFFileHandler(_CLAVRxHelper, BaseFileHandler):
         ds_info = {
             'file_type': self.filetype_info['file_type'],
             'name': var_name,
-            'coordinates': ["longitude", "latitude"]
         }
         return ds_info
 
@@ -467,7 +466,7 @@ class CLAVRXNetCDFFileHandler(_CLAVRxHelper, BaseFileHandler):
         """Get a dataset."""
         var_name = ds_info.get('name', dataset_id['name'])
         data = self[var_name]
-        data = _CLAVRxHelper._get_data(data, dataset_id, ds_info)
+        data = _CLAVRxHelper._get_data(data, dataset_id)
         data.attrs = _CLAVRxHelper.get_metadata(self.sensor, self.platform,
                                                 data.attrs, ds_info)
         return data

--- a/satpy/tests/reader_tests/test_clavrx.py
+++ b/satpy/tests/reader_tests/test_clavrx.py
@@ -376,7 +376,7 @@ class TestCLAVRXReaderGeo(unittest.TestCase):
             self.assertEqual(v.attrs['units'], '1')
             self.assertIsInstance(v.attrs['area'], AreaDefinition)
             if v.attrs["name"] == 'variable1':
-                self.assertIsInstance(v.attrs["valid_range"], tuple)
+                self.assertIsInstance(v.attrs["valid_range"], list)
             else:
                 self.assertNotIn('valid_range', v.attrs)
         self.assertIsNotNone(datasets['variable3'].attrs.get('flag_meanings'))

--- a/satpy/tests/reader_tests/test_clavrx.py
+++ b/satpy/tests/reader_tests/test_clavrx.py
@@ -217,7 +217,6 @@ class TestCLAVRXReaderPolar(unittest.TestCase):
                            'variable3'])
         self.assertEqual(len(datasets), 3)
         for v in datasets.values():
-            assert 'calibration' not in v.attrs
             self.assertEqual(v.attrs['units'], '1')
             self.assertEqual(v.attrs['platform_name'], 'npp')
             self.assertEqual(v.attrs['sensor'], 'viirs')
@@ -373,9 +372,13 @@ class TestCLAVRXReaderGeo(unittest.TestCase):
             datasets = r.load(['variable1', 'variable2', 'variable3'])
         self.assertEqual(len(datasets), 3)
         for v in datasets.values():
-            assert 'calibration' not in v.attrs
+            self.assertNotIn('calibration', v.attrs)
             self.assertEqual(v.attrs['units'], '1')
             self.assertIsInstance(v.attrs['area'], AreaDefinition)
+            if v.attrs["name"] == 'variable1':
+                self.assertIsInstance(v.attrs["valid_range"], tuple)
+            else:
+                self.assertNotIn('valid_range', v.attrs)
         self.assertIsNotNone(datasets['variable3'].attrs.get('flag_meanings'))
 
     def test_load_all_new_donor(self):
@@ -406,7 +409,7 @@ class TestCLAVRXReaderGeo(unittest.TestCase):
             datasets = r.load(['variable1', 'variable2', 'variable3'])
         self.assertEqual(len(datasets), 3)
         for v in datasets.values():
-            assert 'calibration' not in v.attrs
+            self.assertNotIn('calibration', v.attrs)
             self.assertEqual(v.attrs['units'], '1')
             self.assertIsInstance(v.attrs['area'], AreaDefinition)
             self.assertTrue(v.attrs['area'].is_geostationary)

--- a/satpy/tests/reader_tests/test_clavrx.py
+++ b/satpy/tests/reader_tests/test_clavrx.py
@@ -219,7 +219,7 @@ class TestCLAVRXReaderPolar(unittest.TestCase):
         for v in datasets.values():
             assert 'calibration' not in v.attrs
             self.assertEqual(v.attrs['units'], '1')
-            self.assertEqual(v.attrs['platform'], 'npp')
+            self.assertEqual(v.attrs['platform_name'], 'npp')
             self.assertEqual(v.attrs['sensor'], 'viirs')
             self.assertIsInstance(v.attrs['area'], SwathDefinition)
             self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 16)
@@ -410,6 +410,6 @@ class TestCLAVRXReaderGeo(unittest.TestCase):
             self.assertEqual(v.attrs['units'], '1')
             self.assertIsInstance(v.attrs['area'], AreaDefinition)
             self.assertTrue(v.attrs['area'].is_geostationary)
-            self.assertEqual(v.attrs['platform'], 'himawari8')
+            self.assertEqual(v.attrs['platform_name'], 'himawari8')
             self.assertEqual(v.attrs['sensor'], 'ahi')
         self.assertIsNotNone(datasets['variable3'].attrs.get('flag_meanings'))

--- a/satpy/tests/reader_tests/test_clavrx.py
+++ b/satpy/tests/reader_tests/test_clavrx.py
@@ -98,7 +98,7 @@ class FakeHDF4FileHandlerPolar(FakeHDF4FileHandler):
                 '_FillValue': -128,
                 'flag_meanings': 'clear water supercooled mixed ice unknown',
                 'flag_values': [0, 1, 2, 3, 4, 5],
-                'units': '1',
+                'units': 'none',
             })
         file_content['variable3/shape'] = DEFAULT_FILE_SHAPE
 

--- a/satpy/tests/reader_tests/test_clavrx_nc.py
+++ b/satpy/tests/reader_tests/test_clavrx_nc.py
@@ -73,7 +73,7 @@ def fake_test_content(filename, **kwargs):
                                     'scale_factor': 1.,
                                     'add_offset': 0.,
                                     'units': '1',
-                                    'valid_range': (-32767, 32767),
+                                    'valid_range': [-32767, 32767],
                                     })
 
     # data with fill values
@@ -84,7 +84,7 @@ def fake_test_content(filename, **kwargs):
                                     'scale_factor': 1.,
                                     'add_offset': 0.,
                                     'units': '1',
-                                    'valid_range': (-32767, 32767),
+                                    'valid_range': [-32767, 32767],
                                     })
     variable2 = variable2.where(variable2 % 2 != 0)
 
@@ -188,7 +188,9 @@ class TestCLAVRXReaderGeo:
                     assert 'calibration' not in v.attrs
                     assert v.attrs['units'] == '1'
                     assert isinstance(v.attrs['area'], AreaDefinition)
-                    assert v.attrs['platform'] == 'himawari8'
+                    assert v.attrs['platform_name'] == 'himawari8'
                     assert v.attrs['sensor'] == 'AHI'
                     assert 'rows_per_scan' not in v.coords.get('longitude').attrs
+                    if v.attrs["name"] in ["variable1", "variable2"]:
+                        assert isinstance(v.attrs["valid_range"], list)
                 assert (datasets['variable3'].attrs.get('flag_meanings')) is not None

--- a/satpy/tests/reader_tests/test_clavrx_nc.py
+++ b/satpy/tests/reader_tests/test_clavrx_nc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2018 Satpy developers
+# Copyright (c) 2021 Satpy developers
 #
 # This file is part of satpy.
 #

--- a/satpy/tests/writer_tests/test_awips_tiled.py
+++ b/satpy/tests/writer_tests/test_awips_tiled.py
@@ -188,6 +188,7 @@ class TestAWIPSTiledWriter:
             check_required_common_attributes(ds)
             assert ds.attrs['my_global'] == 'TEST'
             assert ds.attrs['sector_id'] == 'TEST'
+            assert 'physical_element' in ds.attrs
             stime = input_data_arr.attrs['start_time']
             assert ds.attrs['start_date_time'] == stime.strftime('%Y-%m-%dT%H:%M:%S')
 

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -864,7 +864,6 @@ class NetCDFTemplate:
         for data_arr in data_arrays:
             new_var_name, new_data_arr = self._render_variable(data_arr)
             new_ds[new_var_name] = new_data_arr
-
         new_coords = self._render_coordinates(new_ds)
         new_ds.coords.update(new_coords)
         # use first data array as "representative" for global attributes
@@ -969,6 +968,7 @@ class AWIPSNetCDFTemplate(NetCDFTemplate):
             new_encoding['scale_factor'] = sf
             new_encoding['add_offset'] = ao
             new_encoding['_FillValue'] = fill
+            new_encoding['coordinates'] = ' '.join([ele for ele in input_data_arr.dims])
         return new_encoding
 
     def _get_projection_attrs(self, area_def):

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -911,6 +911,11 @@ class AWIPSNetCDFTemplate(NetCDFTemplate):
     def _global_awips_id(self, input_metadata):
         return "AWIPS_" + input_metadata['name']
 
+    def _global_physical_element(self, input_metadata):
+        var_config = self._var_tree.find_match(**input_metadata)
+        result = self._render_attrs(var_config["attributes"], input_metadata)
+        return result["physical_element"]
+
     def _global_production_location(self, input_metadata):
         """Get default global production_location attribute."""
         del input_metadata


### PR DESCRIPTION
Changes are made to the awips_tiled yaml so that the physical_element is made into a global attribute addressing #1756 
for the clavrx products.  
Adds units to the variables in the awips_tiled yaml for clavrx products so that units are in the output data.

 - This pull request adds checks in the testing code to verify that valid_range is passed as a tuple, list or is not defined when there is no valid_range attribute in the original data. 
