### PR TITLE
Fix ABI cloud_phase composite recipe and enhancement

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -363,6 +363,7 @@ composites:
       - name: C04
       - name: C02
       - name: C05
+
   ash:
     description: >
       Ash RGB, for GOESR: NASA, NOAA
@@ -618,12 +619,10 @@ composites:
 
   cloud_phase:
     description: >
-      Cloud Phase RGB, for EUMETSAT
-      Day Cloud Phase RGB, for EUMETSAT (https://www.eumetsat.int/website/home/Images/ImageLibrary/DAT_2861499.html)
-      "When we use the NIR2.3 instead of the VIS0.8 on the green beam, we can devise a new RGB product (let us call it 'Day Cloud Phase RGB') that has similar cloud colours than the Natural Colour RGB, but with improved separation of ice and water clouds."
+      EUMETSAT Cloud Phase RGB product
     references:
       EUMETRAIN Quick Guide: http://www.eumetrain.org/rgb_quick_guides/quick_guides/CloudPhaseRGB.pdf
-      Cloud Phase recipe and typical colours: https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_IL_18_05_13&RevisionSelectionMethod=LatestReleased&Rendition=Web
+      Recipe : http://eumetrain.org/RGBguide/recipes/RGB_recipes.pdf
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
       - name: C05
@@ -632,17 +631,17 @@ composites:
         modifiers: [sunz_corrected]
       - name: C02
         modifiers: [sunz_corrected, rayleigh_corrected]
-    standard_name: natural_color
+    standard_name: cloud_phase
 
   cloud_phase_raw:
     description: >
-      same as cloud_phase
+      same as eum_cloud_phase RGB product, without modifiers
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
       - name: C05
       - name: C06
       - name: C02
-    standard_name: natural_color
+    standard_name: cloud_phase
 
   tropical_airmass:
     description: >

--- a/satpy/etc/enhancements/abi.yaml
+++ b/satpy/etc/enhancements/abi.yaml
@@ -155,3 +155,15 @@ enhancements:
           threshold: 242.0
           min_in: 163.0
           max_in: 330.0
+
+  # EumetSat cloud phase and cloud type RGB recipes
+  # http://eumetrain.org/RGBguide/recipes/RGB_recipes.pdf
+  cloud_phase:
+    standard_name: cloud_phase
+    operations:
+      - name: stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs:
+          stretch: crude
+          min_stretch: [ 0,  0,   0]
+          max_stretch: [50, 50, 100]


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

The current Eumetsat cloud phase composite in the abi.yaml config file seems not correct according to the recipe found on the  [Eumetsat website](http://eumetrain.org/RGBguide/recipes/RGB_recipes.pdf). 
![eum_cloud_phase](https://user-images.githubusercontent.com/42622956/144910135-98114542-7593-4f45-a3a0-66a85460cd99.jpg)
Also the link to the reference documentation in the cloud phase composite description is dead. 
This PR has fixed the recipe in the enhancement and composite config files. Below is a sample of the cloud phase composite.
![cloud_phase_2021340175021-1](https://user-images.githubusercontent.com/42622956/144910096-e1d5e9d0-599a-48dc-ab4d-87dfcbd2e42d.jpg)
For the interpretation of the colours in the image, please refer to this [Cloud Phase RGB Quick Guide](http://www.eumetrain.org/rgb_quick_guides/quick_guides/CloudPhaseRGB.pdf)

For comparison, here is a sample from the current implementation of the cloud phase composite recipe.
![cloud_phase_nogood](https://user-images.githubusercontent.com/42622956/144915326-bba972ff-162b-4fd8-8ec7-a9a00aab53fc.jpg)