### PR TITLE
Write offset consistent with temperature units in ninjogeotiff writer

### DIFF
--- a/satpy/tests/writer_tests/test_ninjogeotiff.py
+++ b/satpy/tests/writer_tests/test_ninjogeotiff.py
@@ -606,10 +606,11 @@ def test_write_and_read_file_units(
                                0.465379, rtol=1e-5)
     np.testing.assert_allclose(float(tgs["ninjo_AxisIntercept"]),
                                -79.86838)
+    fn2 = os.fspath(tmp_path / "test2.tif")
     with caplog.at_level(logging.WARNING):
         ngtw.save_dataset(
             test_image_small_mid_atlantic_K_L.data,
-            filename=fn,
+            filename=fn2,
             fill_value=0,
             blockxsize=128,
             blockysize=128,

--- a/satpy/writers/ninjogeotiff.py
+++ b/satpy/writers/ninjogeotiff.py
@@ -204,7 +204,7 @@ class NinJoGeoTIFFWriter(GeoTIFFWriter):
         data_units = image.data.attrs.get("units")
         if (quantity.lower() == "temperature" and
                 unit == "C" and
-                image.data.attrs.get("units") == "K"):
+                data_units == "K"):
             logger.debug("Adding offset for K → °C conversion")
             new_attrs = copy.deepcopy(image.data.attrs)
             im2 = type(image)(image.data.copy())

--- a/satpy/writers/ninjogeotiff.py
+++ b/satpy/writers/ninjogeotiff.py
@@ -145,7 +145,11 @@ class NinJoGeoTIFFWriter(GeoTIFFWriter):
             SatelliteNameID (int)
                 NinJo Satellite ID
             PhysicUnit (str)
-                NinJo label for unit (example: "C")
+                NinJo label for unit (example: "C").  If PhysicValue is set to
+                "Temperature", PhysicUnit is set to "C", but data attributes
+                incidate the data have unit "K", then the writer will adapt the
+                header ``ninjo_AxisIntercept`` such that data are interpreted
+                in units of "C".
             PhysicValue (str)
                 NinJo label for quantity (example: "temperature")
 
@@ -198,9 +202,9 @@ class NinJoGeoTIFFWriter(GeoTIFFWriter):
         enhancement history aren't touched.
         """
         data_units = image.data.attrs.get("units")
-        if (quantity == "Temperature" and
+        if (quantity.lower() == "temperature" and
                 unit == "C" and
-                image.data.attrs.get("units")) == "K":
+                image.data.attrs.get("units") == "K"):
             logger.debug("Adding offset for K → °C conversion")
             new_attrs = copy.deepcopy(image.data.attrs)
             im2 = type(image)(image.data.copy())


### PR DESCRIPTION
In the NinJoGeoTIFF writer, make sure the offset (axisintercept) written to the headers is consistent with the units.

This is implemented by adding a scale factor / offset in front of the enhancement history.

 - [x] Closes #2018<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
