### PR TITLE
Fix composites failing when inputs are different chunk sizes

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -19,7 +19,6 @@
 
 import logging
 import os
-import string
 import warnings
 
 import dask.array as da
@@ -156,32 +155,7 @@ class CompositeBase:
         """Match data arrays so that they can be used together in a composite."""
         self.check_geolocation(data_arrays)
         new_arrays = self.drop_coordinates(data_arrays)
-        return self.unify_chunks(new_arrays)
-
-    def unify_chunks(self, data_arrays):
-        """Unify chunk sizes across multiple DataArray objects.
-
-        Useful to avoid errors when calling dask's "map_blocks" or other
-        similar functions where inputs are expected to have the same number
-        of chunks.
-
-        """
-        arr_pairs = self._data_arr_to_dask_array_dim_pairs(data_arrays)
-        _, new_dask_arrs = da.core.unify_chunks(*arr_pairs)
-        for data_arr, dask_arr in zip(data_arrays, new_dask_arrs):
-            data_arr.data = dask_arr  # inplace
-        return data_arrays
-
-    @staticmethod
-    def _data_arr_to_dask_array_dim_pairs(data_arrays):
-        all_dims = set.union(*(set(x.dims) for x in data_arrays))
-        dim_map = dict(zip(all_dims, string.ascii_lowercase))
-        arr_pairs = []
-        for data_arr in data_arrays:
-            dask_arr = data_arr.data
-            dims = data_arr.dims
-            arr_pairs.extend([dask_arr, "".join(dim_map[dim_name] for dim_name in dims)])
-        return arr_pairs
+        return xr.unify_chunks(*new_arrays)
 
     def drop_coordinates(self, data_arrays):
         """Drop neglible non-dimensional coordinates."""

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -155,7 +155,7 @@ class CompositeBase:
         """Match data arrays so that they can be used together in a composite."""
         self.check_geolocation(data_arrays)
         new_arrays = self.drop_coordinates(data_arrays)
-        return xr.unify_chunks(*new_arrays)
+        return list(xr.unify_chunks(*new_arrays))
 
     def drop_coordinates(self, data_arrays):
         """Drop neglible non-dimensional coordinates."""

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -166,6 +166,13 @@ class CompositeBase:
         of chunks.
 
         """
+        arr_pairs = self._data_arr_to_dask_array_dim_pairs(data_arrays)
+        _, new_dask_arrs = da.core.unify_chunks(*arr_pairs)
+        for data_arr, dask_arr in zip(data_arrays, new_dask_arrs):
+            data_arr.data = dask_arr  # inplace
+        return data_arrays
+
+    def _data_arr_to_dask_array_dim_pairs(self, data_arrays):
         all_dims = set.union(*(set(x.dims) for x in data_arrays))
         dim_map = dict(zip(all_dims, string.ascii_lowercase))
         arr_pairs = []
@@ -173,10 +180,7 @@ class CompositeBase:
             dask_arr = data_arr.data
             dims = data_arr.dims
             arr_pairs.extend([dask_arr, "".join(dim_map[dim_name] for dim_name in dims)])
-        _, new_dask_arrs = da.core.unify_chunks(*arr_pairs)
-        for data_arr, dask_arr in zip(data_arrays, new_dask_arrs):
-            data_arr.data = dask_arr  # inplace
-        return data_arrays
+        return arr_pairs
 
     def drop_coordinates(self, data_arrays):
         """Drop neglible non-dimensional coordinates."""

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -46,13 +46,9 @@ MASKING_COMPOSITOR_METHODS = ['less', 'less_equal', 'equal', 'greater_equal',
 class IncompatibleAreas(Exception):
     """Error raised upon compositing things of different shapes."""
 
-    pass
-
 
 class IncompatibleTimes(Exception):
     """Error raised upon compositing things from different times."""
-
-    pass
 
 
 def check_times(projectables):
@@ -77,8 +73,7 @@ def check_times(projectables):
         # Is there a more gracious way to handle this ?
         if np.max(times) - np.min(times) > np.timedelta64(1, 's'):
             raise IncompatibleTimes
-        else:
-            mid_time = (np.max(times) - np.min(times)) / 2 + np.min(times)
+        mid_time = (np.max(times) - np.min(times)) / 2 + np.min(times)
         return mid_time
 
 
@@ -213,7 +208,7 @@ class CompositeBase:
         areas = [ds.attrs.get('area') for ds in data_arrays]
         if all(a is None for a in areas):
             return
-        elif any(a is None for a in areas):
+        if any(a is None for a in areas):
             raise ValueError("Missing 'area' attribute")
 
         if not all(areas[0] == x for x in areas[1:]):

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -172,7 +172,8 @@ class CompositeBase:
             data_arr.data = dask_arr  # inplace
         return data_arrays
 
-    def _data_arr_to_dask_array_dim_pairs(self, data_arrays):
+    @staticmethod
+    def _data_arr_to_dask_array_dim_pairs(data_arrays):
         all_dims = set.union(*(set(x.dims) for x in data_arrays))
         dim_map = dict(zip(all_dims, string.ascii_lowercase))
         arr_pairs = []

--- a/satpy/modifiers/_crefl.py
+++ b/satpy/modifiers/_crefl.py
@@ -149,20 +149,20 @@ class ReflectanceCorrector(ModifierBase, DataDownloadMixin):
             return np.iinfo(dtype).min
 
     def _get_data_and_angles(self, datasets, optional_datasets):
-        angles = self._extract_angle_data_arrays(datasets, optional_datasets)
+        vis, angles = self._extract_angle_data_arrays(datasets, optional_datasets)
         angles = [xr.DataArray(dask_arr, dims=('y', 'x')) for dask_arr in angles]
-        return [datasets[0]] + angles
+        return [vis] + angles
 
     def _extract_angle_data_arrays(self, datasets, optional_datasets):
         all_datasets = datasets + optional_datasets
         if len(all_datasets) == 1:
             vis = self.match_data_arrays(datasets)[0]
-            return self.get_angles(vis)
+            return vis, self.get_angles(vis)
         if len(all_datasets) == 5:
             vis, *angles = self.match_data_arrays(
                 datasets + optional_datasets)
             # get the dask array underneath
-            return [data_arr.data for data_arr in angles]
+            return vis, [data_arr.data for data_arr in angles]
         raise ValueError("Not sure how to handle provided dependencies. "
                          "Either all 4 angles must be provided or none of "
                          "of them.")

--- a/satpy/tests/modifier_tests/test_crefl.py
+++ b/satpy/tests/modifier_tests/test_crefl.py
@@ -16,6 +16,7 @@
 import unittest
 from unittest import mock
 from contextlib import contextmanager
+from datetime import datetime
 
 import numpy as np
 import pytest
@@ -120,6 +121,20 @@ class TestViirsReflectanceCorrectorAnglesTest(unittest.TestCase):
         self.assertEqual(args[6], 0)
 
 
+def _make_viirs_xarray(data, area, name, standard_name, wavelength=None, units='degrees', calibration=None):
+    return xr.DataArray(data, dims=('y', 'x'),
+                        attrs={
+                            'start_orbit': 1708, 'end_orbit': 1708, 'wavelength': wavelength,
+                            'modifiers': None, 'calibration': calibration,
+                            'resolution': 371, 'name': name,
+                            'standard_name': standard_name, 'platform_name': 'Suomi-NPP',
+                            'polarization': None, 'sensor': 'viirs', 'units': units,
+                            'start_time': datetime(2012, 2, 25, 18, 1, 24, 570942),
+                            'end_time': datetime(2012, 2, 25, 18, 11, 21, 175760), 'area': area,
+                            'ancillary_variables': []
+                        })
+
+
 class TestReflectanceCorrectorModifier:
     """Test the CREFL modifier."""
 
@@ -135,11 +150,11 @@ class TestReflectanceCorrectorModifier:
             cols, rows,
             (-5434894.954752679, -5434894.964451744, 5434894.964451744, 5434894.954752679))
 
-        dnb = np.zeros((rows, cols)) + 25
-        dnb[3, :] += 25
-        dnb[4:, :] += 50
-        dnb = da.from_array(dnb, chunks=100)
-        return area, dnb
+        data = np.zeros((rows, cols)) + 25
+        data[3, :] += 25
+        data[4:, :] += 50
+        data = da.from_array(data, chunks=100)
+        return area, data
 
     def test_reflectance_corrector_abi(self):
         """Test ReflectanceCorrector modifier with ABI data."""
@@ -222,7 +237,6 @@ class TestReflectanceCorrectorModifier:
         ])
     def test_reflectance_corrector_viirs(self, tmpdir, url, dem_mock_cm, dem_sds):
         """Test ReflectanceCorrector modifier with VIIRS data."""
-        import datetime
         from satpy.modifiers._crefl import ReflectanceCorrector
         from satpy.tests.utils import make_dsq
 
@@ -257,28 +271,14 @@ class TestReflectanceCorrectorModifier:
             make_dsq(name='solar_azimuth_angle'),
             make_dsq(name='solar_zenith_angle')]
 
-        area, dnb = self.data_area_ref_corrector()
-
-        def make_xarray(name, standard_name, wavelength=None, units='degrees', calibration=None):
-            return xr.DataArray(dnb, dims=('y', 'x'),
-                                attrs={
-                                    'start_orbit': 1708, 'end_orbit': 1708, 'wavelength': wavelength, 'level': None,
-                                    'modifiers': None, 'calibration': calibration,
-                                    'resolution': 371, 'name': name,
-                                    'standard_name': standard_name, 'platform_name': 'Suomi-NPP',
-                                    'polarization': None, 'sensor': 'viirs', 'units': units,
-                                    'start_time': datetime.datetime(2012, 2, 25, 18, 1, 24, 570942),
-                                    'end_time': datetime.datetime(2012, 2, 25, 18, 11, 21, 175760), 'area': area,
-                                    'ancillary_variables': []
-                                })
-
-        c01 = make_xarray('I01', 'toa_bidirectional_reflectance',
-                          wavelength=(0.6, 0.64, 0.68), units='%',
-                          calibration='reflectance')
-        c02 = make_xarray('satellite_azimuth_angle', 'sensor_azimuth_angle')
-        c03 = make_xarray('satellite_zenith_angle', 'sensor_zenith_angle')
-        c04 = make_xarray('solar_azimuth_angle', 'solar_azimuth_angle')
-        c05 = make_xarray('solar_zenith_angle', 'solar_zenith_angle')
+        area, data = self.data_area_ref_corrector()
+        c01 = _make_viirs_xarray(data, area, 'I01', 'toa_bidirectional_reflectance',
+                                 wavelength=(0.6, 0.64, 0.68), units='%',
+                                 calibration='reflectance')
+        c02 = _make_viirs_xarray(data, area, 'satellite_azimuth_angle', 'sensor_azimuth_angle')
+        c03 = _make_viirs_xarray(data, area, 'satellite_zenith_angle', 'sensor_zenith_angle')
+        c04 = _make_viirs_xarray(data, area, 'solar_azimuth_angle', 'solar_azimuth_angle')
+        c05 = _make_viirs_xarray(data, area, 'solar_zenith_angle', 'solar_zenith_angle')
 
         with dem_mock_cm(tmpdir, url):
             res = ref_cor([c01], [c02, c03, c04, c05])
@@ -294,8 +294,8 @@ class TestReflectanceCorrectorModifier:
         assert res.attrs['platform_name'] == 'Suomi-NPP'
         assert res.attrs['sensor'] == 'viirs'
         assert res.attrs['units'] == '%'
-        assert res.attrs['start_time'] == datetime.datetime(2012, 2, 25, 18, 1, 24, 570942)
-        assert res.attrs['end_time'] == datetime.datetime(2012, 2, 25, 18, 11, 21, 175760)
+        assert res.attrs['start_time'] == datetime(2012, 2, 25, 18, 1, 24, 570942)
+        assert res.attrs['end_time'] == datetime(2012, 2, 25, 18, 11, 21, 175760)
         assert res.attrs['area'] == area
         assert res.attrs['ancillary_variables'] == []
         data = res.values
@@ -306,7 +306,6 @@ class TestReflectanceCorrectorModifier:
 
     def test_reflectance_corrector_modis(self):
         """Test ReflectanceCorrector modifier with MODIS data."""
-        import datetime
         from satpy.modifiers._crefl import ReflectanceCorrector
         from satpy.tests.utils import make_dsq
         sataa_did = make_dsq(name='satellite_azimuth_angle')
@@ -332,17 +331,16 @@ class TestReflectanceCorrectorModifier:
 
         area, dnb = self.data_area_ref_corrector()
 
-        def make_xarray(name, calibration, wavelength=None, modifiers=None, resolution=1000,
-                        file_type='hdf_eos_geo'):
+        def make_xarray(name, calibration, wavelength=None, modifiers=None, resolution=1000):
             return xr.DataArray(dnb,
                                 dims=('y', 'x'),
                                 attrs={
                                     'wavelength': wavelength, 'level': None, 'modifiers': modifiers,
-                                    'calibration': calibration, 'resolution': resolution, 'file_type': file_type,
+                                    'calibration': calibration, 'resolution': resolution,
                                     'name': name, 'coordinates': ['longitude', 'latitude'],
                                     'platform_name': 'EOS-Aqua', 'polarization': None, 'sensor': 'modis',
-                                    'units': '%', 'start_time': datetime.datetime(2012, 8, 13, 18, 46, 1, 439838),
-                                    'end_time': datetime.datetime(2012, 8, 13, 18, 57, 47, 746296), 'area': area,
+                                    'units': '%', 'start_time': datetime(2012, 8, 13, 18, 46, 1, 439838),
+                                    'end_time': datetime(2012, 8, 13, 18, 57, 47, 746296), 'area': area,
                                     'ancillary_variables': []
                                 })
 
@@ -365,8 +363,8 @@ class TestReflectanceCorrectorModifier:
         assert res.attrs['platform_name'] == 'EOS-Aqua'
         assert res.attrs['sensor'] == 'modis'
         assert res.attrs['units'] == '%'
-        assert res.attrs['start_time'] == datetime.datetime(2012, 8, 13, 18, 46, 1, 439838)
-        assert res.attrs['end_time'] == datetime.datetime(2012, 8, 13, 18, 57, 47, 746296)
+        assert res.attrs['start_time'] == datetime(2012, 8, 13, 18, 46, 1, 439838)
+        assert res.attrs['end_time'] == datetime(2012, 8, 13, 18, 57, 47, 746296)
         assert res.attrs['area'] == area
         assert res.attrs['ancillary_variables'] == []
         data = res.values
@@ -383,3 +381,54 @@ class TestReflectanceCorrectorModifier:
         pytest.raises(ValueError, ref_cor, [1], [2, 3, 4])
         pytest.raises(ValueError, ref_cor, [1, 2, 3, 4], [])
         pytest.raises(ValueError, ref_cor, [], [1, 2, 3, 4])
+
+    @pytest.mark.parametrize(
+        'url,dem_mock_cm,dem_sds',
+        [
+            (None, mock_cmgdem, "average elevation"),
+            ("CMGDEM.hdf", mock_cmgdem, "averaged elevation"),
+            ("tbase.hdf", mock_tbase, "Elevation"),
+        ])
+    def test_reflectance_corrector_different_chunks(self, tmpdir, url, dem_mock_cm, dem_sds):
+        """Test that the modifier works with different chunk sizes for inputs.
+
+        The modifier uses dask's "map_blocks". If the input chunks aren't the
+        same an error is raised.
+
+        """
+        from satpy.modifiers._crefl import ReflectanceCorrector
+        from satpy.tests.utils import make_dsq
+
+        ref_cor = ReflectanceCorrector(
+            optional_prerequisites=[
+                make_dsq(name='satellite_azimuth_angle'),
+                make_dsq(name='satellite_zenith_angle'),
+                make_dsq(name='solar_azimuth_angle'),
+                make_dsq(name='solar_zenith_angle')
+            ],
+            name='I01',
+            prerequisites=[],
+            wavelength=(0.6, 0.64, 0.68),
+            resolution=371,
+            calibration='reflectance',
+            modifiers=('sunz_corrected_iband', 'rayleigh_corrected_crefl_iband'),
+            sensor='viirs',
+            url=url,
+            dem_sds=dem_sds,
+        )
+
+        area, data = self.data_area_ref_corrector()
+        c01 = _make_viirs_xarray(data, area, 'I01', 'toa_bidirectional_reflectance',
+                                 wavelength=(0.6, 0.64, 0.68), units='%',
+                                 calibration='reflectance')
+        c02 = _make_viirs_xarray(data, area, 'satellite_azimuth_angle', 'sensor_azimuth_angle')
+        c02.data = c02.data.rechunk((1, -1))
+        c03 = _make_viirs_xarray(data, area, 'satellite_zenith_angle', 'sensor_zenith_angle')
+        c04 = _make_viirs_xarray(data, area, 'solar_azimuth_angle', 'solar_azimuth_angle')
+        c05 = _make_viirs_xarray(data, area, 'solar_zenith_angle', 'solar_zenith_angle')
+
+        with dem_mock_cm(tmpdir, url):
+            res = ref_cor([c01], [c02, c03, c04, c05])
+
+        # make sure it can actually compute
+        res.compute()

--- a/satpy/tests/modifier_tests/test_crefl.py
+++ b/satpy/tests/modifier_tests/test_crefl.py
@@ -345,7 +345,7 @@ class TestReflectanceCorrectorModifier:
                                 })
 
         c01 = make_xarray('1', 'reflectance', wavelength=(0.62, 0.645, 0.67), modifiers='sunz_corrected',
-                          resolution=500, file_type='hdf_eos_data_500m')
+                          resolution=500)
         c02 = make_xarray('satellite_azimuth_angle', None)
         c03 = make_xarray('satellite_zenith_angle', None)
         c04 = make_xarray('solar_azimuth_angle', None)
@@ -358,7 +358,6 @@ class TestReflectanceCorrectorModifier:
         assert res.attrs['modifiers'] == ('sunz_corrected', 'rayleigh_corrected_crefl',)
         assert res.attrs['calibration'] == 'reflectance'
         assert res.attrs['resolution'] == 500
-        assert res.attrs['file_type'] == 'hdf_eos_data_500m'
         assert res.attrs['name'] == '1'
         assert res.attrs['platform_name'] == 'EOS-Aqua'
         assert res.attrs['sensor'] == 'modis'

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -51,7 +51,7 @@ class TestMatchDataArrays(unittest.TestCase):
         ds1 = self._get_test_ds()
         comp = CompositeBase('test_comp')
         ret_datasets = comp.match_data_arrays((ds1,))
-        self.assertIs(ret_datasets[0], ds1)
+        assert ret_datasets[0].identical(ds1)
 
     def test_mult_ds_area(self):
         """Test multiple datasets successfully pass."""
@@ -60,8 +60,8 @@ class TestMatchDataArrays(unittest.TestCase):
         ds2 = self._get_test_ds()
         comp = CompositeBase('test_comp')
         ret_datasets = comp.match_data_arrays((ds1, ds2))
-        self.assertIs(ret_datasets[0], ds1)
-        self.assertIs(ret_datasets[1], ds2)
+        assert ret_datasets[0].identical(ds1)
+        assert ret_datasets[1].identical(ds2)
 
     def test_mult_ds_no_area(self):
         """Test that all datasets must have an area attribute."""
@@ -96,8 +96,8 @@ class TestMatchDataArrays(unittest.TestCase):
         ds2 = self._get_test_ds(shape=(3, 100, 50), dims=('bands', 'x', 'y'))
         comp = CompositeBase('test_comp')
         ret_datasets = comp.match_data_arrays((ds1, ds2))
-        self.assertIs(ret_datasets[0], ds1)
-        self.assertIs(ret_datasets[1], ds2)
+        assert ret_datasets[0].identical(ds1)
+        assert ret_datasets[1].identical(ds2)
 
     def test_mult_ds_diff_size(self):
         """Test that datasets with different sizes fail."""


### PR DESCRIPTION
While working on using the CREFL rayleigh correction on MODIS data I noticed a couple issues. Any composites that use map_blocks or blockwise will fail if they have different chunk sizes for their inputs. This is happening for MODIS data due to the angle datasets being returned as 64-bit floats when they only need to be 32-bit floats (that'll be another PR) and the EWA resampling dynamically determining output chunk size (dask's `auto` chunk size) which takes `dtype` into account. Anyway, I've added a unify_chunks method that is automatically run as part of match_data_arrays that all Composites typically follow.

Replaces #1812 

 - [x] Tests added <!-- for all bug fixes or enhancements -->

