### PR TITLE
Add additional ACSPO reader file patterns

### DIFF
--- a/satpy/etc/readers/acspo.yaml
+++ b/satpy/etc/readers/acspo.yaml
@@ -8,7 +8,7 @@ reader:
 file_types:
   acspo_sst:
     file_reader: !!python/name:satpy.readers.acspo.ACSPOFileHandler
-    file_patterns: ['{start_time:%Y%m%d%H%M%S}-{rdac:4s}-L2P_GHRSST-SSTskin-{sensor_id}-ACSPO_V{version}-v{gds_version}-fv{file_version}.nc']
+    file_patterns: ['{start_time:%Y%m%d%H%M%S}-{rdac:4s}-L2P_GHRSST-{dataset_name}-{sensor_id}-ACSPO_V{version}-v{gds_version}-fv{file_version}.nc']
 
 datasets:
   longitude:

--- a/satpy/tests/reader_tests/test_acspo.py
+++ b/satpy/tests/reader_tests/test_acspo.py
@@ -22,8 +22,8 @@ from datetime import datetime, timedelta
 import numpy as np
 from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
 from satpy.tests.utils import convert_file_content_to_data_array
-import unittest
 from unittest import mock
+import pytest
 
 DEFAULT_FILE_DTYPE = np.uint16
 DEFAULT_FILE_SHAPE = (10, 300)
@@ -44,6 +44,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         dt = filename_info.get('start_time', datetime(2016, 1, 1, 12, 0, 0))
         sat, inst = {
             'VIIRS_NPP': ('NPP', 'VIIRS'),
+            'VIIRS_N20': ('N20', 'VIIRS'),
         }[filename_info['sensor_id']]
 
         file_content = {
@@ -96,12 +97,12 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         return file_content
 
 
-class TestACSPOReader(unittest.TestCase):
+class TestACSPOReader:
     """Test ACSPO Reader."""
 
     yaml_file = "acspo.yaml"
 
-    def setUp(self):
+    def setup_method(self):
         """Wrap NetCDF4 file handler with our own fake handler."""
         from satpy._config import config_search_paths
         from satpy.readers.acspo import ACSPOFileHandler
@@ -111,21 +112,26 @@ class TestACSPOReader(unittest.TestCase):
         self.fake_handler = self.p.start()
         self.p.is_local = True
 
-    def tearDown(self):
+    def teardown_method(self):
         """Stop wrapping the NetCDF4 file handler."""
         self.p.stop()
 
-    def test_init(self):
+    @pytest.mark.parametrize(
+        ("filename",),
+        [
+            ["20170401174600-STAR-L2P_GHRSST-SSTskin-VIIRS_NPP-ACSPO_V2.40-v02.0-fv01.0.nc"],
+            ["20210916161708-STAR-L2P_GHRSST-SSTsubskin-VIIRS_N20-ACSPO_V2.80-v02.0-fv01.0.nc"],
+        ]
+    )
+    def test_init(self, filename):
         """Test basic init with no extra parameters."""
         from satpy.readers import load_reader
         r = load_reader(self.reader_configs)
-        loadables = r.select_files_from_pathnames([
-            '20170401174600-STAR-L2P_GHRSST-SSTskin-VIIRS_NPP-ACSPO_V2.40-v02.0-fv01.0.nc',
-        ])
-        self.assertEqual(len(loadables), 1)
+        loadables = r.select_files_from_pathnames([filename])
+        assert len(loadables) == 1
         r.create_filehandlers(loadables)
         # make sure we have some files
-        self.assertTrue(r.file_handlers)
+        assert r.file_handlers
 
     def test_load_every_dataset(self):
         """Test loading all datasets."""
@@ -139,6 +145,6 @@ class TestACSPOReader(unittest.TestCase):
                            'satellite_zenith_angle',
                            'sea_ice_fraction',
                            'wind_speed'])
-        self.assertEqual(len(datasets), 4)
+        assert len(datasets) == 4
         for d in datasets.values():
-            self.assertTupleEqual(d.shape, DEFAULT_FILE_SHAPE)
+            assert d.shape == DEFAULT_FILE_SHAPE


### PR DESCRIPTION
New versions of the ACSPO files can have new filenames where "SSTskin" was replaced with "SSTsubskin". This PR also changes the unittest-based test class to a pytest one so that I could do parametrize tests.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
