### PR TITLE
added link to the GOES-2-go package in the docs as a download source.

### DIFF
--- a/doc/source/data_download.rst
+++ b/doc/source/data_download.rst
@@ -36,7 +36,9 @@ NOAA GOES on Amazon Web Services
 * `Data Browser <http://noaa-goes16.s3.amazonaws.com/index.html>`__
 * Associated Readers: ``abi_l1b``
 
-In addition ot the pages above, Brian Blaylock has prepared some instructions
+In addition to the pages above, Brian Blaylock's `GOES-2-Go <https://github.com/blaylockbk/goes2go>`_
+python package is useful for downloading GOES data to your local machine. 
+Brian also prepared some instructions
 for using the ``rclone`` tool for downloading AWS data to a local machine. The
 instructions can be found
 `here <https://github.com/blaylockbk/pyBKB_v3/blob/master/rclone_howto.md>`_.


### PR DESCRIPTION
I just saw that your documents link to my rclone tutorial for downloading GOES data. Thanks for sharing that! I also have a python package called "GOES-2-go" that downloads GOES data from AWS to your local machine. This link could be helpful to others who use satpy, and I hoped you consider including this link in your docs. 