### PR TITLE
Make sure RGBs do not have units attributes.

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -979,7 +979,9 @@ class RatioSharpenedRGB(GenericCompositor):
         info.update(self.attrs)
         # Force certain pieces of metadata that we *know* to be true
         info.setdefault("standard_name", "true_color")
-        return super(RatioSharpenedRGB, self).__call__((r, g, b), **info)
+        res = super(RatioSharpenedRGB, self).__call__((r, g, b), **info)
+        res.attrs.pop("units", None)
+        return res
 
 
 def _mean4(data, offset=(0, 0), block_id=None):

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -920,7 +920,10 @@ class RatioSharpenedRGB(GenericCompositor):
         return ret
 
     def __call__(self, datasets, optional_datasets=None, **info):
-        """Sharpen low resolution datasets by multiplying by the ratio of ``high_res / low_res``."""
+        """Sharpen low resolution datasets by multiplying by the ratio of ``high_res / low_res``.
+
+        The resulting RGB has the units attribute removed.
+        """
         if len(datasets) != 3:
             raise ValueError("Expected 3 datasets, got %d" % (len(datasets), ))
         if not all(x.shape == datasets[0].shape for x in datasets[1:]) or \

--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -1007,4 +1007,6 @@ class SnowAge(GenericCompositor):
         ch2.attrs = info
         ch3.attrs = info
 
-        return super(SnowAge, self).__call__([ch1, ch2, ch3], **info)
+        res = super(SnowAge, self).__call__([ch1, ch2, ch3], **info)
+        res.attrs.pop("units", None)
+        return res

--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -974,11 +974,13 @@ class SnowAge(GenericCompositor):
         The algorithm and the product are described in this
         presentation :
         http://www.ssec.wisc.edu/meetings/cspp/2015/Agenda%20PDF/Wednesday/Roquet_snow_product_cspp2015.pdf
+        as well as in the paper http://dx.doi.org/10.1016/j.rse.2017.04.028
         For further information you may contact
         Bernard Bellec at Bernard.Bellec@meteo.fr
         or
         Pascale Roquet at Pascale.Roquet@meteo.fr
 
+        The resulting RGB has the units attribute removed.
         """
         if len(projectables) != 5:
             raise ValueError("Expected 5 datasets, got %d" %

--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -953,18 +953,19 @@ class SnowAge(GenericCompositor):
     Product is based on method presented at the second
     CSPP/IMAPP users' meeting at Eumetsat in Darmstadt on 14-16 April 2015
 
-    # Bernard Bellec snow Look-Up Tables V 1.0 (c) Meteo-France
-    # These Look-up Tables allow you to create the RGB snow product
-    # for SUOMI-NPP VIIRS Imager according to the algorithm
-    # presented at the second CSPP/IMAPP users' meeting at Eumetsat
-    # in Darmstadt on 14-16 April 2015
-    # The algorithm and the product are described in this
-    # presentation :
-    # http://www.ssec.wisc.edu/meetings/cspp/2015/Agenda%20PDF/Wednesday/Roquet_snow_product_cspp2015.pdf
-    # For further information you may contact
-    # Bernard Bellec at Bernard.Bellec@meteo.fr
-    # or
-    # Pascale Roquet at Pascale.Roquet@meteo.fr
+    Bernard Bellec snow Look-Up Tables V 1.0 (c) Meteo-France
+    These Look-up Tables allow you to create the RGB snow product
+    for SUOMI-NPP VIIRS Imager according to the algorithm
+    presented at the second CSPP/IMAPP users' meeting at Eumetsat
+    in Darmstadt on 14-16 April 2015
+    The algorithm and the product are described in this
+    presentation :
+    http://www.ssec.wisc.edu/meetings/cspp/2015/Agenda%20PDF/Wednesday/Roquet_snow_product_cspp2015.pdf
+    as well as in the paper http://dx.doi.org/10.1016/j.rse.2017.04.028
+    For further information you may contact
+    Bernard Bellec at Bernard.Bellec@meteo.fr
+    or
+    Pascale Roquet at Pascale.Roquet@meteo.fr
     """
 
     def __call__(self, projectables, nonprojectables=None, **info):

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -179,3 +179,25 @@ class TestVIIRSComposites:
                           2.09233451e-01, 1.43916324e+02, 2.03528498e+02,
                           2.49270516e+02]
             np.testing.assert_allclose(nonnan_unique, exp_unique)
+
+    def test_snow_age(self, area):
+        """Test the 'snow_age' compositor."""
+        from satpy.composites.viirs import SnowAge
+
+        projectables = tuple(
+           xr.DataArray(
+                da.from_array(np.full(area.shape, 5.*i), chunks=5),
+                dims=("y", "x"),
+                attrs={"name": f"M0{i:d}",
+                       "calibration": "reflectance",
+                       "units": "%"})
+           for i in range(7, 12))
+        comp = SnowAge(
+                "snow_age",
+                prerequisites=("M07", "M08", "M09", "M10", "M11",),
+                standard_name="snow_age")
+        res = comp(projectables)
+        assert isinstance(res, xr.DataArray)
+        assert isinstance(res.data, da.Array)
+        assert res.attrs["name"] == "snow_age"
+        assert "units" not in res.attrs

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -135,6 +135,8 @@ class TestRatioSharpenedCompositors(unittest.TestCase):
                  'start_time': datetime(2018, 1, 1, 18),
                  'modifiers': tuple(),
                  'resolution': 1000,
+                 'calibration': 'reflectance',
+                 'units': '%',
                  'name': 'test_vis'}
         ds1 = xr.DataArray(da.ones((2, 2), chunks=2, dtype=np.float64),
                            attrs=attrs, dims=('y', 'x'),
@@ -228,6 +230,13 @@ class TestRatioSharpenedCompositors(unittest.TestCase):
         np.testing.assert_allclose(res[0], self.ds1.values)
         np.testing.assert_allclose(res[1], np.array([[3, 3], [3, 3]], dtype=np.float64))
         np.testing.assert_allclose(res[2], np.array([[4, 4], [4, 4]], dtype=np.float64))
+
+    def test_no_units(self):
+        """Test that the computed RGB has no units attribute."""
+        from satpy.composites import RatioSharpenedRGB
+        comp = RatioSharpenedRGB(name='true_color')
+        res = comp((self.ds1, self.ds2, self.ds3))
+        assert "units" not in res.attrs
 
 
 class TestDifferenceCompositor(unittest.TestCase):


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

As per the discussion in #2066, make sure that RGBs do not have units attributes.

Also in this PR:

 - [x] Refactor VIIRS unit tests
 - [x] Add unit test for VIIRS snow age RGB
 - [x] Add or extend unit tests for false color, natural color, ocean color, true color, and true color crefl, including tests for absence of RGBs

 - [x] Closes #2066 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

Does not change the `ssec_fog` composite, because the result of the `DifferenceCompositor` is still a quantity and should correctly have units.