### PR TITLE
Move tests_require to special "tests" extra for easier installation

### DIFF
--- a/doc/source/dev_guide/index.rst
+++ b/doc/source/dev_guide/index.rst
@@ -61,7 +61,7 @@ clone your fork. The package can then be installed in development mode by doing:
 The first command will install all dependencies needed by the Satpy
 conda-forge package, but won't actually install Satpy. The second command
 should be run from the root of the cloned Satpy repository (where the
-`setup.py` is) and will install the actual package.
+``setup.py`` is) and will install the actual package.
 
 You can now edit the python files in your cloned repository and have them
 immediately reflected in your conda environment.
@@ -69,11 +69,24 @@ immediately reflected in your conda environment.
 Running tests
 =============
 
-Satpy tests are written using the python :mod:`unittest` module and the
-third-party :doc:`pytest <pytest:index>` package. Satpy tests can be executed by
-running::
+Satpy tests are written using the third-party :doc:`pytest <pytest:index>`
+package. There is usually no need to run all Satpy tests, but instead only
+run the tests related to the component you are working on. All tests are
+automatically run from the GitHub Pull Request using multiple versions of
+Python, multiple operating systems, and multiple versions of dependency
+libraries. If you want to run all Satpy tests you will need to install
+additional dependencies that aren't needed for regular Satpy usage. To install
+them run::
+
+    pip install -e .[tests]
+
+Satpy tests can be executed by running::
 
     pytest satpy/tests
+
+You can also run a specific tests by specifying a sub-directory or module::
+
+    pytest satpy/tests/reader_tests/test_abi_l1b.py
 
 Running benchmarks
 ==================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools>=42", "wheel", "setuptools_scm[toml]>=3.4", 'setuptools_scm_git_archive']
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2", 'setuptools_scm_git_archive']
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
 write_to = "satpy/version.py"

--- a/satpy/__init__.py
+++ b/satpy/__init__.py
@@ -18,7 +18,14 @@
 """Satpy Package initializer."""
 
 import os
-from satpy.version import version as __version__  # noqa
+
+try:
+    from satpy.version import version as __version__  # noqa
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(
+        "No module named satpy.version. This could mean "
+        "you didn't install 'satpy' properly. Try reinstalling ('pip "
+        "install').")
 
 CHUNK_SIZE = int(os.getenv('PYTROLL_CHUNK_SIZE', 4096))
 

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ extras_require = {
     # Other
     'geoviews': ['geoviews'],
     'overlays': ['pycoast', 'pydecorate'],
+    'tests': test_requires,
 }
 all_extras = []
 for extra_deps in extras_require.values():
@@ -154,7 +155,6 @@ setup(name=NAME,
       use_scm_version={'write_to': 'satpy/version.py'},
       setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
       install_requires=requires,
-      tests_require=test_requires,
       python_requires='>=3.7',
       extras_require=extras_require,
       entry_points=entry_points,


### PR DESCRIPTION
Based on the discussion in #1829, I thought it would be best to clear up some of the confusion in the developer's guide about running tests and test dependencies. I realized while commenting on that issue that `tests_require` in `setup.py` no longer serve any purpose as we don't use `python setup.py test` to run our tests. As far as I can tell there is no fully supported way currently to define your test dependencies except as an "extra" in `setup.py`.

As part of this work I looked into how you are supposed to define things in `pyproject.toml`. Although there are some examples, it didn't seem like a fully supported method. I mean, completely replacing our setup.py static information with metadata in pyproject.toml seems like more work and seems like it may not be fully supported by `pip` and other tools right now. I think we can save that for a later time and let larger projects run into the gotchas first. I know projects like xarray already define everything in their `setup.cfg`.

For reference: https://www.python.org/dev/peps/pep-0621

 - [x] Closes #1829 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
