### PR TITLE
Update angle generation to prefer "actual" satellite position

### DIFF
--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -242,6 +242,22 @@ will download and cache any necessary data files to :ref:`data_dir_setting`
 when needed. If ``False`` then pre-downloaded files will be used, but any
 other files will not be downloaded or checked for validity.
 
+Sensor Angles Position Preference
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Environment variable**: ``SATPY_SENSOR_ANGLES_POSITION_PREFERENCE``
+* **YAML/Config Key**: ``sensor_angles_position_preference``
+* **Default**: "actual"
+
+Control which satellite position should be preferred when generating sensor
+azimuth and sensor zenith angles. This value is passed directly to the
+:func:`~satpy.utils.get_satpos` function. See the documentation for that
+function for more information on how the value will be used. This is used
+as part of the :func:`~satpy.modifiers.angles.get_angles` and
+:func:`~satpy.modifiers.angles.get_satellite_zenith_angle` functions which is
+used by multiple modifiers and composites including the default rayleigh
+correction.
+
 .. _component_configuration:
 
 Component Configuration

--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -43,6 +43,7 @@ _CONFIG_DEFAULTS = {
     'data_dir': _satpy_dirs.user_data_dir,
     'demo_data_dir': '.',
     'download_aux': True,
+    'sensor_angles_position_preference': 'actual',
 }
 
 # Satpy main configuration object

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -337,7 +337,7 @@ def _get_sun_azimuth_ndarray(lons: np.ndarray, lats: np.ndarray, start_time: dat
 
 
 def _get_sensor_angles(data_arr: xr.DataArray) -> tuple[xr.DataArray, xr.DataArray]:
-    sat_lon, sat_lat, sat_alt = get_satpos(data_arr)
+    sat_lon, sat_lat, sat_alt = get_satpos(data_arr, preference="actual")
     area_def = data_arr.attrs["area"]
     sata, satz = _get_sensor_angles_from_sat_pos(sat_lon, sat_lat, sat_alt,
                                                  data_arr.attrs["start_time"],

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -337,7 +337,8 @@ def _get_sun_azimuth_ndarray(lons: np.ndarray, lats: np.ndarray, start_time: dat
 
 
 def _get_sensor_angles(data_arr: xr.DataArray) -> tuple[xr.DataArray, xr.DataArray]:
-    sat_lon, sat_lat, sat_alt = get_satpos(data_arr, preference="actual")
+    preference = satpy.config.get('sensor_angles_position_preference', 'actual')
+    sat_lon, sat_lat, sat_alt = get_satpos(data_arr, preference=preference)
     area_def = data_arr.attrs["area"]
     sata, satz = _get_sensor_angles_from_sat_pos(sat_lon, sat_lat, sat_alt,
                                                  data_arr.attrs["start_time"],

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -540,6 +540,40 @@ class TestAngleGeneration:
         args = gol.call_args[0]
         assert args[:4] == (10.0, 0.0, 12345.678, data.attrs["start_time"])
 
+    def test_get_angles_satpos_preference(self):
+        """Test that 'actual' satellite position is used for generating sensor angles."""
+        from satpy.modifiers.angles import get_angles
+
+        input_data1 = _get_angle_test_data()
+        # add additional satellite position metadata
+        input_data1.attrs["orbital_parameters"]["nadir_longitude"] = 9.0
+        input_data1.attrs["orbital_parameters"]["nadir_latitude"] = 0.01
+        input_data1.attrs["orbital_parameters"]["satellite_actual_longitude"] = 9.5
+        input_data1.attrs["orbital_parameters"]["satellite_actual_latitude"] = 0.005
+        input_data1.attrs["orbital_parameters"]["satellite_actual_altitude"] = 12345679
+        input_data2 = input_data1.copy(deep=True)
+        input_data2.attrs["orbital_parameters"]["nadir_longitude"] = 9.1
+        input_data2.attrs["orbital_parameters"]["nadir_latitude"] = 0.02
+        input_data2.attrs["orbital_parameters"]["satellite_actual_longitude"] = 9.5
+        input_data2.attrs["orbital_parameters"]["satellite_actual_latitude"] = 0.005
+        input_data2.attrs["orbital_parameters"]["satellite_actual_altitude"] = 12345679
+
+        from pyorbital.orbital import get_observer_look
+        with mock.patch("satpy.modifiers.angles.get_observer_look", wraps=get_observer_look) as gol:
+            angles1 = get_angles(input_data1)
+            da.compute(angles1)
+            angles2 = get_angles(input_data2)
+            da.compute(angles2)
+
+        # get_observer_look should have been called once per array chunk
+        assert gol.call_count == input_data1.data.blocks.size * 2
+        exp_call = mock.call(9.5, 0.005, 12345.679, input_data1.attrs["start_time"], mock.ANY, mock.ANY, 0)
+        all_same_calls = [exp_call] * gol.call_count
+        gol.assert_has_calls(all_same_calls)
+        # the dask arrays should have the same name to prove they are the same computation
+        for angle_arr1, angle_arr2 in zip(angles1, angles2):
+            assert angle_arr1.data.name == angle_arr2.data.name
+
     @pytest.mark.parametrize("force_bad_glob", [False, True])
     @pytest.mark.parametrize(
         ("input2_func", "exp_equal_sun", "exp_num_zarr"),

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -18,6 +18,7 @@
 """Tests for modifiers in modifiers/__init__.py."""
 import contextlib
 import unittest
+from copy import deepcopy
 from datetime import datetime, timedelta
 from glob import glob
 from typing import Optional, Union
@@ -540,7 +541,8 @@ class TestAngleGeneration:
         args = gol.call_args[0]
         assert args[:4] == (10.0, 0.0, 12345.678, data.attrs["start_time"])
 
-    def test_get_angles_satpos_preference(self):
+    @pytest.mark.parametrize("forced_preference", ["actual", "nadir"])
+    def test_get_angles_satpos_preference(self, forced_preference):
         """Test that 'actual' satellite position is used for generating sensor angles."""
         from satpy.modifiers.angles import get_angles
 
@@ -552,6 +554,7 @@ class TestAngleGeneration:
         input_data1.attrs["orbital_parameters"]["satellite_actual_latitude"] = 0.005
         input_data1.attrs["orbital_parameters"]["satellite_actual_altitude"] = 12345679
         input_data2 = input_data1.copy(deep=True)
+        input_data2.attrs = deepcopy(input_data1.attrs)
         input_data2.attrs["orbital_parameters"]["nadir_longitude"] = 9.1
         input_data2.attrs["orbital_parameters"]["nadir_latitude"] = 0.02
         input_data2.attrs["orbital_parameters"]["satellite_actual_longitude"] = 9.5
@@ -559,7 +562,8 @@ class TestAngleGeneration:
         input_data2.attrs["orbital_parameters"]["satellite_actual_altitude"] = 12345679
 
         from pyorbital.orbital import get_observer_look
-        with mock.patch("satpy.modifiers.angles.get_observer_look", wraps=get_observer_look) as gol:
+        with mock.patch("satpy.modifiers.angles.get_observer_look", wraps=get_observer_look) as gol, \
+                satpy.config.set(sensor_angles_position_preference=forced_preference):
             angles1 = get_angles(input_data1)
             da.compute(angles1)
             angles2 = get_angles(input_data2)
@@ -567,12 +571,18 @@ class TestAngleGeneration:
 
         # get_observer_look should have been called once per array chunk
         assert gol.call_count == input_data1.data.blocks.size * 2
-        exp_call = mock.call(9.5, 0.005, 12345.679, input_data1.attrs["start_time"], mock.ANY, mock.ANY, 0)
-        all_same_calls = [exp_call] * gol.call_count
-        gol.assert_has_calls(all_same_calls)
-        # the dask arrays should have the same name to prove they are the same computation
-        for angle_arr1, angle_arr2 in zip(angles1, angles2):
-            assert angle_arr1.data.name == angle_arr2.data.name
+        if forced_preference == "actual":
+            exp_call = mock.call(9.5, 0.005, 12345.679, input_data1.attrs["start_time"], mock.ANY, mock.ANY, 0)
+            all_same_calls = [exp_call] * gol.call_count
+            gol.assert_has_calls(all_same_calls)
+            # the dask arrays should have the same name to prove they are the same computation
+            for angle_arr1, angle_arr2 in zip(angles1, angles2):
+                assert angle_arr1.data.name == angle_arr2.data.name
+        else:
+            # nadir 1
+            gol.assert_any_call(9.0, 0.01, 12345.679, input_data1.attrs["start_time"], mock.ANY, mock.ANY, 0)
+            # nadir 2
+            gol.assert_any_call(9.1, 0.02, 12345.679, input_data1.attrs["start_time"], mock.ANY, mock.ANY, 0)
 
     @pytest.mark.parametrize("force_bad_glob", [False, True])
     @pytest.mark.parametrize(


### PR DESCRIPTION
As discussed in #2012 and #2031 and #2030, some data like AHI HSD have inconsistent satellite position data between bands and even segments. This PR updates sensor angle generation so it requests the "actual" satellite position instead of the "nadir" satellite position. This allows AHI HSD `true_color` to be generated in 3 minutes instead of 4+.

However, now that I re-read the documentation for the nadir position I see it says that nadir should be used for computing viewing angles. This makes me wonder if I should have rounded the nadir position instead of the "actual" position. Thoughts @sfinkens @mraspaud @pnuu @simonrp84?

```
  * ``nadir_longitude/latitude``: Intersection of the instrument's Nadir with the surface of the
    earth. May differ from the actual satellite position, if the instrument is pointing slightly
    off the axis (satellite, earth-center). If available, this should be used to compute viewing
    angles etc. Otherwise, use the actual satellite position.
```

Additionally, @mraspaud do you want me to define a configuration option for this preference?

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
