### PR TITLE
Fix ABI readers not assigning 'platform_name' for GOES-18/19

### DIFF
--- a/satpy/readers/abi_base.py
+++ b/satpy/readers/abi_base.py
@@ -172,10 +172,9 @@ class NC_ABI_BASE(BaseFileHandler):
         """Get the area definition of the data at hand."""
         if 'goes_imager_projection' in self.nc:
             return self._get_areadef_fixedgrid(key)
-        elif 'goes_lat_lon_projection' in self.nc:
+        if 'goes_lat_lon_projection' in self.nc:
             return self._get_areadef_latlon(key)
-        else:
-            raise ValueError('Unsupported projection found in the dataset')
+        raise ValueError('Unsupported projection found in the dataset')
 
     def _get_areadef_latlon(self, key):
         """Get the area definition of the data at hand."""

--- a/satpy/readers/abi_base.py
+++ b/satpy/readers/abi_base.py
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 PLATFORM_NAMES = {
     'G16': 'GOES-16',
     'G17': 'GOES-17',
+    'G18': 'GOES-18',
+    'G19': 'GOES-19',
 }
 
 


### PR DESCRIPTION
Simple fix so that the ABI-based readers know about GOES-18/19. This came up in SIFT development where the data and most of the metadata was perfectly fine, but `platform_name` was missing (was set to `None`).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
