### PR TITLE
Fix loading multi-sensor composites for manually added data

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -151,7 +151,12 @@ class Scene:
         for data_arr in self.values():
             if "sensor" not in data_arr.attrs:
                 continue
-            sensor_names.update(data_arr.attrs["sensor"])
+            if isinstance(data_arr.attrs["sensor"], str):
+                sensor_names.add(data_arr.attrs["sensor"])
+            elif isinstance(data_arr.attrs["sensor"], set):
+                sensor_names.update(data_arr.attrs["sensor"])
+            else:
+                raise TypeError("Unexpected type in sensor collection")
         return sensor_names
 
     @property

--- a/satpy/tests/etc/composites/fake_sensor.yaml
+++ b/satpy/tests/etc/composites/fake_sensor.yaml
@@ -241,3 +241,8 @@ composites:
         prerequisites:
           - name: ds13
             modifiers: ['mod1', 'mod_opt_only']
+  comp_multi:
+    compositor: !!python/name:satpy.tests.utils.FakeCompositor
+    prerequisites:
+      - ds1
+      - ds4_b

--- a/satpy/tests/etc/readers/fake4.yaml
+++ b/satpy/tests/etc/readers/fake4.yaml
@@ -1,0 +1,19 @@
+reader:
+  name: fake4
+  description: Fake reader used for easier testing
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
+  sensors: [fake_sensor_4]
+datasets:
+  ds4_a:
+    name: ds4_a
+    wavelength: [0.1, 0.2, 0.3]
+    file_type: fake_file4
+  ds4_b:
+    name: ds4_b
+    wavelength: [0.4, 0.5, 0.6]
+    file_type: fake_file4
+file_types:
+  fake_file4:
+    file_reader: !!python/name:satpy.tests.utils.FakeFileHandler
+    file_patterns: ['fake4_{file_idx:d}.txt']
+    sensor: fake_sensor_4

--- a/satpy/tests/etc/readers/fake4.yaml
+++ b/satpy/tests/etc/readers/fake4.yaml
@@ -4,12 +4,24 @@ reader:
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
   sensors: [fake_sensor_4]
 datasets:
+  lons:
+    name: lons
+    resolution: [250, 500, 1000]
+    standard_name: longitude
+    file_type: fake_file4
+  lats:
+    name: lats
+    resolution: [250, 500, 1000]
+    standard_name: latitude
+    file_type: fake_file4
   ds4_a:
     name: ds4_a
+    resolution: 1000
     wavelength: [0.1, 0.2, 0.3]
     file_type: fake_file4
   ds4_b:
     name: ds4_b
+    resolution: 1000
     wavelength: [0.4, 0.5, 0.6]
     file_type: fake_file4
 file_types:

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1632,6 +1632,21 @@ class TestSceneResampling:
         new_scn.load(["comp2"])
         assert "comp2" in new_scn
 
+    def test_comp_loading_multisensor_composite_created_user(self):
+        """Test that multisensor composite can be created manually.
+
+        Test that if the user has created datasets "manually", that
+        multi-sensor composites provided can still be read.
+        """
+        scene1 = Scene(filenames=["fake1_1.txt"], reader="fake1")
+        scene1.load(["ds2"])
+        scene2 = Scene(filenames=["fake4_1.txt"], reader="fake4")
+        scene2.load(["ds4_b"])
+        scene3 = Scene()
+        scene3["ds2"] = scene1["ds2"]
+        scene3["ds4_b"] = scene2["ds4_b"]
+        scene3.load(["comp_multi"])
+
     def test_comps_need_resampling_optional_mod_deps(self):
         """Test that a composite with complex dependencies.
 

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1639,11 +1639,11 @@ class TestSceneResampling:
         multi-sensor composites provided can still be read.
         """
         scene1 = Scene(filenames=["fake1_1.txt"], reader="fake1")
-        scene1.load(["ds2"])
+        scene1.load(["ds1"])
         scene2 = Scene(filenames=["fake4_1.txt"], reader="fake4")
         scene2.load(["ds4_b"])
         scene3 = Scene()
-        scene3["ds2"] = scene1["ds2"]
+        scene3["ds1"] = scene1["ds1"]
         scene3["ds4_b"] = scene2["ds4_b"]
         scene3.load(["comp_multi"])
 

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -200,10 +200,6 @@ class FakeCompositor(GenericCompositor):
                          dims=['y', 'x', 'bands'],
                          coords={'bands': ['R', 'G', 'B']})
 
-    def check_geolocation(self, data_arrays):
-        """For testing purposes, geolocation always matches."""
-        return True
-
 
 class FakeFileHandler(BaseFileHandler):
     """Fake file handler to be used by test readers."""

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -200,6 +200,10 @@ class FakeCompositor(GenericCompositor):
                          dims=['y', 'x', 'bands'],
                          coords={'bands': ['R', 'G', 'B']})
 
+    def check_geolocation(self, data_arrays):
+        """For testing purposes, geolocation always matches."""
+        return True
+
 
 class FakeFileHandler(BaseFileHandler):
     """Fake file handler to be used by test readers."""


### PR DESCRIPTION
Fix loading multi-sensor composites from a scene where scene datasets have been added to the scene directly by the user.

So far this draft PR contains only a failing unit test.

 - [x] Closes #1898
 - [x] Tests added
