### PR TITLE
Fix reference to dask distributed setup page

### DIFF
--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -174,7 +174,7 @@ This will compute one video frame (image) at a time and write it to the MPEG-4
 video file. For users with more powerful systems it is possible to use
 the ``client`` and ``batch_size`` keyword arguments to compute multiple frames
 in parallel using the dask ``distributed`` library (if installed).
-See the :doc:`dask distributed <dask:setup/single-distributed>` documentation
+See the :doc:`dask distributed <dask:how-to/deploy-dask/single-distributed>` documentation
 for information on creating a ``Client`` object. If working on a cluster
 you may want to use :doc:`dask jobqueue <jobqueue:index>` to take advantage
 of multiple nodes at a time.


### PR DESCRIPTION
Dask docs were restructured and our previous intersphinx reference to the dask single-distributed page was not being found because it moved to a new location. This PR fixes it.

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
