### PR TITLE
Exclude subprocess and Popen usage in HRIT reader from Bandit

### DIFF
--- a/satpy/readers/hrit_base.py
+++ b/satpy/readers/hrit_base.py
@@ -32,7 +32,7 @@ import logging
 import os
 from datetime import timedelta
 from io import BytesIO
-from subprocess import PIPE, Popen
+from subprocess import PIPE, Popen  # nosec B404
 from tempfile import gettempdir
 
 import dask.array as da
@@ -132,7 +132,7 @@ def decompress(infile, outdir='.'):
     cwd = os.getcwd()
     os.chdir(outdir)
 
-    p = Popen([cmd, infile], stdout=PIPE)
+    p = Popen([cmd, infile], stdout=PIPE)  # nosec B603
     stdout = BytesIO(p.communicate()[0])
     status = p.returncode
     os.chdir(cwd)


### PR DESCRIPTION
The HRIT reader uses an external tool for decompression.
Since this is currently the only viable option, the use of subprocess / Popen is in this instance acceptable (discussed in #2063)

 - [x] Closes #2063 
 - [ ] Tests added
 - [ ] Fully documented
 - [x] Add your name to `AUTHORS.md` if not there already
