### PR TITLE
Support `group_attrs` in cf_writer

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -461,6 +461,44 @@ class TestCFWriter(unittest.TestCase):
                 self.assertEqual(f.attrs['bool_'], 'true')
                 self.assertTrue('none' not in f.attrs.keys())
 
+    def test_group_attrs(self):
+        """Check group attributes are set."""
+        from satpy import Scene
+        import xarray as xr
+        scn = Scene()
+        start_time = datetime(2018, 5, 30, 10, 0)
+        end_time = datetime(2018, 5, 30, 10, 15)
+        scn['test-array'] = xr.DataArray([1, 2, 3],
+                                         attrs=dict(start_time=start_time,
+                                                    end_time=end_time))
+        with TempFile() as filename:
+            group_attrs = {'sensor': 'SEVIRI',
+                           'orbit': 99999,
+                           'none': None,
+                           'list': [1, 2, 3],
+                           'set': {1, 2, 3},
+                           'dict': {'a': 1, 'b': 2},
+                           'nested': {'outer': {'inner1': 1, 'inner2': 2}},
+                           'bool': True,
+                           'bool_': np.bool_(True)}
+            scn.save_datasets(filename=filename,
+                              groups={'test-group': ['test-array']},
+                              group_attrs=group_attrs,
+                              flatten_attrs=True,
+                              writer='cf')
+            with xr.open_dataset(filename, group='test-group') as f:
+                self.assertEqual(f.attrs['sensor'], 'SEVIRI')
+                self.assertEqual(f.attrs['orbit'], 99999)
+                np.testing.assert_array_equal(f.attrs['list'], [1, 2, 3])
+                self.assertEqual(f.attrs['set'], '{1, 2, 3}')
+                self.assertEqual(f.attrs['dict_a'], 1)
+                self.assertEqual(f.attrs['dict_b'], 2)
+                self.assertEqual(f.attrs['nested_outer_inner1'], 1)
+                self.assertEqual(f.attrs['nested_outer_inner2'], 2)
+                self.assertEqual(f.attrs['bool'], 'true')
+                self.assertEqual(f.attrs['bool_'], 'true')
+                self.assertTrue('none' not in f.attrs.keys())
+
     def get_test_attrs(self):
         """Create some dataset attributes for testing purpose.
 

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -763,9 +763,10 @@ class CFWriter(Writer):
 
         return datas, start_times, end_times
 
-    def save_datasets(self, datasets, filename=None, groups=None, header_attrs=None, engine=None, epoch=EPOCH,
-                      flatten_attrs=False, exclude_attrs=None, include_lonlats=True, pretty=False,
-                      compression=None, include_orig_name=True, numeric_name_prefix='CHANNEL_', **to_netcdf_kwargs):
+    def save_datasets(self, datasets, filename=None, groups=None, header_attrs=None, group_attrs=None,
+                      engine=None, epoch=EPOCH, flatten_attrs=False, exclude_attrs=None, include_lonlats=True,
+                      pretty=False, compression=None, include_orig_name=True,
+                      numeric_name_prefix='CHANNEL_', **to_netcdf_kwargs):
         """Save the given datasets in one netCDF file.
 
         Note that all datasets (if grouping: in one group) must have the same projection coordinates.
@@ -781,6 +782,8 @@ class CFWriter(Writer):
                 results will not be fully CF compliant!
             header_attrs:
                 Global attributes to be included
+            group_attrs:
+                Group attributes to be included
             engine (str):
                 Module to be used for writing netCDF files. Follows xarray's
                 :meth:`~xarray.Dataset.to_netcdf` engine choices with a
@@ -850,6 +853,11 @@ class CFWriter(Writer):
             else:
                 grp_str = ' of group {}'.format(group_name) if group_name is not None else ''
                 logger.warning('No time dimension in datasets{}, skipping time bounds creation.'.format(grp_str))
+
+            if group_attrs is not None:
+                if flatten_attrs:
+                    group_attrs = flatten_dict(group_attrs)
+                dataset.attrs = encode_attrs_nc(group_attrs)
 
             encoding, other_to_netcdf_kwargs = update_encoding(dataset, to_netcdf_kwargs, numeric_name_prefix)
             res = dataset.to_netcdf(filename, engine=engine, group=group_name, mode='a', encoding=encoding,


### PR DESCRIPTION

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

Sometimes when we save datasets to NetCDF as groups, it will be useful to add the group attributes. In this PR, I add the option by passing `group_attrs`. It works as same as `header_attrs`.

Here's an example:
```
from satpy import Scene
from glob import glob

tropomi_dir = './'
scn = Scene(glob(tropomi_dir+'S5P_OFFL_L2__NO2____20190630T0901*.nc'), reader='tropomi_l2')
vnames = ['nitrogendioxide_tropospheric_column']
scn.load(vnames)

header_attrs = {'description': 'Global sttrs'}
group_attrs = {'description': 'Group sttrs of data'}

scn.save_datasets(filename='test_cf_group.nc',
                    datasets=vnames,
                    groups={'S5P': vnames},
                    compute=True,
                    header_attrs=header_attrs,
                    group_attrs=group_attrs,
                    writer='cf',
                    engine='netcdf4',
                    )
```

Output of `ncdump -h `:
```
netcdf test_cf_group {

// global attributes:
		:description = "Global sttrs" ;
		:history = "Created by pytroll/satpy on 2021-12-02 09:54:54.089499" ;

group: S5P {
  dimensions:
  	time = 1 ;
  	y = 3245 ;
  	x = 450 ;
  	bnds_1d = 2 ;
  variables:
  	int64 time(time) ;
  		time:bounds = "time_bnds" ;
  		time:standard_name = "time" ;
  		time:units = "days since 2019-06-30" ;
  		time:calendar = "proleptic_gregorian" ;
  	float latitude(y, x) ;
  		latitude:_FillValue = NaNf ;
  		latitude:name = "latitude" ;
  		latitude:standard_name = "latitude" ;
  		latitude:units = "degrees_north" ;
  	float longitude(y, x) ;
  		longitude:_FillValue = NaNf ;
  		longitude:name = "longitude" ;
  		longitude:standard_name = "longitude" ;
  		longitude:units = "degrees_east" ;
  	float nitrogendioxide_tropospheric_column(time, y, x) ;
  		nitrogendioxide_tropospheric_column:_FillValue = NaNf ;
  		nitrogendioxide_tropospheric_column:ancillary_variables = "nitrogendioxide_tropospheric_column_precision air_mass_factor_troposphere air_mass_factor_total averaging_kernel" ;
  		nitrogendioxide_tropospheric_column:end_time = "2019-06-30 10:43:01" ;
  		nitrogendioxide_tropospheric_column:file_key = "PRODUCT/nitrogendioxide_tropospheric_column" ;
  		nitrogendioxide_tropospheric_column:file_type = "tropomi_l2" ;
  		nitrogendioxide_tropospheric_column:long_name = "Tropospheric vertical column of nitrogen dioxide" ;
  		nitrogendioxide_tropospheric_column:modifiers = "" ;
  		nitrogendioxide_tropospheric_column:multiplication_factor_to_convert_to_molecules_percm2 = 6.02214e+19f ;
  		nitrogendioxide_tropospheric_column:platform_shortname = "S5P" ;
  		nitrogendioxide_tropospheric_column:sensor = "tropomi" ;
  		nitrogendioxide_tropospheric_column:standard_name = "troposphere_mole_content_of_nitrogen_dioxide" ;
  		nitrogendioxide_tropospheric_column:start_time = "2019-06-30 09:01:31" ;
  		nitrogendioxide_tropospheric_column:units = "mol m-2" ;
  		nitrogendioxide_tropospheric_column:coordinates = "longitude latitude" ;
  	double time_bnds(time, bnds_1d) ;

  // group attributes:
  		:description = "Group sttrs of data" ;
  } // group S5P
}
```