### PR TITLE
Add missing metadata to MODIS L1b and L2 readers

### DIFF
--- a/satpy/etc/readers/modis_l1b.yaml
+++ b/satpy/etc/readers/modis_l1b.yaml
@@ -438,28 +438,52 @@ datasets:
   solar_zenith_angle:
     name: solar_zenith_angle
     sensor: modis
-    resolution: [1000, 500, 250]
+    resolution:
+      1000:
+        file_type: [hdf_eos_geo, hdf_eos_data_1000m]
+      500:
+        file_type: [hdf_eos_geo]
+      250:
+        file_type: [hdf_eos_geo]
     coordinates: [longitude, latitude]
     file_type: [hdf_eos_geo, hdf_eos_data_1000m]
 
   solar_azimuth_angle:
     name: solar_azimuth_angle
     sensor: modis
-    resolution: [1000, 500, 250]
+    resolution:
+      1000:
+        file_type: [hdf_eos_geo, hdf_eos_data_1000m]
+      500:
+        file_type: [hdf_eos_geo]
+      250:
+        file_type: [hdf_eos_geo]
     coordinates: [longitude, latitude]
     file_type: [hdf_eos_geo, hdf_eos_data_1000m]
 
   satellite_zenith_angle:
     name: satellite_zenith_angle
     sensor: modis
-    resolution: [1000, 500, 250]
+    resolution:
+      1000:
+        file_type: [hdf_eos_geo, hdf_eos_data_1000m]
+      500:
+        file_type: [hdf_eos_geo]
+      250:
+        file_type: [hdf_eos_geo]
     coordinates: [longitude, latitude]
     file_type: [hdf_eos_geo, hdf_eos_data_1000m]
 
   satellite_azimuth_angle:
     name: satellite_azimuth_angle
     sensor: modis
-    resolution: [1000, 500, 250]
+    resolution:
+      1000:
+        file_type: [hdf_eos_geo, hdf_eos_data_1000m]
+      500:
+        file_type: [hdf_eos_geo]
+      250:
+        file_type: [hdf_eos_geo]
     coordinates: [longitude, latitude]
     file_type: [hdf_eos_geo, hdf_eos_data_1000m]
 

--- a/satpy/readers/hdfeos_base.py
+++ b/satpy/readers/hdfeos_base.py
@@ -27,7 +27,7 @@ import numpy as np
 from pyhdf.error import HDF4Error
 from pyhdf.SD import SD
 
-from satpy import CHUNK_SIZE
+from satpy import CHUNK_SIZE, DataID
 from satpy.readers.file_handlers import BaseFileHandler
 
 logger = logging.getLogger(__name__)
@@ -121,6 +121,12 @@ class HDFEOSBaseFileReader(BaseFileHandler):
         return mda
 
     @property
+    def metadata_platform_name(self):
+        """Platform name from the internal file metadata."""
+        return self.metadata['INVENTORYMETADATA']['ASSOCIATEDPLATFORMINSTRUMENTSENSOR'][
+            'ASSOCIATEDPLATFORMINSTRUMENTSENSORCONTAINER']['ASSOCIATEDPLATFORMSHORTNAME']['VALUE']
+
+    @property
     def start_time(self):
         """Get the start time of the dataset."""
         date = (self.metadata['INVENTORYMETADATA']['RANGEDATETIME']['RANGEBEGINNINGDATE']['VALUE'] + ' ' +
@@ -165,10 +171,32 @@ class HDFEOSBaseFileReader(BaseFileHandler):
 
         scale_factor = data.attrs.get('scale_factor')
         if scale_factor is not None:
-            data = data * scale_factor
+            data = data * np.float32(scale_factor)
 
         data = data.where(good_mask, new_fill)
         return data
+
+    def _add_satpy_metadata(self, data_id: DataID, data_arr: xr.DataArray):
+        """Add metadata that is specific to Satpy."""
+        new_attrs = {
+            'platform_name': 'EOS-' + self.metadata_platform_name,
+            'sensor': 'modis',
+        }
+
+        res = data_id["resolution"]
+        rps = self._resolution_to_rows_per_scan(res)
+        new_attrs["rows_per_scan"] = rps
+
+        data_arr.attrs.update(new_attrs)
+
+    def _resolution_to_rows_per_scan(self, resolution: int) -> int:
+        known_rps = {
+            5000: 2,
+            1000: 10,
+            500: 20,
+            250: 40,
+        }
+        return known_rps.get(resolution, 10)
 
 
 class HDFEOSGeoReader(HDFEOSBaseFileReader):
@@ -293,5 +321,6 @@ class HDFEOSGeoReader(HDFEOSBaseFileReader):
         for key in ('standard_name', 'units'):
             if key in dataset_info:
                 data.attrs[key] = dataset_info[key]
+        self._add_satpy_metadata(dataset_keys, data)
 
         return data

--- a/satpy/readers/modis_l1b.py
+++ b/satpy/readers/modis_l1b.py
@@ -81,12 +81,6 @@ class HDFEOSBandReader(HDFEOSBaseFileReader):
                   'EV_500_RefSB'],
             250: ['EV_250_RefSB']}
 
-        platform_name = self.metadata['INVENTORYMETADATA']['ASSOCIATEDPLATFORMINSTRUMENTSENSOR'][
-            'ASSOCIATEDPLATFORMINSTRUMENTSENSORCONTAINER']['ASSOCIATEDPLATFORMSHORTNAME']['VALUE']
-
-        info.update({'platform_name': 'EOS-' + platform_name})
-        info.update({'sensor': 'modis'})
-
         if self.resolution != key['resolution']:
             return
 
@@ -181,6 +175,7 @@ class HDFEOSBandReader(HDFEOSBaseFileReader):
             #         satscene[band].area = geometry.SwathDefinition(
             #             lons=satscene[band].area.lons[indices, :],
             #             lats=satscene[band].area.lats[indices, :])
+            self._add_satpy_metadata(key, projectable)
             return projectable
 
 

--- a/satpy/readers/modis_l2.py
+++ b/satpy/readers/modis_l2.py
@@ -163,6 +163,7 @@ class ModisL2HDFFileHandler(HDFEOSGeoReader):
         else:
             dataset = self.load_dataset(dataset_name_in_file)
 
+        self._add_satpy_metadata(dataset_id, dataset)
         return dataset
 
 

--- a/satpy/tests/reader_tests/test_modis_l1b.py
+++ b/satpy/tests/reader_tests/test_modis_l1b.py
@@ -143,6 +143,11 @@ TEST_DATA = {
                      'fill_value': -32767,
                      'attrs': {'dim_labels': ['2*nscans:MODIS_SWATH_Type_L1B', '1KM_geo_dim:MODIS_SWATH_Type_L1B'],
                                'scale_factor': 0.01}},
+    'SensorAzimuth': {'data': TEST_SATZ,
+                      'type': SDC.INT16,
+                      'fill_value': -32767,
+                      'attrs': {'dim_labels': ['2*nscans:MODIS_SWATH_Type_L1B', '1KM_geo_dim:MODIS_SWATH_Type_L1B'],
+                                'scale_factor': 0.01}},
 }
 
 
@@ -259,7 +264,7 @@ class TestModisL2(unittest.TestCase):
         """Test that datasets are available."""
         scene = Scene(reader='modis_l1b', filenames=[self.file_name])
         available_datasets = scene.all_dataset_names()
-        self.assertTrue(len(available_datasets) > 0)
+        assert len(available_datasets) > 0
         self.assertIn('longitude', available_datasets)
         self.assertIn('latitude', available_datasets)
         for chan_num in list(range(1, 13)) + ['13lo', '13hi', '14lo', '14hi'] + list(range(15, 37)):
@@ -295,6 +300,16 @@ class TestModisL2(unittest.TestCase):
             self.assertEqual(longitude_5km.shape, TEST_DATA[dataset_name.capitalize()]['data'].shape)
             test_func(dataset_name, longitude_5km.values, 0)
             self._check_shared_metadata(longitude_5km)
+
+    def test_load_sat_zenith_angle(self):
+        """Test loading satellite zenith angle band."""
+        scene = Scene(reader='modis_l1b', filenames=[self.file_name])
+        dataset_name = 'satellite_zenith_angle'
+        scene.load([dataset_name])
+        dataset = scene[dataset_name]
+        self.assertEqual(dataset.shape, (5*SCAN_WIDTH, 5*SCAN_LEN+4))
+        assert dataset.attrs['resolution'] == 1000
+        self._check_shared_metadata(dataset)
 
     def test_load_vis(self):
         """Test loading visible band."""

--- a/satpy/tests/reader_tests/test_modis_l1b.py
+++ b/satpy/tests/reader_tests/test_modis_l1b.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2019 Satpy developers
+# Copyright (c) 2021 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -233,8 +233,8 @@ def create_test_data():
     return base_dir, file_name
 
 
-class TestModisL2(unittest.TestCase):
-    """Test MODIS L2 reader."""
+class TestModisL1b(unittest.TestCase):
+    """Test MODIS L1b reader."""
 
     def setUp(self):
         """Create fake HDF4 MODIS file."""

--- a/satpy/tests/reader_tests/test_modis_l1b.py
+++ b/satpy/tests/reader_tests/test_modis_l1b.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""Unit tests for MODIS L2 HDF reader."""
+"""Unit tests for MODIS L1b HDF reader."""
 
 import os
 import unittest
@@ -44,23 +44,105 @@ TEST_DATA = {
                   'type': SDC.FLOAT32,
                   'fill_value': -999,
                   'attrs': {'dim_labels': ['Cell_Along_Swath_5km:mod35', 'Cell_Across_Swath_5km:mod35']}},
-    'Sensor_Zenith': {'data': TEST_SATZ,
-                      'type': SDC.INT32,
-                      'fill_value': -32767,
-                      'attrs': {'dim_labels': ['Cell_Along_Swath_5km:mod35', 'Cell_Across_Swath_5km:mod35'],
-                                'scale_factor': 0.01}},
-    'Cloud_Mask': {'data': np.zeros((6, 5*SCAN_WIDTH, 5*SCAN_LEN+4), dtype=np.int8),
-                   'type': SDC.INT8,
-                   'fill_value': 0,
-                   'attrs': {'dim_labels': ['Byte_Segment:mod35',
-                                            'Cell_Along_Swath_1km:mod35',
-                                            'Cell_Across_Swath_1km:mod35']}},
-    'Quality_Assurance': {'data': np.ones((5*SCAN_WIDTH, 5*SCAN_LEN+4, 10), dtype=np.int8),
-                          'type': SDC.INT8,
-                          'fill_value': 0,
-                          'attrs': {'dim_labels': ['Cell_Along_Swath_1km:mod35',
-                                                   'Cell_Across_Swath_1km:mod35',
-                                                   'QA_Dimension:mod35']}}
+    'EV_1KM_RefSB': {
+        'data': np.zeros((15, 5*SCAN_WIDTH, 5*SCAN_LEN+4), dtype=np.uint16),
+        'type': SDC.UINT16,
+        'fill_value': 0,
+        'attrs': {
+            'dim_labels': ['Band_1KM_RefSB:MODIS_SWATH_Type_L1B',
+                           '10*nscans:MODIS_SWATH_Type_L1B',
+                           'Max_EV_frames:MODIS_SWATH_Type_L1B'],
+            'valid_range': (0, 32767),
+            'reflectance_scales': (1,) * 15,
+            'reflectance_offsets': (0,) * 15,
+            'band_names': '8,9,10,11,12,13lo,13hi,14lo,14hi,15,16,17,18,19,26',
+        },
+    },
+    'EV_1KM_RefSB_Uncert_Indexes': {
+        'data': np.zeros((15, 5*SCAN_WIDTH, 5*SCAN_LEN+4), dtype=np.uint8),
+        'type': SDC.UINT8,
+        'fill_value': 255,
+        'attrs': {
+            'dim_labels': ['Band_1KM_RefSB:MODIS_SWATH_Type_L1B',
+                           '10*nscans:MODIS_SWATH_Type_L1B',
+                           'Max_EV_frames:MODIS_SWATH_Type_L1B'],
+        },
+    },
+    'EV_500_Aggr1km_RefSB': {
+        'data': np.zeros((5, 5*SCAN_WIDTH, 5*SCAN_LEN+4), dtype=np.uint16),
+        'type': SDC.UINT16,
+        'fill_value': 0,
+        'attrs': {
+            'dim_labels': ['Band_500M:MODIS_SWATH_Type_L1B',
+                           '10*nscans:MODIS_SWATH_Type_L1B',
+                           'Max_EV_frames:MODIS_SWATH_Type_L1B'],
+            'valid_range': (0, 32767),
+            'reflectance_scales': (1,) * 5,
+            'reflectance_offsets': (0,) * 5,
+            'band_names': '3,4,5,6,7',
+        },
+    },
+    'EV_500_Aggr1km_RefSB_Uncert_Indexes': {
+        'data': np.zeros((5, 5*SCAN_WIDTH, 5*SCAN_LEN+4), dtype=np.uint8),
+        'type': SDC.UINT8,
+        'fill_value': 255,
+        'attrs': {
+            'dim_labels': ['Band_500M:MODIS_SWATH_Type_L1B',
+                           '10*nscans:MODIS_SWATH_Type_L1B',
+                           'Max_EV_frames:MODIS_SWATH_Type_L1B'],
+        },
+    },
+    'EV_250_Aggr1km_RefSB': {
+        'data': np.zeros((2, 5*SCAN_WIDTH, 5*SCAN_LEN+4), dtype=np.uint16),
+        'type': SDC.UINT16,
+        'fill_value': 0,
+        'attrs': {
+            'dim_labels': ['Band_250M:MODIS_SWATH_Type_L1B',
+                           '10*nscans:MODIS_SWATH_Type_L1B',
+                           'Max_EV_frames:MODIS_SWATH_Type_L1B'],
+            'valid_range': (0, 32767),
+            'reflectance_scales': (1,) * 2,
+            'reflectance_offsets': (0,) * 2,
+            'band_names': '1,2',
+        },
+    },
+    'EV_250_Aggr1km_RefSB_Uncert_Indexes': {
+        'data': np.zeros((2, 5*SCAN_WIDTH, 5*SCAN_LEN+4), dtype=np.uint8),
+        'type': SDC.UINT8,
+        'fill_value': 255,
+        'attrs': {
+            'dim_labels': ['Band_250M:MODIS_SWATH_Type_L1B',
+                           '10*nscans:MODIS_SWATH_Type_L1B',
+                           'Max_EV_frames:MODIS_SWATH_Type_L1B'],
+        },
+    },
+    'EV_1KM_Emmissive': {
+        'data': np.zeros((16, 5*SCAN_WIDTH, 5*SCAN_LEN+4), dtype=np.uint16),
+        'type': SDC.UINT16,
+        'fill_value': 0,
+        'attrs': {
+            'dim_labels': ['Band_1KM_Emissive:MODIS_SWATH_Type_L1B',
+                           '10*nscans:MODIS_SWATH_Type_L1B',
+                           'Max_EV_frames:MODIS_SWATH_Type_L1B'],
+            'valid_range': (0, 32767),
+            'band_names': '20,21,22,23,24,25,27,28,29,30,31,32,33,34,35,36',
+        },
+    },
+    'EV_1KM_Emissive_Uncert_Indexes': {
+        'data': np.zeros((16, 5*SCAN_WIDTH, 5*SCAN_LEN+4), dtype=np.uint8),
+        'type': SDC.UINT8,
+        'fill_value': 255,
+        'attrs': {
+            'dim_labels': ['Band_1KM_Emissive:MODIS_SWATH_Type_L1B',
+                           '10*nscans:MODIS_SWATH_Type_L1B',
+                           'Max_EV_frames:MODIS_SWATH_Type_L1B'],
+        },
+    },
+    'SensorZenith': {'data': TEST_SATZ,
+                     'type': SDC.INT16,
+                     'fill_value': -32767,
+                     'attrs': {'dim_labels': ['2*nscans:MODIS_SWATH_Type_L1B', '1KM_geo_dim:MODIS_SWATH_Type_L1B'],
+                               'scale_factor': 0.01}},
 }
 
 
@@ -69,12 +151,8 @@ def generate_file_name():
     import tempfile
     from datetime import datetime
 
-    creation_time = datetime.now()
-    processing_time = datetime.now()
-    file_name = 'MOD35_L2.A{}.{}.061.{}.hdf'.format(
-        creation_time.strftime("%Y%j"),
-        creation_time.strftime("%H%M"),
-        processing_time.strftime("%Y%j%H%M%S")
+    file_name = 'MOD021km_A{0:%y%j_%H%M%S}_{0:%Y%j%H%M%S}.hdf'.format(
+        datetime.now()
     )
 
     base_dir = tempfile.mkdtemp()
@@ -83,7 +161,7 @@ def generate_file_name():
 
 
 def create_test_data():
-    """Create a fake MODIS 35 L2 HDF4 file with headers."""
+    """Create a fake MODIS L1b HDF4 file with headers."""
     from datetime import datetime, timedelta
 
     base_dir, file_name = generate_file_name()
@@ -113,12 +191,16 @@ def create_test_data():
                     "VALUE = \"MODIS\"\nEND_OBJECT = ASSOCIATEDINSTRUMENTSHORTNAME\n\n" \
                     "END_OBJECT = ASSOCIATEDPLATFORMINSTRUMENTSENSORCONTAINER\n\n" \
                     "END_GROUP              = ASSOCIATEDPLATFORMINSTRUMENTSENSOR\n\n"
-    core_metadata_header += "\n\n" + inst_metadata
+    collection_metadata = "GROUP = COLLECTIONDESCRIPTIONCLASS\n\nOBJECT = SHORTNAME\nNUM_VAL = 1\n"\
+                          "VALUE = \"MOD021KM\"\nEND_OBJECT = SHORTNAME\n\n"\
+                          "OBJECT = VERSIONID\nNUM_VAL = 1\nVALUE = 6\nEND_OBJECT = VERSIONID\n\n"\
+                          "END_GROUP = COLLECTIONDESCRIPTIONCLASS\n\n"
+    core_metadata_header += "\n\n" + inst_metadata + collection_metadata
     struct_metadata_header = "GROUP=SwathStructure\n"\
                              "GROUP=SWATH_1\n"\
                              "GROUP=DimensionMap\n"\
                              "OBJECT=DimensionMap_2\n"\
-                             "GeoDimension=\"Cell_Along_Swath_5km\"\n"\
+                             "GeoDimension=\"2*nscans\"\n"\
                              "END_OBJECT=DimensionMap_2\n"\
                              "END_GROUP=DimensionMap\n"\
                              "END_GROUP=SWATH_1\n"\
@@ -138,6 +220,10 @@ def create_test_data():
             dim_count += 1
         v.setfillvalue(TEST_DATA[dataset]['fill_value'])
         v.scale_factor = TEST_DATA[dataset]['attrs'].get('scale_factor', SCALE_FACTOR)
+        for attr_key, attr_val in TEST_DATA[dataset]['attrs'].items():
+            if attr_key == 'dim_labels':
+                continue
+            setattr(v, attr_key, attr_val)
     h.end()
     return base_dir, file_name
 
@@ -163,20 +249,21 @@ class TestModisL2(unittest.TestCase):
         assert data_arr.attrs["platform_name"] == "EOS-Terra"
         assert "rows_per_scan" in data_arr.attrs
         assert isinstance(data_arr.attrs["rows_per_scan"], int)
-        assert data_arr.attrs['reader'] == 'modis_l2'
+        assert data_arr.attrs['reader'] == 'modis_l1b'
 
     def test_available_reader(self):
-        """Test that MODIS L2 reader is available."""
-        self.assertIn('modis_l2', available_readers())
+        """Test that MODIS L1b reader is available."""
+        self.assertIn('modis_l1b', available_readers())
 
     def test_scene_available_datasets(self):
         """Test that datasets are available."""
-        scene = Scene(reader='modis_l2', filenames=[self.file_name])
+        scene = Scene(reader='modis_l1b', filenames=[self.file_name])
         available_datasets = scene.all_dataset_names()
         self.assertTrue(len(available_datasets) > 0)
-        self.assertIn('cloud_mask', available_datasets)
-        self.assertIn('latitude', available_datasets)
         self.assertIn('longitude', available_datasets)
+        self.assertIn('latitude', available_datasets)
+        for chan_num in list(range(1, 13)) + ['13lo', '13hi', '14lo', '14hi'] + list(range(15, 37)):
+            self.assertIn(str(chan_num), available_datasets)
 
     def test_load_longitude_latitude(self):
         """Test that longitude and latitude datasets are loaded correctly."""
@@ -191,7 +278,7 @@ class TestModisL2(unittest.TestCase):
                 # np.testing.assert_equal(x > y, True)
                 np.testing.assert_array_less(y, x)
 
-        scene = Scene(reader='modis_l2', filenames=[self.file_name])
+        scene = Scene(reader='modis_l1b', filenames=[self.file_name])
         for dataset_name in ['longitude', 'latitude']:
             # Default resolution should be the interpolated 1km
             scene.load([dataset_name])
@@ -209,38 +296,11 @@ class TestModisL2(unittest.TestCase):
             test_func(dataset_name, longitude_5km.values, 0)
             self._check_shared_metadata(longitude_5km)
 
-    def test_load_quality_assurance(self):
-        """Test loading quality assurance."""
-        from satpy.tests.utils import make_dataid
-        scene = Scene(reader='modis_l2', filenames=[self.file_name])
-        dataset_name = 'quality_assurance'
+    def test_load_vis(self):
+        """Test loading visible band."""
+        scene = Scene(reader='modis_l1b', filenames=[self.file_name])
+        dataset_name = '1'
         scene.load([dataset_name])
-        quality_assurance_id = make_dataid(name=dataset_name, resolution=1000)
-        self.assertIn(quality_assurance_id, scene)
-        quality_assurance = scene[quality_assurance_id]
-        self.assertEqual(quality_assurance.shape, (5*SCAN_WIDTH, 5*SCAN_LEN+4))
-        self._check_shared_metadata(quality_assurance)
-
-    def test_load_1000m_cloud_mask_dataset(self):
-        """Test loading 1000m cloud mask."""
-        from satpy.tests.utils import make_dataid
-        scene = Scene(reader='modis_l2', filenames=[self.file_name])
-        dataset_name = 'cloud_mask'
-        scene.load([dataset_name], resolution=1000)
-        cloud_mask_id = make_dataid(name=dataset_name, resolution=1000)
-        self.assertIn(cloud_mask_id, scene)
-        cloud_mask = scene[cloud_mask_id]
-        self.assertEqual(cloud_mask.shape, (5*SCAN_WIDTH, 5*SCAN_LEN+4))
-        self._check_shared_metadata(cloud_mask)
-
-    def test_load_250m_cloud_mask_dataset(self):
-        """Test loading 250m cloud mask."""
-        from satpy.tests.utils import make_dataid
-        scene = Scene(reader='modis_l2', filenames=[self.file_name])
-        dataset_name = 'cloud_mask'
-        scene.load([dataset_name], resolution=250)
-        cloud_mask_id = make_dataid(name=dataset_name, resolution=250)
-        self.assertIn(cloud_mask_id, scene)
-        cloud_mask = scene[cloud_mask_id]
-        self.assertEqual(cloud_mask.shape, (4*5*SCAN_WIDTH, 4*(5*SCAN_LEN+4)))
-        self._check_shared_metadata(cloud_mask)
+        dataset = scene[dataset_name]
+        self.assertEqual(dataset.shape, (5*SCAN_WIDTH, 5*SCAN_LEN+4))
+        self._check_shared_metadata(dataset)


### PR DESCRIPTION
I noticed that the angle datasets from the MODIS readers were missing the sensor and platform_name metadata. I also needed to add `rows_per_scan` to match what I was doing in the old Polar2Grid reader. Also turns out there were no tests for the 'modis_l1b' reader so those were added as well. :vomiting_face: 

 - [x] Tests added <!-- for all bug fixes or enhancements -->
