### PR TITLE
Fix dynamic_dnb composite converting NaNs to 0s

### DIFF
--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -340,7 +340,7 @@ class ERFDNB(CompositeBase):
         else:
             inner_sqrt = (output_dataset - min_val) / (max_val - min_val)
             # clip negative values to 0 before the sqrt
-            inner_sqrt = inner_sqrt.where(inner_sqrt > 0, 0)
+            inner_sqrt.data = np.clip(inner_sqrt.data, 0, None)
             output_dataset.data = np.sqrt(inner_sqrt).data
 
         info = dnb_data.attrs.copy()

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -137,6 +137,7 @@ class TestVIIRSComposites(unittest.TestCase):
                       standard_name='toa_outgoing_radiance_per_'
                                     'unit_wavelength')
         dnb = np.zeros((rows, cols)) + 0.25
+        dnb[2, :cols // 2] = np.nan
         dnb[3, :] += 0.25
         dnb[4:, :] += 0.5
         dnb = da.from_array(dnb, chunks=25)
@@ -168,8 +169,12 @@ class TestVIIRSComposites(unittest.TestCase):
                          'equalized_radiance')
         data = res.compute()
         unique = np.unique(data)
-        np.testing.assert_allclose(unique, [0.00000000e+00, 1.00446703e-01, 1.64116082e-01, 2.09233451e-01,
-                                            1.43916324e+02, 2.03528498e+02, 2.49270516e+02])
+        assert np.isnan(unique).any()
+        nonnan_unique = unique[~np.isnan(unique)]
+        np.testing.assert_allclose(
+            nonnan_unique,
+            [0.00000000e+00, 1.00446703e-01, 1.64116082e-01, 2.09233451e-01,
+             1.43916324e+02, 2.03528498e+02, 2.49270516e+02])
 
     def test_hncc_dnb(self):
         """Test the 'hncc_dnb' compositor."""


### PR DESCRIPTION
Noticed this in a small edge case with Polar2Grid where on the edge of a bad granule where half was all NaNs and the other half was good data, there was a layer of "gray" pixels between. This was caused by resampling blending the valid data with the 0s of the bad data, but the bad data were meant to be NaNs and excluded. This all comes down to handling NaNs properly in the compositor: `data < 0` is not the same as `~(data >= 0)`.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
