### PR TITLE
Fix GPM IMERG reader.

### DIFF
--- a/satpy/readers/gpm_imerg.py
+++ b/satpy/readers/gpm_imerg.py
@@ -28,6 +28,7 @@ from datetime import datetime
 
 import h5py
 import dask.array as da
+import numpy as np
 from pyresample.geometry import AreaDefinition
 
 from satpy.readers.hdf5_utils import HDF5FileHandler
@@ -82,6 +83,9 @@ class Hdf5IMERG(HDF5FileHandler):
             val = data.attrs[key]
             if isinstance(val, h5py.h5r.Reference):
                 del data.attrs[key]
+            if isinstance(val, np.ndarray):
+                if isinstance(val[0][0], h5py.h5r.Reference):
+                    del data.attrs[key]
         return data
 
     def get_area_def(self, dsid):

--- a/satpy/readers/gpm_imerg.py
+++ b/satpy/readers/gpm_imerg.py
@@ -27,7 +27,7 @@ import logging
 from datetime import datetime
 
 import h5py
-import numpy as np
+import dask.array as da
 from pyresample.geometry import AreaDefinition
 
 from satpy.readers.hdf5_utils import HDF5FileHandler
@@ -69,18 +69,19 @@ class Hdf5IMERG(HDF5FileHandler):
         """Load a dataset."""
         file_key = ds_info.get('file_key', dataset_id['name'])
         dsname = 'Grid/' + file_key
-        data = self[dsname].squeeze().transpose()
-        data.values = np.flipud(data.values)
+        data = self.get(dsname)
+        data = data.squeeze().transpose()
+        if data.ndim >= 2:
+            data = data.rename({data.dims[-2]: 'y', data.dims[-1]: 'x'})
+        data.data = da.flip(data.data, axis=0)
 
         fill = data.attrs['_FillValue']
-        pts = (data.values == fill).nonzero()
-        data.values[pts] = np.nan
+        data = data.where(data != fill)
 
         for key in list(data.attrs.keys()):
             val = data.attrs[key]
             if isinstance(val, h5py.h5r.Reference):
                 del data.attrs[key]
-
         return data
 
     def get_area_def(self, dsid):

--- a/satpy/tests/reader_tests/test_gpm_imerg.py
+++ b/satpy/tests/reader_tests/test_gpm_imerg.py
@@ -18,6 +18,7 @@
 
 
 import os
+import h5py
 import unittest
 from datetime import datetime
 from unittest import mock
@@ -61,6 +62,8 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
                     '_FillValue': -9999.9,
                     'units': 'mm/hr',
                     'Units': 'mm/hr',
+                    'badval': h5py.h5r.Reference,
+                    'badvals': np.array([[h5py.h5r.Reference]])
                 },
                 dims=('time', 'lon', 'lat')),
         }

--- a/satpy/tests/reader_tests/test_gpm_imerg.py
+++ b/satpy/tests/reader_tests/test_gpm_imerg.py
@@ -62,8 +62,8 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
                     '_FillValue': -9999.9,
                     'units': 'mm/hr',
                     'Units': 'mm/hr',
-                    'badval': h5py.h5r.Reference,
-                    'badvals': np.array([[h5py.h5r.Reference]])
+                    'badval': h5py.h5r.Reference(),
+                    'badvals': np.array([[h5py.h5r.Reference()]])
                 },
                 dims=('time', 'lon', 'lat')),
         }

--- a/satpy/tests/reader_tests/test_gpm_imerg.py
+++ b/satpy/tests/reader_tests/test_gpm_imerg.py
@@ -55,7 +55,7 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
         selection = {
             'Grid/IRprecipitation':
             xr.DataArray(
-                da.ones((1, num_rows, num_cols), chunks=1024,
+                da.ones((1, num_cols, num_rows), chunks=1024,
                         dtype=np.float32),
                 attrs={
                     '_FillValue': -9999.9,


### PR DESCRIPTION
The IMERG reader was not correctly dealing with coordinates, and was using numpy instead of dask. This PR fixes these problems and also updates the tests.