### PR TITLE
Ignore alpha when adding luminance in Sandwich compositor

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1101,7 +1101,8 @@ class SandwichCompositor(GenericCompositor):
 
         # Get the enhanced version of the RGB composite to be sharpened
         rgb_img = enhance2dataset(projectables[1])
-        rgb_img *= luminance
+        # Ignore alpha band when applying luminance
+        rgb_img = rgb_img.where(rgb_img.bands == 'A', rgb_img * luminance)
         return super(SandwichCompositor, self).__call__(rgb_img, *args, **kwargs)
 
 

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -452,9 +452,13 @@ class TestSandwichCompositor:
     """Test sandwich compositor."""
 
     # Test RGB and RGBA
-    @pytest.mark.parametrize("input_shape,bands",
-                              [((3, 2, 2), ['R', 'G', 'B']),
-                              ((4, 2, 2), ['R', 'G', 'B', 'A'])])
+    @pytest.mark.parametrize(
+        "input_shape,bands",
+        [
+            ((3, 2, 2), ['R', 'G', 'B']),
+            ((4, 2, 2), ['R', 'G', 'B', 'A'])
+        ]
+    )
     @mock.patch('satpy.composites.enhance2dataset')
     def test_compositor(self, e2d, input_shape, bands):
         """Test luminance sharpening compositor."""

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -459,7 +459,7 @@ class TestSandwichCompositor(unittest.TestCase):
         # Test RGBA
         bands = ['R', 'G', 'B', 'A']
         rgba_arr = da.from_array(np.random.random((4, 2, 2)), chunks=2)
-        rgba = xr.DataArray(rgba_arr, dims=['bands', 'y', 'x'], 
+        rgba = xr.DataArray(rgba_arr, dims=['bands', 'y', 'x'],
                             coords={'bands': bands})
         lum_arr = da.from_array(100 * np.random.random((2, 2)), chunks=2)
         lum = xr.DataArray(lum_arr, dims=['y', 'x'])
@@ -473,11 +473,11 @@ class TestSandwichCompositor(unittest.TestCase):
         for band in rgba:
             if band.bands != 'A':
                 # Check compositor has modified this band
-                np.testing.assert_allclose(res.loc[band.bands].to_numpy(), 
+                np.testing.assert_allclose(res.loc[band.bands].to_numpy(),
                                             band.to_numpy() * lum_arr / 100.)
             else:
                 # Check Alpha band remains intact
-                np.testing.assert_allclose(res.loc[band.bands].to_numpy(), 
+                np.testing.assert_allclose(res.loc[band.bands].to_numpy(),
                                             band.to_numpy())
         # make sure the compositor doesn't modify the input data
         np.testing.assert_allclose(lum.values, lum_arr.compute())

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -452,9 +452,9 @@ class TestSandwichCompositor:
     """Test sandwich compositor."""
 
     # Test RGB and RGBA
-    @pytest.mark.parametrize("input_shape,bands", 
-                             [((3, 2, 2), ['R', 'G', 'B']),
-                             ((4, 2, 2), ['R', 'G', 'B', 'A'])])  
+    @pytest.mark.parametrize("input_shape,bands",
+                              [((3, 2, 2), ['R', 'G', 'B']),
+                              ((4, 2, 2), ['R', 'G', 'B', 'A'])])
     @mock.patch('satpy.composites.enhance2dataset')
     def test_compositor(self, e2d, input_shape, bands):
         """Test luminance sharpening compositor."""
@@ -462,7 +462,7 @@ class TestSandwichCompositor:
 
         rgb_arr = da.from_array(np.random.random(input_shape), chunks=2)
         rgb = xr.DataArray(rgb_arr, dims=['bands', 'y', 'x'],
-                            coords={'bands': bands})
+                           coords={'bands': bands})
         lum_arr = da.from_array(100 * np.random.random((2, 2)), chunks=2)
         lum = xr.DataArray(lum_arr, dims=['y', 'x'])
 

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -474,11 +474,11 @@ class TestSandwichCompositor(unittest.TestCase):
             if band.bands != 'A':
                 # Check compositor has modified this band
                 np.testing.assert_allclose(res.loc[band.bands].to_numpy(),
-                                            band.to_numpy() * lum_arr / 100.)
+                                           band.to_numpy() * lum_arr / 100.)
             else:
                 # Check Alpha band remains intact
                 np.testing.assert_allclose(res.loc[band.bands].to_numpy(),
-                                            band.to_numpy())
+                                           band.to_numpy())
         # make sure the compositor doesn't modify the input data
         np.testing.assert_allclose(lum.values, lum_arr.compute())
 

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -459,7 +459,8 @@ class TestSandwichCompositor(unittest.TestCase):
         # Test RGBA
         bands = ['R', 'G', 'B', 'A']
         rgba_arr = da.from_array(np.random.random((4, 2, 2)), chunks=2)
-        rgba = xr.DataArray(rgba_arr, dims=['bands', 'y', 'x'], coords={'bands': bands})
+        rgba = xr.DataArray(rgba_arr, dims=['bands', 'y', 'x'], 
+                            coords={'bands': bands})
         lum_arr = da.from_array(100 * np.random.random((2, 2)), chunks=2)
         lum = xr.DataArray(lum_arr, dims=['y', 'x'])
 
@@ -472,10 +473,12 @@ class TestSandwichCompositor(unittest.TestCase):
         for band in rgba:
             if band.bands != 'A':
                 # Check compositor has modified this band
-                np.testing.assert_allclose(res.loc[band.bands].to_numpy(), band.to_numpy() * lum_arr / 100.)
+                np.testing.assert_allclose(res.loc[band.bands].to_numpy(), 
+                                            band.to_numpy() * lum_arr / 100.)
             else:
                 # Check Alpha band remains intact
-                np.testing.assert_allclose(res.loc[band.bands].to_numpy(), band.to_numpy())
+                np.testing.assert_allclose(res.loc[band.bands].to_numpy(), 
+                                            band.to_numpy())
         # make sure the compositor doesn't modify the input data
         np.testing.assert_allclose(lum.values, lum_arr.compute())
 


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

This updates the Sandwich compositor to ignore the alpha band when modifying.

- [x]  Tests added