### PR TITLE
Fix nucaps reader failing when given multiple input files

### DIFF
--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -207,7 +207,7 @@ class NUCAPSFileHandler(NetCDF4FileHandler):
             if 'Number_of_CrIS_FORs' in sp.dims:
                 sp = sp.rename({'Number_of_CrIS_FORs': 'y'})
             if 'surface_pressure' in ds_info:
-                ds_info['surface_pressure'] = xr.concat((ds_info['surface_pressure'], sp))
+                ds_info['surface_pressure'] = xr.concat((ds_info['surface_pressure'], sp), dim='y')
             else:
                 ds_info['surface_pressure'] = sp
             # include all the pressure levels

--- a/satpy/tests/reader_tests/test_nucaps.py
+++ b/satpy/tests/reader_tests/test_nucaps.py
@@ -252,6 +252,20 @@ class TestNUCAPSReader(unittest.TestCase):
             if np.issubdtype(v.dtype, np.floating):
                 assert '_FillValue' not in v.attrs
 
+    def test_load_multiple_files_pressure(self):
+        """Test loading Temperature from multiple input files."""
+        from satpy.readers import load_reader
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'NUCAPS-EDR_v1r0_npp_s201603011158009_e201603011158307_c201603011222270.nc',
+            'NUCAPS-EDR_v1r0_npp_s201603011159009_e201603011159307_c201603011222270.nc',
+        ])
+        r.create_filehandlers(loadables)
+        datasets = r.load(r.pressure_dataset_names['Temperature'], pressure_levels=True)
+        self.assertEqual(len(datasets), 100)
+        for v in datasets.values():
+            self.assertEqual(v.ndim, 1)
+
     def test_load_individual_pressure_levels_true(self):
         """Test loading Temperature with individual pressure datasets."""
         from satpy.readers import load_reader


### PR DESCRIPTION
@scottlindstrom pointed out while working with Polar2Grid that he wasn't able to give the nucaps reader multiple files as input. This PR should fix the issues he was running into.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
