### PR TITLE
Catch ImportError on UnsafeLoader in composites/config_loader

### DIFF
--- a/satpy/composites/config_loader.py
+++ b/satpy/composites/config_loader.py
@@ -21,7 +21,11 @@ import logging
 import warnings
 
 import yaml
-from yaml import UnsafeLoader
+
+try:
+    from yaml import UnsafeLoader
+except ImportError:
+    from yaml import Loader as UnsafeLoader
 
 from satpy import DatasetDict, DataQuery, DataID
 from satpy._config import (get_entry_points_config_dirs, config_search_paths,


### PR DESCRIPTION
Add Try/Except around UnsafeLoader import to match the other 6 imports and support old versions of pyyaml.  

The default pyyaml on colab.google is still 3.13.  This individual import prevents satpy from being used without also manually installing an updated pyyaml.  6 of the 7 other UnsafeLoader imports already have this logic so just cover this one remaining import with it.  

 - [ ] Closes #1859 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests ? | Would require testing against various pyyaml versions. 
