### PR TITLE
Fix Scene.coarsest/finest_area not returning consistent results

### DIFF
--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -604,7 +604,7 @@ class VIIRSSDRReader(FileYAMLReader):
             LOG.warning("Required file type '%s' not found or loaded for "
                         "'%s'", ds_info['file_type'], dsid['name'])
         else:
-            if len(set(ds_info['dataset_groups']) & set(['GITCO', 'GIMGO', 'GMTCO', 'GMODO'])) > 1:
+            if len(set(ds_info['dataset_groups']) & {'GITCO', 'GIMGO', 'GMTCO', 'GMODO'}) > 1:
                 fhs = self.get_right_geo_fhs(dsid, fhs)
             return fhs
 

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import logging
 import os
 import warnings
+from typing import Callable
 
 import numpy as np
 import xarray as xr
@@ -238,26 +239,33 @@ class Scene:
             if not all(ad.crs == first_crs for ad in areas[1:]):
                 raise ValueError("Can't compare areas with different "
                                  "projections.")
+            return self._compare_area_defs(compare_func, areas)
+        return self._compare_swath_defs(compare_func, areas)
 
-            def _key_func(area_def: AreaDefinition) -> tuple:
-                """Get comparable version of area based on resolution.
+    @staticmethod
+    def _compare_area_defs(compare_func: Callable, area_defs: list[AreaDefinition]) -> list[AreaDefinition]:
+        def _key_func(area_def: AreaDefinition) -> tuple:
+            """Get comparable version of area based on resolution.
 
-                Pixel size x is the primary comparison parameter followed by
-                the y dimension pixel size. The extent of the area and the
-                name (area_id) of the area are also used to act as
-                "tiebreakers" between areas of the same resolution.
+            Pixel size x is the primary comparison parameter followed by
+            the y dimension pixel size. The extent of the area and the
+            name (area_id) of the area are also used to act as
+            "tiebreakers" between areas of the same resolution.
 
-                """
-                pixel_size_x_inverse = 1. / abs(area_def.pixel_size_x)
-                pixel_size_y_inverse = 1. / abs(area_def.pixel_size_y)
-                area_id = area_def.area_id
-                return pixel_size_x_inverse, pixel_size_y_inverse, area_def.area_extent, area_id
-            return compare_func(areas, key=_key_func)
+            """
+            pixel_size_x_inverse = 1. / abs(area_def.pixel_size_x)
+            pixel_size_y_inverse = 1. / abs(area_def.pixel_size_y)
+            area_id = area_def.area_id
+            return pixel_size_x_inverse, pixel_size_y_inverse, area_def.area_extent, area_id
+        return compare_func(area_defs, key=_key_func)
 
+    @staticmethod
+    def _compare_swath_defs(compare_func: Callable, swath_defs: list[SwathDefinition]) -> list[SwathDefinition]:
         def _key_func(swath_def: SwathDefinition) -> tuple:
-            return swath_def.shape[1], swath_def.shape[0], None, None
-
-        return compare_func(areas, key=_key_func)
+            attrs = getattr(swath_def.lons, "attrs", {})
+            lon_ds_name = attrs.get("name")
+            return swath_def.shape[1], swath_def.shape[0], lon_ds_name
+        return compare_func(swath_defs, key=_key_func)
 
     def _gather_all_areas(self, datasets):
         """Gather all areas from datasets.

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -239,14 +239,25 @@ class Scene:
                 raise ValueError("Can't compare areas with different "
                                  "projections.")
 
-            def key_func(ds):
-                return 1. / abs(ds.pixel_size_x)
-        else:
-            def key_func(ds):
-                return ds.shape
+            def _key_func(area_def: AreaDefinition) -> tuple:
+                """Get comparable version of area based on resolution.
 
-        # find the highest/lowest area among the provided
-        return compare_func(areas, key=key_func)
+                Pixel size x is the primary comparison parameter followed by
+                the y dimension pixel size. The extent of the area and the
+                name (area_id) of the area are also used to act as
+                "tiebreakers" between areas of the same resolution.
+
+                """
+                pixel_size_x_inverse = 1. / abs(area_def.pixel_size_x)
+                pixel_size_y_inverse = 1. / abs(area_def.pixel_size_y)
+                area_id = area_def.area_id
+                return pixel_size_x_inverse, pixel_size_y_inverse, area_def.area_extent, area_id
+            return compare_func(areas, key=_key_func)
+
+        def _key_func(swath_def: SwathDefinition) -> tuple:
+            return swath_def.shape[1], swath_def.shape[0], None, None
+
+        return compare_func(areas, key=_key_func)
 
     def _gather_all_areas(self, datasets):
         """Gather all areas from datasets.

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -644,7 +644,7 @@ def _create_coarest_finest_data_array(shape, area_def, attrs=None):
     return data_arr
 
 
-def _create_coarsest_area_def(shape, extents):
+def _create_coarsest_finest_area_def(shape, extents):
     from pyresample import AreaDefinition
     proj_str = '+proj=lcc +datum=WGS84 +ellps=WGS84 +lon_0=-95. +lat_0=25 +lat_1=25 +units=m +no_defs'
     area_def = AreaDefinition(
@@ -680,8 +680,8 @@ class TestFinestCoarsestArea:
     )
     def test_coarsest_finest_area_different_shape(self, coarse_shape, fine_shape, coarse_extents, fine_extents):
         """Test 'coarsest_area' and 'finest_area' methods for upright areas."""
-        coarser_area = _create_coarsest_area_def(coarse_shape, coarse_extents)
-        finer_area = _create_coarsest_area_def(fine_shape, fine_extents)
+        coarser_area = _create_coarsest_finest_area_def(coarse_shape, coarse_extents)
+        finer_area = _create_coarsest_finest_area_def(fine_shape, fine_extents)
         ds1 = _create_coarest_finest_data_array(coarse_shape, coarser_area, {"wavelength": (0.1, 0.2, 0.3)})
         ds2 = _create_coarest_finest_data_array(fine_shape, finer_area, {"wavelength": (0.4, 0.5, 0.6)})
         ds3 = _create_coarest_finest_data_array(fine_shape, finer_area, {"wavelength": (0.7, 0.8, 0.9)})
@@ -697,8 +697,8 @@ class TestFinestCoarsestArea:
     @pytest.mark.parametrize(
         ("area_def", "shifted_area"),
         [
-            (_create_coarsest_area_def((2, 5), (-1000.0, -1500.0, 1000.0, 1500.0)),
-             _create_coarsest_area_def((2, 5), (-900.0, -1400.0, 1100.0, 1600.0))),
+            (_create_coarsest_finest_area_def((2, 5), (-1000.0, -1500.0, 1000.0, 1500.0)),
+             _create_coarsest_finest_area_def((2, 5), (-900.0, -1400.0, 1100.0, 1600.0))),
             (_create_coarsest_finest_swath_def((2, 5), (-1000.0, -1500.0, 1000.0, 1500.0), "1"),
              _create_coarsest_finest_swath_def((2, 5), (-900.0, -1400.0, 1100.0, 1600.0), "2")),
         ],

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -672,27 +672,27 @@ class TestFinestCoarsestArea:
     """Test the Scene logic for finding the finest and coarsest area."""
 
     @pytest.mark.parametrize(
-        ("coarse_shape", "fine_shape", "coarse_extents", "fine_extents"),
+        ("coarse_area", "fine_area"),
         [
-            ((2, 5), (4, 10), (1000.0, 1500.0, -1000.0, -1500.0), (1000.0, 1500.0, -1000.0, -1500.0)),
-            ((2, 5), (4, 10), (-1000.0, -1500.0, 1000.0, 1500.0), (-1000.0, -1500.0, 1000.0, 1500.0)),
+            (_create_coarsest_finest_area_def((2, 5), (1000.0, 1500.0, -1000.0, -1500.0)),
+             _create_coarsest_finest_area_def((4, 10), (1000.0, 1500.0, -1000.0, -1500.0))),
+            (_create_coarsest_finest_area_def((2, 5), (-1000.0, -1500.0, 1000.0, 1500.0)),
+             _create_coarsest_finest_area_def((4, 10), (-1000.0, -1500.0, 1000.0, 1500.0))),
         ]
     )
-    def test_coarsest_finest_area_different_shape(self, coarse_shape, fine_shape, coarse_extents, fine_extents):
+    def test_coarsest_finest_area_different_shape(self, coarse_area, fine_area):
         """Test 'coarsest_area' and 'finest_area' methods for upright areas."""
-        coarser_area = _create_coarsest_finest_area_def(coarse_shape, coarse_extents)
-        finer_area = _create_coarsest_finest_area_def(fine_shape, fine_extents)
-        ds1 = _create_coarest_finest_data_array(coarse_shape, coarser_area, {"wavelength": (0.1, 0.2, 0.3)})
-        ds2 = _create_coarest_finest_data_array(fine_shape, finer_area, {"wavelength": (0.4, 0.5, 0.6)})
-        ds3 = _create_coarest_finest_data_array(fine_shape, finer_area, {"wavelength": (0.7, 0.8, 0.9)})
+        ds1 = _create_coarest_finest_data_array(coarse_area.shape, coarse_area, {"wavelength": (0.1, 0.2, 0.3)})
+        ds2 = _create_coarest_finest_data_array(fine_area.shape, fine_area, {"wavelength": (0.4, 0.5, 0.6)})
+        ds3 = _create_coarest_finest_data_array(fine_area.shape, fine_area, {"wavelength": (0.7, 0.8, 0.9)})
         scn = Scene()
         scn["1"] = ds1
         scn["2"] = ds2
         scn["3"] = ds3
 
-        assert scn.coarsest_area() is coarser_area
-        assert scn.finest_area() is finer_area
-        assert scn.coarsest_area(['2', '3']) is finer_area
+        assert scn.coarsest_area() is coarse_area
+        assert scn.finest_area() is fine_area
+        assert scn.coarsest_area(['2', '3']) is fine_area
 
     @pytest.mark.parametrize(
         ("area_def", "shifted_area"),

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -695,6 +695,32 @@ class TestFinestCoarsestArea:
         assert self.scene.finest_area() is area_def2_flipped
         assert self.scene.coarsest_area(['2', '3']) is area_def2_flipped
 
+    def test_coarsest_finest_area_same_shape(self):
+        """Test that two areas with the same shape are consistently returned.
+
+        If two AreaDefinitions have the same resolution (shape) but different
+        geolocation, which one has the finest resolution is ultimately
+        determined by the semi-random ordering of the internal container of
+        the Scene (a dict). This test makes sure that it is always the same
+        object returned.
+
+        """
+        ds1 = self.ds1.copy()
+        ds2 = self.ds1.copy()
+        ds1.attrs["area"] = self.area_def1
+        ds2.attrs["area"] = self.area_def1.copy(area_extent=tuple(x + 100 for x in self.area_def1.area_extent))
+        scn = Scene()
+        scn["ds1"] = ds1
+        scn["ds2"] = ds2
+        course_area1 = scn.coarsest_area()
+
+        scn = Scene()
+        scn["ds2"] = ds2
+        scn["ds1"] = ds1
+        coarse_area2 = scn.coarsest_area()
+        # doesn't matter what order they were added, this should be the same area
+        assert coarse_area2 is course_area1
+
 
 class TestSceneAvailableDatasets:
     """Test the Scene's handling of various dependencies."""

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -678,6 +678,8 @@ class TestFinestCoarsestArea:
              _create_coarsest_finest_area_def((4, 10), (1000.0, 1500.0, -1000.0, -1500.0))),
             (_create_coarsest_finest_area_def((2, 5), (-1000.0, -1500.0, 1000.0, 1500.0)),
              _create_coarsest_finest_area_def((4, 10), (-1000.0, -1500.0, 1000.0, 1500.0))),
+            (_create_coarsest_finest_swath_def((2, 5), (1000.0, 1500.0, -1000.0, -1500.0), "1"),
+             _create_coarsest_finest_swath_def((4, 10), (1000.0, 1500.0, -1000.0, -1500.0), "1")),
         ]
     )
     def test_coarsest_finest_area_different_shape(self, coarse_area, fine_area):

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -662,32 +662,25 @@ def _create_coarsest_area_def(width=100, height=200, extents=(-1000.0, -1500.0, 
 class TestFinestCoarsestArea:
     """Test the Scene logic for finding the finest and coarsest area."""
 
-    def test_coarsest_finest_area_upright_area(self):
+    @pytest.mark.parametrize(
+        ("coarse_shape", "fine_shape", "coarse_extents", "fine_extents"),
+        [
+            ((2, 5), (4, 10), (1000.0, 1500.0, -1000.0, -1500.0), (1000.0, 1500.0, -1000.0, -1500.0)),
+            ((2, 5), (4, 10), (-1000.0, -1500.0, 1000.0, 1500.0), (-1000.0, -1500.0, 1000.0, 1500.0)),
+        ]
+    )
+    def test_coarsest_finest_area_upright_area(self, coarse_shape, fine_shape, coarse_extents, fine_extents):
         """Test 'coarsest_area' and 'finest_area' methods for upright areas."""
-        coarser_area = _create_coarsest_area_def()
-        finer_area = _create_coarsest_area_def(width=200, height=400)
-        ds1 = _create_coarest_finest_data_array((2, 5), coarser_area, {"wavelength": (0.1, 0.2, 0.3)})
-        ds2 = _create_coarest_finest_data_array((4, 10), finer_area, {"wavelength": (0.4, 0.5, 0.6)})
-        ds3 = _create_coarest_finest_data_array((4, 10), finer_area, {"wavelength": (0.7, 0.8, 0.9)})
+        coarser_area = _create_coarsest_area_def(width=coarse_shape[1], height=coarse_shape[0])
+        finer_area = _create_coarsest_area_def(width=fine_shape[1], height=fine_shape[0])
+        ds1 = _create_coarest_finest_data_array(coarse_shape, coarser_area, {"wavelength": (0.1, 0.2, 0.3)})
+        ds2 = _create_coarest_finest_data_array(fine_shape, finer_area, {"wavelength": (0.4, 0.5, 0.6)})
+        ds3 = _create_coarest_finest_data_array(fine_shape, finer_area, {"wavelength": (0.7, 0.8, 0.9)})
         scn = Scene()
         scn["1"] = ds1
         scn["2"] = ds2
         scn["3"] = ds3
-        assert scn.coarsest_area() is coarser_area
-        assert scn.finest_area() is finer_area
-        assert scn.coarsest_area(['2', '3']) is finer_area
 
-    def test_coarsest_finest_area_flipped_area(self):
-        """Test 'coarsest_area' and 'finest_area' methods for flipped areas with negative pixel sizes."""
-        coarser_area = _create_coarsest_area_def(extents=(1000.0, 1500.0, -1000.0, -1500.0))
-        finer_area = _create_coarsest_area_def(width=200, height=400, extents=(1000.0, 1500.0, -1000.0, -1500.0))
-        ds1 = _create_coarest_finest_data_array((2, 5), coarser_area, {"wavelength": (0.1, 0.2, 0.3)})
-        ds2 = _create_coarest_finest_data_array((4, 10), finer_area, {"wavelength": (0.4, 0.5, 0.6)})
-        ds3 = _create_coarest_finest_data_array((4, 10), finer_area, {"wavelength": (0.7, 0.8, 0.9)})
-        scn = Scene()
-        scn["1"] = ds1
-        scn["2"] = ds2
-        scn["3"] = ds3
         assert scn.coarsest_area() is coarser_area
         assert scn.finest_area() is finer_area
         assert scn.coarsest_area(['2', '3']) is finer_area

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -721,6 +721,45 @@ class TestFinestCoarsestArea:
         # doesn't matter what order they were added, this should be the same area
         assert coarse_area2 is course_area1
 
+    def test_coarsest_finest_swath_same_shape(self):
+        """Test that two swaths with the same shape are consistently returned.
+
+        If two SwathDefinitions have the same resolution (shape) but different
+        geolocation, which one has the finest resolution is ultimately
+        determined by the semi-random ordering of the internal container of
+        the Scene (a dict). This test makes sure that it is always the same
+        object returned.
+
+        """
+        from pyresample import SwathDefinition
+        ds1 = self.ds1.copy()
+        ds2 = self.ds1.copy()
+        lons_arr = da.zeros(ds1.shape, dtype=np.float32)
+        lons_data_arr = xr.DataArray(lons_arr, attrs={"name": "longitude1"})
+        lats_arr = da.zeros(ds1.shape, dtype=np.float32)
+        lats_data_arr = xr.DataArray(lats_arr, attrs={"name": "latitude1"})
+        swath_def1 = SwathDefinition(lons_data_arr, lats_data_arr)
+
+        lons_arr = da.ones(ds1.shape, dtype=np.float32)
+        lons_data_arr = xr.DataArray(lons_arr, attrs={"name": "longitude2"})
+        lats_arr = da.ones(ds1.shape, dtype=np.float32)
+        lats_data_arr = xr.DataArray(lats_arr, attrs={"name": "latitude2"})
+        swath_def2 = SwathDefinition(lons_data_arr, lats_data_arr)
+
+        ds1.attrs["area"] = swath_def1
+        ds2.attrs["area"] = swath_def2
+        scn = Scene()
+        scn["ds1"] = ds1
+        scn["ds2"] = ds2
+        course_area1 = scn.coarsest_area()
+
+        scn = Scene()
+        scn["ds2"] = ds2
+        scn["ds1"] = ds1
+        coarse_area2 = scn.coarsest_area()
+        # doesn't matter what order they were added, this should be the same area
+        assert coarse_area2 is course_area1
+
 
 class TestSceneAvailableDatasets:
     """Test the Scene's handling of various dependencies."""

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -671,8 +671,8 @@ class TestFinestCoarsestArea:
     )
     def test_coarsest_finest_area_upright_area(self, coarse_shape, fine_shape, coarse_extents, fine_extents):
         """Test 'coarsest_area' and 'finest_area' methods for upright areas."""
-        coarser_area = _create_coarsest_area_def(width=coarse_shape[1], height=coarse_shape[0])
-        finer_area = _create_coarsest_area_def(width=fine_shape[1], height=fine_shape[0])
+        coarser_area = _create_coarsest_area_def(width=coarse_shape[1], height=coarse_shape[0], extents=coarse_extents)
+        finer_area = _create_coarsest_area_def(width=fine_shape[1], height=fine_shape[0], extents=fine_extents)
         ds1 = _create_coarest_finest_data_array(coarse_shape, coarser_area, {"wavelength": (0.1, 0.2, 0.3)})
         ds2 = _create_coarest_finest_data_array(fine_shape, finer_area, {"wavelength": (0.4, 0.5, 0.6)})
         ds3 = _create_coarest_finest_data_array(fine_shape, finer_area, {"wavelength": (0.7, 0.8, 0.9)})


### PR DESCRIPTION
In rare cases some readers return multiple AreaDefinitions or SwathDefinitions of the same resolution, but with different coordinates. The case I ran into is the AMSR2 sensor with its A and B views. They have the same resolution (shape), but are slightly shifted from one another. Having Scene.coarsest_area and Scene.finest_area return either one of these is fine, but you run into issues if they are not consistent. In my case I was using the result to freeze a `DynamicAreaDefinition` and then compare my final geotiffs against expected results. Currently the Scene's choice between the A and B geometries is based on the order that the DataArrays is sorted which is essentially random. My tests would sometimes match and sometimes not match depending on what order was ultimately used.

This PR fixes this to include other properties of the geometry objects to decide which one should be returned. It isn't perfect, especially when it comes to SwathDefinitions, but it is a start.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
