### PR TITLE
Add a reader for Radarsat 2 SGF data

### DIFF
--- a/satpy/etc/readers/sar-rs02.yaml
+++ b/satpy/etc/readers/sar-rs02.yaml
@@ -1,0 +1,125 @@
+reader:
+  description: Reader for Radarsat02 data
+  name: sar-rs02
+  sensors: [sar]
+  default_channels: []
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
+  data_identification_keys:
+    name:
+      required: true
+    polarization:
+      transitive: true
+    resolution:
+      transitive: false
+    calibration:
+      enum:
+        - gamma
+        - sigma_nought
+        - beta_nought
+      transitive: true
+    quantity:
+      enum:
+        - natural
+        - dB
+      transitive: true
+    modifiers:
+      default: []
+      type: !!python/name:satpy.dataset.dataid.ModifierTuple
+
+  coord_identification_keys:
+    name:
+      required: true
+    polarization:
+      transitive: true
+    resolution:
+      transitive: false
+
+file_types:
+    rs02_measurement:
+        file_reader: !!python/name:satpy.readers.sar_rs02.SARRS02MeasurementFileHandler
+        file_patterns: ['{mission_id:3s}_{start_time:%Y%m%d_%H%M%S}_{filler1:4s}_{scan_mode:s}_{polarization_set:s}_{processing_level:s}_{filler2:6s}_{filler3:4s}_{filler4:8s}/imagery_{polarization:2s}.tif']
+        requires: [rs02_calibration_beta, rs02_calibration_sigma, rs02_calibration_gamma]
+    rs02_calibration_beta:
+        file_reader: !!python/name:satpy.readers.sar_rs02.SARRS02CalibrationFileHandler
+        file_patterns: ['{mission_id:3s}_{start_time:%Y%m%d_%H%M%S}_{filler1:4s}_{scan_mode:s}_{polarization_set:s}_{processing_level:s}_{filler2:6s}_{filler3:4s}_{filler4:8s}/lutBeta.xml']
+    rs02_calibration_sigma:
+        file_reader: !!python/name:satpy.readers.sar_rs02.SARRS02CalibrationFileHandler
+        file_patterns: ['{mission_id:3s}_{start_time:%Y%m%d_%H%M%S}_{filler1:4s}_{scan_mode:s}_{polarization_set:s}_{processing_level:s}_{filler2:6s}_{filler3:4s}_{filler4:8s}/lutSigma.xml']
+    rs02_calibration_gamma:
+        file_reader: !!python/name:satpy.readers.sar_rs02.SARRS02CalibrationFileHandler
+        file_patterns: ['{mission_id:3s}_{start_time:%Y%m%d_%H%M%S}_{filler1:4s}_{scan_mode:s}_{polarization_set:s}_{processing_level:s}_{filler2:6s}_{filler3:4s}_{filler4:8s}/lutGamma.xml']
+
+
+datasets:
+
+#  latitude:
+#    name: latitude
+#    resolution: 100
+#    file_type: rs02_measurement
+#    standard_name: latitude
+#    polarization: [hh, hv, vv, vh]
+#    units: degree
+#
+#  longitude:
+#    name: longitude
+#    resolution: 100
+#    file_type: rs02_measurement
+#    standard_name: longitude
+#    polarization: [hh, hv, vv, vh]
+#    units: degree
+#
+#  altitude:
+#    name: altitude
+#    resolution: 100
+#    file_type: rs02_measurement
+#    standard_name: altitude
+#    polarization: [hh, hv, vv, vh]
+#    units: meter
+
+
+  measurement:
+    name: measurement
+    sensor: sar
+    wavelength: [5.400, 5.405, 5.410]
+    resolution: 100
+    polarization: [hh, hv, vv, vh]
+    calibration:
+      gamma:
+        standard_name: backscatter
+        units: 1
+      sigma_nought:
+        standard_name: backscatter
+        units: 1
+      beta_nought:
+        standard_name: backscatter
+        units: 1
+    quantity: [natural, dB]
+    #coordinates: [longitude, latitude]
+    file_type: rs02_measurement
+
+  sigma:
+    name: sigma_squared
+    sensor: sar-c
+    resolution: 100
+    polarization: [hh, hv, vv, vh]
+    file_type: rs02_calibration_sigma
+    xml_item: calibrationVector
+    xml_tag: sigma
+
+  beta:
+    name: beta_squared
+    sensor: sar-c
+    resolution: 100
+    polarization: [hh, hv, vv, vh]
+    file_type: rs02_calibration_beta
+    xml_item: calibrationVector
+    xml_tag: beta
+
+  gamma:
+    name: gamma_squared
+    sensor: sar-c
+    resolution: 100
+    polarization: [hh, hv, vv, vh]
+    file_type: rs02_calibration_gamma
+    xml_item: calibrationVector
+    xml_tag: gamma

--- a/satpy/readers/sar_c_safe.py
+++ b/satpy/readers/sar_c_safe.py
@@ -568,18 +568,7 @@ class SAFEGRD(BaseFileHandler):
             data.attrs.update(info)
             data.attrs.update({'platform_name': self._mission_id})
 
-            data = self._change_quantity(data, key['quantity'])
-
-        return data
-
-    @staticmethod
-    def _change_quantity(data, quantity):
-        """Change quantity to dB if needed."""
-        if quantity == 'dB':
-            data.data = 10 * np.log10(data.data)
-            data.attrs['units'] = 'dB'
-        else:
-            data.attrs['units'] = '1'
+            data = change_quantity(data, key['quantity'])
 
         return data
 
@@ -680,3 +669,14 @@ class SAFEGRD(BaseFileHandler):
     def end_time(self):
         """Get the end time."""
         return self._end_time
+
+
+def change_quantity(data, quantity):
+    """Change quantity to dB if needed."""
+    if quantity == 'dB':
+        data.data = 10 * np.log10(data.data)
+        data.attrs['units'] = 'dB'
+    else:
+        data.attrs['units'] = '1'
+
+    return data

--- a/satpy/readers/sar_rs02.py
+++ b/satpy/readers/sar_rs02.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2022 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Reader for Radarsat 2 SGF SAR data."""
+
+import defusedxml.ElementTree as ElementTree
+import numpy as np
+import rioxarray
+
+from satpy.readers.file_handlers import BaseFileHandler
+
+from .sar_c_safe import change_quantity
+
+
+class SARRS02GenericFileHandler(BaseFileHandler):
+    """Base class for Radarsat 2 file handlers."""
+
+    @property
+    def start_time(self):
+        """Start time for the data."""
+        return self.filename_info["start_time"]
+
+
+class SARRS02MeasurementFileHandler(SARRS02GenericFileHandler):
+    """File handler for Radarsat 2 imagery files."""
+
+    def __init__(self, filename, filename_info, filetype_info, cal_beta_fh, cal_sigma_fh, cal_gamma_fh):
+        """Initialize the file handler."""
+        super().__init__(filename, filename_info, filetype_info)
+        self.gamma_fh = cal_gamma_fh
+        self.sigma_fh = cal_sigma_fh
+        self.beta_fh = cal_beta_fh
+        self.polarization = self.filename_info["polarization"].lower()
+
+    def get_dataset(self, dataid, ds_info=None):
+        """Get dataset."""
+        if self.polarization != dataid["polarization"]:
+            return
+        data = rioxarray.open_rasterio(self.filename, chunks=(1, "auto", "auto")).squeeze()
+        if dataid.get("calibration") == "gamma":
+            dn_squared = data.astype(float) ** 2
+            data = dn_squared / self.gamma_fh.get_dataset()
+        if dataid.get("calibration") == "sigma_nought":
+            dn_squared = data.astype(float) ** 2
+            data = dn_squared / self.sigma_fh.get_dataset()
+        if dataid.get("calibration") == "beta_nought":
+            dn_squared = data.astype(float) ** 2
+            data = dn_squared / self.beta_fh.get_dataset()
+        data = change_quantity(data, dataid.get("quantity"))
+        return data
+
+
+class SARRS02CalibrationFileHandler(SARRS02GenericFileHandler):
+    """File handler for Radarsat 2 calibration look-up tables."""
+
+    def get_dataset(self):
+        """Get dataset."""
+        root = ElementTree.parse(self.filename)
+        res = root.find("gains").text.split()
+        return np.array(res).astype(float)

--- a/satpy/tests/reader_tests/test_radarsat02.py
+++ b/satpy/tests/reader_tests/test_radarsat02.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2022 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Module for testing the satpy.readers.sar-rs02 module."""
+
+import os
+import shutil
+from datetime import datetime
+from tempfile import mkdtemp
+
+import numpy as np
+import rasterio
+from trollsift import parse
+
+from satpy.readers.sar_rs02 import SARRS02CalibrationFileHandler, SARRS02MeasurementFileHandler
+from satpy.tests.utils import make_dsq
+
+imagery_pattern = ('{mission_id:3s}_{start_time:%Y%m%d_%H%M%S}_{filler1:4s}_{scan_mode:s}_{polarization_set:s}_{process'
+                   'ing_level:s}_{filler2:6s}_{filler3:4s}_{filler4:8s}/imagery_{polarization:2s}.tif')
+
+
+def create_fake_rs02_dataset():
+    """Create a fake Radarsat 2 dataset."""
+    dirpath = mkdtemp()
+    rs2_name = "RS2_20220114_045216_0076_SCWA_HHHV_SGF_948791_1370_46579936"
+    rs2_dir = os.path.join(dirpath, rs2_name)
+    os.makedirs(rs2_dir)
+
+    arr = np.full((30, 20), 2, dtype=np.uint16)
+
+    for filename in ["imagery_HH.tif", "imagery_HV.tif"]:
+        with rasterio.open(
+                os.path.join(rs2_dir, filename),
+                'w',
+                driver='GTiff',
+                height=arr.shape[0],
+                width=arr.shape[1],
+                count=1,
+                dtype=arr.dtype,
+                crs='+proj=latlong',
+        ) as dst:
+            dst.write(arr, 1)
+
+    lut_prefix = ('<lut copyright="RADARSAT-2 Data and Products (c) MDA Geospatial Services Inc., 2022 - All Rights Res'
+                  'erved.">'
+                  '<offset>0.000000e+00</offset>'
+                  '<gains>')
+    lut_suffix = '</gains></lut>'
+    sigma = ("3.178132e+09 3.177661e+09 3.177190e+09 3.176724e+09 3.176248e+09 3.175782e+09 3.175311e+09 3.174839e+09 "
+             "3.174369e+09 3.173898e+09 3.173427e+09 3.172957e+09 3.172487e+09 3.172016e+09 3.171551e+09 3.171075e+09 "
+             "3.170605e+09 3.170140e+09 3.169665e+09 3.169195e+09")
+
+    beta = ("2.415050e+09 2.414618e+09 2.414185e+09 2.413757e+09 2.413320e+09 2.412892e+09 2.412460e+09 2.412027e+09 "
+            "2.411595e+09 2.411163e+09 2.410731e+09 2.410299e+09 2.409867e+09 2.409435e+09 2.409008e+09 2.408572e+09 "
+            "2.408141e+09 2.407713e+09 2.407278e+09 2.406846e+09")
+
+    gamma = ("2.065928e+09 2.065709e+09 2.065489e+09 2.065273e+09 2.065051e+09 2.064835e+09 2.064615e+09 2.064396e+09 "
+             "2.064177e+09 2.063958e+09 2.063739e+09 2.063520e+09 2.063301e+09 2.063081e+09 2.062866e+09 2.062644e+09 "
+             "2.062425e+09 2.062209e+09 2.061987e+09 2.061768e+09")
+
+    for lutname, arr in zip(["lutBeta.xml", "lutSigma.xml", "lutGamma.xml"], [beta, sigma, gamma]):
+        with open(os.path.join(rs2_dir, lutname), mode="w") as dst:
+            dst.write(lut_prefix + arr + lut_suffix)
+
+    return dirpath, rs2_name
+
+
+class TestSARRS02FileHandlers:
+    """Test the Radarsat 2 file handlers."""
+
+    def setup(self):
+        """Set up test case."""
+        self.base_dir, rs2_dir = create_fake_rs02_dataset()
+        self.rs2_dir = os.path.join(self.base_dir, rs2_dir)
+        basename = os.path.join(rs2_dir, "imagery_HV.tif")
+        self.filename = os.path.join(self.base_dir, basename)
+        self.filename_info = parse(imagery_pattern, basename)
+
+    def teardown(self):
+        """Tear down the test case."""
+        shutil.rmtree(self.base_dir)
+
+    def test_image_shape(self):
+        """Test that image has correct shape."""
+        fh = SARRS02MeasurementFileHandler(self.filename, self.filename_info, None, None, None, None)
+        data = fh.get_dataset(make_dsq(name="hv", polarization="hv"))
+        assert data.shape == (30, 20)
+
+    def test_lut_reading(self):
+        """Test that calibration luts are read correctly."""
+        filename_calibration = os.path.join(self.rs2_dir, "lutGamma.xml")
+        filename_info = self.filename_info.copy()
+        cal_fh = SARRS02CalibrationFileHandler(filename_calibration, filename_info, None)
+        cal_data = cal_fh.get_dataset()
+        assert cal_data.shape == (20, )
+        assert cal_data[0] == 2.065928e+09
+
+    def test_calibration_to_gamma(self):
+        """Test the calibration of the data to gamma."""
+        calibration = "gamma"
+        self.check_calibrated_data(calibration)
+
+    def check_calibrated_data(self, calibration):
+        """Check the calibrated data is correct."""
+        cal_data, fh = self.get_fh_with_calibration(calibration)
+        data = fh.get_dataset(make_dsq(name="measurement", polarization="hv")).astype(float)
+        calibrated = fh.get_dataset(make_dsq(name="hv", polarization="hv", calibration=calibration))
+        np.testing.assert_allclose(calibrated, data * data / cal_data)
+
+    def get_fh_with_calibration(self, calibration):
+        """Get a filehandler with calibration filehandlers provided."""
+        calibrations = {"beta_nought": ("lutBeta.xml", "cal_beta_fh"),
+                        "sigma_nought": ("lutSigma.xml", "cal_sigma_fh"),
+                        "gamma": ("lutGamma.xml", "cal_gamma_fh")}
+        kwargs = dict(cal_beta_fh=None, cal_sigma_fh=None, cal_gamma_fh=None)
+        lut_filename, keyword = calibrations[calibration]
+        filename_calibration = os.path.join(self.rs2_dir, lut_filename)
+        cal_fh = SARRS02CalibrationFileHandler(filename_calibration, self.filename_info, None)
+        cal_data = cal_fh.get_dataset()
+        kwargs[keyword] = cal_fh
+        fh = SARRS02MeasurementFileHandler(self.filename, self.filename_info, None, **kwargs)
+        return cal_data, fh
+
+    def test_calibration_to_sigma(self):
+        """Test the calibration of the data to sigma nought."""
+        calibration = "sigma_nought"
+        self.check_calibrated_data(calibration)
+
+    def test_calibration_to_beta(self):
+        """Test the calibration of the data to beta nought."""
+        calibration = "beta_nought"
+        self.check_calibrated_data(calibration)
+
+    def test_wrong_file_makes_get_dataset_return_none(self):
+        """Test that providing a file with wrong polarization makes get_dataset return None."""
+        fh = SARRS02MeasurementFileHandler(self.filename, self.filename_info, None, None, None, None)
+        data = fh.get_dataset(make_dsq(name="hh", polarization="hh"))
+        assert data is None
+
+    def test_units_are_provided(self):
+        """Test that the resulting DataArray has units."""
+        fh = SARRS02MeasurementFileHandler(self.filename, self.filename_info, None, None, None, None)
+        data = fh.get_dataset(make_dsq(name="hv", polarization="hv"))
+        assert data.attrs["units"] == "1"
+
+    def test_units_are_db_when_requested(self):
+        """Test that the resulting DataArray has units in dB when needed."""
+        fh = SARRS02MeasurementFileHandler(self.filename, self.filename_info, None, None, None, None)
+        data = fh.get_dataset(make_dsq(name="hv", polarization="hv", quantity="dB"))
+        assert data.attrs["units"] == "dB"
+
+    def test_start_time(self):
+        """Test that the start time of the file handler is correct."""
+        fh = SARRS02MeasurementFileHandler(self.filename, self.filename_info, None, None, None, None)
+        assert fh.start_time == datetime(2022, 1, 14, 4, 52, 16)
+
+    def test_calibration_start_time(self):
+        """Test that the start time of the calibration file handler is correct."""
+        filename_calibration = os.path.join(self.rs2_dir, "lutGamma.xml")
+        fh = SARRS02CalibrationFileHandler(filename_calibration, self.filename_info, None)
+        assert fh.start_time == datetime(2022, 1, 14, 4, 52, 16)


### PR DESCRIPTION
This PR adds a reader for Radarsat 2 SGF data.

 - [ ] Add support for geolocation
 - [ ] Add new line in the documentation's reader table
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

Example output using the sar-ice-log composite
![sar-ice-log_20220114_045216-gamma](https://user-images.githubusercontent.com/167802/149907180-b7ca076a-9322-47c4-9f95-d15b136e8361.jpg)

