### PR TITLE
Add reader kwarg to 'ahi_hrit' to disable exact start_time

### DIFF
--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -195,7 +195,7 @@ class HRITJMAFileHandler(HRITFileHandler):
 
         scene = Scene(filenames=filenames,
                       reader='ahi_hrit',
-                      reader_kwargs={'use_exact_start_time': True})
+                      reader_kwargs={'use_acquisition_time_as_start_time': True})
 
     As this time is different for every channel, time-dependent calculations like SZA correction
     can be pretty slow when multiple channels are used.
@@ -217,7 +217,7 @@ class HRITJMAFileHandler(HRITFileHandler):
 
     """
 
-    def __init__(self, filename, filename_info, filetype_info, use_exact_start_time=False):
+    def __init__(self, filename, filename_info, filetype_info, use_acquisition_time_as_start_time=False):
         """Initialize the reader."""
         super(HRITJMAFileHandler, self).__init__(filename, filename_info,
                                                  filetype_info,
@@ -225,7 +225,7 @@ class HRITJMAFileHandler(HRITFileHandler):
                                                   jma_variable_length_headers,
                                                   jma_text_headers))
 
-        self._use_exact_start_time = use_exact_start_time
+        self._use_acquisition_time_as_start_time = use_acquisition_time_as_start_time
         self.mda['segment_sequence_number'] = self.mda['image_segm_seq_no']
         self.mda['planned_end_segment_number'] = self.mda['total_no_image_segm']
         self.mda['planned_start_segment_number'] = 1
@@ -458,7 +458,7 @@ class HRITJMAFileHandler(HRITFileHandler):
     @property
     def start_time(self):
         """Get start time of the scan."""
-        if self._use_exact_start_time:
+        if self._use_acquisition_time_as_start_time:
             return self.acq_time[0].astype(datetime)
         return self._start_time
 

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -190,16 +190,34 @@ def mjd2datetime64(mjd):
 class HRITJMAFileHandler(HRITFileHandler):
     """JMA HRIT format reader.
 
-    By default, the reader computes the exact start time.  As this time is different for every channel,
-    things like angle calculation (SZA correction) can get very slow.  To use approximate times, the user can
-    define an keyword argument to use the time parsed from the filename::
+    By default, the reader uses the start time parsed from the filename. To use exact time, computed
+    from the metadata, the user can define a keyword argument::
 
         scene = Scene(filenames=filenames,
                       reader='ahi_hrit',
-                      reader_kwargs={'use_exact_start_time': False})
+                      reader_kwargs={'use_exact_start_time': True})
+
+    As this time is different for every channel, time-dependent calculations like SZA correction
+    can be pretty slow when multiple channels are used.
+
+    The exact scanline times are always available as coordinates of an individual channels::
+
+        scene.load(["B03"])
+        print(scene["B03].coords["acq_time"].data)
+
+    would print something similar to::
+
+        array(['2021-12-08T06:00:20.131200000', '2021-12-08T06:00:20.191948000',
+               '2021-12-08T06:00:20.252695000', ...,
+               '2021-12-08T06:09:39.449390000', '2021-12-08T06:09:39.510295000',
+               '2021-12-08T06:09:39.571200000'], dtype='datetime64[ns]')
+
+    The first value represents the exact start time, and the last one the exact end time of the data
+    acquisition.
+
     """
 
-    def __init__(self, filename, filename_info, filetype_info, use_exact_start_time=True):
+    def __init__(self, filename, filename_info, filetype_info, use_exact_start_time=False):
         """Initialize the reader."""
         super(HRITJMAFileHandler, self).__init__(filename, filename_info,
                                                  filetype_info,

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -328,7 +328,18 @@ class TestHRITJMAFileHandler(unittest.TestCase):
                                        atol=45000)
 
     def test_start_time_from_filename(self):
-        """Test that 'use_exact_start_time=False' returns the datetime in the filename."""
+        """Test that by default the datetime in the filename is returned."""
+        import datetime as dt
+        start_time = dt.datetime(2022, 1, 20, 12, 10)
+        for platform in ['Himawari-8', 'MTSAT-2']:
+            mda = self._get_mda(platform=platform)
+            reader = self._get_reader(
+                mda=mda,
+                filename_info={'start_time': start_time})
+            assert reader._start_time == start_time
+
+    def test_start_time_from_aqc_time(self):
+        """Test that by the datetime from the metadata returned when `use_exact_start_time=True`."""
         import datetime as dt
         start_time = dt.datetime(2022, 1, 20, 12, 10)
         for platform in ['Himawari-8', 'MTSAT-2']:
@@ -336,5 +347,5 @@ class TestHRITJMAFileHandler(unittest.TestCase):
             reader = self._get_reader(
                 mda=mda,
                 filename_info={'start_time': start_time},
-                reader_kwargs={'use_exact_start_time': False})
-            assert reader._start_time == start_time
+                reader_kwargs={'use_exact_start_time': True})
+            assert reader.start_time == reader.acq_time[0].astype(dt.datetime)

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -339,7 +339,7 @@ class TestHRITJMAFileHandler(unittest.TestCase):
             assert reader._start_time == start_time
 
     def test_start_time_from_aqc_time(self):
-        """Test that by the datetime from the metadata returned when `use_exact_start_time=True`."""
+        """Test that by the datetime from the metadata returned when `use_acquisition_time_as_start_time=True`."""
         import datetime as dt
         start_time = dt.datetime(2022, 1, 20, 12, 10)
         for platform in ['Himawari-8', 'MTSAT-2']:
@@ -347,5 +347,5 @@ class TestHRITJMAFileHandler(unittest.TestCase):
             reader = self._get_reader(
                 mda=mda,
                 filename_info={'start_time': start_time},
-                reader_kwargs={'use_exact_start_time': True})
+                reader_kwargs={'use_acquisition_time_as_start_time': True})
             assert reader.start_time == reader.acq_time[0].astype(dt.datetime)

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -29,13 +29,18 @@ class TestHRITJMAFileHandler(unittest.TestCase):
     """Test the HRITJMAFileHandler."""
 
     @mock.patch('satpy.readers.hrit_jma.HRITFileHandler.__init__')
-    def _get_reader(self, mocked_init, mda, filename_info=None):
+    def _get_reader(self, mocked_init, mda, filename_info=None, filetype_info=None, reader_kwargs=None):
         from satpy.readers.hrit_jma import HRITJMAFileHandler
         if not filename_info:
             filename_info = {}
+        if not filetype_info:
+            filetype_info = {}
+        if not reader_kwargs:
+            reader_kwargs = {}
         HRITJMAFileHandler.filename = 'filename'
         HRITJMAFileHandler.mda = mda
-        return HRITJMAFileHandler('filename', filename_info, {})
+        HRITJMAFileHandler._start_time = filename_info.get('start_time')
+        return HRITJMAFileHandler('filename', filename_info, filetype_info, **reader_kwargs)
 
     def _get_acq_time(self, nlines):
         """Get sample header entry for scanline acquisition times.
@@ -321,3 +326,15 @@ class TestHRITJMAFileHandler(unittest.TestCase):
             np.testing.assert_allclose(reader.acq_time.astype(np.int64),
                                        acq_time_exp.astype(np.int64),
                                        atol=45000)
+
+    def test_start_time_from_filename(self):
+        """Test that 'use_exact_start_time=False' returns the datetime in the filename."""
+        import datetime as dt
+        start_time = dt.datetime(2022, 1, 20, 12, 10)
+        for platform in ['Himawari-8', 'MTSAT-2']:
+            mda = self._get_mda(platform=platform)
+            reader = self._get_reader(
+                mda=mda,
+                filename_info={'start_time': start_time},
+                reader_kwargs={'use_exact_start_time': False})
+            assert reader._start_time == start_time


### PR DESCRIPTION
The `'ahi_hrit'` by default takes the exact `start_time` from the data it self. The `start_time` is down to microsecond level, and is different for every dataset. This will cause for example Sun zenith angle correction to be computed separately for every VIS channel.

This PR introduces a reader keyword argument `use_acquisition_time_as_start_time` to control whether nominal (parsed from the filename) or exact acquisition start time will be used. The default, due to significantly better performance, is the nominal time parsed from the filename (`reader_kwargs={'use_acquisition_time_as_start_time': False}`).

The exact times are always available from the channel coordinates:

```python
scene.load(["B03"])
print(scene["B03].coords["acq_time"].data)
array(['2021-12-08T06:00:20.131200000', '2021-12-08T06:00:20.191948000',
       '2021-12-08T06:00:20.252695000', ...,
       '2021-12-08T06:09:39.449390000', '2021-12-08T06:09:39.510295000',
       '2021-12-08T06:09:39.571200000'], dtype='datetime64[ns]')
```

The first value represents the exact start time, and the last one the exact end time of the data acquisition.

Another option would've been to ensure all the angle computations were using a rounded time (to closest minute or so), but that might not be desirable for some use cases.

 - [x] Closes #1384  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
