### PR TITLE
Make raw metadata optional in SEVIRI HRIT/Native

### DIFF
--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -114,16 +114,6 @@ The SEVIRI L1.5 readers provide the following metadata:
 * The ``orbital_parameters`` attribute provides the nominal and actual satellite
   position, as well as the projection centre. See the `Metadata` section in
   the :doc:`../readers` chapter for more information.
-* The ``raw_metadata`` attribute provides raw metadata from the file header
-  (HRIT and Native format). By default, arrays with more than 100 elements are
-  excluded to limit memory usage. This threshold can be adjusted using the
-  ``mda_max_array_size`` reader keyword argument:
-
-  .. code-block:: python
-
-       scene = satpy.Scene(filenames,
-                          reader='seviri_l1b_hrit/native',
-                          reader_kwargs={'mda_max_array_size': 1000})
 
 * The ``acq_time`` coordinate provides the mean acquisition time for each
   scanline. Use a ``MultiIndex`` to enable selection by acquisition time:
@@ -136,6 +126,20 @@ The SEVIRI L1.5 readers provide the following metadata:
       scn['IR_108']['y'] = mi
       scn['IR_108'].sel(time=np.datetime64('2019-03-01T12:06:13.052000000'))
 
+* Raw metadata from the file header can be included by setting the reader
+  argument ``include_raw_metadata=True`` (HRIT and Native format only). Note
+  that this comes with a performance penalty of up to 10% if raw metadata from
+  multiple segments or scans need to be combined. By default arrays with more
+  than 100 elements are excluded to limit the performance penalty. This
+  threshold can be adjusted using the ``mda_max_array_size`` reader keyword
+  argument:
+
+  .. code-block:: python
+
+       scene = satpy.Scene(filenames,
+                          reader='seviri_l1b_hrit/native',
+                          reader_kwargs={'include_raw_metadata': True,
+                                         'mda_max_array_size': 1000})
 
 References:
     - `MSG Level 1.5 Image Data Format Description`_

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -210,7 +210,8 @@ class HRITMSGPrologueFileHandler(HRITMSGPrologueEpilogueBase):
     """SEVIRI HRIT prologue reader."""
 
     def __init__(self, filename, filename_info, filetype_info, calib_mode='nominal',
-                 ext_calib_coefs=None, mda_max_array_size=None, fill_hrv=None):
+                 ext_calib_coefs=None, include_raw_metadata=False,
+                 mda_max_array_size=None, fill_hrv=None):
         """Initialize the reader."""
         super(HRITMSGPrologueFileHandler, self).__init__(filename, filename_info,
                                                          filetype_info,
@@ -282,7 +283,8 @@ class HRITMSGEpilogueFileHandler(HRITMSGPrologueEpilogueBase):
     """SEVIRI HRIT epilogue reader."""
 
     def __init__(self, filename, filename_info, filetype_info, calib_mode='nominal',
-                 ext_calib_coefs=None, mda_max_array_size=None, fill_hrv=None):
+                 ext_calib_coefs=None, include_raw_metadata=False,
+                 mda_max_array_size=None, fill_hrv=None):
         """Initialize the reader."""
         super(HRITMSGEpilogueFileHandler, self).__init__(filename, filename_info,
                                                          filetype_info,
@@ -336,7 +338,8 @@ class HRITMSGFileHandler(HRITFileHandler):
 
     def __init__(self, filename, filename_info, filetype_info,
                  prologue, epilogue, calib_mode='nominal',
-                 ext_calib_coefs=None, mda_max_array_size=100, fill_hrv=True):
+                 ext_calib_coefs=None, include_raw_metadata=False,
+                 mda_max_array_size=100, fill_hrv=True):
         """Initialize the reader."""
         super(HRITMSGFileHandler, self).__init__(filename, filename_info,
                                                  filetype_info,
@@ -349,6 +352,7 @@ class HRITMSGFileHandler(HRITFileHandler):
         self.prologue = prologue.prologue
         self.epilogue = epilogue.epilogue
         self._filename_info = filename_info
+        self.include_raw_metadata = include_raw_metadata
         self.mda_max_array_size = mda_max_array_size
         self.fill_hrv = fill_hrv
         self.calib_mode = calib_mode
@@ -625,7 +629,8 @@ class HRITMSGFileHandler(HRITFileHandler):
             'projection_altitude': self.mda['projection_parameters']['h']}
         res.attrs['orbital_parameters'].update(self.mda['orbital_parameters'])
         res.attrs['georef_offset_corrected'] = self.mda['offset_corrected']
-        res.attrs['raw_metadata'] = self._get_raw_mda()
+        if self.include_raw_metadata:
+            res.attrs['raw_metadata'] = self._get_raw_mda()
 
     def _get_calib_coefs(self, channel_name):
         """Get coefficients for calibration from counts to radiance."""

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -84,7 +84,7 @@ class NativeMSGFileHandler(BaseFileHandler):
 
     def __init__(self, filename, filename_info, filetype_info,
                  calib_mode='nominal', fill_disk=False, ext_calib_coefs=None,
-                 mda_max_array_size=100):
+                 include_raw_metadata=False, mda_max_array_size=100):
         """Initialize the reader."""
         super(NativeMSGFileHandler, self).__init__(filename,
                                                    filename_info,
@@ -93,6 +93,7 @@ class NativeMSGFileHandler(BaseFileHandler):
         self.calib_mode = calib_mode
         self.ext_calib_coefs = ext_calib_coefs or {}
         self.fill_disk = fill_disk
+        self.include_raw_metadata = include_raw_metadata
         self.mda_max_array_size = mda_max_array_size
 
         # Declare required variables.
@@ -588,9 +589,10 @@ class NativeMSGFileHandler(BaseFileHandler):
         except NoValidOrbitParams as err:
             logger.warning(err)
         dataset.attrs['orbital_parameters'] = orbital_parameters
-        dataset.attrs['raw_metadata'] = reduce_mda(
-            self.header, max_size=self.mda_max_array_size
-        )
+        if self.include_raw_metadata:
+            dataset.attrs['raw_metadata'] = reduce_mda(
+                self.header, max_size=self.mda_max_array_size
+            )
 
     @cached_property
     def satpos(self):

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -17,7 +17,6 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """The HRIT msg reader tests package."""
 
-import copy
 import unittest
 from unittest import mock
 from datetime import datetime
@@ -43,11 +42,6 @@ class TestHRITMSGBase(unittest.TestCase):
 
     def assert_attrs_equal(self, attrs, attrs_exp):
         """Assert equality of dataset attributes."""
-        attrs = copy.deepcopy(attrs)
-        attrs_exp = copy.deepcopy(attrs_exp)
-        # Raw metadata: Check existence only
-        self.assertIn('raw_metadata', attrs)
-        attrs.pop('raw_metadata')
         assert_attrs_equal(attrs, attrs_exp, tolerance=1e-4)
 
 
@@ -165,6 +159,12 @@ class TestHRITMSGFileHandler(TestHRITMSGBase):
             projection_longitude=self.projection_longitude
         )
 
+    def _get_fake_data(self):
+        return xr.DataArray(
+            data=np.zeros((self.nlines, self.ncols)),
+            dims=('y', 'x')
+        )
+
     def test_get_area_def(self):
         """Test getting the area def."""
         from pyresample.utils import proj4_radius_parameters
@@ -204,10 +204,7 @@ class TestHRITMSGFileHandler(TestHRITMSGBase):
     @mock.patch('satpy.readers.seviri_l1b_hrit.HRITMSGFileHandler.calibrate')
     def test_get_dataset(self, calibrate, parent_get_dataset):
         """Test getting the dataset."""
-        data = xr.DataArray(
-            data=np.zeros((self.nlines, self.ncols)),
-            dims=('y', 'x')
-        )
+        data = self._get_fake_data()
         parent_get_dataset.return_value = mock.MagicMock()
         calibrate.return_value = data
 
@@ -226,6 +223,17 @@ class TestHRITMSGFileHandler(TestHRITMSGBase):
             res.attrs,
             setup.get_attrs_exp(self.projection_longitude)
         )
+
+    @mock.patch('satpy.readers.seviri_l1b_hrit.HRITFileHandler.get_dataset')
+    @mock.patch('satpy.readers.seviri_l1b_hrit.HRITMSGFileHandler.calibrate')
+    def test_get_dataset_with_raw_metadata(self, calibrate, parent_get_dataset):
+        """Test getting the dataset."""
+        calibrate.return_value = self._get_fake_data()
+        key = make_dataid(name='VIS006', calibration='reflectance')
+        info = setup.get_fake_dataset_info()
+        self.reader.include_raw_metadata = True
+        res = self.reader.get_dataset(key, info)
+        assert 'raw_metadata' in res.attrs
 
     def test_get_raw_mda(self):
         """Test provision of raw metadata."""

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1157,6 +1157,7 @@ class TestNativeMSGDataset:
             fh.fill_disk = False
             fh.calib_mode = 'NOMINAL'
             fh.ext_calib_coefs = {}
+            fh.include_raw_metadata = False
             fh.mda_max_array_size = 100
             return fh
 
@@ -1204,9 +1205,24 @@ class TestNativeMSGDataset:
                                       np.datetime64('1958-01-02 00:00:03'),
                                       np.datetime64('1958-01-02 00:00:04')])
         xr.testing.assert_equal(dataset, expected)
-        assert 'raw_metadata' in dataset.attrs
-        dataset.attrs.pop('raw_metadata')
+        assert 'raw_metadata' not in dataset.attrs
         assert_attrs_equal(dataset.attrs, expected.attrs, tolerance=1e-4)
+
+    def test_get_dataset_with_raw_metadata(self, file_handler):
+        """Test provision of raw metadata."""
+        file_handler.include_raw_metadata = True
+        dataset_id = make_dataid(
+            name='VIS006',
+            resolution=3000,
+            calibration='counts'
+        )
+        dataset_info = {
+            'units': '1',
+            'wavelength': (1, 2, 3),
+            'standard_name': 'counts'
+        }
+        res = file_handler.get_dataset(dataset_id, dataset_info)
+        assert 'raw_metadata' in res.attrs
 
     def test_satpos_no_valid_orbit_polynomial(self, file_handler):
         """Test satellite position if there is no valid orbit polynomial."""


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Make the provision of raw metadata optional in SEVIRI HRIT and Native readers. This avoids the associated performance penalty for the majority of use cases where those metadata are not needed. For this purpose a new reader kwarg `include_raw_metadata` is added. The option for limiting the array size in the metadata remains, because it still allows users to speed up the loading if they don't need those large arrays. Example:

```python
scn = satpy.Scene(
    filenames,
    reader='seviri_l1b_hrit',
    reader_kwargs={'include_raw_metadata': True, 'mda_max_array_size': 10}
)
```

The performance penalty in the current version is ~10% at max (see table below). Its origin is the comparison of large nested dictionaries from multiple segments (HRIT) or files (Native). Array comparison is responsible for approx. half of that penalty. The other half is spent with dictionary iteration and comparison of scalar objects. The latter amount can only be reduced if raw metadata are excluded.

Here are some timings for a single IR channel in HRIT format. For higher resolution channels the relative penalty is smaller, because the actual loading takes longer.

| Variant  | Time | Relative to current version | 
| ------------- | ------------- | ------------- |
| Without raw metadata (the default in this PR) | 0.74s | 89% |
| Max metadata array size = 1  | 0.79s | 95% |
| Max metadata array size = 10  | 0.81s | 98% |
| Max metadata array size = 100 (current version)  | 0.83s | 100% |
| Max metadata array size = unlimited  | 0.85s | 102% |


<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Closes #1718  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
