### PR TITLE
Maintain categorical clavrx data as integer arrays

### DIFF
--- a/satpy/readers/clavrx.py
+++ b/satpy/readers/clavrx.py
@@ -131,12 +131,14 @@ class _CLAVRxHelper:
             data = _CLAVRxHelper._scale_data(data, factor, offset)
             # don't need _FillValue if it has been applied.
             attrs.pop('_FillValue', None)
-            fill = _CLAVRxHelper._scale_data(fill, factor, offset)
 
         if all(valid_range):
             valid_min = _CLAVRxHelper._scale_data(valid_range[0], factor, offset)
             valid_max = _CLAVRxHelper._scale_data(valid_range[1], factor, offset)
-            data = data.where((data >= valid_min) & (data <= valid_max))
+            if flags:
+                data = data.where((data >= valid_min) & (data <= valid_max), fill)
+            else:
+                data = data.where((data >= valid_min) & (data <= valid_max))
             attrs['valid_range'] = [valid_min, valid_max]
 
         data.attrs = _CLAVRxHelper._remove_attributes(attrs)

--- a/satpy/tests/reader_tests/test_clavrx.py
+++ b/satpy/tests/reader_tests/test_clavrx.py
@@ -377,14 +377,17 @@ class TestCLAVRXReaderGeo(unittest.TestCase):
             self.assertNotIn('calibration', v.attrs)
             self.assertEqual(v.attrs['units'], '1')
             self.assertIsInstance(v.attrs['area'], AreaDefinition)
-            self.assertIn('_FillValue', v.attrs)
+            if v.attrs.get("flag_values"):
+                self.assertIn('_FillValue', v.attrs)
+            else:
+                self.assertNotIn('_FillValue', v.attrs)
             if v.attrs["name"] == 'variable1':
                 self.assertIsInstance(v.attrs["valid_range"], list)
             else:
                 self.assertNotIn('valid_range', v.attrs)
             if 'flag_values' in v.attrs:
-                np.issubdtype(v.dtype, int)
-        self.assertIsNotNone(datasets['variable3'].attrs.get('flag_meanings'))
+                self.assertTrue(np.issubdtype(v.dtype, np.integer))
+                self.assertIsNotNone(v.attrs.get('flag_meanings'))
 
     def test_load_all_new_donor(self):
         """Test loading all test datasets with new donor."""

--- a/satpy/tests/reader_tests/test_clavrx.py
+++ b/satpy/tests/reader_tests/test_clavrx.py
@@ -95,6 +95,7 @@ class FakeHDF4FileHandlerPolar(FakeHDF4FileHandler):
         file_content['variable3'] = xr.DataArray(
             da.from_array(DEFAULT_FILE_DATA, chunks=4096).astype(np.byte),
             attrs={
+                'SCALED': 0,
                 '_FillValue': -128,
                 'flag_meanings': 'clear water supercooled mixed ice unknown',
                 'flag_values': [0, 1, 2, 3, 4, 5],
@@ -291,6 +292,7 @@ class FakeHDF4FileHandlerGeo(FakeHDF4FileHandler):
             DEFAULT_FILE_DATA.astype(np.byte),
             dims=('y', 'x'),
             attrs={
+                'SCALED': 0,
                 '_FillValue': -128,
                 'flag_meanings': 'clear water supercooled mixed ice unknown',
                 'flag_values': [0, 1, 2, 3, 4, 5],
@@ -375,10 +377,13 @@ class TestCLAVRXReaderGeo(unittest.TestCase):
             self.assertNotIn('calibration', v.attrs)
             self.assertEqual(v.attrs['units'], '1')
             self.assertIsInstance(v.attrs['area'], AreaDefinition)
+            self.assertIn('_FillValue', v.attrs)
             if v.attrs["name"] == 'variable1':
                 self.assertIsInstance(v.attrs["valid_range"], list)
             else:
                 self.assertNotIn('valid_range', v.attrs)
+            if 'flag_values' in v.attrs:
+                np.issubdtype(v.dtype, int)
         self.assertIsNotNone(datasets['variable3'].attrs.get('flag_meanings'))
 
     def test_load_all_new_donor(self):

--- a/satpy/tests/reader_tests/test_clavrx_nc.py
+++ b/satpy/tests/reader_tests/test_clavrx_nc.py
@@ -92,7 +92,8 @@ def fake_test_content(filename, **kwargs):
     variable3 = xr.DataArray(DEFAULT_FILE_DATA.astype(np.byte),
                              dims=('scan_lines_along_track_direction',
                                    'pixel_elements_along_scan_direction'),
-                             attrs={'_FillValue': -128,
+                             attrs={'SCALED': 0,
+                                    '_FillValue': -128,
                                     'flag_meanings': 'clear water supercooled mixed ice unknown',
                                     'flag_values': [0, 1, 2, 3, 4, 5],
                                     'units': '1',
@@ -193,4 +194,8 @@ class TestCLAVRXReaderGeo:
                     assert 'rows_per_scan' not in v.coords.get('longitude').attrs
                     if v.attrs["name"] in ["variable1", "variable2"]:
                         assert isinstance(v.attrs["valid_range"], list)
-                assert (datasets['variable3'].attrs.get('flag_meanings')) is not None
+                        assert v.dtype == np.float32
+                    else:
+                        assert (datasets['variable3'].attrs.get('flag_meanings')) is not None
+                        assert "_FillValue" in v.attrs.keys()
+                        assert np.issubdtype(v.dtype, np.integer)


### PR DESCRIPTION
Fixes bug that turns categorical data into float arrays after the valid_range is applied.  This is done by using the fill value to fill the data outside of the valid_range for integer.  This PR also adds tests to make verify that int arrays have _FillValue and remain integer, while float arrays have no _FillValue in the output attributes and remain float.  