### PR TITLE
Enable writing to cloud-optimized geotiff (COG)

### DIFF
--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -530,6 +530,10 @@ class TestYAMLFiles(unittest.TestCase):
 class TestComputeWriterResults(unittest.TestCase):
     """Test compute_writer_results()."""
 
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, caplog):
+        self._caplog = caplog
+
     def setUp(self):
         """Create temporary directory to save files to and a mock scene."""
         import tempfile
@@ -581,6 +585,24 @@ class TestComputeWriterResults(unittest.TestCase):
                                      writer='geotiff', compute=False)
         compute_writer_results([res])
         self.assertTrue(os.path.isfile(fname))
+
+    def test_cog(self):
+        """Test writing to cloud-optimized geotiff (COG) file."""
+        from satpy.writers import compute_writer_results
+        import logging
+
+        fname = os.path.join(self.base_dir, 'geotiff.tif')
+        with self._caplog.at_level(logging.DEBUG):
+            res = self.scn.save_datasets(filename=fname,
+                                         datasets=['test'],
+                                         driver='COG',
+                                         tile=True,
+                                         blockxsize=32,
+                                         blockysize=32,
+                                         writer='geotiff', compute=False)
+            compute_writer_results([res])
+        assert "driver: COG" in self._caplog.text
+
 
 # FIXME: This reader needs more information than exist at the moment
 #    def test_mitiff(self):

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -573,7 +573,7 @@ class TestComputeWriterResults(unittest.TestCase):
         self.assertTrue(os.path.isfile(fname))
 
     def test_geotiff(self):
-        """Test writing to mitiff file."""
+        """Test writing to geotiff file."""
         from satpy.writers import compute_writer_results
         fname = os.path.join(self.base_dir, 'geotiff.tif')
         res = self.scn.save_datasets(filename=fname,

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -79,7 +79,8 @@ class GeoTIFFWriter(ImageWriter):
                     "profile",
                     "bigtiff",
                     "pixeltype",
-                    "copy_src_overviews",)
+                    "copy_src_overviews",
+                    "driver",)
 
     def __init__(self, dtype=None, tags=None, **kwargs):
         """Init the writer."""


### PR DESCRIPTION
This PR enables the writing of cloud-optimized geotiffs added to Trollimage in https://github.com/pytroll/trollimage/pull/94

At the bare minimum, this enables the writing using the `'COG'` GDAL driver:
```python
scn.save_datasets(driver='COG')
```

The downside is that this driver seems to be a lot slower. For my test data (Himawari-8/AHI in HRIT format) and images (18 composites) it takes 112 seconds compared to 93 s for `scn.save_datasets(base_dir='/tmp/', tiled=True, blockxsize=512, blockysize=512, overviews=[32, 16, 8, 4, 2])`.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
