### PR TITLE
Correct phrasing of upside-down

### DIFF
--- a/doc/source/readers.rst
+++ b/doc/source/readers.rst
@@ -79,13 +79,13 @@ loading datasets::
 
     >>> scn.load([0.6, 10.8], pad_data=False)
 
-For geostationary products, where the imagery is stored in the files in a flipped orientation
-(e.g. MSG SEVIRI L1.5 data which is flipped upside-down and left-right), the keyword argument
+For geostationary products, where the imagery is stored in the files in an unconventional orientation
+(e.g. MSG SEVIRI L1.5 data are stored with the southwest corner in the upper right), the keyword argument
 ``upper_right_corner`` can be passed into the load call to automatically flip the datasets to the
 wished orientation. Accepted argument values are ``'NE'``, ``'NW'``, ``'SE'``, ``'SW'``,
 and ``'native'``.
 By default, no flipping is applied (corresponding to ``upper_right_corner='native'``) and
-the data is delivered in the original format. To get the data in the common upright orientation,
+the data are delivered in the original format. To get the data in the common upright orientation,
 load the datasets using e.g.::
 
     >>> scn.load(['VIS008'], upper_right_corner='NE')


### PR DESCRIPTION
Correct phrasing of upside-down describing GEO images.  The directions
involved are north, south, east, or west.  There is no vertical
coordinate, therefore the phrase upside-down is incorrect.

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
