### PR TITLE
Update AHI HRIT reader with time parameters

### DIFF
--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -372,7 +372,7 @@ class HRITJMAFileHandler(HRITFileHandler):
         self._check_sensor_platform_consistency(info['sensor'])
 
         # Calibrate and mask space pixels
-        res = self._mask_space(self.calibrate(res, key.calibration))
+        res = self._mask_space(self.calibrate(res, key['calibration']))
 
         # Add scanline acquisition time
         res.coords['acq_time'] = ('y', self.acq_time)
@@ -388,6 +388,12 @@ class HRITJMAFileHandler(HRITFileHandler):
             'projection_longitude': float(self.mda['projection_parameters']['SSP_longitude']),
             'projection_latitude': 0.,
             'projection_altitude': float(self.mda['projection_parameters']['h'])}
+        res.attrs['time_parameters'] = {
+            'observation_start_time': self.acq_time[0],
+            'observation_end_time': self.acq_time[-1],
+            'nominal_start_time': self._start_time,
+            'nominal_end_time': self.end_time,
+        }
 
         return res
 
@@ -439,8 +445,6 @@ class HRITJMAFileHandler(HRITFileHandler):
 
     def calibrate(self, data, calibration):
         """Calibrate the data."""
-        tic = datetime.now()
-
         if calibration == 'counts':
             return data
         if calibration == 'radiance':
@@ -452,7 +456,6 @@ class HRITJMAFileHandler(HRITFileHandler):
                            dims=data.dims, attrs=data.attrs,
                            coords=data.coords)
         res = res.where(data < 65535)
-        logger.debug("Calibration time " + str(datetime.now() - tic))
         return res
 
     @property


### PR DESCRIPTION
Similar to the recent AHI HSD work, this PR is meant to update the AHI HRIT reader with the various `time_parameters`. However now that I've started looking at the actual code I'm a little confused. It seems @pnuu's keyword argument only modifies the `start_time` to be either the start time from the **filename** or the first acquisition time. This is fine as it easily maps to our new concept of nominal time and observation time, respectively. However, for `end_time` it is currently always using the last `acq_time`. If AHI HRIT is always full disk, is there a way to *know* the nominal end time based on the nominal start time?

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
