### PR TITLE
Implement adaptive FCI chunks padding and create a new FCIChunksYAMLReader class

### DIFF
--- a/satpy/_compat.py
+++ b/satpy/_compat.py
@@ -18,7 +18,7 @@
 """Backports and compatibility fixes for satpy."""
 
 try:
-    from functools import cached_property
+    from functools import cached_property  # type: ignore
 except ImportError:
     # for python < 3.8
     from functools import lru_cache

--- a/satpy/etc/readers/fci_l1c_nc.yaml
+++ b/satpy/etc/readers/fci_l1c_nc.yaml
@@ -6,7 +6,7 @@ reader:
     Reader for FCI L1c data in NetCDF4 format.
     Used to read Meteosat Third Generation (MTG) Flexible
     Combined Imager (FCI) L1c data.
-  reader: !!python/name:satpy.readers.yaml_reader.GEOSegmentYAMLReader
+  reader: !!python/name:satpy.readers.yaml_reader.FCIChunksYAMLReader
   sensors: [ fci ]
 
 # Source: MTG FCI L1 Product User Guide [FCIL1PUG]

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -173,6 +173,18 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
         logger.debug('Start: {}'.format(self.start_time))
         logger.debug('End: {}'.format(self.end_time))
 
+        # store position information of chunk
+        self.chunk_position_info = {
+            '1km': {'start_position_row': self['data/vis_04/measured/start_position_row'].item(),
+                    'end_position_row': self['data/vis_04/measured/end_position_row'].item(),
+                    'chunk_height': self['data/vis_04/measured/end_position_row'].item() -
+                    self['data/vis_04/measured/start_position_row'].item() + 1},
+            '2km': {'start_position_row': self['data/ir_105/measured/start_position_row'].item(),
+                    'end_position_row': self['data/ir_105/measured/end_position_row'].item(),
+                    'chunk_height': self['data/ir_105/measured/end_position_row'].item() -
+                    self['data/ir_105/measured/start_position_row'].item() + 1}
+        }
+
         self._cache = {}
 
     @property

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -1347,6 +1347,8 @@ class FCIChunksYAMLReader(GEOSegmentYAMLReader):
     FCI L1c chunking configuration. Since the size of the FCI L1c chunks is configurable by the data producer,
     this YAMLReader computes the sizes of the padded chunks using the information available in the files, so that
     gaps of any size can be filled as needed.
+
+    For more information on please see the documentation of GEOSegmentYAMLReader.
     """
 
     def create_filehandlers(self, filenames, fh_kwargs=None):

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -1341,7 +1341,13 @@ def _get_empty_segment_with_height(empty_segment, new_height, dim):
 
 
 class FCIChunksYAMLReader(GEOSegmentYAMLReader):
-    """FCIChunksYAMLReader."""
+    """FCIChunksYAMLReader for handling FCI L1c chunk files.
+
+    This YAMLReader ovverrides  parts of the GEOSegmentYAMLReader to account for specific format properties of the
+    FCI L1c chunking configuration. Since the size of the FCI L1c chunks is configurable by the data producer,
+    this YAMLReader computes the sizes of the padded chunks using the information available in the files, so that
+    gaps of any size can be filled as needed.
+    """
 
     def create_filehandlers(self, filenames, fh_kwargs=None):
         """Create file handler objects and determine expected segments for each."""

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -1186,7 +1186,7 @@ class GEOSegmentYAMLReader(GEOFlippableFileYAMLReader):
         for i, sli in enumerate(slice_list):
             if sli is None:
                 if padding_fci_scene:
-                    segment_height = chunk_heights_FCI[FCI_WIDTH_TO_GRID_TYPE[empty_segment.shape[1]]][counter + 1]
+                    segment_height = chunk_heights_FCI[FCI_WIDTH_TO_GRID_TYPE[empty_segment.shape[1]]][i]
                     slice_list[i] = _get_empty_segment_with_height(empty_segment,
                                                                    segment_height,
                                                                    dim=dim)
@@ -1195,7 +1195,7 @@ class GEOSegmentYAMLReader(GEOFlippableFileYAMLReader):
 
         while expected_segments > counter:
             if padding_fci_scene:
-                segment_height = chunk_heights_FCI[FCI_WIDTH_TO_GRID_TYPE[empty_segment.shape[1]]][counter + 1]
+                segment_height = chunk_heights_FCI[FCI_WIDTH_TO_GRID_TYPE[empty_segment.shape[1]]][counter]
                 slice_list.append(_get_empty_segment_with_height(empty_segment,
                                                                  segment_height,
                                                                  dim=dim))
@@ -1439,7 +1439,7 @@ def _compute_optimal_chunk_sizes_for_FCI(file_handlers, grid_type, expected_size
                 chunk_end_rows[group[n]] = chunk_start_rows[group[n]] + proposed_sizes_missing_chunks[n]
             chunk_heights[group[n]] = proposed_sizes_missing_chunks[n]
 
-    return chunk_heights
+    return chunk_heights.astype('int')
 
 
 def split_integer_in_most_equal_parts(x, n):

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -1058,10 +1058,12 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
                          seg2_extent)
         AreaDefinition.assert_called_once_with(*expected_call)
 
+    @patch.object(yr.FileYAMLReader, "__init__", lambda x: None)
     @patch('satpy.readers.yaml_reader.AreaDefinition')
     def test_pad_later_segments_area_for_FCI_padding(self, AreaDefinition):
         """Test _pad_later_segments_area() in the FCI padding case."""
-        from satpy.readers.yaml_reader import _pad_later_segments_area as plsa
+        from satpy.readers.yaml_reader import FCIChunksYAMLReader
+        reader = FCIChunksYAMLReader()
 
         seg1_area = MagicMock()
         seg1_area.crs = 'some_crs'
@@ -1076,12 +1078,20 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         fh_1.filetype_info = filetype_info
         fh_1.filename_info = filename_info
         fh_1.get_area_def = get_area_def
+        fh_1.chunk_position_info = {
+            '1km': {'start_position_row': 11136-278-556,
+                    'end_position_row': 11136-278,
+                    'chunk_height': 556},
+            '2km': {'start_position_row': 140,
+                    'end_position_row': 140+277,
+                    'chunk_height': 278}}
         file_handlers = [fh_1]
+        reader._extract_chunk_location_dicts(file_handlers)
         dataid = 'dataid'
-        res = plsa(file_handlers, dataid)
+        res = reader._pad_later_segments_area(file_handlers, dataid)
         self.assertEqual(len(res), 2)
 
-        # the previous chunk size is 556, which is exactly double the size of the FCI chunk 2 size (278)
+        # The previous chunk size is 556, which is exactly double the size of the FCI chunk 2 size (278)
         # therefore, the new vertical area extent should be half of the previous size (1000-500)/2=250.
         # The new area extent lower-left row is therefore 1000+250=1250
         seg2_extent = (0, 1250, 200, 1000)
@@ -1118,11 +1128,12 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
                          seg1_extent)
         AreaDefinition.assert_called_once_with(*expected_call)
 
+    @patch.object(yr.FileYAMLReader, "__init__", lambda x: None)
     @patch('satpy.readers.yaml_reader.AreaDefinition')
     def test_pad_earlier_segments_area_for_FCI_padding(self, AreaDefinition):
         """Test _pad_earlier_segments_area() for the FCI case."""
-        from satpy.readers.yaml_reader import _pad_earlier_segments_area as pesa
-
+        from satpy.readers.yaml_reader import FCIChunksYAMLReader
+        reader = FCIChunksYAMLReader()
         seg2_area = MagicMock()
         seg2_area.crs = 'some_crs'
         seg2_area.area_extent = [0, 1000, 200, 500]
@@ -1136,14 +1147,25 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         fh_2.filetype_info = filetype_info
         fh_2.filename_info = filename_info
         fh_2.get_area_def = get_area_def
+        fh_2.chunk_position_info = {
+            '1km': {'start_position_row': 101,
+                    'end_position_row': 202,
+                    'chunk_height': 101},
+            '2km': {'start_position_row': 140,
+                    'end_position_row': 140+277,
+                    'chunk_height': 278}
+        }
         file_handlers = [fh_2]
+        reader._extract_chunk_location_dicts(file_handlers)
         dataid = 'dataid'
         area_defs = {2: seg2_area}
-        res = pesa(file_handlers, dataid, area_defs)
+        res = reader._pad_earlier_segments_area(file_handlers, dataid, area_defs)
         self.assertEqual(len(res), 2)
 
-        # the previous chunk size is 278, which is exactly double the size of the FCI chunk 1 size (139)
-        # therefore, the new vertical area extent should be half of the previous size (1000-500)/2=250.
+        # the later vertical chunk (nr. 2) size is 278, which is exactly double the size
+        # of the gap left by the missing first chunk (139, as the second chunk starts at line 140).
+        # Therefore, the new vertical area extent for the first chunk should be
+        # half of the previous size (1000-500)/2=250.
         # The new area extent lower-left row is therefore 500-250=250
         seg1_extent = (0, 500, 200, 250)
         expected_call = ('fill', 'fill', 'fill', 'some_crs', 5568, 139,

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -1139,6 +1139,7 @@ class TestFCIChunksYAMLReader(unittest.TestCase):
     @patch('satpy.readers.yaml_reader.AreaDefinition')
     def test_pad_earlier_segments_area(self, AreaDefinition):
         """Test _pad_earlier_segments_area() for the FCI case."""
+        # implicitly checks also _extract_chunk_location_dicts and chunk_heights for the first-chunk-missing case
         from satpy.readers.yaml_reader import FCIChunksYAMLReader
         reader = FCIChunksYAMLReader()
         seg2_area = MagicMock()
@@ -1169,7 +1170,7 @@ class TestFCIChunksYAMLReader(unittest.TestCase):
         res = reader._pad_earlier_segments_area(file_handlers, dataid, area_defs)
         self.assertEqual(len(res), 2)
 
-        # the later vertical chunk (nr. 2) size is 278, which is exactly double the size
+        # The later vertical chunk (nr. 2) size is 278, which is exactly double the size
         # of the gap left by the missing first chunk (139, as the second chunk starts at line 140).
         # Therefore, the new vertical area extent for the first chunk should be
         # half of the previous size (1000-500)/2=250.
@@ -1183,6 +1184,7 @@ class TestFCIChunksYAMLReader(unittest.TestCase):
     @patch('satpy.readers.yaml_reader.AreaDefinition')
     def test_pad_later_segments_area(self, AreaDefinition):
         """Test _pad_later_segments_area() in the FCI padding case."""
+        # implicitly checks also _extract_chunk_location_dicts and chunk_heights for the last-chunk-missing case
         from satpy.readers.yaml_reader import FCIChunksYAMLReader
         reader = FCIChunksYAMLReader()
 
@@ -1212,7 +1214,8 @@ class TestFCIChunksYAMLReader(unittest.TestCase):
         res = reader._pad_later_segments_area(file_handlers, dataid)
         self.assertEqual(len(res), 2)
 
-        # The previous chunk size is 556, which is exactly double the size of the FCI chunk 2 size (278)
+        # The previous chunk size is 556, which is exactly double the size of the gap left
+        # by the missing last chunk (278, as the second-to-last chunk ends at line 11136 - 278 )
         # therefore, the new vertical area extent should be half of the previous size (1000-500)/2=250.
         # The new area extent lower-left row is therefore 1000+250=1250
         seg2_extent = (0, 1250, 200, 1000)

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -833,6 +833,25 @@ class TestGEOFlippableFileYAMLReader(unittest.TestCase):
         np.testing.assert_equal(res.coords['time'], np.flip(np.arange(4)))
 
 
+def _create_mocked_fh_and_areadef(aex, ashape, expected_segments, segment, chk_pos_info):
+    seg_area = MagicMock()
+    seg_area.crs = 'some_crs'
+    seg_area.area_extent = aex
+    seg_area.shape = ashape
+    get_area_def = MagicMock()
+    get_area_def.return_value = seg_area
+
+    fh = MagicMock()
+    filetype_info = {'expected_segments': expected_segments}
+    filename_info = {'segment': segment}
+    fh.filetype_info = filetype_info
+    fh.filename_info = filename_info
+    fh.get_area_def = get_area_def
+    fh.chunk_position_info = chk_pos_info
+
+    return fh, seg_area
+
+
 class TestGEOSegmentYAMLReader(unittest.TestCase):
     """Test GEOSegmentYAMLReader."""
 
@@ -1105,23 +1124,6 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         self.assertEqual(slice_list, [None, projectable, None])
         self.assertFalse(failure)
         self.assertTrue(proj is projectable)
-
-
-def _create_mocked_fh_and_areadef(aex, ashape, expected_segments, segment, chk_pos_info):
-    seg_area = MagicMock()
-    seg_area.crs = 'some_crs'
-    seg_area.area_extent = aex
-    seg_area.shape = ashape
-    get_area_def = MagicMock()
-    get_area_def.return_value = seg_area
-    fh = MagicMock()
-    filetype_info = {'expected_segments': expected_segments}
-    filename_info = {'segment': segment}
-    fh.filetype_info = filetype_info
-    fh.filename_info = filename_info
-    fh.get_area_def = get_area_def
-    fh.chunk_position_info = chk_pos_info
-    return fh, seg_area
 
 
 class TestFCIChunksYAMLReader(unittest.TestCase):

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -1026,18 +1026,11 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         from satpy.readers.yaml_reader import GEOSegmentYAMLReader
         reader = GEOSegmentYAMLReader()
 
-        seg1_area = MagicMock()
-        seg1_area.crs = 'some_crs'
-        seg1_area.area_extent = [0, 1000, 200, 500]
-        seg1_area.shape = [200, 500]
-        get_area_def = MagicMock()
-        get_area_def.return_value = seg1_area
-        fh_1 = MagicMock()
-        filetype_info = {'expected_segments': 2}
-        filename_info = {'segment': 1}
-        fh_1.filetype_info = filetype_info
-        fh_1.filename_info = filename_info
-        fh_1.get_area_def = get_area_def
+        expected_segments = 2
+        segment = 1
+        aex = [0, 1000, 200, 500]
+        ashape = [200, 500]
+        fh_1, _ = _create_mocked_fh_and_areadef(aex, ashape, expected_segments, segment, None)
         file_handlers = [fh_1]
         dataid = 'dataid'
         res = reader._pad_later_segments_area(file_handlers, dataid)
@@ -1054,18 +1047,12 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         from satpy.readers.yaml_reader import GEOSegmentYAMLReader
         reader = GEOSegmentYAMLReader()
 
-        seg2_area = MagicMock()
-        seg2_area.crs = 'some_crs'
-        seg2_area.area_extent = [0, 1000, 200, 500]
-        seg2_area.shape = [200, 500]
-        get_area_def = MagicMock()
-        get_area_def.return_value = seg2_area
-        fh_2 = MagicMock()
-        filetype_info = {'expected_segments': 2}
-        filename_info = {'segment': 2}
-        fh_2.filetype_info = filetype_info
-        fh_2.filename_info = filename_info
-        fh_2.get_area_def = get_area_def
+        expected_segments = 2
+        segment = 2
+        aex = [0, 1000, 200, 500]
+        ashape = [200, 500]
+        fh_2, seg2_area = _create_mocked_fh_and_areadef(aex, ashape, expected_segments, segment, None)
+
         file_handlers = [fh_2]
         dataid = 'dataid'
         area_defs = {2: seg2_area}
@@ -1120,6 +1107,23 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         self.assertTrue(proj is projectable)
 
 
+def _create_mocked_fh_and_areadef(aex, ashape, expected_segments, segment, chk_pos_info):
+    seg_area = MagicMock()
+    seg_area.crs = 'some_crs'
+    seg_area.area_extent = aex
+    seg_area.shape = ashape
+    get_area_def = MagicMock()
+    get_area_def.return_value = seg_area
+    fh = MagicMock()
+    filetype_info = {'expected_segments': expected_segments}
+    filename_info = {'segment': segment}
+    fh.filetype_info = filetype_info
+    fh.filename_info = filename_info
+    fh.get_area_def = get_area_def
+    fh.chunk_position_info = chk_pos_info
+    return fh, seg_area
+
+
 class TestFCIChunksYAMLReader(unittest.TestCase):
     """Test FCIChunksYAMLReader."""
 
@@ -1130,20 +1134,8 @@ class TestFCIChunksYAMLReader(unittest.TestCase):
         # implicitly checks also _extract_chunk_location_dicts and chunk_heights for the first-chunk-missing case
         from satpy.readers.yaml_reader import FCIChunksYAMLReader
         reader = FCIChunksYAMLReader()
-        seg2_area = MagicMock()
-        seg2_area.crs = 'some_crs'
-        seg2_area.area_extent = [0, 1000, 200, 500]
-        seg2_area.shape = [278, 5568]
-        get_area_def = MagicMock()
-        get_area_def.return_value = seg2_area
-        fh_2 = MagicMock()
-        filetype_info = {'expected_segments': 2}
-        filename_info = {'segment': 2}
-        fh_2.filetype_info = filetype_info
-        fh_2.filename_info = filename_info
-        fh_2.get_area_def = get_area_def
         # setting to 0 or None values that shouldn't be relevant
-        fh_2.chunk_position_info = {
+        chk_pos_info = {
             '1km': {'start_position_row': 0,
                     'end_position_row': 0,
                     'chunk_height': 0},
@@ -1151,6 +1143,12 @@ class TestFCIChunksYAMLReader(unittest.TestCase):
                     'end_position_row': None,
                     'chunk_height': 278}
         }
+        expected_segments = 2
+        segment = 2
+        aex = [0, 1000, 200, 500]
+        ashape = [278, 5568]
+        fh_2, seg2_area = _create_mocked_fh_and_areadef(aex, ashape, expected_segments, segment, chk_pos_info)
+
         file_handlers = [fh_2]
         reader._extract_chunk_location_dicts(file_handlers)
         dataid = 'dataid'
@@ -1176,26 +1174,19 @@ class TestFCIChunksYAMLReader(unittest.TestCase):
         from satpy.readers.yaml_reader import FCIChunksYAMLReader
         reader = FCIChunksYAMLReader()
 
-        seg1_area = MagicMock()
-        seg1_area.crs = 'some_crs'
-        seg1_area.area_extent = [0, 1000, 200, 500]
-        seg1_area.shape = [556, 11136]
-        get_area_def = MagicMock()
-        get_area_def.return_value = seg1_area
-        fh_1 = MagicMock()
-        filetype_info = {'expected_segments': 2}
-        filename_info = {'segment': 1}
-        fh_1.filetype_info = filetype_info
-        fh_1.filename_info = filename_info
-        fh_1.get_area_def = get_area_def
-        # setting to 0 or None values that shouldn't be relevant
-        fh_1.chunk_position_info = {
+        chk_pos_info = {
             '1km': {'start_position_row': None,
                     'end_position_row': 11136 - 278,
                     'chunk_height': 556},
             '2km': {'start_position_row': 0,
                     'end_position_row': 0,
                     'chunk_height': 0}}
+
+        expected_segments = 2
+        segment = 1
+        aex = [0, 1000, 200, 500]
+        ashape = [556, 11136]
+        fh_1, _ = _create_mocked_fh_and_areadef(aex, ashape, expected_segments, segment, chk_pos_info)
         file_handlers = [fh_1]
         reader._extract_chunk_location_dicts(file_handlers)
         dataid = 'dataid'
@@ -1228,66 +1219,40 @@ class TestFCIChunksYAMLReader(unittest.TestCase):
 
         AreaDefinition.side_effect = side_effect_areadef
 
-        seg1_area = MagicMock()
-        seg1_area.crs = 'some_crs'
-        seg1_area.area_extent = [0, 1000, 200, 500]
-        seg1_area.shape = [100, 11136]
-        get_area_def = MagicMock()
-        get_area_def.return_value = seg1_area
-        fh_1 = MagicMock()
-        filetype_info = {'expected_segments': 8}
-        filename_info = {'segment': 1}
-        fh_1.filetype_info = filetype_info
-        fh_1.filename_info = filename_info
-        fh_1.get_area_def = get_area_def
-        # setting to 0 or None values that shouldn't be relevant
-        fh_1.chunk_position_info = {
+        chk_pos_info = {
             '1km': {'start_position_row': 11136 - 600 - 100 + 1,
                     'end_position_row': 11136 - 600,
                     'chunk_height': 100},
             '2km': {'start_position_row': 0,
                     'end_position_row': 0,
                     'chunk_height': 0}}
+        expected_segments = 8
+        segment = 1
+        aex = [0, 1000, 200, 500]
+        ashape = [100, 11136]
+        fh_1, _ = _create_mocked_fh_and_areadef(aex, ashape, expected_segments, segment, chk_pos_info)
 
-        seg4_area = MagicMock()
-        seg4_area.crs = 'some_crs'
-        seg4_area.area_extent = [0, 1000, 200, 500]
-        seg4_area.shape = [100, 11136]
-        get_area_def = MagicMock()
-        get_area_def.return_value = seg4_area
-        fh_4 = MagicMock()
-        filetype_info = {'expected_segments': 8}
-        filename_info = {'segment': 4}
-        fh_4.filetype_info = filetype_info
-        fh_4.filename_info = filename_info
-        fh_4.get_area_def = get_area_def
-        fh_4.chunk_position_info = {
+        chk_pos_info = {
             '1km': {'start_position_row': 11136 - 300 - 100 + 1,
                     'end_position_row': 11136 - 300,
                     'chunk_height': 100},
             '2km': {'start_position_row': 0,
                     'end_position_row': 0,
                     'chunk_height': 0}}
+        segment = 4
+        fh_4, _ = _create_mocked_fh_and_areadef(aex, ashape, expected_segments, segment, chk_pos_info)
 
-        seg5_area = MagicMock()
-        seg5_area.crs = 'some_crs'
-        seg5_area.area_extent = [0, 1000, 200, 500]
-        seg5_area.shape = [100, 11136]
-        get_area_def_5 = MagicMock()
-        get_area_def_5.return_value = seg5_area
-        fh_5 = MagicMock()
-        filename_info = {'segment': 8}
-        fh_5.filetype_info = filetype_info
-        fh_5.filename_info = filename_info
-        fh_5.get_area_def = get_area_def_5
-        fh_5.chunk_position_info = {
+        chk_pos_info = {
             '1km': {'start_position_row': 11136 - 100 + 1,
                     'end_position_row': None,
                     'chunk_height': 100},
             '2km': {'start_position_row': 0,
                     'end_position_row': 0,
                     'chunk_height': 0}}
-        file_handlers = [fh_1, fh_4, fh_5]
+        segment = 8
+        fh_8, _ = _create_mocked_fh_and_areadef(aex, ashape, expected_segments, segment, chk_pos_info)
+
+        file_handlers = [fh_1, fh_4, fh_8]
 
         reader._extract_chunk_location_dicts(file_handlers)
         dataid = 'dataid'

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -1012,8 +1012,8 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
     @patch.object(yr.FileYAMLReader, "__init__", lambda x: None)
     @patch('satpy.readers.yaml_reader._load_area_def')
     @patch('satpy.readers.yaml_reader._stack_area_defs')
-    @patch('satpy.readers.yaml_reader._pad_earlier_segments_area')
-    @patch('satpy.readers.yaml_reader._pad_later_segments_area')
+    @patch('satpy.readers.yaml_reader.GEOSegmentYAMLReader._pad_earlier_segments_area')
+    @patch('satpy.readers.yaml_reader.GEOSegmentYAMLReader._pad_later_segments_area')
     def test_load_area_def(self, pesa, plsa, sad, parent_load_area_def):
         """Test _load_area_def()."""
         from satpy.readers.yaml_reader import GEOSegmentYAMLReader
@@ -1030,10 +1030,12 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         reader._load_area_def(dataid, file_handlers, pad_data=False)
         parent_load_area_def.assert_called_once_with(dataid, file_handlers)
 
+    @patch.object(yr.FileYAMLReader, "__init__", lambda x: None)
     @patch('satpy.readers.yaml_reader.AreaDefinition')
     def test_pad_later_segments_area(self, AreaDefinition):
         """Test _pad_later_segments_area()."""
-        from satpy.readers.yaml_reader import _pad_later_segments_area as plsa
+        from satpy.readers.yaml_reader import GEOSegmentYAMLReader
+        reader = GEOSegmentYAMLReader()
 
         seg1_area = MagicMock()
         seg1_area.crs = 'some_crs'
@@ -1049,7 +1051,7 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         fh_1.get_area_def = get_area_def
         file_handlers = [fh_1]
         dataid = 'dataid'
-        res = plsa(file_handlers, dataid)
+        res = reader._pad_later_segments_area(file_handlers, dataid)
         self.assertEqual(len(res), 2)
         seg2_extent = (0, 1500, 200, 1000)
         expected_call = ('fill', 'fill', 'fill', 'some_crs', 500, 200,
@@ -1087,10 +1089,12 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
                          seg2_extent)
         AreaDefinition.assert_called_once_with(*expected_call)
 
+    @patch.object(yr.FileYAMLReader, "__init__", lambda x: None)
     @patch('satpy.readers.yaml_reader.AreaDefinition')
     def test_pad_earlier_segments_area(self, AreaDefinition):
         """Test _pad_earlier_segments_area()."""
-        from satpy.readers.yaml_reader import _pad_earlier_segments_area as pesa
+        from satpy.readers.yaml_reader import GEOSegmentYAMLReader
+        reader = GEOSegmentYAMLReader()
 
         seg2_area = MagicMock()
         seg2_area.crs = 'some_crs'
@@ -1107,7 +1111,7 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         file_handlers = [fh_2]
         dataid = 'dataid'
         area_defs = {2: seg2_area}
-        res = pesa(file_handlers, dataid, area_defs)
+        res = reader._pad_earlier_segments_area(file_handlers, dataid, area_defs)
         self.assertEqual(len(res), 2)
         seg1_extent = (0, 500, 200, 0)
         expected_call = ('fill', 'fill', 'fill', 'some_crs', 500, 200,


### PR DESCRIPTION
This PR implements a new YAMLReader to handle FCI chunks. This was needed since a new functionality needed to be implemented: the chunk sizes of the FCI files is configurable by the data producer, hence the gaps to be padded can be of variable sizes. The new YAMLReader computes the chunks to be padded in an adaptive way. 
To keep the GEOSegmentYAMLReader code clean and generic, it was decided to create this new class. 

New tests have been added. The old tests were passing after minor adaptations for the new code structure (e.g. change from function to class method).

Code check with real data:
```python
from satpy.scene import Scene
from glob import glob
from matplotlib import pyplot as plt

path_to_testdata = glob("/path_to_test_data_with_missing_chunks" + "/*BODY*.nc")
scn = Scene(filenames=path_to_testdata, reader=['fci_l1c_nc'])

scn.load(['vis_04'], calibration='radiance', upper_right_corner='NE')

v = scn['vis_04'].values
plt.figure()
plt.imshow(v)
plt.colorbar()
plt.show(block=False)

scn_r = scn.resample('msg_seviri_fes_3km')

v = scn_r['vis_04'].values
plt.figure()
plt.imshow(v)
plt.colorbar()
plt.show(block=False)
```
![image](https://user-images.githubusercontent.com/49722768/144617517-4b390363-f4d2-41bc-a264-e237136af106.png)

Both images look the same, showing that the full-disk padding works and also the geolocation of the padded chunks is correct.


Similarly for SEVIRI HRIT:
```python
path_to_testdata = '/path_to_test_data_with_missing_chunks/' 
scn = Scene(filenames=glob(path_to_testdata + "H*"), reader=['seviri_l1b_hrit'])

scn.load([channel_name], upper_right_corner='NE')

plt.figure()
plt.imshow(scn[channel_name].values)
plt.show(block=False)

scn_r = scn.resample('msg_seviri_fes_1km')

plt.figure()
plt.imshow(scn_r[channel_name].values)
plt.colorbar()
plt.show(block=False)
```
![image](https://user-images.githubusercontent.com/49722768/144619055-f2859ffb-89be-4940-a172-06e79ca39f31.png)

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

PS: On a side, it adds a # type: ignore for the cached_property imports, to avoid issues with the `mypy` git hooks.