### PR TITLE
Update tests to be more flexible to CRS and enhancement changes

### DIFF
--- a/satpy/tests/enhancement_tests/test_viirs.py
+++ b/satpy/tests/enhancement_tests/test_viirs.py
@@ -23,6 +23,8 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
+from .test_enhancements import run_and_check_enhancement
+
 
 class TestVIIRSEnhancement(unittest.TestCase):
     """Class for testing the VIIRS enhancement function in satpy.enhancements.viirs."""
@@ -70,19 +72,5 @@ class TestVIIRSEnhancement(unittest.TestCase):
         from satpy.enhancements.viirs import water_detection
         expected = [[[1, 7, 8, 8, 8, 9, 10, 11, 14, 8],
                      [20, 23, 26, 10, 12, 15, 18, 21, 24, 27]]]
-        self._test_enhancement(water_detection, self.da, expected,
-                               palettes=self.palette)
-
-    def _test_enhancement(self, func, data, expected, **kwargs):
-        from trollimage.xrimage import XRImage
-
-        pre_attrs = data.attrs
-        img = XRImage(data)
-        func(img, **kwargs)
-
-        self.assertIsInstance(img.data.data, da.Array)
-        self.assertListEqual(sorted(pre_attrs.keys()),
-                             sorted(img.data.attrs.keys()),
-                             "DataArray attributes were not preserved")
-
-        np.testing.assert_allclose(img.data.values, expected, atol=1.e-6, rtol=0)
+        run_and_check_enhancement(water_detection, self.da, expected,
+                                  palettes=self.palette)

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -42,7 +42,7 @@ class TestGenericImage(unittest.TestCase):
 
         # Create area definition
         pcs_id = 'ETRS89 / LAEA Europe'
-        proj4_dict = {'init': 'epsg:3035'}
+        proj4_dict = "EPSG:3035"
         self.x_size = 100
         self.y_size = 100
         area_extent = (2426378.0132, 1528101.2618, 6293974.6215, 5446513.5222)


### PR DESCRIPTION
This is an update needed for https://github.com/pytroll/pyresample/pull/415 so that satpy tests still pass with those pyresample changes. One lesson learned is that `+init=EPSG:XXXX` does not respect the axis order of the EPSG definition. Using `EPSG:XXXX` does.

This PR also includes refactoring of the enhancements tests because they were causing failures when combined with my trollimage PR here: https://github.com/pytroll/trollimage/pull/99

 - [x] Tests added <!-- for all bug fixes or enhancements -->
