### PR TITLE
Update AHI HSD calibration coefficients

### DIFF
--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -307,7 +307,7 @@ class AHIHSDFileHandler(BaseFileHandler):
     """
 
     def __init__(self, filename, filename_info, filetype_info,
-                 mask_space=True, calib_mode='nominal',
+                 mask_space=True, calib_mode='update',
                  user_calibration=None):
         """Initialize the reader."""
         super(AHIHSDFileHandler, self).__init__(filename, filename_info,
@@ -658,7 +658,7 @@ class AHIHSDFileHandler(BaseFileHandler):
                 user_slope, user_offset = get_user_calibration_factors(self.band_name,
                                                                        self.user_calibration)
 
-        data = (data * dn_gain + dn_offset).clip(0)
+        data = (data * dn_gain + dn_offset)
         # If using radiance correction factors from GSICS or similar, apply here
         if correction_type == 'RAD':
             data = apply_rad_correction(data, user_slope, user_offset)


### PR DESCRIPTION
Currently, the AHI HSD reader uses the default calibration coefficients for VIS channels: `gain_count2rad_conversion` and `offset_count2rad_conversion` in Block 5 of the header.
However, updated calibration coefficients are available in Block 6 of the header: `cali_gain_count2rad_conversion` and `cali_offset_count2rad_conversion`.

This PR switches from using the old coefficients by default to using the new ones by default.

In addition, this PR removes the clipping of negative radiances. In the current `main` branch any radiances below zero are automatically set to zero. This is undesirable as negative radiances are useful for analysing sensor noise, amongst other things, so I remove this unnecessary clipping.
There is also clipping for the reflectance values, but I've left that in for further discussion.