### PR TITLE
Fix SAFE SAR azimuth noise array construction

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -28,6 +28,7 @@ dependencies:
   - rasterio
   - bottleneck
   - rioxarray
+  - defusedxml
   - imageio
   - pyhdf
   - mock

--- a/satpy/readers/sar_c_safe.py
+++ b/satpy/readers/sar_c_safe.py
@@ -35,10 +35,10 @@ References:
 """
 
 import logging
-import xml.etree.ElementTree as ET
 from functools import lru_cache
 from threading import Lock
 
+import defusedxml.ElementTree as ET
 import numpy as np
 import rasterio
 import rioxarray
@@ -281,16 +281,20 @@ class AzimuthNoiseReader:
 
     def _create_dask_slice_from_block_line(self, current_line, chunks):
         """Create a dask slice from the blocks at the current line."""
-        current_blocks = self._find_blocks_covering_line(current_line)
-        current_blocks.sort(key=(lambda x: x.coords['x'][0]))
-
-        next_line = min((arr.coords['y'][-1] for arr in current_blocks))
-        current_y = np.arange(current_line, next_line + 1)
-
-        pieces = [arr.sel(y=current_y) for arr in current_blocks]
+        pieces = self._get_array_pieces_for_current_line(current_line)
         dask_pieces = self._get_padded_dask_pieces(pieces, chunks)
         new_slice = da.hstack(dask_pieces)
+
         return new_slice
+
+    def _get_array_pieces_for_current_line(self, current_line):
+        """Get the array pieces that cover the current line."""
+        current_blocks = self._find_blocks_covering_line(current_line)
+        current_blocks.sort(key=(lambda x: x.coords['x'][0]))
+        next_line = self._get_next_start_line(current_blocks, current_line)
+        current_y = np.arange(current_line, next_line)
+        pieces = [arr.sel(y=current_y) for arr in current_blocks]
+        return pieces
 
     def _find_blocks_covering_line(self, current_line):
         """Find the blocks covering a given line."""
@@ -300,11 +304,36 @@ class AzimuthNoiseReader:
                 current_blocks.append(block)
         return current_blocks
 
+    def _get_next_start_line(self, current_blocks, current_line):
+        next_line = min((arr.coords['y'][-1] for arr in current_blocks)) + 1
+        blocks_starting_soon = [block for block in self.blocks if current_line < block.coords["y"][0] < next_line]
+        if blocks_starting_soon:
+            next_start_line = min((arr.coords["y"][0] for arr in blocks_starting_soon))
+            next_line = min(next_line, next_start_line)
+        return next_line
+
     def _get_padded_dask_pieces(self, pieces, chunks):
         """Get the padded pieces of a slice."""
-        dask_pieces = [piece.data for piece in pieces]
+        pieces = sorted(pieces, key=(lambda x: x.coords['x'][0]))
+        dask_pieces = self._get_full_dask_pieces(pieces, chunks)
         self._pad_dask_pieces_before(pieces, dask_pieces, chunks)
         self._pad_dask_pieces_after(pieces, dask_pieces, chunks)
+        return dask_pieces
+
+    @staticmethod
+    def _get_full_dask_pieces(pieces, chunks):
+        """Get the dask pieces without wholes."""
+        dask_pieces = []
+        for i, piece in enumerate(pieces[:-1]):
+            dask_pieces.append(piece.data)
+            previous_x_end = piece.coords['x'][-1]
+            next_x_start = pieces[i + 1].coords['x'][0]
+            if previous_x_end != next_x_start - 1:
+                missing_x = np.arange(previous_x_end, next_x_start - 1)
+                missing_y = piece.coords['y']
+                new_piece = da.full((len(missing_y), len(missing_x)), np.nan, chunks=chunks)
+                dask_pieces.append(new_piece)
+        dask_pieces.append(pieces[-1].data)
         return dask_pieces
 
     @staticmethod

--- a/satpy/tests/reader_tests/test_sar_c_safe.py
+++ b/satpy/tests/reader_tests/test_sar_c_safe.py
@@ -423,6 +423,142 @@ noise_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
 </noise>
 """
 
+noise_xml_with_holes = b"""<?xml version="1.0" encoding="UTF-8"?>
+<noise>
+  <noiseRangeVectorList count="3">
+    <noiseRangeVector>
+      <azimuthTime>2020-03-15T05:04:28.137817</azimuthTime>
+      <line>0</line>
+      <pixel count="6">0 2 4 6 8 9</pixel>
+      <noiseRangeLut count="6">0.00000e+00 2.00000e+00 4.00000e+00 6.00000e+00 8.00000e+00 9.00000e+00</noiseRangeLut>
+    </noiseRangeVector>
+    <noiseRangeVector>
+      <azimuthTime>2020-03-15T05:04:28.137817</azimuthTime>
+      <line>5</line>
+      <pixel count="6">0 2 4 7 8 9</pixel>
+      <noiseRangeLut count="6">0.00000e+00 2.00000e+00 4.00000e+00 7.00000e+00 8.00000e+00 9.00000e+00</noiseRangeLut>
+    </noiseRangeVector>
+    <noiseRangeVector>
+      <azimuthTime>2020-03-15T05:04:28.137817</azimuthTime>
+      <line>9</line>
+      <pixel count="6">0 2 5 7 8 9</pixel>
+      <noiseRangeLut count="6">0.00000e+00 2.00000e+00 5.00000e+00 7.00000e+00 8.00000e+00 9.00000e+00</noiseRangeLut>
+    </noiseRangeVector>
+  </noiseRangeVectorList>
+  <noiseAzimuthVectorList count="12">
+    <noiseAzimuthVector>
+      <swath>IW1</swath>
+      <firstAzimuthLine>0</firstAzimuthLine>
+      <firstRangeSample>3</firstRangeSample>
+      <lastAzimuthLine>2</lastAzimuthLine>
+      <lastRangeSample>5</lastRangeSample>
+      <line count="1">0</line>
+      <noiseAzimuthLut count="1">1.000000e+00</noiseAzimuthLut>
+    </noiseAzimuthVector>
+    <noiseAzimuthVector>
+      <swath>IW1</swath>
+      <firstAzimuthLine>1</firstAzimuthLine>
+      <firstRangeSample>0</firstRangeSample>
+      <lastAzimuthLine>5</lastAzimuthLine>
+      <lastRangeSample>1</lastRangeSample>
+      <line count="4">2 4 5</line>
+      <noiseAzimuthLut count="4">2.000000e+00 2.000000e+00 2.000000e+00</noiseAzimuthLut>
+    </noiseAzimuthVector>
+    <noiseAzimuthVector>
+      <swath>IW2</swath>
+      <firstAzimuthLine>2</firstAzimuthLine>
+      <firstRangeSample>8</firstRangeSample>
+      <lastAzimuthLine>4</lastAzimuthLine>
+      <lastRangeSample>9</lastRangeSample>
+      <line count="2">2 4</line>
+      <noiseAzimuthLut count="2">3.000000e+00 3.000000e+00</noiseAzimuthLut>
+    </noiseAzimuthVector>
+    <noiseAzimuthVector>
+      <swath>IW3</swath>
+      <firstAzimuthLine>3</firstAzimuthLine>
+      <firstRangeSample>2</firstRangeSample>
+      <lastAzimuthLine>5</lastAzimuthLine>
+      <lastRangeSample>3</lastRangeSample>
+      <line count="2">3 5</line>
+      <noiseAzimuthLut count="2">4.000000e+00 4.000000e+00</noiseAzimuthLut>
+    </noiseAzimuthVector>
+    <noiseAzimuthVector>
+      <swath>IW2</swath>
+      <firstAzimuthLine>3</firstAzimuthLine>
+      <firstRangeSample>4</firstRangeSample>
+      <lastAzimuthLine>4</lastAzimuthLine>
+      <lastRangeSample>5</lastRangeSample>
+      <line count="2">3 4</line>
+      <noiseAzimuthLut count="2">5.000000e+00 5.000000e+00</noiseAzimuthLut>
+    </noiseAzimuthVector>
+    <noiseAzimuthVector>
+      <swath>IW3</swath>
+      <firstAzimuthLine>4</firstAzimuthLine>
+      <firstRangeSample>6</firstRangeSample>
+      <lastAzimuthLine>4</lastAzimuthLine>
+      <lastRangeSample>7</lastRangeSample>
+      <line count="2">4</line>
+      <noiseAzimuthLut count="2">6.000000e+00</noiseAzimuthLut>
+    </noiseAzimuthVector>
+    <noiseAzimuthVector>
+      <swath>IW2</swath>
+      <firstAzimuthLine>5</firstAzimuthLine>
+      <firstRangeSample>4</firstRangeSample>
+      <lastAzimuthLine>7</lastAzimuthLine>
+      <lastRangeSample>6</lastRangeSample>
+      <line count="1">5 7</line>
+      <noiseAzimuthLut count="1">7.000000e+00 7.000000e+00</noiseAzimuthLut>
+    </noiseAzimuthVector>
+    <noiseAzimuthVector>
+      <swath>IW3</swath>
+      <firstAzimuthLine>5</firstAzimuthLine>
+      <firstRangeSample>7</firstRangeSample>
+      <lastAzimuthLine>7</lastAzimuthLine>
+      <lastRangeSample>9</lastRangeSample>
+      <line count="1">6</line>
+      <noiseAzimuthLut count="1">8.000000e+00</noiseAzimuthLut>
+    </noiseAzimuthVector>
+    <noiseAzimuthVector>
+      <swath>IW2</swath>
+      <firstAzimuthLine>6</firstAzimuthLine>
+      <firstRangeSample>0</firstRangeSample>
+      <lastAzimuthLine>7</lastAzimuthLine>
+      <lastRangeSample>3</lastRangeSample>
+      <line count="2">6 7</line>
+      <noiseAzimuthLut count="2">9.000000e+00 9.000000e+00</noiseAzimuthLut>
+    </noiseAzimuthVector>
+    <noiseAzimuthVector>
+      <swath>IW3</swath>
+      <firstAzimuthLine>8</firstAzimuthLine>
+      <firstRangeSample>0</firstRangeSample>
+      <lastAzimuthLine>9</lastAzimuthLine>
+      <lastRangeSample>0</lastRangeSample>
+      <line count="2">8</line>
+      <noiseAzimuthLut count="2">10.000000e+00</noiseAzimuthLut>
+    </noiseAzimuthVector>
+    <noiseAzimuthVector>
+      <swath>IW2</swath>
+      <firstAzimuthLine>8</firstAzimuthLine>
+      <firstRangeSample>2</firstRangeSample>
+      <lastAzimuthLine>9</lastAzimuthLine>
+      <lastRangeSample>3</lastRangeSample>
+      <line count="1">8 9</line>
+      <noiseAzimuthLut count="1">11.000000e+00 11.000000e+00</noiseAzimuthLut>
+    </noiseAzimuthVector>
+    <noiseAzimuthVector>
+      <swath>IW3</swath>
+      <firstAzimuthLine>8</firstAzimuthLine>
+      <firstRangeSample>4</firstRangeSample>
+      <lastAzimuthLine>8</lastAzimuthLine>
+      <lastRangeSample>5</lastRangeSample>
+      <line count="1">8</line>
+      <noiseAzimuthLut count="1">12.000000e+00</noiseAzimuthLut>
+    </noiseAzimuthVector>
+  </noiseAzimuthVectorList>
+</noise>
+"""
+
+
 calibration_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
 <calibration>
   <adsHeader>
@@ -490,6 +626,8 @@ class TestSAFEXMLNoise(unittest.TestCase):
         filename_info = dict(start_time=None, end_time=None, polarization="vv")
         self.annotation_fh = SAFEXMLAnnotation(BytesIO(annotation_xml), filename_info, mock.MagicMock())
         self.noise_fh = SAFEXMLNoise(BytesIO(noise_xml), filename_info, mock.MagicMock(), self.annotation_fh)
+        self.noise_fh_with_holes = SAFEXMLNoise(BytesIO(noise_xml_with_holes), filename_info, mock.MagicMock(),
+                                                self.annotation_fh)
 
         self.expected_azimuth_noise = np.array([[np.nan, 1, 1, 1, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
                                                 [np.nan, 1, 1, 1, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
@@ -515,10 +653,28 @@ class TestSAFEXMLNoise(unittest.TestCase):
                                               [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
                                               ])
 
+        self.expected_azimuth_noise_with_holes = np.array(
+            [[np.nan, np.nan, np.nan, 1, 1, 1, np.nan, np.nan, np.nan, np.nan],
+             [2, 2, np.nan, 1, 1, 1, np.nan, np.nan, np.nan, np.nan],
+             [2, 2, np.nan, 1, 1, 1, np.nan, np.nan, 3, 3],
+             [2, 2, 4, 4, 5, 5, np.nan, np.nan, 3, 3],
+             [2, 2, 4, 4, 5, 5, 6, 6, 3, 3],
+             [2, 2, 4, 4, 7, 7, 7, 8, 8, 8],
+             [9, 9, 9, 9, 7, 7, 7, 8, 8, 8],
+             [9, 9, 9, 9, 7, 7, 7, 8, 8, 8],
+             [10, np.nan, 11, 11, 12, 12, np.nan, np.nan, np.nan, np.nan],
+             [10, np.nan, 11, 11, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]
+             ])
+
     def test_azimuth_noise_array(self):
         """Test reading the azimuth-noise array."""
         res = self.noise_fh.azimuth_noise_reader.read_azimuth_noise_array()
         np.testing.assert_array_equal(res, self.expected_azimuth_noise)
+
+    def test_azimuth_noise_array_with_holes(self):
+        """Test reading the azimuth-noise array."""
+        res = self.noise_fh_with_holes.azimuth_noise_reader.read_azimuth_noise_array()
+        np.testing.assert_array_equal(res, self.expected_azimuth_noise_with_holes)
 
     def test_range_noise_array(self):
         """Test reading the range-noise array."""

--- a/satpy/tests/reader_tests/test_sar_c_safe.py
+++ b/satpy/tests/reader_tests/test_sar_c_safe.py
@@ -626,8 +626,6 @@ class TestSAFEXMLNoise(unittest.TestCase):
         filename_info = dict(start_time=None, end_time=None, polarization="vv")
         self.annotation_fh = SAFEXMLAnnotation(BytesIO(annotation_xml), filename_info, mock.MagicMock())
         self.noise_fh = SAFEXMLNoise(BytesIO(noise_xml), filename_info, mock.MagicMock(), self.annotation_fh)
-        self.noise_fh_with_holes = SAFEXMLNoise(BytesIO(noise_xml_with_holes), filename_info, mock.MagicMock(),
-                                                self.annotation_fh)
 
         self.expected_azimuth_noise = np.array([[np.nan, 1, 1, 1, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
                                                 [np.nan, 1, 1, 1, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan],
@@ -653,6 +651,8 @@ class TestSAFEXMLNoise(unittest.TestCase):
                                               [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
                                               ])
 
+        self.noise_fh_with_holes = SAFEXMLNoise(BytesIO(noise_xml_with_holes), filename_info, mock.MagicMock(),
+                                                self.annotation_fh)
         self.expected_azimuth_noise_with_holes = np.array(
             [[np.nan, np.nan, np.nan, 1, 1, 1, np.nan, np.nan, np.nan, np.nan],
              [2, 2, np.nan, 1, 1, 1, np.nan, np.nan, np.nan, np.nan],

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.11.0', 'trollsift',
 
 test_requires = ['behave', 'h5py', 'netCDF4', 'pyhdf', 'imageio', 'pylibtiff',
                  'rasterio', 'geoviews', 'trollimage', 'fsspec', 'bottleneck',
-                 'rioxarray', 'pytest', 'pytest-lazy-fixture']
+                 'rioxarray', 'pytest', 'pytest-lazy-fixture', 'defusedxml']
 
 extras_require = {
     # Readers:
@@ -55,7 +55,7 @@ extras_require = {
     'hrit_msg': ['pytroll-schedule'],
     'msi_safe': ['rioxarray', "bottleneck", "python-geotiepoints"],
     'nc_nwcsaf_msg': ['netCDF4 >= 1.1.8'],
-    'sar_c': ['python-geotiepoints >= 1.1.7', 'rasterio', 'rioxarray'],
+    'sar_c': ['python-geotiepoints >= 1.1.7', 'rasterio', 'rioxarray', 'defusedxml'],
     'abi_l1b': ['h5netcdf'],
     'seviri_l1b_hrit': ['pyorbital >= 1.3.1'],
     'seviri_l1b_native': ['pyorbital >= 1.3.1'],


### PR DESCRIPTION
The implementation of the azimuth noise array in the SAR-C SAFE reader was assuming a nicer arangement of data blocks than what can happen in reality.

In this PR, we fix this issue by filling in missing block that are between existing data blocks, so that each horizontal slice of the azimuth noise array has the correct number of columns.

Another thing this PR fixes is the use of the insecure `xml.etree` library by replacing it by `defusedxml` as recommended by bandit. This adds a new dependency for the SAR reader, and also for the satpy tests in general.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
