### PR TITLE
Fix various dask array bugs in CREFL modifier

### DIFF
--- a/satpy/modifiers/_crefl_utils.py
+++ b/satpy/modifiers/_crefl_utils.py
@@ -420,11 +420,16 @@ def run_crefl(refl, coeffs,
     if use_abi:
         LOG.debug("Using ABI CREFL algorithm")
         corr_refl = da.map_blocks(_run_crefl_abi, refl.data, mus.data, muv.data, phi.data,
-                                  solar_zenith, sensor_zenith, height, *coeffs, percent=percent)
+                                  solar_zenith, sensor_zenith, height, *coeffs,
+                                  meta=np.ndarray((), dtype=refl.dtype),
+                                  chunks=refl.chunks, dtype=refl.dtype,
+                                  percent=percent)
     else:
         LOG.debug("Using original VIIRS CREFL algorithm")
         corr_refl = da.map_blocks(_run_crefl, refl.data, mus.data, muv.data, phi.data,
-                                  height, *coeffs, chunks=refl.chunks, dtype=refl.dtype,
+                                  height, *coeffs,
+                                  meta=np.ndarray((), dtype=refl.dtype),
+                                  chunks=refl.chunks, dtype=refl.dtype,
                                   percent=percent)
     return xr.DataArray(corr_refl, dims=refl.dims, coords=refl.coords, attrs=refl.attrs)
 

--- a/satpy/modifiers/_crefl_utils.py
+++ b/satpy/modifiers/_crefl_utils.py
@@ -420,7 +420,7 @@ def run_crefl(refl, coeffs,
     if use_abi:
         LOG.debug("Using ABI CREFL algorithm")
         corr_refl = da.map_blocks(_run_crefl_abi, refl.data, mus.data, muv.data, phi.data,
-                                  solar_zenith, sensor_zenith, height, *coeffs,
+                                  solar_zenith.data, sensor_zenith.data, height, *coeffs,
                                   meta=np.ndarray((), dtype=refl.dtype),
                                   chunks=refl.chunks, dtype=refl.dtype,
                                   percent=percent)

--- a/satpy/tests/modifier_tests/test_crefl.py
+++ b/satpy/tests/modifier_tests/test_crefl.py
@@ -102,7 +102,7 @@ class TestReflectanceCorrectorModifier:
         data = np.zeros((rows, cols)) + 25
         data[3, :] += 25
         data[4:, :] += 50
-        data = da.from_array(data, chunks=100)
+        data = da.from_array(data, chunks=2)
         return area, data
 
     def test_reflectance_corrector_abi(self):

--- a/satpy/tests/modifier_tests/test_crefl.py
+++ b/satpy/tests/modifier_tests/test_crefl.py
@@ -23,6 +23,8 @@ import xarray as xr
 from dask import array as da
 from pyresample.geometry import AreaDefinition
 
+from ..utils import assert_maximum_dask_computes
+
 
 @contextmanager
 def mock_cmgdem(tmpdir, url):
@@ -139,7 +141,8 @@ class TestReflectanceCorrectorModifier:
                                'start_time': '2017-09-20 17:30:40.800000', 'end_time': '2017-09-20 17:41:17.500000',
                                'area': area, 'ancillary_variables': []
                            })
-        res = ref_cor([c01], [])
+        with assert_maximum_dask_computes(0):
+            res = ref_cor([c01], [])
 
         assert isinstance(res, xr.DataArray)
         assert isinstance(res.data, da.Array)
@@ -227,7 +230,7 @@ class TestReflectanceCorrectorModifier:
         c04 = _make_viirs_xarray(data, area, 'solar_azimuth_angle', 'solar_azimuth_angle')
         c05 = _make_viirs_xarray(data, area, 'solar_zenith_angle', 'solar_zenith_angle')
 
-        with dem_mock_cm(tmpdir, url):
+        with dem_mock_cm(tmpdir, url), assert_maximum_dask_computes(0):
             res = ref_cor([c01], [c02, c03, c04, c05])
 
         assert isinstance(res, xr.DataArray)

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Utilities for various satpy tests."""
 
+from contextlib import contextmanager
 from datetime import datetime
 from unittest import mock
 
@@ -282,6 +283,14 @@ class CustomScheduler(object):
             raise RuntimeError("Too many dask computations were scheduled: "
                                "{}".format(self.total_computes))
         return dask.get(dsk, keys, **kwargs)
+
+
+@contextmanager
+def assert_maximum_dask_computes(max_computes=1):
+    """Context manager to make sure dask computations are not executed more than ``max_computes`` times."""
+    import dask
+    with dask.config.set(scheduler=CustomScheduler(max_computes=max_computes)) as new_config:
+        yield new_config
 
 
 def make_fake_scene(content_dict, daskify=False, area=True,


### PR DESCRIPTION
@ralphk11 pointed out to me on slack some issues he was having with processing ABI data with the CREFL modifier. Turned out to be two separate bugs. One was that there was a `map_blocks` call with no `dtype` or `chunks` defined so dask was computing the result immediately. The second issue is that crefl was passing DataArrays to `da.map_blocks`. This apparently passes the entire DataArray array as a single chunk (it isn't recognized as containing a dask array). This wasn't caught in the tests because the tests were using dask arrays of one giant chunk (one giant chunk == entire array).

 - [x] Tests added <!-- for all bug fixes or enhancements -->

