### PR TITLE
Support reading FSFiles in SEVIRI HRIT reader.

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -695,15 +695,15 @@ class FSFile(os.PathLike):
         """Representation of the object."""
         return '<FSFile "' + str(self._file) + '">'
 
-    def open(self):
+    def open(self, *args, **kwargs):
         """Open the file.
 
         This is read-only.
         """
         try:
-            return self._fs.open(self._file)
+            return self._fs.open(self._file, *args, **kwargs)
         except AttributeError:
-            return open(self._file)
+            return open(self._file, *args, **kwargs)
 
     def __lt__(self, other):
         """Implement ordering.

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import logging
 import os
-import pickle
+import pickle  # nosec B403
 import warnings
 from datetime import datetime, timedelta
 from functools import total_ordering
@@ -739,7 +739,7 @@ class FSFile(os.PathLike):
         try:
             fshash = hash(self._fs)
         except TypeError:  # fsspec < 0.8.8 for CachingFileSystem
-            fshash = hash(pickle.dumps(self._fs))
+            fshash = hash(pickle.dumps(self._fs))  # nosec B403
         return hash(self._file) ^ fshash
 
 

--- a/satpy/readers/hrit_base.py
+++ b/satpy/readers/hrit_base.py
@@ -188,7 +188,7 @@ class HRITFileHandler(BaseFileHandler):
         """Open the file, read and get the basic file header info and set the mda dictionary."""
         hdr_map, variable_length_headers, text_headers = hdr_info
 
-        with utils.generic_open(self.filename) as fp:
+        with utils.generic_open(self.filename, mode="rb") as fp:
             total_header_length = 16
             while fp.tell() < total_header_length:
                 hdr_id = get_header_id(fp)

--- a/satpy/readers/hrit_base.py
+++ b/satpy/readers/hrit_base.py
@@ -327,16 +327,17 @@ class HRITFileHandler(BaseFileHandler):
         elif self.mda['number_of_bits_per_pixel'] in [8, 10]:
             dtype = np.uint8
         shape = (shape, )
-        # check, whether 'filename' is a str, thus path to a file on disk,
+        # check, if 'filename' is a file on disk,
         #  or a file like obj, possibly residing already in memory
-        if isinstance(self.filename, str):
+        try:
             # For reading the image data, unzip_context is faster than generic_open
             with utils.unzip_context(self.filename) as fn:
                 data = np.memmap(fn, mode='r',
                                  offset=self.mda['total_header_length'],
                                  dtype=dtype,
                                  shape=shape)
-        else:  # filename is likely to be a file-like object
+        except (FileNotFoundError, AttributeError):
+            # filename is likely to be a file-like object, already in memory
             with utils.generic_open(self.filename, mode="rb") as fp:
                 no_elements = np.prod(shape)
                 fp.seek(self.mda['total_header_length'])

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -246,7 +246,7 @@ class HRITMSGPrologueFileHandler(HRITMSGPrologueEpilogueBase):
 
     def read_prologue(self):
         """Read the prologue metadata."""
-        with utils.generic_open(self.filename) as fp_:
+        with utils.generic_open(self.filename, mode="rb") as fp_:
             fp_.seek(self.mda['total_header_length'])
             data = np.frombuffer(fp_.read(hrit_prologue.itemsize), dtype=hrit_prologue, count=1)
             self.prologue.update(recarray2dict(data))
@@ -319,7 +319,7 @@ class HRITMSGEpilogueFileHandler(HRITMSGPrologueEpilogueBase):
 
     def read_epilogue(self):
         """Read the epilogue metadata."""
-        with utils.generic_open(self.filename) as fp_:
+        with utils.generic_open(self.filename, mode="rb") as fp_:
             fp_.seek(self.mda['total_header_length'])
             data = np.frombuffer(fp_.read(hrit_epilogue.itemsize), dtype=hrit_epilogue, count=1)
             self.epilogue.update(recarray2dict(data))

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -38,7 +38,7 @@ follows:
     H-000-MSG4__-MSG4________-_________-EPI______-201903011200-__
 
 Each image is decomposed into 24 segments (files) for the high-resolution-visible (HRV) channel and 8 segments for other
-visible (VIS) and infrared (IR) channels. Additionally there is one prologue and one epilogue file for the entire scan
+visible (VIS) and infrared (IR) channels. Additionally, there is one prologue and one epilogue file for the entire scan
 which contain global metadata valid for all channels.
 
 Reader Arguments

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -43,7 +43,7 @@ which contain global metadata valid for all channels.
 
 Reader Arguments
 ----------------
-Some arguments can be provided to the reader to change it's behaviour. These are
+Some arguments can be provided to the reader to change its behaviour. These are
 provided through the `Scene` instantiation, eg::
 
   Scene(reader="seviri_l1b_hrit", filenames=fnames, reader_kwargs={'fill_hrv': False})

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -107,9 +107,80 @@ Output:
         modifiers:                ()
         ancillary_variables:      []
 
+The `filenames` argument can either be a list of strings, see the example above, or a list of
+:class:`satpy.readers.FSFile` objects. FSFiles can be used in conjunction with `fsspec`_,
+e.g. to handle in-memory data:
+
+.. code-block:: python
+
+    import glob
+
+    from fsspec.implementations.memory import MemoryFile, MemoryFileSystem
+    from satpy import Scene
+    from satpy.readers import FSFile
+
+    # In this example, we will make use of `MemoryFile`s in a `MemoryFileSystem`.
+    memory_fs = MemoryFileSystem()
+
+    # Usually, the data already resides in memory.
+    # For explanatory reasons, we will load the files found with glob in memory,
+    #  and load the scene with FSFiles.
+    filenames = glob.glob('data/H-000-MSG4__-MSG4________-*201903011200*')
+    fs_files = []
+    for fn in filenames:
+        with open(fn, 'rb') as fh:
+            fs_files.append(MemoryFile(
+                fs=memory_fs,
+                path="{}{}".format(memory_fs.root_marker, fn),
+                data=fh.read()
+            ))
+            fs_files[-1].commit()  # commit the file to the filesystem
+    fs_files = [FSFile(open_file) for open_file in filenames]  # wrap MemoryFiles as FSFiles
+    # similar to the example above, we pass a list of FSFiles to the `Scene`
+    scn = Scene(filenames=fs_files, reader='seviri_l1b_hrit')
+    scn.load(['VIS006', 'IR_108'])
+    print(scn['IR_108'])
+
+
+Output:
+
+.. code-block:: none
+
+    <xarray.DataArray (y: 3712, x: 3712)>
+    dask.array<shape=(3712, 3712), dtype=float32, chunksize=(464, 3712)>
+    Coordinates:
+        acq_time  (y) datetime64[ns] NaT NaT NaT NaT NaT NaT ... NaT NaT NaT NaT NaT
+      * x         (x) float64 5.566e+06 5.563e+06 5.56e+06 ... -5.566e+06 -5.569e+06
+      * y         (y) float64 -5.566e+06 -5.563e+06 ... 5.566e+06 5.569e+06
+    Attributes:
+        orbital_parameters:       {'projection_longitude': 0.0, 'projection_latit...
+        platform_name:            Meteosat-11
+        georef_offset_corrected:  True
+        standard_name:            brightness_temperature
+        raw_metadata:             {'file_type': 0, 'total_header_length': 6198, '...
+        wavelength:               (9.8, 10.8, 11.8)
+        units:                    K
+        sensor:                   seviri
+        platform_name:            Meteosat-11
+        start_time:               2019-03-01 12:00:09.716000
+        end_time:                 2019-03-01 12:12:42.946000
+        area:                     Area ID: some_area_name\\nDescription: On-the-fl...
+        name:                     IR_108
+        resolution:               3000.403165817
+        calibration:              brightness_temperature
+        polarization:             None
+        level:                    None
+        modifiers:                ()
+        ancillary_variables:      []
+
+
+References:
+    - `MSG Level 1.5 Image Data Format Description`_
+
 .. _MSG Level 1.5 Image Data Format Description:
     https://www-cdn.eumetsat.int/files/2020-05/pdf_ten_05105_msg_img_data.pdf
-
+.. _fsspec:
+    https://filesystem-spec.readthedocs.io
 """
 
 from __future__ import division

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -200,7 +200,7 @@ def get_sub_area(area, xslice, yslice):
 
 def unzip_file(filename):
     """Unzip the file if file is bzipped = ending with 'bz2'."""
-    if str(filename).endswith('bz2'):
+    if os.fspath(filename).endswith('bz2'):
         fdn, tmpfilepath = tempfile.mkstemp()
         LOGGER.info("Using temp file for BZ2 decompression: %s", tmpfilepath)
         # try pbzip2
@@ -293,7 +293,7 @@ class generic_open():
 
     def __enter__(self):
         """Return a file-like object."""
-        if str(self.filename).endswith('.bz2'):
+        if os.fspath(self.filename).endswith('.bz2'):
             self.fp = bz2.open(self.filename, *self.open_args, **self.open_kwargs)
         else:
             if hasattr(self.filename, "open"):

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -200,7 +200,7 @@ def get_sub_area(area, xslice, yslice):
 
 def unzip_file(filename):
     """Unzip the file if file is bzipped = ending with 'bz2'."""
-    if filename.endswith('bz2'):
+    if str(filename).endswith('bz2'):
         fdn, tmpfilepath = tempfile.mkstemp()
         LOGGER.info("Using temp file for BZ2 decompression: %s", tmpfilepath)
         # try pbzip2
@@ -293,7 +293,7 @@ class generic_open():
 
     def __enter__(self):
         """Return a file-like object."""
-        if self.filename.endswith('.bz2'):
+        if str(self.filename).endswith('.bz2'):
             self.fp = bz2.open(self.filename, *self.open_args, **self.open_kwargs)
         else:
             self.fp = open(self.filename, *self.open_args, **self.open_kwargs)

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -296,7 +296,10 @@ class generic_open():
         if str(self.filename).endswith('.bz2'):
             self.fp = bz2.open(self.filename, *self.open_args, **self.open_kwargs)
         else:
-            self.fp = open(self.filename, *self.open_args, **self.open_kwargs)
+            if hasattr(self.filename, "open"):
+                self.fp = self.filename.open(*self.open_args, **self.open_kwargs)
+            else:
+                self.fp = open(self.filename, *self.open_args, **self.open_kwargs)
 
         return self.fp
 

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -318,7 +318,7 @@ class TestHelpers(unittest.TestCase):
     def test_generic_open_FSFile_MemoryFileSystem(self):
         """Test the generic_open method with FSFile in MemoryFileSystem."""
         mem_fs = MemoryFileSystem()
-        mem_file = MemoryFile(fs=mem_fs, path="test.DAT", data=b"TEST")
+        mem_file = MemoryFile(fs=mem_fs, path="{}test.DAT".format(mem_fs.root_marker), data=b"TEST")
         mem_file.commit()
         fsf = FSFile(mem_file)
         with hf.generic_open(fsf) as file_object:

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -27,8 +27,10 @@ import numpy as np
 import numpy.testing
 import pyresample.geometry
 import xarray as xr
+from fsspec.implementations.memory import MemoryFile, MemoryFileSystem
 from pyproj import CRS
 
+from satpy.readers import FSFile
 from satpy.readers import utils as hf
 
 
@@ -300,8 +302,8 @@ class TestHelpers(unittest.TestCase):
         self.assertIsNone(new_fname)
 
     @mock.patch('bz2.BZ2File')
-    def test_generic_open(self, bz2_mock):
-        """Test the bz2 file unzipping context manager."""
+    def test_generic_open_BZ2File(self, bz2_mock):
+        """Test the generic_open method with bz2 filename input."""
         mock_bz2_open = mock.MagicMock()
         mock_bz2_open.read.return_value = b'TEST'
         bz2_mock.return_value = mock_bz2_open
@@ -312,6 +314,30 @@ class TestHelpers(unittest.TestCase):
             assert data == b'TEST'
 
         assert mock_bz2_open.read.called
+
+    def test_generic_open_FSFile_MemoryFileSystem(self):
+        """Test the generic_open method with FSFile in MemoryFileSystem."""
+        mem_fs = MemoryFileSystem()
+        mem_file = MemoryFile(fs=mem_fs, path="test.DAT", data=b"TEST")
+        mem_file.commit()
+        fsf = FSFile(mem_file)
+        with hf.generic_open(fsf) as file_object:
+            data = file_object.read()
+            assert data == b'TEST'
+
+    @mock.patch('satpy.readers.utils.open')
+    def test_generic_open_filename(self, open_mock):
+        """Test the generic_open method with filename (str)."""
+        mock_fn_open = mock.MagicMock()
+        mock_fn_open.read.return_value = b'TEST'
+        open_mock.return_value = mock_fn_open
+
+        filename = "test.DAT"
+        with hf.generic_open(filename) as file_object:
+            data = file_object.read()
+            assert data == b'TEST'
+
+        assert mock_fn_open.read.called
 
     @mock.patch("os.remove")
     @mock.patch("satpy.readers.utils.unzip_file", return_value='dummy.txt')


### PR DESCRIPTION
Hi there!

since I work heavily with in-memory files, I needed a way to pass FSFiles to the SEVIRI HRIT reader.
Previous work #1975 #2060 already added a lot of the changes, so I adapted the `generic_open` method to be even more _generic_ to allow passing in `FSFile` objects.

There is one significant change to [hrit_base.py](https://github.com/pytroll/satpy/compare/main...sbrodehl:dev-more-generic-open?expand=1#diff-496db35c37f8b536168bb1594101fece041896db0320e706b4b5d6acc8f06cac), where one needs to either memmap (to memory on disk) or load the data from a buffer. There were [performance concerns](https://github.com/pytroll/satpy/pull/2060#issuecomment-1070488588) in #2060, but with file-like objects there is not much we can do. (I argue by possibly already holding the files in-memory, we already have a performamce gain; On another note: I also think that the performance comparisson by @mraspaud did not measure `generic_open` / `unzip_context`, but `np.memmap` / `np.frombuffer`.)

I would like to get your input on how to test this, since I am not familiar with the test tools for mocking and patching things.
Let me know what you think!

---
Edit: Here is an example of what I am doing (with this PR)
```python
mem_fs = MemoryFileSystem()  # create a fsspec.MemoryFileSystem
fs_files = [
    MemoryFile(fs=mem_fs, path="H-000-MSG4__-MSG4________-VIS006___-000004___-202105260000-__", data=b"..."),  # data is already in memory
    ...  # many more files like above
]
[cmt_f.commit() for cmt_f in fs_files]  # commit the files to the fs
fs_files = [FSFile(open_file) for open_file in fs_files]
# Load Satpy scene
scn = Scene(filenames=fs_files, reader='seviri_l1b_hrit')
...  # do stuff with the scene
```

---

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
