### PR TITLE
Add warning in 'awips_tiled' writer when 'units' are too long

### DIFF
--- a/satpy/tests/writer_tests/test_awips_tiled.py
+++ b/satpy/tests/writer_tests/test_awips_tiled.py
@@ -191,8 +191,9 @@ class TestAWIPSTiledWriter:
         with warnings.catch_warnings(record=True) as caught_warnings:
             w.save_dataset(input_data_arr, sector_id='TEST', source_name='TESTS')
         assert len(caught_warnings) == 1
-        assert "too long" in caught_warnings[0].message
-        assert "this is a really long units string" in caught_warnings[0].message
+        warn_msg = caught_warnings[0].message.args[0]
+        assert "too long" in warn_msg
+        assert "this is a really long units string" in warn_msg
 
     @pytest.mark.parametrize(
         ("tile_count", "tile_size"),

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -1095,6 +1095,16 @@ class AWIPSNetCDFTemplate(NetCDFTemplate):
         new_ds.attrs['creation_time'] = creation_time.strftime('%Y-%m-%dT%H:%M:%S')
         return new_ds
 
+    def _render_variable_attributes(self, var_config, input_metadata):
+        attrs = super()._render_variable_attributes(var_config, input_metadata)
+        # AWIPS validation checks
+        if len(attrs.get("units", "")) > 26:
+            warnings.warn(
+                "AWIPS 'units' must be limited to a maximum of 26 characters. "
+                "Units '{}' is too long and will be truncated.".format(attrs["units"]))
+            attrs["units"] = attrs["units"][:26]
+        return attrs
+
     def render(self, dataset_or_data_arrays, area_def,
                tile_info, sector_id, creator=None, creation_time=None,
                shared_attrs=None, extra_global_attrs=None):


### PR DESCRIPTION
AWIPS has nice random limits to attributes depending on where and how it puts it in a database. Apparently the `units` attribute is limited to 26 characters. This PR adds a warning and forces the units to 26 characters.

CC @deeplycloudy @nbearson