### PR TITLE
Fix 'ahi_hsd' reader crashing when 'observation_timeline' was invalid

### DIFF
--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -436,6 +436,13 @@ class AHIHSDFileHandler(BaseFileHandler):
         """Get the nominal end time."""
         return self._modify_observation_time_for_nominal(self.observation_end_time)
 
+    @staticmethod
+    def _is_valid_timeline(timeline):
+        """Check that the `observation_timeline` value is not a fill value."""
+        if int(timeline[:2]) > 23:
+            return False
+        return True
+
     def _modify_observation_time_for_nominal(self, observation_time):
         """Round observation time to a nominal time based on known observation frequency.
 
@@ -450,17 +457,19 @@ class AHIHSDFileHandler(BaseFileHandler):
 
         """
         timeline = "{:04d}".format(self.basic_info['observation_timeline'][0])
+        if not self._is_valid_timeline(timeline):
+            warnings.warn("Observation timeline is fill value, not rounding observation time.")
+            return observation_time
+
         if self.observation_area == 'FLDK':
             dt = 0
         else:
             observation_frequency_seconds = {'JP': 150, 'R3': 150, 'R4': 30, 'R5': 30}[self.observation_area[:2]]
             dt = observation_frequency_seconds * (int(self.observation_area[2:]) - 1)
-        if int(timeline[:2]) < 24:
-            return observation_time.replace(
-                hour=int(timeline[:2]), minute=int(timeline[2:4]) + dt//60,
-                second=dt % 60, microsecond=0)
-        warnings.warn("Observation timeline is fill value, not rounding observation time.")
-        return observation_time
+
+        return observation_time.replace(
+            hour=int(timeline[:2]), minute=int(timeline[2:4]) + dt//60,
+            second=dt % 60, microsecond=0)
 
     def get_dataset(self, key, info):
         """Get the dataset."""

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -459,9 +459,8 @@ class AHIHSDFileHandler(BaseFileHandler):
             return observation_time.replace(
                 hour=int(timeline[:2]), minute=int(timeline[2:4]) + dt//60,
                 second=dt % 60, microsecond=0)
-        else:
-            warnings.warn("Observation timeline is fill value, not rounding observation time.")
-            return observation_time
+        warnings.warn("Observation timeline is fill value, not rounding observation time.")
+        return observation_time
 
     def get_dataset(self, key, info):
         """Get the dataset."""

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -455,9 +455,13 @@ class AHIHSDFileHandler(BaseFileHandler):
         else:
             observation_frequency_seconds = {'JP': 150, 'R3': 150, 'R4': 30, 'R5': 30}[self.observation_area[:2]]
             dt = observation_frequency_seconds * (int(self.observation_area[2:]) - 1)
-        return observation_time.replace(
-            hour=int(timeline[:2]), minute=int(timeline[2:4]) + dt//60,
-            second=dt % 60, microsecond=0)
+        if int(timeline[:2]) < 24:
+            return observation_time.replace(
+                hour=int(timeline[:2]), minute=int(timeline[2:4]) + dt//60,
+                second=dt % 60, microsecond=0)
+        else:
+            warnings.warn("Observation timeline is fill value, not rounding observation time.")
+            return observation_time
 
     def get_dataset(self, key, info):
         """Get the dataset."""

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -359,10 +359,14 @@ class TestAHIHSDFileHandler:
                 fh._check_fpos(fp_, fpos, 0, 'header 1')
                 assert len(w) > 0
 
+    def test_is_valid_time(self):
+        """Test that valid times are correctly itentified"""
+
+        assert AHIHSDFileHandler._is_valid_timeline(FAKE_BASIC_INFO['observation_timeline'])
+        assert not AHIHSDFileHandler._is_valid_timeline('65526')
+
     def test_time_rounding(self):
         """Test rounding of the nominal time."""
-        assert AHIHSDFileHandler._is_valid_timeline(FAKE_BASIC_INFO['observation_timeline']) is True
-        assert AHIHSDFileHandler._is_valid_timeline('65526') is False
 
         mocker = mock.MagicMock()
         in_date = datetime(2020, 1, 1, 12, 0, 0)

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -360,14 +360,12 @@ class TestAHIHSDFileHandler:
                 assert len(w) > 0
 
     def test_is_valid_time(self):
-        """Test that valid times are correctly itentified"""
-
+        """Test that valid times are correctly identified."""
         assert AHIHSDFileHandler._is_valid_timeline(FAKE_BASIC_INFO['observation_timeline'])
         assert not AHIHSDFileHandler._is_valid_timeline('65526')
 
     def test_time_rounding(self):
         """Test rounding of the nominal time."""
-
         mocker = mock.MagicMock()
         in_date = datetime(2020, 1, 1, 12, 0, 0)
 

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -361,7 +361,6 @@ class TestAHIHSDFileHandler:
 
     def test_time_rounding(self):
         """Test rounding of the nominal time."""
-
         assert AHIHSDFileHandler._is_valid_timeline(FAKE_BASIC_INFO['observation_timeline']) is True
         assert AHIHSDFileHandler._is_valid_timeline('65526') is False
 


### PR DESCRIPTION
If an AHI data file contains fill value for the `'observation_timeline'` property then the `ahi_hsd` reader crashes when it tried to round the observation times across segments.
This PR checks whether the timeline is valid and only performs rounding if it is. If invalid, no rounding is done and a warning is shown to the user.