### PR TITLE
Fix for missing attributes when requesting 'counts' calibration from ABI L1B reader.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -9,6 +9,7 @@ The following people have made contributions to this project:
 
 - [Trygve Aspenes (TAlonglong)](https://github.com/TAlonglong)
 - [Talfan Barnie (TalfanBarnie)](https://github.com/TalfanBarnie)
+- [Jonathan Beavers (jon4than)](https://github.com/jon4than)
 - [Suyash Behera (Suyash458)](https://github.com/Suyash458)
 - [Ray Bell (raybellwaves)](https://github.com/raybellwaves)
 - [Jorge Bravo (jhbravo)](https://github.com/jhbravo)

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -40,14 +40,16 @@ class NC_ABI_L1B(NC_ABI_BASE):
         logger.debug('Reading in get_dataset %s.', key['name'])
         # For raw cal, don't apply scale and offset, return raw file counts
         if key['calibration'] == 'counts':
-            return self._raw_calibrate(self.nc['Rad'])
-        radiances = self['Rad']
+            radiances = self.nc['Rad']
+        else:
+            radiances = self['Rad']
 
         # mapping of calibration types to calibration functions
         cal_dictionary = {
             'reflectance': self._vis_calibrate,
             'brightness_temperature': self._ir_calibrate,
-            'radiance': self._rad_calibrate
+            'radiance': self._rad_calibrate,
+            'counts': self._raw_calibrate,
         }
 
         try:

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -40,7 +40,7 @@ class NC_ABI_L1B(NC_ABI_BASE):
         logger.debug('Reading in get_dataset %s.', key['name'])
         # For raw cal, don't apply scale and offset, return raw file counts
         if key['calibration'] == 'counts':
-            radiances = self.nc['Rad']
+            radiances = self.nc['Rad'].copy()
         else:
             radiances = self['Rad']
 

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -296,14 +296,39 @@ class Test_NC_ABI_L1B_raw_cal(Test_NC_ABI_L1B_Base):
         # We expect the raw data to be unchanged
         expected = res.data
         self.assertTrue(np.allclose(res.data, expected, equal_nan=True))
-        self.assertEqual(res.data.dtype, np.int16, "int16 data type expected")
+
+        # check for the presence of typical attributes
         self.assertIn('scale_factor', res.attrs)
         self.assertIn('add_offset', res.attrs)
         self.assertIn('_FillValue', res.attrs)
+        self.assertIn('orbital_parameters', res.attrs)
+        self.assertIn('platform_shortname', res.attrs)
+        self.assertIn('scene_id', res.attrs)
+
+        # determine if things match their expected values/types.
+        self.assertEqual(res.data.dtype, np.int16, "int16 data type expected")
         self.assertEqual(res.attrs['standard_name'],
                          'counts')
         self.assertEqual(res.attrs['long_name'],
                          'Raw Counts')
+
+
+class Test_NC_ABI_L1B_invalid_cal(Test_NC_ABI_L1B_Base):
+    """Test the NC_ABI_L1B reader with invalid calibration."""
+
+    def test_invalid_calibration(self):
+        """Test detection of invalid calibration values."""
+
+        # Need to use a custom DataID class because the real DataID class is
+        # smart enough to detect the invalid calibration before the ABI L1B
+        # get_dataset method gets a chance to run.
+        class FakeDataID(dict):
+            def to_dict(self):
+                return self
+
+        with self.assertRaises(ValueError, msg='Did not detect invalid cal'):
+            did = FakeDataID(name='C05', calibration='invalid', modifiers=())
+            self.reader.get_dataset(did, {})
 
 
 class Test_NC_ABI_File(unittest.TestCase):

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -318,7 +318,6 @@ class Test_NC_ABI_L1B_invalid_cal(Test_NC_ABI_L1B_Base):
 
     def test_invalid_calibration(self):
         """Test detection of invalid calibration values."""
-
         # Need to use a custom DataID class because the real DataID class is
         # smart enough to detect the invalid calibration before the ABI L1B
         # get_dataset method gets a chance to run.


### PR DESCRIPTION
As part of Pull Request #1692, we added an early return to abi_l1b.py's get_dataset method when the requested calibration is "counts".

The problem is that the early return results in a number of missing attributes in the object returned from get_dataset.

I also took the liberty of updating the unit tests to check for some of the missing attributes, as well as including a test for invalid calibration.

As an aside, I agree with the logic for _why_ it was decided to return early; the `self.nc['Rad']` values aren't radiances. That said, I couldn't think of a more straightforward way to write this code.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
