### PR TITLE
Fix file handlers improperly matching some file types

### DIFF
--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -157,7 +157,7 @@ class BaseFileHandler(metaclass=ABCMeta):
         """
         if isinstance(ds_ftype, str) and ds_ftype == self.filetype_info['file_type']:
             return True
-        elif self.filetype_info['file_type'] in ds_ftype:
+        elif isinstance(ds_ftype, (list, tuple)) and self.filetype_info['file_type'] in ds_ftype:
             return True
         return None
 

--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -151,13 +151,18 @@ class BaseFileHandler(metaclass=ABCMeta):
             ds_ftype (str or list): File type or list of file types that a
                 dataset is configured to be loaded from.
 
-        Returns: ``True`` if this file handler object's type matches the
-            dataset's file type(s), ``False`` otherwise.
+        Returns:
+            ``True`` if this file handler object's type matches the
+            dataset's file type(s), ``None`` otherwise. ``None`` is returned
+            instead of ``False`` to follow the convention of the
+            :meth:`available_datasets` method.
 
         """
         if not isinstance(ds_ftype, (list, tuple)):
             ds_ftype = [ds_ftype]
-        return self.filetype_info['file_type'] in ds_ftype
+        if self.filetype_info['file_type'] in ds_ftype:
+            return True
+        return None
 
     def available_datasets(self, configured_datasets=None):
         """Get information of available datasets in this file.
@@ -195,7 +200,8 @@ class BaseFileHandler(metaclass=ABCMeta):
                 available datasets. This argument could be the result of a
                 previous file handler's implementation of this method.
 
-        Returns: Iterator of (bool or None, dict) pairs where dict is the
+        Returns:
+            Iterator of (bool or None, dict) pairs where dict is the
             dataset's metadata. If the dataset is available in the current
             file type then the boolean value should be ``True``, ``False``
             if we **know** about the dataset but it is unavailable, or

--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -157,7 +157,7 @@ class BaseFileHandler(metaclass=ABCMeta):
         """
         if isinstance(ds_ftype, str) and ds_ftype == self.filetype_info['file_type']:
             return True
-        elif isinstance(ds_ftype, (list, tuple)) and self.filetype_info['file_type'] in ds_ftype:
+        if isinstance(ds_ftype, (list, tuple)) and self.filetype_info['file_type'] in ds_ftype:
             return True
         return None
 

--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -155,11 +155,9 @@ class BaseFileHandler(metaclass=ABCMeta):
             dataset's file type(s), ``False`` otherwise.
 
         """
-        if isinstance(ds_ftype, str) and ds_ftype == self.filetype_info['file_type']:
-            return True
-        if isinstance(ds_ftype, (list, tuple)) and self.filetype_info['file_type'] in ds_ftype:
-            return True
-        return None
+        if not isinstance(ds_ftype, (list, tuple)):
+            ds_ftype = [ds_ftype]
+        return self.filetype_info['file_type'] in ds_ftype
 
     def available_datasets(self, configured_datasets=None):
         """Get information of available datasets in this file.

--- a/satpy/tests/etc/readers/fake1.yaml
+++ b/satpy/tests/etc/readers/fake1.yaml
@@ -39,7 +39,7 @@ datasets:
     name: ds5
     resolution:
       250:
-        file_type: fake_file_highres
+        file_type: fake_file1_highres
       500:
         file_type: fake_file1
       1000:
@@ -111,7 +111,7 @@ file_types:
     file_reader: !!python/name:satpy.tests.utils.FakeFileHandler
     file_patterns: ['fake1_{file_idx:d}.txt']
     sensor: fake_sensor
-  fake_file_highres:
+  fake_file1_highres:
     file_reader: !!python/name:satpy.tests.utils.FakeFileHandler
     file_patterns: ['fake1_highres_{file_idx:d}.txt']
     sensor: fake_sensor

--- a/satpy/tests/features/steps/steps-load.py
+++ b/satpy/tests/features/steps/steps-load.py
@@ -58,12 +58,8 @@ def step_impl_user_loads_no_config(context):
 @then(u'the data is available in a scene object')
 def step_impl_data_available_in_scene(context):
     """Check that the data is available in the scene."""
-    assert (context.scene["M02"] is not None)
-    try:
-        context.scene["M01"] is None
-        raise AssertionError()
-    except KeyError:
-        pass
+    assert context.scene["M02"] is not None
+    assert context.scene.get("M01") is None
 
 
 @when(u'some items are not available')

--- a/satpy/tests/features/steps/steps-save.py
+++ b/satpy/tests/features/steps/steps-save.py
@@ -15,21 +15,23 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Behave steps related to saving or showing datasets."""
+
 from behave import given, when, then, use_step_matcher
 
-try:
-    from unittest.mock import patch
-except ImportError:
-    from mock import patch
+from unittest.mock import patch
 
 
 use_step_matcher("re")
 
 
-@given("a dataset is available")  # noqa: F811
+@given("a dataset is available")
 def step_impl(context):
-    """
-    :type context: behave.runner.Context
+    """Create a Scene with a fake dataset for testing.
+
+    Args:
+        context (behave.runner.Context): Test context
+
     """
     from satpy import Scene
     from xarray import DataArray
@@ -38,47 +40,61 @@ def step_impl(context):
     context.scene = scn
 
 
-@when("the show command is called")  # noqa: F811
+@when("the show command is called")
 def step_impl(context):
-    """
-    :type context: behave.runner.Context
+    """Call the Scene.show method.
+
+    Args:
+        context (behave.runner.Context): Test context
+
     """
     with patch('trollimage.xrimage.XRImage.show') as mock_show:
         context.scene.show("MyDataset")
         mock_show.assert_called_once_with()
 
 
-@then("an image should pop up")  # noqa: F811
+@then("an image should pop up")
 def step_impl(context):
+    """Check that a image window pops up (no-op currently).
+
+    Args:
+        context (behave.runner.Context): Test context
+
     """
-    :type context: behave.runner.Context
-    """
-    pass
 
 
-@when("the save_dataset command is called")  # noqa: F811
+@when("the save_dataset command is called")
 def step_impl(context):
-    """
-    :type context: behave.runner.Context
+    """Run Scene.save_dataset to create a PNG image.
+
+    Args:
+        context (behave.runner.Context): Test context
+
     """
     context.filename = "/tmp/test_dataset.png"
     context.scene.save_dataset("MyDataset", context.filename)
 
 
-@then("a file should be saved on disk")  # noqa: F811
+@then("a file should be saved on disk")
 def step_impl(context):
-    """
-    :type context: behave.runner.Context
+    """Check that a file exists on disk and then remove it.
+
+    Args:
+        context (behave.runner.Context): Test context
+
     """
     import os
     assert(os.path.exists(context.filename))
     os.remove(context.filename)
 
 
-@given("a bunch of datasets are available")  # noqa: F811
+@given("a bunch of datasets are available")
 def step_impl(context):
-    """
-    :type context: behave.runner.Context
+    """Create a Scene with two fake datasets for testing.
+
+    Args:
+        context (behave.runner.Context): Test context
+
     """
     from satpy import Scene
     from xarray import DataArray
@@ -88,18 +104,24 @@ def step_impl(context):
     context.scene = scn
 
 
-@when("the save_datasets command is called")  # noqa: F811
+@when("the save_datasets command is called")
 def step_impl(context):
-    """
-    :type context: behave.runner.Context
+    """Run Scene.save_datsets to create PNG images.
+
+    Args:
+        context (behave.runner.Context): Test context
+
     """
     context.scene.save_datasets(writer="simple_image", filename="{name}.png")
 
 
-@then("a bunch of files should be saved on disk")  # noqa: F811
+@then("a bunch of files should be saved on disk")
 def step_impl(context):
-    """
-    :type context: behave.runner.Context
+    """Check that two PNGs exist.
+
+    Args:
+        context (behave.runner.Context): Test context
+
     """
     import os
     for filename in ["MyDataset.png", "MyDataset2.png"]:

--- a/satpy/tests/test_file_handlers.py
+++ b/satpy/tests/test_file_handlers.py
@@ -160,20 +160,17 @@ class TestBaseFileHandler(unittest.TestCase):
 
 
 @pytest.mark.parametrize(
-    ("file_type", "ds_file_type", "exp_match"),
+    ("file_type", "ds_file_type", "exp_result"),
     [
         ("fake1", "fake1", True),
         ("fake1", ["fake1"], True),
         ("fake1", ["fake1", "fake2"], True),
-        ("fake1", ["fake2"], False),
-        ("fake1", "fake2", False),
-        ("fake1", "fake1_with_suffix", False),
+        ("fake1", ["fake2"], None),
+        ("fake1", "fake2", None),
+        ("fake1", "fake1_with_suffix", None),
     ]
 )
-def test_file_type_match(file_type, ds_file_type, exp_match):
+def test_file_type_match(file_type, ds_file_type, exp_result):
     """Test that file type matching uses exactly equality."""
     fh = FakeFileHandler("some_file.txt", {}, {"file_type": file_type})
-    if exp_match:
-        assert fh.file_type_matches(ds_file_type)
-    else:
-        assert not fh.file_type_matches(ds_file_type)
+    assert fh.file_type_matches(ds_file_type) is exp_result

--- a/satpy/tests/test_file_handlers.py
+++ b/satpy/tests/test_file_handlers.py
@@ -21,8 +21,10 @@ import unittest
 from unittest import mock
 
 import numpy as np
+import pytest
 
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.tests.utils import FakeFileHandler
 
 
 class TestBaseFileHandler(unittest.TestCase):
@@ -155,3 +157,23 @@ class TestBaseFileHandler(unittest.TestCase):
     def tearDown(self):
         """Tear down the test."""
         BaseFileHandler.__abstractmethods__ = self._old_set
+
+
+@pytest.mark.parametrize(
+    ("file_type", "ds_file_type", "exp_match"),
+    [
+        ("fake1", "fake1", True),
+        ("fake1", ["fake1"], True),
+        ("fake1", ["fake1", "fake2"], True),
+        ("fake1", ["fake2"], False),
+        ("fake1", "fake2", False),
+        ("fake1", "fake1_with_suffix", False),
+    ]
+)
+def test_file_type_match(file_type, ds_file_type, exp_match):
+    """Test that file type matching uses exactly equality."""
+    fh = FakeFileHandler("some_file.txt", {}, {"file_type": file_type})
+    if exp_match:
+        assert fh.file_type_matches(ds_file_type)
+    else:
+        assert not fh.file_type_matches(ds_file_type)

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ exclude =
 per-file-ignores =
     satpy/tests/*/conftest.py:F401
     doc/source/doi_role.py:D103
+    satpy/tests/features/steps/*.py:F811
 
 [coverage:run]
 relative_files = True

--- a/utils/convert_to_ninjotiff.py
+++ b/utils/convert_to_ninjotiff.py
@@ -15,9 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""
-First version of a simple command line too that converts an
-image into a NinJo Tiff file.
+"""Simple command line too that converts an image into a NinJo Tiff file.
 
 NinJo Tiff metadata can be passed as command line input or
 through a config file (an example is given in the ninjo-cmd.yaml


### PR DESCRIPTION
I noticed this while working on other issues. The file handler's `available_datasets` method uses a method to check if the current file handler's file type matches the file type for the current dataset being evaluated. The issue is that the way the condition was written it was producing a false positive where it was matching file types with similar names. For example, `if "file_type_name" in "file_type_name2"`. This is only suppose to match if it matches exactly, but the if statement was assuming the second parameter was a list/container.

This PR fixes this issue and "adds" tests by putting one of the fake readers used in multiple tests so that it matches the failing real world case I ran in to.

 - [x] Tests added <!-- for all bug fixes or enhancements -->

