### PR TITLE
read the "elevation" variable in slstr_l1b

### DIFF
--- a/satpy/etc/readers/slstr_l1b.yaml
+++ b/satpy/etc/readers/slstr_l1b.yaml
@@ -89,6 +89,16 @@ datasets:
     standard_name: latitude
     units: degree
 
+  elevation:
+    name: elevation
+    resolution: [500, 1000]
+    view: [nadir, oblique]
+    stripe: [a, b, i, f]
+    file_type: esa_geo
+    file_key: elevation_{stripe:1s}{view:1s}
+    standard_name: elevation
+    units: m
+
   # The channels S1-S3 are available in nadir (default) and oblique view.
   S1:
     name: S1


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->

The slstr_l1b drivers now can read the "elevation" variable along with latitude and longitude in the geodetic files.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ X] Add your name to `AUTHORS.md` if not there already
