### PR TITLE
Add access point to global_attrs to netCDF4FileHandler

### DIFF
--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -196,7 +196,7 @@ class NetCDF4FileHandler(BaseFileHandler):
         val = self.file_content[key]
         if isinstance(val, netCDF4.Variable):
             return self._get_variable(key, val)
-        elif isinstance(val, netCDF4.Group):
+        if isinstance(val, netCDF4.Group):
             return self._get_group(key, val)
         return val
 

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -136,24 +136,25 @@ class NetCDF4FileHandler(BaseFileHandler):
         """Collect all the global attributes for the provided file object."""
         global_attrs = {}
         for key in obj.ncattrs():
-            value = getattr(obj, key)
             fc_key = f"/attr/{key}"
-            try:
-                value = np2str(value)
-            except ValueError:
-                pass
+            value = self._get_attr_value(obj, key)
             self.file_content[fc_key] = global_attrs[key] = value
         self.file_content["/attrs"] = global_attrs
 
     def _collect_attrs(self, name, obj):
         """Collect all the attributes for the provided file object."""
         for key in obj.ncattrs():
-            value = getattr(obj, key)
             fc_key = f"{name}/attr/{key}"
-            try:
-                self.file_content[fc_key] = np2str(value)
-            except ValueError:
-                self.file_content[fc_key] = value
+            value = self._get_attr_value(obj, key)
+            self.file_content[fc_key] = value
+
+    def _get_attr_value(self, obj, key):
+        value = getattr(obj, key)
+        try:
+            value = np2str(value)
+        except ValueError:
+            pass
+        return value
 
     def collect_metadata(self, name, obj):
         """Collect all file variables and attributes for the provided file object.

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -227,6 +227,7 @@ class NetCDF4FileHandler(BaseFileHandler):
         return val
 
     def _get_group(self, key, val):
+        """"Get a group from the netcdf file."""
         # Full groups are conveniently read with xr even if file_handle is available
         with xr.open_dataset(self.filename, group=key,
                              **self._xarray_kwargs) as nc:

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -201,6 +201,7 @@ class NetCDF4FileHandler(BaseFileHandler):
         return val
 
     def _get_global_attrs(self):
+        """Get the global attributes of the netcfd file."""
         global_attrs = {}
         for _key, _val in self.file_content.items():
             if _key.startswith('/attr/'):

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -187,6 +187,12 @@ class NetCDF4FileHandler(BaseFileHandler):
 
     def __getitem__(self, key):
         """Get item for given key."""
+        if key in ('/attr', '/attrs'):
+            global_attrs = {}
+            for _key, _val in self.file_content.items():
+                if _key.startswith('/attr/'):
+                    global_attrs[_key] = _val
+            return global_attrs
         val = self.file_content[key]
         if isinstance(val, netCDF4.Variable):
             if key in self.cached_file_content:

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -199,7 +199,7 @@ class NetCDF4FileHandler(BaseFileHandler):
         elif isinstance(val, netCDF4.Group):
             return self._get_group(key, val)
         return val
-        
+
     def _get_global_attrs(self):
         global_attrs = {}
         for _key, _val in self.file_content.items():
@@ -223,11 +223,11 @@ class NetCDF4FileHandler(BaseFileHandler):
         else:
             val = self._get_var_from_xr(group, key)
         return val
-    
+
     def _get_group(self, key, val):
         # Full groups are conveniently read with xr even if file_handle is available
         with xr.open_dataset(self.filename, group=key,
-                                **self._xarray_kwargs) as nc:
+                             **self._xarray_kwargs) as nc:
             val = nc
         return val
 

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -51,6 +51,10 @@ class NetCDF4FileHandler(BaseFileHandler):
 
         wrapper["/attr/platform_short_name"]
 
+    Or for all of global attributes:
+
+        wrapper["/attr"] or wrapper["/attrs"]
+
     Note that loading datasets requires reopening the original file
     (unless those datasets are cached, see below), but to get just the
     shape of the dataset append "/shape" to the item string:

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -209,6 +209,7 @@ class NetCDF4FileHandler(BaseFileHandler):
         return global_attrs
 
     def _get_variable(self, key, val):
+        """Get a variable from the netcdf file."""
         if key in self.cached_file_content:
             return self.cached_file_content[key]
         # these datasets are closed and inaccessible when the file is

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -53,7 +53,7 @@ class NetCDF4FileHandler(BaseFileHandler):
 
     Or for all of global attributes:
 
-        wrapper["/attr"] or wrapper["/attrs"]
+        wrapper["/attrs"]
 
     Note that loading datasets requires reopening the original file
     (unless those datasets are cached, see below), but to get just the
@@ -132,11 +132,24 @@ class NetCDF4FileHandler(BaseFileHandler):
             except RuntimeError:  # presumably closed already
                 pass
 
+    def _collect_global_attrs(self, obj):
+        """Collect all the global attributes for the provided file object."""
+        global_attrs = {}
+        for key in obj.ncattrs():
+            value = getattr(obj, key)
+            fc_key = f"/attr/{key}"
+            try:
+                value = np2str(value)
+            except ValueError:
+                pass
+            self.file_content[fc_key] = global_attrs[key] = value
+        self.file_content["/attrs"] = global_attrs
+
     def _collect_attrs(self, name, obj):
         """Collect all the attributes for the provided file object."""
         for key in obj.ncattrs():
             value = getattr(obj, key)
-            fc_key = "{}/attr/{}".format(name, key)
+            fc_key = f"{name}/attr/{key}"
             try:
                 self.file_content[fc_key] = np2str(value)
             except ValueError:
@@ -149,11 +162,21 @@ class NetCDF4FileHandler(BaseFileHandler):
         """
         # Look through each subgroup
         base_name = name + "/" if name else ""
+        self._collect_groups_info(base_name, obj)
+        self._collect_variables_info(base_name, obj)
+        if not name:
+            self._collect_global_attrs(obj)
+        else:
+            self._collect_attrs(name, obj)
+
+    def _collect_groups_info(self, base_name, obj):
         for group_name, group_obj in obj.groups.items():
             full_group_name = base_name + group_name
             self.file_content[full_group_name] = group_obj
             self._collect_attrs(full_group_name, group_obj)
             self.collect_metadata(full_group_name, group_obj)
+
+    def _collect_variables_info(self, base_name, obj):
         for var_name, var_obj in obj.variables.items():
             var_name = base_name + var_name
             self.file_content[var_name] = var_obj
@@ -161,7 +184,6 @@ class NetCDF4FileHandler(BaseFileHandler):
             self.file_content[var_name + "/shape"] = var_obj.shape
             self.file_content[var_name + "/dimensions"] = var_obj.dimensions
             self._collect_attrs(var_name, var_obj)
-        self._collect_attrs(name, obj)
 
     def collect_dimensions(self, name, obj):
         """Collect dimensions."""
@@ -191,22 +213,12 @@ class NetCDF4FileHandler(BaseFileHandler):
 
     def __getitem__(self, key):
         """Get item for given key."""
-        if key in ('/attr', '/attrs'):
-            return self._get_global_attrs()
         val = self.file_content[key]
         if isinstance(val, netCDF4.Variable):
             return self._get_variable(key, val)
         if isinstance(val, netCDF4.Group):
             return self._get_group(key, val)
         return val
-
-    def _get_global_attrs(self):
-        """Get the global attributes of the netcfd file."""
-        global_attrs = {}
-        for _key, _val in self.file_content.items():
-            if _key.startswith('/attr/'):
-                global_attrs[_key] = _val
-        return global_attrs
 
     def _get_variable(self, key, val):
         """Get a variable from the netcdf file."""

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -227,7 +227,7 @@ class NetCDF4FileHandler(BaseFileHandler):
         return val
 
     def _get_group(self, key, val):
-        """"Get a group from the netcdf file."""
+        """Get a group from the netcdf file."""
         # Full groups are conveniently read with xr even if file_handle is available
         with xr.open_dataset(self.filename, group=key,
                              **self._xarray_kwargs) as nc:

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -146,12 +146,11 @@ class TestNetCDF4FileHandler(unittest.TestCase):
         self.assertEqual(file_handler['/attr/test_attr_float'], 1.2)
 
         global_attrs = {
-            '/attr/test_attr_str': 'test_string',
-            '/attr/test_attr_str_arr': 'test_string2',
-            '/attr/test_attr_int': 0,
-            '/attr/test_attr_float': 1.2
+            'test_attr_str': 'test_string',
+            'test_attr_str_arr': 'test_string2',
+            'test_attr_int': 0,
+            'test_attr_float': 1.2
             }
-        self.assertEqual(file_handler['/attr'], global_attrs)
         self.assertEqual(file_handler['/attrs'], global_attrs)
 
         self.assertIsInstance(file_handler.get('ds2_f')[:], xr.DataArray)

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -145,6 +145,16 @@ class TestNetCDF4FileHandler(unittest.TestCase):
         self.assertEqual(file_handler['/attr/test_attr_int'], 0)
         self.assertEqual(file_handler['/attr/test_attr_float'], 1.2)
 
+        global_attrs = {
+            '/attr/test_attr_str': 'test_string',
+            '/attr/test_attr_str_arr': 'test_string2',
+            '/attr/test_attr_int': 0,
+            '/attr/test_attr_float': 1.2
+            }
+        self.assertEqual(file_handler['/attr'], global_attrs)
+        self.assertEqual(file_handler['/attrs'], global_attrs)
+
+
         self.assertIsInstance(file_handler.get('ds2_f')[:], xr.DataArray)
         self.assertIsNone(file_handler.get('fake_ds'))
         self.assertEqual(file_handler.get('fake_ds', 'test'), 'test')

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -154,7 +154,6 @@ class TestNetCDF4FileHandler(unittest.TestCase):
         self.assertEqual(file_handler['/attr'], global_attrs)
         self.assertEqual(file_handler['/attrs'], global_attrs)
 
-
         self.assertIsInstance(file_handler.get('ds2_f')[:], xr.DataArray)
         self.assertIsNone(file_handler.get('fake_ds'))
         self.assertEqual(file_handler.get('fake_ds', 'test'), 'test')


### PR DESCRIPTION
In the `NetCDF4FileHandler`, it can't get all global_attributes in NetCDF with a single command.
I think `NetCDF4FileHandler` should have a method to get all global_attributes at once without the attribute’s name.

In this PR, we can access all global_attributes with 

`wrapper['/attr']` or `wrapper['/attrs']`

 - [x] Tests added
 - [x] Fully documented
