### PR TITLE
Bugfixes seviri l2 grib reader

### DIFF
--- a/satpy/etc/areas.yaml
+++ b/satpy/etc/areas.yaml
@@ -114,6 +114,58 @@ msg_seviri_iodc_1km:
     lower_left_xy: [-5571248.412732527, -5566247.740968115]
     upper_right_xy: [5566247.740968115,  5571248.412732527]
 
+# Full disk - segmented products
+msg_seviri_fes_9km:
+  description:
+    MSG SEVIRI Full Earth Scanning service area definition
+    with 9 km resolution
+  projection:
+    proj: geos
+    lon_0: 0.0
+    a: 6378169.0
+    b: 6356583.8
+    h: 35785831.0
+  shape:
+    height: 1237
+    width: 1237
+  area_extent:
+    lower_left_xy: [-5567248.074173927, -5567248.074173927]
+    upper_right_xy: [5567248.074173927, 5567248.074173927]
+
+msg_seviri_rss_9km:
+  description:
+    MSG SEVIRI Rapid Scanning Service area definition
+    with 9 km resolution
+  projection:
+    proj: geos
+    lon_0: 9.5
+    a: 6378169.0
+    b: 6356583.8
+    h: 35785831.0
+  shape:
+    height: 1237
+    width: 1237
+  area_extent:
+    lower_left_xy: [-5567248.074173927, -5567248.074173927]
+    upper_right_xy: [5567248.074173927, 5567248.074173927]
+
+msg_seviri_iodc_9km:
+  description:
+    MSG SEVIRI Indian Ocean Data Coverage service area definition
+    with 9 km resolution
+  projection:
+    proj: geos
+    lon_0: 41.5
+    a: 6378169.0
+    b: 6356583.8
+    h: 35785831.0
+  shape:
+    height: 1237
+    width: 1237
+  area_extent:
+    lower_left_xy: [-5567248.074173927, -5567248.074173927]
+    upper_right_xy: [5567248.074173927, 5567248.074173927]
+
 
 # Regional
 

--- a/satpy/etc/readers/seviri_l2_grib.yaml
+++ b/satpy/etc/readers/seviri_l2_grib.yaml
@@ -4,7 +4,8 @@ reader:
   long_name: MSG SEVIRI L2 (GRIB)
   description: Reader for EUMETSAT MSG SEVIRI L2 files in GRIB format.
   sensors: [seviri]
-  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
+  reader: !!python/name:satpy.readers.yaml_reader.GEOFlippableFileYAMLReader
+
 
 file_types:
   # EUMETSAT MSG SEVIRI L2 Cloud Mask files in GRIB format
@@ -70,7 +71,7 @@ datasets:
 
   cloud_mask:
     name: cloud_mask
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_clm
     parameter_number: 7
     units: "1"
@@ -78,7 +79,7 @@ datasets:
 
   pixel_scene_type:
     name: pixel_scene_type
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_oca
     parameter_number: 8
     units: "1"
@@ -86,7 +87,7 @@ datasets:
 
   measurement_cost:
     name: measurement_cost
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_oca
     parameter_number: 30
     units: "1"
@@ -94,7 +95,7 @@ datasets:
 
   upper_layer_cloud_optical_depth:
     name: upper_layer_cloud_optical_depth
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_oca
     parameter_number: 31
     units: "1"
@@ -102,7 +103,7 @@ datasets:
 
   upper_layer_cloud_top_pressure:
     name: upper_layer_cloud_top_pressure
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_oca
     parameter_number: 32
     units: Pa
@@ -110,7 +111,7 @@ datasets:
 
   upper_layer_cloud_effective_radius:
     name: upper_layer_cloud_effective_radius
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_oca
     parameter_number: 33
     units: m
@@ -118,7 +119,7 @@ datasets:
 
   error_in_upper_layer_cloud_optical_depth:
     name: error_in_upper_layer_cloud_optical_depth
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_oca
     parameter_number: 34
     units: "1"
@@ -126,7 +127,7 @@ datasets:
 
   error_in_upper_layer_cloud_top_pressure:
     name: error_in_upper_layer_cloud_top_pressure
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_oca
     parameter_number: 35
     units: Pa
@@ -134,7 +135,7 @@ datasets:
 
   error_in_upper_layer_cloud_effective_radius:
     name: error_in_upper_layer_cloud_effective_radius
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_oca
     parameter_number: 36
     units: m
@@ -142,7 +143,7 @@ datasets:
 
   lower_layer_cloud_optical_depth:
     name: lower_layer_cloud_optical_depth
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_oca
     parameter_number: 37
     units: "1"
@@ -150,7 +151,7 @@ datasets:
 
   lower_layer_cloud_top_pressure:
     name: lower_layer_cloud_top_pressure
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_oca
     parameter_number: 38
     units: Pa
@@ -158,7 +159,7 @@ datasets:
 
   error_in_lower_layer_cloud_optical_depth:
     name: error_in_lower_layer_cloud_optical_depth
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_oca
     parameter_number: 39
     units: "1"
@@ -166,7 +167,7 @@ datasets:
 
   error_in_lower_layer_cloud_top_pressure:
     name: error_in_lower_layer_cloud_top_pressure
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_oca
     parameter_number: 40
     units: Pa
@@ -174,7 +175,7 @@ datasets:
 
   fire_probability:
     name: fire_probability
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_fir
     parameter_number: 192
     units: "%"
@@ -182,7 +183,7 @@ datasets:
 
   active_fires:
     name: active_fires
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_fir
     parameter_number: 9
     units: "1"
@@ -190,7 +191,7 @@ datasets:
 
   aerosol_optical_thickness_vis06:
     name: aerosol_optical_thickness_vis06
-    resolution: 3000
+    resolution: 9001.209497451
     file_type: grib_seviri_aes
     parameter_number: 20
     units: "um"
@@ -198,7 +199,7 @@ datasets:
 
   aerosol_optical_thickness_vis08:
     name: aerosol_optical_thickness_vis08
-    resolution: 3000
+    resolution: 9001.209497451
     file_type: grib_seviri_aes
     parameter_number: 21
     units: "um"
@@ -206,7 +207,7 @@ datasets:
 
   aerosol_optical_thickness_vis16:
     name: aerosol_optical_thickness_vis16
-    resolution: 3000
+    resolution: 9001.209497451
     file_type: grib_seviri_aes
     parameter_number: 22
     units: "um"
@@ -214,7 +215,7 @@ datasets:
 
   angstroem_coefficient:
     name: angstroem_coefficient
-    resolution: 3000
+    resolution: 9001.209497451
     file_type: grib_seviri_aes
     parameter_number: 23
     units: "1"
@@ -222,7 +223,7 @@ datasets:
 
   aes_quality:
     name: aes_quality
-    resolution: 3000
+    resolution: 9001.209497451
     file_type: grib_seviri_aes
     parameter_number: 192
     units: "1"
@@ -230,7 +231,7 @@ datasets:
 
   cloud_top_height:
     name: cloud_top_height
-    resolution: 3000
+    resolution: 9001.209497451
     file_type: grib_seviri_cth
     parameter_number: 2
     units: Pa
@@ -238,7 +239,7 @@ datasets:
 
   cloud_top_quality:
     name: cloud_top_quality
-    resolution: 3000
+    resolution: 9001.209497451
     file_type: grib_seviri_cth
     parameter_number: 3
     units: "1"
@@ -246,7 +247,7 @@ datasets:
 
   vis_refl_06:
     name: vis_refl_06
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_crm
     parameter_number: 9
     units: "%"
@@ -254,7 +255,7 @@ datasets:
 
   vis_refl_08:
     name: vis_refl_08
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_crm
     parameter_number: 10
     units: "%"
@@ -262,7 +263,7 @@ datasets:
 
   vis_refl_16:
     name: vis_refl_16
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_crm
     parameter_number: 11
     units: "%"
@@ -270,7 +271,7 @@ datasets:
 
   nir_refl_39:
     name: nir_refl_39
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_crm
     parameter_number: 12
     units: "%"
@@ -278,7 +279,7 @@ datasets:
 
   num_accumulations:
     name: num_accumulations
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_crm
     parameter_number: 6
     units: "1"
@@ -286,7 +287,7 @@ datasets:
 
   azimuth_angle:
     name: azimuth_angle
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_crm
     parameter_number: 7
     units: degrees
@@ -294,7 +295,7 @@ datasets:
 
   relative_azimuth_angle:
     name: relative_azimuth_angle
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_crm
     parameter_number: 8
     units: degrees
@@ -302,7 +303,7 @@ datasets:
 
   instantaneous_rain_rate:
     name: instantaneous_rain_rate
-    resolution: 3000
+    resolution: 3000.403165817
     file_type: grib_seviri_mpe
     parameter_number: 1
     units: "kg m-2 s-1"

--- a/satpy/etc/readers/seviri_l2_grib.yaml
+++ b/satpy/etc/readers/seviri_l2_grib.yaml
@@ -289,13 +289,13 @@ datasets:
     units: "1"
     long_name:  num_accumulations
 
-  azimuth_angle:
-    name: azimuth_angle
+  solar_zenith_angle:
+    name: solar_zenith_angle
     resolution: 3000.403165817
     file_type: grib_seviri_crm
     parameter_number: 7
     units: degrees
-    long_name: azimuth_angle
+    long_name: solar_zenith_angle
 
   relative_azimuth_angle:
     name: relative_azimuth_angle

--- a/satpy/etc/readers/seviri_l2_grib.yaml
+++ b/satpy/etc/readers/seviri_l2_grib.yaml
@@ -194,7 +194,7 @@ datasets:
     resolution: 9001.209497451
     file_type: grib_seviri_aes
     parameter_number: 20
-    units: "um"
+    units: "1"
     long_name: aerosol_optical_thickness_vis06
 
   aerosol_optical_thickness_vis08:
@@ -202,7 +202,7 @@ datasets:
     resolution: 9001.209497451
     file_type: grib_seviri_aes
     parameter_number: 21
-    units: "um"
+    units: "1"
     long_name: aerosol_optical_thickness_vis08
 
   aerosol_optical_thickness_vis16:
@@ -210,8 +210,8 @@ datasets:
     resolution: 9001.209497451
     file_type: grib_seviri_aes
     parameter_number: 22
-    units: "um"
-    long_name: aerosol_optical_thickness_vis06
+    units: "1"
+    long_name: aerosol_optical_thickness_vis16
 
   angstroem_coefficient:
     name: angstroem_coefficient
@@ -234,7 +234,7 @@ datasets:
     resolution: 9001.209497451
     file_type: grib_seviri_cth
     parameter_number: 2
-    units: Pa
+    units: m
     long_name: cloud_top_height
 
   cloud_top_quality:
@@ -248,6 +248,7 @@ datasets:
   vis_refl_06:
     name: vis_refl_06
     resolution: 3000.403165817
+    wavelength: [0.56, 0.635, 0.71]
     file_type: grib_seviri_crm
     parameter_number: 9
     units: "%"
@@ -256,6 +257,7 @@ datasets:
   vis_refl_08:
     name: vis_refl_08
     resolution: 3000.403165817
+    wavelength: [0.74, 0.81, 0.88]
     file_type: grib_seviri_crm
     parameter_number: 10
     units: "%"
@@ -264,6 +266,7 @@ datasets:
   vis_refl_16:
     name: vis_refl_16
     resolution: 3000.403165817
+    wavelength: [1.5, 1.64, 1.78]
     file_type: grib_seviri_crm
     parameter_number: 11
     units: "%"
@@ -272,6 +275,7 @@ datasets:
   nir_refl_39:
     name: nir_refl_39
     resolution: 3000.403165817
+    wavelength: [3.48, 3.92, 4.36]
     file_type: grib_seviri_crm
     parameter_number: 12
     units: "%"

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -826,39 +826,32 @@ class OrbitPolynomialFinder:
         return closest_match, distance
 
 
-def calculate_area_extent(area_dict):
+def calculate_area_extent(center_point, north, east, south, west, we_offset, ns_offset, column_step, line_step):
     """Calculate the area extent seen by a geostationary satellite.
 
     Args:
-        area_dict: A dictionary containing the required parameters
-            center_point: Center point for the projection
-            resolution: Pixel resulution in meters
-            north: Northmost row number
-            east: Eastmost column number
-            west: Westmost column number
-            south: Southmost row number
-            [column_offset: Column offset, defaults to 0 if not given]
-            [row_offset: Row offset, defaults to 0 if not given]
+        center_point: Center point for the projection
+        north: Northmost row number
+        east: Eastmost column number
+        west: Westmost column number
+        south: Southmost row number
+        we_offset: Column offset
+        ns_offset: Row offset
+        column_step: Pixel resulution in meters in east-west direction
+        line_step: Pixel resulution in meters in soutth-north direction
     Returns:
         tuple: An area extent for the scene defined by the lower left and
                upper right corners
 
+    # For Earth model 2 and full disk VISIR, (center_point - west - 0.5 + we_offset) must be -1856.5 .
+    # See MSG Level 1.5 Image Data Format Description Figure 7 - Alignment and numbering of the non-HRV pixels.
     """
-    # For Earth model 2 and full disk resolution center point
-    # column and row is (1856.5, 1856.5)
-    # See: MSG Level 1.5 Image Data Format Description, Figure 7
-    cp_c = area_dict['center_point'] + area_dict.get('column_offset', 0)
-    cp_r = area_dict['center_point'] + area_dict.get('row_offset', 0)
+    ll_c = (center_point - east + 0.5 + we_offset) * column_step
+    ll_l = (north - center_point + 0.5 + ns_offset) * line_step
+    ur_c = (center_point - west - 0.5 + we_offset) * column_step
+    ur_l = (south - center_point - 0.5 + ns_offset) * line_step
 
-    # Calculate column and row for lower left and upper right corners.
-    ll_c = (area_dict['west'] - cp_c)
-    ll_r = (area_dict['north'] - cp_r + 1)
-    ur_c = (area_dict['east'] - cp_c - 1)
-    ur_r = (area_dict['south'] - cp_r)
-
-    aex = np.array([ll_c, ll_r, ur_c, ur_r]) * area_dict['resolution']
-
-    return tuple(aex)
+    return (ll_c, ll_l, ur_c, ur_l)
 
 
 def create_coef_dict(coefs_nominal, coefs_gsics, radiance_type, ext_coefs):

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -826,19 +826,21 @@ class OrbitPolynomialFinder:
         return closest_match, distance
 
 
-def calculate_area_extent(center_point, north, east, south, west, we_offset, ns_offset, column_step, line_step):
+# def calculate_area_extent(center_point, north, east, south, west, we_offset, ns_offset, column_step, line_step):
+def calculate_area_extent(area_dict):
     """Calculate the area extent seen by a geostationary satellite.
 
     Args:
-        center_point: Center point for the projection
-        north: Northmost row number
-        east: Eastmost column number
-        west: Westmost column number
-        south: Southmost row number
-        we_offset: Column offset
-        ns_offset: Row offset
-        column_step: Pixel resulution in meters in east-west direction
-        line_step: Pixel resulution in meters in soutth-north direction
+        area_dict: A dictionary containing the required parameters
+            center_point: Center point for the projection
+            north: Northmost row number
+            east: Eastmost column number
+            west: Westmost column number
+            south: Southmost row number
+            column_step: Pixel resulution in meters in east-west direction
+            line_step: Pixel resulution in meters in soutth-north direction
+            [column_offset: Column offset, defaults to 0 if not given]
+            [line_offset: Line offset, defaults to 0 if not given]
     Returns:
         tuple: An area extent for the scene defined by the lower left and
                upper right corners
@@ -846,10 +848,20 @@ def calculate_area_extent(center_point, north, east, south, west, we_offset, ns_
     # For Earth model 2 and full disk VISIR, (center_point - west - 0.5 + we_offset) must be -1856.5 .
     # See MSG Level 1.5 Image Data Format Description Figure 7 - Alignment and numbering of the non-HRV pixels.
     """
-    ll_c = (center_point - east + 0.5 + we_offset) * column_step
-    ll_l = (north - center_point + 0.5 + ns_offset) * line_step
-    ur_c = (center_point - west - 0.5 + we_offset) * column_step
-    ur_l = (south - center_point - 0.5 + ns_offset) * line_step
+    center_point = area_dict['center_point']
+    east = area_dict['east']
+    west = area_dict['west']
+    south = area_dict['south']
+    north = area_dict['north']
+    column_step = area_dict['column_step']
+    line_step = area_dict['line_step']
+    column_offset = area_dict.get('column_offset', 0)
+    line_offset = area_dict.get('line_offset', 0)
+
+    ll_c = (center_point - east + 0.5 + column_offset) * column_step
+    ll_l = (north - center_point + 0.5 + line_offset) * line_step
+    ur_c = (center_point - west - 0.5 + column_offset) * column_step
+    ur_l = (south - center_point - 0.5 + line_offset) * line_step
 
     return (ll_c, ll_l, ur_c, ur_l)
 

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -55,6 +55,7 @@ from satpy.readers.seviri_base import (
     get_satpos,
     pad_data_horizontally,
     pad_data_vertically,
+    calculate_area_extent,
 )
 from satpy.readers.seviri_l1b_native_hdr import (
     DEFAULT_15_SECONDARY_PRODUCT_HEADER,
@@ -135,19 +136,6 @@ class NativeMSGFileHandler(BaseFileHandler):
         """Read the repeat cycle end time from metadata."""
         return self.header['15_DATA_HEADER']['ImageAcquisition'][
             'PlannedAcquisitionTime']['PlannedRepeatCycleEnd']
-
-    @staticmethod
-    def _calculate_area_extent(center_point, north, east, south, west,
-                               we_offset, ns_offset, column_step, line_step):
-        # For Earth model 2 and full disk VISIR, (center_point - west - 0.5 + we_offset) must be -1856.5 .
-        # See MSG Level 1.5 Image Data Format Description Figure 7 - Alignment and numbering of the non-HRV pixels.
-
-        ll_c = (center_point - east + 0.5 + we_offset) * column_step
-        ll_l = (north - center_point + 0.5 + ns_offset) * line_step
-        ur_c = (center_point - west - 0.5 + we_offset) * column_step
-        ur_l = (south - center_point - 0.5 + ns_offset) * line_step
-
-        return (ll_c, ll_l, ur_c, ur_l)
 
     def _get_data_dtype(self):
         """Get the dtype of the file based on the actual available channels."""
@@ -421,8 +409,8 @@ class NativeMSGFileHandler(BaseFileHandler):
 
             nlines = north_bound - south_bound + 1
             ncolumns = west_bound - east_bound + 1
-            aex = self._calculate_area_extent(center_point, north_bound, east_bound, south_bound, west_bound,
-                                              we_offset, ns_offset, column_step, line_step)
+            aex = calculate_area_extent(center_point, north_bound, east_bound, south_bound, west_bound,
+                                        we_offset, ns_offset, column_step, line_step)
 
             aex_data['area_extent'].append(aex)
             aex_data['nlines'].append(nlines)

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -49,13 +49,13 @@ from satpy.readers.seviri_base import (
     OrbitPolynomialFinder,
     SEVIRICalibrationHandler,
     add_scanline_acq_time,
+    calculate_area_extent,
     create_coef_dict,
     dec10216,
     get_cds_time,
     get_satpos,
     pad_data_horizontally,
     pad_data_vertically,
-    calculate_area_extent,
 )
 from satpy.readers.seviri_l1b_native_hdr import (
     DEFAULT_15_SECONDARY_PRODUCT_HEADER,

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -409,8 +409,19 @@ class NativeMSGFileHandler(BaseFileHandler):
 
             nlines = north_bound - south_bound + 1
             ncolumns = west_bound - east_bound + 1
-            aex = calculate_area_extent(center_point, north_bound, east_bound, south_bound, west_bound,
-                                        we_offset, ns_offset, column_step, line_step)
+
+            area_dict = {'center_point': center_point,
+                         'east': east_bound,
+                         'west': west_bound,
+                         'south': south_bound,
+                         'north': north_bound,
+                         'column_step': column_step,
+                         'line_step': line_step,
+                         'column_offset': we_offset,
+                         'line_offset': ns_offset
+                         }
+
+            aex = calculate_area_extent(area_dict)
 
             aex_data['area_extent'].append(aex)
             aex_data['nlines'].append(nlines)

--- a/satpy/readers/seviri_l2_grib.py
+++ b/satpy/readers/seviri_l2_grib.py
@@ -93,7 +93,6 @@ class SeviriL2GribFileHandler(BaseFileHandler):
         xarr = None
         message_found = False
         with open(self.filename, 'rb') as fh:
-            print('Number of messages:', ec.codes_count_in_file(fh))
 
             # Iterate over all messages and fetch data when the correct parameter number is found
             while True:

--- a/satpy/readers/seviri_l2_grib.py
+++ b/satpy/readers/seviri_l2_grib.py
@@ -68,21 +68,10 @@ class SeviriL2GribFileHandler(BaseFileHandler):
 
     def get_area_def(self, dataset_id):
         """Return the area definition for a dataset."""
-        # The area extension depends on the pixel-level resolution and possible segment size of the dataset
-        column_step = dataset_id.resolution
-        line_step = dataset_id.resolution
+        self._area_dict['column_step'] = dataset_id.resolution
+        self._area_dict['line_step'] = dataset_id.resolution
 
-        center_point = self._area_dict['center_point']
-        south = self._area_dict['south']
-        north = self._area_dict['north']
-        east = self._area_dict['east']
-        west = self._area_dict['west']
-
-        we_offset = self._area_dict.get('column_offset', 0)
-        ns_offset = self._area_dict.get('row_offset', 0)
-
-        area_extent = calculate_area_extent(center_point, north, east, south, west,
-                                            we_offset, ns_offset, column_step, line_step)
+        area_extent = calculate_area_extent(self._area_dict)
 
         # Call the get_area_definition function to obtain the area
         area_def = get_area_definition(self._pdict, area_extent)

--- a/satpy/readers/seviri_l2_grib.py
+++ b/satpy/readers/seviri_l2_grib.py
@@ -21,11 +21,10 @@
 References:
     FM 92 GRIB Edition 2
     https://www.wmo.int/pages/prog/www/WMOCodes/Guides/GRIB/GRIB2_062006.pdf
-
     EUMETSAT Product Navigator
     https://navigator.eumetsat.int/
-
 """
+
 import logging
 from datetime import timedelta
 
@@ -44,7 +43,6 @@ except ImportError:
     raise ImportError(
         "Missing eccodes-python and/or eccodes C-library installation. Use conda to install eccodes")
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -56,48 +54,6 @@ class SeviriL2GribFileHandler(BaseFileHandler):
         super().__init__(filename, filename_info, filetype_info)
         # Turn on support for multiple fields in single GRIB messages (required for SEVIRI L2 files)
         ec.codes_grib_multi_support_on()
-        self._read_global_attributes()
-
-    def _read_global_attributes(self):
-        """Read the global product attributes from the first message.
-
-        Read the information about the date and time of the data product,
-        the projection and area definition and the number of messages.
-
-        """
-        with open(self.filename, 'rb') as fh:
-            gid = ec.codes_grib_new_from_file(fh)
-
-            if gid is None:
-                # Could not obtain a valid message id: set attributes to None, number of messages to 0
-                logger.warning("Could not obtain a valid message id in GRIB file")
-
-                self._ssp_lon = None
-                self._nrows = None
-                self._ncols = None
-                self._pdict, self._area_dict = None, None
-
-                return
-
-            # Read SSP and date/time
-            self._ssp_lon = self._get_from_msg(gid, 'longitudeOfSubSatellitePointInDegrees')
-
-            # Read number of points on the x and y axes
-            self._nrows = self._get_from_msg(gid, 'Ny')
-            self._ncols = self._get_from_msg(gid, 'Nx')
-
-            # Creates the projection and area dictionaries
-            self._pdict, self._area_dict = self._get_proj_area(gid)
-
-            # Determine the number of messages in the product by iterating until an invalid id is obtained
-            i = 1
-            ec.codes_release(gid)
-            while True:
-                gid = ec.codes_grib_new_from_file(fh)
-                if gid is None:
-                    break
-                ec.codes_release(gid)
-                i = i+1
 
     @property
     def start_time(self):
@@ -122,54 +78,80 @@ class SeviriL2GribFileHandler(BaseFileHandler):
         return area_def
 
     def get_dataset(self, dataset_id, dataset_info):
-        """Get dataset using the parameter_number key in dataset_info."""
+        """Get dataset using the parameter_number key in dataset_info.
+
+        In a previous version of the reader, the attributes (nrows, ncols, ssp_lon) and projection information
+        (pdict and area_dict) were computed while initializing the file handler. Also the code would break out from
+        the While-loop below as soon as the correct parameter_number was found. This has now been revised becasue the
+        reader would sometimes give corrupt information about the number of messages in the file and the dataset
+        dimensions within a given message if the file was only partly read (not looping over all messages) in an earlier
+        instance.
+        """
         logger.debug('Reading in file to get dataset with parameter number %d.',
                      dataset_info['parameter_number'])
 
         xarr = None
-
+        message_found = False
         with open(self.filename, 'rb') as fh:
-            # Iterate until a message containing the correct parameter number is found
+            print('Number of messages:', ec.codes_count_in_file(fh))
+
+            # Iterate over all messages and fetch data when the correct parameter number is found
             while True:
                 gid = ec.codes_grib_new_from_file(fh)
 
                 if gid is None:
-                    # Could not obtain a valid message ID, break out of the loop
-                    logger.warning("Could not find parameter_number %d in GRIB file, no valid Dataset created",
-                                   dataset_info['parameter_number'])
+                    if not message_found:
+                        # Could not obtain a valid message ID from the grib file
+                        logger.warning("Could not find parameter_number %d in GRIB file, no valid Dataset created",
+                                       dataset_info['parameter_number'])
                     break
 
                 # Check if the parameter number in the GRIB message corresponds to the required key
                 parameter_number = self._get_from_msg(gid, 'parameterNumber')
 
-                if parameter_number != dataset_info['parameter_number']:
-                    # The parameter number is not the correct one, skip to next message
+                if parameter_number == dataset_info['parameter_number']:
+
+                    self._read_attributes(gid)
+
+                    # Read the missing value
+                    missing_value = self._get_from_msg(gid, 'missingValue')
+
+                    # Retrieve values and metadata from the GRIB message, masking the values equal to missing_value
+                    xarr = self._get_xarray_from_msg(gid)
+
+                    xarr.data = da.where(xarr.data == missing_value, np.nan, xarr.data)
+
                     ec.codes_release(gid)
-                    continue
 
-                # Read the missing value
-                missing_value = self._get_from_msg(gid, 'missingValue')
+                    # Combine all metadata into the dataset attributes and break out of the loop
+                    xarr.attrs.update(dataset_info)
+                    xarr.attrs.update(self._get_attributes())
 
-                # Retrieve values and metadata from the GRIB message, masking the values equal to missing_value
-                xarr = self._get_xarray_from_msg(gid)
+                    message_found = True
 
-                xarr.data = da.where(xarr.data == missing_value, np.nan, xarr.data)
-
-                ec.codes_release(gid)
-
-                # Combine all metadata into the dataset attributes and break out of the loop
-                xarr.attrs.update(dataset_info)
-                xarr.attrs.update(self._get_global_attributes())
-                break
+                else:
+                    # The parameter number is not the correct one, release gid and skip to next message
+                    ec.codes_release(gid)
 
         return xarr
+
+    def _read_attributes(self, gid):
+        """Read the parameter attributes from the message and create the projection and area dictionaries."""
+        # Read SSP and date/time
+        self._ssp_lon = self._get_from_msg(gid, 'longitudeOfSubSatellitePointInDegrees')
+
+        # Read number of points on the x and y axes
+        self._nrows = self._get_from_msg(gid, 'Ny')
+        self._ncols = self._get_from_msg(gid, 'Nx')
+
+        # Creates the projection and area dictionaries
+        self._pdict, self._area_dict = self._get_proj_area(gid)
 
     def _get_proj_area(self, gid):
         """Compute the dictionary with the projection and area definition from a GRIB message.
 
         Args:
             gid: The ID of the GRIB message.
-
         Returns:
             tuple: A tuple of two dictionaries for the projection and the area definition.
                 pdict:
@@ -188,14 +170,13 @@ class SeviriL2GribFileHandler(BaseFileHandler):
                     east: coodinate of the east limit
                     west: coodinate of the west limit
                     south: coodinate of the south limit
-
         """
         # Read all projection and area parameters from the message
-        earth_major_axis_in_meters = self._get_from_msg(gid, 'earthMajorAxis') * 1000.0   # [m]
-        earth_minor_axis_in_meters = self._get_from_msg(gid, 'earthMinorAxis') * 1000.0   # [m]
+        earth_major_axis_in_meters = self._get_from_msg(gid, 'earthMajorAxis') * 1000.0  # [m]
+        earth_minor_axis_in_meters = self._get_from_msg(gid, 'earthMinorAxis') * 1000.0  # [m]
         nr_in_radius_of_earth = self._get_from_msg(gid, 'NrInRadiusOfEarth')
         xp_in_grid_lengths = self._get_from_msg(gid, 'XpInGridLengths')
-        h_in_meters = earth_major_axis_in_meters * (nr_in_radius_of_earth - 1.0)   # [m]
+        h_in_meters = earth_major_axis_in_meters * (nr_in_radius_of_earth - 1.0)  # [m]
 
         # Create the dictionary with the projection data
         pdict = {
@@ -226,10 +207,8 @@ class SeviriL2GribFileHandler(BaseFileHandler):
 
         Args:
             gid: The ID of the GRIB message.
-
         Returns:
             DataArray: The array containing the retrieved values.
-
         """
         # Data from GRIB message are read into an Xarray...
         xarr = xr.DataArray(da.from_array(ec.codes_get_values(
@@ -237,15 +216,14 @@ class SeviriL2GribFileHandler(BaseFileHandler):
 
         return xarr
 
-    def _get_global_attributes(self):
-        """Create a dictionary of global attributes to be added to all datasets.
+    def _get_attributes(self):
+        """Create a dictionary of  attributes to be added to the dataset.
 
         Returns:
-            dict: A dictionary of global attributes.
+            dict: A dictionary of parameter attributes.
                 ssp_lon: longitude of subsatellite point
                 sensor: name of sensor
                 platform_name: name of the platform
-
         """
         orbital_parameters = {
             'projection_longitude': self._ssp_lon
@@ -258,16 +236,15 @@ class SeviriL2GribFileHandler(BaseFileHandler):
         }
         return attributes
 
-    def _get_from_msg(self, gid, key):
+    @staticmethod
+    def _get_from_msg(gid, key):
         """Get a value from the GRIB message based on the key, return None if missing.
 
         Args:
             gid: The ID of the GRIB message.
             key: The key of the required attribute.
-
         Returns:
             The retrieved attribute or None if the key is missing.
-
         """
         try:
             attr = ec.codes_get(gid, key)

--- a/satpy/tests/reader_tests/test_seviri_l2_grib.py
+++ b/satpy/tests/reader_tests/test_seviri_l2_grib.py
@@ -170,7 +170,8 @@ class Test_SeviriL2GribFileHandler(unittest.TestCase):
                     with mock.patch('satpy.readers.seviri_l2_grib.get_area_definition', mock.Mock()) as gad:
                         self.reader.get_area_def(mock.Mock(resolution=400.))
                         # Asserts that calculate_area_extent has been called with the correct arguments
-                        expected_args = (500, 1200, 1, 1, 1000, 0, 0, 400, 400)
+                        expected_args = ({'center_point': 500, 'east': 1, 'west': 1000, 'south': 1, 'north': 1200,
+                                         'column_step': 400., 'line_step': 400.},)
                         name, args, kwargs = cae.mock_calls[0]
                         self.assertEqual(args, expected_args)
                         # Asserts that get_area_definition has been called with the correct arguments


### PR DESCRIPTION
This purpose of this PR is to standardize the area definitions of the SEVIRI L2 grib products. During implementation three bugs were identified and resolved:

1. When looping over multiple grib files, information from a previously opened grib file would sometimes be passed on to the next call. This has been resolved by always lopping over all messages in the grib file, such that no additional information can be passed on. An issue for this unexpected behavior has been created in the python-ecCodes github (https://github.com/ecmwf/eccodes-python/issues/58).

2. The computation of the area extent did not provide correct results for segmented products. The implementation used in the seviri_l1b_native reader is now used (the method has been moved to seviri_base to allow both reader to access it).

3. In the aerosol over sea product the Earth's minor axis is provided in the wrong unit (off by a factor 1e8). A work-around has been temporarily implemented that will make sure that all earth axis dimensions are of the correct magnitude. This work-around can be used until the issue has been resolved by EUMETSAT. 

 - [x] Tests added <!-- for all bug fixes or enhancements -->

