### PR TITLE
Replace 'libtiff' python dependency with 'pylibtiff'

### DIFF
--- a/satpy/etc/areas.yaml
+++ b/satpy/etc/areas.yaml
@@ -285,7 +285,7 @@ sve:
   description:
     Sweden and baltic sea
   projection:
-    init: epsg:3006
+    EPSG: 3006
   shape:
     height: 2000
     width: 2000
@@ -297,7 +297,15 @@ iber:
     North half of the Iberian Peninsula and the Gulf of Biscay
     image 0 degrees
   projection:
-    proj: utm
+    proj: tmerc
+    lat_0: 0
+    lon_0: -183
+    k: 0.9996
+    x_0: 500000
+    y_0: 0
+    datum: WGS84
+    units: m
+    no_defs: true
   shape:
     height: 1000
     width: 2000

--- a/satpy/etc/areas.yaml
+++ b/satpy/etc/areas.yaml
@@ -292,28 +292,6 @@ sve:
   area_extent:
     lower_left_xy: [-342379.698, 6032580.06]
     upper_right_xy: [1423701.52, 8029648.75]
-iber:
-  description:
-    North half of the Iberian Peninsula and the Gulf of Biscay
-    image 0 degrees
-  projection:
-    proj: tmerc
-    lat_0: 0
-    lon_0: -183
-    k: 0.9996
-    x_0: 500000
-    y_0: 0
-    datum: WGS84
-    units: m
-    no_defs: true
-  shape:
-    height: 1000
-    width: 2000
-  area_extent:
-    lower_left_xy: [-342379.698, 4432580.06]
-    upper_right_xy: [723701.52, 5029648.75]
-    units: m
-
 brazil2:
   description: brazil, platecarree
   projection:

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.11.0', 'trollsift',
             'dask[array] >=0.17.1', 'pyproj>=2.2', 'zarr', 'donfig', 'appdirs',
             'pooch']
 
-test_requires = ['behave', 'h5py', 'netCDF4', 'pyhdf', 'imageio', 'libtiff',
+test_requires = ['behave', 'h5py', 'netCDF4', 'pyhdf', 'imageio', 'pylibtiff',
                  'rasterio', 'geoviews', 'trollimage', 'fsspec', 'bottleneck',
                  'rioxarray', 'pytest', 'pytest-lazy-fixture']
 
@@ -67,7 +67,7 @@ extras_require = {
     'cf': ['h5netcdf >= 0.7.3'],
     'awips_tiled': ['netCDF4 >= 1.1.8'],
     'geotiff': ['rasterio', 'trollimage[geotiff]'],
-    'mitiff': ['libtiff'],
+    'mitiff': ['pylibtiff'],
     'ninjo': ['pyninjotiff', 'pint'],
     # Composites/Modifiers:
     'rayleigh': ['pyspectral >= 0.10.1'],


### PR DESCRIPTION
The python libtiff packages was renamed a long time ago to pylibtiff. This PR replaces that PyPI (setup.py) dependency name with the new name.