### PR TITLE
Check that time is not already a coordinate in CF writer

### DIFF
--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -174,7 +174,7 @@ This will compute one video frame (image) at a time and write it to the MPEG-4
 video file. For users with more powerful systems it is possible to use
 the ``client`` and ``batch_size`` keyword arguments to compute multiple frames
 in parallel using the dask ``distributed`` library (if installed).
-See the :doc:`dask distributed <dask:how-to/deploy-dask/single-distributed>` documentation
+See the :doc:`dask distributed <dask:deploying-python>` documentation
 for information on creating a ``Client`` object. If working on a cluster
 you may want to use :doc:`dask jobqueue <jobqueue:index>` to take advantage
 of multiple nodes at a time.

--- a/satpy/etc/readers/slstr_l1b.yaml
+++ b/satpy/etc/readers/slstr_l1b.yaml
@@ -89,6 +89,16 @@ datasets:
     standard_name: latitude
     units: degree
 
+  elevation:
+    name: elevation
+    resolution: [500, 1000]
+    view: [nadir, oblique]
+    stripe: [a, b, i, f]
+    file_type: esa_geo
+    file_key: elevation_{stripe:1s}{view:1s}
+    standard_name: elevation
+    units: m
+
   # The channels S1-S3 are available in nadir (default) and oblique view.
   S1:
     name: S1

--- a/satpy/modifiers/geometry.py
+++ b/satpy/modifiers/geometry.py
@@ -103,7 +103,7 @@ class SunZenithCorrector(SunZenithCorrectorBase):
     .. code-block:: yaml
 
       sunz_corrected:
-        compositor: !!python/name:satpy.composites.SunZenithCorrector
+        modifier: !!python/name:satpy.modifiers.SunZenithCorrector
         max_sza: !!null
         optional_prerequisites:
         - solar_zenith_angle
@@ -149,7 +149,7 @@ class EffectiveSolarPathLengthCorrector(SunZenithCorrectorBase):
     .. code-block:: yaml
 
       effective_solar_pathlength_corrected:
-        compositor: !!python/name:satpy.composites.EffectiveSolarPathLengthCorrector
+        modifier: !!python/name:satpy.modifiers.EffectiveSolarPathLengthCorrector
         max_sza: !!null
         optional_prerequisites:
         - solar_zenith_angle

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -300,16 +300,16 @@ class TestCFWriter(unittest.TestCase):
         from satpy import Scene
         scn = Scene()
         test_array = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+        times = np.array(['2018-05-30T10:05:00', '2018-05-30T10:05:01',
+                          '2018-05-30T10:05:02', '2018-05-30T10:05:03'], dtype=np.datetime64)
         scn['test-array'] = xr.DataArray(test_array,
                                          dims=['y', 'x'],
-                                         coords={'time': ('y', np.array(['2018-05-30T10:05:00',
-                                                                         '2018-05-30T10:05:01',
-                                                                         '2018-05-30T10:05:02',
-                                                                         '2018-05-30T10:05:03'], dtype=np.datetime64))})
+                                         coords={'time': ('y', times)},
+                                         attrs=dict(start_time=times[0], end_time=times[-1]))
         with TempFile() as filename:
-            scn.save_datasets(filename=filename, writer='cf')
+            scn.save_datasets(filename=filename, writer='cf', pretty=True)
             with xr.open_dataset(filename, decode_cf=True) as f:
-                np.testing.assert_array_equal(f['test-array_time'], scn['test-array']['time'])
+                np.testing.assert_array_equal(f['time'], scn['test-array']['time'])
 
     def test_bounds(self):
         """Test setting time bounds."""

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -293,6 +293,24 @@ class TestCFWriter(unittest.TestCase):
                 bounds_exp = np.array([[start_time, end_time]], dtype='datetime64[m]')
                 np.testing.assert_array_equal(f['time_bnds'], bounds_exp)
 
+    def test_time_coordinate_on_a_swath(self):
+        """Test that time dimension is not added on swath data with time already as a coordinate."""
+        import xarray as xr
+
+        from satpy import Scene
+        scn = Scene()
+        test_array = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
+        scn['test-array'] = xr.DataArray(test_array,
+                                         dims=['y', 'x'],
+                                         coords={'time': ('y', np.array(['2018-05-30T10:05:00',
+                                                                         '2018-05-30T10:05:01',
+                                                                         '2018-05-30T10:05:02',
+                                                                         '2018-05-30T10:05:03'], dtype=np.datetime64))})
+        with TempFile() as filename:
+            scn.save_datasets(filename=filename, writer='cf')
+            with xr.open_dataset(filename, decode_cf=True) as f:
+                np.testing.assert_array_equal(f['test-array_time'], scn['test-array']['time'])
+
     def test_bounds(self):
         """Test setting time bounds."""
         import xarray as xr

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -702,7 +702,7 @@ class CFWriter(Writer):
             new_data['time'].encoding['units'] = epoch
             new_data['time'].attrs['standard_name'] = 'time'
             new_data['time'].attrs.pop('bounds', None)
-            if 'time' not in new_data.dims:
+            if 'time' not in new_data.dims and 'time' not in new_data.coords:
                 new_data = new_data.expand_dims('time')
         return new_data
 

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -702,7 +702,7 @@ class CFWriter(Writer):
             new_data['time'].encoding['units'] = epoch
             new_data['time'].attrs['standard_name'] = 'time'
             new_data['time'].attrs.pop('bounds', None)
-            if 'time' not in new_data.dims and 'time' not in new_data.coords:
+            if 'time' not in new_data.dims and new_data["time"].size not in new_data.shape:
                 new_data = new_data.expand_dims('time')
         return new_data
 

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -656,7 +656,6 @@ class CFWriter(Writer):
             new_data.encoding.update(compression)
 
         new_data = CFWriter._encode_time(new_data, epoch)
-
         new_data = CFWriter._encode_coords(new_data)
 
         if 'long_name' not in new_data.attrs and 'standard_name' not in new_data.attrs:
@@ -702,8 +701,13 @@ class CFWriter(Writer):
             new_data['time'].encoding['units'] = epoch
             new_data['time'].attrs['standard_name'] = 'time'
             new_data['time'].attrs.pop('bounds', None)
-            if 'time' not in new_data.dims and new_data["time"].size not in new_data.shape:
-                new_data = new_data.expand_dims('time')
+            new_data = CFWriter._add_time_dimension(new_data)
+        return new_data
+
+    @staticmethod
+    def _add_time_dimension(new_data):
+        if 'time' not in new_data.dims and new_data["time"].size not in new_data.shape:
+            new_data = new_data.expand_dims('time')
         return new_data
 
     @staticmethod


### PR DESCRIPTION
Fix for CF writer for cases like swath data where scan line times can be already set as a coordinate for the along-track dimension. In these cases the time dimension shouldn't be added.

Below is what happens with the current `main` branch, which should have been in a separate issue.

 - [x] Tests added <!-- for all bug fixes or enhancements -->

I was trying to save multiple NWC SAF PPS granules to a single NetCDF file:

```python
#!/usr/bin/env python

import glob

from satpy import Scene


def main():
    fnames = glob.glob(
        "/home/lahtinep/data/satellite/polar/ears_pps/*48471.nc")
    dsets = ['cma', 'ct', 'ctth_alti', 'ctth_pres', 'ctth_tempe', 'lon', 'lat']
    glbl = Scene(reader='nwcsaf-pps_nc', filenames=fnames)
    glbl.load(dsets)
    dtype_int16 = {'dtype': np.int16}
    dtype_float32 = {'dtype': np.float32}
    encoding = {'cma': dtype_int16,
                'ct': dtype_int16}
    glbl.save_datasets(writer='cf', base_dir='/tmp/', encoding=encoding, include_lonlats=True)


if __name__ == "__main__":
    main()
```

Using the current `main` branch, this fails with:

```python
Can't load ancillary dataset cma_conditions
Can't load ancillary dataset cma_quality
Can't load ancillary dataset cma_status_flag
Can't load ancillary dataset cma_testlist1
Can't load ancillary dataset cma_testlist2
/home/lahtinep/Software/pytroll/pytroll_packages/satpy/satpy/writers/cf_writer.py:571: FutureWarning: The default behaviour of the CF writer will soon change to not compress data by default.
  warnings.warn("The default behaviour of the CF writer will soon change to not compress data by default.",
/home/lahtinep/Software/pytroll/pytroll_packages/satpy/satpy/writers/cf_writer.py:742: UserWarning: Dtype uint8 not compatible with CF-1.7.
  warnings.warn('Dtype {} not compatible with {}.'.format(str(ds.dtype), CF_VERSION))
Traceback (most recent call last):
  File "/home/lahtinep/bin/test_ears_nwc2netcdf.py", line 64, in <module>
    main()
  File "/home/lahtinep/bin/test_ears_nwc2netcdf.py", line 55, in main
    glbl.save_datasets(writer='cf', base_dir='/tmp/', encoding=encoding, include_lonlats=True)
  File "/home/lahtinep/Software/pytroll/pytroll_packages/satpy/satpy/scene.py", line 1143, in save_datasets
    return writer.save_datasets(dataarrays, compute=compute, **save_kwargs)
  File "/home/lahtinep/Software/pytroll/pytroll_packages/satpy/satpy/writers/cf_writer.py", line 840, in save_datasets
    datas, start_times, end_times = self._collect_datasets(
  File "/home/lahtinep/Software/pytroll/pytroll_packages/satpy/satpy/writers/cf_writer.py", line 753, in _collect_datasets
    new_var = self.da2cf(new_ds, epoch=epoch, flatten_attrs=flatten_attrs,
  File "/home/lahtinep/Software/pytroll/pytroll_packages/satpy/satpy/writers/cf_writer.py", line 658, in da2cf
    new_data = CFWriter._encode_time(new_data, epoch)
  File "/home/lahtinep/Software/pytroll/pytroll_packages/satpy/satpy/writers/cf_writer.py", line 706, in _encode_time
    new_data = new_data.expand_dims('time')
  File "/home/lahtinep/mambaforge/envs/pytroll/lib/python3.9/site-packages/xarray/core/dataarray.py", line 1952, in expand_dims
    ds = self._to_temp_dataset().expand_dims(dim, axis)
  File "/home/lahtinep/mambaforge/envs/pytroll/lib/python3.9/site-packages/xarray/core/dataset.py", line 3658, in expand_dims
    raise ValueError(
ValueError: time already exists as coordinate or variable name.
```
