### PR TITLE
Fix ACSPO 'sensor' attribute not being lowercase

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,7 @@ repos:
           - types-pkg-resources
           - types-PyYAML
           - types-requests
+        args: ["--python-version", "3.8", "--ignore-missing-imports"]
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -2,7 +2,7 @@ name: readthedocs
 channels:
   - conda-forge
 dependencies:
-  - python=3.7
+  - python=3.10
   - pip
   - dask
   - donfig

--- a/doc/source/dev_guide/remote_file_support.rst
+++ b/doc/source/dev_guide/remote_file_support.rst
@@ -14,7 +14,7 @@ To add this feature to a reader the call to :func:`xarray.open_dataset`
 has to be replaced by the function :func:`~satpy.readers.file_handlers.open_dataset`
 included in Satpy which handles passing on the filename to be opened regardless
 if it is a local file path or a :class:`~satpy.readers.FSFile` object which can wrap
-:func:`fsspec.open` objects. 
+:func:`fsspec.open` objects.
 
 To be able to cache the ``open_dataset`` call which is favourable for remote files
 it should be separated from the ``get_dataset`` method which needs to be implemented

--- a/satpy/readers/acspo.py
+++ b/satpy/readers/acspo.py
@@ -55,8 +55,8 @@ class ACSPOFileHandler(NetCDF4FileHandler):
         """Get instrument name for this file's data."""
         res = self['/attr/sensor']
         if isinstance(res, np.ndarray):
-            return str(res.astype(str))
-        return res
+            res = str(res.astype(str))
+        return res.lower()
 
     def get_shape(self, ds_id, ds_info):
         """Get numpy array shape for the specified dataset.

--- a/satpy/tests/reader_tests/test_acspo.py
+++ b/satpy/tests/reader_tests/test_acspo.py
@@ -151,3 +151,4 @@ class TestACSPOReader:
         for d in datasets.values():
             assert d.shape == DEFAULT_FILE_SHAPE
             assert d.dims == ("y", "x")
+            assert d.attrs["sensor"] == "viirs"

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,7 @@ setup(name=NAME,
                               ]},
       zip_safe=False,
       install_requires=requires,
-      python_requires='>=3.7',
+      python_requires='>=3.8',
       extras_require=extras_require,
       entry_points=entry_points,
       )


### PR DESCRIPTION
Sensor names were coming from file attributes, but weren't lowercase which is semi-standard in Satpy. This was causing issues in Polar2Grid where the sensor wasn't matching custom config entries.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
