### PR TITLE
Fix config path handling on Windows

### DIFF
--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -119,13 +119,20 @@ Note that this value must be a list. In Python, this could be set by doing:
     satpy.config.set(config_path=['/path/custom1', '/path/custom2'])
 
 If setting an environment variable then it must be a
-colon-separated string and must be set **before** calling/importing Satpy.
+colon-separated (``:``) string on Linux/OSX or semicolon-separate (``;``)
+separated string and must be set **before** calling/importing Satpy.
 If the environment variable is a single path it will be converted to a list
 when Satpy is imported.
 
 .. code-block:: bash
 
     export SATPY_CONFIG_PATH="/path/custom1:/path/custom2"
+
+On Windows, with paths on the `C:` drive, these paths would be:
+
+.. code-block:: bash
+
+    set SATPY_CONFIG_PATH="C:/path/custom1;C:/path/custom2"
 
 Satpy will always include the builtin configuration files that it
 is distributed with regardless of this setting. When a component supports

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -27,8 +27,7 @@ workers by doing the following at the **top** of your python code:
 .. code-block:: python
 
     import dask
-    from multiprocessing.pool import ThreadPool
-    dask.config.set(pool=ThreadPool(8))
+    dask.config.set(num_workers=8)
     # all other Satpy imports and code
 
 This will limit dask to using 8 workers. Typically numbers between 4 and 8

--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -79,7 +79,7 @@ if _satpy_config_path is not None:
     else:
         # colon-separated are ordered by custom -> builtins
         # i.e. last-applied/highest priority to first-applied/lowest priority
-        _satpy_config_path = _satpy_config_path.split(':')
+        _satpy_config_path = _satpy_config_path.split(os.pathsep)
 
     os.environ['SATPY_CONFIG_PATH'] = repr(_satpy_config_path)
     for config_dir in _satpy_config_path:

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -209,8 +209,7 @@ class TestConfigObject:
 
 def _os_specific_multipaths():
     exp_paths = ['/my/configs1', '/my/configs2', '/my/configs3']
-    path_str = ":".join(exp_paths)
     if sys.platform.startswith("win"):
         exp_paths = ["C:" + p for p in exp_paths]
-        path_str = ";".join(exp_paths)
+    path_str = os.pathsep.join(exp_paths)
     return exp_paths, path_str

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -18,6 +18,7 @@
 """Test objects and functions in the satpy.config module."""
 
 import os
+import sys
 import unittest
 from unittest import mock
 import pytest
@@ -154,7 +155,7 @@ class TestConfigObject:
         from importlib import reload
         import satpy
         old_vars = {
-            'SATPY_CONFIG_PATH': '/my/configs1:/my/configs2:/my/configs3',
+            'SATPY_CONFIG_PATH': _os_specific_multipaths(),
         }
 
         with mock.patch.dict('os.environ', old_vars):
@@ -174,7 +175,7 @@ class TestConfigObject:
         from importlib import reload
         import satpy
         old_vars = {
-            'SATPY_CONFIG_PATH': '/my/configs1:/my/configs2:/my/configs3',
+            'SATPY_CONFIG_PATH': _os_specific_multipaths(),
         }
 
         with mock.patch.dict('os.environ', old_vars):
@@ -206,3 +207,10 @@ class TestConfigObject:
         # strings are not allowed, lists are
         with satpy.config.set(config_path='/single/string/paths/are/bad'):
             pytest.raises(ValueError, satpy._config.get_config_path_safe)
+
+
+def _os_specific_multipaths():
+    path_str = "/my/configs1:/my/configs2:/my/configs3"
+    if sys.platform.startswith("win"):
+        path_str = path_str.replace(":", ";").replace("/my", "C:/my")
+    return path_str

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -154,16 +154,15 @@ class TestConfigObject:
         """Test that multiple config paths are accepted."""
         from importlib import reload
         import satpy
+        exp_paths, env_paths = _os_specific_multipaths()
         old_vars = {
-            'SATPY_CONFIG_PATH': _os_specific_multipaths(),
+            'SATPY_CONFIG_PATH': env_paths,
         }
 
         with mock.patch.dict('os.environ', old_vars):
             reload(satpy._config)
             reload(satpy)
-            assert satpy.config.get('config_path') == ['/my/configs1',
-                                                       '/my/configs2',
-                                                       '/my/configs3']
+            assert satpy.config.get('config_path') == exp_paths
 
     def test_config_path_multiple_load(self):
         """Test that config paths from subprocesses load properly.
@@ -174,8 +173,9 @@ class TestConfigObject:
         """
         from importlib import reload
         import satpy
+        exp_paths, env_paths = _os_specific_multipaths()
         old_vars = {
-            'SATPY_CONFIG_PATH': _os_specific_multipaths(),
+            'SATPY_CONFIG_PATH': env_paths,
         }
 
         with mock.patch.dict('os.environ', old_vars):
@@ -186,9 +186,7 @@ class TestConfigObject:
             # load the updated env variable and parse it again.
             reload(satpy._config)
             reload(satpy)
-            assert satpy.config.get('config_path') == ['/my/configs1',
-                                                       '/my/configs2',
-                                                       '/my/configs3']
+            assert satpy.config.get('config_path') == exp_paths
 
     def test_bad_str_config_path(self):
         """Test that a str config path isn't allowed."""
@@ -210,7 +208,9 @@ class TestConfigObject:
 
 
 def _os_specific_multipaths():
-    path_str = "/my/configs1:/my/configs2:/my/configs3"
+    exp_paths = ['/my/configs1', '/my/configs2', '/my/configs3']
+    path_str = ":".join(exp_paths)
     if sys.platform.startswith("win"):
-        path_str = path_str.replace(":", ";").replace("/my", "C:/my")
-    return path_str
+        exp_paths = ["C:" + p for p in exp_paths]
+        path_str = ";".join(exp_paths)
+    return exp_paths, path_str


### PR DESCRIPTION
As discussed on the mailing list, you can't use `:` as a path separator on Windows which has drive letters like `C:/`. With this first and single commit, I expect the tests to fail as they haven't been updated to use `;` for Windows. I'm making this PR before updating them to make sure they fail as I don't have a Windows system to test on right now.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
