### PR TITLE
Fix linting errors

### DIFF
--- a/satpy/readers/aapp_l1b.py
+++ b/satpy/readers/aapp_l1b.py
@@ -183,6 +183,13 @@ class AVHRRAAPPL1BFile(AAPPL1BaseFileHandler):
         self._get_platform_name(AVHRR_PLATFORM_IDS2NAMES)
         self.sensor = 'avhrr-3'
 
+        self._get_all_interpolated_angles = functools.lru_cache(maxsize=10)(
+            self._get_all_interpolated_angles_uncached
+        )
+        self._get_all_interpolated_coordinates = functools.lru_cache(maxsize=10)(
+            self._get_all_interpolated_coordinates_uncached
+        )
+
     def _set_filedata_layout(self):
         """Set the file data type/layout."""
         self._header_offset = 22016
@@ -234,8 +241,7 @@ class AVHRRAAPPL1BFile(AAPPL1BaseFileHandler):
         name_to_variable = dict(zip(self._angle_names, (satz, sunz, azidiff)))
         return create_xarray(name_to_variable[angle_id])
 
-    @functools.lru_cache(maxsize=10)
-    def _get_all_interpolated_angles(self):
+    def _get_all_interpolated_angles_uncached(self):
         sunz40km, satz40km, azidiff40km = self._get_tiepoint_angles_in_degrees()
         return self._interpolate_arrays(sunz40km, satz40km, azidiff40km)
 
@@ -286,8 +292,7 @@ class AVHRRAAPPL1BFile(AAPPL1BaseFileHandler):
 
         raise KeyError("Coordinate {} unknown.".format(coordinate_id))
 
-    @functools.lru_cache(maxsize=10)
-    def _get_all_interpolated_coordinates(self):
+    def _get_all_interpolated_coordinates_uncached(self):
         lons40km, lats40km = self._get_coordinates_in_degrees()
         return self._interpolate_arrays(lons40km, lats40km, geolocation=True)
 

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -153,8 +153,8 @@ References
 """
 
 import abc
+import functools
 import warnings
-from functools import lru_cache
 
 import dask.array as da
 import numpy as np
@@ -565,6 +565,9 @@ class FiduceoMviriBase(BaseFileHandler):
         self.projection_longitude = float(filename_info['projection_longitude'])
         self.calib_coefs = self._get_calib_coefs()
 
+        self._get_angles = functools.cache(self._get_angles_uncached)
+        self._get_acq_time = functools.cache(self._get_acq_time_uncached)
+
     def get_dataset(self, dataset_id, dataset_info):
         """Get the dataset."""
         name = dataset_id['name']
@@ -605,8 +608,7 @@ class FiduceoMviriBase(BaseFileHandler):
         ds['acq_time'] = self._get_acq_time(resolution)
         return ds
 
-    @lru_cache(maxsize=8)  # 4 angle datasets with two resolutions each
-    def _get_angles(self, name, resolution):
+    def _get_angles_uncached(self, name, resolution):
         """Get angle dataset.
 
         Files provide angles (solar/satellite zenith & azimuth) at a coarser
@@ -689,8 +691,7 @@ class FiduceoMviriBase(BaseFileHandler):
 
         return coefs
 
-    @lru_cache(maxsize=3)  # Three channels
-    def _get_acq_time(self, resolution):
+    def _get_acq_time_uncached(self, resolution):
         """Get scanline acquisition time for the given resolution.
 
         Note that the acquisition time does not increase monotonically

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -565,8 +565,12 @@ class FiduceoMviriBase(BaseFileHandler):
         self.projection_longitude = float(filename_info['projection_longitude'])
         self.calib_coefs = self._get_calib_coefs()
 
-        self._get_angles = functools.cache(self._get_angles_uncached)
-        self._get_acq_time = functools.cache(self._get_acq_time_uncached)
+        self._get_angles = functools.lru_cache(maxsize=8)(
+            self._get_angles_uncached
+        )
+        self._get_acq_time = functools.lru_cache(maxsize=3)(
+            self._get_acq_time_uncached
+        )
 
     def get_dataset(self, dataset_id, dataset_info):
         """Get the dataset."""

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -22,10 +22,10 @@ References:
 
 """
 
+import functools
 import logging
 import os
 from datetime import datetime
-from functools import lru_cache
 
 import dask.array as da
 import numpy as np
@@ -103,6 +103,10 @@ class NcNWCSAF(BaseFileHandler):
             kwrgs = {'platform_name': self.nc.attrs['platform']}
 
         self.set_platform_and_sensor(**kwrgs)
+
+        self.upsample_geolocation = functools.lru_cache(maxsize=1)(
+            self._upsample_geolocation_uncached
+        )
 
     def set_platform_and_sensor(self, **kwargs):
         """Set some metadata: platform_name, sensors, and pps (identifying PPS or Geo)."""
@@ -245,8 +249,7 @@ class NcNWCSAF(BaseFileHandler):
             variable = variable[1:, :]
         return variable
 
-    @lru_cache(maxsize=1)
-    def upsample_geolocation(self):
+    def _upsample_geolocation_uncached(self):
         """Upsample the geolocation (lon,lat) from the tiepoint grid."""
         from geotiepoints import SatelliteInterpolator
 

--- a/satpy/tests/reader_tests/test_eps_l1b.py
+++ b/satpy/tests/reader_tests/test_eps_l1b.py
@@ -149,8 +149,7 @@ class TestEPSL1B(BaseTestCaseEPSL1B):
         assert(res.attrs['name'] == 'solar_zenith_angle')
 
     @mock.patch('satpy.readers.eps_l1b.EPSAVHRRFile.__getitem__')
-    @mock.patch('satpy.readers.eps_l1b.EPSAVHRRFile.__init__')
-    def test_get_full_angles_twice(self, mock__init__, mock__getitem__):
+    def test_get_full_angles_twice(self, mock__getitem__):
         """Test get full angles twice."""
         geotiemock = mock.Mock()
         metop20kmto1km = geotiemock.metop20kmto1km
@@ -162,9 +161,13 @@ class TestEPSL1B(BaseTestCaseEPSL1B):
                     "ANGULAR_RELATIONS_LAST": np.zeros((7, 4)),
                     "NAV_SAMPLE_RATE": 20}
             return data[key]
-        mock__init__.return_value = None
         mock__getitem__.side_effect = mock_getitem
-        avhrr_reader = satpy.readers.eps_l1b.EPSAVHRRFile()
+
+        avhrr_reader = satpy.readers.eps_l1b.EPSAVHRRFile(
+            filename="foo",
+            filename_info={"start_time": "foo", "end_time": "bar"},
+            filetype_info={"foo": "bar"}
+        )
         avhrr_reader.scanlines = 7
         avhrr_reader.pixels = 2048
 

--- a/satpy/tests/reader_tests/test_nwcsaf_msg.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_msg.py
@@ -24,6 +24,8 @@ from collections import OrderedDict
 import h5py
 import numpy as np
 
+from satpy.tests.reader_tests.utils import fill_h5
+
 CTYPE_TEST_ARRAY = (np.random.rand(1856, 3712) * 255).astype(np.uint8)
 CTYPE_TEST_FRAME = (np.arange(100).reshape(10, 10) / 100. * 20).astype(np.uint8)
 CTYPE_TEST_ARRAY[1000:1010, 1000:1010] = CTYPE_TEST_FRAME
@@ -450,32 +452,19 @@ class TestH5NWCSAF(unittest.TestCase):
             "SAFNWC_MSG3_CTTH_201611090800_MSG-N_______.PLAX.CTTH.0.h5",
         )
 
-        def fill_h5(root, stuff):
-            for key, val in stuff.items():
-                if key in ["value", "attrs"]:
-                    continue
-                if "value" in val:
-                    root[key] = val["value"]
-                else:
-                    grp = root.create_group(key)
-                    fill_h5(grp, stuff[key])
-                if "attrs" in val:
-                    for attrs, val in val["attrs"].items():
-                        if isinstance(val, str) and val.startswith(
-                            "<HDF5 object reference>"
-                        ):
-                            root[key].attrs[attrs] = root[val[24:]].ref
-                        else:
-                            root[key].attrs[attrs] = val
+        def cut_h5_object_ref(root, attr):
+            if isinstance(attr, str) and attr.startswith("<HDF5 object reference>"):
+                return root[attr[24:]].ref
+            return attr
 
         h5f = h5py.File(self.filename_ct, mode="w")
-        fill_h5(h5f, fake_ct)
+        fill_h5(h5f, fake_ct, attr_processor=cut_h5_object_ref)
         for attr, val in fake_ct["attrs"].items():
             h5f.attrs[attr] = val
         h5f.close()
 
         h5f = h5py.File(self.filename_ctth, mode="w")
-        fill_h5(h5f, fake_ctth)
+        fill_h5(h5f, fake_ctth, attr_processor=cut_h5_object_ref)
         for attr, val in fake_ctth["attrs"].items():
             h5f.attrs[attr] = val
         h5f.close()

--- a/satpy/tests/reader_tests/test_viirs_compact.py
+++ b/satpy/tests/reader_tests/test_viirs_compact.py
@@ -25,6 +25,8 @@ from contextlib import suppress
 import h5py
 import numpy as np
 
+from satpy.tests.reader_tests.utils import fill_h5
+
 
 class TestCompact(unittest.TestCase):
     """Test class for reading compact viirs format."""
@@ -2418,19 +2420,6 @@ class TestCompact(unittest.TestCase):
             "SVDNBC_j01_d20191025_t0611251_e0612478_b10015_c20191025062459000870_eum_ops.h5",
         )
         h5f = h5py.File(self.filename, mode="w")
-
-        def fill_h5(root, stuff):
-            for key, val in stuff.items():
-                if key in ["value", "attrs"]:
-                    continue
-                if "value" in val:
-                    root[key] = val["value"]
-                else:
-                    grp = root.create_group(key)
-                    fill_h5(grp, stuff[key])
-                if "attrs" in val:
-                    for attrs, val in val["attrs"].items():
-                        root[key].attrs[attrs] = val
 
         fill_h5(h5f, fake_dnb)
         for attr, val in fake_dnb["attrs"].items():

--- a/satpy/tests/reader_tests/utils.py
+++ b/satpy/tests/reader_tests/utils.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2022 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Utilities for reader tests."""
+
+
+def default_attr_processor(root, attr):
+    """Do not change the attribute."""
+    return attr
+
+
+def fill_h5(root, contents, attr_processor=default_attr_processor):
+    """Fill hdf5 file with the given contents.
+
+    Args:
+        root: hdf5 file rott
+        contents: Contents to be written into the file
+        attr_processor: A method for modifying attributes before they are
+          written to the file.
+    """
+    for key, val in contents.items():
+        if key in ["value", "attrs"]:
+            continue
+        if "value" in val:
+            root[key] = val["value"]
+        else:
+            grp = root.create_group(key)
+            fill_h5(grp, contents[key])
+        if "attrs" in val:
+            for attr_name, attr_val in val["attrs"].items():
+                root[key].attrs[attr_name] = attr_processor(root, attr_val)


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->

This PR fixes a couple of linting errors recently reported by Flake8 Bugbear (see https://github.com/pytroll/satpy/runs/5641087592?check_suite_focus=true for example)

#### B019 Use of `functools.lru_cache` or `functools.cache` on class methods can lead to memory leaks. The cache may retain instance references, preventing garbage collection.

- [x] satpy/readers/aapp_l1b.py:237:6
- [x] satpy/readers/aapp_l1b.py:289:6
- [x] satpy/readers/mviri_l1b_fiduceo_nc.py:608:6
- [x] satpy/readers/mviri_l1b_fiduceo_nc.py:692:6
- [X] satpy/readers/eps_l1b.py:192:6
- [X] satpy/readers/eps_l1b.py:242:6
- [X] satpy/readers/sar_c_safe.py:137:6
- [X] satpy/readers/sar_c_safe.py:159:6
- [X] satpy/readers/sar_c_safe.py:189:6
- [X] satpy/readers/sar_c_safe.py:619:6
- [X] satpy/readers/nwcsaf_nc.py:248:6

I used the following workaround (from https://www.youtube.com/watch?v=sVjtp6tGo0g):

```python
class FileHandler:
    def __init__(self):
        self.compute = lru_cache(maxsize=123)(self._compute_uncached)
    
    def _compute_uncached(self, x, y):
        # expensive computation
        pass
```
#### B020 Found for loop that reassigns the iterable it is iterating with each iterable value.

- [x] satpy/tests/reader_tests/test_nwcsaf_msg.py:463:32
- [x] satpy/tests/reader_tests/test_viirs_compact.py:2432:32

This was basically the same problem in two locations, so I factorized that method.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->


