### PR TITLE
Write GeoTIFFs while computing necessary NinJo tags

### DIFF
--- a/satpy/tests/writer_tests/test_ninjogeotiff.py
+++ b/satpy/tests/writer_tests/test_ninjogeotiff.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021- Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for writing GeoTIFF files with NinJoTIFF tags."""
+
+import datetime
+import unittest.mock
+
+import dask.array as da
+import pytest
+import xarray as xr
+
+
+@pytest.fixture
+def fake_datasets():
+    """Create fake datasets for testing writing routines."""
+    return [xr.DataArray(
+        da.zeros((100, 200), chunks=50),
+        dims=("y", "x"),
+        attrs={"name": "test",
+               "start_time": datetime.datetime(1985, 8, 13, 15, 0)})]
+
+
+def test_ninjogeotiff(fake_datasets):
+    """Test that it writes a GeoTIFF with the appropriate NinJo-tags."""
+    from satpy.writers.ninjogeotiff import NinJoGeoTIFFWriter
+    w = NinJoGeoTIFFWriter()
+    with unittest.mock.patch("satpy.writers.geotiff.GeoTIFFWriter") as swgg:
+        w.save_datasets(
+                fake_datasets,
+                physic_unit="C",
+                sat_id=6400014,
+                chan_id=900015,
+                data_cat="GORN",
+                data_source="EUMETCAST",
+                ch_min_measurement_unit=-87.5,
+                ch_max_measurement_unit=40)
+        assert swgg.save_datasets.called_with(
+                tags={"ninjo_physic_unit": "C",
+                      "ninjo_sat_id": "6400014",
+                      "ninjo_chan_id": "900015",
+                      "ninjo_data_cat": "GORN",
+                      "ninjo_data_source": "EUMETCAST",
+                      "ninjo_ch_min_measurement_unit": "-87.5",
+                      "ninjo_ch_max_measurement_unit": "40",
+                      "ninjo_TransparentPixel": "0"})


### PR DESCRIPTION
Add a writer that writes a regular GeoTIFF writer with NinJo tags added in TIFF tag 42112, using the GDALMetadata XML tag.

This PR is still in VERY early statges.  So far this contains only a broken and breaking unit test that isn't even testing the right thing yet, so even if nothing written so far might even survive, at least it's a start ☺.

 - [ ] Closes #1838 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

