### PR TITLE
Add 'l2_flags' quality filtering to 'seadas_l2' reader

### DIFF
--- a/satpy/readers/seadas_l2.py
+++ b/satpy/readers/seadas_l2.py
@@ -19,6 +19,13 @@
 
 This reader currently only supports MODIS and VIIRS Chlorophyll A from SEADAS.
 
+The reader includes an additional keyword argument ``apply_quality_flags``
+which can be used to mask out low-quality pixels based on quality flags
+contained in the file (``l2_flags``). This option defaults to ``False``, but
+when set to ``True`` the "CHLWARN" pixels of the ``l2_flags`` variable
+are masked out. These pixels represent data where the chlorophyll algorithm
+warned about the quality of the result.
+
 """
 
 from datetime import datetime

--- a/satpy/readers/seadas_l2.py
+++ b/satpy/readers/seadas_l2.py
@@ -31,6 +31,11 @@ TIME_FORMAT = "%Y%j%H%M%S"
 class SEADASL2HDFFileHandler(HDF4FileHandler):
     """Simple handler of SEADAS L2 files."""
 
+    def __init__(self, filename, filename_info, filetype_info, apply_quality_flags=False):
+        """Initialize file handler and determine if data quality flags should be applied."""
+        super().__init__(filename, filename_info, filetype_info)
+        self.apply_quality_flags = apply_quality_flags and "l2_flags" in self
+
     def _add_satpy_metadata(self, data):
         data.attrs["sensor"] = self.sensor_names
         data.attrs["platform_name"] = self._platform_name()
@@ -79,6 +84,10 @@ class SEADASL2HDFFileHandler(HDF4FileHandler):
         valid_range = data.attrs["valid_range"]
         data = data.where(valid_range[0] <= data)
         data = data.where(data <= valid_range[1])
+        if self.apply_quality_flags and not ("lon" in file_key or "lat" in file_key):
+            l2_flags = self["l2_flags"]
+            mask = (l2_flags & 0b00000000010000000000000000000000) != 0
+            data = data.where(~mask)
         for attr_name in ("standard_name", "long_name", "units"):
             val = data.attrs[attr_name]
             if val[-1] == "\x00":


### PR DESCRIPTION
In an attempt to improve the quality of the chlorophyll product, @kathys and I are looking at adding the ability to use the file's `l2_flags` to remove low-quality pixels. This PR is an initial attempt at this work while we try different flag combinations.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
