### PR TITLE
Allow skipping unit conversion in NinJoTIFF

### DIFF
--- a/satpy/tests/writer_tests/test_ninjotiff.py
+++ b/satpy/tests/writer_tests/test_ninjotiff.py
@@ -67,6 +67,19 @@ class TestNinjoTIFFWriter(unittest.TestCase):
             uconv.assert_called_once_with(dataset, 'K', 'CELSIUS')
         self.assertEqual(iwsd.call_count, 1)
 
+    @mock.patch('satpy.writers.ninjotiff.ImageWriter.save_dataset')
+    @mock.patch('satpy.writers.ninjotiff.nt', pyninjotiff_mock.ninjotiff)
+    def test_dataset_skip_unit_conversion(self, iwsd):
+        """Test saving a dataset without unit conversion."""
+        from satpy.writers.ninjotiff import NinjoTIFFWriter
+        ntw = NinjoTIFFWriter()
+        dataset = xr.DataArray([1, 2, 3], attrs={'units': 'K'})
+        with mock.patch('satpy.writers.ninjotiff.convert_units') as uconv:
+            ntw.save_dataset(dataset, physic_unit='CELSIUS',
+                             convert_temperature_units=False)
+            uconv.assert_not_called()
+        self.assertEqual(iwsd.call_count, 1)
+
     @mock.patch('satpy.writers.ninjotiff.NinjoTIFFWriter.save_dataset')
     @mock.patch('satpy.writers.ninjotiff.ImageWriter.save_image')
     @mock.patch('satpy.writers.ninjotiff.nt', pyninjotiff_mock.ninjotiff)

--- a/satpy/writers/ninjotiff.py
+++ b/satpy/writers/ninjotiff.py
@@ -116,6 +116,7 @@ def convert_units(dataset, in_unit, out_unit):
         return dataset
 
     if in_unit.lower() in {"k", "kelvin"} and out_unit.lower() in {"c", "celsius"}:
+        logger.debug("Converting temperature units from K to °C")
         with xr.set_options(keep_attrs=True):
             new_dataset = dataset - 273.15
         new_dataset.attrs["units"] = out_unit
@@ -205,6 +206,8 @@ class NinjoTIFFWriter(ImageWriter):
             else:
                 if convert_temperature_units:
                     dataset = convert_units(dataset, units, nunits)
+                else:
+                    logger.debug("Omitting unit conversion")
         return super(NinjoTIFFWriter, self).save_dataset(
             dataset, filename=filename, compute=compute, fill_value=fill_value, **kwargs
         )

--- a/satpy/writers/ninjotiff.py
+++ b/satpy/writers/ninjotiff.py
@@ -177,12 +177,14 @@ class NinjoTIFFWriter(ImageWriter):
         return nt.save(img, filename, data_is_scaled_01=True, compute=compute, **kwargs)
 
     def save_dataset(
-        self, dataset, filename=None, fill_value=None, compute=True, **kwargs
+        self, dataset, filename=None, fill_value=None, compute=True,
+        convert_temperature_units=True, **kwargs
     ):
         """Save a dataset to ninjotiff format.
 
         This calls `save_image` in turn, but first preforms some unit conversion
-        if necessary.
+        if necessary and desired.  Unit conversion can be suppressed by passing
+        ``convert_temperature_units=False``.
         """
         nunits = kwargs.get("physic_unit", None)
         if nunits is None:
@@ -201,7 +203,8 @@ class NinjoTIFFWriter(ImageWriter):
                     "Saving to physical ninjo file without units defined in dataset!"
                 )
             else:
-                dataset = convert_units(dataset, units, nunits)
+                if convert_temperature_units:
+                    dataset = convert_units(dataset, units, nunits)
         return super(NinjoTIFFWriter, self).save_dataset(
             dataset, filename=filename, compute=compute, fill_value=fill_value, **kwargs
         )


### PR DESCRIPTION
Add an option to the NinJoTIFF writer to skip unit conversion.  For a
detailed rationale, see https://github.com/pytroll/satpy/issues/2024.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #2024<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
