### PR TITLE
Fix the sensor name for msu_gsa_l1b reader

### DIFF
--- a/satpy/readers/msu_gsa_l1b.py
+++ b/satpy/readers/msu_gsa_l1b.py
@@ -62,7 +62,7 @@ class MSUGSAFileHandler(HDF5FileHandler):
     @property
     def sensor_name(self):
         """Sensor name is hardcoded."""
-        sensor = 'MSU-GS/A'
+        sensor = 'msu_gsa'
         return sensor
 
     @property

--- a/satpy/readers/msu_gsa_l1b.py
+++ b/satpy/readers/msu_gsa_l1b.py
@@ -68,7 +68,7 @@ class MSUGSAFileHandler(HDF5FileHandler):
     @property
     def platform_name(self):
         """Platform name is also hardcoded."""
-        platform = 'Arctica-M N1'
+        platform = 'Arctica-M-N1'
         return platform
 
     @staticmethod

--- a/satpy/tests/reader_tests/test_msu_gsa_l1b.py
+++ b/satpy/tests/reader_tests/test_msu_gsa_l1b.py
@@ -152,7 +152,7 @@ class TestMSUGSABReader:
         res = self.reader.load(ds_ids)
         assert 'C09' in res
         assert res['C09'].attrs['calibration'] == 'brightness_temperature'
-        assert res['C09'].attrs['platform_name'] == 'Arctica-M N1'
+        assert res['C09'].attrs['platform_name'] == 'Arctica-M-N1'
         assert res['C09'].attrs['sat_latitude'] == 71.25
         assert res['C09'].attrs['sat_longitude'] == 21.44
         assert res['C09'].attrs['sat_altitude'] == 38500.


### PR DESCRIPTION
The `sensor` property is used to find for example the enhancement configuration files for the data. The original platform name `MSU-GS/A` doesn't work for this, as there is the `/` character that denotes a sub-directory in *NIX world. This PR changes the sensor name to "Pytroll standards".
