### PR TITLE
Fix mviri l1b fiduceo reader compatibility with newer xarray

### DIFF
--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -608,7 +608,7 @@ class FiduceoMviriBase(BaseFileHandler):
                 ds = qc.mask(ds)
             else:
                 qc.check()
-        ds['acq_time'] = ('y', self._get_acq_time(resolution))
+        ds['acq_time'] = self._get_acq_time(resolution)
         return ds
 
     @lru_cache(maxsize=8)  # 4 angle datasets with two resolutions each

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -919,8 +919,8 @@ class Scene:
             if not isinstance(lons, DataArray):
                 lons = DataArray(lons, dims=('y', 'x'))
                 lats = DataArray(lats, dims=('y', 'x'))
-            ds = xr.Dataset(ds_dict, coords={"latitude": (["y", "x"], lats),
-                                             "longitude": (["y", "x"], lons)})
+            ds = xr.Dataset(ds_dict, coords={"latitude": lats,
+                                             "longitude": lons})
 
         ds.attrs = mdata
         return ds

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -109,6 +109,9 @@ u_vis_refl_exp = xr.DataArray(
         dtype=np.float32
     ),
     dims=('y', 'x'),
+    coords={
+        'acq_time': ('y', acq_time_vis_exp),
+    },
     attrs=attrs_exp
 )
 acq_time_ir_wv_exp = [np.datetime64('1970-01-01 00:30'),
@@ -194,6 +197,9 @@ quality_pixel_bitmask_exp = xr.DataArray(
         dtype=np.uint8
     ),
     dims=('y', 'x'),
+    coords={
+        'acq_time': ('y', acq_time_vis_exp),
+    },
     attrs=attrs_exp
 )
 sza_vis_exp = xr.DataArray(
@@ -267,10 +273,8 @@ def fixture_fake_dataset():
             'count_vis': (('y', 'x'), count_vis),
             'count_wv': (('y_ir_wv', 'x_ir_wv'), count_wv),
             'count_ir': (('y_ir_wv', 'x_ir_wv'), count_ir),
-            'toa_bidirectional_reflectance_vis': (
-                ('y', 'x'), vis_refl_exp / 100),
-            'u_independent_toa_bidirectional_reflectance': (
-                ('y', 'x'), u_vis_refl_exp / 100),
+            'toa_bidirectional_reflectance_vis': vis_refl_exp / 100,
+            'u_independent_toa_bidirectional_reflectance': u_vis_refl_exp / 100,
             'quality_pixel_bitmask': (('y', 'x'), mask),
             'solar_zenith_angle': (('y_tie', 'x_tie'), sza),
             'time_ir_wv': (('y_ir_wv', 'x_ir_wv'), time),


### PR DESCRIPTION
Discovered in #1776, the new version of xarray now doesn't allow you to assign a Variable object with a DataArray. This can accidentally happen when you create a Dataset with `('y', 'x', some_data)` where `some_data` is a DataArray. The dimensions are redundant and being a tuple tells xarray that you are trying to make a Variable from scratch.

This PR is my best attempt at fixing this.
