### PR TITLE
Remove confusing and unused cache_dir default of '.'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,9 @@
 name: CI
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency
+# https://docs.github.com/en/developers/webhooks-and-events/events/github-event-types#pullrequestevent
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.type }}
+  cancel-in-progress: true
 
 on: [push, pull_request]
 

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -536,6 +536,8 @@ class KDTreeResampler(BaseResampler):
     def _check_numpy_cache(self, cache_dir, mask=None,
                            **kwargs):
         """Check if there's Numpy cache file and convert it to zarr."""
+        if cache_dir is None:
+            return
         fname_np = self._create_cache_filename(cache_dir,
                                                prefix='resample_lut-',
                                                mask=mask, fmt='.npz',
@@ -564,14 +566,15 @@ class KDTreeResampler(BaseResampler):
         cached = {}
         self._check_numpy_cache(cache_dir, mask=mask_name, **kwargs)
 
-        filename = self._create_cache_filename(cache_dir, prefix='nn_lut-',
-                                               mask=mask_name, **kwargs)
         for idx_name in NN_COORDINATES:
             if mask_name in self._index_caches:
                 cached[idx_name] = self._apply_cached_index(
                     self._index_caches[mask_name][idx_name], idx_name)
             elif cache_dir:
                 try:
+                    filename = self._create_cache_filename(
+                        cache_dir, prefix='nn_lut-',
+                        mask=mask_name, **kwargs)
                     fid = zarr.open(filename, 'r')
                     cache = np.array(fid[idx_name])
                     if idx_name == 'valid_input_index':

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -242,14 +242,12 @@ def add_xy_coords(data_arr, area, crs=None):
     if 'x' in data_arr.coords and 'y' in data_arr.coords:
         # x/y coords already provided
         return data_arr
-    elif 'x' not in data_arr.dims or 'y' not in data_arr.dims:
+    if 'x' not in data_arr.dims or 'y' not in data_arr.dims:
         # no defined x and y dimensions
         return data_arr
-
-    if hasattr(area, 'get_proj_vectors'):
-        x, y = area.get_proj_vectors()
-    else:
+    if not hasattr(area, 'get_proj_vectors'):
         return data_arr
+    x, y = area.get_proj_vectors()
 
     # convert to DataArrays
     y_attrs = {}
@@ -1021,9 +1019,8 @@ class NativeResampler(BaseResampler):
             y_size = 1. / repeats[0]
             x_size = 1. / repeats[1]
             return cls.aggregate(d_arr, y_size, x_size)
-        else:
-            raise ValueError("Must either expand or reduce in both "
-                             "directions")
+        raise ValueError("Must either expand or reduce in both "
+                         "directions")
 
     def compute(self, data, expand=True, **kwargs):
         """Resample data with NativeResampler."""
@@ -1316,7 +1313,7 @@ def prepare_resampler(source_area, destination_area, resampler=None, **resample_
     if isinstance(resampler, (BaseResampler, PRBaseResampler)):
         raise ValueError("Trying to create a resampler when one already "
                          "exists.")
-    elif isinstance(resampler, str):
+    if isinstance(resampler, str):
         resampler_class = RESAMPLERS.get(resampler, None)
         if resampler_class is None:
             if resampler == "gradient_search":

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -1014,7 +1014,7 @@ class NativeResampler(BaseResampler):
                     raise ValueError("Expand factor must be a whole number")
                 d_arr = da.repeat(d_arr, int(factor), axis=axis)
             return d_arr
-        elif all(x <= 1 for x in repeats.values()):
+        if all(x <= 1 for x in repeats.values()):
             # reduce
             y_size = 1. / repeats[0]
             x_size = 1. / repeats[1]

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -995,7 +995,7 @@ class NativeResampler(BaseResampler):
             d_arr = da.from_array(d_arr, chunks=CHUNK_SIZE)
         if all(x == 1 for x in repeats.values()):
             return d_arr
-        elif all(x >= 1 for x in repeats.values()):
+        if all(x >= 1 for x in repeats.values()):
             # rechunk so new chunks are the same size as old chunks
             c_size = max(x[0] for x in d_arr.chunks)
 

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -440,12 +440,10 @@ class BaseResampler(object):
         cache_id = self.precompute(cache_dir=cache_dir, **kwargs)
         return self.compute(data, cache_id=cache_id, **kwargs)
 
-    def _create_cache_filename(self, cache_dir=None, prefix='',
+    def _create_cache_filename(self, cache_dir, prefix='',
                                fmt='.zarr', **kwargs):
         """Create filename for the cached resampling parameters."""
-        cache_dir = cache_dir or '.'
         hash_str = self.get_hash(**kwargs)
-
         return os.path.join(cache_dir, prefix + hash_str + fmt)
 
 


### PR DESCRIPTION
As described in #1456, the source code for resampling suggests that if resampling `cache_dir` is not provided it will default to the current directory. This is never used as this portion of the code is only used *if* `cache_dir` is specified.

 - [x] Closes #1456 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
