### PR TITLE
Fix 'viirs_sdr' repeating data when TC geolocation was not available

### DIFF
--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -531,7 +531,7 @@ class VIIRSSDRReader(FileYAMLReader):
         """Load filenames from the N_GEO_Ref attribute of a dataset's file."""
         file_handlers = self._get_file_handlers(dsid)
         if not file_handlers:
-            return None
+            return []
 
         fns = []
         for fh in file_handlers:
@@ -620,7 +620,8 @@ class VIIRSSDRReader(FileYAMLReader):
 
             # check the dataset file for the geolocation filename
             geo_filenames = self._load_filenames_from_geo_ref(dsid)
-            self._update_coords_groups_for_geo(c_info, geo_filenames, prime_geo, second_geo)
+            self._create_new_geo_file_handlers(geo_filenames)
+            self._remove_not_loaded_geo_dataset_group(c_info['dataset_groups'], prime_geo, second_geo)
 
         return coords
 
@@ -632,13 +633,6 @@ class VIIRSSDRReader(FileYAMLReader):
             return prime_geo, second_geo
         except ValueError:  # DNB
             return None, None
-
-    def _update_coords_groups_for_geo(self, c_info, geo_filenames, prime_geo, second_geo):
-        if not geo_filenames:
-            c_info['dataset_groups'] = [second_geo]
-        else:
-            self._create_new_geo_file_handlers(geo_filenames)
-            self._remove_not_loaded_geo_dataset_group(c_info['dataset_groups'], prime_geo, second_geo)
 
     def _create_new_geo_file_handlers(self, geo_filenames):
         existing_filenames = set([fh.filename for fh in self.file_handlers['generic_file']])

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -627,7 +627,9 @@ class VIIRSSDRReader(FileYAMLReader):
                 c_info['dataset_groups'] = [rem_geo]
             else:
                 # concatenate all values
-                new_fhs = sum(self.create_filehandlers(geo_filenames).values(), [])
+                existing_filenames = set([fh.filename for fh in self.file_handlers['generic_file']])
+                geo_filenames = set(geo_filenames) - existing_filenames
+                new_fhs = sum(self.create_filehandlers(geo_filenames).values(), self.file_handlers['generic_file'])
                 desired, other = split_desired_other(new_fhs, req_geo, rem_geo)
                 if desired:
                     c_info['dataset_groups'].remove(rem_geo)

--- a/satpy/tests/reader_tests/test_viirs_sdr.py
+++ b/satpy/tests/reader_tests/test_viirs_sdr.py
@@ -292,6 +292,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         if with_area:
             self.assertIn('area', data_arr.attrs)
             self.assertIsNotNone(data_arr.attrs['area'])
+            self.assertEqual(data_arr.attrs['area'].shape, data_arr.shape)
         else:
             self.assertNotIn('area', data_arr.attrs)
 
@@ -303,6 +304,7 @@ class TestVIIRSSDRReader(unittest.TestCase):
         if with_area:
             self.assertIn('area', data_arr.attrs)
             self.assertIsNotNone(data_arr.attrs['area'])
+            self.assertEqual(data_arr.attrs['area'].shape, data_arr.shape)
         else:
             self.assertNotIn('area', data_arr.attrs)
 
@@ -314,8 +316,14 @@ class TestVIIRSSDRReader(unittest.TestCase):
         if with_area:
             self.assertIn('area', data_arr.attrs)
             self.assertIsNotNone(data_arr.attrs['area'])
+            self.assertEqual(data_arr.attrs['area'].shape, data_arr.shape)
         else:
             self.assertNotIn('area', data_arr.attrs)
+
+    def _touch_geo_file(self, prefix):
+        geo_fn = prefix + '_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
+        open(geo_fn, 'w')
+        return geo_fn
 
     def setUp(self):
         """Wrap HDF5 file handler with our own fake handler."""
@@ -437,9 +445,8 @@ class TestVIIRSSDRReader(unittest.TestCase):
             'SVM10_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
             'SVM11_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
         ])
-        # make a fake geo file
-        geo_fn = 'GMTCO_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
-        open(geo_fn, 'w')
+        geo_fn1 = self._touch_geo_file("GMTCO")
+        geo_fn2 = self._touch_geo_file("GMODO")
 
         try:
             r.create_filehandlers(loadables)
@@ -456,7 +463,8 @@ class TestVIIRSSDRReader(unittest.TestCase):
                          'M11',
                          ])
         finally:
-            os.remove(geo_fn)
+            os.remove(geo_fn1)
+            os.remove(geo_fn2)
 
         self.assertEqual(len(ds), 11)
         for d in ds.values():
@@ -480,19 +488,25 @@ class TestVIIRSSDRReader(unittest.TestCase):
             'SVM11_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
             'GMTCO_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
         ])
-        r.create_filehandlers(loadables)
-        ds = r.load(['M01',
-                     'M02',
-                     'M03',
-                     'M04',
-                     'M05',
-                     'M06',
-                     'M07',
-                     'M08',
-                     'M09',
-                     'M10',
-                     'M11',
-                     ])
+        geo_fn1 = self._touch_geo_file("GMTCO")
+        geo_fn2 = self._touch_geo_file("GMODO")
+        try:
+            r.create_filehandlers(loadables)
+            ds = r.load(['M01',
+                         'M02',
+                         'M03',
+                         'M04',
+                         'M05',
+                         'M06',
+                         'M07',
+                         'M08',
+                         'M09',
+                         'M10',
+                         'M11',
+                         ])
+        finally:
+            os.remove(geo_fn1)
+            os.remove(geo_fn2)
         self.assertEqual(len(ds), 11)
         for d in ds.values():
             self._assert_reflectance_properties(d, with_area=True)
@@ -520,19 +534,25 @@ class TestVIIRSSDRReader(unittest.TestCase):
             'GMTCO_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
             'GMODO_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
         ])
-        r.create_filehandlers(loadables, {'use_tc': False})
-        ds = r.load(['M01',
-                     'M02',
-                     'M03',
-                     'M04',
-                     'M05',
-                     'M06',
-                     'M07',
-                     'M08',
-                     'M09',
-                     'M10',
-                     'M11',
-                     ])
+        geo_fn1 = self._touch_geo_file("GMTCO")
+        geo_fn2 = self._touch_geo_file("GMODO")
+        try:
+            r.create_filehandlers(loadables, {'use_tc': False})
+            ds = r.load(['M01',
+                         'M02',
+                         'M03',
+                         'M04',
+                         'M05',
+                         'M06',
+                         'M07',
+                         'M08',
+                         'M09',
+                         'M10',
+                         'M11',
+                         ])
+        finally:
+            os.remove(geo_fn1)
+            os.remove(geo_fn2)
         self.assertEqual(len(ds), 11)
         for d in ds.values():
             self._assert_reflectance_properties(d, with_area=True)
@@ -559,19 +579,23 @@ class TestVIIRSSDRReader(unittest.TestCase):
             'SVM11_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
             'GMODO_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5',
         ])
-        r.create_filehandlers(loadables, {'use_tc': None})
-        ds = r.load(['M01',
-                     'M02',
-                     'M03',
-                     'M04',
-                     'M05',
-                     'M06',
-                     'M07',
-                     'M08',
-                     'M09',
-                     'M10',
-                     'M11',
-                     ])
+        geo_fn2 = self._touch_geo_file("GMODO")
+        try:
+            r.create_filehandlers(loadables, {'use_tc': None})
+            ds = r.load(['M01',
+                         'M02',
+                         'M03',
+                         'M04',
+                         'M05',
+                         'M06',
+                         'M07',
+                         'M08',
+                         'M09',
+                         'M10',
+                         'M11',
+                         ])
+        finally:
+            os.remove(geo_fn2)
         self.assertEqual(len(ds), 11)
         for d in ds.values():
             self._assert_reflectance_properties(d, with_area=True)


### PR DESCRIPTION
The 'viirs_sdr' reader is meant to choose terrain corrected geolocation data if available or fall back to non-TC. You can control this with the `use_tc` kwarg where True means only use TC, False means only use non-TC, and None means use TC if available, non-TC otherwise. As described in #1786, if you have only non-TC files the reader will produce a DataArray with the correct number of rows, but the SwathDefinition in `.attrs['area']` will contain 3x the number of rows as it should.

This issue is caused by the geolocation determination step loading geolocation files regardless of whether or not they have been loaded before. I think this was not caught or has started being an issue for two reasons:

1. The tests weren't properly testing things (see below)
2. I think the `yaml_reader.py` file handler/filename stuff was optimized by me and the assumption was made that the file handlers are only ever created once. The viirs_sdr did not fit this assumption.

The tests were bad for two reasons:

1. They didn't check the same of the area against the shape of the data. Not a huge thing, but something that is important to check in hindsight.
2. They didn't create the on-disk geolocation files which are needed because the reader uses `glob` to find the geolocation filenames matching the glob pattern created from the data file's geo reference attribute.

 - [x] Closes #1786 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

Possible alternative fixes:

1. Update the base reader to not create file handlers if they already exist. Given the assumption mentioned above this would really only benefit the VIIRS SDR reader (and maybe a couple others) for these special case situations.
2. Do fancier checking for "I want to load geo file X which is of file type FT, do I have that already? Yes? Then don't try to create any new file handlers".