### PR TITLE
Update abi_l2_nc to include filename metadata similar to abi_l1b

### DIFF
--- a/satpy/etc/readers/abi_l2_nc.yaml
+++ b/satpy/etc/readers/abi_l2_nc.yaml
@@ -449,11 +449,7 @@ file_types:
 
   abi_l2_cod:
     file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-    file_patterns:
-    # F (Full Disk) or C (CONUS)
-    - '{system_environment:2s}_{mission_id:3s}-L2-COD{scene_abbr:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
-    # M1 or M2 for mesoscale
-    - '{system_environment:2s}_{mission_id:3s}-L2-COD{scene_abbr:2s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-COD{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     observation_type: "COD"
 
   # CSPP Geo keeps Day and Night algorithm outputs separate
@@ -471,11 +467,7 @@ file_types:
 
   abi_l2_cps:
     file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-    file_patterns:
-      # F (Full Disk) or C (CONUS)
-    - '{system_environment:2s}_{mission_id:3s}-L2-CPS{scene_abbr:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
-      # M1 or M2 for mesoscale
-    - '{system_environment:2s}_{mission_id:3s}-L2-CPS{scene_abbr:2s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CPS{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     observation_type: "CPS"
 
   # CSPP Geo keeps Day and Night algorithm outputs separate

--- a/satpy/etc/readers/abi_l2_nc.yaml
+++ b/satpy/etc/readers/abi_l2_nc.yaml
@@ -333,184 +333,226 @@ datasets:
 # ----
 file_types:
   abi_l2_cmip_c01:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C01_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C01_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c02:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C02_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C02_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c03:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C03_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C03_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c04:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C04_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C04_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c05:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C05_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C05_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c06:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C06_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C06_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c07:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C07_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C07_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c08:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C08_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C08_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c09:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C09_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C09_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c10:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C10_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C10_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c11:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C11_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C11_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c12:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C12_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C12_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c13:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C13_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C13_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c14:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C14_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C14_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c15:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C15_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C15_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_cmip_c16:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{area_code:1s}-{scan_mode:2s}C16_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:1s}-{scan_mode:2s}C16_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CMIP"
 
   abi_l2_mcmip:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-MCMIP{scene_abbr:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-MCMIP{scene_abbr:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "MCMIP"
 
   abi_l2_acha:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACHA{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACHA{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "ACHA"
 
   abi_l2_acht:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACHT{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACHT{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "ACHT"
 
   abi_l2_acm:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACM{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACM{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "ACM"
 
   abi_l2_actp:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACTP{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ACTP{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "ACTP"
 
   abi_l2_adp:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ADP{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-ADP{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "ADP"
 
   abi_l2_aod:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-AOD{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-AOD{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "AOD"
 
   abi_l2_cod:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns:
-        # F (Full Disk) or C (CONUS)
-        - '{system_environment:2s}_{mission_id:3s}-L2-COD{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
-        # M1 or M2 for mesoscale
-        - '{system_environment:2s}_{mission_id:3s}-L2-CODM{area_code:1d}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns:
+    # F (Full Disk) or C (CONUS)
+    - '{system_environment:2s}_{mission_id:3s}-L2-COD{scene_abbr:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+    # M1 or M2 for mesoscale
+    - '{system_environment:2s}_{mission_id:3s}-L2-COD{scene_abbr:2s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+    observation_type: "COD"
 
   # CSPP Geo keeps Day and Night algorithm outputs separate
   abi_l2_codd:
     file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
     file_patterns:
       - '{system_environment:2s}_{mission_id:3s}-L2-CODD{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+    observation_type: "CODD"
 
   abi_l2_codn:
     file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
     file_patterns:
       - '{system_environment:2s}_{mission_id:3s}-L2-CODN{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+    observation_type: "CODN"
 
   abi_l2_cps:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns:
-          # F (Full Disk) or C (CONUS)
-        - '{system_environment:2s}_{mission_id:3s}-L2-CPS{area_code:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
-          # M1 or M2 for mesoscale
-        - '{system_environment:2s}_{mission_id:3s}-L2-CPSM{area_code:1d}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns:
+      # F (Full Disk) or C (CONUS)
+    - '{system_environment:2s}_{mission_id:3s}-L2-CPS{scene_abbr:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+      # M1 or M2 for mesoscale
+    - '{system_environment:2s}_{mission_id:3s}-L2-CPS{scene_abbr:2s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+    observation_type: "CPS"
 
   # CSPP Geo keeps Day and Night algorithm outputs separate
   abi_l2_cpsd:
     file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
     file_patterns:
       - '{system_environment:2s}_{mission_id:3s}-L2-CPSD{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+    observation_type: "CPSD"
 
   abi_l2_cpsn:
     file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
     file_patterns:
       - '{system_environment:2s}_{mission_id:3s}-L2-CPSN{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+    observation_type: "CPSN"
 
   abi_l2_ctp:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CTP{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CTP{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "CTP"
 
   abi_l2_dsi:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-DSI{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-DSI{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "DSI"
 
   abi_l2_drs:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-DRS{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-DRS{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "DRS"
 
   abi_l2_fdc:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-FDC{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-FDC{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "FDC"
 
   abi_l2_fsc:
     file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
     file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-FSC{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "FSC"
 
   abi_l2_lst:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-LST{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-LST{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "LST"
 
   abi_l2_rrqpe:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-RRQPE{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-RRQPE{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "RRQPE"
 
   abi_l2_rsr:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-RSR{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-RSR{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "RSR"
 
   abi_l2_dsr:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-DSR{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-DSR{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "DSR"
 
   abi_l2_sst:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-SST{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-SST{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "SST"
 
   abi_l2_tpw:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-TPW{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-TPW{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "TPW"
 
   abi_l2_vaa:
-        file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-        file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-VAA{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc', '{system_environment:2s}_{mission_id:3s}-L2-VAA{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-128600_0.nc']
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-VAA{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc', '{system_environment:2s}_{mission_id:3s}-L2-VAA{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-128600_0.nc']
+    observation_type: "VAA"
 
   # CSPP - Geo Unofficial product
   abi_l2_nav:
     file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
     file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-NAV{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    observation_type: "NAV"

--- a/satpy/tests/reader_tests/test_abi_l2_nc.py
+++ b/satpy/tests/reader_tests/test_abi_l2_nc.py
@@ -91,10 +91,18 @@ class Test_NC_ABI_L2_base(unittest.TestCase):
         fake_cmip_dataset = _create_cmip_dataset()
         with mock.patch('satpy.readers.abi_base.xr') as xr_:
             xr_.open_dataset.return_value = fake_cmip_dataset
-            self.reader = NC_ABI_L2('filename',
-                                    {'platform_shortname': 'G16',
-                                     'scan_mode': 'M3'},
-                                    {'file_type': 'info'})
+            self.reader = NC_ABI_L2(
+                'filename',
+                {
+                    'platform_shortname': 'G16',
+                    'scan_mode': 'M3',
+                    'scene_abbr': 'M1',
+                },
+                {
+                    'file_type': 'info',
+                    'observation_type': 'ACHA',
+                },
+            )
 
 
 class Test_NC_ABI_L2_get_dataset(Test_NC_ABI_L2_base):
@@ -112,6 +120,7 @@ class Test_NC_ABI_L2_get_dataset(Test_NC_ABI_L2_base):
         exp_attrs = {'instrument_ID': None,
                      'modifiers': (),
                      'name': 'HT',
+                     'observation_type': 'ACHA',
                      'orbital_slot': None,
                      'platform_name': 'GOES-16',
                      'platform_shortname': 'G16',
@@ -120,6 +129,7 @@ class Test_NC_ABI_L2_get_dataset(Test_NC_ABI_L2_base):
                      'satellite_latitude': 0.0,
                      'satellite_longitude': -89.5,
                      'scan_mode': 'M3',
+                     'scene_abbr': 'M1',
                      'scene_id': None,
                      'sensor': 'abi',
                      'timeline_ID': None,
@@ -153,6 +163,7 @@ class TestMCMIPReading:
         exp_attrs = {'instrument_ID': None,
                      'modifiers': (),
                      'name': 'C14',
+                     'observation_type': 'MCMIP',
                      'orbital_slot': None,
                      'reader': 'abi_l2_nc',
                      'platform_name': 'GOES-16',
@@ -162,6 +173,7 @@ class TestMCMIPReading:
                      'satellite_latitude': 0.0,
                      'satellite_longitude': -89.5,
                      'scan_mode': 'M6',
+                     'scene_abbr': 'F',
                      'scene_id': None,
                      'sensor': 'abi',
                      'timeline_ID': None,


### PR DESCRIPTION
This PR makes the `abi_l2_nc` reader more consistent with the `abi_l1b` reader. My use case is that I want to format my output filenames (from `Scene.save_datasets`) similarly for all ABI data. Right now that includes some of the information about the sector and a few other parameters in the filename. Not all of this information was available, but has been added in this PR.

CC @yufeizhu600. If you could please review these changes it would be greatly appreciated.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

