### PR TITLE
Update SEVIRI ICARE reader to properly use dask.

### DIFF
--- a/satpy/readers/seviri_l1b_icare.py
+++ b/satpy/readers/seviri_l1b_icare.py
@@ -254,13 +254,13 @@ class SEVIRI_ICARE(HDF4FileHandler):
         offset = data.attrs.get('add_offset')
         scale_factor = data.attrs.get('scale_factor')
         data = data.where(data != fill)
-        data.values = data.values.astype(np.float32)
+        data.data = data.data.astype(np.float32)
         if scale_factor is not None and offset is not None:
-            data.values *= scale_factor
-            data.values += offset
+            data *= scale_factor
+            data += offset
             # Now we correct range from 0-1 to 0-100 for VIS:
             if ds_id['name'] in self.ref_bands:
-                data.values *= 100.
+                data *= 100.
         return data
 
     def get_area_def(self, ds_id):

--- a/satpy/readers/seviri_l1b_icare.py
+++ b/satpy/readers/seviri_l1b_icare.py
@@ -254,7 +254,7 @@ class SEVIRI_ICARE(HDF4FileHandler):
         offset = data.attrs.get('add_offset')
         scale_factor = data.attrs.get('scale_factor')
         data = data.where(data != fill)
-        data.data = data.data.astype(np.float32)
+        data = data.astype(np.float32)
         if scale_factor is not None and offset is not None:
             data = data * scale_factor
             data = data + offset

--- a/satpy/readers/seviri_l1b_icare.py
+++ b/satpy/readers/seviri_l1b_icare.py
@@ -256,11 +256,11 @@ class SEVIRI_ICARE(HDF4FileHandler):
         data = data.where(data != fill)
         data.data = data.data.astype(np.float32)
         if scale_factor is not None and offset is not None:
-            data *= scale_factor
-            data += offset
+            data = data * scale_factor
+            data = data + offset
             # Now we correct range from 0-1 to 0-100 for VIS:
             if ds_id['name'] in self.ref_bands:
-                data *= 100.
+                data = data * 100.
         return data
 
     def get_area_def(self, ds_id):

--- a/satpy/tests/reader_tests/test_seviri_l1b_icare.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_icare.py
@@ -206,3 +206,15 @@ class TestSEVIRIICAREReader(unittest.TestCase):
             self.p.target(mock.MagicMock(),
                           mock.MagicMock(),
                           mock.MagicMock())._get_dsname({'name': 'badband'})
+
+    def test_nocompute(self):
+        """Test that dask does not compute anything in the reader itself."""
+        from satpy.tests.utils import CustomScheduler
+        import dask
+        with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
+            r = load_reader(self.reader_configs)
+            loadables = r.select_files_from_pathnames([
+                'GEO_L1B-MSG1_2004-12-29T12-15-00_G_VIS08_V1-04.hdf'
+            ])
+            r.create_filehandlers(loadables)
+            r.load(['VIS008'])

--- a/satpy/tests/reader_tests/test_seviri_l1b_icare.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_icare.py
@@ -145,8 +145,6 @@ class TestSEVIRIICAREReader(unittest.TestCase):
         r.create_filehandlers(loadables)
         datasets = r.load(['IR_108'])
         self.assertEqual(len(datasets), 1)
-        print("")
-        print(type(datasets['IR_108'].data))
         for v in datasets.values():
             self.assertEqual(v.attrs['calibration'], 'brightness_temperature')
 

--- a/satpy/tests/reader_tests/test_seviri_l1b_icare.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_icare.py
@@ -20,6 +20,7 @@ import os
 import unittest
 from unittest import mock
 
+import dask.array as da
 import numpy as np
 
 from satpy.readers import load_reader
@@ -64,7 +65,7 @@ class FakeHDF4FileHandler2(FakeHDF4FileHandler):
         file_content['Brightness_Temperature/attr/add_offset'] = 0.
         file_content['Brightness_Temperature/shape'] = DEFAULT_FILE_SHAPE
 
-        # convert tp xarrays
+        # convert to xarrays
         from xarray import DataArray
         for key, val in file_content.items():
             if isinstance(val, np.ndarray):
@@ -72,10 +73,7 @@ class FakeHDF4FileHandler2(FakeHDF4FileHandler):
                 for a in ['_FillValue', 'scale_factor', 'add_offset']:
                     if key + '/attr/' + a in file_content:
                         attrs[a] = file_content[key + '/attr/' + a]
-                file_content[key] = DataArray(val, dims=('fakeDim0', 'fakeDim1'), attrs=attrs)
-        if 'y' not in file_content['Normalized_Radiance'].dims:
-            file_content['Normalized_Radiance'] = file_content['Normalized_Radiance'].rename({'fakeDim0': 'x',
-                                                                                              'fakeDim1': 'y'})
+                file_content[key] = DataArray(da.from_array(val), dims=('x', 'y'), attrs=attrs)
         return file_content
 
 
@@ -147,6 +145,8 @@ class TestSEVIRIICAREReader(unittest.TestCase):
         r.create_filehandlers(loadables)
         datasets = r.load(['IR_108'])
         self.assertEqual(len(datasets), 1)
+        print("")
+        print(type(datasets['IR_108'].data))
         for v in datasets.values():
             self.assertEqual(v.attrs['calibration'], 'brightness_temperature')
 
@@ -184,7 +184,6 @@ class TestSEVIRIICAREReader(unittest.TestCase):
                        'Meteosat-11': 'MSG4/SEVIRI'}
         with mock.patch('satpy.tests.reader_tests.test_seviri_l1b_icare.'
                         'FakeHDF4FileHandler2.get_test_content') as patched_func:
-
             def _run_target():
                 patched_func.return_value = file_data
                 return self.p.target(mock.MagicMock(),

--- a/satpy/tests/reader_tests/test_seviri_l1b_icare.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_icare.py
@@ -206,8 +206,9 @@ class TestSEVIRIICAREReader(unittest.TestCase):
 
     def test_nocompute(self):
         """Test that dask does not compute anything in the reader itself."""
-        from satpy.tests.utils import CustomScheduler
         import dask
+
+        from satpy.tests.utils import CustomScheduler
         with dask.config.set(scheduler=CustomScheduler(max_computes=0)):
             r = load_reader(self.reader_configs)
             loadables = r.select_files_from_pathnames([


### PR DESCRIPTION
The iCARE/SEVIRI reader was not daskified, data was being stored as numpy arrays. This raised an error when trying to create a natural_color image as the Rayleigh correction code was expecting dask arrays.

This PR updates the reader so that the data is stored as a dask array.