### PR TITLE
Add missing demo data directory entry to config documentation

### DIFF
--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -150,6 +150,16 @@ defaults to a different path depending on your operating system following the
 
 .. _download_aux_setting:
 
+Demo Data Directory
+^^^^^^^^^^^^^^^^^^^
+
+* **Environment variable**: ``SATPY_DEMO_DATA_DIR``
+* **YAML/Config Key**: ``demo_data_dir``
+* **Default**: <current working directory>
+
+Directory where demo data functions will download data files to. Available
+demo data functions can be found in :mod:`satpy.demo` subpackage.
+
 Download Auxiliary Data
 ^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -37,8 +37,9 @@ PACKAGE_CONFIG_PATH = os.path.join(BASE_PATH, 'etc')
 _satpy_dirs = appdirs.AppDirs(appname='satpy', appauthor='pytroll')
 _CONFIG_DEFAULTS = {
     'cache_dir': _satpy_dirs.user_cache_dir,
-    'data_dir': _satpy_dirs.user_data_dir,
     'config_path': [],
+    'data_dir': _satpy_dirs.user_data_dir,
+    'demo_data_dir': '.',
     'download_aux': True,
 }
 


### PR DESCRIPTION
This was brought up by @gerritholl on slack. This specifies the default value of `'.'` and documents it including a linking to the demo data module.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
