### PR TITLE
Bugfix fci_l2_nc reader

### DIFF
--- a/satpy/etc/readers/fci_l2_nc.yaml
+++ b/satpy/etc/readers/fci_l2_nc.yaml
@@ -48,7 +48,6 @@ datasets:
     file_type: nc_fci_clm
     file_key: cloud_state
     long_name: cloud_mask_classification
-    fill_value: 0
 
   quality_illumination_clm:
     name: quality_illumination_clm
@@ -56,7 +55,6 @@ datasets:
     file_type: nc_fci_clm
     file_key: quality_illumination
     long_name: illumination_classification
-    fill_value: 0
 
   quality_nwp_parameters_clm:
     name: quality_nwp_parameters_clm
@@ -64,7 +62,6 @@ datasets:
     file_type: nc_fci_clm
     file_key: quality_nwp_parameters
     long_name: quality_index
-    fill_value: 0
 
   quality_MTG_parameters_clm:
     name: quality_MTG_parameters_clm
@@ -72,7 +69,7 @@ datasets:
     file_type: nc_fci_clm
     file_key: quality_MTG_parameters
     long_name: quality_index
-    fill_value: [-127, 0]
+    fill_value: -127
 
   quality_overall_processing_clm:
     name: quality_overall_processing_clm
@@ -80,7 +77,6 @@ datasets:
     file_type: nc_fci_clm
     file_key: quality_overall_processing
     long_name: quality_index
-    fill_value: 0
 
   product_quality_clm:
     name: product_quality_clm
@@ -107,7 +103,6 @@ datasets:
     file_type: nc_fci_ct
     file_key: cloud_phase
     long_name: cloud_phase
-    fill_value: 0
 
   cloud_type:
     name: cloud_type
@@ -115,7 +110,6 @@ datasets:
     file_type: nc_fci_ct
     file_key: cloud_type
     long_name: cloud_type
-    fill_value: 0
 
   quality_illumination_ct:
     name: quality_illumination_ct
@@ -123,7 +117,6 @@ datasets:
     file_type: nc_fci_ct
     file_key: quality_illumination
     long_name: illumination_classification
-    fill_value: 0
 
   quality_nwp_parameters_ct:
     name: quality_nwp_parameters_ct
@@ -131,7 +124,6 @@ datasets:
     file_type: nc_fci_ct
     file_key: quality_nwp_parameters
     long_name: quality_index
-    fill_value: 0
 
   quality_MTG_parameters_ct:
     name: quality_MTG_parameters_ct
@@ -139,7 +131,6 @@ datasets:
     file_type: nc_fci_ct
     file_key: quality_MTG_parameters
     long_name: quality_index
-    fill_value: 0
 
   quality_overall_processing_ct:
     name: quality_overall_processing_ct
@@ -147,7 +138,6 @@ datasets:
     file_type: nc_fci_ct
     file_key: quality_overall_processing
     long_name: quality_index
-    fill_value: 0
 
   product_quality_ct:
     name: product_quality_ct
@@ -173,7 +163,6 @@ datasets:
     resolution: 2000
     file_type: nc_fci_ctth
     file_key: cloud_top_aviation_height
-    fill_value: 0
 
   cloud_top_height:
     name: cloud_top_height
@@ -207,7 +196,6 @@ datasets:
     resolution: 2000
     file_type: nc_fci_ctth
     file_key: quality_status
-    fill_value: 0
 
   quality_rtm_ctth:
     name: quality_rtm_ctth
@@ -220,35 +208,31 @@ datasets:
     resolution: 2000
     file_type: nc_fci_ctth
     file_key: quality_method
-    fill_value: 0
 
   quality_nwp_parameters_ctth:
     name: quality_nwp_parameters_ctth
     resolution: 2000
     file_type: nc_fci_ctth
     file_key: quality_nwp_parameters
-    fill_value: 0
 
   quality_MTG_parameters_ctth:
     name: quality_MTG_parameters_ctth
     resolution: 2000
     file_type: nc_fci_ctth
     file_key: quality_MTG_parameters
-    fill_value: [-127, 0]
+    fill_value: -127
 
   quality_overall_processing_ctth:
     name: quality_overall_processing_ctth
     resolution: 2000
     file_type: nc_fci_ctth
     file_key: quality_overall_processing
-    fill_value: 0
 
   quality_overall_processing_aviation_ctth:
     name: quality_overall_processing_aviation_ctth
     resolution: 2000
     file_type: nc_fci_ctth
     file_key: quality_overall_processing_aviation
-    fill_value: 0
 
   product_quality_ctth:
     name: product_quality_ctth
@@ -275,7 +259,6 @@ datasets:
     file_type: nc_fci_oca
     file_key: retrieved_cloud_phase
     standard_name: thermodynamic_phase_of_cloud_water_particles_at_cloud_top
-    fill_value: 0
 
   retrieved_cloud_optical_thickness:
     name: retrieved_cloud_optical_thickness

--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -240,8 +240,12 @@ class FciL2NCFileHandler(FciL2CommonFunctions, BaseFileHandler):
         """Extract projection and area information."""
         # Read the projection data from the mtg_geos_projection variable
         a = float(self._projection.attrs['semi_major_axis'])
-        rf = float(self._projection.attrs['inverse_flattering'])
         h = float(self._projection.attrs['perspective_point_height'])
+
+        # TODO: Some L2PF test data files have a typo in the keyname for the inverse flattening parameter. Until this
+        #       has been resolved a default value is used as fallback. Remove this workaround once all L2PF test files
+        #       are correctly formatted.
+        rf = float(self._projection.attrs.get('inverse_flattening', 298.257223563))
 
         res = dataset_id.resolution
 

--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -241,10 +241,8 @@ class FciL2NCFileHandler(FciL2CommonFunctions, BaseFileHandler):
         # Read the projection data from the mtg_geos_projection variable
         a = float(self._projection.attrs['semi_major_axis'])
         h = float(self._projection.attrs['perspective_point_height'])
-
-        # TODO: Some L2PF test data files have a typo in the keyname for the inverse flattening parameter. Until this
-        #       has been resolved a default value is used as fallback. Remove this workaround once all L2PF test files
-        #       are correctly formatted.
+        # FIXME: Some L2PF test data files have a typo in the keyname for the inverse flattening parameter. Use a
+        #        default value as fallback until all L2PF test files are correctly formatted.
         rf = float(self._projection.attrs.get('inverse_flattening', 298.257223563))
 
         res = dataset_id.resolution

--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -241,8 +241,9 @@ class FciL2NCFileHandler(FciL2CommonFunctions, BaseFileHandler):
         # Read the projection data from the mtg_geos_projection variable
         a = float(self._projection.attrs['semi_major_axis'])
         h = float(self._projection.attrs['perspective_point_height'])
-        # FIXME: Some L2PF test data files have a typo in the keyname for the inverse flattening parameter. Use a
-        #        default value as fallback until all L2PF test files are correctly formatted.
+
+        # Some L2PF test data files have a typo in the keyname for the inverse flattening parameter. Use a default value
+        # as fallback until all L2PF test files are correctly formatted.
         rf = float(self._projection.attrs.get('inverse_flattening', 298.257223563))
 
         res = dataset_id.resolution

--- a/satpy/tests/reader_tests/test_fci_l2_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l2_nc.py
@@ -99,7 +99,7 @@ class TestFciL2NCFileHandler(unittest.TestCase):
             mtg_geos_projection = nc.createVariable('mtg_geos_projection', int, dimensions=())
             mtg_geos_projection.longitude_of_projection_origin = 0.0
             mtg_geos_projection.semi_major_axis = 6378137.
-            mtg_geos_projection.inverse_flattering = 298.257223563
+            mtg_geos_projection.inverse_flattening = 298.257223563
             mtg_geos_projection.perspective_point_height = 35786400.
 
         self.fh = FciL2NCFileHandler(filename=self.test_file, filename_info={}, filetype_info={})
@@ -461,7 +461,7 @@ class TestFciL2NCReadingByteData(unittest.TestCase):
             mtg_geos_projection = nc_byte.createVariable('mtg_geos_projection', int, dimensions=())
             mtg_geos_projection.longitude_of_projection_origin = 0.0
             mtg_geos_projection.semi_major_axis = 6378137.
-            mtg_geos_projection.inverse_flattering = 298.257223563
+            mtg_geos_projection.inverse_flattening = 298.257223563
             mtg_geos_projection.perspective_point_height = 35786400.
 
             test_dataset = nc_byte.createVariable('cloud_mask_test_flag', np.float32,


### PR DESCRIPTION
This PR fixes two minor bugs introduced with the recent merge of [PR1927](https://github.com/pytroll/satpy/pull/1927).

1. Due to a typo in some of the L2PF filenames for the projection attribute `inverse_flattening`, the reader did not work properly. A temporary workaround has been implemented for the time being until the L2PF test files are correctly formatted. 
2. The filtering of some categorical dataset flags has been removed as the information can be useful.

 - [X] Test modified/corrected accordingly
