### PR TITLE
Fix MultiScene.group in case of differing identifier properties

### DIFF
--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -69,29 +69,59 @@ def timeseries(datasets):
     return res
 
 
-def add_group_aliases(scenes, groups):
-    """Add aliases for the groups datasets belong to."""
+def add_group_aliases_to_scenes(scenes, groups):
+    """Add group aliases to multiple scenes."""
     for scene in scenes:
-        scene = scene.copy()
-        for group_id, member_names in groups.items():
-            # Find out whether one of the datasets in this scene belongs
-            # to this group
-            member_ids = [scene[name].attrs['_satpy_id']
-                          for name in member_names if name in scene]
+        yield _duplicate_datasets_to_be_grouped(scene, groups)
 
-            # Add an alias for the group it belongs to
-            if len(member_ids) == 1:
-                member_id = member_ids[0]
-                new_ds = scene[member_id].copy()
-                new_ds.attrs.update(group_id.to_dict())
-                scene[group_id] = new_ds
-            elif len(member_ids) > 1:
-                raise ValueError('Cannot add multiple datasets from the same '
-                                 'scene to a group')
-            else:
-                # Datasets in this scene don't belong to any group
-                pass
-        yield scene
+
+def _duplicate_datasets_to_be_grouped(scene, groups):
+    scene = scene.copy()
+    for group_id, group_members in groups.items():
+        _duplicate_dataset_to_be_grouped(group_id, group_members, scene)
+    return scene
+
+
+def _duplicate_dataset_to_be_grouped(group_id, group_members, scene):
+    member_ids = _get_dataset_id_of_group_members_in_scene(group_members, scene)
+    if len(member_ids) == 1:
+        _duplicate_dataset_with_different_id(
+            dataset_id=member_ids[0],
+            alias_id=group_id,
+            scene=scene
+        )
+    elif len(member_ids) > 1:
+        raise ValueError('Cannot add multiple datasets from a scene '
+                         'to the same group')
+
+
+def _get_dataset_id_of_group_members_in_scene(group_members, scene):
+    return [
+        scene[member].attrs['_satpy_id']
+        for member in group_members if member in scene
+    ]
+
+
+def _duplicate_dataset_with_different_id(dataset_id, alias_id, scene):
+    dataset = scene[dataset_id].copy()
+    _prepare_dataset_for_being_duplicated(dataset, alias_id)
+    scene[alias_id] = dataset
+
+
+def _prepare_dataset_for_being_duplicated(dataset, alias_id):
+    # Drop all identifier attributes from the original dataset. Otherwise
+    # they might invalidate the dataset ID of the alias.
+    _drop_id_attrs(dataset)
+    dataset.attrs.update(alias_id.to_dict())
+
+
+def _drop_id_attrs(dataset):
+    for drop_key in _get_id_attrs(dataset):
+        dataset.attrs.pop(drop_key)
+
+
+def _get_id_attrs(dataset):
+    return dataset.attrs["_satpy_id"].to_dict().keys()
 
 
 class _SceneGenerator(object):
@@ -338,7 +368,7 @@ class MultiScene(object):
                 DataQuery('my_group', wavelength=(10, 11, 12)): ['IR_108', 'B13', 'C13']
             }
         """
-        self._scenes = add_group_aliases(self._scenes, groups)
+        self._scenes = add_group_aliases_to_scenes(self._scenes, groups)
 
     def _distribute_save_datasets(self, scenes_iter, client, batch_size=1, **kwargs):
         """Distribute save_datasets across a cluster."""

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -211,6 +211,10 @@ class TestMultiScene(unittest.TestCase):
                     time_threshold=30)
             assert len(mscn.scenes) == 12
 
+
+class TestMultiSceneGrouping:
+    """Test dataset grouping in MultiScene."""
+
     def test_group(self):
         """Test group."""
         from satpy import DataQuery, MultiScene, Scene
@@ -231,7 +235,7 @@ class TestMultiScene(unittest.TestCase):
                   DataQuery(name='even'): ['ds2', 'ds4']}
         multi_scene.group(groups)
         shared_ids_exp = {make_dataid(name="odd"), make_dataid(name="even")}
-        self.assertSetEqual(multi_scene.shared_dataset_ids, shared_ids_exp)
+        assert multi_scene.shared_dataset_ids == shared_ids_exp
 
     def test_add_group_aliases(self):
         """Test adding group aliases."""
@@ -265,11 +269,11 @@ class TestMultiScene(unittest.TestCase):
 
         # Test adding aliases
         with_aliases = add_group_aliases(iter(scenes), groups)
-        self.assertIsInstance(with_aliases, types.GeneratorType)
+        assert isinstance(with_aliases, types.GeneratorType)
         with_aliases = list(with_aliases)
-        self.assertSetEqual(set(with_aliases[0].keys()), {make_dataid(**g1.to_dict()), ds_id1})
-        self.assertSetEqual(set(with_aliases[1].keys()), {make_dataid(**g2.to_dict()), ds_id2})
-        self.assertSetEqual(set(with_aliases[2].keys()), {make_dataid(**g1.to_dict()), ds_id3, ds_id31})
+        assert set(with_aliases[0].keys()) == {make_dataid(**g1.to_dict()), ds_id1}
+        assert set(with_aliases[1].keys()) == {make_dataid(**g2.to_dict()), ds_id2}
+        assert set(with_aliases[2].keys()) == {make_dataid(**g1.to_dict()), ds_id3, ds_id31}
 
         np.testing.assert_array_equal(with_aliases[0]['g1'].values, [1])
         np.testing.assert_array_equal(with_aliases[0]['ds1'].values, [1])
@@ -280,11 +284,12 @@ class TestMultiScene(unittest.TestCase):
         np.testing.assert_array_equal(with_aliases[2]['ds31'].values, [4])
 
         # Make sure that modifying the result doesn't modify the original
-        self.assertNotIn(g1, scene1)
+        assert g1 not in scene1
 
         # Adding an alias for multiple datasets in one scene should fail
         gen = add_group_aliases([scene3], {g1: ['ds3', 'ds31']})
-        self.assertRaises(ValueError, list, gen)
+        with pytest.raises(ValueError):
+            list(gen)
 
 
 class TestMultiSceneSave(unittest.TestCase):

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -273,29 +273,13 @@ class TestMultiSceneGrouping:
             DataQuery(name='even'): ['ds2', 'ds4']
         }
 
-    @pytest.fixture
-    def grouped_multi_scene(self, multi_scene, groups):
-        """Group the MultiScene."""
+    def test_multi_scene_grouping(self, multi_scene, groups, scene1):
+        """Test grouping a MultiScene."""
         multi_scene.group(groups)
-        return multi_scene
-
-    @pytest.fixture
-    def shared_ids_exp(self):
-        """Get expected shared dataset IDs of the grouped MultiScene."""
-        return {make_dataid(name="odd"), make_dataid(name="even")}
-
-    def test_shared_dataset_ids_of_grouped_multi_scene(self, grouped_multi_scene, shared_ids_exp):
-        """Test shared dataset IDs of the grouped MultiScene."""
-        assert grouped_multi_scene.shared_dataset_ids == shared_ids_exp
-
-    def test_group_alias_equals_original_dataset(self, grouped_multi_scene, scene1):
-        """Test that the group alias equals the original dataset."""
-        scene1_grp = grouped_multi_scene.scenes[0]
-        xr.testing.assert_allclose(scene1_grp["ds1"], scene1["ds1"])
-
-    def test_grouping_does_not_modify_orignal_dataset(self, grouped_multi_scene, scene1):
-        """Test that grouping does not modify the original dataset."""
+        shared_ids_exp = {make_dataid(name="odd"), make_dataid(name="even")}
+        assert multi_scene.shared_dataset_ids == shared_ids_exp
         assert DataQuery(name='odd') not in scene1
+        xr.testing.assert_allclose(multi_scene.scenes[0]["ds1"], scene1["ds1"])
 
     def test_fails_to_add_multiple_datasets_from_the_same_scene_to_a_group(self, multi_scene):
         """Test that multiple datasets from the same scene in one group fails."""

--- a/satpy/tests/test_multiscene.py
+++ b/satpy/tests/test_multiscene.py
@@ -25,7 +25,9 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
+import xarray as xr
 
+from satpy import DataQuery
 from satpy.dataset.dataid import DataID, ModifierTuple, WavelengthRange
 
 DEFAULT_SHAPE = (5, 10)
@@ -215,81 +217,92 @@ class TestMultiScene(unittest.TestCase):
 class TestMultiSceneGrouping:
     """Test dataset grouping in MultiScene."""
 
-    def test_group(self):
-        """Test group."""
-        from satpy import DataQuery, MultiScene, Scene
+    @pytest.fixture
+    def scene1(self):
+        """Create first test scene."""
+        from satpy import Scene
+        scene = Scene()
+        dsid1 = make_dataid(
+            name="ds1",
+            resolution=123,
+            wavelength=(1, 2, 3),
+            polarization="H"
+        )
+        scene[dsid1] = _create_test_dataset(name='ds1')
+        dsid2 = make_dataid(
+            name="ds2",
+            resolution=456,
+            wavelength=(4, 5, 6),
+            polarization="V"
+        )
+        scene[dsid2] = _create_test_dataset(name='ds2')
+        return scene
 
-        ds1 = _create_test_dataset(name='ds1')
-        ds2 = _create_test_dataset(name='ds2')
-        ds3 = _create_test_dataset(name='ds3')
-        ds4 = _create_test_dataset(name='ds4')
-        scene1 = Scene()
-        scene1['ds1'] = ds1
-        scene1['ds2'] = ds2
-        scene2 = Scene()
-        scene2['ds3'] = ds3
-        scene2['ds4'] = ds4
+    @pytest.fixture
+    def scene2(self):
+        """Create second test scene."""
+        from satpy import Scene
+        scene = Scene()
+        dsid1 = make_dataid(
+            name="ds3",
+            resolution=123.1,
+            wavelength=(1.1, 2.1, 3.1),
+            polarization="H"
+        )
+        scene[dsid1] = _create_test_dataset(name='ds3')
+        dsid2 = make_dataid(
+            name="ds4",
+            resolution=456.1,
+            wavelength=(4.1, 5.1, 6.1),
+            polarization="V"
+        )
+        scene[dsid2] = _create_test_dataset(name='ds4')
+        return scene
 
-        multi_scene = MultiScene([scene1, scene2])
-        groups = {DataQuery(name='odd'): ['ds1', 'ds3'],
-                  DataQuery(name='even'): ['ds2', 'ds4']}
+    @pytest.fixture
+    def multi_scene(self, scene1, scene2):
+        """Create small multi scene for testing."""
+        from satpy import MultiScene
+        return MultiScene([scene1, scene2])
+
+    @pytest.fixture
+    def groups(self):
+        """Get group definitions for the MultiScene."""
+        return {
+            DataQuery(name='odd'): ['ds1', 'ds3'],
+            DataQuery(name='even'): ['ds2', 'ds4']
+        }
+
+    @pytest.fixture
+    def grouped_multi_scene(self, multi_scene, groups):
+        """Group the MultiScene."""
         multi_scene.group(groups)
-        shared_ids_exp = {make_dataid(name="odd"), make_dataid(name="even")}
-        assert multi_scene.shared_dataset_ids == shared_ids_exp
+        return multi_scene
 
-    def test_add_group_aliases(self):
-        """Test adding group aliases."""
-        import types
+    @pytest.fixture
+    def shared_ids_exp(self):
+        """Get expected shared dataset IDs of the grouped MultiScene."""
+        return {make_dataid(name="odd"), make_dataid(name="even")}
 
-        import numpy as np
-        import xarray as xr
+    def test_shared_dataset_ids_of_grouped_multi_scene(self, grouped_multi_scene, shared_ids_exp):
+        """Test shared dataset IDs of the grouped MultiScene."""
+        assert grouped_multi_scene.shared_dataset_ids == shared_ids_exp
 
-        from satpy import DataQuery, Scene
-        from satpy.multiscene import add_group_aliases
+    def test_group_alias_equals_original_dataset(self, grouped_multi_scene, scene1):
+        """Test that the group alias equals the original dataset."""
+        scene1_grp = grouped_multi_scene.scenes[0]
+        xr.testing.assert_allclose(scene1_grp["ds1"], scene1["ds1"])
 
-        # Define test scenes
-        ds_id1 = make_dataid(name='ds1', wavelength=(10.7, 10.8, 10.9))
-        ds_id2 = make_dataid(name='ds2', wavelength=(1.9, 2.0, 2.1))
-        ds_id3 = make_dataid(name='ds3', wavelength=(10.8, 10.9, 11.0))
-        ds_id31 = make_dataid(name='ds31', polarization='H')
+    def test_grouping_does_not_modify_orignal_dataset(self, grouped_multi_scene, scene1):
+        """Test that grouping does not modify the original dataset."""
+        assert DataQuery(name='odd') not in scene1
 
-        scene1 = Scene()
-        scene1[ds_id1] = xr.DataArray([1])
-        scene2 = Scene()
-        scene2[ds_id2] = xr.DataArray([2])
-        scene3 = Scene()
-        scene3[ds_id3] = xr.DataArray([3])
-        scene3[ds_id31] = xr.DataArray([4])
-        scenes = [scene1, scene2, scene3]
-
-        # Define groups
-        g1 = DataQuery(name='g1', wavelength=(10, 11, 12))
-        g2 = DataQuery(name='g2', wavelength=(1, 2, 3), polarization='V')
-        groups = {g1: ['ds1', 'ds3'], g2: ['ds2']}
-
-        # Test adding aliases
-        with_aliases = add_group_aliases(iter(scenes), groups)
-        assert isinstance(with_aliases, types.GeneratorType)
-        with_aliases = list(with_aliases)
-        assert set(with_aliases[0].keys()) == {make_dataid(**g1.to_dict()), ds_id1}
-        assert set(with_aliases[1].keys()) == {make_dataid(**g2.to_dict()), ds_id2}
-        assert set(with_aliases[2].keys()) == {make_dataid(**g1.to_dict()), ds_id3, ds_id31}
-
-        np.testing.assert_array_equal(with_aliases[0]['g1'].values, [1])
-        np.testing.assert_array_equal(with_aliases[0]['ds1'].values, [1])
-        np.testing.assert_array_equal(with_aliases[1]['g2'].values, [2])
-        np.testing.assert_array_equal(with_aliases[1]['ds2'].values, [2])
-        np.testing.assert_array_equal(with_aliases[2]['g1'].values, [3])
-        np.testing.assert_array_equal(with_aliases[2]['ds3'].values, [3])
-        np.testing.assert_array_equal(with_aliases[2]['ds31'].values, [4])
-
-        # Make sure that modifying the result doesn't modify the original
-        assert g1 not in scene1
-
-        # Adding an alias for multiple datasets in one scene should fail
-        gen = add_group_aliases([scene3], {g1: ['ds3', 'ds31']})
+    def test_fails_to_add_multiple_datasets_from_the_same_scene_to_a_group(self, multi_scene):
+        """Test that multiple datasets from the same scene in one group fails."""
+        groups = {DataQuery(name='mygroup'): ['ds1', 'ds2']}
+        multi_scene.group(groups)
         with pytest.raises(ValueError):
-            list(gen)
+            next(multi_scene.scenes)
 
 
 class TestMultiSceneSave(unittest.TestCase):


### PR DESCRIPTION
Fix #2089 by dropping identifier attributes before adding the group alias.

 - [X] Tests added <!-- for all bug fixes or enhancements -->

