### PR TITLE
Fix ABI rayleigh_corrected_crefl modifier using deprecated DEM specifier

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -3,7 +3,8 @@ sensor_name: visir/abi
 modifiers:
   rayleigh_corrected_crefl:
     modifier: !!python/name:satpy.modifiers.atmosphere.ReflectanceCorrector
-    dem_filename: CMGDEM.hdf
+    url: "https://www.ssec.wisc.edu/~davidh/polar2grid/viirs_crefl/CMGDEM.hdf"
+    known_hash: "sha256:f33f1f867d79fff4fafe128f61c154236dd74fcc97bf418ea1437977a38d0604"
     optional_prerequisites:
       - name: satellite_azimuth_angle
       - name: satellite_zenith_angle


### PR DESCRIPTION
Forgot to fix this in #2015. The ABI crefl modifier wasn't updated when I changed how the CMGDEM.hdf files are downloaded/loaded by the modifier. It should point to a URL that can get downloaded and not a non-existent file.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
