### PR TITLE
Rename duplicate night_overview

### DIFF
--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -510,7 +510,7 @@ composites:
     standard_name: ncc_radiance
     units: "1"
 
-  night_overview:
+  dnb_hncc_overview:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
     - hncc_dnb


### PR DESCRIPTION
Rename the duplicate night_overview to dnb_hncc_overview.  Keep standard
name the same, I think that ensures it will use the same enhancement.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #1964 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
