### PR TITLE
Update documentation to refer to all EO satellite data

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -3,7 +3,7 @@ Satpy's Documentation
 =====================
 
 Satpy is a python library for reading, manipulating, and writing data from
-remote-sensing earth-observing meteorological satellite instruments. Satpy
+remote-sensing earth-observing satellite instruments. Satpy
 provides users with readers that convert geophysical parameters from various
 file formats to the common Xarray :class:`~xarray.DataArray` and
 :class:`~xarray.Dataset` classes for easier interoperability with other
@@ -30,7 +30,7 @@ libraries maintained by the Pytroll group including:
 
 Go to the Satpy project_ page for source code and downloads.
 
-Satpy is designed to be easily extendable to support any meteorological
+Satpy is designed to be easily extendable to support any earth observation
 satellite by the creation of plugins (readers, compositors, writers, etc).
 The table at the bottom of this page shows the input formats supported by
 the base Satpy installation.


### PR DESCRIPTION
Currently, the frontpage of read the docs states that Sapy supports meteorological satellites. While that is true, it doesn't do satpy justice as a wide range of non-meteorological satellites / sensors are also supported such as the Sentinels and MODIS.
This updates the docs front page to state "earth observation" instead of "meteorological".

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Fully documented 