### PR TITLE
Fix unify_chunks usage in compositors and fix image mode in BackgroundCompositor

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -833,8 +833,10 @@ class RatioSharpenedRGB(GenericCompositor):
         new_attrs = {}
         if optional_datasets:
             datasets = self.match_data_arrays(datasets + optional_datasets)
-            high_res = datasets[-1]
-            p1, p2, p3 = datasets[:3]
+            p1 = datasets[0]
+            p2 = datasets[1]
+            p3 = datasets[2]
+            high_res = datasets[3]
             if 'rows_per_scan' in high_res.attrs:
                 new_attrs.setdefault('rows_per_scan', high_res.attrs['rows_per_scan'])
             new_attrs.setdefault('resolution', high_res.attrs['resolution'])
@@ -859,7 +861,9 @@ class RatioSharpenedRGB(GenericCompositor):
             b = self._get_band(high_res, p3, 'blue', ratio)
         else:
             datasets = self.match_data_arrays(datasets)
-            r, g, b = datasets[:3]
+            r = datasets[0]
+            g = datasets[1]
+            b = datasets[2]
 
         # combine the masks
         mask = ~(r.isnull() | g.isnull() | b.isnull())

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1195,6 +1195,9 @@ class BackgroundCompositor(GenericCompositor):
 
         # Get merged metadata
         attrs = combine_metadata(foreground, background)
+        # 'mode' is no longer valid after we've remove the 'A'
+        # let the base class __call__ determine mode
+        attrs.pop("mode", None)
         if attrs.get('sensor') is None:
             # sensor can be a set
             attrs['sensor'] = self._get_sensors(projectables)

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -31,6 +31,7 @@ from satpy.dataset import DataID, combine_metadata
 from satpy.dataset.dataid import minimal_default_keys_config
 from satpy.aux_download import DataDownloadMixin
 from satpy.writers import get_enhanced_image
+from satpy.utils import unify_chunks
 
 
 LOG = logging.getLogger(__name__)
@@ -156,13 +157,7 @@ class CompositeBase:
         """Match data arrays so that they can be used together in a composite."""
         self.check_geolocation(data_arrays)
         new_arrays = self.drop_coordinates(data_arrays)
-        # Only unify chunks for pure y/x DataArrays
-        # Other dimensions like 'bands' may have different sizes which is
-        # allowed and expected in certain cases. It is not possible to
-        # unify chunks in those cases.
-        if hasattr(xr, 'unify_chunks') and not any(set(x.dims) - {'y', 'x'} for x in data_arrays):
-            # xarray 0.19+
-            new_arrays = list(xr.unify_chunks(*new_arrays))
+        new_arrays = list(unify_chunks(*new_arrays))
         return new_arrays
 
     def drop_coordinates(self, data_arrays):

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -155,7 +155,14 @@ class CompositeBase:
         """Match data arrays so that they can be used together in a composite."""
         self.check_geolocation(data_arrays)
         new_arrays = self.drop_coordinates(data_arrays)
-        return list(xr.unify_chunks(*new_arrays))
+        # Only unify chunks for pure y/x DataArrays
+        # Other dimensions like 'bands' may have different sizes which is
+        # allowed and expected in certain cases. It is not possible to
+        # unify chunks in those cases.
+        if hasattr(xr, 'unify_chunks') and not any(set(x.dims) - {'y', 'x'} for x in data_arrays):
+            # xarray 0.19+
+            new_arrays = list(xr.unify_chunks(*new_arrays))
+        return new_arrays
 
     def drop_coordinates(self, data_arrays):
         """Drop neglible non-dimensional coordinates."""

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -1045,120 +1045,64 @@ def _enhance2dataset(dataset, convert_p=False):
 class TestBackgroundCompositor:
     """Test case for the background compositor."""
 
+    @classmethod
+    def setup_class(cls):
+        """Create shared input data arrays."""
+        foreground_data = {
+            "L": np.array([[[1., 0.5], [0., np.nan]]]),
+            "LA": np.array([[[1., 0.5], [0., np.nan]], [[0.5, 0.5], [0.5, 0.5]]]),
+            "RGB": np.array([
+                [[1., 0.5], [0., np.nan]],
+                [[1., 0.5], [0., np.nan]],
+                [[1., 0.5], [0., np.nan]]]),
+            "RGBA": np.array([
+                [[1.0, 0.5], [0.0, np.nan]],
+                [[1.0, 0.5], [0.0, np.nan]],
+                [[1.0, 0.5], [0.0, np.nan]],
+                [[0.5, 0.5], [0.5, 0.5]]]),
+        }
+        cls.foreground_data = foreground_data
+
     @mock.patch('satpy.composites.enhance2dataset', _enhance2dataset)
-    def test_call(self):
+    @pytest.mark.parametrize(
+        ('foreground_bands', 'background_bands', 'exp_bands', 'exp_result'),
+        [
+            ('L', 'L', 'L', np.array([[1.0, 0.5], [0.0, 1.0]])),
+            ('LA', 'LA', 'L', np.array([[1.0, 0.75], [0.5, 1.0]])),
+            ('RGB', 'RGB', 'RGB', np.array([
+                [[1., 0.5], [0., 1.]],
+                [[1., 0.5], [0., 1.]],
+                [[1., 0.5], [0., 1.]]])),
+            ('RGBA', 'RGBA', 'RGB', np.array([
+                [[1., 0.75], [0.5, 1.]],
+                [[1., 0.75], [0.5, 1.]],
+                [[1., 0.75], [0.5, 1.]]])),
+            ('RGBA', 'RGB', 'RGB', np.array([
+                [[1., 0.75], [0.5, 1.]],
+                [[1., 0.75], [0.5, 1.]],
+                [[1., 0.75], [0.5, 1.]]])),
+        ]
+    )
+    def test_call(self, foreground_bands, background_bands, exp_bands, exp_result):
         """Test the background compositing."""
         from satpy.composites import BackgroundCompositor
-        import numpy as np
         comp = BackgroundCompositor("name")
 
         # L mode images
-        attrs = {'mode': 'L', 'area': 'foo'}
-        foreground = xr.DataArray(np.array([[[1., 0.5],
-                                             [0., np.nan]]]),
-                                  dims=('bands', 'y', 'x'),
-                                  coords={'bands': [c for c in attrs['mode']]},
-                                  attrs=attrs)
-        background = xr.DataArray(np.ones((1, 2, 2)), dims=('bands', 'y', 'x'),
-                                  coords={'bands': [c for c in attrs['mode']]},
-                                  attrs=attrs)
-        res = comp([foreground, background])
-        assert res.attrs['area'] == 'foo'
-        np.testing.assert_allclose(res, np.array([[1., 0.5], [0., 1.]]))
-        assert res.attrs['mode'] == 'L'
-
-        # LA mode images
-        attrs = {'mode': 'LA', 'area': 'foo'}
-        foreground = xr.DataArray(np.array([[[1., 0.5],
-                                             [0., np.nan]],
-                                            [[0.5, 0.5],
-                                             [0.5, 0.5]]]),
-                                  dims=('bands', 'y', 'x'),
-                                  coords={'bands': [c for c in attrs['mode']]},
-                                  attrs=attrs)
-        background = xr.DataArray(np.ones((2, 2, 2)), dims=('bands', 'y', 'x'),
-                                  coords={'bands': [c for c in attrs['mode']]},
-                                  attrs=attrs)
-        res = comp([foreground, background])
-        np.testing.assert_allclose(res, np.array([[1., 0.75], [0.5, 1.]]))
-        assert res.attrs['mode'] == 'L'
-
-        # RGB mode images
-        attrs = {'mode': 'RGB', 'area': 'foo'}
-        foreground = xr.DataArray(np.array([[[1., 0.5],
-                                             [0., np.nan]],
-                                            [[1., 0.5],
-                                             [0., np.nan]],
-                                            [[1., 0.5],
-                                             [0., np.nan]]]),
-                                  dims=('bands', 'y', 'x'),
-                                  coords={'bands': [c for c in attrs['mode']]},
-                                  attrs=attrs)
-        background = xr.DataArray(np.ones((3, 2, 2)), dims=('bands', 'y', 'x'),
-                                  coords={'bands': [c for c in attrs['mode']]},
-                                  attrs=attrs)
-
-        res = comp([foreground, background])
-        np.testing.assert_allclose(res, np.array([[[1., 0.5], [0., 1.]],
-                                                  [[1., 0.5], [0., 1.]],
-                                                  [[1., 0.5], [0., 1.]]]))
-        assert res.attrs['mode'] == 'RGB'
-
-        # RGBA mode images
-        attrs = {'mode': 'RGBA', 'area': 'foo'}
-        foreground = xr.DataArray(np.array([[[1., 0.5],
-                                             [0., np.nan]],
-                                            [[1., 0.5],
-                                             [0., np.nan]],
-                                            [[1., 0.5],
-                                             [0., np.nan]],
-                                            [[0.5, 0.5],
-                                             [0.5, 0.5]]]),
-                                  dims=('bands', 'y', 'x'),
-                                  coords={'bands': [c for c in attrs['mode']]},
-                                  attrs=attrs)
-        background = xr.DataArray(np.ones((4, 2, 2)), dims=('bands', 'y', 'x'),
-                                  coords={'bands': [c for c in attrs['mode']]},
-                                  attrs=attrs)
-
-        res = comp([foreground, background])
-        np.testing.assert_allclose(res, np.array([[[1., 0.75], [0.5, 1.]],
-                                                  [[1., 0.75], [0.5, 1.]],
-                                                  [[1., 0.75], [0.5, 1.]]]))
-        assert res.attrs['mode'] == 'RGB'
-
-    @mock.patch('satpy.composites.enhance2dataset', _enhance2dataset)
-    def test_joining_rgb_rgba(self):
-        """Test combining an RGB foreground to an RGBA background."""
-        from satpy.composites import BackgroundCompositor
-        import numpy as np
-        import dask.array as da
-        comp = BackgroundCompositor("name")
-
-        attrs = {'mode': 'RGBA', 'area': 'foo'}
-        foreground_data = np.array([[[1., 0.5],
-                                     [0., np.nan]],
-                                    [[1., 0.5],
-                                     [0., np.nan]],
-                                    [[1., 0.5],
-                                     [0., np.nan]],
-                                    [[0.5, 0.5],
-                                     [0.5, 0.5]]])
+        foreground_data = self.foreground_data[foreground_bands]
+        attrs = {'mode': foreground_bands, 'area': 'foo'}
         foreground = xr.DataArray(da.from_array(foreground_data),
                                   dims=('bands', 'y', 'x'),
                                   coords={'bands': [c for c in attrs['mode']]},
                                   attrs=attrs)
-        attrs = {'mode': 'RGB', 'area': 'foo'}
-        background = xr.DataArray(da.ones((3, 2, 2)), dims=('bands', 'y', 'x'),
+        attrs = {'mode': background_bands, 'area': 'foo'}
+        background = xr.DataArray(da.ones((len(background_bands), 2, 2)), dims=('bands', 'y', 'x'),
                                   coords={'bands': [c for c in attrs['mode']]},
                                   attrs=attrs)
-
         res = comp([foreground, background])
-        np.testing.assert_allclose(res.values,
-                                   np.array([[[1., 0.75], [0.5, 1.]],
-                                             [[1., 0.75], [0.5, 1.]],
-                                             [[1., 0.75], [0.5, 1.]]]))
-        assert res.attrs['mode'] == 'RGB'
+        assert res.attrs['area'] == 'foo'
+        np.testing.assert_allclose(res, exp_result)
+        assert res.attrs['mode'] == exp_bands
 
     @mock.patch('satpy.composites.enhance2dataset', _enhance2dataset)
     def test_multiple_sensors(self):
@@ -1169,13 +1113,13 @@ class TestBackgroundCompositor:
 
         # L mode images
         attrs = {'mode': 'L', 'area': 'foo'}
-        foreground = xr.DataArray(np.array([[[1., 0.5],
-                                             [0., np.nan]]]),
+        foreground_data = self.foreground_data["L"]
+        foreground = xr.DataArray(da.from_array(foreground_data),
                                   dims=('bands', 'y', 'x'),
                                   coords={'bands': [c for c in attrs['mode']]},
                                   attrs=attrs.copy())
         foreground.attrs['sensor'] = 'abi'
-        background = xr.DataArray(np.ones((1, 2, 2)), dims=('bands', 'y', 'x'),
+        background = xr.DataArray(da.ones((1, 2, 2)), dims=('bands', 'y', 'x'),
                                   coords={'bands': [c for c in attrs['mode']]},
                                   attrs=attrs.copy())
         background.attrs['sensor'] = 'glm'

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -1081,7 +1081,7 @@ class TestBackgroundCompositor(unittest.TestCase):
                                   attrs=attrs)
         res = comp([foreground, background])
         self.assertTrue(np.all(res == np.array([[1., 0.75], [0.5, 1.]])))
-        self.assertEqual(res.attrs['mode'], 'LA')
+        self.assertEqual(res.attrs['mode'], 'L')
 
         # RGB mode images
         attrs = {'mode': 'RGB', 'area': 'foo'}
@@ -1125,7 +1125,7 @@ class TestBackgroundCompositor(unittest.TestCase):
         self.assertTrue(np.all(res == np.array([[[1., 0.75], [0.5, 1.]],
                                                 [[1., 0.75], [0.5, 1.]],
                                                 [[1., 0.75], [0.5, 1.]]])))
-        self.assertEqual(res.attrs['mode'], 'RGBA')  # This is wrong!!!
+        self.assertEqual(res.attrs['mode'], 'RGB')
 
     @mock.patch('satpy.composites.enhance2dataset', _enhance2dataset)
     def test_joining_rgb_rgba(self):
@@ -1158,7 +1158,7 @@ class TestBackgroundCompositor(unittest.TestCase):
                                    np.array([[[1., 0.75], [0.5, 1.]],
                                              [[1., 0.75], [0.5, 1.]],
                                              [[1., 0.75], [0.5, 1.]]]))
-        assert res.attrs['mode'] == 'RGBA'  # FIXME: This is wrong!!!
+        assert res.attrs['mode'] == 'RGB'
 
     @mock.patch('satpy.composites.enhance2dataset', _enhance2dataset)
     def test_multiple_sensors(self):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -1042,7 +1042,7 @@ def _enhance2dataset(dataset, convert_p=False):
     return dataset
 
 
-class TestBackgroundCompositor(unittest.TestCase):
+class TestBackgroundCompositor:
     """Test case for the background compositor."""
 
     @mock.patch('satpy.composites.enhance2dataset', _enhance2dataset)
@@ -1063,9 +1063,9 @@ class TestBackgroundCompositor(unittest.TestCase):
                                   coords={'bands': [c for c in attrs['mode']]},
                                   attrs=attrs)
         res = comp([foreground, background])
-        self.assertEqual(res.attrs['area'], 'foo')
-        self.assertTrue(np.all(res == np.array([[1., 0.5], [0., 1.]])))
-        self.assertEqual(res.attrs['mode'], 'L')
+        assert res.attrs['area'] == 'foo'
+        np.testing.assert_allclose(res, np.array([[1., 0.5], [0., 1.]]))
+        assert res.attrs['mode'] == 'L'
 
         # LA mode images
         attrs = {'mode': 'LA', 'area': 'foo'}
@@ -1080,8 +1080,8 @@ class TestBackgroundCompositor(unittest.TestCase):
                                   coords={'bands': [c for c in attrs['mode']]},
                                   attrs=attrs)
         res = comp([foreground, background])
-        self.assertTrue(np.all(res == np.array([[1., 0.75], [0.5, 1.]])))
-        self.assertEqual(res.attrs['mode'], 'L')
+        np.testing.assert_allclose(res, np.array([[1., 0.75], [0.5, 1.]]))
+        assert res.attrs['mode'] == 'L'
 
         # RGB mode images
         attrs = {'mode': 'RGB', 'area': 'foo'}
@@ -1099,10 +1099,10 @@ class TestBackgroundCompositor(unittest.TestCase):
                                   attrs=attrs)
 
         res = comp([foreground, background])
-        self.assertTrue(np.all(res == np.array([[[1., 0.5], [0., 1.]],
-                                                [[1., 0.5], [0., 1.]],
-                                                [[1., 0.5], [0., 1.]]])))
-        self.assertEqual(res.attrs['mode'], 'RGB')
+        np.testing.assert_allclose(res, np.array([[[1., 0.5], [0., 1.]],
+                                                  [[1., 0.5], [0., 1.]],
+                                                  [[1., 0.5], [0., 1.]]]))
+        assert res.attrs['mode'] == 'RGB'
 
         # RGBA mode images
         attrs = {'mode': 'RGBA', 'area': 'foo'}
@@ -1122,10 +1122,10 @@ class TestBackgroundCompositor(unittest.TestCase):
                                   attrs=attrs)
 
         res = comp([foreground, background])
-        self.assertTrue(np.all(res == np.array([[[1., 0.75], [0.5, 1.]],
-                                                [[1., 0.75], [0.5, 1.]],
-                                                [[1., 0.75], [0.5, 1.]]])))
-        self.assertEqual(res.attrs['mode'], 'RGB')
+        np.testing.assert_allclose(res, np.array([[[1., 0.75], [0.5, 1.]],
+                                                  [[1., 0.75], [0.5, 1.]],
+                                                  [[1., 0.75], [0.5, 1.]]]))
+        assert res.attrs['mode'] == 'RGB'
 
     @mock.patch('satpy.composites.enhance2dataset', _enhance2dataset)
     def test_joining_rgb_rgba(self):
@@ -1180,10 +1180,10 @@ class TestBackgroundCompositor(unittest.TestCase):
                                   attrs=attrs.copy())
         background.attrs['sensor'] = 'glm'
         res = comp([foreground, background])
-        self.assertEqual(res.attrs['area'], 'foo')
-        self.assertTrue(np.all(res == np.array([[1., 0.5], [0., 1.]])))
-        self.assertEqual(res.attrs['mode'], 'L')
-        self.assertEqual(res.attrs['sensor'], {'abi', 'glm'})
+        assert res.attrs['area'] == 'foo'
+        np.testing.assert_allclose(res, np.array([[1., 0.5], [0., 1.]]))
+        assert res.attrs['mode'] == 'L'
+        assert res.attrs['sensor'] == {'abi', 'glm'}
 
 
 class TestMaskingCompositor(unittest.TestCase):

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -25,7 +25,7 @@ import warnings
 from unittest import mock
 
 import pytest
-from numpy import sqrt
+import numpy as np
 import xarray as xr
 import dask.array as da
 
@@ -68,14 +68,14 @@ class TestUtils(unittest.TestCase):
         self.assertAlmostEqual(z__, -1)
 
         x__, y__, z__ = lonlat2xyz(0, 45)
-        self.assertAlmostEqual(x__, sqrt(2) / 2)
+        self.assertAlmostEqual(x__, np.sqrt(2) / 2)
         self.assertAlmostEqual(y__, 0)
-        self.assertAlmostEqual(z__, sqrt(2) / 2)
+        self.assertAlmostEqual(z__, np.sqrt(2) / 2)
 
         x__, y__, z__ = lonlat2xyz(0, 60)
-        self.assertAlmostEqual(x__, sqrt(1) / 2)
+        self.assertAlmostEqual(x__, np.sqrt(1) / 2)
         self.assertAlmostEqual(y__, 0)
-        self.assertAlmostEqual(z__, sqrt(3) / 2)
+        self.assertAlmostEqual(z__, np.sqrt(3) / 2)
 
     def test_angle2xyz(self):
         """Test the lonlat2xyz function."""
@@ -131,13 +131,13 @@ class TestUtils(unittest.TestCase):
 
         x__, y__, z__ = angle2xyz(0, 45)
         self.assertAlmostEqual(x__, 0)
-        self.assertAlmostEqual(y__, sqrt(2) / 2)
-        self.assertAlmostEqual(z__, sqrt(2) / 2)
+        self.assertAlmostEqual(y__, np.sqrt(2) / 2)
+        self.assertAlmostEqual(z__, np.sqrt(2) / 2)
 
         x__, y__, z__ = angle2xyz(0, 60)
         self.assertAlmostEqual(x__, 0)
-        self.assertAlmostEqual(y__, sqrt(3) / 2)
-        self.assertAlmostEqual(z__, sqrt(1) / 2)
+        self.assertAlmostEqual(y__, np.sqrt(3) / 2)
+        self.assertAlmostEqual(z__, np.sqrt(1) / 2)
 
     def test_xyz2lonlat(self):
         """Test xyz2lonlat."""
@@ -157,7 +157,7 @@ class TestUtils(unittest.TestCase):
         self.assertAlmostEqual(lon, 0)
         self.assertAlmostEqual(lat, 90)
 
-        lon, lat = xyz2lonlat(sqrt(2) / 2, sqrt(2) / 2, 0)
+        lon, lat = xyz2lonlat(np.sqrt(2) / 2, np.sqrt(2) / 2, 0)
         self.assertAlmostEqual(lon, 45)
         self.assertAlmostEqual(lat, 0)
 
@@ -179,7 +179,7 @@ class TestUtils(unittest.TestCase):
         self.assertAlmostEqual(azi, 0)
         self.assertAlmostEqual(zen, 0)
 
-        azi, zen = xyz2angle(sqrt(2) / 2, sqrt(2) / 2, 0)
+        azi, zen = xyz2angle(np.sqrt(2) / 2, np.sqrt(2) / 2, 0)
         self.assertAlmostEqual(azi, 45)
         self.assertAlmostEqual(zen, 90)
 
@@ -266,9 +266,6 @@ def test_make_fake_scene():
     purposes, it has grown sufficiently complex that it needs its own
     testing.
     """
-    import numpy as np
-    import dask.array as da
-    import xarray as xr
     from satpy.tests.utils import make_fake_scene
 
     assert make_fake_scene({}).keys() == []


### PR DESCRIPTION
This PR reduces the cases where `unify_chunks` is called in `match_data_arrays`. Previously it was run all the time, but would fail if RGB and RGBA (or any differing sized dimensions) were run together. This is pretty common with the BackgroundCompositor and DayNightCompositor. So this PR makes it so it just isn't run at all if there are dimensions others than pure "y" and "x".

While adding the test for this I discovered that the BackgroundCompositor was assigning the incorrect image mode attribute to its output. Although you may provide an RGBA or LA image as the foreground for an image, this Alpha is used to determine the blending and is then removed. So RGBA foregrounds become RGB. I've fixed this here as well.

 - [x] Closes #1821  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

