### PR TITLE
Include units with AVHRR EPS metadata

### DIFF
--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -141,6 +141,9 @@ class EPSAVHRRFile(BaseFileHandler):
 
     sensors = {"AVHR": "avhrr-3"}
 
+    units = {"reflectance": "%",
+             "brightness_temperature": "K"}
+
     def __init__(self, filename, filename_info, filetype_info):
         """Initialize FileHandler."""
         super(EPSAVHRRFile, self).__init__(
@@ -296,6 +299,8 @@ class EPSAVHRRFile(BaseFileHandler):
 
         dataset.attrs['platform_name'] = self.platform_name
         dataset.attrs['sensor'] = self.sensor_name
+        if "calibration" in key:
+            dataset.attrs["units"] = self.units[key["calibration"]]
         dataset.attrs.update(info)
         dataset.attrs.update(key.to_dict())
         return dataset

--- a/satpy/tests/reader_tests/test_eps_l1b.py
+++ b/satpy/tests/reader_tests/test_eps_l1b.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2019 Satpy developers
+# Copyright (c) 2019, 2022 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -119,6 +119,7 @@ class TestEPSL1B(BaseTestCaseEPSL1B):
         assert(res.attrs['sensor'] == 'avhrr-3')
         assert(res.attrs['name'] == '1')
         assert(res.attrs['calibration'] == 'reflectance')
+        assert(res.attrs['units'] == '%')
 
         did = make_dataid(name='4', calibration='brightness_temperature')
         res = self.fh.get_dataset(did, {})
@@ -127,6 +128,7 @@ class TestEPSL1B(BaseTestCaseEPSL1B):
         assert(res.attrs['sensor'] == 'avhrr-3')
         assert(res.attrs['name'] == '4')
         assert(res.attrs['calibration'] == 'brightness_temperature')
+        assert(res.attrs['units'] == 'K')
 
     def test_navigation(self):
         """Test the navigation."""


### PR DESCRIPTION
When loading channel data using the AVHRR EPS L1b reader, make sure the returned dataset attributes include the units for the channel loaded.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #2026 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
