### PR TITLE
Remove marine_clean_aerosol from default AHI rayleigh_corrected modifier

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -11,6 +11,7 @@ dependencies:
   - Cython
   - sphinx
   - cartopy
+  - panel>=0.12.7
   - pillow
   - matplotlib
   - scipy

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -4,22 +4,9 @@ modifiers:
   rayleigh_corrected:
     modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
     atmosphere: us-standard
-    aerosol_type: marine_clean_aerosol
-    prerequisites:
-    - wavelength: 0.64
-      modifiers: [sunz_corrected]
-    optional_prerequisites:
-    - satellite_azimuth_angle
-    - satellite_zenith_angle
-    - solar_azimuth_angle
-    - solar_zenith_angle
-
-  no_aerosol_rayleigh_corrected:
-    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
-    atmosphere: us-standard
     aerosol_type: rayleigh_only
     prerequisites:
-    - name: B03
+    - wavelength: B03
       modifiers: [sunz_corrected]
     optional_prerequisites:
     - satellite_azimuth_angle
@@ -48,9 +35,9 @@ composites:
     fractions: [0.6321, 0.2928, 0.0751]
     prerequisites:
     - name: B02
-      modifiers: [sunz_corrected, no_aerosol_rayleigh_corrected]
+      modifiers: [sunz_corrected, rayleigh_corrected]
     - name: B03
-      modifiers: [sunz_corrected, no_aerosol_rayleigh_corrected]
+      modifiers: [sunz_corrected, rayleigh_corrected]
     - name: B04
       modifiers: [sunz_corrected]
     standard_name: none
@@ -247,10 +234,10 @@ composites:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
       - name: B03
-        modifiers: [sunz_corrected, no_aerosol_rayleigh_corrected]
+        modifiers: [sunz_corrected, rayleigh_corrected]
       - name: green_true_color_reproduction
       - name: B01
-        modifiers: [sunz_corrected, no_aerosol_rayleigh_corrected]
+        modifiers: [sunz_corrected, rayleigh_corrected]
     standard_name: true_color_reproduction
 
 #  true_color_reducedsize_land:

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -6,7 +6,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: rayleigh_only
     prerequisites:
-    - wavelength: B03
+    - name: B03
       modifiers: [sunz_corrected]
     optional_prerequisites:
     - satellite_azimuth_angle


### PR DESCRIPTION
This was brought up on slack a while ago by me, but was never acted on. I noticed that ABI only uses "rayleigh_only" for its pyspectral settings for the `rayleigh_corrected` modifier while the AHI version uses `marine_clean_aerosol`. When discussed with @adybbroe, he said:

```
It might "just" be a coincidence but from what I recall my own thoughts way back I thought the AHI disk is having more ocean (Pacific) views than ABI and that could motivate a LUT more adapted to marine type aerosols. But very unscientific - bottom line: we should keep the rayleigh_only as default for both until someone proves we should change!
```

And @simonrp84 said:

```
I agree with Adam that both should be Rayleigh only for now. It's the safer option and provides better consistency, using a marine aerosol over, say, the polluted regions of China or India will not be terribly good.
```

Even the new JMA true color reproduction made a new version of rayleigh_corrected with this change made.

Here's what I get for the two versions. Original `marine_clean_aerosol`:

![image](https://user-images.githubusercontent.com/1828519/161408630-0f133239-9ab3-44e7-90e0-76da9fe890e0.png)

New rayleigh_only:

![image](https://user-images.githubusercontent.com/1828519/161408642-37a2aac1-af26-442d-9e6d-383aae2a3be2.png)

If you swap between them you can see major differences on the outer parts of the disk and a general brightness/contrast difference.

Related: https://github.com/ssec/polar2grid/issues/403
 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
