### PR TITLE
Update codecov uploader

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,7 +148,7 @@ jobs:
           coverage xml
 
       - name: Upload behaviour test coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           flags: behaviourtests
           file: ./coverage.xml


### PR DESCRIPTION
Switch to version 2 of the codecov uploader since version 1 is deprecated and will be turned off in Feb. 2022
