### PR TITLE
Fix handling of non-existent reflectance bands in 'viirs_l1b' reader

### DIFF
--- a/satpy/readers/viirs_l1b.py
+++ b/satpy/readers/viirs_l1b.py
@@ -175,7 +175,7 @@ class VIIRSL1BFileHandler(NetCDF4FileHandler):
         file_units = self._get_dataset_file_units(dataset_id, ds_info, var_path)
 
         # Get extra metadata
-        if '/dimension/number_of_scans' in self:
+        if '/dimension/number_of_scans' in self and isinstance(shape, tuple) and shape:
             rows_per_scan = int(shape[0] / self['/dimension/number_of_scans'])
             ds_info.setdefault('rows_per_scan', rows_per_scan)
 

--- a/satpy/tests/reader_tests/test_viirs_l1b.py
+++ b/satpy/tests/reader_tests/test_viirs_l1b.py
@@ -44,18 +44,6 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         """Mimic reader input file content."""
         dt = filename_info.get('start_time', datetime(2016, 1, 1, 12, 0, 0))
         file_type = filename[:5].lower()
-        # num_lines = {
-        #     'vl1bi': 3248 * 2,
-        #     'vl1bm': 3248,
-        #     'vl1bd': 3248,
-        # }[file_type]
-        # num_pixels = {
-        #     'vl1bi': 6400,
-        #     'vl1bm': 3200,
-        #     'vl1bd': 4064,
-        # }[file_type]
-        # num_scans = 203
-        # num_luts = 65536
         num_lines = DEFAULT_FILE_SHAPE[0]
         num_pixels = DEFAULT_FILE_SHAPE[1]
         num_scans = 5
@@ -72,9 +60,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
             '/attr/platform': 'Suomi-NPP',
         }
         self._fill_contents_with_default_data(file_content, file_type)
-
         self._set_dataset_specific_metadata(file_content)
-
         convert_file_content_to_data_array(file_content)
         return file_content
 

--- a/satpy/tests/reader_tests/test_viirs_l1b.py
+++ b/satpy/tests/reader_tests/test_viirs_l1b.py
@@ -171,6 +171,20 @@ class TestVIIRSL1BReaderDay:
         # make sure we have some files
         assert r.file_handlers
 
+    def test_available_datasets_m_bands(self):
+        """Test available datasets for M band files."""
+        from satpy.readers import load_reader
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'VL1BM_snpp_d20161130_t012400_c20161130054822.nc',
+            'VGEOM_snpp_d20161130_t012400_c20161130054822.nc',
+        ])
+        r.create_filehandlers(loadables)
+        avail_names = r.available_dataset_names
+        angles = {"satellite_azimuth_angle", "satellite_zenith_angle", "solar_azimuth_angle", "solar_zenith_angle"}
+        geo = {"m_lon", "m_lat"}
+        assert set(avail_names) == set(self.fake_cls.M_BANDS) | angles | geo
+
     def test_load_every_m_band_bt(self):
         """Test loading all M band brightness temperatures."""
         from satpy.readers import load_reader


### PR DESCRIPTION
The VIIRS L1b format was changed a couple years ago to save space by only including reflectance band when there is day data in the scene. The variables in these cases do not exist in the files. This resulted in two problems:

1. Trying to load a reflectance band would produce an unexpected error related to trying to treat an integer shape (default return value to handle scalar variables) as a tuple.
2. Listing the reflectance bands as available in `Scene.available_dataset_ids/names`.

This PR fixes both those cases.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

