### PR TITLE
Fix reflectances for VII l1b reader V1

### DIFF
--- a/satpy/readers/vii_l1b_nc.py
+++ b/satpy/readers/vii_l1b_nc.py
@@ -76,7 +76,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
             calibrated_variable = self._calibrate_bt(variable, cw, a, b)
             calibrated_variable.attrs = variable.attrs
         elif calibration_name == 'reflectance':
-            scale = 1/(dataset_info['wavelength'][2] - dataset_info['wavelength'][0])
+            scale = 1e3  # Why needed?
             # Extract the values of calibration coefficients for the current channel
             chan_index = dataset_info['chan_solar_index']
             isi = scale * self._integrated_solar_irradiance[chan_index]
@@ -141,5 +141,5 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
             numpy ndarray: array containing the calibrated reflectance values.
 
         """
-        refl_values = (np.pi / isi) * angle_factor * radiance
+        refl_values = 100 * (np.pi / isi) * angle_factor * radiance
         return refl_values


### PR DESCRIPTION
Fix the scaling of reflectances for VII l1b reader.
There should be a multiplication with 100 in the conversion to reflectances as reflectances have unit %.
The band averaged solar irradiance is already calculated per µm and the wavelengths
should not need to be used for scaling. However there seem to be a scale factor
missing (1e3) for band averaged solar irradiance. Also channel cw thermal has a missing scale factor 1e-3.
This might be fixed in later versions of the testdata or in the actual data.
With this update the resulting reflectances are more similar to the metop reflectances used to simulate the testdata.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->

