### PR TITLE
Fix VIIRS SDR reader not handling multi-granule files with fewer scans

### DIFF
--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -308,13 +308,7 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
     def concatenate_dataset(self, dataset_group, var_path):
         """Concatenate dataset."""
         scan_size = self._scan_size(dataset_group)
-        number_of_granules_path = 'Data_Products/{dataset_group}/{dataset_group}_Aggr/attr/AggregateNumberGranules'
-        nb_granules_path = number_of_granules_path.format(dataset_group=DATASET_KEYS[dataset_group])
-        scans = []
-        for granule in range(self[nb_granules_path]):
-            scans_path = 'Data_Products/{dataset_group}/{dataset_group}_Gran_{granule}/attr/N_Number_Of_Scans'
-            scans_path = scans_path.format(dataset_group=DATASET_KEYS[dataset_group], granule=granule)
-            scans.append(self[scans_path])
+        scans = self._get_scans_per_granule(dataset_group)
         start_scan = 0
         data_chunks = []
         scans = xr.DataArray(scans)
@@ -327,6 +321,16 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
             return xr.concat(data_chunks, 'y')
         else:
             return self.expand_single_values(variable, scans)
+
+    def _get_scans_per_granule(self, dataset_group):
+        number_of_granules_path = 'Data_Products/{dataset_group}/{dataset_group}_Aggr/attr/AggregateNumberGranules'
+        nb_granules_path = number_of_granules_path.format(dataset_group=DATASET_KEYS[dataset_group])
+        scans = []
+        for granule in range(self[nb_granules_path]):
+            scans_path = 'Data_Products/{dataset_group}/{dataset_group}_Gran_{granule}/attr/N_Number_Of_Scans'
+            scans_path = scans_path.format(dataset_group=DATASET_KEYS[dataset_group], granule=granule)
+            scans.append(self[scans_path])
+        return scans
 
     def mask_fill_values(self, data, ds_info):
         """Mask fill values."""

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -234,7 +234,7 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
         old_chunks = data.chunks
         dask_data = data.data.rechunk((tuple(rows_per_gran), data.data.chunks[1]))
         dask_data = da.map_blocks(_apply_factors, dask_data, factors,
-                                  chunks=data.chunks, dtype=data.dtype,
+                                  chunks=dask_data.chunks, dtype=data.dtype,
                                   meta=np.array([[]], dtype=data.dtype))
         data.data = dask_data.rechunk(old_chunks)
         return data

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -225,10 +225,14 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
         Multi-granule (a.k.a. aggregated) files will have more than the usual two values.
         """
         rows_per_gran = self._get_rows_per_granule(dataset_group)
-        factors = scaling_factors.where(scaling_factors > -999, np.float32(np.nan))
-        factors = factors.data.reshape((-1, 2)).rechunk((1, 2))  # make it so map_blocks happens per factor
+        factors = self._mask_and_reshape_factors(scaling_factors)
         data = self._map_and_apply_factors(data, factors, rows_per_gran)
         return data
+
+    @staticmethod
+    def _mask_and_reshape_factors(factors):
+        factors = factors.where(factors > -999, np.float32(np.nan))
+        return factors.data.reshape((-1, 2)).rechunk((1, 2))  # make it so map_blocks happens per factor
 
     @staticmethod
     def _map_and_apply_factors(data, factors, rows_per_gran):

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -288,7 +288,7 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
         if ds_id['name'] in ['dnb_longitude', 'dnb_latitude']:
             if self.use_tc is True:
                 return var_path + '_TC'
-            elif self.use_tc is None and var_path + '_TC' in self.file_content:
+            if self.use_tc is None and var_path + '_TC' in self.file_content:
                 return var_path + '_TC'
         return var_path
 
@@ -363,9 +363,8 @@ class VIIRSSDRFileHandler(HDF5FileHandler):
         dataset_group = [ds_group for ds_group in ds_info['dataset_groups'] if ds_group in self.datasets]
         if not dataset_group:
             return
-        else:
-            dataset_group = dataset_group[0]
-            ds_info['dataset_group'] = dataset_group
+        dataset_group = dataset_group[0]
+        ds_info['dataset_group'] = dataset_group
         var_path = self._generate_file_key(dataset_id, ds_info)
         factor_var_path = ds_info.get("factors_key", var_path + "Factors")
 

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -862,14 +862,14 @@ class TestAggrVIIRSSDRReader(unittest.TestCase):
         np.testing.assert_allclose(lats, expected_lats)
 
 
-class FakeTruncatedHDF5FileHandlerAggr(FakeHDF5FileHandler2):
+class FakeShortHDF5FileHandlerAggr(FakeHDF5FileHandler2):
     """Fake file that has less scans than usual in a couple granules."""
 
     _num_test_granules = 3
     _num_scans_per_gran = [47, 48, 47]
 
 
-class TestTruncatedAggrVIIRSSDRReader(unittest.TestCase):
+class TestShortAggrVIIRSSDRReader(unittest.TestCase):
     """Test VIIRS SDR Reader with a file that has truncated granules."""
 
     yaml_file = "viirs_sdr.yaml"
@@ -880,7 +880,7 @@ class TestTruncatedAggrVIIRSSDRReader(unittest.TestCase):
         from satpy.readers.viirs_sdr import VIIRSSDRFileHandler
         self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
         # http://stackoverflow.com/questions/12219967/how-to-mock-a-base-class-with-python-mock-library
-        self.p = mock.patch.object(VIIRSSDRFileHandler, '__bases__', (FakeTruncatedHDF5FileHandlerAggr,))
+        self.p = mock.patch.object(VIIRSSDRFileHandler, '__bases__', (FakeShortHDF5FileHandlerAggr,))
         self.fake_handler = self.p.start()
         self.p.is_local = True
 
@@ -899,5 +899,5 @@ class TestTruncatedAggrVIIRSSDRReader(unittest.TestCase):
         ds = r.load(["I01"])
         self.assertEqual(len(ds), 1)
         i01_data = ds["I01"].compute()
-        expected_rows = sum(FakeTruncatedHDF5FileHandlerAggr._num_scans_per_gran) * DEFAULT_FILE_SHAPE[0]
+        expected_rows = sum(FakeShortHDF5FileHandlerAggr._num_scans_per_gran) * DEFAULT_FILE_SHAPE[0]
         self.assertEqual(i01_data.shape, (expected_rows, 300))

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -898,6 +898,6 @@ class TestTruncatedAggrVIIRSSDRReader(unittest.TestCase):
         r.create_filehandlers(loadables)
         ds = r.load(["I01"])
         self.assertEqual(len(ds), 1)
-        i01_data = ds["I01"]
+        i01_data = ds["I01"].compute()
         expected_rows = sum(FakeTruncatedHDF5FileHandlerAggr._num_scans_per_gran) * DEFAULT_FILE_SHAPE[0]
         self.assertEqual(i01_data.shape, (expected_rows, 300))

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -24,14 +24,11 @@ import numpy as np
 from satpy.tests.reader_tests.test_hdf5_utils import FakeHDF5FileHandler
 
 DEFAULT_FILE_DTYPE = np.uint16
-DEFAULT_FILE_SHAPE = (10, 300)
+DEFAULT_FILE_SHAPE = (32, 300)
+# Mimicking one scan line of data
 DEFAULT_FILE_DATA = np.arange(DEFAULT_FILE_SHAPE[0] * DEFAULT_FILE_SHAPE[1],
                               dtype=DEFAULT_FILE_DTYPE).reshape(DEFAULT_FILE_SHAPE)
 DEFAULT_FILE_FACTORS = np.array([2.0, 1.0], dtype=np.float32)
-DEFAULT_LAT_DATA = np.linspace(45, 65, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
-DEFAULT_LAT_DATA = np.repeat([DEFAULT_LAT_DATA], DEFAULT_FILE_SHAPE[0], axis=0)
-DEFAULT_LON_DATA = np.linspace(5, 45, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
-DEFAULT_LON_DATA = np.repeat([DEFAULT_LON_DATA], DEFAULT_FILE_SHAPE[0], axis=0)
 
 DATASET_KEYS = {'GDNBO': 'VIIRS-DNB-GEO',
                 'SVDNB': 'VIIRS-DNB-SDR',
@@ -67,6 +64,7 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
     """Swap-in HDF5 File Handler."""
 
     _num_test_granules = 1
+    _num_scans_per_gran = [48]
 
     def __init__(self, filename, filename_info, filetype_info, include_factors=True):
         """Create fake file handler."""
@@ -74,7 +72,7 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
         super(FakeHDF5FileHandler2, self).__init__(filename, filename_info, filetype_info)
 
     @staticmethod
-    def _add_basic_metadata_to_file_content(file_content, filename_info):
+    def _add_basic_metadata_to_file_content(file_content, filename_info, num_grans):
         start_time = filename_info['start_time']
         end_time = filename_info['end_time'].replace(year=start_time.year,
                                                      month=start_time.month,
@@ -84,7 +82,7 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
         ending_date = end_time.strftime('%Y%m%d')
         ending_time = end_time.strftime('%H%M%S.%fZ')
         new_file_content = {
-            "{prefix2}/attr/AggregateNumberGranules": 1,
+            "{prefix2}/attr/AggregateNumberGranules": num_grans,
             "{prefix2}/attr/AggregateBeginningDate": begin_date,
             "{prefix2}/attr/AggregateBeginningTime": begin_time,
             "{prefix2}/attr/AggregateEndingDate": ending_date,
@@ -98,36 +96,25 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
         }
         file_content.update(new_file_content)
 
-    @staticmethod
     def _add_granule_specific_info_to_file_content(
-            file_content, dataset_group, num_granules, gran_group_prefix):
-        lats_lists = [
-            np.array(
-                [
-                    67.969505, 65.545685, 63.103046, 61.853905, 55.169273,
-                    57.062447, 58.86063, 66.495514
-                ],
-                dtype=np.float32),
-            np.array(
-                [
-                    72.74879, 70.2493, 67.84738, 66.49691, 58.77254,
-                    60.465942, 62.11525, 71.08249
-                ],
-                dtype=np.float32),
-            np.array(
-                [
-                    77.393425, 74.977875, 72.62976, 71.083435, 62.036346,
-                    63.465122, 64.78075, 75.36842
-                ],
-                dtype=np.float32),
-            np.array(
-                [
-                    81.67615, 79.49934, 77.278656, 75.369415, 64.72178,
-                    65.78417, 66.66166, 79.00025
-                ],
-                dtype=np.float32),
-        ]
-        lons_lists = [
+            self,
+            file_content, dataset_group, num_granules, num_scans_per_granule,
+            gran_group_prefix):
+        lons_lists = self._get_per_granule_lons()
+        lats_lists = self._get_per_granule_lats()
+        file_content["{prefix3}/NumberOfScans"] = np.array([48] * num_granules)
+        for granule_idx in range(num_granules):
+            prefix_gran = '{prefix}/{dataset_group}_Gran_{idx}'.format(prefix=gran_group_prefix,
+                                                                       dataset_group=dataset_group,
+                                                                       idx=granule_idx)
+            num_scans = num_scans_per_granule[granule_idx]
+            file_content[prefix_gran + '/attr/N_Number_Of_Scans'] = num_scans
+            file_content[prefix_gran + '/attr/G-Ring_Longitude'] = lons_lists[granule_idx]
+            file_content[prefix_gran + '/attr/G-Ring_Latitude'] = lats_lists[granule_idx]
+
+    @staticmethod
+    def _get_per_granule_lons():
+        return [
             np.array(
                 [
                     50.51393, 49.566296, 48.865967, 18.96082, -4.0238385,
@@ -153,16 +140,40 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
                 ],
                 dtype=np.float32)
         ]
-        file_content["{prefix3}/NumberOfScans"] = np.array([48] * num_granules)
-        for granule_idx in range(num_granules):
-            prefix_gran = '{prefix}/{dataset_group}_Gran_{idx}'.format(prefix=gran_group_prefix,
-                                                                       dataset_group=dataset_group,
-                                                                       idx=granule_idx)
-            file_content[prefix_gran + '/attr/N_Number_Of_Scans'] = 48
-            file_content[prefix_gran + '/attr/G-Ring_Longitude'] = lons_lists[granule_idx]
-            file_content[prefix_gran + '/attr/G-Ring_Latitude'] = lats_lists[granule_idx]
 
-    def _add_data_info_to_file_content(self, file_content, filename, data_var_prefix):
+    @staticmethod
+    def _get_per_granule_lats():
+        return [
+            np.array(
+                [
+                    67.969505, 65.545685, 63.103046, 61.853905, 55.169273,
+                    57.062447, 58.86063, 66.495514
+                ],
+                dtype=np.float32),
+            np.array(
+                [
+                    72.74879, 70.2493, 67.84738, 66.49691, 58.77254,
+                    60.465942, 62.11525, 71.08249
+                ],
+                dtype=np.float32),
+            np.array(
+                [
+                    77.393425, 74.977875, 72.62976, 71.083435, 62.036346,
+                    63.465122, 64.78075, 75.36842
+                ],
+                dtype=np.float32),
+            np.array(
+                [
+                    81.67615, 79.49934, 77.278656, 75.369415, 64.72178,
+                    65.78417, 66.66166, 79.00025
+                ],
+                dtype=np.float32),
+        ]
+
+    def _add_data_info_to_file_content(self, file_content, filename, data_var_prefix, num_grans):
+        # SDR files always produce data with 48 scans per granule even if there are less
+        total_rows = DEFAULT_FILE_SHAPE[0] * 48 * num_grans
+        new_shape = (total_rows, DEFAULT_FILE_SHAPE[1])
         if filename[2:5] in ['M{:02d}'.format(x) for x in range(12)] + ['I01', 'I02', 'I03']:
             keys = ['Radiance', 'Reflectance']
         elif filename[2:5] in ['M{:02d}'.format(x) for x in range(12, 17)] + ['I04', 'I05']:
@@ -173,13 +184,17 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
 
         for k in keys:
             k = data_var_prefix + "/" + k
-            file_content[k] = DEFAULT_FILE_DATA.copy()
-            file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
+            file_content[k] = np.repeat(DEFAULT_FILE_DATA.copy(), 48 * num_grans, axis=0)
+            file_content[k + "/shape"] = new_shape
             if self.include_factors:
-                file_content[k + "Factors"] = DEFAULT_FILE_FACTORS.copy()
+                file_content[k + "Factors"] = np.repeat(
+                    DEFAULT_FILE_FACTORS.copy()[None, :], num_grans, axis=0).ravel()
 
     @staticmethod
-    def _add_geolocation_info_to_file_content(file_content, filename, data_var_prefix):
+    def _add_geolocation_info_to_file_content(file_content, filename, data_var_prefix, num_grans):
+        # SDR files always produce data with 48 scans per granule even if there are less
+        total_rows = DEFAULT_FILE_SHAPE[0] * 48 * num_grans
+        new_shape = (total_rows, DEFAULT_FILE_SHAPE[1])
         is_dnb = filename[:5] not in ['GMODO', 'GIMGO']
         if not is_dnb:
             lon_data = np.linspace(15, 55, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE_DTYPE)
@@ -191,13 +206,13 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
         for k in ["Latitude"]:
             k = data_var_prefix + "/" + k
             file_content[k] = lat_data
-            file_content[k] = np.repeat([file_content[k]], DEFAULT_FILE_SHAPE[0], axis=0)
-            file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
+            file_content[k] = np.repeat([file_content[k]], total_rows, axis=0)
+            file_content[k + "/shape"] = new_shape
         for k in ["Longitude"]:
             k = data_var_prefix + "/" + k
             file_content[k] = lon_data
-            file_content[k] = np.repeat([file_content[k]], DEFAULT_FILE_SHAPE[0], axis=0)
-            file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
+            file_content[k] = np.repeat([file_content[k]], total_rows, axis=0)
+            file_content[k + "/shape"] = new_shape
 
         angles = ['SolarZenithAngle',
                   'SolarAzimuthAngle',
@@ -208,8 +223,8 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
         for k in angles:
             k = data_var_prefix + "/" + k
             file_content[k] = lon_data  # close enough to SZA
-            file_content[k] = np.repeat([file_content[k]], DEFAULT_FILE_SHAPE[0], axis=0)
-            file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
+            file_content[k] = np.repeat([file_content[k]], total_rows, axis=0)
+            file_content[k + "/shape"] = new_shape
 
     @staticmethod
     def _add_geo_ref(file_content, filename):
@@ -244,18 +259,21 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
             prefix3 = 'All_Data/{dataset_group}_All'.format(dataset_group=dataset_group)
 
             file_content = {}
-            self._add_basic_metadata_to_file_content(file_content, filename_info)
+            self._add_basic_metadata_to_file_content(file_content, filename_info, self._num_test_granules)
             self._add_granule_specific_info_to_file_content(file_content, dataset_group,
-                                                            self._num_test_granules, prefix1)
+                                                            self._num_test_granules, self._num_scans_per_gran,
+                                                            prefix1)
             self._add_geo_ref(file_content, filename)
 
             for k, v in list(file_content.items()):
                 file_content[k.format(prefix1=prefix1, prefix2=prefix2, prefix3=prefix3)] = v
 
             if filename[:3] in ['SVM', 'SVI', 'SVD']:
-                self._add_data_info_to_file_content(file_content, filename, prefix3)
+                self._add_data_info_to_file_content(file_content, filename, prefix3,
+                                                    self._num_test_granules)
             elif filename[0] == 'G':
-                self._add_geolocation_info_to_file_content(file_content, filename, prefix3)
+                self._add_geolocation_info_to_file_content(file_content, filename, prefix3,
+                                                           self._num_test_granules)
             final_content.update(file_content)
         self._convert_numpy_content_to_dataarray(final_content)
         return final_content
@@ -798,6 +816,7 @@ class FakeHDF5FileHandlerAggr(FakeHDF5FileHandler2):
     """Swap-in HDF5 File Handler with 4 VIIRS Granules per file."""
 
     _num_test_granules = 4
+    _num_scans_per_gran = [48] * 4
 
 
 class TestAggrVIIRSSDRReader(unittest.TestCase):
@@ -841,3 +860,44 @@ class TestAggrVIIRSSDRReader(unittest.TestCase):
         lons, lats = r.file_handlers['generic_file'][0].get_bounding_box()
         np.testing.assert_allclose(lons, expected_lons)
         np.testing.assert_allclose(lats, expected_lats)
+
+
+class FakeTruncatedHDF5FileHandlerAggr(FakeHDF5FileHandler2):
+    """Fake file that has less scans than usual in a couple granules."""
+
+    _num_test_granules = 3
+    _num_scans_per_gran = [47, 48, 47]
+
+
+class TestTruncatedAggrVIIRSSDRReader(unittest.TestCase):
+    """Test VIIRS SDR Reader with a file that has truncated granules."""
+
+    yaml_file = "viirs_sdr.yaml"
+
+    def setUp(self):
+        """Wrap HDF5 file handler with our own fake handler."""
+        from satpy._config import config_search_paths
+        from satpy.readers.viirs_sdr import VIIRSSDRFileHandler
+        self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
+        # http://stackoverflow.com/questions/12219967/how-to-mock-a-base-class-with-python-mock-library
+        self.p = mock.patch.object(VIIRSSDRFileHandler, '__bases__', (FakeTruncatedHDF5FileHandlerAggr,))
+        self.fake_handler = self.p.start()
+        self.p.is_local = True
+
+    def tearDown(self):
+        """Stop wrapping the HDF5 file handler."""
+        self.p.stop()
+
+    def test_load_truncated_band(self):
+        """Test loading a single truncated band."""
+        from satpy.readers import load_reader
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
+        ])
+        r.create_filehandlers(loadables)
+        ds = r.load(["I01"])
+        self.assertEqual(len(ds), 1)
+        i01_data = ds["I01"]
+        expected_rows = sum(FakeTruncatedHDF5FileHandlerAggr._num_scans_per_gran) * DEFAULT_FILE_SHAPE[0]
+        self.assertEqual(i01_data.shape, (expected_rows, 300))


### PR DESCRIPTION
This was brought up by Artur on slack. He had some direct broadcast files from CSPP that had 6 granules in one file. Turns out that they weren't readable by the `viirs_sdr` reader. The reader would fail when apply scale factors because it was calculating a different number of total rows. The data arrays in his files total 4608 rows for the M02 band. If you check the number of scans per granule you'll notice that the first and the last have one missing:

<details>
<summary>h5dump output + grep</summary>

```
$ h5dump -A SVM02_j01_d20210719_t0941272_e0949569_b18998_c20210719100133953612_cspp_dev.h5 | grep -A 4 "Number_Of_Scans"
            ATTRIBUTE "N_Number_Of_Scans" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SIMPLE { ( 1, 1 ) / ( 1, 1 ) }
               DATA {
               (0,0): 47
--
            ATTRIBUTE "N_Number_Of_Scans" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SIMPLE { ( 1, 1 ) / ( 1, 1 ) }
               DATA {
               (0,0): 48
--
            ATTRIBUTE "N_Number_Of_Scans" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SIMPLE { ( 1, 1 ) / ( 1, 1 ) }
               DATA {
               (0,0): 48
--
            ATTRIBUTE "N_Number_Of_Scans" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SIMPLE { ( 1, 1 ) / ( 1, 1 ) }
               DATA {
               (0,0): 48
--
            ATTRIBUTE "N_Number_Of_Scans" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SIMPLE { ( 1, 1 ) / ( 1, 1 ) }
               DATA {
               (0,0): 48
--
            ATTRIBUTE "N_Number_Of_Scans" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SIMPLE { ( 1, 1 ) / ( 1, 1 ) }
               DATA {
               (0,0): 47
```

</details>

So [47, 48, 48, 48, 48, 47] scans per granule. The data array is truncated based on this information so you get each of those number of scans multiplied by 16 which leads to a final data array with 4576 rows. Now for the scaling factors, previously we were taking `data.shape[0] // num_granules`. In this data case that is not a round integer value (762.6666 versus 762). This leads to 4572 rows for the expanded scaling factors. Finally numpy/dask fails because it can't do arithmetic between 4576 and 4572 rows.

This overall situation for this particular data case (one with truncated granules at the beginning and end of the data file) would actually produce invalid factor <-> granule data mapping and apply the wrong factors. I think we made the assumption that a truncated granule can only happen at the end of a pass...apparently that's not true.

## This Solution

In this PR I change the file handler in to important ways:

1. I update the factors to be chunked per granule.
2. I also temporarily rechunk the data and use map_blocks to handle the "this factor pair goes with this chunk of data". This should perform much better because we aren't repeating factors (producing a large array that doesn't need to exist) **and** because we are only adding one high level dask task.

## Other Info

I had to really improve the tests to make a test that failed for this. Because the failing number of scans per granule depended on a non-round integer result I actually discovered that this failure depends on the number of granules provided and their size. A lot of our fake data did the minimum of what it had to to produce something that could be tested, but they weren't accurate. The number of granules was always 1, the size of the data was always only a single scan (10 rows). I've updated this to be more realistic with 32 rows per scan and having the data array repeated for test cases with more than one granule.

 - [x] Tests added <!-- for all bug fixes or enhancements -->

