### PR TITLE
Fix DifferenceCompositor not using metadata from YAML

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -257,7 +257,8 @@ class DifferenceCompositor(CompositeBase):
         projectables = self.match_data_arrays(projectables)
         info = combine_metadata(*projectables)
         info['name'] = self.attrs['name']
-        info.update(attrs)
+        info.update(self.attrs)  # attrs from YAML/__init__
+        info.update(attrs)  # overwriting of DataID properties
 
         proj = projectables[0] - projectables[1]
         proj.attrs = info

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -269,8 +269,8 @@ class TestDifferenceCompositor(unittest.TestCase):
     def test_basic_diff(self):
         """Test that a basic difference composite works."""
         from satpy.composites import DifferenceCompositor
-        comp = DifferenceCompositor(name='diff')
-        res = comp((self.ds1, self.ds2), standard_name='temperature_difference')
+        comp = DifferenceCompositor(name='diff', standard_name='temperature_difference')
+        res = comp((self.ds1, self.ds2))
         np.testing.assert_allclose(res.values, -2)
         assert res.attrs.get('standard_name') == 'temperature_difference'
 


### PR DESCRIPTION
Found out the `standard_name:` I was assigning in the YAML wasn't being assigned.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

