### PR TITLE
Refactor 'ahi_hsd' reader and make overview/overview_raw consistent with ABI

### DIFF
--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -155,13 +155,22 @@ composites:
     standard_name: fire_temperature
     name: fire_temperature_39refl
 
-
   overview:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-    - 0.65
-    - 0.85
-    - 10.4
+    - name: B03
+      modifiers: [sunz_corrected]
+    - name: B04
+      modifiers: [sunz_corrected]
+    - name: B13
+    standard_name: overview
+
+  overview_raw:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - B03
+      - B04
+      - B13
     standard_name: overview
 
   natural_color:

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -26,7 +26,7 @@ import warnings
 from contextlib import closing
 from io import BytesIO
 from shutil import which
-from subprocess import PIPE, Popen
+from subprocess import PIPE, Popen  # nosec
 
 import numpy as np
 import pyproj
@@ -104,12 +104,13 @@ def get_geostationary_angle_extent(geos_area):
     return xmax, ymax
 
 
-def get_geostationary_mask(area):
+def get_geostationary_mask(area, chunks=None):
     """Compute a mask of the earth's shape as seen by a geostationary satellite.
 
     Args:
         area (pyresample.geometry.AreaDefinition) : Corresponding area
                                                     definition
+        chunks (int or tuple): Chunk size for the 2D array that is generated.
 
     Returns:
         Boolean mask, True inside the earth's shape, False outside.
@@ -122,7 +123,7 @@ def get_geostationary_mask(area):
     ymax *= h
 
     # Compute projection coordinates at the centre of each pixel
-    x, y = area.get_proj_coords(chunks=CHUNK_SIZE)
+    x, y = area.get_proj_coords(chunks=chunks or CHUNK_SIZE)
 
     # Compute mask of the earth's elliptical shape
     return ((x / xmax) ** 2 + (y / ymax) ** 2) <= 1
@@ -216,7 +217,7 @@ def unzip_file(filename):
                 runner = [pbzip,
                           '-dc',
                           filename]
-            p = Popen(runner, stdout=PIPE, stderr=PIPE)
+            p = Popen(runner, stdout=PIPE, stderr=PIPE)  # nosec
             stdout = BytesIO(p.communicate()[0])
             status = p.returncode
             if status != 0:


### PR DESCRIPTION
This is a mini-PR on the path toward improving the performance of the ahi_hsd/abi_l1b true_color generation as discussed in #1902. This is mostly just cleanup with a small modification to the space masking code to pass the chunk size of the data that the mask will be used on. This is just to avoid future issues where fancy chunking may not match with the `PYTROLL_CHUNK_SIZE`.

I also updated the `overview` composite to add an `overview_raw` so they match what the ABI composites do. I also made the composites based on channel name instead of wavelength.

About pre-commit: bandit complained about the use of PIPE in the utils module, but I'm not sure there is an easy way around that. Mypy also complained about an import in `_compat.py` but I couldn't seem to make it happy (the import only exists in Python 3.8+ and it must be running in Python 3.7). I turned off hooks so I could do the last commit.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
