### PR TITLE
Fix angle generation caching occassionally swapping results

### DIFF
--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -151,7 +151,7 @@ class ZarrCacheHelper:
         # if we did any caching, let's load from the zarr files
         if should_cache:
             # re-calculate the cached paths
-            zarr_paths = glob(zarr_format.format("*"))
+            zarr_paths = sorted(glob(zarr_format.format("*")))
             if not zarr_paths:
                 raise RuntimeError("Data was cached to disk but no files were found")
             res = tuple(da.from_zarr(zarr_path) for zarr_path in zarr_paths)


### PR DESCRIPTION
This PR fixes angle generation caching in the rare case that `glob` (which is defined as not being sorted) would return the list of zarr directories in the wrong order. My caching code assumed that it was getting the zarr files in the same order as the return results of the function being cached. And even though I know that `glob` behaves this way I somehow missed the `sorted` on the call. :man_shrugging: 

 - [x] Closes #2010  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
