### PR TITLE
Update Scene.sensor_names to include sensors from readers and contained data

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,3 @@
-skips: ["B506"]
-exclude_dirs: ["satpy/tests"]
+[bandit]
+skips: B506
+exclude: satpy/tests

--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,2 @@
 skips: ["B506"]
-exclude: ["satpy/tests"]
+exclude_dirs: ["satpy/tests"]

--- a/.bandit
+++ b/.bandit
@@ -1,1 +1,2 @@
 skips: ["B506"]
+exclude: ["satpy/tests"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: '1.7.0' # Update me!
     hooks:
       - id: bandit
-        args: [-x, satpy/tests, -c, .bandit]
+        args: [-c, .bandit]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v0.910-1'  # Use the sha / tag you want to point at
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     rev: '1.7.0' # Update me!
     hooks:
       - id: bandit
-        args: [-c, .bandit]
+        args: [--ini, .bandit]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v0.910-1'  # Use the sha / tag you want to point at
     hooks:

--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -748,10 +748,8 @@ def _calculate_weights(tile_size):
     # that has all 8 surrounding tiles available
     # create our empty template tiles
     template_tile = np.zeros((3, 3, tile_size, tile_size), dtype=np.float32)
-    """
     # TEMP FOR TESTING, create a weight tile that does no interpolation
-    template_tile[1,1] = template_tile[1,1] + 1.0
-    """
+    # template_tile[1,1] = template_tile[1,1] + 1.0
 
     # for ease of calculation, figure out the index of the center pixel in a tile
     # and how far that pixel is from the edge of the tile (in pixel units)

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -24,7 +24,7 @@ import shutil
 from datetime import datetime
 from functools import update_wrapper
 from glob import glob
-from typing import Any, Callable, Optional, Union, cast
+from typing import Any, Callable, Optional, Union
 
 import dask
 import dask.array as da
@@ -160,9 +160,6 @@ class ZarrCacheHelper:
         should_cache = should_cache and can_cache
         if cache_dir is None:
             cache_dir = satpy.config.get("cache_dir")
-        if cache_dir is None:
-            should_cache = False
-        cache_dir = cast(str, cache_dir)
         return should_cache, cache_dir
 
     def _cache_results(self, res, zarr_format):
@@ -218,7 +215,7 @@ def _hash_args(*args):
         elif isinstance(arg, datetime):
             arg = arg.isoformat(" ")
         hashable_args.append(arg)
-    arg_hash = hashlib.sha1()
+    arg_hash = hashlib.sha1()  # nosec
     arg_hash.update(json.dumps(tuple(hashable_args)).encode('utf8'))
     return arg_hash.hexdigest()
 
@@ -297,7 +294,7 @@ def _get_sun_angles(data_arr: xr.DataArray) -> tuple[xr.DataArray, xr.DataArray]
     return suna, sunz
 
 
-def _get_sun_angles_wrapper(lons: da.Array, lats: da.Array, start_time: datetime) -> tuple[da.Array, da.Array]:
+def _get_sun_angles_wrapper(lons: da.Array, lats: da.Array, start_time: datetime) -> np.ndarray:
     with ignore_invalid_float_warnings():
         suna = get_alt_az(start_time, lons, lats)[1]
         suna = np.rad2deg(suna)
@@ -325,7 +322,7 @@ def _get_sensor_angles_from_sat_pos(sat_lon, sat_lat, sat_alt, start_time, area_
     return res[0], res[1]
 
 
-def _get_sensor_angles_wrapper(lons, lats, start_time, sat_lon, sat_lat, sat_alt):
+def _get_sensor_angles_wrapper(lons, lats, start_time, sat_lon, sat_lat, sat_alt) -> np.ndarray:
     with ignore_invalid_float_warnings():
         sata, satel = get_observer_look(
             sat_lon,

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -135,16 +135,15 @@ class Scene:
         Sensor information is collected from data contained in the Scene
         whether loaded from a reader or generated as a composite with
         :meth:`load` or added manually using ``scn["name"] = data_arr``).
-        If no data is currently contained in the Scene or no sensor
-        information is found in the data metadata, loaded readers will be
-        consulted for sensor information.
+        Sensor information is also collected from any loaded readers.
+        In some rare cases this may mean that the reader includes sensor
+        information for data that isn't actually loaded or even available.
 
         """
-        sensor_names = self._contained_sensor_names()
-        if not sensor_names:
-            sensor_names = set([sensor for reader_instance in self._readers.values()
-                                for sensor in reader_instance.sensor_names])
-        return sensor_names
+        contained_sensor_names = self._contained_sensor_names()
+        reader_sensor_names = set([sensor for reader_instance in self._readers.values()
+                                   for sensor in reader_instance.sensor_names])
+        return contained_sensor_names | reader_sensor_names
 
     def _contained_sensor_names(self) -> set[str]:
         sensor_names = set()

--- a/satpy/tests/etc/readers/fake4.yaml
+++ b/satpy/tests/etc/readers/fake4.yaml
@@ -19,11 +19,13 @@ datasets:
     resolution: 1000
     wavelength: [0.1, 0.2, 0.3]
     file_type: fake_file4
+    coordinates: [lons, lats]
   ds4_b:
     name: ds4_b
-    resolution: 1000
+    resolution: 250
     wavelength: [0.4, 0.5, 0.6]
     file_type: fake_file4
+    coordinates: [lons, lats]
 file_types:
   fake_file4:
     file_reader: !!python/name:satpy.tests.utils.FakeFileHandler

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -98,6 +98,41 @@ class TestScene:
             assert scene.start_time == FAKE_FILEHANDLER_START
             assert scene.end_time == FAKE_FILEHANDLER_END
 
+    @pytest.mark.parametrize(
+        ("reader", "filenames", "exp_sensors"),
+        [
+            ("fake1", ["fake1_1.txt"], {"fake_sensor"}),
+            (None, {"fake1": ["fake1_1.txt"], "fake2_1ds": ["fake2_1ds_1.txt"]}, {"fake_sensor", "fake_sensor2"}),
+        ]
+    )
+    def test_sensor_names_readers(self, reader, filenames, exp_sensors):
+        """Test that Scene sensor_names handles different cases properly."""
+        scene = Scene(reader=reader, filenames=filenames)
+        assert scene.start_time == FAKE_FILEHANDLER_START
+        assert scene.end_time == FAKE_FILEHANDLER_END
+        assert scene.sensor_names == exp_sensors
+
+    @pytest.mark.parametrize(
+        ("include_reader", "added_sensor", "exp_sensors"),
+        [
+            (False, "my_sensor", {"my_sensor"}),
+            (True, "my_sensor", {"my_sensor", "fake_sensor"}),
+            (False, {"my_sensor"}, {"my_sensor"}),
+            (True, {"my_sensor"}, {"my_sensor", "fake_sensor"}),
+            (False, {"my_sensor1", "my_sensor2"}, {"my_sensor1", "my_sensor2"}),
+            (True, {"my_sensor1", "my_sensor2"}, {"my_sensor1", "my_sensor2", "fake_sensor"}),
+        ]
+    )
+    def test_sensor_names_added_datasets(self, include_reader, added_sensor, exp_sensors):
+        """Test that Scene sensor_names handles contained sensors properly."""
+        if include_reader:
+            scene = Scene(reader="fake1", filenames=["fake1_1.txt"])
+        else:
+            scene = Scene()
+
+        scene["my_ds"] = xr.DataArray([], attrs={"sensor": added_sensor})
+        assert scene.sensor_names == exp_sensors
+
     def test_init_alone(self):
         """Test simple initialization."""
         scn = Scene()

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1693,6 +1693,7 @@ class TestSceneResampling:
         scene3["ds1"] = scene1["ds1"]
         scene3["ds4_b"] = scene2["ds4_b"]
         scene3.load(["comp_multi"])
+        assert "comp_multi" in scene3
 
     def test_comps_need_resampling_optional_mod_deps(self):
         """Test that a composite with complex dependencies.


### PR DESCRIPTION
This PR updates Scene.sensor_names so it includes sensor information from both the loaded readers (if any) and the contained data (if any). Previously it would only include the reader information if there were no contained datasets with sensor information. The case I was hoping to avoid (reader's including more sensors than we care about) turns out to be more prohibitive than this new solution.

This should be tested by @gerritholl before being merged just to be sure. If there is another test case that you think is worth adding let me know.

 - [x] Closes #1900 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
