### PR TITLE
Update 'viirs_edr_active_fires' to work with newer Active Fires output

### DIFF
--- a/satpy/etc/readers/viirs_edr_active_fires.yaml
+++ b/satpy/etc/readers/viirs_edr_active_fires.yaml
@@ -7,7 +7,7 @@ reader:
 file_types:
     fires_netcdf_img:
         file_reader: !!python/name:satpy.readers.viirs_edr_active_fires.VIIRSActiveFiresFileHandler
-        variable_prefix: ""
+        variable_prefix: "Fire Pixels/"
         file_patterns:
             - 'AFIMG_{satellite_name}_d{start_time:%Y%m%d_t%H%M%S%f}_e{end_time:%H%M%S%f}_b{orbit:5d}_c{creation_time}_{source}.nc'
     fires_netcdf:

--- a/satpy/readers/viirs_edr_active_fires.py
+++ b/satpy/readers/viirs_edr_active_fires.py
@@ -75,7 +75,7 @@ class VIIRSActiveFiresFileHandler(NetCDF4FileHandler):
             data.attrs['units'] = 'K'
 
         data.attrs["platform_name"] = PLATFORM_MAP.get(self.filename_info['satellite_name'].upper(), "unknown")
-        data.attrs["sensor"] = "VIIRS"
+        data.attrs["sensor"] = self.sensor_name
 
         return data
 
@@ -92,7 +92,7 @@ class VIIRSActiveFiresFileHandler(NetCDF4FileHandler):
     @property
     def sensor_name(self):
         """Name of sensor for this file."""
-        return self["sensor"]
+        return self["sensor"].lower()
 
     @property
     def platform_name(self):

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -90,12 +90,12 @@ class FakeImgFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
         file_content['satellite_name'] = "npp"
         file_content['sensor'] = 'VIIRS'
 
-        file_content['FP_latitude'] = DEFAULT_LATLON_FILE_DATA
-        file_content['FP_longitude'] = DEFAULT_LATLON_FILE_DATA
-        file_content['FP_power'] = DEFAULT_POWER_FILE_DATA
-        file_content['FP_T4'] = DEFAULT_M13_FILE_DATA
-        file_content['FP_T4/attr/units'] = 'kelvins'
-        file_content['FP_confidence'] = DEFAULT_DETECTION_FILE_DATA
+        file_content['Fire Pixels/FP_latitude'] = DEFAULT_LATLON_FILE_DATA
+        file_content['Fire Pixels/FP_longitude'] = DEFAULT_LATLON_FILE_DATA
+        file_content['Fire Pixels/FP_power'] = DEFAULT_POWER_FILE_DATA
+        file_content['Fire Pixels/FP_T4'] = DEFAULT_M13_FILE_DATA
+        file_content['Fire Pixels/FP_T4/attr/units'] = 'kelvins'
+        file_content['Fire Pixels/FP_confidence'] = DEFAULT_DETECTION_FILE_DATA
 
         attrs = ('FP_latitude', 'FP_longitude',  'FP_T13', 'FP_confidence')
         convert_file_content_to_data_array(
@@ -208,7 +208,7 @@ class TestModVIIRSActiveFiresNetCDF4(unittest.TestCase):
         for v in datasets.values():
             self.assertEqual(v.attrs['units'], 'MW')
             self.assertEqual(v.attrs['platform_name'], 'NOAA-21')
-            self.assertEqual(v.attrs['sensor'], 'VIIRS')
+            self.assertEqual(v.attrs['sensor'], 'viirs')
 
 
 class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
@@ -265,7 +265,7 @@ class TestImgVIIRSActiveFiresNetCDF4(unittest.TestCase):
         for v in datasets.values():
             self.assertEqual(v.attrs['units'], 'MW')
             self.assertEqual(v.attrs['platform_name'], 'Suomi-NPP')
-            self.assertEqual(v.attrs['sensor'], 'VIIRS')
+            self.assertEqual(v.attrs['sensor'], 'viirs')
 
 
 @mock.patch('satpy.readers.viirs_edr_active_fires.dd.read_csv')


### PR DESCRIPTION
The new active fires software now puts Image-resolution output in a NetCDF group "Fire Pixels". This matches what the MOD resolution products had. This updates the reader for this new version, but does not provide backwards compatibility.

This PR also fixes the sensor not being lowercase as is standard in satpy.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
