### PR TITLE
Fix missing 'rb' mode for opening files

### DIFF
--- a/satpy/readers/hrit_base.py
+++ b/satpy/readers/hrit_base.py
@@ -188,7 +188,7 @@ class HRITFileHandler(BaseFileHandler):
         """Open the file, read and get the basic file header info and set the mda dictionary."""
         hdr_map, variable_length_headers, text_headers = hdr_info
 
-        with utils.generic_open(self.filename) as fp:
+        with utils.generic_open(self.filename, mode='rb') as fp:
             total_header_length = 16
             while fp.tell() < total_header_length:
                 hdr_id = get_header_id(fp)

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -246,7 +246,7 @@ class HRITMSGPrologueFileHandler(HRITMSGPrologueEpilogueBase):
 
     def read_prologue(self):
         """Read the prologue metadata."""
-        with utils.generic_open(self.filename) as fp_:
+        with utils.generic_open(self.filename, mode='rb') as fp_:
             fp_.seek(self.mda['total_header_length'])
             data = np.frombuffer(fp_.read(hrit_prologue.itemsize), dtype=hrit_prologue, count=1)
             self.prologue.update(recarray2dict(data))
@@ -319,7 +319,7 @@ class HRITMSGEpilogueFileHandler(HRITMSGPrologueEpilogueBase):
 
     def read_epilogue(self):
         """Read the epilogue metadata."""
-        with utils.generic_open(self.filename) as fp_:
+        with utils.generic_open(self.filename, mode='rb') as fp_:
             fp_.seek(self.mda['total_header_length'])
             data = np.frombuffer(fp_.read(hrit_epilogue.itemsize), dtype=hrit_epilogue, count=1)
             self.epilogue.update(recarray2dict(data))

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -313,6 +313,48 @@ class TestHelpers(unittest.TestCase):
 
         assert mock_bz2_open.read.called
 
+    def test_generic_open_text(self):
+        """Test the bz2 file unzipping context manager using dummy text data."""
+        dummy_text_data = 'Hello'
+        dummy_text_filename = 'dummy.txt'
+        with open(dummy_text_filename, 'w') as f:
+            f.write(dummy_text_data)
+
+        with hf.generic_open(dummy_text_filename, 'r') as f:
+            read_text_data = f.read()
+
+        assert read_text_data == dummy_text_data
+
+        dummy_text_filename = 'dummy.txt.bz2'
+        with hf.bz2.open(dummy_text_filename, 'wt') as f:
+            f.write(dummy_text_data)
+
+        with hf.generic_open(dummy_text_filename, 'rt') as f:
+            read_text_data = f.read()
+
+        assert read_text_data == dummy_text_data
+
+    def test_generic_open_binary(self):
+        """Test the bz2 file unzipping context manager using dummy binary data."""
+        dummy_binary_data = b'Hello'
+        dummy_binary_filename = 'dummy.dat'
+        with open(dummy_binary_filename, 'wb') as f:
+            f.write(dummy_binary_data)
+
+        with hf.generic_open(dummy_binary_filename, 'rb') as f:
+            read_binary_data = f.read()
+
+        assert read_binary_data == dummy_binary_data
+
+        dummy_binary_filename = 'dummy.dat.bz2'
+        with hf.bz2.open(dummy_binary_filename, 'wb') as f:
+            f.write(dummy_binary_data)
+
+        with hf.generic_open(dummy_binary_filename, 'rb') as f:
+            read_binary_data = f.read()
+
+        assert read_binary_data == dummy_binary_data
+
     @mock.patch("os.remove")
     @mock.patch("satpy.readers.utils.unzip_file", return_value='dummy.txt')
     def test_pro_reading_gets_unzipped_file(self, fake_unzip_file, fake_remove):


### PR DESCRIPTION
Add a "mode" argument to the calls to `generic_open`. This was the case before
using this context manager and was dropped by mistake in https://github.com/pytroll/satpy/commit/78ef55031a551dd82dd78dc7b3d7f91241799725

 - [ ] Closes #2073  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->

This was not caught by tests as the tests are done with mocks instead of
data files.