### PR TITLE
Add 'preference' option to 'get_satpos' utility

### DIFF
--- a/satpy/tests/modifier_tests/test_crefl.py
+++ b/satpy/tests/modifier_tests/test_crefl.py
@@ -134,21 +134,22 @@ class TestReflectanceCorrectorModifier:
         c01 = xr.DataArray(dnb,
                            dims=('y', 'x'),
                            attrs={
-                               'satellite_longitude': -89.5, 'satellite_latitude': 0.0,
-                               'satellite_altitude': 35786023.4375, 'platform_name': 'GOES-16',
+                               'platform_name': 'GOES-16',
                                'calibration': 'reflectance', 'units': '%', 'wavelength': (0.45, 0.47, 0.49),
                                'name': 'C01', 'resolution': 1000, 'sensor': 'abi',
                                'start_time': '2017-09-20 17:30:40.800000', 'end_time': '2017-09-20 17:41:17.500000',
-                               'area': area, 'ancillary_variables': []
+                               'area': area, 'ancillary_variables': [],
+                               'orbital_parameters': {
+                                   'satellite_nominal_longitude': -89.5,
+                                   'satellite_nominal_latitude': 0.0,
+                                   'satellite_nominal_altitude': 35786023.4375,
+                               },
                            })
         with assert_maximum_dask_computes(0):
             res = ref_cor([c01], [])
 
         assert isinstance(res, xr.DataArray)
         assert isinstance(res.data, da.Array)
-        assert res.attrs['satellite_longitude'] == -89.5
-        assert res.attrs['satellite_latitude'] == 0.0
-        assert res.attrs['satellite_altitude'] == 35786023.4375
         assert res.attrs['modifiers'] == ('sunz_corrected', 'rayleigh_corrected_crefl')
         assert res.attrs['platform_name'] == 'GOES-16'
         assert res.attrs['calibration'] == 'reflectance'

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -209,6 +209,10 @@ class TestUtils(unittest.TestCase):
         res = proj_units_to_meters(prj)
         self.assertEqual(res, '+a=6378137.000 +b=6378137.000 +h=35785863.000')
 
+
+class TestGetSatPos:
+    """Tests for 'get_satpos'."""
+
     def test_get_satpos(self):
         """Test getting the satellite position."""
         orb_params = {'nadir_longitude': 1,
@@ -226,20 +230,20 @@ class TestUtils(unittest.TestCase):
 
         # Nadir
         lon, lat, alt = get_satpos(dataset)
-        self.assertTupleEqual((lon, lat, alt), (1, 2, 3))
+        assert (lon, lat, alt) == (1, 2, 3)
 
         # Actual
         orb_params.pop('nadir_longitude')
         orb_params.pop('nadir_latitude')
         lon, lat, alt = get_satpos(dataset)
-        self.assertTupleEqual((lon, lat, alt), (1.1, 2.1, 3))
+        assert (lon, lat, alt) == (1.1, 2.1, 3)
 
         # Nominal
         orb_params.pop('satellite_actual_longitude')
         orb_params.pop('satellite_actual_latitude')
         orb_params.pop('satellite_actual_altitude')
         lon, lat, alt = get_satpos(dataset)
-        self.assertTupleEqual((lon, lat, alt), (1.2, 2.2, 3.1))
+        assert (lon, lat, alt) == (1.2, 2.2, 3.1)
 
         # Projection
         orb_params.pop('satellite_nominal_longitude')
@@ -247,7 +251,7 @@ class TestUtils(unittest.TestCase):
         orb_params.pop('satellite_nominal_altitude')
         with warnings.catch_warnings(record=True) as caught_warnings:
             lon, lat, alt = get_satpos(dataset)
-        self.assertTupleEqual((lon, lat, alt), (1.3, 2.3, 3.2))
+        assert (lon, lat, alt) == (1.3, 2.3, 3.2)
         assert any("using projection" in str(msg.message) for msg in caught_warnings)
 
 

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -223,10 +223,7 @@ class TestUtils(unittest.TestCase):
                       'satellite_actual_altitude': 3,
                       'satellite_nominal_altitude': 3.1,
                       'projection_altitude': 3.2}
-        dataset = mock.MagicMock(attrs={'orbital_parameters': orb_params,
-                                        'satellite_longitude': -1,
-                                        'satellite_latitude': -2,
-                                        'satellite_altitude': -3})
+        dataset = mock.MagicMock(attrs={'orbital_parameters': orb_params})
 
         # Nadir
         lon, lat, alt = get_satpos(dataset)
@@ -252,11 +249,6 @@ class TestUtils(unittest.TestCase):
         lon, lat, alt = get_satpos(dataset)
         self.assertTupleEqual((lon, lat, alt), (1.3, 2.3, 3.2))
         warn_mock.assert_called()
-
-        # Legacy
-        dataset.attrs.pop('orbital_parameters')
-        lon, lat, alt = get_satpos(dataset)
-        self.assertTupleEqual((lon, lat, alt), (-1, -2, -3))
 
 
 def test_make_fake_scene():

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -209,8 +209,7 @@ class TestUtils(unittest.TestCase):
         res = proj_units_to_meters(prj)
         self.assertEqual(res, '+a=6378137.000 +b=6378137.000 +h=35785863.000')
 
-    @mock.patch('satpy.utils.warnings.warn')
-    def test_get_satpos(self, warn_mock):
+    def test_get_satpos(self):
         """Test getting the satellite position."""
         orb_params = {'nadir_longitude': 1,
                       'satellite_actual_longitude': 1.1,
@@ -246,9 +245,10 @@ class TestUtils(unittest.TestCase):
         orb_params.pop('satellite_nominal_longitude')
         orb_params.pop('satellite_nominal_latitude')
         orb_params.pop('satellite_nominal_altitude')
-        lon, lat, alt = get_satpos(dataset)
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            lon, lat, alt = get_satpos(dataset)
         self.assertTupleEqual((lon, lat, alt), (1.3, 2.3, 3.2))
-        warn_mock.assert_called()
+        assert any("using projection" in str(msg.message) for msg in caught_warnings)
 
 
 def test_make_fake_scene():


### PR DESCRIPTION
As part of the discussion on slack regarding AHI HSD performance and optimizations I've created this PR to allow modifiers and other users hoping to get satellite position information to have control over what precision or quality of data they prefer. This will be useful in the AHI HSD case as the reader can be updated to include a "nominal" satellite position and (hopefully) share calculations of things like sensor zenith/azimuth angles because the satellite position will be the same between bands rather than the "actual" position which differs between bands and even differs between segments of a band.

Related #2029 #2012 

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
