### PR TITLE
Update seadas_l2 chlor_a enhancement to use new log10 stretch

### DIFF
--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -924,4 +924,9 @@ enhancements:
     operations:
       - name: stretch
         method: !!python/name:satpy.enhancements.stretch
-        kwargs: {stretch: crude, min_stretch: 0, max_stretch: 20.0}
+        kwargs:
+          stretch: log
+          base: "10"
+          factor: 21.0
+          min_stretch: 0.0
+          max_stretch: 20.0


### PR DESCRIPTION
Depends on https://github.com/pytroll/trollimage/pull/97 but since this won't fail until it is actually used this could be merged before that trollimage PR is merged and released.

This enhancement now matches what the Polar2Grid user is expecting (as far as we were told).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
