### PR TITLE
Factorize area computation in goes_imager_hrit

### DIFF
--- a/satpy/readers/goes_imager_hrit.py
+++ b/satpy/readers/goes_imager_hrit.py
@@ -30,8 +30,8 @@ from datetime import datetime, timedelta
 import dask.array as da
 import numpy as np
 import xarray as xr
-from pyresample import geometry
 
+from satpy.readers._geos_area import get_area_definition, get_area_extent, get_geos_area_naming
 from satpy.readers.eum_base import recarray2dict, time_cds_short
 from satpy.readers.hrit_base import (
     HRITFileHandler,
@@ -352,6 +352,8 @@ SPACECRAFTS = {
     14: "GOES-14",
     15: "GOES-15"}
 
+SENSOR_NAME = 'goes_imager'
+
 
 class HRITGOESFileHandler(HRITFileHandler):
     """GOES HRIT format reader."""
@@ -385,7 +387,7 @@ class HRITGOESFileHandler(HRITFileHandler):
         new_attrs.update(res.attrs)
         res.attrs = new_attrs
         res.attrs['platform_name'] = self.platform_name
-        res.attrs['sensor'] = 'goes_imager'
+        res.attrs['sensor'] = SENSOR_NAME
         res.attrs['orbital_parameters'] = {'projection_longitude': self.mda['projection_parameters']['SSP_longitude'],
                                            'projection_latitude': 0.0,
                                            'projection_altitude': ALTITUDE}
@@ -442,45 +444,40 @@ class HRITGOESFileHandler(HRITFileHandler):
         res.attrs['units'] = units.get(unit, unit)
         return res
 
-    def get_area_def(self, dsid):
+    def get_area_def(self, dataset_id):
         """Get the area definition of the band."""
-        cfac = np.int32(self.mda['cfac'])
-        lfac = np.int32(self.mda['lfac'])
-        coff = np.float32(self.mda['coff'])
-        loff = np.float32(self.mda['loff'])
-
-        a = EQUATOR_RADIUS
-        b = POLE_RADIUS
-        h = ALTITUDE
-
-        lon_0 = self.prologue['SubSatLongitude']
-
-        nlines = int(self.mda['number_of_lines'])
-        ncols = int(self.mda['number_of_columns'])
-
-        loff = nlines - loff
-
-        area_extent = self.get_area_extent((nlines, ncols),
-                                           (loff, coff),
-                                           (lfac, cfac),
-                                           h)
-
-        proj_dict = {'a': float(a),
-                     'b': float(b),
-                     'lon_0': float(lon_0),
-                     'h': float(h),
-                     'proj': 'geos',
-                     'units': 'm'}
-
-        area = geometry.AreaDefinition(
-            'some_area_name',
-            "On-the-fly area",
-            'geosmsg',
-            proj_dict,
-            ncols,
-            nlines,
-            area_extent)
-
+        proj_dict = self._get_proj_dict(dataset_id)
+        area_extent = get_area_extent(proj_dict)
+        area = get_area_definition(proj_dict, area_extent)
         self.area = area
-
         return area
+
+    def _get_proj_dict(self, dataset_id):
+        loff = np.float32(self.mda['loff'])
+        nlines = np.int32(self.mda['number_of_lines'])
+        loff = nlines - loff
+        name_dict = get_geos_area_naming({
+            'platform_name': self.platform_name,
+            'instrument_name': SENSOR_NAME,
+            'service_name': 'FD',
+            'service_desc': 'Full Disk',
+            'resolution': dataset_id['resolution']
+        })
+        return {
+            'a': EQUATOR_RADIUS,
+            'b': POLE_RADIUS,
+            'ssp_lon': float(self.prologue['SubSatLongitude']),
+            'h': ALTITUDE,
+            'proj': 'geos',
+            'units': 'm',
+            'a_name': name_dict['area_id'],
+            'a_desc': name_dict['description'],
+            'p_id': '',
+            'nlines': nlines,
+            'ncols': np.int32(self.mda['number_of_columns']),
+            'cfac': np.int32(self.mda['cfac']),
+            'lfac': np.int32(self.mda['lfac']),
+            'coff': np.float32(self.mda['coff']),
+            'loff': loff,
+            'scandir': 'N2S'
+        }

--- a/satpy/readers/goes_imager_hrit.py
+++ b/satpy/readers/goes_imager_hrit.py
@@ -459,6 +459,7 @@ class HRITGOESFileHandler(HRITFileHandler):
         name_dict = get_geos_area_naming({
             'platform_name': self.platform_name,
             'instrument_name': SENSOR_NAME,
+            # Partial scans are padded to full disk
             'service_name': 'FD',
             'service_desc': 'Full Disk',
             'resolution': dataset_id['resolution']

--- a/satpy/tests/reader_tests/test_goes_imager_hrit.py
+++ b/satpy/tests/reader_tests/test_goes_imager_hrit.py
@@ -166,3 +166,17 @@ class TestHRITGOESFileHandler(unittest.TestCase):
                              {'projection_longitude': self.reader.mda['projection_parameters']['SSP_longitude'],
                               'projection_latitude': 0.0,
                               'projection_altitude': ALTITUDE})
+
+    def test_get_area_def(self):
+        """Test getting the area definition."""
+        self.reader.mda.update({
+            'cfac': 10216334,
+            'lfac': 10216334,
+            'coff': 1408.0,
+            'loff': 944.0,
+            'number_of_lines': 464,
+            'number_of_columns': 2816
+        })
+        dsid = make_dataid(name="CH1", calibration='reflectance', resolution=3000)
+        area = self.reader.get_area_def(dsid)
+        assert area.area_extent == (-5639254.900260435, 1925159.4881528523, 5643261.475678028, 3784210.48191544)

--- a/satpy/tests/reader_tests/test_goes_imager_hrit.py
+++ b/satpy/tests/reader_tests/test_goes_imager_hrit.py
@@ -22,10 +22,13 @@ import unittest
 from unittest import mock
 
 import numpy as np
+from pyresample.utils import proj4_radius_parameters
 from xarray import DataArray
 
 from satpy.readers.goes_imager_hrit import (
     ALTITUDE,
+    EQUATOR_RADIUS,
+    POLE_RADIUS,
     HRITGOESFileHandler,
     HRITGOESPrologueFileHandler,
     make_gvar_float,
@@ -177,6 +180,20 @@ class TestHRITGOESFileHandler(unittest.TestCase):
             'number_of_lines': 464,
             'number_of_columns': 2816
         })
-        dsid = make_dataid(name="CH1", calibration='reflectance', resolution=3000)
+        dsid = make_dataid(name="CH1", calibration='reflectance',
+                           resolution=3000)
         area = self.reader.get_area_def(dsid)
-        assert area.area_extent == (-5639254.900260435, 1925159.4881528523, 5643261.475678028, 3784210.48191544)
+
+        a, b = proj4_radius_parameters(area.proj_dict)
+        assert a == EQUATOR_RADIUS
+        assert b == POLE_RADIUS
+        assert area.proj_dict['h'] == ALTITUDE
+        assert area.proj_dict['lon_0'] == 100.1640625
+        assert area.proj_dict['proj'] == 'geos'
+        assert area.proj_dict['units'] == 'm'
+        assert area.width == 2816
+        assert area.height == 464
+        assert area.area_id == 'goes-15_goes_imager_fd_3km'
+        area_extent_exp = (-5639254.900260435, 1925159.4881528523,
+                           5643261.475678028, 3784210.48191544)
+        np.testing.assert_allclose(area.area_extent, area_extent_exp)


### PR DESCRIPTION
Use the helper methods from `satpy.readers._geos_area`, which have been around for a while now. Added the test first to make sure the extents remain unchanged.

 - [X] Closes #1022 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [X] Tests added <!-- for all bug fixes or enhancements -->

