### PR TITLE
Fix broken links in composite references

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -321,7 +321,7 @@ composites:
       appear red. With the increasing intensity and temperature the fires will also be detected
       by the 2.2 μm and 1.6 μm bands resulting very intense fires in white.
     references:
-      Research Article: http://rammb.cira.colostate.edu/training/visit/quick_guides/Fire_Temperature_RGB.pdf
+      Research Article: https://rammb.cira.colostate.edu/training/visit/quick_guides/Fire_Temperature_RGB.pdf
     prerequisites:
       - name: C07
       - name: C06
@@ -335,7 +335,7 @@ composites:
       indicative of severe storms. Bright yellow in the RGB indicates strong updrafts prior
       to the mature storm stage.
     references:
-      Research Article: http://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_DayConvectionRGB_final.pdf
+      Research Article: https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_DayConvectionRGB_final.pdf
     prerequisites:
     - compositor: !!python/name:satpy.composites.DifferenceCompositor
       prerequisites:
@@ -368,7 +368,7 @@ composites:
     description: >
       Ash RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/GOES_Ash_RGB.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/GOES_Ash_RGB.pdf
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
       - compositor: !!python/name:satpy.composites.DifferenceCompositor
@@ -386,7 +386,7 @@ composites:
     description: >
       Dust RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/Dust_RGB_Quick_Guide.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/Dust_RGB_Quick_Guide.pdf
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
       - compositor: !!python/name:satpy.composites.DifferenceCompositor
@@ -405,8 +405,8 @@ composites:
       Day Cloud Phase Distinction RGB, for GOESR: NASA, NOAA
       Cloud Type RGB, for  EUMETSAT (https://www.eumetsat.int/website/home/Images/ImageLibrary/DAT_3958037.html)
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/Day_Cloud_Phase_Distinction.pdf
-      Cloud Type recipe and typical colours: https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_IL_18_05_13_A&RevisionSelectionMethod=LatestReleased&Rendition=Web
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_DayCloudPhaseDistinction_final_v2.pdf
+      Cloud Type recipe and typical colours: https://www.eumetsat.int/fr/media/45659
     ## it uses the default used in etc/enhancements/generic.yaml
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
@@ -431,7 +431,7 @@ composites:
     description: >
       Simple Water Vapor RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/Simple_Water_Vapor_RGB.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/Simple_Water_Vapor_RGB.pdf
     ## it uses the default used in etc/enhancements/generic.yaml
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
@@ -444,7 +444,7 @@ composites:
     description: >
       Differential Water Vapor RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_DifferentialWaterVaporRGB_final.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_DifferentialWaterVaporRGB_final.pdf
     ## it uses the default used in etc/enhancements/generic.yaml
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
@@ -460,7 +460,7 @@ composites:
     description: >
       Day Convection RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_DayConvectionRGB_final.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_DayConvectionRGB_final.pdf
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
       - compositor: !!python/name:satpy.composites.DifferenceCompositor
@@ -481,7 +481,7 @@ composites:
     description: >
       SO2 RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/Quick_Guide_SO2_RGB.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/Quick_Guide_SO2_RGB.pdf
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
       - compositor: !!python/name:satpy.composites.DifferenceCompositor
@@ -499,7 +499,7 @@ composites:
     description: >
       Day Snow-Fog RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_DaySnowFog.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_DaySnowFogRGB_final_v2.pdf
     ## it uses the default used in etc/enhancements/generic.yaml of snow_defaul
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
@@ -517,7 +517,7 @@ composites:
     description: >
       Nighttime Microphysics RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_NtMicroRGB_final.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_NtMicroRGB_Final_20191206.pdf
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
       - compositor: !!python/name:satpy.composites.DifferenceCompositor
@@ -535,7 +535,7 @@ composites:
     description: >
       Fire Temperature RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/Fire_Temperature_RGB.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/Fire_Temperature_RGB.pdf
     ## adapted from etc/composites/viirs.yaml
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
@@ -549,7 +549,7 @@ composites:
     description: >
       Day Land Cloud Fire RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_DayLandCloudFireRGB_final.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_DayLandCloudFireRGB_final.pdf
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
       - name: C06
@@ -563,7 +563,7 @@ composites:
     description: >
       Day Land Cloud RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_daylandcloudRGB_final.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_daylandcloudRGB_final.pdf
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
       - name: C05

--- a/satpy/etc/composites/agri.yaml
+++ b/satpy/etc/composites/agri.yaml
@@ -30,7 +30,7 @@ composites:
       Day Cloud Phase Distinction RGB, for GOESR: NASA, NOAA
       Cloud Type RGB, for  EUMETSAT (https://www.eumetsat.int/website/home/Images/ImageLibrary/DAT_3958037.html)
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/Day_Cloud_Phase_Distinction.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_DayCloudPhaseDistinction_final_v2.pdf
       Cloud Type recipe and typical colours: https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_IL_18_05_13_A&RevisionSelectionMethod=LatestReleased&Rendition=Web
     ## it uses the default used in etc/enhancements/generic.yaml
     compositor: !!python/name:satpy.composites.GenericCompositor
@@ -56,7 +56,7 @@ composites:
     description: >
       Day Snow-Fog RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_DaySnowFog.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_DaySnowFogRGB_final_v2.pdf
     ## it uses the default used in etc/enhancements/generic.yaml of snow_defaul
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
@@ -74,7 +74,7 @@ composites:
     description: >
       Fire Temperature RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/Fire_Temperature_RGB.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/Fire_Temperature_RGB.pdf
     ## adapted from etc/composites/viirs.yaml
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
@@ -88,7 +88,7 @@ composites:
     description: >
       Day Land Cloud Fire RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_DayLandCloudFireRGB_final.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_DayLandCloudFireRGB_final.pdf
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
       - name: C06
@@ -102,7 +102,8 @@ composites:
     description: >
       Day Land Cloud RGB, for GOESR: NASA, NOAA
     references:
-      CIRA Quick Guide: http://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_daylandcloudRGB_final.pdf
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_daylandcloudRGB_final.pdf
+
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
       - name: C05


### PR DESCRIPTION
In the references included in the composite definition YAML files, fix broken links to documents on the CIRA and EUMETSAT websites.

There is one change I am not sure about. @jhbravo, could you please confirm: "Cloud Type recipe and typical colours" previously linked to https://www.eumetsat.int/website/wcm/idc/idcplg?IdcService=GET_FILE&dDocName=PDF_IL_18_05_13_A&RevisionSelectionMethod=LatestReleased&Rendition=Web, which is now Error 404.  The closest equivalent I could find is https://www.eumetsat.int/fr/media/45659.  Is that the correct new link?

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
