### PR TITLE
Fix consistency with nucaps sensor metadata (set/lowercase)

### DIFF
--- a/satpy/etc/readers/nucaps.yaml
+++ b/satpy/etc/readers/nucaps.yaml
@@ -2,7 +2,7 @@ reader:
   description: NUCAPS Retrieval Reader
   name: nucaps
   reader: !!python/name:satpy.readers.nucaps.NUCAPSReader
-  sensors: [cris, atms]
+  sensors: [cris, atms, viirs]
   data_identification_keys:
     name:
       required: true

--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -133,8 +133,6 @@ class NUCAPSFileHandler(NetCDF4FileHandler):
         """Return standard sensor or instrument name for the file's data."""
         try:
             res = self['/attr/instrument_name']
-            if isinstance(res, np.ndarray):
-                res = str(res.astype(str))
             res = [x.strip() for x in res.split(',')]
             if len(res) == 1:
                 return res[0].lower()

--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -137,10 +137,10 @@ class NUCAPSFileHandler(NetCDF4FileHandler):
                 res = str(res.astype(str))
             res = [x.strip() for x in res.split(',')]
             if len(res) == 1:
-                return res[0]
-            return res
+                return res[0].lower()
         except KeyError:
-            return ['CrIS', 'ATMS', 'VIIRS']
+            res = ['CrIS', 'ATMS', 'VIIRS']
+        return set(name.lower() for name in res)
 
     def get_shape(self, ds_id, ds_info):
         """Return data array shape for item specified."""

--- a/satpy/tests/reader_tests/test_nucaps.py
+++ b/satpy/tests/reader_tests/test_nucaps.py
@@ -213,7 +213,7 @@ class TestNUCAPSReader(unittest.TestCase):
             # self.assertNotEqual(v.info['resolution'], 0)
             # self.assertEqual(v.info['units'], 'degrees')
             self.assertEqual(v.ndim, 1)
-            self.assertEqual(v.attrs['sensor'], ['CrIS', 'ATMS', 'VIIRS'])
+            self.assertEqual(v.attrs['sensor'], set(['cris', 'atms', 'viirs']))
             self.assertEqual(type(v.attrs['start_time']), datetime.datetime)
             self.assertEqual(type(v.attrs['end_time']), datetime.datetime)
 
@@ -401,7 +401,7 @@ class TestNUCAPSScienceEDRReader(unittest.TestCase):
         self.assertEqual(len(datasets), 5)
         for v in datasets.values():
             self.assertEqual(v.ndim, 1)
-            self.assertEqual(v.attrs['sensor'], ['CrIS', 'ATMS', 'VIIRS'])
+            self.assertEqual(v.attrs['sensor'], set(['cris', 'atms', 'viirs']))
             self.assertEqual(type(v.attrs['start_time']), datetime.datetime)
             self.assertEqual(type(v.attrs['end_time']), datetime.datetime)
 


### PR DESCRIPTION
It is pretty standard in Satpy that the `sensor` piece of metadata be a single lowercase string of a sensor name or a set of lowercase sensor names. This was not the case for the older NUCAPS reader where they were mixed case and a list.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
