### PR TITLE
Add missing GOES-18 support to glm_l2 reader

### DIFF
--- a/satpy/readers/glm_l2.py
+++ b/satpy/readers/glm_l2.py
@@ -35,6 +35,7 @@ logger = logging.getLogger(__name__)
 PLATFORM_NAMES = {
     'G16': 'GOES-16',
     'G17': 'GOES-17',
+    'G18': 'GOES-18',
 }
 
 # class NC_GLM_L2_LCFA(BaseFileHandler): — add this with glmtools


### PR DESCRIPTION
I'm preparing a Geo2Grid release and noticed GLM L2 does not support GOES-18 in the platform names. This simple PR fixes that.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
