### PR TITLE
When no fill value is used, write TransparentPixel=-1 in ninjogeotiff headers

### DIFF
--- a/satpy/tests/writer_tests/test_ninjogeotiff.py
+++ b/satpy/tests/writer_tests/test_ninjogeotiff.py
@@ -366,6 +366,22 @@ def ntg_weird(test_image_weird):
 
 
 @pytest.fixture(scope="module")
+def ntg_no_fill_value(test_image_small_mid_atlantic_L):
+    """Create instance of NinJoTagGenerator class."""
+    from satpy.writers.ninjogeotiff import NinJoTagGenerator
+    return NinJoTagGenerator(
+            test_image_small_mid_atlantic_L,
+            None,
+            "bulgur.tif",
+            ChannelID=900015,
+            DataType="GORN",
+            PhysicUnit="C",
+            PhysicValue="Temperature",
+            SatelliteNameID=6400014,
+            DataSource="dowsing rod")
+
+
+@pytest.fixture(scope="module")
 def ntg_rgba(test_image_rgba_merc):
     """Create NinJoTagGenerator instance with RGBA image."""
     from satpy.writers.ninjogeotiff import NinJoTagGenerator
@@ -509,6 +525,7 @@ def test_write_and_read_file_LA(test_image_latlon, tmp_path):
     np.testing.assert_allclose(float(tgs["ninjo_Gradient"]), 0.30816176470588236)
     np.testing.assert_allclose(float(tgs["ninjo_AxisIntercept"]), -49.603125)
     assert tgs["ninjo_PhysicValue"] == "Reflectance"
+    assert tgs["ninjo_TransparentPixel"] == "-1"  # meaning not set
 
 
 def test_write_and_read_file_P(test_image_small_arctic_P, tmp_path):
@@ -774,13 +791,14 @@ def test_get_ref_lat_2(ntg1, ntg2, ntg3):
     np.testing.assert_allclose(ntg2.get_ref_lat_3(), 0.0)
 
 
-def test_get_transparent_pixel(ntg1, ntg2, ntg3):
+def test_get_transparent_pixel(ntg1, ntg2, ntg3, ntg_no_fill_value):
     """Test getting fill value."""
     tp = ntg1.get_transparent_pixel()
     assert isinstance(tp, int)
     assert tp == 255
-    assert ntg2.get_transparent_pixel() == 0  # when not set ??
+    assert ntg2.get_transparent_pixel() == 0
     assert ntg3.get_transparent_pixel() == 255
+    assert ntg_no_fill_value.get_transparent_pixel() == -1
 
 
 def test_get_xmax(ntg1, ntg2, ntg3):

--- a/satpy/writers/ninjogeotiff.py
+++ b/satpy/writers/ninjogeotiff.py
@@ -432,6 +432,8 @@ class NinJoTagGenerator:
 
     def get_transparent_pixel(self):
         """Get the transparent pixel value, also known as the fill value."""
+        if self.fill_value is None:
+            return -1
         return self.fill_value
 
     def get_xmaximum(self):

--- a/satpy/writers/ninjogeotiff.py
+++ b/satpy/writers/ninjogeotiff.py
@@ -431,7 +431,12 @@ class NinJoTagGenerator:
                 f"{self.dataset.attrs['area'].description}")
 
     def get_transparent_pixel(self):
-        """Get the transparent pixel value, also known as the fill value."""
+        """Get the transparent pixel value, also known as the fill value.
+
+        When the no fill value is defined (value `None`), such as for RGBA or
+        LA images, returns -1, in accordance with the file format
+        specification.
+        """
         if self.fill_value is None:
             return -1
         return self.fill_value


### PR DESCRIPTION
When an image with an alpha layer is written, fill value is not applicable.  In the satpy source code, this is signalled by `fill_value=None`.  However, this value `None` should not be written to the `TransparentPixel` tag.  Instead, the standard calls for `fill_value=-1` when a fill value is not applicable.  This PR makes sure that when an image with an alpha layer is written, the GDALMetaData tag `TransparentPixel` will be written with the value of `-1` by the ninjogeotiff writer.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1930 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
