### PR TITLE
Fix VIIRS L1B reader sensor not matching VIIRS SDR reader

### DIFF
--- a/satpy/readers/viirs_l1b.py
+++ b/satpy/readers/viirs_l1b.py
@@ -70,10 +70,7 @@ class VIIRSL1BFileHandler(NetCDF4FileHandler):
     @property
     def sensor_name(self):
         """Get sensor name."""
-        res = self['/attr/instrument']
-        if isinstance(res, np.ndarray):
-            res = str(res.astype(str))
-        return res.lower()
+        return self['/attr/instrument'].lower()
 
     def adjust_scaling_factors(self, factors, file_units, output_units):
         """Adjust scaling factors."""

--- a/satpy/readers/viirs_l1b.py
+++ b/satpy/readers/viirs_l1b.py
@@ -72,9 +72,8 @@ class VIIRSL1BFileHandler(NetCDF4FileHandler):
         """Get sensor name."""
         res = self['/attr/instrument']
         if isinstance(res, np.ndarray):
-            return str(res.astype(str))
-        else:
-            return res
+            res = str(res.astype(str))
+        return res.lower()
 
     def adjust_scaling_factors(self, factors, file_units, output_units):
         """Adjust scaling factors."""

--- a/satpy/tests/reader_tests/test_viirs_l1b.py
+++ b/satpy/tests/reader_tests/test_viirs_l1b.py
@@ -18,7 +18,6 @@
 """Module for testing the satpy.readers.viirs_l1b module."""
 
 import os
-import unittest
 from datetime import datetime, timedelta
 from unittest import mock
 
@@ -152,12 +151,12 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
             file_content[k + '/attr/add_offset'] = 0.1
 
 
-class TestVIIRSL1BReader(unittest.TestCase):
+class TestVIIRSL1BReader:
     """Test VIIRS L1B Reader."""
 
     yaml_file = "viirs_l1b.yaml"
 
-    def setUp(self):
+    def setup_method(self):
         """Wrap NetCDF4 file handler with our own fake handler."""
         from satpy._config import config_search_paths
         from satpy.readers.viirs_l1b import VIIRSL1BFileHandler
@@ -167,7 +166,7 @@ class TestVIIRSL1BReader(unittest.TestCase):
         self.fake_handler = self.p.start()
         self.p.is_local = True
 
-    def tearDown(self):
+    def teardown_method(self):
         """Stop wrapping the NetCDF4 file handler."""
         self.p.stop()
 
@@ -178,10 +177,10 @@ class TestVIIRSL1BReader(unittest.TestCase):
         loadables = r.select_files_from_pathnames([
             'VL1BM_snpp_d20161130_t012400_c20161130054822.nc',
         ])
-        self.assertEqual(len(loadables), 1)
+        assert len(loadables) == 1
         r.create_filehandlers(loadables)
         # make sure we have some files
-        self.assertTrue(r.file_handlers)
+        assert r.file_handlers
 
     def test_load_every_m_band_bt(self):
         """Test loading all M band brightness temperatures."""
@@ -197,13 +196,13 @@ class TestVIIRSL1BReader(unittest.TestCase):
                            'M14',
                            'M15',
                            'M16'])
-        self.assertEqual(len(datasets), 5)
+        assert len(datasets) == 5
         for v in datasets.values():
-            self.assertEqual(v.attrs['calibration'], 'brightness_temperature')
-            self.assertEqual(v.attrs['units'], 'K')
-            self.assertEqual(v.attrs['rows_per_scan'], 2)
-            self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 2)
-            self.assertEqual(v.attrs['area'].lats.attrs['rows_per_scan'], 2)
+            assert v.attrs['calibration'] == 'brightness_temperature'
+            assert v.attrs['units'] == 'K'
+            assert v.attrs['rows_per_scan'] == 2
+            assert v.attrs['area'].lons.attrs['rows_per_scan'] == 2
+            assert v.attrs['area'].lats.attrs['rows_per_scan'] == 2
             assert v.attrs['sensor'] == "viirs"
 
     def test_load_every_m_band_refl(self):
@@ -226,13 +225,13 @@ class TestVIIRSL1BReader(unittest.TestCase):
                            'M09',
                            'M10',
                            'M11'])
-        self.assertEqual(len(datasets), 11)
+        assert len(datasets) == 11
         for v in datasets.values():
-            self.assertEqual(v.attrs['calibration'], 'reflectance')
-            self.assertEqual(v.attrs['units'], '%')
-            self.assertEqual(v.attrs['rows_per_scan'], 2)
-            self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 2)
-            self.assertEqual(v.attrs['area'].lats.attrs['rows_per_scan'], 2)
+            assert v.attrs['calibration'] == 'reflectance'
+            assert v.attrs['units'] == '%'
+            assert v.attrs['rows_per_scan'] == 2
+            assert v.attrs['area'].lons.attrs['rows_per_scan'] == 2
+            assert v.attrs['area'].lats.attrs['rows_per_scan'] == 2
             assert v.attrs['sensor'] == "viirs"
 
     def test_load_every_m_band_rad(self):
@@ -261,13 +260,13 @@ class TestVIIRSL1BReader(unittest.TestCase):
                            make_dataid(name='M14', calibration='radiance'),
                            make_dataid(name='M15', calibration='radiance'),
                            make_dataid(name='M16', calibration='radiance')])
-        self.assertEqual(len(datasets), 16)
+        assert len(datasets) == 16
         for v in datasets.values():
-            self.assertEqual(v.attrs['calibration'], 'radiance')
-            self.assertEqual(v.attrs['units'], 'W m-2 um-1 sr-1')
-            self.assertEqual(v.attrs['rows_per_scan'], 2)
-            self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 2)
-            self.assertEqual(v.attrs['area'].lats.attrs['rows_per_scan'], 2)
+            assert v.attrs['calibration'] == 'radiance'
+            assert v.attrs['units'] == 'W m-2 um-1 sr-1'
+            assert v.attrs['rows_per_scan'] == 2
+            assert v.attrs['area'].lons.attrs['rows_per_scan'] == 2
+            assert v.attrs['area'].lats.attrs['rows_per_scan'] == 2
             assert v.attrs['sensor'] == "viirs"
 
     def test_load_dnb_radiance(self):
@@ -280,13 +279,13 @@ class TestVIIRSL1BReader(unittest.TestCase):
         ])
         r.create_filehandlers(loadables)
         datasets = r.load(['DNB'])
-        self.assertEqual(len(datasets), 1)
+        assert len(datasets) == 1
         for v in datasets.values():
-            self.assertEqual(v.attrs['calibration'], 'radiance')
-            self.assertEqual(v.attrs['units'], 'W m-2 sr-1')
-            self.assertEqual(v.attrs['rows_per_scan'], 2)
-            self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 2)
-            self.assertEqual(v.attrs['area'].lats.attrs['rows_per_scan'], 2)
+            assert v.attrs['calibration'] == 'radiance'
+            assert v.attrs['units'] == 'W m-2 sr-1'
+            assert v.attrs['rows_per_scan'] == 2
+            assert v.attrs['area'].lons.attrs['rows_per_scan'] == 2
+            assert v.attrs['area'].lats.attrs['rows_per_scan'] == 2
             assert v.attrs['sensor'] == "viirs"
 
     def test_load_dnb_angles(self):
@@ -305,10 +304,10 @@ class TestVIIRSL1BReader(unittest.TestCase):
                            'dnb_lunar_zenith_angle',
                            'dnb_lunar_azimuth_angle',
                            ])
-        self.assertEqual(len(datasets), 6)
+        assert len(datasets) == 6
         for v in datasets.values():
-            self.assertEqual(v.attrs['units'], 'degrees')
-            self.assertEqual(v.attrs['rows_per_scan'], 2)
-            self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 2)
-            self.assertEqual(v.attrs['area'].lats.attrs['rows_per_scan'], 2)
+            assert v.attrs['units'] == 'degrees'
+            assert v.attrs['rows_per_scan'] == 2
+            assert v.attrs['area'].lons.attrs['rows_per_scan'] == 2
+            assert v.attrs['area'].lats.attrs['rows_per_scan'] == 2
             assert v.attrs['sensor'] == "viirs"

--- a/satpy/tests/reader_tests/test_viirs_l1b.py
+++ b/satpy/tests/reader_tests/test_viirs_l1b.py
@@ -69,7 +69,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
             '/attr/time_coverage_start': dt.strftime('%Y-%m-%dT%H:%M:%S.000Z'),
             '/attr/time_coverage_end': (dt + timedelta(minutes=6)).strftime('%Y-%m-%dT%H:%M:%S.000Z'),
             '/attr/orbit_number': 26384,
-            '/attr/instrument': 'viirs',
+            '/attr/instrument': 'VIIRS',
             '/attr/platform': 'Suomi-NPP',
         }
         self._fill_contents_with_default_data(file_content, file_type)
@@ -204,6 +204,7 @@ class TestVIIRSL1BReader(unittest.TestCase):
             self.assertEqual(v.attrs['rows_per_scan'], 2)
             self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 2)
             self.assertEqual(v.attrs['area'].lats.attrs['rows_per_scan'], 2)
+            assert v.attrs['sensor'] == "viirs"
 
     def test_load_every_m_band_refl(self):
         """Test loading all M band reflectances."""
@@ -232,6 +233,7 @@ class TestVIIRSL1BReader(unittest.TestCase):
             self.assertEqual(v.attrs['rows_per_scan'], 2)
             self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 2)
             self.assertEqual(v.attrs['area'].lats.attrs['rows_per_scan'], 2)
+            assert v.attrs['sensor'] == "viirs"
 
     def test_load_every_m_band_rad(self):
         """Test loading all M bands as radiances."""
@@ -266,6 +268,7 @@ class TestVIIRSL1BReader(unittest.TestCase):
             self.assertEqual(v.attrs['rows_per_scan'], 2)
             self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 2)
             self.assertEqual(v.attrs['area'].lats.attrs['rows_per_scan'], 2)
+            assert v.attrs['sensor'] == "viirs"
 
     def test_load_dnb_radiance(self):
         """Test loading the main DNB dataset."""
@@ -284,6 +287,7 @@ class TestVIIRSL1BReader(unittest.TestCase):
             self.assertEqual(v.attrs['rows_per_scan'], 2)
             self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 2)
             self.assertEqual(v.attrs['area'].lats.attrs['rows_per_scan'], 2)
+            assert v.attrs['sensor'] == "viirs"
 
     def test_load_dnb_angles(self):
         """Test loading all DNB angle datasets."""
@@ -307,3 +311,4 @@ class TestVIIRSL1BReader(unittest.TestCase):
             self.assertEqual(v.attrs['rows_per_scan'], 2)
             self.assertEqual(v.attrs['area'].lons.attrs['rows_per_scan'], 2)
             self.assertEqual(v.attrs['area'].lats.attrs['rows_per_scan'], 2)
+            assert v.attrs['sensor'] == "viirs"


### PR DESCRIPTION
The 'viirs_sdr' reader produces a lowercase sensor name. The 'viirs_l1b' reader produced whatever case was in the file which for the data I have is uppercase. This is inconsistent and doesn't follow the general standard practice in satpy to have lowercase sensor names.

 - [x] Tests added <!-- for all bug fixes or enhancements -->

