### PR TITLE
Update SEVIRI native reader to select the correct scene start/end times.

### DIFF
--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -487,6 +487,18 @@ class HRITMSGFileHandler(HRITFileHandler):
         self.channel_name = CHANNEL_NAMES[self.mda['spectral_channel_id']]
 
     @property
+    def nominal_start_time(self):
+        """Get the start time."""
+        return self.prologue['ImageAcquisition'][
+            'PlannedAcquisitionTime']['TrueRepeatCycleStart']
+
+    @property
+    def nominal_end_time(self):
+        """Get the end time."""
+        return self.prologue['ImageAcquisition'][
+            'PlannedAcquisitionTime']['PlannedRepeatCycleEnd']
+
+    @property
     def start_time(self):
         """Get the start time."""
         return self.epilogue['ImageProductionStats'][
@@ -706,6 +718,8 @@ class HRITMSGFileHandler(HRITFileHandler):
         res.attrs['standard_name'] = info['standard_name']
         res.attrs['platform_name'] = self.platform_name
         res.attrs['sensor'] = 'seviri'
+        res.attrs['nominal_start_time'] = self.nominal_start_time
+        res.attrs['nominal_end_time'] = self.nominal_end_time
         res.attrs['orbital_parameters'] = {
             'projection_longitude': self.mda['projection_parameters']['SSP_longitude'],
             'projection_latitude': self.mda['projection_parameters']['SSP_latitude'],

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -126,16 +126,28 @@ class NativeMSGFileHandler(BaseFileHandler):
             return istream.read(36) == ascii_startswith
 
     @property
-    def start_time(self):
-        """Read the repeat cycle start time from metadata."""
+    def nominal_start_time(self):
+        """Read the repeat cycle nominal start time from metadata."""
         return self.header['15_DATA_HEADER']['ImageAcquisition'][
             'PlannedAcquisitionTime']['TrueRepeatCycleStart']
 
     @property
-    def end_time(self):
-        """Read the repeat cycle end time from metadata."""
+    def nominal_end_time(self):
+        """Read the repeat cycle nominal end time from metadata."""
         return self.header['15_DATA_HEADER']['ImageAcquisition'][
             'PlannedAcquisitionTime']['PlannedRepeatCycleEnd']
+
+    @property
+    def start_time(self):
+        """Read the repeat cycle sensing start time from metadata."""
+        return self.trailer['15TRAILER']['ImageProductionStats'][
+            'ActualScanningSummary']['ForwardScanStart']
+
+    @property
+    def end_time(self):
+        """Read the repeat cycle sensing end time from metadata."""
+        return self.trailer['15TRAILER']['ImageProductionStats'][
+            'ActualScanningSummary']['ForwardScanEnd']
 
     def _get_data_dtype(self):
         """Get the dtype of the file based on the actual available channels."""
@@ -575,6 +587,8 @@ class NativeMSGFileHandler(BaseFileHandler):
         dataset.attrs['standard_name'] = dataset_info['standard_name']
         dataset.attrs['platform_name'] = self.mda['platform_name']
         dataset.attrs['sensor'] = 'seviri'
+        dataset.attrs['nominal_start_time'] = self.nominal_start_time
+        dataset.attrs['nominal_end_time'] = self.nominal_end_time
         dataset.attrs['georef_offset_corrected'] = self.mda[
             'offset_corrected']
         orbital_parameters = {

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit_setup.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit_setup.py
@@ -121,7 +121,8 @@ def get_fake_prologue(projection_longitude, orbit_polynomials):
          },
          'ImageAcquisition': {
             'PlannedAcquisitionTime': {
-                'TrueRepeatCycleStart': datetime(2006, 1, 1, 12, 15, 9, 304888)
+                'TrueRepeatCycleStart': datetime(2006, 1, 1, 12, 15, 9, 304888),
+                'PlannedRepeatCycleEnd': datetime(2006, 1, 1, 12, 30, 0, 0)
             }
          }
     }
@@ -220,5 +221,7 @@ def get_attrs_exp(projection_longitude=0.0):
                                'satellite_actual_longitude': -3.55117540817073,
                                'satellite_actual_latitude': -0.5711243456528018,
                                'satellite_actual_altitude': 35783296.150123544},
-        'georef_offset_corrected': True
+        'georef_offset_corrected': True,
+        'nominal_start_time': datetime(2006, 1, 1, 12, 15, 9, 304888),
+        'nominal_end_time': datetime(2006, 1, 1, 12, 30, 0, 0)
     }

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1019,11 +1019,21 @@ class TestNativeMSGCalibration(TestFileHandlerCalibrationBase):
                 }
             }
         }
+        trailer = {
+            '15TRAILER': {
+                'ImageProductionStats': {
+                    'ActualScanningSummary': {
+                        'ForwardScanStart': self.scan_time
+                    }
+                }
+            }
+        }
         header['15_DATA_HEADER'].update(TEST_HEADER_CALIB)
         with mock.patch('satpy.readers.seviri_l1b_native.NativeMSGFileHandler.__init__',
                         return_value=None):
             fh = NativeMSGFileHandler()
             fh.header = header
+            fh.trailer = trailer
             fh.platform_id = self.platform_id
             return fh
 
@@ -1097,12 +1107,21 @@ class TestNativeMSGDataset:
                 },
                 'ImageAcquisition': {
                     'PlannedAcquisitionTime': {
-                        'TrueRepeatCycleStart': datetime(
-                            2006, 1, 1, 12, 15, 9, 304888
-                        )
+                        'TrueRepeatCycleStart': datetime(2006, 1, 1, 12, 15, 0, 0),
+                        'PlannedRepeatCycleEnd': datetime(2006, 1, 1, 12, 30, 0, 0),
                     }
                 }
             },
+        }
+        trailer = {
+            '15TRAILER': {
+                'ImageProductionStats': {
+                    'ActualScanningSummary': {
+                        'ForwardScanStart': datetime(2006, 1, 1, 12, 15, 9, 304888),
+                        'ForwardScanEnd': datetime(2006, 1, 1, 12, 27, 9, 304888)
+                    }
+                }
+            }
         }
         header['15_DATA_HEADER'].update(TEST_HEADER_CALIB)
         mda = {
@@ -1146,6 +1165,7 @@ class TestNativeMSGDataset:
                         return_value=None):
             fh = NativeMSGFileHandler()
             fh.header = header
+            fh.trailer = trailer
             fh.mda = mda
             fh.dask_array = da.from_array(data)
             fh.platform_id = 324
@@ -1192,7 +1212,9 @@ class TestNativeMSGDataset:
                 'sensor': 'seviri',
                 'units': '1',
                 'wavelength': (1, 2, 3),
-                'standard_name': 'counts'
+                'standard_name': 'counts',
+                'nominal_start_time': datetime(2006, 1, 1, 12, 15, 0),
+                'nominal_end_time': datetime(2006, 1, 1, 12, 30, 0),
             }
         )
         expected['acq_time'] = ('y', [np.datetime64('1958-01-02 00:00:01'),
@@ -1201,6 +1223,8 @@ class TestNativeMSGDataset:
                                       np.datetime64('1958-01-02 00:00:04')])
         xr.testing.assert_equal(dataset, expected)
         assert 'raw_metadata' not in dataset.attrs
+        assert file_handler.start_time == datetime(2006, 1, 1, 12, 15, 9, 304888)
+        assert file_handler.end_time == datetime(2006, 1, 1, 12, 27, 9, 304888)
         assert_attrs_equal(dataset.attrs, expected.attrs, tolerance=1e-4)
 
     def test_get_dataset_with_raw_metadata(self, file_handler):


### PR DESCRIPTION
The SEVIRI HRIT and NAT readers are currently inconsistent with their start/end time values:
```
from satpy import Scene
scn = Scene([my_nat_file], reader='seviri_l1b_native')
scn.load(['IR_108'])
print("NATIVE")
print(scn['IR_108'].attrs['start_time'])
print(scn['IR_108'].attrs['end_time'])

scn = Scene(my_hrit_files, reader='seviri_l1b_hrit')
scn.load(['IR_108'])
print("HRIT")
print(scn['IR_108'].attrs['start_time'])
print(scn['IR_108'].attrs['end_time'])
```
Gives:
```
NATIVE
2021-11-09 12:00:10.388905
2021-11-09 12:15:10.076995

HRIT 
2021-11-09 12:00:10.388000
2021-11-09 12:12:43.089000
```

This is because the HRIT reader selects:
 -  `['ImageProductionStats']['ActualScanningSummary']['ForwardScanStart']` and
 -  `['ImageProductionStats']['ActualScanningSummary']['ForwardScanEnd']` from the trailer / epilogue.
 
The NAT reader, though, selects:
 -  `['ImageAcquisition']['PlannedAcquisitionTime']['TrueRepeatCycleStart']` and
 -  `['ImageAcquisition']['PlannedAcquisitionTime']['PlannedRepeatCycleEnd']` from the header.

In this PR I update the NAT reader to select the same start/end time values as the HRIT reader uses. With the PR, the output of the above code snippet is:
```
NATIVE
2021-11-09 12:00:10.388000
2021-11-09 12:12:43.089000

HRIT 
2021-11-09 12:00:10.388000
2021-11-09 12:12:43.089000
```
