### PR TITLE
Add option to replace saturated MODIS L1b values with max valid value

### DIFF
--- a/satpy/readers/hdfeos_base.py
+++ b/satpy/readers/hdfeos_base.py
@@ -91,7 +91,7 @@ def _find_and_run_interpolation(interpolation_functions, src_resolution, dst_res
 class HDFEOSBaseFileReader(BaseFileHandler):
     """Base file handler for HDF EOS data for both L1b and L2 products."""
 
-    def __init__(self, filename, filename_info, filetype_info):
+    def __init__(self, filename, filename_info, filetype_info, **kwargs):
         """Initialize the base reader."""
         BaseFileHandler.__init__(self, filename, filename_info, filetype_info)
         try:
@@ -291,9 +291,9 @@ class HDFEOSGeoReader(HDFEOSBaseFileReader):
         'solar_zenith_angle': ('SolarZenith', 'Solar_Zenith'),
     }
 
-    def __init__(self, filename, filename_info, filetype_info):
+    def __init__(self, filename, filename_info, filetype_info, **kwargs):
         """Initialize the geographical reader."""
-        HDFEOSBaseFileReader.__init__(self, filename, filename_info, filetype_info)
+        HDFEOSBaseFileReader.__init__(self, filename, filename_info, filetype_info, **kwargs)
         self.cache = {}
 
     @staticmethod

--- a/satpy/readers/modis_l1b.py
+++ b/satpy/readers/modis_l1b.py
@@ -197,6 +197,8 @@ class HDFEOSBandReader(HDFEOSBaseFileReader):
         return array
 
     def _mask_uncertain_pixels(self, array, uncertainty, band_index):
+        if not self._mask_saturated:
+            return array
         band_uncertainty = from_sds(uncertainty, chunks=CHUNK_SIZE)[band_index, :, :]
         array = array.where(band_uncertainty < 15)
         return array

--- a/satpy/readers/modis_l1b.py
+++ b/satpy/readers/modis_l1b.py
@@ -62,6 +62,16 @@ class HDFEOSBandReader(HDFEOSBaseFileReader):
            "Q": 250,
            "H": 500}
 
+    res_to_possible_variable_names = {
+        1000: ['EV_250_Aggr1km_RefSB',
+               'EV_500_Aggr1km_RefSB',
+               'EV_1KM_RefSB',
+               'EV_1KM_Emissive'],
+        500: ['EV_250_Aggr500_RefSB',
+              'EV_500_RefSB'],
+        250: ['EV_250_RefSB'],
+    }
+
     def __init__(self, filename, filename_info, filetype_info, mask_saturated=True, **kwargs):
         """Init the file handler."""
         HDFEOSBaseFileReader.__init__(self, filename, filename_info, filetype_info, **kwargs)
@@ -73,19 +83,10 @@ class HDFEOSBandReader(HDFEOSBaseFileReader):
 
     def get_dataset(self, key, info):
         """Read data from file and return the corresponding projectables."""
-        datadict = {
-            1000: ['EV_250_Aggr1km_RefSB',
-                   'EV_500_Aggr1km_RefSB',
-                   'EV_1KM_RefSB',
-                   'EV_1KM_Emissive'],
-            500: ['EV_250_Aggr500_RefSB',
-                  'EV_500_RefSB'],
-            250: ['EV_250_RefSB']}
-
         if self.resolution != key['resolution']:
             return
 
-        datasets = datadict[self.resolution]
+        datasets = self.res_to_possible_variable_names[self.resolution]
         for dataset in datasets:
             subdata = self.sd.select(dataset)
             var_attrs = subdata.attributes()

--- a/satpy/readers/modis_l1b.py
+++ b/satpy/readers/modis_l1b.py
@@ -25,11 +25,33 @@ The ``modis_l1b`` reader reads and calibrates Modis L1 image data in hdf-eos for
 a pattern similar to the following one:
 
 .. parsed-literal::
+
     M[O/Y]D02[1/H/Q]KM.A[date].[time].[collection].[processing_time].hdf
 
 Other patterns where "collection" and/or "proccessing_time" are missing might also work
 (see the readers yaml file for details). Geolocation files (MOD03) are also supported.
+The IMAPP direct broadcast naming format is also supported with names like:
+``a1.12226.1846.1000m.hdf``.
 
+Saturation Handling
+-------------------
+
+Band 2 of the MODIS sensor is available in 250m, 500m, and 1km resolutions.
+The band data may include a special fill value to indicate when the detector
+was saturated in the 250m version of the data. When the data is aggregated to
+coarser resolutions this saturation fill value is converted to a
+"can't aggregate" fill value. By default, Satpy will replace these fill values
+with NaN to indicate they are invalid. This is typically undesired when
+generating images for the data as they appear as "holes" in bright clouds.
+To control this the keyword argument ``mask_saturated`` can be passed and set
+to ``False`` to set these two fill values to the maximum valid value.
+
+.. code-block:: python
+
+    scene = satpy.Scene(filenames=filenames,
+                        reader='modis_l1b',
+                        reader_kwargs={'mask_saturated': False})
+    scene.load(['2'])
 
 Geolocation files
 -----------------

--- a/satpy/readers/modis_l1b.py
+++ b/satpy/readers/modis_l1b.py
@@ -102,7 +102,7 @@ class HDFEOSBandReader(HDFEOSBaseFileReader):
 
     def __init__(self, filename, filename_info, filetype_info, mask_saturated=True, **kwargs):
         """Init the file handler."""
-        HDFEOSBaseFileReader.__init__(self, filename, filename_info, filetype_info, **kwargs)
+        super().__init__(self, filename, filename_info, filetype_info, **kwargs)
         self._mask_saturated = mask_saturated
 
         ds = self.metadata['INVENTORYMETADATA'][

--- a/satpy/readers/modis_l1b.py
+++ b/satpy/readers/modis_l1b.py
@@ -102,7 +102,7 @@ class HDFEOSBandReader(HDFEOSBaseFileReader):
 
     def __init__(self, filename, filename_info, filetype_info, mask_saturated=True, **kwargs):
         """Init the file handler."""
-        super().__init__(self, filename, filename_info, filetype_info, **kwargs)
+        super().__init__(filename, filename_info, filetype_info, **kwargs)
         self._mask_saturated = mask_saturated
 
         ds = self.metadata['INVENTORYMETADATA'][

--- a/satpy/tests/reader_tests/_modis_fixtures.py
+++ b/satpy/tests/reader_tests/_modis_fixtures.py
@@ -85,6 +85,14 @@ def _generate_visible_data(resolution: int, num_bands: int, dtype=np.uint16) -> 
     return data
 
 
+def _generate_visible_uncertainty_data(shape: tuple) -> np.ndarray:
+    uncertainty = np.zeros(shape, dtype=np.uint8)
+    uncertainty[:, -1, -1] = 15  # fill value
+    uncertainty[:, -1, -2] = 15  # saturated
+    uncertainty[:, -1, -3] = 15  # can't aggregate
+    return uncertainty
+
+
 def _get_lonlat_variable_info(resolution: int) -> dict:
     lon_5km, lat_5km = _generate_lonlat_data(resolution)
     return {
@@ -122,6 +130,7 @@ def _get_angles_variable_info(resolution: int) -> dict:
 def _get_visible_variable_info(var_name: str, resolution: int, bands: list[str]):
     num_bands = len(bands)
     data = _generate_visible_data(resolution, len(bands))
+    uncertainty = _generate_visible_uncertainty_data(data.shape)
     dim_factor = RES_TO_REPEAT_FACTOR[resolution] * 2
     band_dim_name = f"Band_{resolution}_{num_bands}_RefSB:MODIS_SWATH_Type_L1B"
     row_dim_name = f'{dim_factor}*nscans:MODIS_SWATH_Type_L1B'
@@ -143,7 +152,7 @@ def _get_visible_variable_info(var_name: str, resolution: int, bands: list[str])
             },
         },
         var_name + '_Uncert_Indexes': {
-            'data': np.zeros(data.shape, dtype=np.uint8),
+            'data': uncertainty,
             'type': SDC.UINT8,
             'fill_value': 255,
             'attrs': {

--- a/satpy/tests/reader_tests/_modis_fixtures.py
+++ b/satpy/tests/reader_tests/_modis_fixtures.py
@@ -75,6 +75,13 @@ def _generate_angle_data(resolution: int) -> np.ndarray:
 def _generate_visible_data(resolution: int, num_bands: int, dtype=np.uint16) -> np.ndarray:
     shape = _shape_for_resolution(resolution)
     data = np.zeros((num_bands, shape[0], shape[1]), dtype=dtype)
+
+    # add fill value to every band
+    data[:, -1, -1] = 65535
+
+    # add band 2 saturation and can't aggregate fill values
+    data[1, -1, -2] = 65533
+    data[1, -1, -3] = 65528
     return data
 
 


### PR DESCRIPTION
As discussed on slack, the MODIS L1b files include a special fill value (65535) that indicates that the detector saturated. This value is only present for band 2. Additionally there is a fill value that means that the value could not be aggregated from the finer resolution version of the band to the 500m or 1km version. This "can't aggregate" value shows up when saturated pixels as well.

This PR adds a new "mask_saturated" kwarg to the `modis_l1b` reader that, by default, replaces these values with NaNs as it is now. If `False`, the saturated and can't aggregate fill values are replaced with the max valid value. The name of this kwarg matches the MSI reader (https://github.com/pytroll/satpy/blob/main/satpy/readers/msi_safe.py#L114) which has the same default and behavior.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

