### PR TITLE
Refactor the ratio-sharpened RGB compositor to use dask map_blocks

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -976,9 +976,9 @@ def _ratio_sharpened_rgb(red, green, blue, high_res=None, low_resolution_index=0
         # we don't need ridiculously high ratios, they just make bright pixels
         np.clip(ratio, 0, 1.5, out=ratio)
 
-        red = high_res if low_resolution_index == 0 else red
-        green = high_res if low_resolution_index == 1 else green
-        blue = high_res if low_resolution_index == 2 else blue
+        red = high_res if low_resolution_index == 0 else red * ratio
+        green = high_res if low_resolution_index == 1 else green * ratio
+        blue = high_res if low_resolution_index == 2 else blue * ratio
 
     # combine the masks
     mask = np.isnan(red) | np.isnan(green) | np.isnan(blue)

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -916,21 +916,23 @@ class RatioSharpenedRGB(GenericCompositor):
                                     'the same size. Must resample first.')
 
         new_attrs = {}
+        optional_datasets = tuple() if optional_datasets is None else optional_datasets
         datasets = self.match_data_arrays(datasets + optional_datasets)
-        colors = ['red', 'green', 'blue']
-        low_res_idx = colors.index(self.high_resolution_band)
         r = datasets[0]
         g = datasets[1]
         b = datasets[2]
-        if optional_datasets:
+        if optional_datasets and self.high_resolution_band is not None:
             LOG.debug("Sharpening image with high resolution {} band".format(self.high_resolution_band))
             high_res = datasets[3]
             if 'rows_per_scan' in high_res.attrs:
                 new_attrs.setdefault('rows_per_scan', high_res.attrs['rows_per_scan'])
             new_attrs.setdefault('resolution', high_res.attrs['resolution'])
+            colors = ['red', 'green', 'blue']
+            low_res_idx = colors.index(self.high_resolution_band)
         else:
             LOG.debug("No sharpening band specified for ratio sharpening")
             high_res = None
+            low_res_idx = 0
 
         rgb = da.map_blocks(
             _ratio_sharpened_rgb,

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -902,15 +902,6 @@ class RatioSharpenedRGB(GenericCompositor):
         kwargs.setdefault('common_channel_mask', False)
         super(RatioSharpenedRGB, self).__init__(*args, **kwargs)
 
-    def _get_band(self, high_res, low_res, color, ratio):
-        """Figure out what data should represent this color."""
-        if self.high_resolution_band == color:
-            ret = high_res
-        else:
-            ret = low_res * ratio
-            ret.attrs = low_res.attrs.copy()
-        return ret
-
     def __call__(self, datasets, optional_datasets=None, **info):
         """Sharpen low resolution datasets by multiplying by the ratio of ``high_res / low_res``.
 
@@ -925,58 +916,75 @@ class RatioSharpenedRGB(GenericCompositor):
                                     'the same size. Must resample first.')
 
         new_attrs = {}
+        datasets = self.match_data_arrays(datasets + optional_datasets)
+        colors = ['red', 'green', 'blue']
+        low_res_idx = colors.index(self.high_resolution_band)
+        r = datasets[0]
+        g = datasets[1]
+        b = datasets[2]
         if optional_datasets:
-            datasets = self.match_data_arrays(datasets + optional_datasets)
-            p1 = datasets[0]
-            p2 = datasets[1]
-            p3 = datasets[2]
+            LOG.debug("Sharpening image with high resolution {} band".format(self.high_resolution_band))
             high_res = datasets[3]
             if 'rows_per_scan' in high_res.attrs:
                 new_attrs.setdefault('rows_per_scan', high_res.attrs['rows_per_scan'])
             new_attrs.setdefault('resolution', high_res.attrs['resolution'])
-            colors = ['red', 'green', 'blue']
-
-            if self.high_resolution_band in colors:
-                LOG.debug("Sharpening image with high resolution {} band".format(self.high_resolution_band))
-                low_res = datasets[:3][colors.index(self.high_resolution_band)]
-                ratio = high_res / low_res
-                # make ratio a no-op (multiply by 1) where the ratio is NaN or
-                # infinity or it is negative.
-                ratio = ratio.where(np.isfinite(ratio) & (ratio >= 0), 1.)
-                # we don't need ridiculously high ratios, they just make bright pixels
-                ratio = ratio.clip(0, 1.5)
-            else:
-                LOG.debug("No sharpening band specified for ratio sharpening")
-                high_res = None
-                ratio = 1.
-
-            r = self._get_band(high_res, p1, 'red', ratio)
-            g = self._get_band(high_res, p2, 'green', ratio)
-            b = self._get_band(high_res, p3, 'blue', ratio)
         else:
-            datasets = self.match_data_arrays(datasets)
-            r = datasets[0]
-            g = datasets[1]
-            b = datasets[2]
+            LOG.debug("No sharpening band specified for ratio sharpening")
+            high_res = None
 
-        # combine the masks
-        mask = ~(r.isnull() | g.isnull() | b.isnull())
-        r = r.where(mask)
-        g = g.where(mask)
-        b = b.where(mask)
+        rgb = da.map_blocks(
+            _ratio_sharpened_rgb,
+            r.data, g.data, b.data,
+            high_res.data if high_res is not None else high_res,
+            low_resolution_index=low_res_idx,
+            new_axis=[0],
+            meta=np.array((), dtype=r.dtype),
+            chunks=((3,),) + r.chunks,
+        )
 
         # Collect information that is the same between the projectables
         # we want to use the metadata from the original datasets since the
         # new r, g, b arrays may have lost their metadata during calculations
-        info = combine_metadata(*datasets)
-        info.update(new_attrs)
+        combined_info = combine_metadata(*datasets)
+        combined_info.update(info)
+        combined_info.update(new_attrs)
         # Update that information with configured information (including name)
-        info.update(self.attrs)
+        combined_info.update(self.attrs)
         # Force certain pieces of metadata that we *know* to be true
-        info.setdefault("standard_name", "true_color")
-        res = super(RatioSharpenedRGB, self).__call__((r, g, b), **info)
+        combined_info.setdefault("standard_name", "true_color")
+        combined_info["mode"] = "RGB"
+
+        rgb_data_arr = xr.DataArray(
+            rgb,
+            dims=("bands",) + r.dims,
+            coords={"bands": ["R", "G", "B"]},
+            attrs=combined_info
+        )
+
+        res = super(RatioSharpenedRGB, self).__call__((rgb_data_arr,), **combined_info)
         res.attrs.pop("units", None)
         return res
+
+
+def _ratio_sharpened_rgb(red, green, blue, high_res=None, low_resolution_index=0):
+    if high_res is not None:
+        low_res = (red, green, blue)[low_resolution_index]
+        ratio = high_res / low_res
+        # make ratio a no-op (multiply by 1) where the ratio is NaN or
+        # infinity or it is negative.
+        ratio[~np.isfinite(ratio) | (ratio < 0)] = 1.0
+        # we don't need ridiculously high ratios, they just make bright pixels
+        np.clip(ratio, 0, 1.5, out=ratio)
+
+        red = high_res if low_resolution_index == 0 else red
+        green = high_res if low_resolution_index == 1 else green
+        blue = high_res if low_resolution_index == 2 else blue
+
+    # combine the masks
+    mask = np.isnan(red) | np.isnan(green) | np.isnan(blue)
+    rgb = np.stack((red, green, blue))
+    rgb[:, mask] = np.nan
+    return rgb
 
 
 def _mean4(data, offset=(0, 0), block_id=None):

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -941,6 +941,7 @@ class RatioSharpenedRGB(GenericCompositor):
             low_resolution_index=low_res_idx,
             new_axis=[0],
             meta=np.array((), dtype=r.dtype),
+            dtype=r.dtype,
             chunks=((3,),) + r.chunks,
         )
 


### PR DESCRIPTION
While working on some performance benchmarking I got annoyed at the number of dask tasks produced for ratio-sharpening of an RGB. This PR refactors the code to run in a dask `map_blocks` function so it is done in a single task. This has limited performance improvements given the limited tasks involved...but it is obvious now that this sharpening takes a long time. That's a separate PR though :wink: 

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

