### PR TITLE
Drop nwcsaf y coord

### DIFF
--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -148,7 +148,11 @@ class NcNWCSAF(BaseFileHandler):
         variable = self.nc[file_key]
         variable = self.remove_timedim(variable)
         variable = self.scale_dataset(variable, info)
-
+        try:
+            variable = variable.drop_vars('y')
+            variable = variable.drop_vars('x')
+        except ValueError:
+            pass
         return variable
 
     def _get_varname_in_file(self, info, info_type="file_key"):
@@ -279,6 +283,8 @@ class NcNWCSAF(BaseFileHandler):
         lons, lats = satint.interpolate()
         lon = xr.DataArray(lons, attrs=lon_reduced.attrs, dims=['y', 'x'])
         lat = xr.DataArray(lats, attrs=lat_reduced.attrs, dims=['y', 'x'])
+        lat = lat.drop_vars('y', 'x')        
+        lon = lon.drop_vars('y', 'x')
         return lon, lat
 
     def get_area_def(self, dsid):

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -126,8 +126,16 @@ class NcNWCSAF(BaseFileHandler):
             data = var[0, :, :]
             data.attrs = var.attrs
             var = data
-
         return var
+
+    def drop_xycoords(self, variable):
+        """Drop x, y coords when y is scan line number."""
+        try:
+            if variable.coords['y'].attrs['long_name'] == "scan line number":
+                return variable.drop_vars(['y', 'x'])
+        except KeyError:
+            pass
+        return variable
 
     def get_dataset(self, dsid, info):
         """Load a dataset."""
@@ -148,10 +156,7 @@ class NcNWCSAF(BaseFileHandler):
         variable = self.nc[file_key]
         variable = self.remove_timedim(variable)
         variable = self.scale_dataset(variable, info)
-        try:
-            variable = variable.drop_vars('y', 'x')
-        except ValueError:
-            pass
+        variable = self.drop_xycoords(variable)
         return variable
 
     def _get_varname_in_file(self, info, info_type="file_key"):
@@ -282,8 +287,8 @@ class NcNWCSAF(BaseFileHandler):
         lons, lats = satint.interpolate()
         lon = xr.DataArray(lons, attrs=lon_reduced.attrs, dims=['y', 'x'])
         lat = xr.DataArray(lats, attrs=lat_reduced.attrs, dims=['y', 'x'])
-        lat = lat.drop_vars('y', 'x')
-        lon = lon.drop_vars('y', 'x')
+        lat = self.drop_xycoords(lat)
+        lon = self.drop_xycoords(lon)
         return lon, lat
 
     def get_area_def(self, dsid):

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -149,8 +149,7 @@ class NcNWCSAF(BaseFileHandler):
         variable = self.remove_timedim(variable)
         variable = self.scale_dataset(variable, info)
         try:
-            variable = variable.drop_vars('y')
-            variable = variable.drop_vars('x')
+            variable = variable.drop_vars('y', 'x')
         except ValueError:
             pass
         return variable
@@ -283,7 +282,7 @@ class NcNWCSAF(BaseFileHandler):
         lons, lats = satint.interpolate()
         lon = xr.DataArray(lons, attrs=lon_reduced.attrs, dims=['y', 'x'])
         lat = xr.DataArray(lats, attrs=lat_reduced.attrs, dims=['y', 'x'])
-        lat = lat.drop_vars('y', 'x')        
+        lat = lat.drop_vars('y', 'x')
         lon = lon.drop_vars('y', 'x')
         return lon, lat
 

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -93,6 +93,28 @@ class TestNcNWCSAF(unittest.TestCase):
         self.fh.nc.attrs = PROJ
         _check_area_def(self.fh.get_area_def(dsid))
 
+    def test_drop_xycoords(self):
+        """Test the drop of x and y coords."""
+        y_line = xr.DataArray(list(range(5)), dims=('y'), attrs={"long_name": "scan line number"})
+        x_pixel = xr.DataArray(list(range(10)), dims=('x'), attrs={"long_name": "pixel number"})
+        lat = xr.DataArray(np.ones((5, 10)),
+                           dims=('y', 'x'),
+                           coords={'y': y_line, 'x': x_pixel},
+                           attrs={'name': 'lat',
+                                  'standard_name': 'latitude'})
+        lon = xr.DataArray(np.ones((5, 10)),
+                           dims=('y', 'x'),
+                           coords={'y': y_line, 'x': x_pixel},
+                           attrs={'name': 'lon',
+                                  'standard_name': 'longitude'})
+        data_array_in = xr.DataArray(np.ones((5, 10)),
+                                     attrs={"scale_factor": np.array(0, dtype=float),
+                                            "add_offset": np.array(1, dtype=float)},
+                                     dims=('y', 'x'),
+                                     coords={'lon': lon, 'lat': lat, 'y': y_line, 'x': x_pixel})
+        data_array_out = self.fh.drop_xycoords(data_array_in)
+        self.assertNotIn('y', data_array_out.coords)
+
     def test_scale_dataset_attr_removal(self):
         """Test the scaling of the dataset and removal of obsolete attributes."""
         import numpy as np


### PR DESCRIPTION
Drop y and x coords to solve issue #2095. This is because the y-dimension from the NWCSAF has coordinates scan line number and they are counted relative to the actual granule from 0 to 767. When these are concatenated the coordinates will be repeated and this causes the BackgroundCompositor to crash.

 - [x] Closes #2095 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->


