### PR TITLE
Update PDF metadata for sphinx documentation

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -234,8 +234,8 @@ htmlhelp_basename = 'NWCSAFMSGPPdoc'
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('index', 'satpy.tex', u'Satpy Documentation',
-   u'Satpy Developers', 'manual'),
+  ('index', 'satpy.tex', 'Satpy Documentation',
+   'Satpy Developers', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of


### PR DESCRIPTION
I noticed that if you download the PDF of the docs from readthedocs it says the author is SMHI. I thought changing this to Satpy Developers was more accurate.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
