### PR TITLE
Update VII reader for test data v2

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -52,6 +52,7 @@ The following people have made contributions to this project:
 - [Esben S. Nielsen (storpipfugl)](https://github.com/storpipfugl)
 - [Tom Parker (tparker-usgs)](https://github.com/tparker-usgs)
 - [Christian Peters (peters77)](https://github.com/peters77)
+- [Pepe Phillips (pepephillips)](https://github.com/pepephillips)
 - [Ghislain Picard (ghislainp)](https://github.com/ghislainp)
 - [Simon R. Proud (simonrp84)](https://github.com/simonrp84)
 - [Lars Ørum Rasmussen (loerum)](https://github.com/loerum)

--- a/satpy/etc/readers/vii_l1b_nc.yaml
+++ b/satpy/etc/readers/vii_l1b_nc.yaml
@@ -3,7 +3,7 @@ reader:
   short_name: VII L1B RAD NetCDF4
   long_name: EPS-SG VII L1B Radiance (NetCDF4)
   description: >
-    Reader for EUMETSAT EPSG-SG Visual Infrared Imager Level 1B Radiance files in NetCDF4 format.
+    Reader for EUMETSAT EPS-SG Visual Infrared Imager Level 1B Radiance files in NetCDF4 format per FS V4A.
   sensors: [vii]
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
 
@@ -11,9 +11,7 @@ file_types:
   # EUMETSAT EPSG-SG Visual Infrared Imager Level 1B Radiance files in NetCDF4 format
   nc_vii_l1b_rad:
     file_reader: !!python/name:satpy.readers.vii_l1b_nc.ViiL1bNCFileHandler
-    file_patterns: ['W_DE-AIRBUSDS-Friedrichshafen,SAT,{spacecraft_name:s}-VII-1B-RAD_C_EUM_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc',
-                    'W_xx-eumetsat-darmstadt,SAT,{spacecraft_name:s}-VII-1B-RAD_C_EUM_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc',
-                    'W_xx-eumetsat-darmstadt,SAT,{spacecraft_name:s}-VII-1B-RAD_C_EUMT_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
+    file_patterns: ['W_XX-EUMETSAT-Darmstadt,SAT,{spacecraft_name:s}-VII-1B-RAD_C_EUMT_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
     cached_longitude: data/measurement_data/longitude
     cached_latitude: data/measurement_data/latitude
 
@@ -51,7 +49,7 @@ datasets:
     name: vii_443
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_443
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -65,7 +63,7 @@ datasets:
     name: vii_555
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_555
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -79,7 +77,7 @@ datasets:
     name: vii_668
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_668
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -93,7 +91,7 @@ datasets:
     name: vii_752
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_752
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -107,7 +105,7 @@ datasets:
     name: vii_763
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_763
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration: [reflectance, radiance]
     chan_solar_index: 4
     wavelength: [0.75695, 0.7627, 0.76845]
@@ -116,7 +114,7 @@ datasets:
     name: vii_865
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_865
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -130,7 +128,7 @@ datasets:
     name: vii_914
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_914
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -144,7 +142,7 @@ datasets:
     name: vii_1240
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_1240
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -158,7 +156,7 @@ datasets:
     name: vii_1375
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_1375
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -172,7 +170,7 @@ datasets:
     name: vii_1630
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_1630
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -186,7 +184,7 @@ datasets:
     name: vii_2250
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_2250
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       reflectance:
         standard_name: toa_bidirectional_reflectance
@@ -200,7 +198,7 @@ datasets:
     name: vii_3740
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_3740
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -214,7 +212,7 @@ datasets:
     name: vii_3959
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_3959
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -228,7 +226,7 @@ datasets:
     name: vii_4050
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_4050
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -242,7 +240,7 @@ datasets:
     name: vii_6725
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_6725
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -256,7 +254,7 @@ datasets:
     name: vii_7325
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_7325
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -270,7 +268,7 @@ datasets:
     name: vii_8540
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_8540
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -284,7 +282,7 @@ datasets:
     name: vii_10690
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_10690
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -298,7 +296,7 @@ datasets:
     name: vii_12020
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_12020
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -312,7 +310,7 @@ datasets:
     name: vii_13345
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_13345
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature
@@ -329,28 +327,28 @@ datasets:
     standard_name: solar_zenith_angle
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/solar_zenith
-    coordinates: [lon_tie_points, lat_tie_points]
+    coordinates: [lat_tie_points, lon_tie_points]
 
   solar_azimuth_tie_points:
     name: solar_azimuth_tie_points
     standard_name: solar_azimuth_angle
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/solar_azimuth
-    coordinates: [lon_tie_points, lat_tie_points]
+    coordinates: [lat_tie_points, lon_tie_points]
 
   observation_zenith_tie_points:
     name: observation_zenith_tie_points
     standard_name: sensor_zenith_angle
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/observation_zenith
-    coordinates: [lon_tie_points, lat_tie_points]
+    coordinates: [lat_tie_points, lon_tie_points]
 
   observation_azimuth_tie_points:
     name: observation_azimuth_tie_points
     standard_name: sensor_azimuth_angle
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/observation_azimuth
-    coordinates: [lon_tie_points, lat_tie_points]
+    coordinates: [lat_tie_points, lon_tie_points]
 
   solar_zenith:
     name: solar_zenith
@@ -358,7 +356,7 @@ datasets:
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/solar_zenith
     interpolate: True
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
 
   solar_azimuth:
     name: solar_azimuth
@@ -366,7 +364,7 @@ datasets:
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/solar_azimuth
     interpolate: True
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
 
   observation_zenith:
     name: observation_zenith
@@ -374,7 +372,7 @@ datasets:
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/observation_zenith
     interpolate: True
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
 
   observation_azimuth:
     name: observation_azimuth
@@ -382,19 +380,19 @@ datasets:
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/observation_azimuth
     interpolate: True
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
 
   # --- Orthorectification data ---
   delta_lat_N_dem:
     name: delta_lat_N_dem
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/delta_lat_N_dem
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: parallax_delta_latitude
 
   delta_lon_N_dem:
     name: delta_lon_N_dem
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/delta_lon_N_dem
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: parallax_delta_longitude

--- a/satpy/readers/vii_base_nc.py
+++ b/satpy/readers/vii_base_nc.py
@@ -18,12 +18,6 @@
 
 """EUMETSAT EPS-SG Visible/Infrared Imager (VII) readers base class."""
 
-#     P.Phillips 14/01/22  Removed the following as resulted in no data on one side of the
-#     Greenwich meridian being lost and not needed for test data V2:
-#         If the dataset contains a longitude, change it to the interval [0., 360.) as natively in the product
-#          since the unwrapping performed during the interpolation might have created values outside this range
-#         if dataset_info.get('standard_name', None) == 'longitude':
-#             variable %= 360.
 
 import logging
 from datetime import datetime

--- a/satpy/readers/vii_base_nc.py
+++ b/satpy/readers/vii_base_nc.py
@@ -18,6 +18,13 @@
 
 """EUMETSAT EPS-SG Visible/Infrared Imager (VII) readers base class."""
 
+#     P.Phillips 14/01/22  Removed the following as resulted in no data on one side of the
+#     Greenwich meridian being lost and not needed for test data V2:
+#         If the dataset contains a longitude, change it to the interval [0., 360.) as natively in the product
+#          since the unwrapping performed during the interpolation might have created values outside this range
+#         if dataset_info.get('standard_name', None) == 'longitude':
+#             variable %= 360.
+
 import logging
 from datetime import datetime
 
@@ -100,11 +107,6 @@ class ViiNCBaseFileHandler(NetCDF4FileHandler):
             orthorect_data_name = dataset_info.get('orthorect_data', None)
             if orthorect_data_name is not None:
                 variable = self._perform_orthorectification(variable, orthorect_data_name)
-
-        # If the dataset contains a longitude, change it to the interval [0., 360.) as natively in the product
-        # since the unwrapping performed during the interpolation might have created values outside this range
-        if dataset_info.get('standard_name', None) == 'longitude':
-            variable %= 360.
 
         # Manage the attributes of the dataset
         variable.attrs.setdefault('units', None)

--- a/satpy/readers/vii_l1b_nc.py
+++ b/satpy/readers/vii_l1b_nc.py
@@ -71,7 +71,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
         if calibration_name == 'brightness_temperature':
             # Extract the values of calibration coefficients for the current channel
             chan_index = dataset_info['chan_thermal_index']
-            cw = self._channel_cw_thermal[chan_index]  # wavelengths now in µm
+            cw = self._channel_cw_thermal[chan_index]
             a = self._bt_conversion_a[chan_index]
             b = self._bt_conversion_b[chan_index]
             # Perform the calibration
@@ -80,9 +80,9 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
         elif calibration_name == 'reflectance':
             # Extract the values of calibration coefficients for the current channel
             chan_index = dataset_info['chan_solar_index']
-            isi = self._integrated_solar_irradiance[chan_index]  # Band averaged solar irradiance in (W/m2/µm)
+            isi = self._integrated_solar_irradiance[chan_index]
             # Perform the calibration
-            calibrated_variable = self._calibrate_refl(variable, self.angle_factor.values, isi)
+            calibrated_variable = self._calibrate_refl(variable, self.angle_factor, isi)
             calibrated_variable.attrs = variable.attrs
         elif calibration_name == 'radiance':
             calibrated_variable = variable
@@ -142,5 +142,6 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
             numpy ndarray: array containing the calibrated reflectance values.
 
         """
-        refl_values = (np.pi / isi) * angle_factor * radiance * 100.0  # should be in %?
+        print(type(isi), type(angle_factor), type(radiance))
+        refl_values = (np.pi / isi) * angle_factor.values * radiance * 100.0
         return refl_values

--- a/satpy/readers/vii_l1b_nc.py
+++ b/satpy/readers/vii_l1b_nc.py
@@ -82,7 +82,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
             chan_index = dataset_info['chan_solar_index']
             isi = self._integrated_solar_irradiance[chan_index]
             # Perform the calibration
-            calibrated_variable = self._calibrate_refl(variable, self.angle_factor, isi)
+            calibrated_variable = self._calibrate_refl(variable, self.angle_factor.data, isi)
             calibrated_variable.attrs = variable.attrs
         elif calibration_name == 'radiance':
             calibrated_variable = variable
@@ -142,6 +142,5 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
             numpy ndarray: array containing the calibrated reflectance values.
 
         """
-        print(type(isi), type(angle_factor), type(radiance))
-        refl_values = (np.pi / isi) * angle_factor.values * radiance * 100.0
+        refl_values = (np.pi / isi) * angle_factor * radiance * 100.0
         return refl_values

--- a/satpy/readers/vii_l1b_nc.py
+++ b/satpy/readers/vii_l1b_nc.py
@@ -18,7 +18,9 @@
 """EUMETSAT EPS-SG Visible/Infrared Imager (VII) Level 1B products reader.
 
 The ``vii_l1b_nc`` reader reads and calibrates EPS-SG VII L1b image data in netCDF format. The format is explained
-in the `EPS-SG VII Level 1B Product Format Specification`_.
+in the `EPS-SG VII Level 1B Product Format Specification V4A`_.
+
+This version is applicable for the vii test data V2 to be released in Jan 2022.
 
 .. _EPS-SG VII Level 1B Product Format Specification: https://www.eumetsat.int/media/44393
 
@@ -69,19 +71,18 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
         if calibration_name == 'brightness_temperature':
             # Extract the values of calibration coefficients for the current channel
             chan_index = dataset_info['chan_thermal_index']
-            cw = self._channel_cw_thermal[chan_index] * 1e-3
+            cw = self._channel_cw_thermal[chan_index] #* 1e-3
             a = self._bt_conversion_a[chan_index]
             b = self._bt_conversion_b[chan_index]
             # Perform the calibration
             calibrated_variable = self._calibrate_bt(variable, cw, a, b)
             calibrated_variable.attrs = variable.attrs
         elif calibration_name == 'reflectance':
-            scale = 1/(dataset_info['wavelength'][2] - dataset_info['wavelength'][0])
             # Extract the values of calibration coefficients for the current channel
             chan_index = dataset_info['chan_solar_index']
-            isi = scale * self._integrated_solar_irradiance[chan_index]
+            isi = 1.0*self._integrated_solar_irradiance[chan_index]
             # Perform the calibration
-            calibrated_variable = self._calibrate_refl(variable, self.angle_factor, isi)
+            calibrated_variable = self._calibrate_refl(variable, self.angle_factor.values, isi)
             calibrated_variable.attrs = variable.attrs
         elif calibration_name == 'radiance':
             calibrated_variable = variable
@@ -141,5 +142,5 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
             numpy ndarray: array containing the calibrated reflectance values.
 
         """
-        refl_values = (np.pi / isi) * angle_factor * radiance
+        refl_values = (np.pi / isi) * angle_factor * radiance * 100.0 # should be in %?
         return refl_values

--- a/satpy/readers/vii_l1b_nc.py
+++ b/satpy/readers/vii_l1b_nc.py
@@ -22,7 +22,7 @@ in the `EPS-SG VII Level 1B Product Format Specification V4A`_.
 
 This version is applicable for the vii test data V2 to be released in Jan 2022.
 
-.. _EPS-SG VII Level 1B Product Format Specification: https://www.eumetsat.int/media/44393
+.. _EPS-SG VII Level 1B Product Format Specification V4A: https://www.eumetsat.int/media/44393
 
 """
 

--- a/satpy/readers/vii_l1b_nc.py
+++ b/satpy/readers/vii_l1b_nc.py
@@ -71,7 +71,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
         if calibration_name == 'brightness_temperature':
             # Extract the values of calibration coefficients for the current channel
             chan_index = dataset_info['chan_thermal_index']
-            cw = self._channel_cw_thermal[chan_index] #* 1e-3
+            cw = self._channel_cw_thermal[chan_index] # wavelengths now in µm
             a = self._bt_conversion_a[chan_index]
             b = self._bt_conversion_b[chan_index]
             # Perform the calibration
@@ -80,7 +80,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
         elif calibration_name == 'reflectance':
             # Extract the values of calibration coefficients for the current channel
             chan_index = dataset_info['chan_solar_index']
-            isi = 1.0*self._integrated_solar_irradiance[chan_index]
+            isi = self._integrated_solar_irradiance[chan_index] # Band averaged solar irradiance in (W/m2/µm)
             # Perform the calibration
             calibrated_variable = self._calibrate_refl(variable, self.angle_factor.values, isi)
             calibrated_variable.attrs = variable.attrs
@@ -125,6 +125,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
             numpy ndarray: array containing the calibrated brightness temperature values.
 
         """
+
         log_expr = np.log(1.0 + C1 / ((cw ** 5) * radiance))
         bt_values = b + (a * C2 / (cw * log_expr))
         return bt_values

--- a/satpy/readers/vii_l1b_nc.py
+++ b/satpy/readers/vii_l1b_nc.py
@@ -71,7 +71,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
         if calibration_name == 'brightness_temperature':
             # Extract the values of calibration coefficients for the current channel
             chan_index = dataset_info['chan_thermal_index']
-            cw = self._channel_cw_thermal[chan_index] # wavelengths now in µm
+            cw = self._channel_cw_thermal[chan_index]  # wavelengths now in µm
             a = self._bt_conversion_a[chan_index]
             b = self._bt_conversion_b[chan_index]
             # Perform the calibration
@@ -80,7 +80,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
         elif calibration_name == 'reflectance':
             # Extract the values of calibration coefficients for the current channel
             chan_index = dataset_info['chan_solar_index']
-            isi = self._integrated_solar_irradiance[chan_index] # Band averaged solar irradiance in (W/m2/µm)
+            isi = self._integrated_solar_irradiance[chan_index]  # Band averaged solar irradiance in (W/m2/µm)
             # Perform the calibration
             calibrated_variable = self._calibrate_refl(variable, self.angle_factor.values, isi)
             calibrated_variable.attrs = variable.attrs
@@ -125,7 +125,6 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
             numpy ndarray: array containing the calibrated brightness temperature values.
 
         """
-
         log_expr = np.log(1.0 + C1 / ((cw ** 5) * radiance))
         bt_values = b + (a * C2 / (cw * log_expr))
         return bt_values
@@ -143,5 +142,5 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
             numpy ndarray: array containing the calibrated reflectance values.
 
         """
-        refl_values = (np.pi / isi) * angle_factor * radiance * 100.0 # should be in %?
+        refl_values = (np.pi / isi) * angle_factor * radiance * 100.0  # should be in %?
         return refl_values

--- a/satpy/tests/reader_tests/test_vii_l1b_nc.py
+++ b/satpy/tests/reader_tests/test_vii_l1b_nc.py
@@ -15,9 +15,9 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""
+"""The vii_l1b_nc reader tests package.
 
-The vii_l1b_nc reader tests package. This version test the readers for VII test data V2 as per PFS V4A.
+This version tests the readers for VII test data V2 as per PFS V4A.
 
 """
 

--- a/satpy/tests/reader_tests/test_vii_l1b_nc.py
+++ b/satpy/tests/reader_tests/test_vii_l1b_nc.py
@@ -16,7 +16,8 @@
 # You should have received a copy of the GNU General Public License
 # along with satpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""The vii_l1b_nc reader tests package."""
+"""The vii_l1b_nc reader tests package. This version test the readers for VII test data V2 as per PFS V4A"""
+
 
 import datetime
 import os
@@ -75,9 +76,9 @@ class TestViiL1bNCFileHandler(unittest.TestCase):
 
             # Add variables to data/measurement_data group
             sza = g1_2.createVariable('solar_zenith', np.float32,
-                                      dimensions=('num_tie_points_act', 'num_tie_points_alt'))
+                                      dimensions=('num_tie_points_alt', 'num_tie_points_act'))
             sza[:] = 25.0
-            delta_lat = g1_2.createVariable('delta_lat', np.float32, dimensions=('num_pixels', 'num_lines'))
+            delta_lat = g1_2.createVariable('delta_lat', np.float32, dimensions=('num_lines', 'num_pixels'))
             delta_lat[:] = 1.0
 
         self.reader = ViiL1bNCFileHandler(
@@ -116,25 +117,25 @@ class TestViiL1bNCFileHandler(unittest.TestCase):
         angle_factor = 0.4
         isi = 2.0
         refl = self.reader._calibrate_refl(radiance, angle_factor, isi)
-        expected_refl = np.array([[0.628318531, 1.256637061, 3.141592654],
-                                  [4.398229715, 6.283185307, 12.56637061]])
+        expected_refl = np.array([[62.8318531, 125.6637061, 314.1592654],
+                                  [439.8229715, 628.3185307, 1256.637061]])
         self.assertTrue(np.allclose(refl, expected_refl))
 
     def test_functions(self):
         """Test the functions."""
         # Checks that the _perform_orthorectification function is correctly executed
         variable = xr.DataArray(
-            dims=('num_pixels', 'num_lines'),
+            dims=('num_lines', 'num_pixels'),
             name='test_name',
             attrs={
                 'key_1': 'value_1',
                 'key_2': 'value_2'
             },
-            data=da.from_array(np.ones((72, 600)))
+            data=da.from_array(np.ones((600, 72)))
         )
 
         orthorect_variable = self.reader._perform_orthorectification(variable, 'data/measurement_data/delta_lat')
-        expected_values = np.degrees(np.ones((72, 600)) / MEAN_EARTH_RADIUS) + np.ones((72, 600))
+        expected_values = np.degrees(np.ones((600, 72)) / MEAN_EARTH_RADIUS) + np.ones((600, 72))
         self.assertTrue(np.allclose(orthorect_variable.values, expected_values))
 
         # Checks that the _perform_calibration function is correctly executed in all cases
@@ -151,7 +152,8 @@ class TestViiL1bNCFileHandler(unittest.TestCase):
         calibrated_variable = self.reader._perform_calibration(variable,
                                                                {'calibration': 'brightness_temperature',
                                                                 'chan_thermal_index': 3})
-        expected_values = np.ones((72, 600)) * 302007.42728603
+
+        expected_values = np.ones((600, 72)) * 1101.10413712
         self.assertTrue(np.allclose(calibrated_variable.values, expected_values))
 
         # reflectance calibration: checks that the return value is correct
@@ -159,5 +161,5 @@ class TestViiL1bNCFileHandler(unittest.TestCase):
                                                                {'calibration': 'reflectance',
                                                                 'wavelength': [0.658, 0.668, 0.678],
                                                                 'chan_solar_index': 2})
-        expected_values = np.ones((72, 600)) * 1.733181982 * (0.678 - 0.658)
+        expected_values = np.ones((600, 72)) * 173.3181982
         self.assertTrue(np.allclose(calibrated_variable.values, expected_values))

--- a/satpy/tests/reader_tests/test_vii_l1b_nc.py
+++ b/satpy/tests/reader_tests/test_vii_l1b_nc.py
@@ -15,8 +15,11 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""
 
-"""The vii_l1b_nc reader tests package. This version test the readers for VII test data V2 as per PFS V4A"""
+The vii_l1b_nc reader tests package. This version test the readers for VII test data V2 as per PFS V4A.
+
+"""
 
 
 import datetime
@@ -152,7 +155,6 @@ class TestViiL1bNCFileHandler(unittest.TestCase):
         calibrated_variable = self.reader._perform_calibration(variable,
                                                                {'calibration': 'brightness_temperature',
                                                                 'chan_thermal_index': 3})
-
         expected_values = np.ones((600, 72)) * 1101.10413712
         self.assertTrue(np.allclose(calibrated_variable.values, expected_values))
 

--- a/satpy/tests/reader_tests/test_vii_l1b_nc.py
+++ b/satpy/tests/reader_tests/test_vii_l1b_nc.py
@@ -155,7 +155,7 @@ class TestViiL1bNCFileHandler(unittest.TestCase):
         calibrated_variable = self.reader._perform_calibration(variable,
                                                                {'calibration': 'brightness_temperature',
                                                                 'chan_thermal_index': 3})
-        expected_values = np.ones((600, 72)) * 1101.10413712
+        expected_values = np.full((600, 72), 1101.10413712)
         self.assertTrue(np.allclose(calibrated_variable.values, expected_values))
 
         # reflectance calibration: checks that the return value is correct
@@ -163,5 +163,5 @@ class TestViiL1bNCFileHandler(unittest.TestCase):
                                                                {'calibration': 'reflectance',
                                                                 'wavelength': [0.658, 0.668, 0.678],
                                                                 'chan_solar_index': 2})
-        expected_values = np.ones((600, 72)) * 173.3181982
+        expected_values = np.full((600, 72), 173.3181982)
         self.assertTrue(np.allclose(calibrated_variable.values, expected_values))


### PR DESCRIPTION
<!-- This PR is for readers that are to be used for the new vii test data release V2 (January 2022) with format PFS V4A -->
<!-- The main changes to the data are:  -->
<!--  1. Change in dimension order of the data from (col,row) to (row,col) format -->
<!--  2. Corrections to the radiance and BT conversion coefficients -->
<!--  Files updated are vii_l1b_nc.py, vii_base_nc.py, test_vii_l1b_nc.py, authors.md -->
<!--  The updated viiinterpolator.py in geotiepoints is needed in addition to these satpy updates-->
<!--  Note that these readers will not work for the old test data V1 i.e. are not back compatible -->

 - [ ] Closes #1842  and should also address #1462 and #1460 in that the issues are solved for the new test data V2 (V1 is now obsolete).
 - [ ]  <!-- Fixes bug where data on one side of Greenwich meridian was missing from plots (from A. Meraner)  -->
 - [ ] Tests added <!-- test_vii_l1b_nc.py updated for vii test data V2 -->


