### PR TITLE
Fix invalid YAML syntax in enhancement documentation

### DIFF
--- a/doc/source/enhancements.rst
+++ b/doc/source/enhancements.rst
@@ -27,7 +27,7 @@ on both ends of the scale, but these can be overridden with
       method: !!python/name:satpy.enhancements.stretch
       kwargs:
         stretch: linear
-        cutoffs: (0.003, 0.005)
+        cutoffs: [0.003, 0.005]
 
 .. note::
 


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

The example requires a change to brackets for correct usage in yaml.

- name: stretch
  method: !!python/name:satpy.enhancements.stretch
  kwargs:
    stretch: linear
    cutoffs: (0.003, 0.005) <<- should be cutoffs: [0.003, 0.005]
