### PR TITLE
Add ability to read comma-separated colormaps during enhancement

### DIFF
--- a/satpy/_compat.py
+++ b/satpy/_compat.py
@@ -18,7 +18,7 @@
 """Backports and compatibility fixes for satpy."""
 
 try:
-    from functools import cached_property
+    from functools import cached_property  # type: ignore
 except ImportError:
     # for python < 3.8
     from functools import lru_cache

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -29,6 +29,7 @@ import xarray as xr
 from trollimage.xrimage import XRImage
 
 from satpy._compat import ArrayLike
+from satpy._config import get_config_path
 
 LOG = logging.getLogger(__name__)
 
@@ -360,8 +361,12 @@ def create_colormap(palette):
     element (color) of the colormap. The filename to load can be provided with
     the ``filename`` key in the provided palette information. A filename
     ending with ``.npy`` is read as an npy file, all other extensions are
-    read as a comma-separated file. The colormap is interpreted as 1 of 4
-    different "colormap modes": ``RGB``, ``RGBA``, ``VRGB``, or ``VRGBA``. The
+    read as a comma-separated file. The path to the colormap can be relative
+    if it is stored in a directory specified by :ref:`config_path_setting`.
+    Otherwise it should be an absolute path.
+
+    The colormap is interpreted as 1 of 4 different "colormap modes":
+    ``RGB``, ``RGBA``, ``VRGB``, or ``VRGBA``. The
     colormap mode can be forced with the ``colormap_mode`` key in the provided
     palette information. If it is not provided then a default will be chosen
     based on the number of columns in the array (3: RGB, 4: VRGB, 5: VRGBA).
@@ -487,6 +492,8 @@ def _create_colormap_from_file(filename, palette, color_scale):
 
 
 def _read_colormap_data_from_file(filename):
+    if not os.path.exists(filename):
+        filename = get_config_path(filename)
     ext = os.path.splitext(filename)[1]
     if ext in (".npy",):
         return np.load(filename)

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -17,6 +17,7 @@
 """Enhancements."""
 
 import logging
+import os
 import warnings
 from functools import partial
 from numbers import Number
@@ -355,8 +356,11 @@ def create_colormap(palette):
     **From a file**
 
     Colormaps can be loaded from ``.npy`` files as 2D raw arrays with rows for
-    each color. The filename to load can be provided with the ``filename`` key
-    in the provided palette information. The colormap is interpreted as 1 of 4
+    each color or from comma-separated text files where each row represents an
+    element (color) of the colormap. The filename to load can be provided with
+    the ``filename`` key in the provided palette information. A filename
+    ending with ``.npy`` is read as an npy file, all other extensions are
+    read as a comma-separated file. The colormap is interpreted as 1 of 4
     different "colormap modes": ``RGB``, ``RGBA``, ``VRGB``, or ``VRGBA``. The
     colormap mode can be forced with the ``colormap_mode`` key in the provided
     palette information. If it is not provided then a default will be chosen
@@ -456,7 +460,7 @@ def _create_colormap_from_sequence(colors, palette, color_scale):
 
 def _create_colormap_from_file(filename, palette, color_scale):
     from trollimage.colormap import Colormap
-    data = np.load(filename)
+    data = _read_colormap_data_from_file(filename)
     cols = data.shape[1]
     default_modes = {
         3: 'RGB',
@@ -480,6 +484,14 @@ def _create_colormap_from_file(filename, palette, color_scale):
             colors = colors / float(color_scale)
         values = np.arange(rows) / float(rows - 1)
     return Colormap(*zip(values, colors))
+
+
+def _read_colormap_data_from_file(filename):
+    ext = os.path.splitext(filename)[1]
+    if ext in (".npy",):
+        return np.load(filename)
+    # CSV
+    return np.loadtxt(filename, delimiter=",")
 
 
 def _three_d_effect_delayed(band_data, kernel, mode):

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -356,7 +356,7 @@ def create_colormap(palette):
 
     **From a file**
 
-    Colormaps can be loaded from ``.npy``, ``.npz``, or comma-separate text
+    Colormaps can be loaded from ``.npy``, ``.npz``, or comma-separated text
     files. Numpy (npy/npz) files should be 2D arrays with rows for each color.
     Comma-separated files should have a row for each color with each column
     representing a single value/channel. The filename to load can be provided

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -239,6 +239,8 @@ def _write_cmap_csv(cmap_filename, cmap_data):
     ext = os.path.splitext(cmap_filename)[1]
     if ext in (".npy",):
         np.save(cmap_filename, cmap_data)
+    elif ext in (".npz",):
+        np.savez(cmap_filename, cmap_data)
     else:
         np.savetxt(cmap_filename, cmap_data, delimiter=",")
 
@@ -274,7 +276,7 @@ class TestColormapLoading:
                                  {},
                                  {"min_value": 50, "max_value": 100},
                              ])
-    @pytest.mark.parametrize("filename_suffix", [".npy", ".csv"])
+    @pytest.mark.parametrize("filename_suffix", [".npy", ".npz", ".csv"])
     def test_cmap_from_npy_file_rgb(self, color_scale, colormap_mode, extra_kwargs, filename_suffix):
         """Test that colormaps can be loaded from a binary file."""
         # create the colormap file on disk

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -235,7 +235,7 @@ def closed_named_temp_file(**kwargs):
         os.remove(tmp_cmap.name)
 
 
-def _write_cmap_csv(cmap_filename, cmap_data):
+def _write_cmap_to_file(cmap_filename, cmap_data):
     ext = os.path.splitext(cmap_filename)[1]
     if ext in (".npy",):
         np.save(cmap_filename, cmap_data)
@@ -277,12 +277,12 @@ class TestColormapLoading:
                                  {"min_value": 50, "max_value": 100},
                              ])
     @pytest.mark.parametrize("filename_suffix", [".npy", ".npz", ".csv"])
-    def test_cmap_from_npy_file_rgb(self, color_scale, colormap_mode, extra_kwargs, filename_suffix):
+    def test_cmap_from_file(self, color_scale, colormap_mode, extra_kwargs, filename_suffix):
         """Test that colormaps can be loaded from a binary file."""
         # create the colormap file on disk
         with closed_named_temp_file(suffix=filename_suffix) as cmap_filename:
             cmap_data = _generate_cmap_test_data(color_scale, colormap_mode)
-            _write_cmap_csv(cmap_filename, cmap_data)
+            _write_cmap_to_file(cmap_filename, cmap_data)
 
             unset_first_value = 128.0 / 255.0 if colormap_mode.startswith("V") else 0.0
             unset_last_value = 134.0 / 255.0 if colormap_mode.startswith("V") else 1.0
@@ -335,7 +335,7 @@ class TestColormapLoading:
         """Test that reading colormaps with the wrong mode fails."""
         with closed_named_temp_file(suffix=filename_suffix) as cmap_filename:
             cmap_data = _generate_cmap_test_data(None, real_mode)
-            _write_cmap_csv(cmap_filename, cmap_data)
+            _write_cmap_to_file(cmap_filename, cmap_data)
             # Force colormap_mode VRGBA to RGBA and we should see an exception
             with pytest.raises(ValueError):
                 create_colormap({'filename': cmap_filename, 'colormap_mode': forced_mode})

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -274,7 +274,7 @@ class TestColormapLoading:
                                  {},
                                  {"min_value": 50, "max_value": 100},
                              ])
-    @pytest.mark.parametrize("filename_suffix", [".npy"])
+    @pytest.mark.parametrize("filename_suffix", [".npy", ".csv"])
     def test_cmap_from_npy_file_rgb(self, color_scale, colormap_mode, extra_kwargs, filename_suffix):
         """Test that colormaps can be loaded from a binary file."""
         # create the colormap file on disk
@@ -328,7 +328,7 @@ class TestColormapLoading:
             ("RGBA", "RGB"),
         ]
     )
-    @pytest.mark.parametrize("filename_suffix", [".npy"])
+    @pytest.mark.parametrize("filename_suffix", [".npy", ".csv"])
     def test_cmap_bad_mode(self, real_mode, forced_mode, filename_suffix):
         """Test that reading colormaps with the wrong mode fails."""
         with closed_named_temp_file(suffix=filename_suffix) as cmap_filename:

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -18,18 +18,18 @@
 """Unit testing the enhancements functions, e.g. cira_stretch."""
 
 import os
-import unittest
 from unittest import mock
 
 import dask.array as da
 import numpy as np
+import pytest
 import xarray as xr
 
 
-class TestEnhancementStretch(unittest.TestCase):
+class TestEnhancementStretch:
     """Class for testing enhancements in satpy.enhancements."""
 
-    def setUp(self):
+    def setup_method(self):
         """Create test data used by every test."""
         data = np.arange(-210, 790, 100).reshape((2, 5)) * 0.95
         data[0, 0] = np.nan  # one bad value for testing
@@ -51,10 +51,8 @@ class TestEnhancementStretch(unittest.TestCase):
         img = XRImage(data)
         func(img, **kwargs)
 
-        self.assertIsInstance(img.data.data, da.Array)
-        self.assertListEqual(sorted(pre_attrs.keys()),
-                             sorted(img.data.attrs.keys()),
-                             "DataArray attributes were not preserved")
+        assert isinstance(img.data.data, da.Array)
+        assert sorted(pre_attrs.keys()) == sorted(img.data.attrs.keys()), "DataArray attributes were not preserved"
 
         np.testing.assert_allclose(img.data.values, expected, atol=1.e-6, rtol=0)
 
@@ -182,7 +180,7 @@ class TestEnhancementStretch(unittest.TestCase):
 
         with mock.patch('satpy.enhancements.create_colormap', create_colormap_mock):
             res = mcp(kwargs)
-        self.assertTrue(res is cmap1)
+        assert res is cmap1
         create_colormap_mock.assert_not_called()
         create_colormap_mock.reset_mock()
         ret_map.reset_mock()
@@ -218,7 +216,7 @@ class TestEnhancementStretch(unittest.TestCase):
         """Clean up."""
 
 
-class TestColormapLoading(unittest.TestCase):
+class TestColormapLoading:
     """Test utilities used with colormaps."""
 
     def test_cmap_from_file_rgb(self):
@@ -239,18 +237,18 @@ class TestColormapLoading(unittest.TestCase):
 
         try:
             cmap = create_colormap({'filename': cmap_filename})
-            self.assertEqual(cmap.colors.shape[0], 4)
+            assert cmap.colors.shape[0] == 4
             np.testing.assert_equal(cmap.colors[0], [1.0, 0, 0])
-            self.assertEqual(cmap.values.shape[0], 4)
-            self.assertEqual(cmap.values[0], 0)
-            self.assertEqual(cmap.values[-1], 1.0)
+            assert cmap.values.shape[0] == 4
+            assert cmap.values[0] == 0
+            assert cmap.values[-1] == 1.0
 
             cmap = create_colormap({'filename': cmap_filename, 'min_value': 50, 'max_value': 100})
-            self.assertEqual(cmap.colors.shape[0], 4)
+            assert cmap.colors.shape[0] == 4
             np.testing.assert_equal(cmap.colors[0], [1.0, 0, 0])
-            self.assertEqual(cmap.values.shape[0], 4)
-            self.assertEqual(cmap.values[0], 50)
-            self.assertEqual(cmap.values[-1], 100)
+            assert cmap.values.shape[0] == 4
+            assert cmap.values[0] == 50
+            assert cmap.values[-1] == 100
         finally:
             os.remove(cmap_filename)
 
@@ -273,19 +271,19 @@ class TestColormapLoading(unittest.TestCase):
         try:
             cmap = create_colormap({'filename': cmap_filename,
                                     'color_scale': 1})
-            self.assertEqual(cmap.colors.shape[0], 4)
+            assert cmap.colors.shape[0] == 4
             np.testing.assert_equal(cmap.colors[0], [1.0, 0, 0])
-            self.assertEqual(cmap.values.shape[0], 4)
-            self.assertEqual(cmap.values[0], 0)
-            self.assertEqual(cmap.values[-1], 1.0)
+            assert cmap.values.shape[0] == 4
+            assert cmap.values[0] == 0
+            assert cmap.values[-1] == 1.0
 
             cmap = create_colormap({'filename': cmap_filename, 'color_scale': 1,
                                     'min_value': 50, 'max_value': 100})
-            self.assertEqual(cmap.colors.shape[0], 4)
+            assert cmap.colors.shape[0] == 4
             np.testing.assert_equal(cmap.colors[0], [1.0, 0, 0])
-            self.assertEqual(cmap.values.shape[0], 4)
-            self.assertEqual(cmap.values[0], 50)
-            self.assertEqual(cmap.values[-1], 100)
+            assert cmap.values.shape[0] == 4
+            assert cmap.values[0] == 50
+            assert cmap.values[-1] == 100
         finally:
             os.remove(cmap_filename)
 
@@ -308,30 +306,31 @@ class TestColormapLoading(unittest.TestCase):
         try:
             # default mode of VRGB
             cmap = create_colormap({'filename': cmap_filename})
-            self.assertEqual(cmap.colors.shape[0], 4)
+            assert cmap.colors.shape[0] == 4
             np.testing.assert_equal(cmap.colors[0], [1.0, 0, 0])
-            self.assertEqual(cmap.values.shape[0], 4)
-            self.assertEqual(cmap.values[0], 128)
-            self.assertEqual(cmap.values[-1], 134)
+            assert cmap.values.shape[0] == 4
+            assert cmap.values[0] == 128
+            assert cmap.values[-1] == 134
 
             cmap = create_colormap({'filename': cmap_filename, 'colormap_mode': 'RGBA'})
-            self.assertEqual(cmap.colors.shape[0], 4)
-            self.assertEqual(cmap.colors.shape[1], 4)  # RGBA
+            assert cmap.colors.shape[0] == 4
+            assert cmap.colors.shape[1] == 4  # RGBA
             np.testing.assert_equal(cmap.colors[0], [128 / 255., 1.0, 0, 0])
-            self.assertEqual(cmap.values.shape[0], 4)
-            self.assertEqual(cmap.values[0], 0)
-            self.assertEqual(cmap.values[-1], 1.0)
+            assert cmap.values.shape[0] == 4
+            assert cmap.values[0] == 0
+            assert cmap.values[-1] == 1.0
 
             cmap = create_colormap({'filename': cmap_filename, 'min_value': 50, 'max_value': 100})
-            self.assertEqual(cmap.colors.shape[0], 4)
+            assert cmap.colors.shape[0] == 4
             np.testing.assert_equal(cmap.colors[0], [1.0, 0, 0])
-            self.assertEqual(cmap.values.shape[0], 4)
-            self.assertEqual(cmap.values[0], 50)
-            self.assertEqual(cmap.values[-1], 100)
+            assert cmap.values.shape[0] == 4
+            assert cmap.values[0] == 50
+            assert cmap.values[-1] == 100
 
-            self.assertRaises(ValueError, create_colormap,
-                              {'filename': cmap_filename, 'colormap_mode': 'RGB',
-                               'min_value': 50, 'max_value': 100})
+            with pytest.raises(ValueError):
+                create_colormap({
+                    'filename': cmap_filename, 'colormap_mode': 'RGB',
+                    'min_value': 50, 'max_value': 100})
         finally:
             os.remove(cmap_filename)
 
@@ -354,23 +353,25 @@ class TestColormapLoading(unittest.TestCase):
         try:
             # default mode of VRGBA
             cmap = create_colormap({'filename': cmap_filename})
-            self.assertEqual(cmap.colors.shape[0], 4)
-            self.assertEqual(cmap.colors.shape[1], 4)  # RGBA
+            assert cmap.colors.shape[0] == 4
+            assert cmap.colors.shape[1] == 4  # RGBA
             np.testing.assert_equal(cmap.colors[0], [128 / 255.0, 1.0, 0, 0])
-            self.assertEqual(cmap.values.shape[0], 4)
-            self.assertEqual(cmap.values[0], 128)
-            self.assertEqual(cmap.values[-1], 134)
+            assert cmap.values.shape[0] == 4
+            assert cmap.values[0] == 128
+            assert cmap.values[-1] == 134
 
-            self.assertRaises(ValueError, create_colormap,
-                              {'filename': cmap_filename, 'colormap_mode': 'RGBA'})
+            with pytest.raises(ValueError):
+                create_colormap({
+                    'filename': cmap_filename,
+                    'colormap_mode': 'RGBA'})
 
             cmap = create_colormap({'filename': cmap_filename, 'min_value': 50, 'max_value': 100})
-            self.assertEqual(cmap.colors.shape[0], 4)
-            self.assertEqual(cmap.colors.shape[1], 4)  # RGBA
+            assert cmap.colors.shape[0] == 4
+            assert cmap.colors.shape[1] == 4  # RGBA
             np.testing.assert_equal(cmap.colors[0], [128 / 255.0, 1.0, 0, 0])
-            self.assertEqual(cmap.values.shape[0], 4)
-            self.assertEqual(cmap.values[0], 50)
-            self.assertEqual(cmap.values[-1], 100)
+            assert cmap.values.shape[0] == 4
+            assert cmap.values[0] == 50
+            assert cmap.values[-1] == 100
         finally:
             os.remove(cmap_filename)
 
@@ -391,8 +392,8 @@ class TestColormapLoading(unittest.TestCase):
             ]))
 
         try:
-            self.assertRaises(ValueError, create_colormap,
-                              {'filename': cmap_filename})
+            with pytest.raises(ValueError):
+                create_colormap({'filename': cmap_filename})
         finally:
             os.remove(cmap_filename)
 
@@ -407,7 +408,8 @@ class TestColormapLoading(unittest.TestCase):
     def test_cmap_no_colormap(self):
         """Test that being unable to create a colormap raises an error."""
         from satpy.enhancements import create_colormap
-        self.assertRaises(ValueError, create_colormap, {})
+        with pytest.raises(ValueError):
+            create_colormap({})
 
     def test_cmap_list(self):
         """Test that colors can be a list/tuple."""
@@ -420,15 +422,15 @@ class TestColormapLoading(unittest.TestCase):
         ]
         values = [2, 4, 6, 8]
         cmap = create_colormap({'colors': colors, 'color_scale': 1})
-        self.assertEqual(cmap.colors.shape[0], 4)
+        assert cmap.colors.shape[0] == 4
         np.testing.assert_equal(cmap.colors[0], [0.0, 0.0, 1.0])
-        self.assertEqual(cmap.values.shape[0], 4)
-        self.assertEqual(cmap.values[0], 0)
-        self.assertEqual(cmap.values[-1], 1.0)
+        assert cmap.values.shape[0] == 4
+        assert cmap.values[0] == 0
+        assert cmap.values[-1] == 1.0
 
         cmap = create_colormap({'colors': colors, 'color_scale': 1, 'values': values})
-        self.assertEqual(cmap.colors.shape[0], 4)
+        assert cmap.colors.shape[0] == 4
         np.testing.assert_equal(cmap.colors[0], [0.0, 0.0, 1.0])
-        self.assertEqual(cmap.values.shape[0], 4)
-        self.assertEqual(cmap.values[0], 2)
-        self.assertEqual(cmap.values[-1], 8)
+        assert cmap.values.shape[0] == 4
+        assert cmap.values[0] == 2
+        assert cmap.values[-1] == 8

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -354,6 +354,26 @@ class TestColormapLoading:
             with pytest.raises(ValueError):
                 create_colormap({'filename': cmap_filename})
 
+    def test_cmap_from_config_path(self, tmp_path):
+        """Test loading a colormap relative to a config path."""
+        import satpy
+        from satpy.enhancements import create_colormap
+
+        cmap_dir = tmp_path / "colormaps"
+        cmap_dir.mkdir()
+        cmap_filename = cmap_dir / "my_colormap.npy"
+        cmap_data = _generate_cmap_test_data(None, "RGBA")
+        np.save(cmap_filename, cmap_data)
+        with satpy.config.set(config_path=[tmp_path]):
+            rel_cmap_filename = os.path.join("colormaps", "my_colormap.npy")
+            cmap = create_colormap({'filename': rel_cmap_filename, 'colormap_mode': "RGBA"})
+            assert cmap.colors.shape[0] == 4
+            assert cmap.colors.shape[1] == 4  # RGBA
+            np.testing.assert_equal(cmap.colors[0], [128 / 255., 1.0, 0, 0])
+            assert cmap.values.shape[0] == 4
+            assert cmap.values[0] == 0
+            assert cmap.values[-1] == 1.0
+
     def test_cmap_from_trollimage(self):
         """Test that colormaps in trollimage can be loaded."""
         from satpy.enhancements import create_colormap


### PR DESCRIPTION
Currently only binary `.npy` files are supported for reusable colormaps (rather than literal lists in the YAML). This PR allows for parsing of CSV (comma-separated) text files in a similar manner.

Note: Initially this PR only consists of refactoring of some of the enhancement tests.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
