### PR TITLE
Fix formatting in configuration documentation

### DIFF
--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -106,7 +106,7 @@ Whether or not generated longitude and latitude coordinates should be cached
 to on-disk zarr arrays. Currently this only works in very specific cases.
 Mainly the lon/lats that are generated when computing sensor and solar zenith
 and azimuth angles used in various modifiers and compositors. This caching is
-only done for ``AreaDefinition``-based geolocation, not ``SwathDefinition``s.
+only done for ``AreaDefinition``-based geolocation, not ``SwathDefinition``.
 Arrays are stored in ``cache_dir`` (see above).
 
 When setting this as an environment variable, this should be set with the
@@ -132,7 +132,7 @@ Cache Sensor Angles
 Whether or not generated sensor azimuth and sensor zenith angles should be
 cached to on-disk zarr arrays. These angles are primarily used in certain
 modifiers and compositors. This caching is only done for
-``AreaDefinition``-based geolocation, not ``SwathDefinition``s.
+``AreaDefinition``-based geolocation, not ``SwathDefinition``.
 Arrays are stored in ``cache_dir`` (see above).
 
 This caching requires producing an estimate of the angles to avoid needing to

--- a/satpy/tests/writer_tests/test_awips_tiled.py
+++ b/satpy/tests/writer_tests/test_awips_tiled.py
@@ -19,7 +19,6 @@
 
 import logging
 import os
-import warnings
 from datetime import datetime, timedelta
 from glob import glob
 
@@ -197,12 +196,8 @@ class TestAWIPSTiledWriter:
         input_data_arr = self._get_test_lcc_data(data, area_def)
         input_data_arr.attrs["units"] = "this is a really long units string"
         w = AWIPSTiledWriter(base_dir=self.base_dir, compress=True)
-        with warnings.catch_warnings(record=True) as caught_warnings:
+        with pytest.warns(UserWarning, match=r'.*this is a really long units string.*too long.*'):
             w.save_dataset(input_data_arr, sector_id='TEST', source_name='TESTS')
-        assert len(caught_warnings) == 1
-        warn_msg = caught_warnings[0].message.args[0]
-        assert "too long" in warn_msg
-        assert "this is a really long units string" in warn_msg
 
     @pytest.mark.parametrize(
         ("tile_count", "tile_size"),


### PR DESCRIPTION
Noticed some bad style related to how I put `s` after a double backtick.
