### PR TITLE
Bzip2 pro epi

### DIFF
--- a/satpy/etc/readers/seviri_l1b_hrit.yaml
+++ b/satpy/etc/readers/seviri_l1b_hrit.yaml
@@ -160,11 +160,11 @@ file_types:
 
     HRIT_PRO:
         file_reader: !!python/name:satpy.readers.seviri_l1b_hrit.HRITMSGPrologueFileHandler
-        file_patterns: ['{rate:1s}-000-{hrit_format:_<6s}-{platform_shortname:4s}_{service:_<7s}-_________-PRO______-{start_time:%Y%m%d%H%M}-__']
+        file_patterns: ['{rate:1s}-000-{hrit_format:_<6s}-{platform_shortname:4s}_{service:_<7s}-_________-PRO______-{start_time:%Y%m%d%H%M}-__', '{rate:1s}-000-{hrit_format:_<6s}-{platform_shortname:4s}_{service:_<7s}-_________-PRO______-{start_time:%Y%m%d%H%M}-__.bz2']
 
     HRIT_EPI:
         file_reader: !!python/name:satpy.readers.seviri_l1b_hrit.HRITMSGEpilogueFileHandler
-        file_patterns: ['{rate:1s}-000-{hrit_format:_<6s}-{platform_shortname:4s}_{service:_<7s}-_________-EPI______-{start_time:%Y%m%d%H%M}-__']
+        file_patterns: ['{rate:1s}-000-{hrit_format:_<6s}-{platform_shortname:4s}_{service:_<7s}-_________-EPI______-{start_time:%Y%m%d%H%M}-__', '{rate:1s}-000-{hrit_format:_<6s}-{platform_shortname:4s}_{service:_<7s}-_________-EPI______-{start_time:%Y%m%d%H%M}-__.bz2']
 
 datasets:
   HRV:

--- a/satpy/readers/hrit_base.py
+++ b/satpy/readers/hrit_base.py
@@ -42,7 +42,6 @@ from pyresample import geometry
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.eum_base import time_cds_short
 from satpy.readers.seviri_base import dec10216
-from satpy.readers.utils import unzip_context
 
 logger = logging.getLogger('hrit_base')
 
@@ -157,20 +156,18 @@ class HRITFileHandler(BaseFileHandler):
         """Initialize the reader."""
         super(HRITFileHandler, self).__init__(filename, filename_info,
                                               filetype_info)
-        with unzip_context(filename) as fn:
-            if fn is not None:
-                self.filename = fn
+
+        self.mda = {}
+        self._get_hd(hdr_info)
+
+        if self.mda.get('compression_flag_for_data'):
+            logger.debug('Unpacking %s', filename)
+            try:
+                self.filename = decompress(filename)
+            except IOError as err:
+                logger.warning("Unpacking failed: %s", str(err))
             self.mda = {}
             self._get_hd(hdr_info)
-
-            if self.mda.get('compression_flag_for_data'):
-                logger.debug('Unpacking %s', filename)
-                try:
-                    self.filename = decompress(filename)
-                except IOError as err:
-                    logger.warning("Unpacking failed: %s", str(err))
-                self.mda = {}
-                self._get_hd(hdr_info)
 
         self._start_time = filename_info['start_time']
         self._end_time = self._start_time + timedelta(minutes=15)

--- a/satpy/readers/hrit_base.py
+++ b/satpy/readers/hrit_base.py
@@ -30,7 +30,6 @@ temporary directory for reading.
 
 import logging
 from datetime import timedelta
-from tempfile import gettempdir
 import os
 from io import BytesIO
 from subprocess import Popen, PIPE

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -212,13 +212,17 @@ class HRITMSGPrologueFileHandler(HRITMSGPrologueEpilogueBase):
     def __init__(self, filename, filename_info, filetype_info, calib_mode='nominal',
                  ext_calib_coefs=None, mda_max_array_size=None, fill_hrv=None):
         """Initialize the reader."""
-        super(HRITMSGPrologueFileHandler, self).__init__(filename, filename_info,
-                                                         filetype_info,
-                                                         (msg_hdr_map,
-                                                          msg_variable_length_headers,
-                                                          msg_text_headers))
-        self.prologue = {}
-        self.read_prologue()
+        with utils.unzip_context(filename) as fn:
+            if fn is not None:
+                self.filename = fn
+
+            super(HRITMSGPrologueFileHandler, self).__init__(self.filename, filename_info,
+                                                             filetype_info,
+                                                             (msg_hdr_map,
+                                                              msg_variable_length_headers,
+                                                              msg_text_headers))
+            self.prologue = {}
+            self.read_prologue()
 
         service = filename_info['service']
         if service == '':
@@ -284,13 +288,16 @@ class HRITMSGEpilogueFileHandler(HRITMSGPrologueEpilogueBase):
     def __init__(self, filename, filename_info, filetype_info, calib_mode='nominal',
                  ext_calib_coefs=None, mda_max_array_size=None, fill_hrv=None):
         """Initialize the reader."""
-        super(HRITMSGEpilogueFileHandler, self).__init__(filename, filename_info,
-                                                         filetype_info,
-                                                         (msg_hdr_map,
-                                                          msg_variable_length_headers,
-                                                          msg_text_headers))
-        self.epilogue = {}
-        self.read_epilogue()
+        with utils.unzip_context(filename) as fn:
+            if fn is not None:
+                self.filename = fn
+            super(HRITMSGEpilogueFileHandler, self).__init__(self.filename, filename_info,
+                                                             filetype_info,
+                                                             (msg_hdr_map,
+                                                              msg_variable_length_headers,
+                                                              msg_text_headers))
+            self.epilogue = {}
+            self.read_epilogue()
 
         service = filename_info['service']
         if service == '':

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -254,6 +254,33 @@ def unzip_file(filename):
 
     return None
 
+class unzip_context():
+    """Context manager for uncompressing a .bz2 file on the fly.
+
+    Uses `unzip_file`. Removes the uncompressed file on exit of the context manager.
+
+    Returns: the filename of the uncompressed file or of the original file if it was not
+    compressed.
+
+    """
+    def __init__(self, filename):
+        """Keep original filename."""
+        self.input_filename = filename
+
+    def __enter__(self):
+        """Uncompress file if necessary and return the relevant filename for the file handler."""
+        unzipped = unzip_file(self.input_filename)
+        if unzipped is not None:
+            self.unzipped_filename = unzipped
+            return unzipped
+        else:
+            self.unzipped_filename = None
+            return self.input_filename
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Remove temporary file."""
+        if self.unzipped_filename is not None:
+            print("Removing", self.unzipped_filename)
 
 def bbox(img):
     """Find the bounding box around nonzero elements in the given array.

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -254,6 +254,7 @@ def unzip_file(filename):
 
     return None
 
+
 class unzip_context():
     """Context manager for uncompressing a .bz2 file on the fly.
 
@@ -263,6 +264,7 @@ class unzip_context():
     compressed.
 
     """
+
     def __init__(self, filename):
         """Keep original filename."""
         self.input_filename = filename
@@ -281,6 +283,7 @@ class unzip_context():
         """Remove temporary file."""
         if self.unzipped_filename is not None:
             print("Removing", self.unzipped_filename)
+
 
 def bbox(img):
     """Find the bounding box around nonzero elements in the given array.

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -282,7 +282,7 @@ class unzip_context():
     def __exit__(self, exc_type, exc_value, traceback):
         """Remove temporary file."""
         if self.unzipped_filename is not None:
-            print("Removing", self.unzipped_filename)
+            os.remove(self.unzipped_filename)
 
 
 def bbox(img):


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

Implement a context reader for unzip_file (for `.bz2` files) and use it for the seviri HRIT
reader, for the prologue and epilogue files.

The context reader is used at the `__init__` stage of `HRITMSGPrologueFileHandler` and
`HRITMSGEpilogueFileHandler` to keep the uncompressed file until the prologue
and epilogue are read.

 - [ ] Closes #1796  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
