### PR TITLE
fix eumetsat urls in satpy/readers

### DIFF
--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -148,9 +148,7 @@ References
     - `[Handbook]`_ MFG User Handbook
     - `[PUG]`_ FIDUCEO MVIRI FCDR Product User Guide
 
-.. _[Handbook]: http://www.eumetsat.int/\
-website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_TD06_MARF&\
-RevisionSelectionMethod=LatestReleased&Rendition=Web
+.. _[Handbook]: https://www.eumetsat.int/media/7323
 .. _[PUG]: http://doi.org/10.15770/EUM_SEC_CLM_0009
 """
 

--- a/satpy/readers/slstr_l1b.py
+++ b/satpy/readers/slstr_l1b.py
@@ -38,7 +38,7 @@ PLATFORM_NAMES = {'S3A': 'Sentinel-3A',
 
 # These are the default channel adjustment factors.
 # Defined in the product notice: S3.PN-SLSTR-L1.06
-# https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_S3A_PN_SLSTR_L1_06&RevisionSelectionMethod=LatestReleased&Rendition=Web
+# https://www4-int.eumetsat.int/media/42788
 CHANCALIB_FACTORS = {'S1_nadir': 1.0,
                      'S2_nadir': 1.0,
                      'S3_nadir': 1.0,

--- a/satpy/readers/vii_l1b_nc.py
+++ b/satpy/readers/vii_l1b_nc.py
@@ -20,8 +20,7 @@
 The ``vii_l1b_nc`` reader reads and calibrates EPS-SG VII L1b image data in netCDF format. The format is explained
 in the `EPS-SG VII Level 1B Product Format Specification`_.
 
-.. _EPS-SG VII Level 1B Product Format Specification: https://www.eumetsat.int/website/wcm/idc/idcplg?
-   IdcService=GET_FILE&dDocName=PDF_EPSSG_VII_L1B_PFS&RevisionSelectionMethod=LatestReleased&Rendition=Web
+.. _EPS-SG VII Level 1B Product Format Specification: https://www.eumetsat.int/media/44393
 
 """
 

--- a/satpy/readers/viirs_compact.py
+++ b/satpy/readers/viirs_compact.py
@@ -25,7 +25,7 @@ dask operations, so it should be relatively performant.
 For more information on this format, the reader can refer to the
 `Compact VIIRS SDR Product Format User Guide` that can be found on this EARS_ page.
 
-.. _EARS: https://www.eumetsat.int/website/home/Data/RegionalDataServiceEARS/EARSVIIRS/index.html
+.. _EARS: https://www.eumetsat.int/media/45988
 
 """
 


### PR DESCRIPTION
I "grepped" for eumetsat.int in satpy/readers and fixed the ones returning an error 404.

 - [x] Closes #1484 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
