### PR TITLE
Add support for CMIC product from PPSv2021

### DIFF
--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -337,43 +337,43 @@ composites:
   cloud_top_phase:
     compositor: !!python/name:satpy.composites.PaletteCompositor
     prerequisites:
-    - cpp_phase
-    - cpp_phase_pal
+    - cmic_phase
+    - cmic_phase_pal
     standard_name: cloud_top_phase
 
   cloud_drop_effective_radius:
     compositor: !!python/name:satpy.composites.ColorizeCompositor
     prerequisites:
-    - cpp_reff
-    - cpp_reff_pal
+    - cmic_reff
+    - cmic_reff_pal
     standard_name: cloud_drop_effective_radius
 
   cloud_optical_thickness:
     compositor: !!python/name:satpy.composites.ColorizeCompositor
     prerequisites:
-    - cpp_cot
-    - cpp_cot_pal
+    - cmic_cot
+    - cmic_cot_pal
     standard_name: cloud_optical_thickness
 
   cloud_water_path:
     compositor: !!python/name:satpy.composites.ColorizeCompositor
     prerequisites:
-    - cpp_cwp
-    - cpp_cwp_pal
+    - cmic_cwp
+    - cmic_cwp_pal
     standard_name: cloud_water_path
 
   ice_water_path:
     compositor: !!python/name:satpy.composites.ColorizeCompositor
     prerequisites:
-    - cpp_iwp
-    - cpp_iwp_pal
+    - cmic_iwp
+    - cmic_iwp_pal
     standard_name: ice_water_path
 
   liquid_water_path:
     compositor: !!python/name:satpy.composites.ColorizeCompositor
     prerequisites:
-    - cpp_lwp
-    - cpp_lwp_pal
+    - cmic_lwp
+    - cmic_lwp_pal
     standard_name: liquid_water_path
 
   night_microphysics:

--- a/satpy/etc/readers/nwcsaf-pps_nc.yaml
+++ b/satpy/etc/readers/nwcsaf-pps_nc.yaml
@@ -35,8 +35,12 @@ file_types:
     nc_nwcsaf_cpp:
         file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
         file_patterns: ['S_NWC_CPP_{platform_id}_{orbit_number}_{start_time:%Y%m%dT%H%M%S%f}Z_{end_time:%Y%m%dT%H%M%S%f}Z.nc']
+        file_key_prefix: cpp_
 
-
+    nc_nwcsaf_cmic:
+        file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
+        file_patterns: ['S_NWC_CMIC_{platform_id}_{orbit_number}_{start_time:%Y%m%dT%H%M%S%f}Z_{end_time:%Y%m%dT%H%M%S%f}Z.nc']
+        file_key_prefix: cmic_
 
 datasets:
 
@@ -214,63 +218,93 @@ datasets:
     file_type: nc_nwcsaf_ctth
 
 
-# ---- CPP products ------------
+# ---- CMIC products (Was CPP in PPS<=2018)------------
 
-  cpp_phase:
-    name: cpp_phase
-    file_type: nc_nwcsaf_cpp
+  cmic_phase:
+    name: cmic_phase
+    file_key: phase
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
     coordinates: [lon, lat]
 
-  cpp_phase_pal:
-    name: cpp_phase_pal
-    file_type: nc_nwcsaf_cpp
+  cmic_phase_pal:
+    name: [cmic_phase_pal, cpp_phase_pal]
+    file_key: phase_pal
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
 
-  cpp_reff:
-    name: cpp_reff
-    file_type: nc_nwcsaf_cpp
+  cmic_reff:
+    name: cmic_reff
+    file_key: reff
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
     coordinates: [lon, lat]
 
-  cpp_reff_pal:
-    name: cpp_reff_pal
-    scale_offset_dataset: cpp_reff
-    file_type: nc_nwcsaf_cpp
+  cmic_reff_pal:
+    name: [cmic_reff_pal, cpp_reff_pal]
+    file_key: reff_pal
+    scale_offset_dataset: reff
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
 
-  cpp_cot:
-    name: cpp_cot
-    file_type: nc_nwcsaf_cpp
+  cmic_cot:
+    name: cmic_cot
+    file_key: cot
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
     coordinates: [lon, lat]
 
-  cpp_cot_pal:
-    name: cpp_cot_pal
-    scale_offset_dataset: cpp_cot
-    file_type: nc_nwcsaf_cpp
+  cmic_cot_pal:
+    name: [cmic_cot_pal, cpp_cot_pal]
+    file_key: cot_pal
+    scale_offset_dataset: cot
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
 
-  cpp_cwp:
-    name: cpp_cwp
-    file_type: nc_nwcsaf_cpp
+  cmic_cwp:
+    name: cmic_cwp
+    file_key: cwp
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
     coordinates: [lon, lat]
 
-  cpp_cwp_pal:
-    name: cpp_cwp_pal
-    scale_offset_dataset: cpp_cwp
-    file_type: nc_nwcsaf_cpp
+  cmic_cwp_pal:
+    name: [cmic_cwp_pal, cpp_cwp_pal]
+    file_key: cwp_pal
+    scale_offset_dataset: cwp
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
 
-  cpp_iwp:
-    name: cpp_iwp
-    file_type: nc_nwcsaf_cpp
+  cmic_iwp:
+    name: cmic_iwp
+    file_key: iwp
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
     coordinates: [lon, lat]
 
-  cpp_iwp_pal:
-    name: cpp_iwp_pal
-    scale_offset_dataset: cpp_iwp
-    file_type: nc_nwcsaf_cpp
+  cmic_iwp_pal:
+    name: [cmic_iwp_pal, cpp_iwp_pal]
+    file_key: iwp_pal
+    scale_offset_dataset: iwp
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
 
-  cpp_lwp:
-    name: cpp_lwp
-    file_type: nc_nwcsaf_cpp
+  cmic_lwp:
+    name: cmic_lwp
+    file_key: lwp
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
     coordinates: [lon, lat]
 
-  cpp_lwp_pal:
-    name: cpp_lwp_pal
-    scale_offset_dataset: cpp_lwp
-    file_type: nc_nwcsaf_cpp
+  cmic_lwp_pal:
+    name: [cmic_lwp_pal, cpp_lwp_pal]
+    file_key: lwp_pal
+    scale_offset_dataset: lwp
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
+
+  cmic_status_flag:
+    name: [cmic_status_flag, cpp_status_flag]
+    file_key: status_flag
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
+    coordinates: [lon, lat]
+
+  cmic_conditions:
+    name: [cmic_conditions, cpp_conditions]
+    file_key: conditions
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
+    coordinates: [lon, lat]
+
+  cmic_quality:
+    name: [cmic_quality, cpp_quality]
+    file_key: quality
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
+    coordinates: [lon, lat]

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -25,6 +25,7 @@ References:
 import logging
 import os
 from datetime import datetime
+from functools import lru_cache
 
 import dask.array as da
 import numpy as np
@@ -131,19 +132,18 @@ class NcNWCSAF(BaseFileHandler):
             logger.debug('Get the data set from cache: %s.', dsid_name)
             return self.cache[dsid_name]
         if dsid_name in ['lon', 'lat'] and dsid_name not in self.nc:
-            dsid_name = dsid_name + '_reduced'
+            # Get full resolution lon,lat from the reduced (tie points) grid
+            lon, lat = self.upsample_geolocation()
+            if dsid_name == "lon":
+                return lon
+            else:
+                return lat
 
         logger.debug('Reading %s.', dsid_name)
         file_key = self._get_filekey(dsid_name, info)
         variable = self.nc[file_key]
         variable = self.remove_timedim(variable)
-        variable = self.scale_dataset(dsid, variable, info)
-
-        if dsid_name.endswith('_reduced'):
-            # Get full resolution lon,lat from the reduced (tie points) grid
-            self.upsample_geolocation(dsid, info)
-
-            return self.cache[dsid['name']]
+        variable = self.scale_dataset(variable, info)
 
         return variable
 
@@ -154,7 +154,7 @@ class NcNWCSAF(BaseFileHandler):
             file_key = dsid_name
         return file_key
 
-    def scale_dataset(self, dsid, variable, info):
+    def scale_dataset(self, variable, info):
         """Scale the data set, applying the attributes from the netCDF file.
 
         The scale and offset attributes will then be removed from the resulting variable.
@@ -192,7 +192,7 @@ class NcNWCSAF(BaseFileHandler):
 
         if 'standard_name' in info:
             variable.attrs.setdefault('standard_name', info['standard_name'])
-        variable = self._adjust_variable_for_legacy_software(variable, dsid)
+        variable = self._adjust_variable_for_legacy_software(variable)
 
         return variable
 
@@ -235,29 +235,26 @@ class NcNWCSAF(BaseFileHandler):
         variable = variable[idx]
         return variable
 
-    def _adjust_variable_for_legacy_software(self, variable, data_id):
-        if self.sw_version == 'NWC/PPS version v2014' and data_id['name'] == 'ctth_alti':
+    def _adjust_variable_for_legacy_software(self, variable):
+        if self.sw_version == 'NWC/PPS version v2014' and variable.attrs.get('standard_name') == 'cloud_top_altitude':
             # pps 2014 valid range and palette don't match
             variable.attrs['valid_range'] = (0., 9000.)
-        if self.sw_version == 'NWC/PPS version v2014' and data_id['name'] == 'ctth_alti_pal':
+        if (self.sw_version == 'NWC/PPS version v2014' and
+                variable.attrs.get('long_name') == 'RGB Palette for ctth_alti'):
             # pps 2014 palette has the nodata color (black) first
             variable = variable[1:, :]
-        if self.sw_version == 'NWC/GEO version v2016' and data_id['name'] == 'ctth_alti':
-            # Geo 2016/18 valid range and palette don't match
-            # Valid range is 0 to 27000 in the file. But after scaling the valid range becomes -2000 to 25000
-            # This now fixed by the scaling of the valid range above.
-            pass
         return variable
 
-    def upsample_geolocation(self, dsid, info):
+    @lru_cache(maxsize=1)
+    def upsample_geolocation(self):
         """Upsample the geolocation (lon,lat) from the tiepoint grid."""
         from geotiepoints import SatelliteInterpolator
 
         # Read the fields needed:
         col_indices = self.nc['nx_reduced'].values
         row_indices = self.nc['ny_reduced'].values
-        lat_reduced = self.scale_dataset(dsid, self.nc['lat_reduced'], info)
-        lon_reduced = self.scale_dataset(dsid, self.nc['lon_reduced'], info)
+        lat_reduced = self.scale_dataset(self.nc['lat_reduced'], {})
+        lon_reduced = self.scale_dataset(self.nc['lon_reduced'], {})
 
         shape = (self.nc['y'].shape[0], self.nc['x'].shape[0])
         cols_full = np.arange(shape[1])
@@ -269,8 +266,9 @@ class NcNWCSAF(BaseFileHandler):
                                        (rows_full, cols_full))
 
         lons, lats = satint.interpolate()
-        self.cache['lon'] = xr.DataArray(lons, attrs=lon_reduced.attrs, dims=['y', 'x'])
-        self.cache['lat'] = xr.DataArray(lats, attrs=lat_reduced.attrs, dims=['y', 'x'])
+        lon = xr.DataArray(lons, attrs=lon_reduced.attrs, dims=['y', 'x'])
+        lat = xr.DataArray(lats, attrs=lat_reduced.attrs, dims=['y', 'x'])
+        return lon, lat
 
     def get_area_def(self, dsid):
         """Get the area definition of the datasets in the file.

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -134,10 +134,7 @@ class NcNWCSAF(BaseFileHandler):
             dsid_name = dsid_name + '_reduced'
 
         logger.debug('Reading %s.', dsid_name)
-        try:
-            file_key = self.file_key_prefix + info["file_key"]
-        except KeyError:
-            file_key = dsid_name
+        file_key = self._get_filekey(dsid_name, info)
         variable = self.nc[file_key]
         variable = self.remove_timedim(variable)
         variable = self.scale_dataset(dsid, variable, info)
@@ -149,6 +146,13 @@ class NcNWCSAF(BaseFileHandler):
             return self.cache[dsid['name']]
 
         return variable
+
+    def _get_filekey(self, dsid_name, info):
+        try:
+            file_key = self.file_key_prefix + info["file_key"]
+        except KeyError:
+            file_key = dsid_name
+        return file_key
 
     def scale_dataset(self, dsid, variable, info):
         """Scale the data set, applying the attributes from the netCDF file.

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -272,8 +272,6 @@ class NcNWCSAF(BaseFileHandler):
         self.cache['lon'] = xr.DataArray(lons, attrs=lon_reduced.attrs, dims=['y', 'x'])
         self.cache['lat'] = xr.DataArray(lats, attrs=lat_reduced.attrs, dims=['y', 'x'])
 
-        return
-
     def get_area_def(self, dsid):
         """Get the area definition of the datasets in the file.
 

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-2020 Satpy developers
+# Copyright (c) 2017-2022 Satpy developers
 #
 # This file is part of satpy.
 #

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2018, 2020 Satpy developers
+# Copyright (c) 2018-2022 Satpy developers
 #
 # This file is part of satpy.
 #

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -49,49 +49,49 @@ class TestNcNWCSAF(unittest.TestCase):
         self.fake_dataset = xr_open_dataset.return_value
         unzip.return_value = ''
         self.filehandler_class = NcNWCSAF
-        self.scn = self.filehandler_class('filename', {}, {})
+        self.fh = self.filehandler_class('filename', {}, {})
 
     def test_sensor_name(self):
         """Test that the correct sensor name is being set."""
-        self.scn.set_platform_and_sensor(platform_name='Metop-B')
-        self.assertEqual(self.scn.sensor, set(['avhrr-3']))
-        self.assertEqual(self.scn.sensor_names, set(['avhrr-3']))
+        self.fh.set_platform_and_sensor(platform_name='Metop-B')
+        self.assertEqual(self.fh.sensor, set(['avhrr-3']))
+        self.assertEqual(self.fh.sensor_names, set(['avhrr-3']))
 
-        self.scn.set_platform_and_sensor(platform_name='NOAA-20')
-        self.assertEqual(self.scn.sensor, set(['viirs']))
-        self.assertEqual(self.scn.sensor_names, set(['viirs']))
+        self.fh.set_platform_and_sensor(platform_name='NOAA-20')
+        self.assertEqual(self.fh.sensor, set(['viirs']))
+        self.assertEqual(self.fh.sensor_names, set(['viirs']))
 
-        self.scn.set_platform_and_sensor(platform_name='Himawari-8')
-        self.assertEqual(self.scn.sensor, set(['ahi']))
-        self.assertEqual(self.scn.sensor_names, set(['ahi']))
+        self.fh.set_platform_and_sensor(platform_name='Himawari-8')
+        self.assertEqual(self.fh.sensor, set(['ahi']))
+        self.assertEqual(self.fh.sensor_names, set(['ahi']))
 
-        self.scn.set_platform_and_sensor(sat_id='GOES16')
-        self.assertEqual(self.scn.sensor, set(['abi']))
-        self.assertEqual(self.scn.sensor_names, set(['abi']))
+        self.fh.set_platform_and_sensor(sat_id='GOES16')
+        self.assertEqual(self.fh.sensor, set(['abi']))
+        self.assertEqual(self.fh.sensor_names, set(['abi']))
 
-        self.scn.set_platform_and_sensor(platform_name='GOES-17')
-        self.assertEqual(self.scn.sensor, set(['abi']))
-        self.assertEqual(self.scn.sensor_names, set(['abi']))
+        self.fh.set_platform_and_sensor(platform_name='GOES-17')
+        self.assertEqual(self.fh.sensor, set(['abi']))
+        self.assertEqual(self.fh.sensor_names, set(['abi']))
 
-        self.scn.set_platform_and_sensor(sat_id='MSG4')
-        self.assertEqual(self.scn.sensor, set(['seviri']))
+        self.fh.set_platform_and_sensor(sat_id='MSG4')
+        self.assertEqual(self.fh.sensor, set(['seviri']))
 
-        self.scn.set_platform_and_sensor(platform_name='Meteosat-11')
-        self.assertEqual(self.scn.sensor, set(['seviri']))
-        self.assertEqual(self.scn.sensor_names, set(['seviri']))
+        self.fh.set_platform_and_sensor(platform_name='Meteosat-11')
+        self.assertEqual(self.fh.sensor, set(['seviri']))
+        self.assertEqual(self.fh.sensor_names, set(['seviri']))
 
     def test_get_area_def(self):
         """Test that get_area_def() returns proper area."""
         dsid = {'name': 'foo'}
-        self.scn.nc[dsid['name']] = xr.DataArray(np.zeros((5, 10)))
+        self.fh.nc[dsid['name']] = xr.DataArray(np.zeros((5, 10)))
 
         # a, b and h in kilometers
-        self.scn.nc.attrs = PROJ_KM
-        _check_area_def(self.scn.get_area_def(dsid))
+        self.fh.nc.attrs = PROJ_KM
+        _check_area_def(self.fh.get_area_def(dsid))
 
         # a, b and h in meters
-        self.scn.nc.attrs = PROJ
-        _check_area_def(self.scn.get_area_def(dsid))
+        self.fh.nc.attrs = PROJ
+        _check_area_def(self.fh.get_area_def(dsid))
 
     def test_scale_dataset_attr_removal(self):
         """Test the scaling of the dataset and removal of obsolete attributes."""
@@ -101,7 +101,7 @@ class TestNcNWCSAF(unittest.TestCase):
         attrs = {'scale_factor': np.array(10),
                  'add_offset': np.array(20)}
         var = xr.DataArray([1, 2, 3], attrs=attrs)
-        var = self.scn.scale_dataset(var, 'dummy')
+        var = self.fh.scale_dataset(var, 'dummy')
         np.testing.assert_allclose(var, [30, 40, 50])
         self.assertNotIn('scale_factor', var.attrs)
         self.assertNotIn('add_offset', var.attrs)
@@ -114,7 +114,7 @@ class TestNcNWCSAF(unittest.TestCase):
                  'add_offset': np.array(2.5),
                  '_FillValue': 1}
         var = xr.DataArray([1, 2, 3], attrs=attrs)
-        var = self.scn.scale_dataset(var, 'dummy')
+        var = self.fh.scale_dataset(var, 'dummy')
         np.testing.assert_allclose(var, [np.nan, 5.5, 7])
         self.assertNotIn('scale_factor', var.attrs)
         self.assertNotIn('add_offset', var.attrs)
@@ -123,7 +123,7 @@ class TestNcNWCSAF(unittest.TestCase):
                  'add_offset': np.array(2.5),
                  'valid_min': 1.1}
         var = xr.DataArray([1, 2, 3], attrs=attrs)
-        var = self.scn.scale_dataset(var, 'dummy')
+        var = self.fh.scale_dataset(var, 'dummy')
         np.testing.assert_allclose(var, [np.nan, 5.5, 7])
         self.assertNotIn('scale_factor', var.attrs)
         self.assertNotIn('add_offset', var.attrs)
@@ -132,7 +132,7 @@ class TestNcNWCSAF(unittest.TestCase):
                  'add_offset': np.array(2.5),
                  'valid_max': 2.1}
         var = xr.DataArray([1, 2, 3], attrs=attrs)
-        var = self.scn.scale_dataset(var, 'dummy')
+        var = self.fh.scale_dataset(var, 'dummy')
         np.testing.assert_allclose(var, [4, 5.5, np.nan])
         self.assertNotIn('scale_factor', var.attrs)
         self.assertNotIn('add_offset', var.attrs)
@@ -141,7 +141,7 @@ class TestNcNWCSAF(unittest.TestCase):
                  'add_offset': np.array(2.5),
                  'valid_range': (1.1, 2.1)}
         var = xr.DataArray([1, 2, 3], attrs=attrs)
-        var = self.scn.scale_dataset(var, 'dummy')
+        var = self.fh.scale_dataset(var, 'dummy')
         np.testing.assert_allclose(var, [np.nan, 5.5, np.nan])
         self.assertNotIn('scale_factor', var.attrs)
         self.assertNotIn('add_offset', var.attrs)
@@ -151,7 +151,7 @@ class TestNcNWCSAF(unittest.TestCase):
                  'add_offset': np.array(-2000.),
                  'valid_range': (0., 27000.)}
         var = xr.DataArray([1, 2, 3], attrs=attrs)
-        var = self.scn.scale_dataset(var, 'dummy')
+        var = self.fh.scale_dataset(var, 'dummy')
         np.testing.assert_allclose(var, [-1999., -1998., -1997.])
         self.assertNotIn('scale_factor', var.attrs)
         self.assertNotIn('add_offset', var.attrs)
@@ -165,12 +165,12 @@ class TestNcNWCSAF(unittest.TestCase):
         offset = 8
         the_array = xr.DataArray(np.ones((5, 10)), attrs={"scale_factor": np.array(scale, dtype=float),
                                                           "add_offset": np.array(offset, dtype=float)})
-        self.scn.nc[dsid['name']] = the_array
+        self.fh.nc[dsid['name']] = the_array
 
         info = dict(name="cpp_cot",
                     file_type="nc_nwcsaf_cpp")
 
-        res = self.scn.get_dataset(dsid, info)
+        res = self.fh.get_dataset(dsid, info)
         np.testing.assert_allclose(res, the_array * scale + offset)
 
     def test_get_dataset_scales_and_offsets_palette_meanings_using_other_dataset(self):
@@ -180,7 +180,7 @@ class TestNcNWCSAF(unittest.TestCase):
         offset = 8
         array = xr.DataArray(np.ones((5, 3)), attrs={"palette_meanings": "1 2 3 4",
                                                      "fill_value_color": (0, 0, 0)})
-        self.scn.nc[dsid['name']] = array
+        self.fh.nc[dsid['name']] = array
 
         so_array = xr.DataArray(np.ones((10, 10)),
                                 attrs={"scale_factor": np.array(scale, dtype=float),
@@ -190,9 +190,9 @@ class TestNcNWCSAF(unittest.TestCase):
         info = dict(name="cpp_cot",
                     file_type="nc_nwcsaf_cpp",
                     scale_offset_dataset="scaleoffset")
-        self.scn.nc["scaleoffset"] = so_array
+        self.fh.nc["scaleoffset"] = so_array
 
-        res = self.scn.get_dataset(dsid, info)
+        res = self.fh.get_dataset(dsid, info)
         np.testing.assert_allclose(res.attrs["palette_meanings"], np.arange(5) * scale + offset)
 
     def test_get_dataset_raises_when_dataset_missing(self):
@@ -201,7 +201,7 @@ class TestNcNWCSAF(unittest.TestCase):
         info = dict(name="cpp_cot",
                     file_type="nc_nwcsaf_cpp")
         with pytest.raises(KeyError):
-            self.scn.get_dataset(dsid, info)
+            self.fh.get_dataset(dsid, info)
 
     def test_get_dataset_uses_file_key_if_present(self):
         """Test that get_dataset() uses a file_key if present."""
@@ -212,18 +212,18 @@ class TestNcNWCSAF(unittest.TestCase):
         the_array = xr.DataArray(np.ones((5, 10)), attrs={"scale_factor": np.array(scale, dtype=float),
                                                           "add_offset": np.array(offset, dtype=float)})
         file_key = "cmic_cot"
-        self.scn.nc[file_key] = the_array
+        self.fh.nc[file_key] = the_array
 
         info_cpp = dict(name="cpp_cot",
                         file_key=file_key,
                         file_type="nc_nwcsaf_cpp")
 
-        res_cpp = self.scn.get_dataset(dsid_cpp, info_cpp)
+        res_cpp = self.fh.get_dataset(dsid_cpp, info_cpp)
 
         info_cmic = dict(name="cmic_cot",
                          file_type="nc_nwcsaf_cpp")
 
-        res_cmic = self.scn.get_dataset(dsid_cmic, info_cmic)
+        res_cmic = self.fh.get_dataset(dsid_cmic, info_cmic)
         np.testing.assert_allclose(res_cpp, res_cmic)
 
 
@@ -242,7 +242,7 @@ class TestNcNWCSAFFileKeyPrefix(unittest.TestCase):
         unzip.return_value = ''
         self.filehandler_class = NcNWCSAF
         self.file_key_prefix = "cmic_"
-        self.scn = self.filehandler_class('filename', {}, {"file_key_prefix": self.file_key_prefix})
+        self.fh = self.filehandler_class('filename', {}, {"file_key_prefix": self.file_key_prefix})
 
     def test_get_dataset_uses_file_key_prefix(self):
         """Test that get_dataset() uses a file_key_prefix."""
@@ -253,18 +253,18 @@ class TestNcNWCSAFFileKeyPrefix(unittest.TestCase):
         the_array = xr.DataArray(np.ones((5, 10)), attrs={"scale_factor": np.array(scale, dtype=float),
                                                           "add_offset": np.array(offset, dtype=float)})
         file_key = "cot"
-        self.scn.nc[self.file_key_prefix + file_key] = the_array
+        self.fh.nc[self.file_key_prefix + file_key] = the_array
 
         info_cpp = dict(name="cpp_cot",
                         file_key=file_key,
                         file_type="nc_nwcsaf_cpp")
 
-        res_cpp = self.scn.get_dataset(dsid_cpp, info_cpp)
+        res_cpp = self.fh.get_dataset(dsid_cpp, info_cpp)
 
         info_cmic = dict(name="cmic_cot",
                          file_type="nc_nwcsaf_cpp")
 
-        res_cmic = self.scn.get_dataset(dsid_cmic, info_cmic)
+        res_cmic = self.fh.get_dataset(dsid_cmic, info_cmic)
         np.testing.assert_allclose(res_cpp, res_cmic)
 
     def test_get_dataset_scales_and_offsets_palette_meanings_using_other_dataset(self):
@@ -274,7 +274,7 @@ class TestNcNWCSAFFileKeyPrefix(unittest.TestCase):
         offset = 8
         array = xr.DataArray(np.ones((5, 3)), attrs={"palette_meanings": "1 2 3 4",
                                                      "fill_value_color": (0, 0, 0)})
-        self.scn.nc[dsid['name']] = array
+        self.fh.nc[dsid['name']] = array
 
         so_array = xr.DataArray(np.ones((10, 10)),
                                 attrs={"scale_factor": np.array(scale, dtype=float),
@@ -284,9 +284,9 @@ class TestNcNWCSAFFileKeyPrefix(unittest.TestCase):
         info = dict(name="cpp_cot_pal",
                     file_type="nc_nwcsaf_cpp",
                     scale_offset_dataset="scaleoffset")
-        self.scn.nc[self.file_key_prefix + "scaleoffset"] = so_array
+        self.fh.nc[self.file_key_prefix + "scaleoffset"] = so_array
 
-        res = self.scn.get_dataset(dsid, info)
+        res = self.fh.get_dataset(dsid, info)
         np.testing.assert_allclose(res.attrs["palette_meanings"], np.arange(5) * scale + offset)
 
 

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -101,7 +101,7 @@ class TestNcNWCSAF(unittest.TestCase):
         attrs = {'scale_factor': np.array(10),
                  'add_offset': np.array(20)}
         var = xr.DataArray([1, 2, 3], attrs=attrs)
-        var = self.scn.scale_dataset('dummy', var, 'dummy')
+        var = self.scn.scale_dataset(var, 'dummy')
         np.testing.assert_allclose(var, [30, 40, 50])
         self.assertNotIn('scale_factor', var.attrs)
         self.assertNotIn('add_offset', var.attrs)
@@ -114,7 +114,7 @@ class TestNcNWCSAF(unittest.TestCase):
                  'add_offset': np.array(2.5),
                  '_FillValue': 1}
         var = xr.DataArray([1, 2, 3], attrs=attrs)
-        var = self.scn.scale_dataset('dummy', var, 'dummy')
+        var = self.scn.scale_dataset(var, 'dummy')
         np.testing.assert_allclose(var, [np.nan, 5.5, 7])
         self.assertNotIn('scale_factor', var.attrs)
         self.assertNotIn('add_offset', var.attrs)
@@ -123,7 +123,7 @@ class TestNcNWCSAF(unittest.TestCase):
                  'add_offset': np.array(2.5),
                  'valid_min': 1.1}
         var = xr.DataArray([1, 2, 3], attrs=attrs)
-        var = self.scn.scale_dataset('dummy', var, 'dummy')
+        var = self.scn.scale_dataset(var, 'dummy')
         np.testing.assert_allclose(var, [np.nan, 5.5, 7])
         self.assertNotIn('scale_factor', var.attrs)
         self.assertNotIn('add_offset', var.attrs)
@@ -132,7 +132,7 @@ class TestNcNWCSAF(unittest.TestCase):
                  'add_offset': np.array(2.5),
                  'valid_max': 2.1}
         var = xr.DataArray([1, 2, 3], attrs=attrs)
-        var = self.scn.scale_dataset('dummy', var, 'dummy')
+        var = self.scn.scale_dataset(var, 'dummy')
         np.testing.assert_allclose(var, [4, 5.5, np.nan])
         self.assertNotIn('scale_factor', var.attrs)
         self.assertNotIn('add_offset', var.attrs)
@@ -141,7 +141,7 @@ class TestNcNWCSAF(unittest.TestCase):
                  'add_offset': np.array(2.5),
                  'valid_range': (1.1, 2.1)}
         var = xr.DataArray([1, 2, 3], attrs=attrs)
-        var = self.scn.scale_dataset('dummy', var, 'dummy')
+        var = self.scn.scale_dataset(var, 'dummy')
         np.testing.assert_allclose(var, [np.nan, 5.5, np.nan])
         self.assertNotIn('scale_factor', var.attrs)
         self.assertNotIn('add_offset', var.attrs)
@@ -151,7 +151,7 @@ class TestNcNWCSAF(unittest.TestCase):
                  'add_offset': np.array(-2000.),
                  'valid_range': (0., 27000.)}
         var = xr.DataArray([1, 2, 3], attrs=attrs)
-        var = self.scn.scale_dataset('dummy', var, 'dummy')
+        var = self.scn.scale_dataset(var, 'dummy')
         np.testing.assert_allclose(var, [-1999., -1998., -1997.])
         self.assertNotIn('scale_factor', var.attrs)
         self.assertNotIn('add_offset', var.attrs)


### PR DESCRIPTION
The CPP product has been renamed in NWCSAF 2021 to CMIC, and even if the datasets inside are the same, the name of the variables in the nc files have been changed. This PR allows reading either file transparently by introducing file_keys and prefixes to the nwcsaf-nc reader.

Moreover, the default composites for these products have been updated.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
