### PR TITLE
Add orbital_parameters to fci_l1c_nc reader

### DIFF
--- a/doc/source/readers.rst
+++ b/doc/source/readers.rst
@@ -207,18 +207,23 @@ For *geostationary* satellites it is described using the following scalar attrib
 
   * ``satellite_actual_longitude/latitude/altitude``: Current position of the satellite at the
     time of observation in geodetic coordinates (i.e. altitude is relative and normal to the
-    surface of the ellipsoid).
+    surface of the ellipsoid). The longitude and latitude are given in degrees, the altitude in meters.
   * ``satellite_nominal_longitude/latitude/altitude``: Center of the station keeping box (a
     confined area in which the satellite is actively maintained in using maneuvers). Inbetween
     major maneuvers, when the satellite is permanently moved, the nominal position is constant.
+    The longitude and latitude are given in degrees, the altitude in meters.
   * ``nadir_longitude/latitude``: Intersection of the instrument's Nadir with the surface of the
     earth. May differ from the actual satellite position, if the instrument is pointing slightly
     off the axis (satellite, earth-center). If available, this should be used to compute viewing
-    angles etc. Otherwise, use the actual satellite position.
+    angles etc. Otherwise, use the actual satellite position. The values are given in degrees.
   * ``projection_longitude/latitude/altitude``: Projection center of the re-projected data. This
     should be used to compute lat/lon coordinates. Note that the projection center can differ
     considerably from the actual satellite position. For example MSG-1 was at times positioned
     at 3.4 degrees west, while the image data was re-projected to 0 degrees.
+    The longitude and latitude are given in degrees, the altitude in meters.
+
+    .. note:: For use in pyorbital, the altitude has to be converted to kilometers, see for example
+              :func:`pyorbital.orbital.get_observer_look`.
 
 For *polar orbiting* satellites the readers usually provide coordinates and viewing angles of
 the swath as ancillary datasets. Additional metadata related to the satellite position includes:

--- a/satpy/tests/reader_tests/test_fci_l1c_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_nc.py
@@ -447,6 +447,34 @@ class TestFCIL1cNCReaderGoodData(TestFCIL1cNCReader):
             else:
                 numpy.testing.assert_array_almost_equal(res[ch], 209.68274099)
 
+    def test_orbital_parameters_attr(self, reader_configs):
+        """Test the orbital parameter attribute."""
+        from satpy.tests.utils import make_dataid
+
+        filenames = [
+            "W_XX-EUMETSAT-Darmstadt,IMG+SAT,MTI1+FCI-1C-RRAD-FDHSI-FD--"
+            "CHK-BODY--L2P-NC4E_C_EUMT_20170410114434_GTT_DEV_"
+            "20170410113925_20170410113934_N__C_0070_0067.nc",
+        ]
+
+        reader = _get_reader_with_filehandlers(filenames, reader_configs)
+        res = reader.load(
+            [make_dataid(name=name) for name in
+             self._chans["solar"] + self._chans["terran"]], pad_data=False)
+
+        for ch in self._chans["solar"] + self._chans["terran"]:
+            assert res[ch].attrs["orbital_parameters"] == {
+                'satellite_actual_longitude': np.mean(np.arange(6000)),
+                'satellite_actual_latitude': np.mean(np.arange(6000)),
+                'satellite_actual_altitude': np.mean(np.arange(6000)),
+                'satellite_nominal_longitude': 0.0,
+                'satellite_nominal_latitude': 0,
+                'satellite_nominal_altitude': 35786400.0,
+                'projection_longitude': 0.0,
+                'projection_latitude': 0,
+                'projection_altitude': 35786400.0,
+            }
+
     def test_load_index_map(self, reader_configs):
         """Test loading of index_map."""
         filenames = [


### PR DESCRIPTION
This PR adds the generation of the `orbital_parameters` attribute for datasets from the `fci_l1c_nc` reader. These are needed e.g. for the generation of some corrected composites.

Each chunk of data (there are 40  chunks building each RC/scene of FCI) contains the actual subsatellite longitude, latitude, and altitude information for the acquisition time period of that chunk, with variable time resolution (e.g. 0.1s). Therefore, we calculate the mean value for each chunk, and the `BaseFileHandler.combine_info` and `_combine_orbital_parameters` methods, called from the `FileYAMLReader`, will take care of averaging the values across all chunks to get the final valid number for the single scene.

On a side, it adds the indication of the units to be used in the dict to the documentation.

 - [x] Closes #1996  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 
FYI @sjoro @strandgren 