### PR TITLE
Fix area defs in cmsaf-claas2 reader

### DIFF
--- a/satpy/readers/cmsaf_claas2.py
+++ b/satpy/readers/cmsaf_claas2.py
@@ -2,13 +2,34 @@
 
 import datetime
 
-import pyresample.geometry
+from satpy.resample import get_area_def
 
 from .netcdf_utils import NetCDF4FileHandler
 
 
+def _is_georef_offset_present(date):
+    # Reference: Product User Manual, section 3.
+    # https://doi.org/10.5676/EUM_SAF_CM/CLAAS/V002_01
+    return date < datetime.date(2017, 12, 6)
+
+
+def _adjust_area_to_match_shifted_data(area):
+    # Reference:
+    # https://github.com/pytroll/satpy/wiki/SEVIRI-georeferencing-offset-correction
+    offset = area.pixel_size_x / 2
+    llx, lly, urx, ury = area.area_extent
+    new_extent = [llx + offset, lly - offset, urx + offset, ury - offset]
+    return area.copy(area_extent=new_extent)
+
+
+FULL_DISK = get_area_def("msg_seviri_fes_3km")
+FULL_DISK_WITH_OFFSET = _adjust_area_to_match_shifted_data(FULL_DISK)
+
+
 class CLAAS2(NetCDF4FileHandler):
     """Handle CMSAF CLAAS-2 files."""
+
+    grid_size = 3636
 
     def __init__(self, *args, **kwargs):
         """Initialise class."""
@@ -74,11 +95,14 @@ class CLAAS2(NetCDF4FileHandler):
 
     def get_area_def(self, dataset_id):
         """Get the area definition."""
-        return pyresample.geometry.AreaDefinition(
-                "some_area_name",
-                "on-the-fly area",
-                "geos",
-                self["/attr/CMSAF_proj4_params"],
-                self["/dimension/x"],
-                self["/dimension/y"],
-                self["/attr/CMSAF_area_extent"])
+        full_disk = self._get_full_disk()
+        return self._subset_full_disk(full_disk)
+
+    def _get_full_disk(self):
+        if _is_georef_offset_present(self.start_time.date()):
+            return FULL_DISK_WITH_OFFSET
+        return FULL_DISK
+
+    def _subset_full_disk(self, full_disk):
+        offset = int((full_disk.width - self.grid_size) // 2)
+        return full_disk[offset:-offset, offset:-offset]

--- a/satpy/readers/cmsaf_claas2.py
+++ b/satpy/readers/cmsaf_claas2.py
@@ -95,14 +95,19 @@ class CLAAS2(NetCDF4FileHandler):
 
     def get_area_def(self, dataset_id):
         """Get the area definition."""
+        return self._get_subset_of_full_disk()
+
+    def _get_subset_of_full_disk(self):
+        """Get subset of the full disk.
+
+        CLAAS products are provided on a grid that is slightly smaller
+        than the full disk (excludes most of the space pixels).
+        """
         full_disk = self._get_full_disk()
-        return self._subset_full_disk(full_disk)
+        offset = int((full_disk.width - self.grid_size) // 2)
+        return full_disk[offset:-offset, offset:-offset]
 
     def _get_full_disk(self):
         if _is_georef_offset_present(self.start_time.date()):
             return FULL_DISK_WITH_OFFSET
         return FULL_DISK
-
-    def _subset_full_disk(self, full_disk):
-        offset = int((full_disk.width - self.grid_size) // 2)
-        return full_disk[offset:-offset, offset:-offset]

--- a/satpy/tests/reader_tests/test_cmsaf_claas.py
+++ b/satpy/tests/reader_tests/test_cmsaf_claas.py
@@ -22,11 +22,12 @@ import os
 from unittest import mock
 
 import numpy as np
-import numpy.testing
 import pytest
 import xarray as xr
+from pyresample.geometry import AreaDefinition
 
 from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
+from satpy.tests.utils import make_dataid
 
 
 class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
@@ -103,64 +104,163 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         return D
 
 
-@pytest.fixture
-def reader():
-    """Return reader for CMSAF CLAAS-2."""
-    from satpy._config import config_search_paths
-    from satpy.readers import load_reader
+class TestCLAAS2:
+    @pytest.fixture
+    def reader(self):
+        """Return reader for CMSAF CLAAS-2."""
+        from satpy._config import config_search_paths
+        from satpy.readers import load_reader
 
-    reader_configs = config_search_paths(
-        os.path.join("readers", "cmsaf-claas2_l2_nc.yaml"))
-    reader = load_reader(reader_configs)
-    return reader
+        reader_configs = config_search_paths(
+            os.path.join("readers", "cmsaf-claas2_l2_nc.yaml"))
+        reader = load_reader(reader_configs)
+        return reader
 
+    @pytest.fixture(autouse=True, scope="class")
+    def fake_handler(self):
+        """Wrap NetCDF4 FileHandler with our own fake handler."""
+        # implementation strongly inspired by test_viirs_l1b.py
+        from satpy.readers.cmsaf_claas2 import CLAAS2
+        p = mock.patch.object(
+                CLAAS2,
+                "__bases__",
+                (FakeNetCDF4FileHandler2,))
+        with p:
+            p.is_local = True
+            yield p
 
-@pytest.fixture(autouse=True, scope="class")
-def fake_handler():
-    """Wrap NetCDF4 FileHandler with our own fake handler."""
-    # implementation strongly inspired by test_viirs_l1b.py
-    from satpy.readers.cmsaf_claas2 import CLAAS2
-    p = mock.patch.object(
-            CLAAS2,
-            "__bases__",
-            (FakeNetCDF4FileHandler2,))
-    with p:
-        p.is_local = True
-        yield p
+    def test_file_pattern(self, reader):
+        """Test file pattern matching."""
+        filenames = [
+                "CTXin20040120091500305SVMSG01MD.nc",
+                "CTXin20040120093000305SVMSG01MD.nc",
+                "CTXin20040120094500305SVMSG01MD.nc",
+                "abcde52034294023489248MVSSG03DD.nc"]
 
+        files = reader.select_files_from_pathnames(filenames)
+        # only 3 out of 4 above should match
+        assert len(files) == 3
 
-def test_file_pattern(reader):
-    """Test file pattern matching."""
-    filenames = [
+    def test_load(self, reader):
+        """Test loading."""
+
+        # testing two filenames to test correctly combined
+        filenames = [
             "CTXin20040120091500305SVMSG01MD.nc",
-            "CTXin20040120093000305SVMSG01MD.nc",
-            "CTXin20040120094500305SVMSG01MD.nc",
-            "abcde52034294023489248MVSSG03DD.nc"]
+            "CTXin20040120093000305SVMSG01MD.nc"]
 
-    files = reader.select_files_from_pathnames(filenames)
-    # only 3 out of 4 above should match
-    assert len(files) == 3
+        loadables = reader.select_files_from_pathnames(filenames)
+        reader.create_filehandlers(loadables)
+        res = reader.load(
+                [make_dataid(name=name) for name in ["cph", "ctt"]])
+        assert 2 == len(res)
+        assert reader.start_time == datetime.datetime(1985, 8, 13, 13, 15)
+        assert reader.end_time == datetime.datetime(2085, 8, 13, 13, 15)
+        np.testing.assert_array_almost_equal(
+                res["cph"].data,
+                np.tile(np.arange(0.0, 12.0, 0.01).reshape((30, 40)), [2, 1]))
+        np.testing.assert_array_almost_equal(
+                res["ctt"].data,
+                np.tile(np.arange(12.0, 0.0, -0.01).reshape((30, 40)), [2, 1]))
 
 
-def test_load(reader):
-    """Test loading."""
-    from satpy.tests.utils import make_dataid
+class TestCLAAS2New:
+    """Test CLAAS2 file handler by writing and reading test file."""
 
-    # testing two filenames to test correctly combined
-    filenames = [
-        "CTXin20040120091500305SVMSG01MD.nc",
-        "CTXin20040120093000305SVMSG01MD.nc"]
+    @pytest.fixture
+    def fake_dataset(self):
+        cph = xr.DataArray(
+            [[[0, 1], [2, 0]]],
+            dims=("time", "y", "x")
+        )
+        ctt = xr.DataArray(
+            [[280, 290], [300, 310]],
+            dims=("y", "x")
+        )
+        time_bounds = xr.DataArray(
+            [[12436.91666667, 12436.92534722]],
+            dims=("time", "bndsize")
+        )
+        attrs = {
+            "CMSAF_proj4_params": "+a=6378169.0 +h=35785831.0 "
+                                  "+b=6356583.8 +lon_0=0 +proj=geos",
+            "CMSAF_area_extent": np.array(
+                [-5456233.41938636, -5453233.01608472,
+                 5453233.01608472, 5456233.41938636]),
+            "time_coverage_start": "1985-08-13T13:15:00Z",
+            "time_coverage_end": "2085-08-13T13:15:00Z",
+        }
+        return xr.Dataset(
+            {
+                "cph": cph,
+                "ctt": ctt,
+                "time_bnds": time_bounds
+            },
+            attrs=attrs
+        )
 
-    loadables = reader.select_files_from_pathnames(filenames)
-    reader.create_filehandlers(loadables)
-    res = reader.load(
-            [make_dataid(name=name) for name in ["cph", "ctt"]])
-    assert 2 == len(res)
-    assert reader.start_time == datetime.datetime(1985, 8, 13, 13, 15)
-    assert reader.end_time == datetime.datetime(2085, 8, 13, 13, 15)
-    np.testing.assert_array_almost_equal(
-            res["cph"].data,
-            np.tile(np.arange(0.0, 12.0, 0.01).reshape((30, 40)), [2, 1]))
-    np.testing.assert_array_almost_equal(
-            res["ctt"].data,
-            np.tile(np.arange(12.0, 0.0, -0.01).reshape((30, 40)), [2, 1]))
+    @pytest.fixture
+    def encoding(self):
+        return {
+            "ctt": {"scale_factor": np.float32(0.01)},
+        }
+
+    @pytest.fixture
+    def fake_file(self, fake_dataset, encoding):
+        filename = "CPPin20140101001500305SVMSG01MD.nc"
+        fake_dataset.to_netcdf(filename, encoding=encoding)
+        yield filename
+        os.unlink(filename)
+
+    @pytest.fixture
+    def file_handler(self, fake_file):
+        from satpy.readers.cmsaf_claas2 import CLAAS2
+        return CLAAS2(fake_file, {}, {})
+
+    def test_get_area_def(self, file_handler):
+        """Test area definition."""
+        MAJOR_AXIS_OF_EARTH_ELLIPSOID = 6378169.0
+        MINOR_AXIS_OF_EARTH_ELLIPSOID = 6356583.8
+        SATELLITE_ALTITUDE = 35785831.0
+        PROJECTION_LONGITUDE = 0.0
+        PROJ_DICT = {
+            "a": MAJOR_AXIS_OF_EARTH_ELLIPSOID,
+            "b": MINOR_AXIS_OF_EARTH_ELLIPSOID,
+            "h": SATELLITE_ALTITUDE,
+            "lon_0": PROJECTION_LONGITUDE,
+            "proj": "geos",
+            "units": "m",
+        }
+        area_exp = AreaDefinition(
+            area_id="some_area_name",
+            description="on-the-fly area",
+            proj_id="geos",
+            projection=PROJ_DICT,
+            area_extent=[-5456233.41938636, -5453233.01608472,
+                         5453233.01608472, 5456233.41938636],
+            width=2,
+            height=2,
+        )
+        area = file_handler.get_area_def(make_dataid(name="foo"))
+        assert area == area_exp
+
+    @pytest.mark.parametrize(
+        "ds_name,expected",
+        [
+            ("ctt", xr.DataArray([[280, 290], [300, 310]], dims=('y', 'x'))),
+            ("cph", xr.DataArray([[0, 1], [2, 0]], dims=('y', 'x'))),
+        ]
+    )
+    def test_get_dataset(self, file_handler, ds_name, expected):
+        """Test dataset loading."""
+        dsid = make_dataid(name=ds_name)
+        ds = file_handler.get_dataset(dsid, {})
+        xr.testing.assert_allclose(ds, expected)
+
+    def test_start_time(self, file_handler):
+        """Test start time property."""
+        assert file_handler.start_time == datetime.datetime(1985, 8, 13, 13, 15)
+
+    def test_end_time(self, file_handler):
+        """Test end time property."""
+        assert file_handler.end_time == datetime.datetime(2085, 8, 13, 13, 15)

--- a/satpy/tests/reader_tests/test_cmsaf_claas.py
+++ b/satpy/tests/reader_tests/test_cmsaf_claas.py
@@ -79,18 +79,15 @@ def fake_file(fake_dataset, encoding, tmp_path):
 
 
 @pytest.fixture
-def fake_files(fake_dataset, encoding):
+def fake_files(fake_dataset, encoding, tmp_path):
     """Write the same fake dataset into two different files."""
     filenames = [
-        "CPPin20140101001500305SVMSG01MD.nc",
-        "CPPin20140101003000305SVMSG01MD.nc",
+        tmp_path / "CPPin20140101001500305SVMSG01MD.nc",
+        tmp_path / "CPPin20140101003000305SVMSG01MD.nc",
     ]
     for filename in filenames:
         fake_dataset.to_netcdf(filename, encoding=encoding)
     yield filenames
-    # Cleanup executed after test
-    for filename in filenames:
-        os.unlink(filename)
 
 
 @pytest.fixture

--- a/satpy/tests/reader_tests/test_cmsaf_claas.py
+++ b/satpy/tests/reader_tests/test_cmsaf_claas.py
@@ -71,13 +71,11 @@ def encoding():
 
 
 @pytest.fixture
-def fake_file(fake_dataset, encoding):
+def fake_file(fake_dataset, encoding, tmp_path):
     """Write a fake dataset to file."""
-    filename = "CPPin20140101001500305SVMSG01MD.nc"
+    filename = tmp_path / "CPPin20140101001500305SVMSG01MD.nc"
     fake_dataset.to_netcdf(filename, encoding=encoding)
     yield filename
-    # Cleanup executed after test
-    os.unlink(filename)
 
 
 @pytest.fixture

--- a/satpy/tests/reader_tests/test_cmsaf_claas.py
+++ b/satpy/tests/reader_tests/test_cmsaf_claas.py
@@ -19,201 +19,153 @@
 
 import datetime
 import os
-from unittest import mock
 
 import numpy as np
 import pytest
 import xarray as xr
 from pyresample.geometry import AreaDefinition
 
-from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
 from satpy.tests.utils import make_dataid
 
 
-class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
-    """Class for faking the NetCDF4 Filehandler."""
-
-    _nrows = 30
-    _ncols = 40
-
-    def __init__(self, *args, auto_maskandscale, **kwargs):
-        """Init the file handler."""
-        # make sure that CLAAS2 reader asks NetCDF4FileHandler for having
-        # auto_maskandscale enabled
-        assert auto_maskandscale
-        super().__init__(*args, **kwargs)
-
-    def _get_global_attributes(self):
-        data = {}
-        attrs = {
-                "CMSAF_proj4_params": "+a=6378169.0 +h=35785831.0 "
-                                      "+b=6356583.8 +lon_0=0 +proj=geos",
-                "CMSAF_area_extent": np.array(
-                    [-5456233.41938636, -5453233.01608472,
-                     5453233.01608472, 5456233.41938636]),
-                "time_coverage_start": "1985-08-13T13:15:00Z",
-                "time_coverage_end": "2085-08-13T13:15:00Z",
-                }
-        for (k, v) in attrs.items():
-            data["/attr/" + k] = v
-        return data
-
-    def _get_data(self):
-        data = {
-                "cph": xr.DataArray(
-                    np.arange(self._nrows*self._ncols, dtype="i4").reshape(
-                        (1, self._nrows, self._ncols))/100,
-                    dims=("time", "y", "x")),
-                "ctt": xr.DataArray(
-                    np.arange(self._nrows*self._ncols, 0, -1,
-                              dtype="i4").reshape(
-                                  (self._nrows, self._ncols))/100,
-                    dims=("y", "x")),
-                "time_bnds": xr.DataArray(
-                    [[12436.91666667, 12436.92534722]],
-                    dims=("time", "time_bnds"))}
-        for k in set(data.keys()):
-            data[f"{k:s}/dimensions"] = data[k].dims
-            data[f"{k:s}/attr/fruit"] = "apple"
-            data[f"{k:s}/attr/scale_factor"] = np.float32(0.01)
-        return data
-
-    def _get_dimensions(self):
-        data = {
-                "/dimension/x": self._nrows,
-                "/dimension/y": self._ncols,
-                "/dimension/time": 1,
-                "/dimension/time_bnds": 2,
-                }
-        return data
-
-    def get_test_content(self, filename, filename_info, filetype_info):
-        """Get the content of the test data."""
-        # mock global attributes
-        # - root groups global
-        # - other groups global
-        # mock data variables
-        # mock dimensions
-        #
-        # ... but only what satpy is using ...
-
-        D = {}
-        D.update(self._get_data())
-        D.update(self._get_dimensions())
-        D.update(self._get_global_attributes())
-        return D
+@pytest.fixture
+def fake_dataset():
+    """Create a CLAAS-like test dataset."""
+    cph = xr.DataArray(
+        [[[0, 1], [2, 0]]],
+        dims=("time", "y", "x")
+    )
+    ctt = xr.DataArray(
+        [[280, 290], [300, 310]],
+        dims=("y", "x")
+    )
+    time_bounds = xr.DataArray(
+        [[12436.91666667, 12436.92534722]],
+        dims=("time", "bndsize")
+    )
+    attrs = {
+        "CMSAF_proj4_params": "+a=6378169.0 +h=35785831.0 "
+                              "+b=6356583.8 +lon_0=0 +proj=geos",
+        "CMSAF_area_extent": np.array(
+            [-5456233.41938636, -5453233.01608472,
+             5453233.01608472, 5456233.41938636]),
+        "time_coverage_start": "1985-08-13T13:15:00Z",
+        "time_coverage_end": "2085-08-13T13:15:00Z",
+    }
+    return xr.Dataset(
+        {
+            "cph": cph,
+            "ctt": ctt,
+            "time_bnds": time_bounds
+        },
+        attrs=attrs
+    )
 
 
-class TestCLAAS2:
+@pytest.fixture
+def encoding():
+    """Dataset encoding."""
+    return {
+        "ctt": {"scale_factor": np.float32(0.01)},
+    }
+
+
+@pytest.fixture
+def fake_file(fake_dataset, encoding):
+    """Write a fake dataset to file."""
+    filename = "CPPin20140101001500305SVMSG01MD.nc"
+    fake_dataset.to_netcdf(filename, encoding=encoding)
+    yield filename
+    # Cleanup executed after test
+    os.unlink(filename)
+
+
+@pytest.fixture
+def fake_files(fake_dataset, encoding):
+    """Write the same fake dataset into two different files."""
+    filenames = [
+        "CPPin20140101001500305SVMSG01MD.nc",
+        "CPPin20140101003000305SVMSG01MD.nc",
+    ]
+    for filename in filenames:
+        fake_dataset.to_netcdf(filename, encoding=encoding)
+    yield filenames
+    # Cleanup executed after test
+    for filename in filenames:
+        os.unlink(filename)
+
+
+@pytest.fixture
+def reader():
+    """Return reader for CMSAF CLAAS-2."""
+    from satpy._config import config_search_paths
+    from satpy.readers import load_reader
+
+    reader_configs = config_search_paths(
+        os.path.join("readers", "cmsaf-claas2_l2_nc.yaml"))
+    reader = load_reader(reader_configs)
+    return reader
+
+
+def test_file_pattern(reader):
+    """Test file pattern matching."""
+    filenames = [
+            "CTXin20040120091500305SVMSG01MD.nc",
+            "CTXin20040120093000305SVMSG01MD.nc",
+            "CTXin20040120094500305SVMSG01MD.nc",
+            "abcde52034294023489248MVSSG03DD.nc"]
+
+    files = reader.select_files_from_pathnames(filenames)
+    # only 3 out of 4 above should match
+    assert len(files) == 3
+
+
+class TestCLAAS2MultiFile:
+    """Test reading multiple CLAAS-2 files."""
+
     @pytest.fixture
-    def reader(self):
-        """Return reader for CMSAF CLAAS-2."""
-        from satpy._config import config_search_paths
-        from satpy.readers import load_reader
-
-        reader_configs = config_search_paths(
-            os.path.join("readers", "cmsaf-claas2_l2_nc.yaml"))
-        reader = load_reader(reader_configs)
+    def multi_file_reader(self, reader, fake_files):
+        """Create a multi-file reader."""
+        loadables = reader.select_files_from_pathnames(fake_files)
+        reader.create_filehandlers(loadables)
         return reader
 
-    @pytest.fixture(autouse=True, scope="class")
-    def fake_handler(self):
-        """Wrap NetCDF4 FileHandler with our own fake handler."""
-        # implementation strongly inspired by test_viirs_l1b.py
-        from satpy.readers.cmsaf_claas2 import CLAAS2
-        p = mock.patch.object(
-                CLAAS2,
-                "__bases__",
-                (FakeNetCDF4FileHandler2,))
-        with p:
-            p.is_local = True
-            yield p
+    @pytest.fixture
+    def multi_file_dataset(self, multi_file_reader):
+        """Load datasets from multiple files."""
+        ds_ids = [make_dataid(name=name) for name in ["cph", "ctt"]]
+        datasets = multi_file_reader.load(ds_ids)
+        return datasets
 
-    def test_file_pattern(self, reader):
-        """Test file pattern matching."""
-        filenames = [
-                "CTXin20040120091500305SVMSG01MD.nc",
-                "CTXin20040120093000305SVMSG01MD.nc",
-                "CTXin20040120094500305SVMSG01MD.nc",
-                "abcde52034294023489248MVSSG03DD.nc"]
+    def test_combine_timestamps(self, multi_file_reader):
+        """Test combination of timestamps."""
+        assert multi_file_reader.start_time == datetime.datetime(1985, 8, 13, 13, 15)
+        assert multi_file_reader.end_time == datetime.datetime(2085, 8, 13, 13, 15)
 
-        files = reader.select_files_from_pathnames(filenames)
-        # only 3 out of 4 above should match
-        assert len(files) == 3
-
-    def test_load(self, reader):
-        """Test loading."""
-
-        # testing two filenames to test correctly combined
-        filenames = [
-            "CTXin20040120091500305SVMSG01MD.nc",
-            "CTXin20040120093000305SVMSG01MD.nc"]
-
-        loadables = reader.select_files_from_pathnames(filenames)
-        reader.create_filehandlers(loadables)
-        res = reader.load(
-                [make_dataid(name=name) for name in ["cph", "ctt"]])
-        assert 2 == len(res)
-        assert reader.start_time == datetime.datetime(1985, 8, 13, 13, 15)
-        assert reader.end_time == datetime.datetime(2085, 8, 13, 13, 15)
+    @pytest.mark.parametrize(
+        "ds_name,expected",
+        [
+            ("cph", [[0, 1], [2, 0], [0, 1], [2, 0]]),
+            ("ctt", [[280, 290], [300, 310], [280, 290], [300, 310]]),
+        ]
+    )
+    def test_combine_datasets(self, multi_file_dataset, ds_name, expected):
+        """Test combination of datasets."""
         np.testing.assert_array_almost_equal(
-                res["cph"].data,
-                np.tile(np.arange(0.0, 12.0, 0.01).reshape((30, 40)), [2, 1]))
-        np.testing.assert_array_almost_equal(
-                res["ctt"].data,
-                np.tile(np.arange(12.0, 0.0, -0.01).reshape((30, 40)), [2, 1]))
-
-
-class TestCLAAS2New:
-    """Test CLAAS2 file handler by writing and reading test file."""
-
-    @pytest.fixture
-    def fake_dataset(self):
-        cph = xr.DataArray(
-            [[[0, 1], [2, 0]]],
-            dims=("time", "y", "x")
-        )
-        ctt = xr.DataArray(
-            [[280, 290], [300, 310]],
-            dims=("y", "x")
-        )
-        time_bounds = xr.DataArray(
-            [[12436.91666667, 12436.92534722]],
-            dims=("time", "bndsize")
-        )
-        attrs = {
-            "CMSAF_proj4_params": "+a=6378169.0 +h=35785831.0 "
-                                  "+b=6356583.8 +lon_0=0 +proj=geos",
-            "CMSAF_area_extent": np.array(
-                [-5456233.41938636, -5453233.01608472,
-                 5453233.01608472, 5456233.41938636]),
-            "time_coverage_start": "1985-08-13T13:15:00Z",
-            "time_coverage_end": "2085-08-13T13:15:00Z",
-        }
-        return xr.Dataset(
-            {
-                "cph": cph,
-                "ctt": ctt,
-                "time_bnds": time_bounds
-            },
-            attrs=attrs
+            multi_file_dataset[ds_name].data, expected
         )
 
-    @pytest.fixture
-    def encoding(self):
-        return {
-            "ctt": {"scale_factor": np.float32(0.01)},
-        }
+    def test_number_of_datasets(self, multi_file_dataset):
+        """Test number of datasets."""
+        assert 2 == len(multi_file_dataset)
 
-    @pytest.fixture
-    def fake_file(self, fake_dataset, encoding):
-        filename = "CPPin20140101001500305SVMSG01MD.nc"
-        fake_dataset.to_netcdf(filename, encoding=encoding)
-        yield filename
-        os.unlink(filename)
+
+class TestCLAAS2SingleFile:
+    """Test reading a single CLAAS2 file."""
 
     @pytest.fixture
     def file_handler(self, fake_file):
+        """Return a CLAAS-2 file handler."""
         from satpy.readers.cmsaf_claas2 import CLAAS2
         return CLAAS2(fake_file, {}, {})
 


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Area extents in CM SAF CLAAS-2 Level 2 data are affected by the following two problems

- They do not take the georeferencing offset (before Dec 2017) into account
- They are incorrect after 2016

Fix those problems by using pre-defined area defs (with and without offset) and ignore the extents from the file.

TODO

- [x] Refactor tests: Write and read small test file
- [x] Add area defs
