### PR TITLE
Fix unit handling in ERF DNB normalization's saturation correction

### DIFF
--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -268,7 +268,7 @@ class ERFDNB(CompositeBase):
                                                 max_val)) / dnb_data.size
         LOG.debug("Dynamic DNB saturation percentage: %f", saturation_pct)
         while saturation_pct > 0.005:
-            max_val *= 1.1 * unit_factor
+            max_val *= 1.1
             saturation_pct = float(np.count_nonzero(
                 dnb_data > max_val)) / dnb_data.size
             LOG.debug("Dynamic DNB saturation percentage: %f",

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -20,7 +20,7 @@
 import unittest
 
 
-class TestVIIRSComposites(unittest.TestCase):
+class TestVIIRSCompositesUnitTest(unittest.TestCase):
     """Test VIIRS-specific composites."""
 
     def test_load_composite_yaml(self):
@@ -116,66 +116,6 @@ class TestVIIRSComposites(unittest.TestCase):
         data = res.compute()
         np.testing.assert_allclose(data.data, 0.999, rtol=1e-4)
 
-    def test_erf_dnb(self):
-        """Test the 'dynamic_dnb' or ERF DNB compositor."""
-        import dask.array as da
-        import numpy as np
-        import xarray as xr
-        from pyresample.geometry import AreaDefinition
-
-        from satpy.composites.viirs import ERFDNB
-        rows = 5
-        cols = 10
-        area = AreaDefinition(
-            'test', 'test', 'test',
-            {'proj': 'eqc', 'lon_0': 0.0,
-             'lat_0': 0.0},
-            cols, rows,
-            (-20037508.34, -10018754.17, 20037508.34, 10018754.17))
-
-        comp = ERFDNB('dynamic_dnb', prerequisites=('dnb',),
-                      standard_name='toa_outgoing_radiance_per_'
-                                    'unit_wavelength')
-        dnb = np.zeros((rows, cols)) + 0.25
-        dnb[2, :cols // 2] = np.nan
-        dnb[3, :] += 0.25
-        dnb[4:, :] += 0.5
-        dnb = da.from_array(dnb, chunks=25)
-        c01 = xr.DataArray(dnb,
-                           dims=('y', 'x'),
-                           attrs={'name': 'DNB', 'area': area})
-        sza = np.zeros((rows, cols)) + 70.0
-        sza[:, 3] += 20.0
-        sza[:, 4:] += 45.0
-        sza = da.from_array(sza, chunks=25)
-        c02 = xr.DataArray(sza,
-                           dims=('y', 'x'),
-                           attrs={'name': 'solar_zenith_angle', 'area': area})
-        lza = np.zeros((rows, cols)) + 70.0
-        lza[:, 3] += 20.0
-        lza[:, 4:] += 45.0
-        lza = da.from_array(lza, chunks=25)
-        c03 = xr.DataArray(lza,
-                           dims=('y', 'x'),
-                           attrs={'name': 'lunar_zenith_angle', 'area': area})
-        mif = xr.DataArray(da.zeros((5,), chunks=5) + 0.1,
-                           dims=('y',),
-                           attrs={'name': 'moon_illumination_fraction', 'area': area})
-        res = comp((c01, c02, c03, mif))
-        self.assertIsInstance(res, xr.DataArray)
-        self.assertIsInstance(res.data, da.Array)
-        self.assertEqual(res.attrs['name'], 'dynamic_dnb')
-        self.assertEqual(res.attrs['standard_name'],
-                         'equalized_radiance')
-        data = res.compute()
-        unique = np.unique(data)
-        assert np.isnan(unique).any()
-        nonnan_unique = unique[~np.isnan(unique)]
-        np.testing.assert_allclose(
-            nonnan_unique,
-            [0.00000000e+00, 1.00446703e-01, 1.64116082e-01, 2.09233451e-01,
-             1.43916324e+02, 2.03528498e+02, 2.49270516e+02])
-
     def test_hncc_dnb(self):
         """Test the 'hncc_dnb' compositor."""
         import dask.array as da
@@ -232,3 +172,66 @@ class TestVIIRSComposites(unittest.TestCase):
             unique, [3.48479712e-04, 6.96955799e-04, 1.04543189e-03, 4.75394738e-03,
                      9.50784532e-03, 1.42617433e-02, 1.50001560e+03, 3.00001560e+03,
                      4.50001560e+03])
+
+
+class TestVIIRSComposites:
+    """Test various VIIRS-specific composites."""
+
+    def test_erf_dnb(self):
+        """Test the 'dynamic_dnb' or ERF DNB compositor."""
+        import dask.array as da
+        import numpy as np
+        import xarray as xr
+        from pyresample.geometry import AreaDefinition
+
+        from satpy.composites.viirs import ERFDNB
+        rows = 5
+        cols = 10
+        area = AreaDefinition(
+            'test', 'test', 'test',
+            {'proj': 'eqc', 'lon_0': 0.0,
+             'lat_0': 0.0},
+            cols, rows,
+            (-20037508.34, -10018754.17, 20037508.34, 10018754.17))
+
+        comp = ERFDNB('dynamic_dnb', prerequisites=('dnb',),
+                      standard_name='toa_outgoing_radiance_per_'
+                                    'unit_wavelength')
+        dnb = np.zeros((rows, cols)) + 0.25
+        dnb[2, :cols // 2] = np.nan
+        dnb[3, :] += 0.25
+        dnb[4:, :] += 0.5
+        dnb = da.from_array(dnb, chunks=25)
+        c01 = xr.DataArray(dnb,
+                           dims=('y', 'x'),
+                           attrs={'name': 'DNB', 'area': area})
+        sza = np.zeros((rows, cols)) + 70.0
+        sza[:, 3] += 20.0
+        sza[:, 4:] += 45.0
+        sza = da.from_array(sza, chunks=25)
+        c02 = xr.DataArray(sza,
+                           dims=('y', 'x'),
+                           attrs={'name': 'solar_zenith_angle', 'area': area})
+        lza = np.zeros((rows, cols)) + 70.0
+        lza[:, 3] += 20.0
+        lza[:, 4:] += 45.0
+        lza = da.from_array(lza, chunks=25)
+        c03 = xr.DataArray(lza,
+                           dims=('y', 'x'),
+                           attrs={'name': 'lunar_zenith_angle', 'area': area})
+        mif = xr.DataArray(da.zeros((5,), chunks=5) + 0.1,
+                           dims=('y',),
+                           attrs={'name': 'moon_illumination_fraction', 'area': area})
+        res = comp((c01, c02, c03, mif))
+        assert isinstance(res, xr.DataArray)
+        assert isinstance(res.data, da.Array)
+        assert res.attrs['name'] == 'dynamic_dnb'
+        assert res.attrs['standard_name'] == 'equalized_radiance'
+        data = res.compute()
+        unique = np.unique(data)
+        assert np.isnan(unique).any()
+        nonnan_unique = unique[~np.isnan(unique)]
+        np.testing.assert_allclose(
+            nonnan_unique,
+            [0.00000000e+00, 1.00446703e-01, 1.64116082e-01, 2.09233451e-01,
+             1.43916324e+02, 2.03528498e+02, 2.49270516e+02])

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -19,6 +19,8 @@
 
 import unittest
 
+import pytest
+
 
 class TestVIIRSCompositesUnitTest(unittest.TestCase):
     """Test VIIRS-specific composites."""
@@ -177,7 +179,8 @@ class TestVIIRSCompositesUnitTest(unittest.TestCase):
 class TestVIIRSComposites:
     """Test various VIIRS-specific composites."""
 
-    def test_erf_dnb(self):
+    @pytest.mark.parametrize("dnb_units", ["W m-2 sr-1", "W cm-2 sr-1"])
+    def test_erf_dnb(self, dnb_units):
         """Test the 'dynamic_dnb' or ERF DNB compositor."""
         import dask.array as da
         import numpy as np
@@ -201,10 +204,12 @@ class TestVIIRSComposites:
         dnb[2, :cols // 2] = np.nan
         dnb[3, :] += 0.25
         dnb[4:, :] += 0.5
+        if dnb_units == "W cm-2 sr-1":
+            dnb /= 10000.0
         dnb = da.from_array(dnb, chunks=25)
         c01 = xr.DataArray(dnb,
                            dims=('y', 'x'),
-                           attrs={'name': 'DNB', 'area': area})
+                           attrs={'name': 'DNB', 'area': area, 'units': dnb_units})
         sza = np.zeros((rows, cols)) + 70.0
         sza[:, 3] += 20.0
         sza[:, 4:] += 45.0

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -17,7 +17,11 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for VIIRS compositors."""
 
+import dask.array as da
+import numpy as np
 import pytest
+import xarray as xr
+from pyresample.geometry import AreaDefinition
 
 
 class TestVIIRSComposites:
@@ -30,11 +34,6 @@ class TestVIIRSComposites:
 
     def test_histogram_dnb(self):
         """Test the 'histogram_dnb' compositor."""
-        import dask.array as da
-        import numpy as np
-        import xarray as xr
-        from pyresample.geometry import AreaDefinition
-
         from satpy.composites.viirs import HistogramDNB
         rows = 5
         cols = 10
@@ -74,11 +73,6 @@ class TestVIIRSComposites:
 
     def test_adaptive_dnb(self):
         """Test the 'adaptive_dnb' compositor."""
-        import dask.array as da
-        import numpy as np
-        import xarray as xr
-        from pyresample.geometry import AreaDefinition
-
         from satpy.composites.viirs import AdaptiveDNB
         rows = 5
         cols = 10
@@ -116,11 +110,6 @@ class TestVIIRSComposites:
 
     def test_hncc_dnb(self):
         """Test the 'hncc_dnb' compositor."""
-        import dask.array as da
-        import numpy as np
-        import xarray as xr
-        from pyresample.geometry import AreaDefinition
-
         from satpy.composites.viirs import NCCZinke
         rows = 5
         cols = 10
@@ -174,11 +163,6 @@ class TestVIIRSComposites:
     @pytest.mark.parametrize("saturation_correction", [False, True])
     def test_erf_dnb(self, dnb_units, saturation_correction):
         """Test the 'dynamic_dnb' or ERF DNB compositor."""
-        import dask.array as da
-        import numpy as np
-        import xarray as xr
-        from pyresample.geometry import AreaDefinition
-
         from satpy.composites.viirs import ERFDNB
         rows = 5
         cols = 10

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -17,13 +17,11 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for VIIRS compositors."""
 
-import unittest
-
 import pytest
 
 
-class TestVIIRSCompositesUnitTest(unittest.TestCase):
-    """Test VIIRS-specific composites."""
+class TestVIIRSComposites:
+    """Test various VIIRS-specific composites."""
 
     def test_load_composite_yaml(self):
         """Test loading the yaml for this sensor."""
@@ -66,11 +64,10 @@ class TestVIIRSCompositesUnitTest(unittest.TestCase):
                            dims=('y', 'x'),
                            attrs={'name': 'solar_zenith_angle', 'area': area})
         res = comp((c01, c02))
-        self.assertIsInstance(res, xr.DataArray)
-        self.assertIsInstance(res.data, da.Array)
-        self.assertEqual(res.attrs['name'], 'histogram_dnb')
-        self.assertEqual(res.attrs['standard_name'],
-                         'equalized_radiance')
+        assert isinstance(res, xr.DataArray)
+        assert isinstance(res.data, da.Array)
+        assert res.attrs['name'] == 'histogram_dnb'
+        assert res.attrs['standard_name'] == 'equalized_radiance'
         data = res.compute()
         unique_values = np.unique(data)
         np.testing.assert_allclose(unique_values, [0.5994, 0.7992, 0.999], rtol=1e-3)
@@ -110,11 +107,10 @@ class TestVIIRSCompositesUnitTest(unittest.TestCase):
                            dims=('y', 'x'),
                            attrs={'name': 'solar_zenith_angle', 'area': area})
         res = comp((c01, c02))
-        self.assertIsInstance(res, xr.DataArray)
-        self.assertIsInstance(res.data, da.Array)
-        self.assertEqual(res.attrs['name'], 'adaptive_dnb')
-        self.assertEqual(res.attrs['standard_name'],
-                         'equalized_radiance')
+        assert isinstance(res, xr.DataArray)
+        assert isinstance(res.data, da.Array)
+        assert res.attrs['name'] == 'adaptive_dnb'
+        assert res.attrs['standard_name'] == 'equalized_radiance'
         data = res.compute()
         np.testing.assert_allclose(data.data, 0.999, rtol=1e-4)
 
@@ -163,21 +159,16 @@ class TestVIIRSCompositesUnitTest(unittest.TestCase):
                            dims=('y',),
                            attrs={'name': 'moon_illumination_fraction', 'area': area})
         res = comp((c01, c02, c03, mif))
-        self.assertIsInstance(res, xr.DataArray)
-        self.assertIsInstance(res.data, da.Array)
-        self.assertEqual(res.attrs['name'], 'hncc_dnb')
-        self.assertEqual(res.attrs['standard_name'],
-                         'ncc_radiance')
+        assert isinstance(res, xr.DataArray)
+        assert isinstance(res.data, da.Array)
+        assert res.attrs['name'] == 'hncc_dnb'
+        assert res.attrs['standard_name'] == 'ncc_radiance'
         data = res.compute()
         unique = np.unique(data)
         np.testing.assert_allclose(
             unique, [3.48479712e-04, 6.96955799e-04, 1.04543189e-03, 4.75394738e-03,
                      9.50784532e-03, 1.42617433e-02, 1.50001560e+03, 3.00001560e+03,
                      4.50001560e+03])
-
-
-class TestVIIRSComposites:
-    """Test various VIIRS-specific composites."""
 
     @pytest.mark.parametrize("dnb_units", ["W m-2 sr-1", "W cm-2 sr-1"])
     @pytest.mark.parametrize("saturation_correction", [False, True])


### PR DESCRIPTION
@kathys noticed that when using the saturation correction option on the dynamic_dnb (ERFDNB) composite that the result was all black. This was a dumb logic bug by me when I ported the code to satpy from Polar2Grid and the tests not being very comprehensive. This PR fixes it. See related PR and issue discussion in Polar2Grid: https://github.com/ssec/polar2grid/pull/424

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

