### PR TITLE
Refactor 'native' resampler to produce less dask tasks

### DIFF
--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -371,22 +371,22 @@ class TestNativeResampler(unittest.TestCase):
 
         from satpy.resample import NativeResampler
         d_arr = da.zeros((6, 20), chunks=4)
-        new_data = NativeResampler.expand_reduce(d_arr, {0: 2., 1: 2.})
+        new_data = NativeResampler._expand_reduce(d_arr, {0: 2., 1: 2.})
         self.assertEqual(new_data.shape, (12, 40))
-        new_data = NativeResampler.expand_reduce(d_arr, {0: .5, 1: .5})
+        new_data = NativeResampler._expand_reduce(d_arr, {0: .5, 1: .5})
         self.assertEqual(new_data.shape, (3, 10))
-        self.assertRaises(ValueError, NativeResampler.expand_reduce,
+        self.assertRaises(ValueError, NativeResampler._expand_reduce,
                           d_arr, {0: 1. / 3, 1: 1.})
-        new_data = NativeResampler.expand_reduce(d_arr, {0: 1., 1: 1.})
+        new_data = NativeResampler._expand_reduce(d_arr, {0: 1., 1: 1.})
         self.assertEqual(new_data.shape, (6, 20))
         self.assertIs(new_data, d_arr)
-        self.assertRaises(ValueError, NativeResampler.expand_reduce,
+        self.assertRaises(ValueError, NativeResampler._expand_reduce,
                           d_arr, {0: 0.333323423, 1: 1.})
-        self.assertRaises(ValueError, NativeResampler.expand_reduce,
+        self.assertRaises(ValueError, NativeResampler._expand_reduce,
                           d_arr, {0: 1.333323423, 1: 1.})
 
         n_arr = np.zeros((6, 20))
-        new_data = NativeResampler.expand_reduce(n_arr, {0: 2., 1: 1.0})
+        new_data = NativeResampler._expand_reduce(n_arr, {0: 2., 1: 1.0})
         self.assertTrue(np.all(new_data.compute()[::2, :] == n_arr))
 
     def test_expand_dims(self):


### PR DESCRIPTION
This is a small quality of debugger life change. While debugging task graphs it because confusing to determine when the native resampler was being used in the overall graph. Additionally, my new general goal is to remove unnecessary dask tasks being created in satpy. Although the changes in this PR don't improve performance in a measurable way, it does overall clean up the dask graph and code when debugging.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
