### PR TITLE
Fix 'awips_tiled' writer producing an invalid y coordinate

### DIFF
--- a/satpy/tests/writer_tests/test_awips_tiled.py
+++ b/satpy/tests/writer_tests/test_awips_tiled.py
@@ -46,6 +46,7 @@ def check_required_common_attributes(ds):
     assert x_attrs.get('standard_name') == 'projection_x_coordinate'
     assert x_attrs.get('units') == 'meters'
     assert 'scale_factor' in x_attrs
+    assert x_attrs['scale_factor'] > 0
     assert 'add_offset' in x_attrs
 
     assert 'y' in ds.coords
@@ -55,6 +56,7 @@ def check_required_common_attributes(ds):
     assert y_attrs.get('standard_name') == 'projection_y_coordinate'
     assert y_attrs.get('units') == 'meters'
     assert 'scale_factor' in y_attrs
+    assert y_attrs['scale_factor'] < 0
     assert 'add_offset' in y_attrs
 
     for attr_name in ('tile_row_offset', 'tile_column_offset',
@@ -147,6 +149,10 @@ class TestAWIPSTiledWriter:
             scale_factor = output_ds['data'].encoding['scale_factor']
             np.testing.assert_allclose(input_data_arr.values, output_ds['data'].data,
                                        atol=scale_factor / 2)
+            x_var = output_ds.coords['x']
+            assert (np.diff(x_var.values) > 0).all()
+            y_var = output_ds.coords['y']
+            assert (np.diff(y_var.values) < 0).all()
 
     @pytest.mark.parametrize(
         ("tile_count", "tile_size"),

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -303,7 +303,7 @@ class NumberedTileGenerator(object):
         else:
             raise ValueError("Either 'tile_count' or 'tile_shape' must be provided")
 
-        # number of pixels per each tile
+        # number of pixels per each tile (rows, cols)
         self.tile_shape = tile_shape
         # number of tiles in each direction (rows, columns)
         self.tile_count = tile_count
@@ -342,9 +342,7 @@ class NumberedTileGenerator(object):
             new_extents,
         )
 
-        x, y = imaginary_grid_def.get_proj_coords()
-        x = x[0].squeeze()  # all rows should have the same coordinates
-        y = y[:, 0].squeeze()  # all columns should have the same coordinates
+        x, y = imaginary_grid_def.get_proj_vectors()
         return x, y
 
     def _get_xy_scaling_parameters(self):
@@ -352,7 +350,7 @@ class NumberedTileGenerator(object):
         gd = self.area_definition
         bx = self.x.min()
         mx = gd.pixel_size_x
-        by = self.y.min()
+        by = self.y.max()
         my = -abs(gd.pixel_size_y)
         return mx, bx, my, by
 


### PR DESCRIPTION
@joleenf pointed out that something was wrong in the coordinates with the 'awips_tiled' writer. After spending a while tracking it down I discovered that the `add_offset` was being set to the `.min()` value of the Y coordinate data. The Y data is always in descending order (negative scale_factor) so using the min as the add_offset results in the scale in-file values being `-5119, -5118, ..., 0`. For the existing templates, these values are int16 with `_Unsigned = 'true'` which means these negative values are incorrect (and -1 is the fill value). It is all just bad overall and resulted in invalid Y coordinates when unscaled from the file.

@joleenf do you think you'd be able to test this with some of the other stuff you've been doing before I merge it?

 - [x] Tests added <!-- for all bug fixes or enhancements -->
