### PR TITLE
Fix a typo in the ninjogeotiff documentation

### DIFF
--- a/satpy/writers/ninjogeotiff.py
+++ b/satpy/writers/ninjogeotiff.py
@@ -48,7 +48,7 @@ such as summarised in this table:
    * - ``chan_id``
      - ``ChannelID``
      - mandatory
-   * - ``data_type``
+   * - ``data_cat``
      - ``DataType``
      - mandatory
    * - ``physic_unit``


### PR DESCRIPTION
Fix a mistake in the ninjogeotiff documentation.

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
