### PR TITLE
Skip dataset flipping in GEOFlippableFileYAMLReader in case of SwathDefinition data 

### DIFF
--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -1010,6 +1010,11 @@ def _set_orientation(dataset, upper_right_corner):
                     "and will not be flipped.".format(dataset.attrs.get('name', 'unknown_name')))
         return dataset
 
+    if isinstance(dataset.attrs['area'], SwathDefinition):
+        logger.info("Dataset {} is in a SwathDefinition "
+                    "and will not be flipped.".format(dataset.attrs.get('name', 'unknown_name')))
+        return dataset
+
     projection_type = _get_projection_type(dataset.attrs['area'])
     accepted_geos_proj_types = ['Geostationary Satellite (Sweep Y)', 'Geostationary Satellite (Sweep X)']
     if projection_type not in accepted_geos_proj_types:


### PR DESCRIPTION
This PR implements an exception in order to not perform dataset flipping in the `GEOFlippableFileYAMLReader` in case of `SwathDefinition` data.

This is needed following the merge of [PR1976](https://github.com/pytroll/satpy/pull/1976) and [PR1927](https://github.com/pytroll/satpy/pull/1927), where the `GEOFlippableFileYAMLReader` is used but the data may be returned either with an `AreaDefinition` (by setting the reader keyword `with_area_definition=True`) or with a `SwathDefintion` (by setting the reader keyword `with_area_definition=False`). In the latter scenario (which is also the default), it's not possible to use the flipping implementations in the `GEOFlippableFileYAMLReader` and hence we need to check for the type of area and simply return the dataset as it is in case of a `SwathDefinition`. 

An additional test for the scenario where no area information at all is available has been added as well, since was missing before.

 - [X] Tests added <!-- for all bug fixes or enhancements -->
