### PR TITLE
Fix angle caching using a large amount of memory

### DIFF
--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -178,7 +178,7 @@ class ZarrCacheHelper:
                 new_sub_res = sub_res.to_zarr(zarr_path, compute=False)
             new_res.append(new_sub_res)
         # actually compute the storage to zarr
-        da.compute(new_sub_res)
+        da.compute(new_res)
 
 
 def cache_to_zarr_if(


### PR DESCRIPTION
While generating some profiling plots to show the effects of the recent optimizations in satpy/pyresample and what caching angles and lon/lat arrays did, I discovered that generating the arrays used a lot of memory. This PR implements a simple fix to work around this by using a trick I developed for my profiling scripts. It essentially tells dask to compute chunks and give the resulting numpy array to an object that will do the writing. Instead of writing or storing anything it just throws the result away. Let's look at some results generating GOES-16 ABI `true_color`...

Before and After Caching and other optimizations:

![resource_profiling_figure](https://user-images.githubusercontent.com/1828519/156063019-efae7f7d-025c-4585-b31a-f7212aa26be8.png)

The plot that isn't in the above is what it looks like when you first fill the cache (12-13GB max memory):

![image](https://user-images.githubusercontent.com/1828519/156063139-1e113d96-eb3e-499f-823b-2ba40c5dd9f9.png)

After this PR, this looks like:

![image](https://user-images.githubusercontent.com/1828519/156063210-62a5c984-676b-4480-a6d4-26cf065a475e.png)


 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
