### PR TITLE
Enable solar zenith angle caching for the DayNightCompositor

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -638,7 +638,7 @@ class DayNightCompositor(GenericCompositor):
                 chunks = foreground_data.sel(bands=foreground_data['bands'][0]).chunks
             except KeyError:
                 chunks = foreground_data.chunks
-            coszen = get_cos_sza(foreground_data, chunks=chunks)
+            coszen = get_cos_sza(foreground_data)
         # Calculate blending weights
         coszen -= np.min((lim_high, lim_low))
         coszen /= np.abs(lim_low - lim_high)

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -631,18 +631,14 @@ class DayNightCompositor(GenericCompositor):
         try:
             coszen = np.cos(np.deg2rad(projectables[2 if self.day_night == "day_night" else 1]))
         except IndexError:
-            from pyorbital.astronomy import cos_zen
+            from satpy.modifiers.angles import get_cos_sza
             LOG.debug("Computing sun zenith angles.")
             # Get chunking that matches the data
             try:
                 chunks = foreground_data.sel(bands=foreground_data['bands'][0]).chunks
             except KeyError:
                 chunks = foreground_data.chunks
-            lons, lats = foreground_data.attrs["area"].get_lonlats(chunks=chunks)
-            coszen = xr.DataArray(cos_zen(foreground_data.attrs["start_time"],
-                                          lons, lats),
-                                  dims=['y', 'x'],
-                                  coords=[foreground_data['y'], foreground_data['x']])
+            coszen = get_cos_sza(foreground_data, chunks=chunks)
         # Calculate blending weights
         coszen -= np.min((lim_high, lim_low))
         coszen /= np.abs(lim_low - lim_high)

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -634,10 +634,6 @@ class DayNightCompositor(GenericCompositor):
             from satpy.modifiers.angles import get_cos_sza
             LOG.debug("Computing sun zenith angles.")
             # Get chunking that matches the data
-            try:
-                chunks = foreground_data.sel(bands=foreground_data['bands'][0]).chunks
-            except KeyError:
-                chunks = foreground_data.chunks
             coszen = get_cos_sza(foreground_data)
         # Calculate blending weights
         coszen -= np.min((lim_high, lim_low))

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -372,10 +372,17 @@ def get_cos_sza(data_arr: xr.DataArray) -> xr.DataArray:
 
 
 def _geo_chunks_from_data_arr(data_arr: xr.DataArray) -> tuple:
-    x_dim_index = data_arr.dims.index("x")
-    y_dim_index = data_arr.dims.index("y")
+    x_dim_index = _dim_index_with_default(data_arr.dims, "x", -1)
+    y_dim_index = _dim_index_with_default(data_arr.dims, "y", -2)
     chunks = (data_arr.chunks[y_dim_index], data_arr.chunks[x_dim_index])
     return chunks
+
+
+def _dim_index_with_default(dims: tuple, dim_name: str, default: int) -> int:
+    try:
+        return dims.index(dim_name)
+    except ValueError:
+        return default
 
 
 @cache_to_zarr_if("cache_lonlats", sanitize_args_func=_sanitize_args_with_chunks)
@@ -388,7 +395,8 @@ def _get_valid_lonlats(area: PRGeometry, chunks: Union[int, str, tuple] = "auto"
 
 
 def _get_sun_angles(data_arr: xr.DataArray) -> tuple[xr.DataArray, xr.DataArray]:
-    lons, lats = _get_valid_lonlats(data_arr.attrs["area"], data_arr.data.chunks)
+    chunks = _geo_chunks_from_data_arr(data_arr)
+    lons, lats = _get_valid_lonlats(data_arr.attrs["area"], chunks)
     suna = da.map_blocks(_get_sun_azimuth_ndarray, lons, lats,
                          data_arr.attrs["start_time"],
                          dtype=lons.dtype, meta=np.array((), dtype=lons.dtype),
@@ -425,9 +433,10 @@ def _get_sensor_angles(data_arr: xr.DataArray) -> tuple[xr.DataArray, xr.DataArr
     preference = satpy.config.get('sensor_angles_position_preference', 'actual')
     sat_lon, sat_lat, sat_alt = get_satpos(data_arr, preference=preference)
     area_def = data_arr.attrs["area"]
+    chunks = _geo_chunks_from_data_arr(data_arr)
     sata, satz = _get_sensor_angles_from_sat_pos(sat_lon, sat_lat, sat_alt,
                                                  data_arr.attrs["start_time"],
-                                                 area_def, data_arr.data.chunks)
+                                                 area_def, chunks)
     sata = _geo_dask_to_data_array(sata)
     satz = _geo_dask_to_data_array(satz)
     return sata, satz

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -365,14 +365,17 @@ def get_cos_sza(data_arr: xr.DataArray) -> xr.DataArray:
         DataArray with the same shape as ``data_arr``.
 
     """
-    x_dim_index = data_arr.dims.index("x")
-    y_dim_index = data_arr.dims.index("y")
-
-    chunks = (data_arr.chunks[y_dim_index], data_arr.chunks[x_dim_index])
-
+    chunks = _geo_chunks_from_data_arr(data_arr)
     lons, lats = _get_valid_lonlats(data_arr.attrs["area"], chunks)
     cos_sza = _get_cos_sza(data_arr.attrs["start_time"], lons, lats)
     return _geo_dask_to_data_array(cos_sza)
+
+
+def _geo_chunks_from_data_arr(data_arr: xr.DataArray) -> tuple:
+    x_dim_index = data_arr.dims.index("x")
+    y_dim_index = data_arr.dims.index("y")
+    chunks = (data_arr.chunks[y_dim_index], data_arr.chunks[x_dim_index])
+    return chunks
 
 
 @cache_to_zarr_if("cache_lonlats", sanitize_args_func=_sanitize_args_with_chunks)

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -371,20 +371,6 @@ def get_cos_sza(data_arr: xr.DataArray) -> xr.DataArray:
     return _geo_dask_to_data_array(cos_sza)
 
 
-def _geo_chunks_from_data_arr(data_arr: xr.DataArray) -> tuple:
-    x_dim_index = _dim_index_with_default(data_arr.dims, "x", -1)
-    y_dim_index = _dim_index_with_default(data_arr.dims, "y", -2)
-    chunks = (data_arr.chunks[y_dim_index], data_arr.chunks[x_dim_index])
-    return chunks
-
-
-def _dim_index_with_default(dims: tuple, dim_name: str, default: int) -> int:
-    try:
-        return dims.index(dim_name)
-    except ValueError:
-        return default
-
-
 @cache_to_zarr_if("cache_lonlats", sanitize_args_func=_sanitize_args_with_chunks)
 def _get_valid_lonlats(area: PRGeometry, chunks: Union[int, str, tuple] = "auto") -> tuple[da.Array, da.Array]:
     with ignore_invalid_float_warnings():
@@ -440,6 +426,20 @@ def _get_sensor_angles(data_arr: xr.DataArray) -> tuple[xr.DataArray, xr.DataArr
     sata = _geo_dask_to_data_array(sata)
     satz = _geo_dask_to_data_array(satz)
     return sata, satz
+
+
+def _geo_chunks_from_data_arr(data_arr: xr.DataArray) -> tuple:
+    x_dim_index = _dim_index_with_default(data_arr.dims, "x", -1)
+    y_dim_index = _dim_index_with_default(data_arr.dims, "y", -2)
+    chunks = (data_arr.chunks[y_dim_index], data_arr.chunks[x_dim_index])
+    return chunks
+
+
+def _dim_index_with_default(dims: tuple, dim_name: str, default: int) -> int:
+    try:
+        return dims.index(dim_name)
+    except ValueError:
+        return default
 
 
 @cache_to_zarr_if("cache_sensor_angles", sanitize_args_func=_sanitize_observer_look_args)

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -358,14 +358,16 @@ def get_satellite_zenith_angle(data_arr: xr.DataArray) -> xr.DataArray:
     return satz
 
 
-def get_cos_sza(data_arr: xr.DataArray) -> xr.DataArray:
+def get_cos_sza(data_arr: xr.DataArray, chunks: Union[int, str, tuple] = None) -> xr.DataArray:
     """Generate the cosine of the solar zenith angle for the provided data.
 
     Returns:
         DataArray with the same shape as ``data_arr``.
 
     """
-    lons, lats = _get_valid_lonlats(data_arr.attrs["area"], data_arr.chunks)
+    if chunks is None:
+        chunks = data_arr.chunks
+    lons, lats = _get_valid_lonlats(data_arr.attrs["area"], chunks)
     cos_sza = _get_cos_sza(data_arr.attrs["start_time"], lons, lats)
     return _geo_dask_to_data_array(cos_sza)
 

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -358,15 +358,18 @@ def get_satellite_zenith_angle(data_arr: xr.DataArray) -> xr.DataArray:
     return satz
 
 
-def get_cos_sza(data_arr: xr.DataArray, chunks: Union[int, str, tuple] = None) -> xr.DataArray:
+def get_cos_sza(data_arr: xr.DataArray) -> xr.DataArray:
     """Generate the cosine of the solar zenith angle for the provided data.
 
     Returns:
         DataArray with the same shape as ``data_arr``.
 
     """
-    if chunks is None:
-        chunks = data_arr.chunks
+    x_dim_index = data_arr.dims.index("x")
+    y_dim_index = data_arr.dims.index("y")
+
+    chunks = (data_arr.chunks[y_dim_index], data_arr.chunks[x_dim_index])
+
     lons, lats = _get_valid_lonlats(data_arr.attrs["area"], chunks)
     cos_sza = _get_cos_sza(data_arr.attrs["start_time"], lons, lats)
     return _geo_dask_to_data_array(cos_sza)

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -27,6 +27,7 @@ import dask.array as da
 import numpy as np
 import pytest
 import xarray as xr
+from pyresample import AreaDefinition
 
 
 class TestMatchDataArrays(unittest.TestCase):
@@ -324,12 +325,12 @@ class TestDayNightCompositor(unittest.TestCase):
         self.sza = xr.DataArray(sza, dims=('y', 'x'))
 
         # fake area
-        my_area = mock.MagicMock()
-        lons = np.array([[-95., -94.], [-93., -92.]])
-        lons = da.from_array(lons, lons.shape)
-        lats = np.array([[40., 41.], [42., 43.]])
-        lats = da.from_array(lats, lats.shape)
-        my_area.get_lonlats.return_value = (lons, lats)
+        my_area = AreaDefinition(
+            "test", "", "",
+            "+proj=longlat",
+            2, 2,
+            (-95.0, 40.0, -92.0, 43.0),
+        )
         self.data_a.attrs['area'] = my_area
         self.data_b.attrs['area'] = my_area
         # not used except to check that it matches the data arrays

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -463,7 +463,9 @@ def _angle_cache_stacked_area_def():
 
 
 def _get_angle_test_data(area_def: Optional[Union[AreaDefinition, StackedAreaDefinition]] = None,
-                         chunks: Optional[Union[int, tuple]] = 2) -> xr.DataArray:
+                         chunks: Optional[Union[int, tuple]] = 2,
+                         shape: tuple = (5, 5),
+                         ) -> xr.DataArray:
     if area_def is None:
         area_def = _angle_cache_area_def()
     orb_params = {
@@ -472,7 +474,7 @@ def _get_angle_test_data(area_def: Optional[Union[AreaDefinition, StackedAreaDef
         "satellite_nominal_latitude": 0.0,
     }
     stime = datetime(2020, 1, 1, 12, 0, 0)
-    data = da.zeros((5, 5), chunks=chunks)
+    data = da.zeros(shape, chunks=chunks)
     vis = xr.DataArray(data,
                        attrs={
                            'area': area_def,
@@ -485,6 +487,10 @@ def _get_angle_test_data(area_def: Optional[Union[AreaDefinition, StackedAreaDef
 def _get_stacked_angle_test_data():
     return _get_angle_test_data(area_def=_angle_cache_stacked_area_def(),
                                 chunks=(5, (2, 2, 1)))
+
+
+def _get_angle_test_data_rgb():
+    return _get_angle_test_data(shape=(3, 5, 5), chunks=((1, 1, 1), (2, 2, 1), (2, 2, 1)))
 
 
 def _get_angle_test_data_odd_chunks():
@@ -528,8 +534,15 @@ def _assert_allclose_if(expect_equal, arr1, arr2):
 class TestAngleGeneration:
     """Test the angle generation utility functions."""
 
-    @pytest.mark.parametrize("input_func", [_get_angle_test_data, _get_stacked_angle_test_data])
-    def test_get_angles(self, input_func):
+    @pytest.mark.parametrize(
+        ("input_func", "exp_calls"),
+        [
+            (_get_angle_test_data, 9),
+            (_get_stacked_angle_test_data, 3),
+            (_get_angle_test_data_rgb, 9),
+        ],
+    )
+    def test_get_angles(self, input_func, exp_calls):
         """Test sun and satellite angle calculation."""
         from satpy.modifiers.angles import get_angles
         data = input_func()
@@ -541,7 +554,7 @@ class TestAngleGeneration:
             da.compute(angles)
 
         # get_observer_look should have been called once per array chunk
-        assert gol.call_count == data.data.blocks.size
+        assert gol.call_count == exp_calls
         # Check arguments of get_orbserver_look() call, especially the altitude
         # unit conversion from meters to kilometers
         args = gol.call_args[0]
@@ -600,15 +613,16 @@ class TestAngleGeneration:
         ]
     )
     @pytest.mark.parametrize(
-        ("input_func", "num_normalized_chunks"),
+        ("input_func", "num_normalized_chunks", "exp_zarr_chunks"),
         [
-            (_get_angle_test_data, 9),
-            (_get_stacked_angle_test_data, 3),
-            (_get_angle_test_data_odd_chunks, 9),
+            (_get_angle_test_data, 9, ((2, 2, 1), (2, 2, 1))),
+            (_get_stacked_angle_test_data, 3, ((5,), (2, 2, 1))),
+            (_get_angle_test_data_odd_chunks, 9, ((2, 1, 2), (1, 1, 2, 1))),
+            (_get_angle_test_data_rgb, 9, ((2, 2, 1), (2, 2, 1))),
         ])
     def test_cache_get_angles(
             self,
-            input_func, num_normalized_chunks,
+            input_func, num_normalized_chunks, exp_zarr_chunks,
             input2_func, exp_equal_sun, exp_num_zarr,
             force_bad_glob, tmp_path):
         """Test get_angles when caching is enabled."""
@@ -624,13 +638,13 @@ class TestAngleGeneration:
                 satpy.config.set(cache_lonlats=True, cache_sensor_angles=True, cache_dir=str(tmp_path)), \
                 warnings.catch_warnings(record=True) as caught_warnings:
             res = get_angles(data)
-            self._check_cached_result(res, data)
+            self._check_cached_result(res, exp_zarr_chunks)
 
             # call again, should be cached
             new_data = input2_func(data)
             with _mock_glob_if(force_bad_glob):
                 res2 = get_angles(new_data)
-            self._check_cached_result(res2, data)
+            self._check_cached_result(res2, exp_zarr_chunks)
 
             res_numpy, res2_numpy = da.compute(res, res2)
             for r1, r2 in zip(res_numpy[:2], res2_numpy[:2]):
@@ -652,11 +666,11 @@ class TestAngleGeneration:
         assert args[:4] == (exp_sat_lon, 0.0, 12345.678, STATIC_EARTH_INERTIAL_DATETIME)
 
     @staticmethod
-    def _check_cached_result(results, input_data):
+    def _check_cached_result(results, exp_zarr_chunks):
         assert all(isinstance(x, xr.DataArray) for x in results)
         # output chunks should be consistent
         for angle_data_arr in results:
-            assert angle_data_arr.chunks == input_data.chunks
+            assert angle_data_arr.chunks == exp_zarr_chunks
 
     @staticmethod
     def _check_cache_and_clear(tmp_path, exp_num_zarr):

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -465,6 +465,7 @@ def _angle_cache_stacked_area_def():
 def _get_angle_test_data(area_def: Optional[Union[AreaDefinition, StackedAreaDefinition]] = None,
                          chunks: Optional[Union[int, tuple]] = 2,
                          shape: tuple = (5, 5),
+                         dims: tuple = None,
                          ) -> xr.DataArray:
     if area_def is None:
         area_def = _angle_cache_area_def()
@@ -476,6 +477,7 @@ def _get_angle_test_data(area_def: Optional[Union[AreaDefinition, StackedAreaDef
     stime = datetime(2020, 1, 1, 12, 0, 0)
     data = da.zeros(shape, chunks=chunks)
     vis = xr.DataArray(data,
+                       dims=dims,
                        attrs={
                            'area': area_def,
                            'start_time': stime,
@@ -490,6 +492,11 @@ def _get_stacked_angle_test_data():
 
 
 def _get_angle_test_data_rgb():
+    return _get_angle_test_data(shape=(5, 5, 3), chunks=((2, 2, 1), (2, 2, 1), (1, 1, 1)),
+                                dims=("y", "x", "bands"))
+
+
+def _get_angle_test_data_rgb_nodims():
     return _get_angle_test_data(shape=(3, 5, 5), chunks=((1, 1, 1), (2, 2, 1), (2, 2, 1)))
 
 
@@ -540,6 +547,7 @@ class TestAngleGeneration:
             (_get_angle_test_data, 9),
             (_get_stacked_angle_test_data, 3),
             (_get_angle_test_data_rgb, 9),
+            (_get_angle_test_data_rgb_nodims, 9),
         ],
     )
     def test_get_angles(self, input_func, exp_calls):
@@ -619,6 +627,7 @@ class TestAngleGeneration:
             (_get_stacked_angle_test_data, 3, ((5,), (2, 2, 1))),
             (_get_angle_test_data_odd_chunks, 9, ((2, 1, 2), (1, 1, 2, 1))),
             (_get_angle_test_data_rgb, 9, ((2, 2, 1), (2, 2, 1))),
+            (_get_angle_test_data_rgb_nodims, 9, ((2, 2, 1), (2, 2, 1))),
         ])
     def test_cache_get_angles(
             self,


### PR DESCRIPTION
At present, the DayNightCompositor does not use the new lat/lon cacheing feature, which slows down processing of this type of composite.
This PR switches the compositor to use the ready-made cache features in `angles.py`. It requires a small modification to the `get_cos_sza` in that file to deal with chunking of RGB composites.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->