### PR TITLE
Fix composites failing when inputs are different chunk sizes

### DIFF
--- a/satpy/etc/composites/modis.yaml
+++ b/satpy/etc/composites/modis.yaml
@@ -4,6 +4,7 @@ modifiers:
     modifier: !!python/name:satpy.modifiers.atmosphere.ReflectanceCorrector
     url: "https://www.ssec.wisc.edu/~davidh/polar2grid/modis_crefl/tbase.hdf"
     known_hash: "sha256:ed5183cddce905361c1cac8ae6e3a447212875ea421a05747751efe76f8a068e"
+    dem_sds: "Elevation"
     prerequisites:
     - name: satellite_azimuth_angle
     - name: satellite_zenith_angle

--- a/satpy/modifiers/_crefl.py
+++ b/satpy/modifiers/_crefl.py
@@ -137,7 +137,16 @@ class ReflectanceCorrector(ModifierBase, DataDownloadMixin):
         f = SD(local_filename, SDC.READ)
         var = f.select(var_name)
         data = var[:]
-        return np.ma.MaskedArray(data, data == var.getfillvalue())
+        fill = ReflectanceCorrector._read_fill_value_from_hdf4(var, data.dtype)
+        return np.ma.MaskedArray(data, data == fill)
+
+    @staticmethod
+    def _read_fill_value_from_hdf4(var, dtype):
+        from pyhdf.error import HDF4Error
+        try:
+            return var.getfillvalue()
+        except HDF4Error:
+            return np.iinfo(dtype).min
 
     def _get_data_and_angles(self, datasets, optional_datasets):
         angles = self._extract_angle_data_arrays(datasets, optional_datasets)

--- a/satpy/tests/modifier_tests/test_crefl.py
+++ b/satpy/tests/modifier_tests/test_crefl.py
@@ -15,11 +15,57 @@
 """Tests for the CREFL ReflectanceCorrector modifier."""
 import unittest
 from unittest import mock
+from contextlib import contextmanager
 
 import numpy as np
 import pytest
 from dask import array as da
 from pyresample.geometry import AreaDefinition
+
+
+@contextmanager
+def mock_cmgdem(tmpdir, url):
+    """Create fake file representing CMGDEM.hdf."""
+    if not url:
+        yield None
+        return
+    rmock_obj = mock.patch('satpy.modifiers._crefl.retrieve')
+    rmock = rmock_obj.start()
+    dem_fn = str(tmpdir.join(url))
+    rmock.return_value = dem_fn
+    from pyhdf.SD import SD, SDC
+
+    h = SD(dem_fn, SDC.WRITE | SDC.CREATE)
+    dem_var = h.create("averaged elevation", SDC.INT16, (10, 10))
+    dem_var.setfillvalue(-9999)
+    dem_var[:] = np.zeros((10, 10), dtype=np.int16)
+    h.end()
+    try:
+        yield rmock_obj
+    finally:
+        rmock_obj.stop()
+
+
+@contextmanager
+def mock_tbase(tmpdir, url):
+    """Create fake file representing tbase.hdf."""
+    if not url:
+        yield None
+        return
+    rmock_obj = mock.patch('satpy.modifiers._crefl.retrieve')
+    rmock = rmock_obj.start()
+    dem_fn = str(tmpdir.join(url))
+    rmock.return_value = dem_fn
+    from pyhdf.SD import SD, SDC
+
+    h = SD(dem_fn, SDC.WRITE | SDC.CREATE)
+    dem_var = h.create("Elevation", SDC.INT16, (10, 10))
+    dem_var[:] = np.zeros((10, 10), dtype=np.int16)
+    h.end()
+    try:
+        yield rmock_obj
+    finally:
+        rmock_obj.stop()
 
 
 class TestViirsReflectanceCorrectorAnglesTest(unittest.TestCase):
@@ -172,8 +218,14 @@ class TestReflectanceCorrectorModifier:
                                             51.909142813383916, 58.8234273736508, 68.84706145641482, 69.91085190887961,
                                             71.10179768327806, 71.33161009169649])
 
-    @pytest.mark.parametrize('url', [None, 'CMGDEM.hdf'])
-    def test_reflectance_corrector_viirs(self, tmpdir, url):
+    @pytest.mark.parametrize(
+        'url,dem_mock_cm,dem_sds',
+        [
+            (None, mock_cmgdem, "average elevation"),
+            ("CMGDEM.hdf", mock_cmgdem, "averaged elevation"),
+            ("tbase.hdf", mock_tbase, "Elevation"),
+        ])
+    def test_reflectance_corrector_viirs(self, tmpdir, url, dem_mock_cm, dem_sds):
         """Test ReflectanceCorrector modifier with VIIRS data."""
         import xarray as xr
         import dask.array as da
@@ -196,7 +248,9 @@ class TestReflectanceCorrectorModifier:
             calibration='reflectance',
             modifiers=('sunz_corrected_iband', 'rayleigh_corrected_crefl_iband'),
             sensor='viirs',
-            url=url)
+            url=url,
+            dem_sds=dem_sds,
+        )
 
         assert ref_cor.attrs['modifiers'] == ('sunz_corrected_iband', 'rayleigh_corrected_crefl_iband')
         assert ref_cor.attrs['calibration'] == 'reflectance'
@@ -234,9 +288,8 @@ class TestReflectanceCorrectorModifier:
         c04 = make_xarray('solar_azimuth_angle', 'solar_azimuth_angle')
         c05 = make_xarray('solar_zenith_angle', 'solar_zenith_angle')
 
-        rmock_obj = self._start_dem_mock(tmpdir, url)
-        res = ref_cor([c01], [c02, c03, c04, c05])
-        self._stop_dem_mock(rmock_obj)
+        with dem_mock_cm(tmpdir, url):
+            res = ref_cor([c01], [c02, c03, c04, c05])
 
         assert isinstance(res, xr.DataArray)
         assert isinstance(res.data, da.Array)
@@ -341,22 +394,3 @@ class TestReflectanceCorrectorModifier:
         pytest.raises(ValueError, ref_cor, [1], [2, 3, 4])
         pytest.raises(ValueError, ref_cor, [1, 2, 3, 4], [])
         pytest.raises(ValueError, ref_cor, [], [1, 2, 3, 4])
-
-    def _start_dem_mock(self, tmpdir, url):
-        if not url:
-            return
-        rmock_obj = mock.patch('satpy.modifiers._crefl.retrieve')
-        rmock = rmock_obj.start()
-        dem_fn = str(tmpdir.join(url))
-        rmock.return_value = dem_fn
-        from pyhdf.SD import SD, SDC
-
-        h = SD(dem_fn, SDC.WRITE | SDC.CREATE)
-        dem_var = h.create("averaged elevation", SDC.FLOAT32, (10, 10))
-        dem_var.setfillvalue(-999.0)
-        dem_var[:] = np.zeros((10, 10), dtype=np.float32)
-        return rmock_obj
-
-    def _stop_dem_mock(self, rmock_obj):
-        if rmock_obj:
-            rmock_obj.stop()

--- a/satpy/tests/modifier_tests/test_crefl.py
+++ b/satpy/tests/modifier_tests/test_crefl.py
@@ -16,6 +16,7 @@
 import unittest
 from unittest import mock
 from contextlib import contextmanager
+from datetime import datetime
 
 import numpy as np
 import pytest
@@ -120,6 +121,20 @@ class TestViirsReflectanceCorrectorAnglesTest(unittest.TestCase):
         self.assertEqual(args[6], 0)
 
 
+def _make_viirs_xarray(data, area, name, standard_name, wavelength=None, units='degrees', calibration=None):
+    return xr.DataArray(data, dims=('y', 'x'),
+                        attrs={
+                            'start_orbit': 1708, 'end_orbit': 1708, 'wavelength': wavelength,
+                            'modifiers': None, 'calibration': calibration,
+                            'resolution': 371, 'name': name,
+                            'standard_name': standard_name, 'platform_name': 'Suomi-NPP',
+                            'polarization': None, 'sensor': 'viirs', 'units': units,
+                            'start_time': datetime(2012, 2, 25, 18, 1, 24, 570942),
+                            'end_time': datetime(2012, 2, 25, 18, 11, 21, 175760), 'area': area,
+                            'ancillary_variables': []
+                        })
+
+
 class TestReflectanceCorrectorModifier:
     """Test the CREFL modifier."""
 
@@ -135,11 +150,11 @@ class TestReflectanceCorrectorModifier:
             cols, rows,
             (-5434894.954752679, -5434894.964451744, 5434894.964451744, 5434894.954752679))
 
-        dnb = np.zeros((rows, cols)) + 25
-        dnb[3, :] += 25
-        dnb[4:, :] += 50
-        dnb = da.from_array(dnb, chunks=100)
-        return area, dnb
+        data = np.zeros((rows, cols)) + 25
+        data[3, :] += 25
+        data[4:, :] += 50
+        data = da.from_array(data, chunks=100)
+        return area, data
 
     def test_reflectance_corrector_abi(self):
         """Test ReflectanceCorrector modifier with ABI data."""
@@ -222,7 +237,6 @@ class TestReflectanceCorrectorModifier:
         ])
     def test_reflectance_corrector_viirs(self, tmpdir, url, dem_mock_cm, dem_sds):
         """Test ReflectanceCorrector modifier with VIIRS data."""
-        import datetime
         from satpy.modifiers._crefl import ReflectanceCorrector
         from satpy.tests.utils import make_dsq
 
@@ -257,28 +271,14 @@ class TestReflectanceCorrectorModifier:
             make_dsq(name='solar_azimuth_angle'),
             make_dsq(name='solar_zenith_angle')]
 
-        area, dnb = self.data_area_ref_corrector()
-
-        def make_xarray(name, standard_name, wavelength=None, units='degrees', calibration=None):
-            return xr.DataArray(dnb, dims=('y', 'x'),
-                                attrs={
-                                    'start_orbit': 1708, 'end_orbit': 1708, 'wavelength': wavelength, 'level': None,
-                                    'modifiers': None, 'calibration': calibration,
-                                    'resolution': 371, 'name': name,
-                                    'standard_name': standard_name, 'platform_name': 'Suomi-NPP',
-                                    'polarization': None, 'sensor': 'viirs', 'units': units,
-                                    'start_time': datetime.datetime(2012, 2, 25, 18, 1, 24, 570942),
-                                    'end_time': datetime.datetime(2012, 2, 25, 18, 11, 21, 175760), 'area': area,
-                                    'ancillary_variables': []
-                                })
-
-        c01 = make_xarray('I01', 'toa_bidirectional_reflectance',
-                          wavelength=(0.6, 0.64, 0.68), units='%',
-                          calibration='reflectance')
-        c02 = make_xarray('satellite_azimuth_angle', 'sensor_azimuth_angle')
-        c03 = make_xarray('satellite_zenith_angle', 'sensor_zenith_angle')
-        c04 = make_xarray('solar_azimuth_angle', 'solar_azimuth_angle')
-        c05 = make_xarray('solar_zenith_angle', 'solar_zenith_angle')
+        area, data = self.data_area_ref_corrector()
+        c01 = _make_viirs_xarray(data, area, 'I01', 'toa_bidirectional_reflectance',
+                                 wavelength=(0.6, 0.64, 0.68), units='%',
+                                 calibration='reflectance')
+        c02 = _make_viirs_xarray(data, area, 'satellite_azimuth_angle', 'sensor_azimuth_angle')
+        c03 = _make_viirs_xarray(data, area, 'satellite_zenith_angle', 'sensor_zenith_angle')
+        c04 = _make_viirs_xarray(data, area, 'solar_azimuth_angle', 'solar_azimuth_angle')
+        c05 = _make_viirs_xarray(data, area, 'solar_zenith_angle', 'solar_zenith_angle')
 
         with dem_mock_cm(tmpdir, url):
             res = ref_cor([c01], [c02, c03, c04, c05])
@@ -294,8 +294,8 @@ class TestReflectanceCorrectorModifier:
         assert res.attrs['platform_name'] == 'Suomi-NPP'
         assert res.attrs['sensor'] == 'viirs'
         assert res.attrs['units'] == '%'
-        assert res.attrs['start_time'] == datetime.datetime(2012, 2, 25, 18, 1, 24, 570942)
-        assert res.attrs['end_time'] == datetime.datetime(2012, 2, 25, 18, 11, 21, 175760)
+        assert res.attrs['start_time'] == datetime(2012, 2, 25, 18, 1, 24, 570942)
+        assert res.attrs['end_time'] == datetime(2012, 2, 25, 18, 11, 21, 175760)
         assert res.attrs['area'] == area
         assert res.attrs['ancillary_variables'] == []
         data = res.values
@@ -306,7 +306,6 @@ class TestReflectanceCorrectorModifier:
 
     def test_reflectance_corrector_modis(self):
         """Test ReflectanceCorrector modifier with MODIS data."""
-        import datetime
         from satpy.modifiers._crefl import ReflectanceCorrector
         from satpy.tests.utils import make_dsq
         sataa_did = make_dsq(name='satellite_azimuth_angle')
@@ -332,17 +331,16 @@ class TestReflectanceCorrectorModifier:
 
         area, dnb = self.data_area_ref_corrector()
 
-        def make_xarray(name, calibration, wavelength=None, modifiers=None, resolution=1000,
-                        file_type='hdf_eos_geo'):
+        def make_xarray(name, calibration, wavelength=None, modifiers=None, resolution=1000):
             return xr.DataArray(dnb,
                                 dims=('y', 'x'),
                                 attrs={
                                     'wavelength': wavelength, 'level': None, 'modifiers': modifiers,
-                                    'calibration': calibration, 'resolution': resolution, 'file_type': file_type,
+                                    'calibration': calibration, 'resolution': resolution,
                                     'name': name, 'coordinates': ['longitude', 'latitude'],
                                     'platform_name': 'EOS-Aqua', 'polarization': None, 'sensor': 'modis',
-                                    'units': '%', 'start_time': datetime.datetime(2012, 8, 13, 18, 46, 1, 439838),
-                                    'end_time': datetime.datetime(2012, 8, 13, 18, 57, 47, 746296), 'area': area,
+                                    'units': '%', 'start_time': datetime(2012, 8, 13, 18, 46, 1, 439838),
+                                    'end_time': datetime(2012, 8, 13, 18, 57, 47, 746296), 'area': area,
                                     'ancillary_variables': []
                                 })
 
@@ -365,8 +363,8 @@ class TestReflectanceCorrectorModifier:
         assert res.attrs['platform_name'] == 'EOS-Aqua'
         assert res.attrs['sensor'] == 'modis'
         assert res.attrs['units'] == '%'
-        assert res.attrs['start_time'] == datetime.datetime(2012, 8, 13, 18, 46, 1, 439838)
-        assert res.attrs['end_time'] == datetime.datetime(2012, 8, 13, 18, 57, 47, 746296)
+        assert res.attrs['start_time'] == datetime(2012, 8, 13, 18, 46, 1, 439838)
+        assert res.attrs['end_time'] == datetime(2012, 8, 13, 18, 57, 47, 746296)
         assert res.attrs['area'] == area
         assert res.attrs['ancillary_variables'] == []
         data = res.values
@@ -383,3 +381,54 @@ class TestReflectanceCorrectorModifier:
         pytest.raises(ValueError, ref_cor, [1], [2, 3, 4])
         pytest.raises(ValueError, ref_cor, [1, 2, 3, 4], [])
         pytest.raises(ValueError, ref_cor, [], [1, 2, 3, 4])
+
+    @pytest.mark.parametrize(
+        'url,dem_mock_cm,dem_sds',
+        [
+            (None, mock_cmgdem, "average elevation"),
+            ("CMGDEM.hdf", mock_cmgdem, "averaged elevation"),
+            ("tbase.hdf", mock_tbase, "Elevation"),
+        ])
+    def test_reflectance_corrector_different_chunks(self, tmpdir, url, dem_mock_cm, dem_sds):
+        """Test that the modifier works with different chunk sizes for inputs.
+
+        The modifier uses dask's "map_blocks". If the input chunks aren't the
+        same an error is raised.
+
+        """
+        from satpy.modifiers._crefl import ReflectanceCorrector
+        from satpy.tests.utils import make_dsq
+
+        ref_cor = ReflectanceCorrector(
+            optional_prerequisites=[
+                make_dsq(name='satellite_azimuth_angle'),
+                make_dsq(name='satellite_zenith_angle'),
+                make_dsq(name='solar_azimuth_angle'),
+                make_dsq(name='solar_zenith_angle')
+            ],
+            name='I01',
+            prerequisites=[],
+            wavelength=(0.6, 0.64, 0.68),
+            resolution=371,
+            calibration='reflectance',
+            modifiers=('sunz_corrected_iband', 'rayleigh_corrected_crefl_iband'),
+            sensor='viirs',
+            url=url,
+            dem_sds=dem_sds,
+        )
+
+        area, data = self.data_area_ref_corrector()
+        c01 = _make_viirs_xarray(data, area, 'I01', 'toa_bidirectional_reflectance',
+                                 wavelength=(0.6, 0.64, 0.68), units='%',
+                                 calibration='reflectance')
+        c02 = _make_viirs_xarray(data, area, 'satellite_azimuth_angle', 'sensor_azimuth_angle')
+        c02.data = c02.data.rechunk((1, -1))
+        c03 = _make_viirs_xarray(data, area, 'satellite_zenith_angle', 'sensor_zenith_angle')
+        c04 = _make_viirs_xarray(data, area, 'solar_azimuth_angle', 'solar_azimuth_angle')
+        c05 = _make_viirs_xarray(data, area, 'solar_zenith_angle', 'solar_zenith_angle')
+
+        with dem_mock_cm(tmpdir, url):
+            res = ref_cor([c01], [c02, c03, c04, c05])
+
+        # make sure it can actually compute
+        res.compute()

--- a/satpy/tests/modifier_tests/test_crefl.py
+++ b/satpy/tests/modifier_tests/test_crefl.py
@@ -20,6 +20,7 @@ from contextlib import contextmanager
 import numpy as np
 import pytest
 from dask import array as da
+import xarray as xr
 from pyresample.geometry import AreaDefinition
 
 
@@ -88,8 +89,6 @@ class TestViirsReflectanceCorrectorAnglesTest(unittest.TestCase):
     @mock.patch('satpy.modifiers._crefl.get_satpos')
     def test_get_angles(self, get_satpos):
         """Test sun and satellite angle calculation."""
-        import numpy as np
-        import dask.array as da
         from satpy.modifiers._crefl import ReflectanceCorrector
 
         # Patch methods
@@ -144,9 +143,6 @@ class TestReflectanceCorrectorModifier:
 
     def test_reflectance_corrector_abi(self):
         """Test ReflectanceCorrector modifier with ABI data."""
-        import xarray as xr
-        import dask.array as da
-        import numpy as np
         from satpy.modifiers._crefl import ReflectanceCorrector
         from satpy.tests.utils import make_dsq
         ref_cor = ReflectanceCorrector(optional_prerequisites=[
@@ -226,9 +222,6 @@ class TestReflectanceCorrectorModifier:
         ])
     def test_reflectance_corrector_viirs(self, tmpdir, url, dem_mock_cm, dem_sds):
         """Test ReflectanceCorrector modifier with VIIRS data."""
-        import xarray as xr
-        import dask.array as da
-        import numpy as np
         import datetime
         from satpy.modifiers._crefl import ReflectanceCorrector
         from satpy.tests.utils import make_dsq
@@ -313,9 +306,6 @@ class TestReflectanceCorrectorModifier:
 
     def test_reflectance_corrector_modis(self):
         """Test ReflectanceCorrector modifier with MODIS data."""
-        import xarray as xr
-        import dask.array as da
-        import numpy as np
         import datetime
         from satpy.modifiers._crefl import ReflectanceCorrector
         from satpy.tests.utils import make_dsq


### PR DESCRIPTION
While working on using the CREFL rayleigh correction on MODIS data I noticed a couple issues. This PR fixes:

1. The variable name was incorrect for the DEM file typically used with MODIS data (tbase.hdf)
2. The tbase.hdf file doesn't have a fill value specified so it was causing the code to fail when reading it.
3. Any composites that use `map_blocks` or `blockwise` will fail if they have different chunk sizes for their inputs. This is happening for MODIS data due to the angle datasets being returned as 64-bit floats when they only need to be 32-bit floats (that'll be another PR). Anyway, I've added a `unify_chunks` method that is automatically run as part of `match_data_arrays` that all Composites typically follow.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
