### PR TITLE
Fix angle generation not working for StackedAreaDefinitions

### DIFF
--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -33,18 +33,20 @@ from dask import array as da
 from pyorbital.astronomy import cos_zen as pyob_cos_zen
 from pyorbital.astronomy import get_alt_az
 from pyorbital.orbital import get_observer_look
-from pyresample.geometry import AreaDefinition, SwathDefinition
+from pyresample.geometry import AreaDefinition, StackedAreaDefinition, SwathDefinition
 
 import satpy
 from satpy.utils import get_satpos, ignore_invalid_float_warnings
 
-PRGeometry = Union[SwathDefinition, AreaDefinition]
+PRGeometry = Union[SwathDefinition, AreaDefinition, StackedAreaDefinition]
 
 # Arbitrary time used when computing sensor angles that is passed to
 # pyorbital's get_observer_look function.
 # The difference is on the order of 1e-10 at most as time changes so we force
 # it to a single time for easier caching. It is *only* used if caching.
 STATIC_EARTH_INERTIAL_DATETIME = datetime(2000, 1, 1, 12, 0, 0)
+DEFAULT_UNCACHE_TYPES = (SwathDefinition, StackedAreaDefinition, xr.DataArray, da.Array)
+DEFAULT_UNHASH_TYPES = DEFAULT_UNCACHE_TYPES
 
 
 class ZarrCacheHelper:
@@ -100,7 +102,7 @@ class ZarrCacheHelper:
     def __init__(self,
                  func: Callable,
                  cache_config_key: str,
-                 uncacheable_arg_types=(SwathDefinition, xr.DataArray, da.Array),
+                 uncacheable_arg_types=DEFAULT_UNCACHE_TYPES,
                  sanitize_args_func: Callable = None,
                  cache_version: int = 1,
                  ):
@@ -135,7 +137,7 @@ class ZarrCacheHelper:
     def __call__(self, *args, cache_dir: Optional[str] = None) -> Any:
         """Call the decorated function."""
         new_args = self._sanitize_args_func(*args) if self._sanitize_args_func is not None else args
-        arg_hash = _hash_args(*new_args)
+        arg_hash = _hash_args(*new_args, unhashable_types=self._uncacheable_arg_types)
         should_cache, cache_dir = self._get_should_cache_and_cache_dir(new_args, cache_dir)
         zarr_fn = self._zarr_pattern(arg_hash)
         zarr_format = os.path.join(cache_dir, zarr_fn)
@@ -183,7 +185,7 @@ class ZarrCacheHelper:
 
 def cache_to_zarr_if(
         cache_config_key: str,
-        uncacheable_arg_types=(SwathDefinition, xr.DataArray, da.Array),
+        uncacheable_arg_types=DEFAULT_UNCACHE_TYPES,
         sanitize_args_func: Callable = None,
 ) -> Callable:
     """Decorate a function and cache the results as a zarr array on disk.
@@ -205,11 +207,11 @@ def cache_to_zarr_if(
     return _decorator
 
 
-def _hash_args(*args):
+def _hash_args(*args, unhashable_types=DEFAULT_UNHASH_TYPES):
     import json
     hashable_args = []
     for arg in args:
-        if isinstance(arg, (xr.DataArray, da.Array, SwathDefinition)):
+        if isinstance(arg, unhashable_types):
             continue
         if isinstance(arg, AreaDefinition):
             arg = hash(arg)

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -46,7 +46,6 @@ PRGeometry = Union[SwathDefinition, AreaDefinition, StackedAreaDefinition]
 # it to a single time for easier caching. It is *only* used if caching.
 STATIC_EARTH_INERTIAL_DATETIME = datetime(2000, 1, 1, 12, 0, 0)
 DEFAULT_UNCACHE_TYPES = (SwathDefinition, xr.DataArray, da.Array)
-DEFAULT_UNHASH_TYPES = DEFAULT_UNCACHE_TYPES
 HASHABLE_GEOMETRIES = (AreaDefinition, StackedAreaDefinition)
 
 
@@ -208,7 +207,7 @@ def cache_to_zarr_if(
     return _decorator
 
 
-def _hash_args(*args, unhashable_types=DEFAULT_UNHASH_TYPES):
+def _hash_args(*args, unhashable_types=DEFAULT_UNCACHE_TYPES):
     import json
     hashable_args = []
     for arg in args:

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -45,8 +45,9 @@ PRGeometry = Union[SwathDefinition, AreaDefinition, StackedAreaDefinition]
 # The difference is on the order of 1e-10 at most as time changes so we force
 # it to a single time for easier caching. It is *only* used if caching.
 STATIC_EARTH_INERTIAL_DATETIME = datetime(2000, 1, 1, 12, 0, 0)
-DEFAULT_UNCACHE_TYPES = (SwathDefinition, StackedAreaDefinition, xr.DataArray, da.Array)
+DEFAULT_UNCACHE_TYPES = (SwathDefinition, xr.DataArray, da.Array)
 DEFAULT_UNHASH_TYPES = DEFAULT_UNCACHE_TYPES
+HASHABLE_GEOMETRIES = (AreaDefinition, StackedAreaDefinition)
 
 
 class ZarrCacheHelper:
@@ -213,7 +214,7 @@ def _hash_args(*args, unhashable_types=DEFAULT_UNHASH_TYPES):
     for arg in args:
         if isinstance(arg, unhashable_types):
             continue
-        if isinstance(arg, AreaDefinition):
+        if isinstance(arg, HASHABLE_GEOMETRIES):
             arg = hash(arg)
         elif isinstance(arg, datetime):
             arg = arg.isoformat(" ")


### PR DESCRIPTION
The optional caching functionality of the angle generation does not work for geometry types that can't be serialized. This includes StackedAreaDefinitions (apparently) which was not being included in the exclusion list and was causing an error.

```python-traceback
  File "/home/a001673/usr/src/satpy/satpy/modifiers/angles.py", line 220, in _hash_args
    arg_hash.update(json.dumps(tuple(hashable_args)).encode('utf8'))
  File "/home/a001673/mambaforge/envs/satpy-3.10/lib/python3.10/json/__init__.py", line 231, in dumps
    return _default_encoder.encode(obj)
  File "/home/a001673/mambaforge/envs/satpy-3.10/lib/python3.10/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/home/a001673/mambaforge/envs/satpy-3.10/lib/python3.10/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/home/a001673/mambaforge/envs/satpy-3.10/lib/python3.10/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type StackedAreaDefinition is not JSON serializable
```

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
