### PR TITLE
Update FCI reader for new test data release and add patches for IDPF data

### DIFF
--- a/doc/source/examples/fci_l1c_natural_color.rst
+++ b/doc/source/examples/fci_l1c_natural_color.rst
@@ -11,6 +11,22 @@ to generate a Natural Color RGB composite over the European area.
     not work with the currently released version of Satpy. Additional updates
     to this example will be coming soon.
 
+.. note::
+
+    For reading compressed data, a decompression library is
+    needed. Either install the FCIDECOMP library (see the [FCI L1 Product User
+    Guide] (www.eumetsat.int/media/45923), or the
+    ``hdf5plugin`` package with::
+
+        pip install hdf5plugin
+
+    or::
+
+        conda install hdf5plugin -c conda-forge
+
+    If you use ``hdf5plugin``, make sure to add the line ``import hdf5plugin``
+    at the top of your script.
+
 .. code-block:: python
 
     from satpy.scene import Scene

--- a/doc/source/examples/fci_l1c_natural_color.rst
+++ b/doc/source/examples/fci_l1c_natural_color.rst
@@ -15,7 +15,7 @@ to generate a Natural Color RGB composite over the European area.
 
     For reading compressed data, a decompression library is
     needed. Either install the FCIDECOMP library (see the [FCI L1 Product User
-    Guide] (www.eumetsat.int/media/45923), or the
+    Guide](www.eumetsat.int/media/45923)), or the
     ``hdf5plugin`` package with::
 
         pip install hdf5plugin

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -82,6 +82,22 @@ All auxiliary data can be obtained by prepending the channel name such as
     ``pixel_quality`` and disambiguated by a to-be-decided property in the
     `DataID`.
 
+.. note::
+
+    For reading compressed data, a decompression library is
+    needed. Either install the FCIDECOMP library (see the [FCI L1 Product User
+    Guide] (www.eumetsat.int/media/45923), or the
+    ``hdf5plugin`` package with::
+
+        pip install hdf5plugin
+
+    or::
+
+        conda install hdf5plugin -c conda-forge
+
+    If you use ``hdf5plugin``, make sure to add the line ``import hdf5plugin``
+    at the top of your script.
+
 .. _PUG: https://www-cdn.eumetsat.int/files/2020-07/pdf_mtg_fci_l1_pug.pdf
 .. _EUMETSAT: https://www.eumetsat.int/mtg-flexible-combined-imager  # noqa: E501
 .. _test data release: https://www.eumetsat.int/simulated-mtg-fci-l1c-enhanced-non-nominal-datasets

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -85,8 +85,7 @@ All auxiliary data can be obtained by prepending the channel name such as
 .. note::
 
     For reading compressed data, a decompression library is
-    needed. Either install the FCIDECOMP library (see the [FCI L1 Product User
-    Guide] (www.eumetsat.int/media/45923), or the
+    needed. Either install the FCIDECOMP library (see `PUG`_), or the
     ``hdf5plugin`` package with::
 
         pip install hdf5plugin

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -307,10 +307,10 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
         """Get the auxiliary data arrays using the index map."""
         # get index map
         index_map = self._get_dataset_index_map(_get_channel_name_from_dsname(dsname))
-        # index map indexing starts from 1
-        index_map -= 1
+        # subtract minimum of index variable (index_offset)
+        index_map -= np.min(self['index'])
 
-        # get lut values from 1-d vector
+        # get lut values from 1-d vector variable
         lut = self._get_aux_data_lut_vector(_get_aux_data_name_from_dsname(dsname))
 
         # assign lut values based on index map indices

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -357,6 +357,7 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
             # TODO remove this check when old versions of IDPF test data (<v5) are deprecated.
             if type(coord_radian.scale_factor) is np.float32:
                 coord_radian.attrs['scale_factor'] = coord_radian.attrs['scale_factor'].astype('float64')
+            if type(coord_radian.add_offset) is np.float32:
                 coord_radian.attrs['add_offset'] = coord_radian.attrs['add_offset'].astype('float64')
 
             coord_radian_num = coord_radian[:] * coord_radian.scale_factor + coord_radian.add_offset

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -555,9 +555,9 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
 
         # TODO remove this check when old versions of IDPF test data (<v5) are deprecated.
         if sun_earth_distance < 0.9 or sun_earth_distance > 1.1:
-            logger.debug('The variable state/celestial/earth_sun_distance contains unexpected values'
-                         '(mean value is {} AU). Defaulting to 1 AU for reflectance calculation.'
-                         ''.format(sun_earth_distance))
+            logger.info('The variable state/celestial/earth_sun_distance contains unexpected values'
+                        '(mean value is {} AU). Defaulting to 1 AU for reflectance calculation.'
+                        ''.format(sun_earth_distance))
             sun_earth_distance = 1
 
         res = 100 * radiance * np.pi * sun_earth_distance ** 2 / cesi

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -537,5 +537,12 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
 
         sun_earth_distance = np.mean(self["state/celestial/earth_sun_distance"]) / 149597870.7  # [AU]
 
+        # TODO remove this check when old versions of IDPF test data (<v5) are deprecated.
+        if sun_earth_distance < 0.9 or sun_earth_distance > 1.1:
+            logger.debug('The variable state/celestial/earth_sun_distance contains unexpected values'
+                         '(mean value is {} AU). Defaulting to 1 AU for reflectance calculation.'
+                         ''.format(sun_earth_distance))
+            sun_earth_distance = 1
+
         res = 100 * radiance * np.pi * sun_earth_distance ** 2 / cesi
         return res

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -349,6 +349,16 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
         extents = {}
         for coord in "xy":
             coord_radian = self["data/{:s}/measured/{:s}".format(channel_name, coord)]
+
+            # TODO remove this check when old versions of IDPF test data (<v4) are deprecated.
+            if coord == "x" and coord_radian.scale_factor > 0:
+                coord_radian.attrs['scale_factor'] *= -1
+
+            # TODO remove this check when old versions of IDPF test data (<v5) are deprecated.
+            if type(coord_radian.scale_factor) is np.float32:
+                coord_radian.attrs['scale_factor'] = coord_radian.attrs['scale_factor'].astype('float64')
+                coord_radian.attrs['add_offset'] = coord_radian.attrs['add_offset'].astype('float64')
+
             coord_radian_num = coord_radian[:] * coord_radian.scale_factor + coord_radian.add_offset
 
             # FCI defines pixels by centroids (see PUG), while pyresample

--- a/satpy/tests/reader_tests/test_fci_l1c_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_nc.py
@@ -123,9 +123,9 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         data[qual.format(ch_str)] = xrda(
             da.arange(nrows * ncols, dtype="uint8").reshape(nrows, ncols) % 128,
             dims=("y", "x"))
-        # add dummy data for index map starting from 1
+        # add dummy data for index map starting from 100
         data[index_map.format(ch_str)] = xrda(
-            (da.arange(nrows * ncols, dtype="uint16").reshape(nrows, ncols) % 6000) + 1,
+            (da.arange(nrows * ncols, dtype="uint16").reshape(nrows, ncols) % 6000) + 100,
             dims=("y", "x"))
 
         data[rad_conv_coeff.format(ch_str)] = xrda(1234.56)
@@ -193,6 +193,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         # compute the last data entry to simulate the FCI caching
         data[list(AUX_DATA.values())[-1]] = data[list(AUX_DATA.values())[-1]].compute()
 
+        data['index'] = xrda(da.arange(indices_dim, dtype="uint16")+100, dims=("index"))
         return data
 
     def _get_global_attributes(self):
@@ -438,7 +439,7 @@ class TestFCIL1cNCReaderGoodData(TestFCIL1cNCReader):
         assert 16 == len(res)
         for ch in self._chans["solar"] + self._chans["terran"]:
             assert res[ch + '_index_map'].shape == (200, 11136)
-            numpy.testing.assert_array_equal(res[ch + '_index_map'][1, 1], 5138)
+            numpy.testing.assert_array_equal(res[ch + '_index_map'][1, 1], 5237)
 
     def test_load_aux_data(self, reader_configs):
         """Test loading of auxiliary data."""

--- a/satpy/tests/reader_tests/test_fci_l1c_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_nc.py
@@ -243,6 +243,29 @@ class FakeNetCDF4FileHandler3(FakeNetCDF4FileHandler2):
         return data
 
 
+class FakeNetCDF4FileHandler4(FakeNetCDF4FileHandler2):
+    """Mock bad data for IDPF TO-DO's."""
+
+    def _get_test_calib_for_channel_vis(self, chroot, meas):
+        data = super()._get_test_calib_for_channel_vis(chroot, meas)
+        data["state/celestial/earth_sun_distance"] = xr.DataArray(da.repeat(da.array([30000000]), 6000))
+        return data
+
+    def _get_test_content_all_channels(self):
+        data = super()._get_test_content_all_channels()
+        data['data/vis_04/measured/x'].attrs['scale_factor'] *= -1
+        data['data/vis_04/measured/x'].attrs['scale_factor'] = \
+            np.float32(data['data/vis_04/measured/x'].attrs['scale_factor'])
+        data['data/vis_04/measured/x'].attrs['add_offset'] = \
+            np.float32(data['data/vis_04/measured/x'].attrs['add_offset'])
+        data['data/vis_04/measured/y'].attrs['scale_factor'] = \
+            np.float32(data['data/vis_04/measured/y'].attrs['scale_factor'])
+        data['data/vis_04/measured/y'].attrs['add_offset'] = \
+            np.float32(data['data/vis_04/measured/y'].attrs['add_offset'])
+
+        return data
+
+
 @pytest.fixture
 def reader_configs():
     """Return reader configs for FCI."""
@@ -593,3 +616,41 @@ class TestFCIL1cNCReaderBadData(TestFCIL1cNCReader):
                 name="vis_04",
                 calibration="reflectance")], pad_data=False)
             assert "cannot produce reflectance" in caplog.text
+
+
+class TestFCIL1cNCReaderBadDataFromIDPF(TestFCIL1cNCReader):
+    """Test the FCI L1c NetCDF Reader for bad data input."""
+
+    _alt_handler = FakeNetCDF4FileHandler4
+
+    def test_handling_bad_earthsun_distance(self, reader_configs, caplog):
+        """Test handling of bad earth-sun distance data."""
+        from satpy.tests.utils import make_dataid
+
+        filenames = [
+            "W_XX-EUMETSAT-Darmstadt,IMG+SAT,MTI1+FCI-1C-RRAD-FDHSI-FD--"
+            "CHK-BODY--L2P-NC4E_C_EUMT_20170410114434_GTT_DEV_"
+            "20170410113925_20170410113934_N__C_0070_0067.nc",
+        ]
+
+        reader = _get_reader_with_filehandlers(filenames, reader_configs)
+
+        res = reader.load([make_dataid(name=["vis_04"], calibration="reflectance")], pad_data=False)
+        numpy.testing.assert_array_almost_equal(res["vis_04"], 100 * 15 * 1 * np.pi / 50)
+
+    def test_bad_xy_coords(self, reader_configs):
+        """Test that the geolocation computation is correct."""
+        filenames = [
+            "W_XX-EUMETSAT-Darmstadt,IMG+SAT,MTI1+FCI-1C-RRAD-FDHSI-FD--"
+            "CHK-BODY--L2P-NC4E_C_EUMT_20170410114434_GTT_DEV_"
+            "20170410113925_20170410113934_N__C_0070_0067.nc",
+        ]
+
+        reader = _get_reader_with_filehandlers(filenames, reader_configs)
+        res = reader.load(['vis_04'], pad_data=False)
+
+        area_def = res['vis_04'].attrs['area']
+        # test area extents computation
+        np.testing.assert_array_almost_equal(np.array(area_def.area_extent),
+                                             np.array([-5568062.270889, 5168057.806632,
+                                                       16704186.298937, 5568062.270889]))


### PR DESCRIPTION
This PR adds minor modifications to the FCI reader:
- the index map retrieval mechanism is updated to use the index variable, to account for format changes in the upcoming test data release. The reader still works also with older test data.
- two patches (wrong geolocation paramters and earth_sun_distance data) are added to make the reader work also for IDPF data (as released e.g. to SAFs) as discussed on Slack.
- a note is added to the FCI example and docstring to note that hdf5plugin can be used for automatic decompression (while we fix the issues in https://github.com/pytroll/satpy/pull/2043

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
