### PR TITLE
Added test to confirm string IDs are accepted in ninjogeotiff writer

### DIFF
--- a/satpy/tests/writer_tests/test_ninjogeotiff.py
+++ b/satpy/tests/writer_tests/test_ninjogeotiff.py
@@ -904,3 +904,17 @@ def test_create_unknown_tags(test_image_small_arctic_P):
             PhysicValue="N/A",
             SatelliteNameID=6500014,
             Locatie="Hozomeen")
+
+
+def test_str_ids(test_image_small_arctic_P):
+    """Test that channel and satellit IDs can be str."""
+    from satpy.writers.ninjogeotiff import NinJoTagGenerator
+    NinJoTagGenerator(
+        test_image_small_arctic_P,
+        42,
+        "quorn.tif",
+        ChannelID="la manche",
+        DataType="GPRN",
+        PhysicUnit="N/A",
+        PhysicValue="N/A",
+        SatelliteNameID="trollsat")


### PR DESCRIPTION
On the side of NinJo there exists an interest to move from numerical IDs
to string IDs for the satellite and channel IDs in the ninjogeotiff
headers.  The ninjogeotiff writer has no objection to this.  Confirm
this no-objection with a unit test.

Offline testing shows the ninjotiff writer does _not_ take string values.  There are no plans to change the ninjotiff writer to change this.

 - [x] Tests added <!-- for all bug fixes or enhancements -->

