### PR TITLE
Add type annotations and cleanup code for geotiff writer

### DIFF
--- a/satpy/_compat.py
+++ b/satpy/_compat.py
@@ -83,7 +83,8 @@ except ImportError:
 
 
 try:
-    from numpy.typing import ArrayLike  # noqa
+    from numpy.typing import ArrayLike, DTypeLike  # noqa
 except ImportError:
     # numpy <1.20
+    from numpy import dtype as DTypeLike  # noqa
     from numpy import ndarray as ArrayLike  # noqa

--- a/satpy/tests/writer_tests/test_geotiff.py
+++ b/satpy/tests/writer_tests/test_geotiff.py
@@ -17,27 +17,27 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for the geotiff writer."""
 
+from datetime import datetime
 from unittest import mock
 
+import dask.array as da
 import numpy as np
+import xarray as xr
+
+
+def _get_test_datasets_2d():
+    """Create a single test dataset."""
+    ds1 = xr.DataArray(
+        da.zeros((100, 200), chunks=50),
+        dims=('y', 'x'),
+        attrs={'name': 'test',
+               'start_time': datetime.utcnow()}
+    )
+    return [ds1]
 
 
 class TestGeoTIFFWriter:
     """Test the GeoTIFF Writer class."""
-
-    def _get_test_datasets(self):
-        """Create a single test dataset."""
-        from datetime import datetime
-
-        import dask.array as da
-        import xarray as xr
-        ds1 = xr.DataArray(
-            da.zeros((100, 200), chunks=50),
-            dims=('y', 'x'),
-            attrs={'name': 'test',
-                   'start_time': datetime.utcnow()}
-        )
-        return [ds1]
 
     def test_init(self):
         """Test creating the writer with no arguments."""
@@ -47,16 +47,14 @@ class TestGeoTIFFWriter:
     def test_simple_write(self, tmp_path):
         """Test basic writer operation."""
         from satpy.writers.geotiff import GeoTIFFWriter
-        datasets = self._get_test_datasets()
+        datasets = _get_test_datasets_2d()
         w = GeoTIFFWriter(base_dir=tmp_path)
         w.save_datasets(datasets)
 
     def test_simple_delayed_write(self, tmp_path):
         """Test writing can be delayed."""
-        import dask.array as da
-
         from satpy.writers.geotiff import GeoTIFFWriter
-        datasets = self._get_test_datasets()
+        datasets = _get_test_datasets_2d()
         w = GeoTIFFWriter(base_dir=tmp_path)
         # when we switch to rio_save on XRImage then this will be sources
         # and targets
@@ -79,7 +77,7 @@ class TestGeoTIFFWriter:
         from trollimage.xrimage import XRImage
 
         from satpy.writers.geotiff import GeoTIFFWriter
-        datasets = self._get_test_datasets()
+        datasets = _get_test_datasets_2d()
         w = GeoTIFFWriter(base_dir=tmp_path)
         # we'd have to customize enhancements to test this through
         # save_datasets. We'll use `save_image` as a workaround.
@@ -94,7 +92,7 @@ class TestGeoTIFFWriter:
 
         """
         from satpy.writers.geotiff import GeoTIFFWriter
-        datasets = self._get_test_datasets()
+        datasets = _get_test_datasets_2d()
         w = GeoTIFFWriter(base_dir=tmp_path,
                           enhance=False,
                           dtype=np.float32)
@@ -103,7 +101,7 @@ class TestGeoTIFFWriter:
     def test_dtype_for_enhance_false(self, tmp_path):
         """Test that dtype of dataset is used if parameters enhance=False and dtype=None."""
         from satpy.writers.geotiff import GeoTIFFWriter
-        datasets = self._get_test_datasets()
+        datasets = _get_test_datasets_2d()
         w = GeoTIFFWriter(base_dir=tmp_path, enhance=False)
         with mock.patch('satpy.writers.XRImage.save') as save_method:
             save_method.return_value = None
@@ -113,7 +111,7 @@ class TestGeoTIFFWriter:
     def test_dtype_for_enhance_false_and_given_dtype(self, tmp_path):
         """Test that dtype of dataset is used if enhance=False and dtype=uint8."""
         from satpy.writers.geotiff import GeoTIFFWriter
-        datasets = self._get_test_datasets()
+        datasets = _get_test_datasets_2d()
         w = GeoTIFFWriter(base_dir=tmp_path, enhance=False, dtype=np.uint8)
         with mock.patch('satpy.writers.XRImage.save') as save_method:
             save_method.return_value = None
@@ -123,7 +121,7 @@ class TestGeoTIFFWriter:
     def test_fill_value_from_config(self, tmp_path):
         """Test fill_value coming from the writer config."""
         from satpy.writers.geotiff import GeoTIFFWriter
-        datasets = self._get_test_datasets()
+        datasets = _get_test_datasets_2d()
         w = GeoTIFFWriter(base_dir=tmp_path)
         w.info['fill_value'] = 128
         with mock.patch('satpy.writers.XRImage.save') as save_method:
@@ -134,7 +132,7 @@ class TestGeoTIFFWriter:
     def test_tags(self, tmp_path):
         """Test tags being added."""
         from satpy.writers.geotiff import GeoTIFFWriter
-        datasets = self._get_test_datasets()
+        datasets = _get_test_datasets_2d()
         w = GeoTIFFWriter(tags={'test1': 1}, base_dir=tmp_path)
         w.info['fill_value'] = 128
         with mock.patch('satpy.writers.XRImage.save') as save_method:
@@ -146,7 +144,7 @@ class TestGeoTIFFWriter:
     def test_scale_offset(self, tmp_path):
         """Test tags being added."""
         from satpy.writers.geotiff import GeoTIFFWriter
-        datasets = self._get_test_datasets()
+        datasets = _get_test_datasets_2d()
         w = GeoTIFFWriter(tags={'test1': 1}, base_dir=tmp_path)
         w.info['fill_value'] = 128
         with mock.patch('satpy.writers.XRImage.save') as save_method:
@@ -157,7 +155,7 @@ class TestGeoTIFFWriter:
     def test_tiled_value_from_config(self, tmp_path):
         """Test tiled value coming from the writer config."""
         from satpy.writers.geotiff import GeoTIFFWriter
-        datasets = self._get_test_datasets()
+        datasets = _get_test_datasets_2d()
         w = GeoTIFFWriter(base_dir=tmp_path)
         with mock.patch('satpy.writers.XRImage.save') as save_method:
             save_method.return_value = None

--- a/satpy/tests/writer_tests/test_geotiff.py
+++ b/satpy/tests/writer_tests/test_geotiff.py
@@ -17,21 +17,20 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for the geotiff writer."""
 
-import unittest
 from unittest import mock
 
 import numpy as np
 
 
-class TestGeoTIFFWriter(unittest.TestCase):
+class TestGeoTIFFWriter:
     """Test the GeoTIFF Writer class."""
 
-    def setUp(self):
+    def setup_method(self):
         """Create temporary directory to save files to."""
         import tempfile
         self.base_dir = tempfile.mkdtemp()
 
-    def tearDown(self):
+    def teardown_method(self):
         """Remove the temporary directory created for a test."""
         try:
             import shutil
@@ -76,12 +75,12 @@ class TestGeoTIFFWriter(unittest.TestCase):
         # and targets
         res = w.save_datasets(datasets, compute=False)
         # this will fail if rasterio isn't installed
-        self.assertIsInstance(res, tuple)
+        assert isinstance(res, tuple)
         # two lists, sources and destinations
-        self.assertEqual(len(res), 2)
-        self.assertIsInstance(res[0], list)
-        self.assertIsInstance(res[1], list)
-        self.assertIsInstance(res[0][0], da.Array)
+        assert len(res) == 2
+        assert isinstance(res[0], list)
+        assert isinstance(res[1], list)
+        assert isinstance(res[0][0], da.Array)
         da.store(res[0], res[1])
         for target in res[1]:
             if hasattr(target, 'close'):
@@ -122,7 +121,7 @@ class TestGeoTIFFWriter(unittest.TestCase):
         with mock.patch('satpy.writers.XRImage.save') as save_method:
             save_method.return_value = None
             w.save_datasets(datasets, compute=False)
-            self.assertEqual(save_method.call_args[1]['dtype'], np.float64)
+            assert save_method.call_args[1]['dtype'] == np.float64
 
     def test_dtype_for_enhance_false_and_given_dtype(self):
         """Test that dtype of dataset is used if enhance=False and dtype=uint8."""
@@ -132,7 +131,7 @@ class TestGeoTIFFWriter(unittest.TestCase):
         with mock.patch('satpy.writers.XRImage.save') as save_method:
             save_method.return_value = None
             w.save_datasets(datasets, compute=False)
-            self.assertEqual(save_method.call_args[1]['dtype'], np.uint8)
+            assert save_method.call_args[1]['dtype'] == np.uint8
 
     def test_fill_value_from_config(self):
         """Test fill_value coming from the writer config."""
@@ -143,7 +142,7 @@ class TestGeoTIFFWriter(unittest.TestCase):
         with mock.patch('satpy.writers.XRImage.save') as save_method:
             save_method.return_value = None
             w.save_datasets(datasets, compute=False)
-            self.assertEqual(save_method.call_args[1]['fill_value'], 128)
+            assert save_method.call_args[1]['fill_value'] == 128
 
     def test_tags(self):
         """Test tags being added."""
@@ -155,7 +154,7 @@ class TestGeoTIFFWriter(unittest.TestCase):
             save_method.return_value = None
             w.save_datasets(datasets, tags={'test2': 2}, compute=False)
             called_tags = save_method.call_args[1]['tags']
-            self.assertDictEqual(called_tags, {'test1': 1, 'test2': 2})
+            assert called_tags == {'test1': 1, 'test2': 2}
 
     def test_scale_offset(self):
         """Test tags being added."""
@@ -166,8 +165,7 @@ class TestGeoTIFFWriter(unittest.TestCase):
         with mock.patch('satpy.writers.XRImage.save') as save_method:
             save_method.return_value = None
             w.save_datasets(datasets, tags={'test2': 2}, compute=False, include_scale_offset=True)
-            called_include = save_method.call_args[1]['include_scale_offset_tags']
-            self.assertTrue(called_include)
+            assert save_method.call_args[1]['include_scale_offset_tags']
 
     def test_tiled_value_from_config(self):
         """Test tiled value coming from the writer config."""
@@ -177,4 +175,4 @@ class TestGeoTIFFWriter(unittest.TestCase):
         with mock.patch('satpy.writers.XRImage.save') as save_method:
             save_method.return_value = None
             w.save_datasets(datasets, compute=False)
-            self.assertEqual(save_method.call_args[1]['tiled'], True)
+            assert save_method.call_args[1]['tiled']

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -23,6 +23,7 @@ For now, this includes enhancement configuration utilities.
 import logging
 import os
 import warnings
+from typing import Optional
 
 import dask.array as da
 import numpy as np
@@ -812,7 +813,13 @@ class ImageWriter(Writer):
                                  decorate=decorate, fill_value=fill_value)
         return self.save_image(img, filename=filename, compute=compute, fill_value=fill_value, **kwargs)
 
-    def save_image(self, img, filename=None, compute=True, **kwargs):
+    def save_image(
+            self,
+            img: XRImage,
+            filename: Optional[str] = None,
+            compute: bool = True,
+            **kwargs
+    ):
         """Save Image object to a given ``filename``.
 
         Args:


### PR DESCRIPTION
While working on a feature that ended up not being needed, I cleaned up the geotiff writer code.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
