### PR TITLE
Fix radiance units in SEVIRI L1.5 nat/nc and FCI L1c nc readers

### DIFF
--- a/satpy/etc/readers/fci_l1c_nc.yaml
+++ b/satpy/etc/readers/fci_l1c_nc.yaml
@@ -10,9 +10,7 @@ reader:
   sensors: [ fci ]
 
 # Source: MTG FCI L1 Product User Guide [FCIL1PUG]
-# ftp://ftp.eumetsat.int/pub/OPS/out/test-data/Test-data-for-External-Users/MTG/MTG_FCI_L1C_Enhanced_and_Non-Nominal_Test_Data/PDF_MTG_FCI_L1_PUG.pdf
-# and Example Products for Pytroll Workshop Package Description,
-# EUM/MTG/DOC/19/1079228
+# https://www.eumetsat.int/media/45923
 file_types:
   fci_l1c_fdhsi:
     file_reader: !!python/name:satpy.readers.fci_l1c_nc.FCIL1cNCFileHandler

--- a/satpy/etc/readers/fci_l1c_nc.yaml
+++ b/satpy/etc/readers/fci_l1c_nc.yaml
@@ -30,12 +30,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   vis_05:
@@ -47,12 +47,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   vis_06:
@@ -64,12 +64,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   vis_08:
@@ -81,12 +81,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   vis_09:
@@ -98,12 +98,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   nir_13:
@@ -115,12 +115,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   nir_16:
@@ -132,12 +132,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   nir_22:
@@ -149,12 +149,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   ir_38:
@@ -166,12 +166,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   wv_63:
@@ -183,12 +183,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   wv_73:
@@ -200,12 +200,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   ir_87:
@@ -217,12 +217,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   ir_97:
@@ -234,12 +234,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   ir_105:
@@ -251,12 +251,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   ir_123:
@@ -268,12 +268,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   ir_133:
@@ -285,12 +285,12 @@ datasets:
       counts:
         standard_name: counts
         units: "count"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
     file_type: fci_l1c_fdhsi
 
   vis_04_pixel_quality:

--- a/satpy/etc/readers/seviri_l1b_native.yaml
+++ b/satpy/etc/readers/seviri_l1b_native.yaml
@@ -31,8 +31,8 @@ datasets:
         standard_name: toa_bidirectional_reflectance
         units: "%"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -47,8 +47,8 @@ datasets:
         standard_name: toa_bidirectional_reflectance
         units: "%"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -63,8 +63,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -79,8 +79,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -95,8 +95,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -111,8 +111,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -127,8 +127,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -143,8 +143,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -159,8 +159,8 @@ datasets:
         standard_name: toa_bidirectional_reflectance
         units: "%"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -175,8 +175,8 @@ datasets:
         standard_name: toa_bidirectional_reflectance
         units: "%"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -191,8 +191,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: "K"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -207,8 +207,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: "K"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count

--- a/satpy/etc/readers/seviri_l1b_nc.yaml
+++ b/satpy/etc/readers/seviri_l1b_nc.yaml
@@ -23,8 +23,8 @@ datasets:
         standard_name: toa_bidirectional_reflectance
         units: "%"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -40,8 +40,8 @@ datasets:
         standard_name: toa_bidirectional_reflectance
         units: "%"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -57,8 +57,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -74,8 +74,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -91,8 +91,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -108,8 +108,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -125,8 +125,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -142,8 +142,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: K
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -159,8 +159,8 @@ datasets:
         standard_name: toa_bidirectional_reflectance
         units: "%"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -177,8 +177,8 @@ datasets:
         standard_name: toa_bidirectional_reflectance
         units: "%"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -194,8 +194,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: "K"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count
@@ -211,8 +211,8 @@ datasets:
         standard_name: toa_brightness_temperature
         units: "K"
       radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
+        standard_name: toa_outgoing_radiance_per_unit_wavenumber
+        units: mW m-2 sr-1 (cm-1)-1
       counts:
         standard_name: counts
         units: count

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -230,7 +230,6 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
         res = self.calibrate(data, key)
 
         # pre-calibration units no longer apply
-        info.pop("units")
         attrs.pop("units")
 
         # For each channel, the effective_radiance contains in the
@@ -441,7 +440,7 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
         if key['calibration'] == "counts":
             # from package description, this just means not applying add_offset
             # and scale_factor
-            data.attrs["units"] = "1"
+            pass
         elif key['calibration'] in ['brightness_temperature', 'reflectance', 'radiance']:
             data = self.calibrate_counts_to_physical_quantity(data, key)
         else:
@@ -467,7 +466,6 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
 
     def calibrate_counts_to_rad(self, data, key):
         """Calibrate counts to radiances."""
-        radiance_units = data.attrs["units"]
         if key['name'] == 'ir_38':
             data = xr.where(((2 ** 12 - 1 < data) & (data <= 2 ** 13 - 1)),
                             (data * data.attrs.get("warm_scale_factor", 1) +
@@ -478,8 +476,6 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
         else:
             data = (data * data.attrs.get("scale_factor", 1) +
                     data.attrs.get("add_offset", 0))
-
-        data.attrs["units"] = radiance_units
 
         return data
 
@@ -512,7 +508,6 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
         denom = a * np.log(1 + (c1 * vc ** 3) / radiance)
 
         res = nom / denom - b / a
-        res.attrs["units"] = "K"
         return res
 
     def calibrate_rad_to_refl(self, radiance, key):
@@ -531,5 +526,4 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
         sun_earth_distance = np.mean(self["state/celestial/earth_sun_distance"]) / 149597870.7  # [AU]
 
         res = 100 * radiance * np.pi * sun_earth_distance ** 2 / cesi
-        res.attrs["units"] = "%"
         return res

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -63,6 +63,9 @@ geolocation calculations.
 The reading routine supports channel data in counts, radiances, and (depending
 on channel) brightness temperatures or reflectances. The brightness temperature and reflectance calculation is based on the formulas indicated in
 `PUG`_.
+Radiance datasets are returned in units of radiance per unit wavenumber (mW m-2 sr-1 (cm-1)-1). Radiances can be
+converted to units of radiance per unit wavelength (W m-2 um-1 sr-1) by multiplying with the
+`radiance_unit_conversion_coefficient` dataset attribute.
 
 For each channel, it also supports a number of auxiliary datasets, such as the pixel quality,
 the index map and the related geometric and acquisition parameters: time,
@@ -266,6 +269,9 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
             res.attrs.pop("scale_factor")
             res.attrs.pop("warm_scale_factor")
 
+        if key['calibration'] == 'radiance':
+            res.attrs.update({'radiance_unit_conversion_coefficient':  self[measured +
+                                                                            '/radiance_unit_conversion_coefficient']})
         # remove attributes from original file which don't apply anymore
         res.attrs.pop('long_name')
 

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -269,9 +269,6 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
             res.attrs.pop("scale_factor")
             res.attrs.pop("warm_scale_factor")
 
-        if key['calibration'] == 'radiance':
-            res.attrs.update({'radiance_unit_conversion_coefficient':  self[measured +
-                                                                            '/radiance_unit_conversion_coefficient']})
         # remove attributes from original file which don't apply anymore
         res.attrs.pop('long_name')
 
@@ -479,6 +476,9 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
             data = (data * data.attrs.get("scale_factor", 1) +
                     data.attrs.get("add_offset", 0))
 
+        measured = self.get_channel_measured_group_path(key['name'])
+        data.attrs.update({'radiance_unit_conversion_coefficient': self[measured +
+                                                                        '/radiance_unit_conversion_coefficient']})
         return data
 
     def calibrate_rad_to_bt(self, radiance, key):

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -443,16 +443,12 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
 
     def calibrate(self, data, key):
         """Calibrate data."""
-        if key['calibration'] == "counts":
-            # from package description, this just means not applying add_offset
-            # and scale_factor
-            pass
-        elif key['calibration'] in ['brightness_temperature', 'reflectance', 'radiance']:
+        if key['calibration'] in ['brightness_temperature', 'reflectance', 'radiance']:
             data = self.calibrate_counts_to_physical_quantity(data, key)
-        else:
+        elif key['calibration'] != "counts":
             logger.error(
                 "Received unknown calibration key.  Expected "
-                "'brightness_temperature', 'reflectance' or 'radiance', got "
+                "'brightness_temperature', 'reflectance', 'radiance' or 'counts', got "
                 + key['calibration'] + ".")
 
         return data

--- a/satpy/tests/reader_tests/test_fci_l1c_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_nc.py
@@ -337,7 +337,7 @@ class TestFCIL1cNCReaderGoodData(TestFCIL1cNCReader):
             assert res[ch].shape == (200 * 2, 11136)
             assert res[ch].dtype == np.uint16
             assert res[ch].attrs["calibration"] == "counts"
-            assert res[ch].attrs["units"] == "1"
+            assert res[ch].attrs["units"] == "count"
             if ch == 'ir_38':
                 numpy.testing.assert_array_equal(res[ch][~0], 1)
                 numpy.testing.assert_array_equal(res[ch][0], 5000)
@@ -363,7 +363,7 @@ class TestFCIL1cNCReaderGoodData(TestFCIL1cNCReader):
             assert res[ch].shape == (200, 11136)
             assert res[ch].dtype == np.float64
             assert res[ch].attrs["calibration"] == "radiance"
-            assert res[ch].attrs["units"] == 'mW.m-2.sr-1.(cm-1)-1'
+            assert res[ch].attrs["units"] == 'mW m-2 sr-1 (cm-1)-1'
             if ch == 'ir_38':
                 numpy.testing.assert_array_equal(res[ch][~0], 15)
                 numpy.testing.assert_array_equal(res[ch][0], 9700)

--- a/satpy/tests/reader_tests/test_fci_l1c_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_nc.py
@@ -62,6 +62,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         rad = meas + "/effective_radiance"
         qual = meas + "/pixel_quality"
         index_map = meas + "/index_map"
+        rad_conv_coeff = meas + "/radiance_unit_conversion_coefficient"
         pos = meas + "/{:s}_position_{:s}"
         shp = rad + "/shape"
         x = meas + "/x"
@@ -127,6 +128,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
             (da.arange(nrows * ncols, dtype="uint16").reshape(nrows, ncols) % 6000) + 1,
             dims=("y", "x"))
 
+        data[rad_conv_coeff.format(ch_str)] = xrda(1234.56)
         data[pos.format(ch_str, "start", "row")] = xrda(0)
         data[pos.format(ch_str, "start", "column")] = xrda(0)
         data[pos.format(ch_str, "end", "row")] = xrda(nrows)
@@ -364,6 +366,7 @@ class TestFCIL1cNCReaderGoodData(TestFCIL1cNCReader):
             assert res[ch].dtype == np.float64
             assert res[ch].attrs["calibration"] == "radiance"
             assert res[ch].attrs["units"] == 'mW m-2 sr-1 (cm-1)-1'
+            assert res[ch].attrs["radiance_unit_conversion_coefficient"] == 1234.56
             if ch == 'ir_38':
                 numpy.testing.assert_array_equal(res[ch][~0], 15)
                 numpy.testing.assert_array_equal(res[ch][0], 9700)


### PR DESCRIPTION
This PR fixes wrong radiance unit labels in the yaml files of the readers
- `seviri_l1b_native`
- `seviri_l1b_nc`
- `fci_l1c_nc`

All the readers had units of radiance per unit wavelength, but the files contain radiances per unit wavenumber.

The PR also makes sure that the FCI reader is not overwriting the yaml unit string with the content of the file. It was discussed and decided at the PCW that the unit inside Satpy shall be indicated as "mW m-2 sr-1 (cm-1)-1", rather than "mW.m-2.sr-1.(cm-1)-1" as indicated inside the file, for consistency with other Satpy readers and to better comply with other conventions.

In addition, the `radiance_unit_conversion_coefficient` is added to the attributes of FCI datasets loaded as radiances, to allow the user to convert between radiances.

PS: The tests of all readers indicated above check that the reader outputs the unit labels contained in the yaml, so no new test has been added (only the FCI one has been updated).

*Additional information*: 
Screenshot of the SEVIRI format description confirming that the data is in units of radiance per unit wavenumber:
![image](https://user-images.githubusercontent.com/49722768/144434601-dc8bc3f0-645c-4d30-9162-1cac67648b80.png)

Screenshot of the FCI L1 Product User Guide confirming that the data is in units of radiance per unit wavenumber:
![image](https://user-images.githubusercontent.com/49722768/144440019-05cc8476-d948-4b73-ad30-9b1dfd3ef9e2.png)


 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
