### PR TITLE
Update Metimage reader for L2 test data

### DIFF
--- a/satpy/etc/composites/vii.yaml
+++ b/satpy/etc/composites/vii.yaml
@@ -1,0 +1,121 @@
+sensor_name: visir/vii
+modifiers:
+  nir_reflectance:
+    modifier: !!python/name:satpy.modifiers.NIRReflectance
+    prerequisites:
+      - name: 'vii_10690'
+    optional_prerequisites:
+      - solar_zenith
+      - name: 'vii_13345'
+    sunz_threshold: 85.0
+
+  rayleigh_corrected:
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: rayleigh_only
+    prerequisites:
+      - wavelength: 0.67
+        modifiers: [ sunz_corrected ]
+    optional_prerequisites:
+      - observation_azimuth
+      - observation_zenith
+      - solar_azimuth
+      - solar_zenith
+
+composites:
+  sepia:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - name: 'vii_443'
+      modifiers: [sunz_corrected]
+    - name: 'vii_555'
+      modifiers: [sunz_corrected]
+    - name: 'vii_668'
+      modifiers: [sunz_corrected]
+    standard_name: sepia
+
+  true_color_uncorrected:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'vii_668'
+        modifiers: [ sunz_corrected ]
+      - name: 'vii_555'
+        modifiers: [ sunz_corrected ]
+      - name: 'vii_443'
+        modifiers: [ sunz_corrected ]
+    standard_name: true_color
+
+  true_color:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'vii_668'
+        modifiers: [ sunz_corrected, rayleigh_corrected ]
+      - name: 'vii_555'
+        modifiers: [ sunz_corrected, rayleigh_corrected ]
+      - name: 'vii_443'
+        modifiers: [ sunz_corrected, rayleigh_corrected ]
+    standard_name: true_color
+
+  natural_color:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'vii_1630'
+        modifiers: [ sunz_corrected ]
+      - name: 'vii_865'
+        modifiers: [ sunz_corrected ]
+      - name: 'vii_668'
+        modifiers: [ sunz_corrected, rayleigh_corrected ]
+    standard_name: natural_color
+
+  day_microphysics:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'vii_865'
+        modifiers: [ sunz_corrected ]
+      - name: 'vii_3740'
+        modifiers: [ nir_reflectance ]
+      - name: 'vii_10690'
+    standard_name: day_microphysics
+
+  snow:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'vii_865'
+        modifiers: [ sunz_corrected ]
+      - name: 'vii_1630'
+        modifiers: [ sunz_corrected ]
+      - name: 'vii_3740'
+        modifiers: [ nir_reflectance ]
+    standard_name: snow
+
+  convection:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: 'vii_6725'
+          - name: 'vii_7325'
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: 'vii_3740'
+            modifiers: [ co2_corrected ]
+          - name: 'vii_10690'
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: 'vii_1630'
+          - name: 'vii_668'
+    standard_name: convection
+
+  dust:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: 'vii_12020'
+          - name: 'vii_10690'
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: 'vii_10690'
+          - name: 'vii_8540'
+      - name: 'vii_10690'
+    standard_name: dust

--- a/satpy/etc/readers/vii_l2_nc.yaml
+++ b/satpy/etc/readers/vii_l2_nc.yaml
@@ -1,4 +1,4 @@
-reader:
+ reader:
   name: vii_l2_nc
   short_name: VII L2 NetCDF4
   long_name: EPS-SG VII L2 (NetCDF4)
@@ -7,11 +7,12 @@ reader:
   sensors: [vii]
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
 
-file_types:
+ file_types:
   # EUMETSAT EPSG-SG Visual Infrared Imager Level 2 Cloud Mask files in NetCDF4 format
   nc_vii_l2_cld:
     file_reader: !!python/name:satpy.readers.vii_l2_nc.ViiL2NCFileHandler
-    file_patterns: ['W_xx-eumetsat-darmstadt,SAT,{spacecraft_name:s}-VII-02-CLD_C_EUM_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
+    file_patterns: ['W_XX-EUMETSAT-Darmstadt,SAT,{spacecraft_name:s}-VII-02-CLD_C_EUMT_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
+    #W_XX-EUMETSAT-Darmstadt,SAT,SGA1-VII-02-CLD_C_EUMT_20211110105731_G_D_20070912084303_20070912084403_T_B____
     cached_longitude: data/measurement_data/longitude
     cached_latitude: data/measurement_data/latitude
     orthorect: False
@@ -19,28 +20,28 @@ file_types:
   # EUMETSAT EPSG-SG Visual Infrared Imager Level 2 Cloud Top Pressure (using the Oxygen-A Band) files in NetCDF4 format
   nc_vii_l2_ctp:
     file_reader: !!python/name:satpy.readers.vii_l2_nc.ViiL2NCFileHandler
-    file_patterns: ['W_xx-eumetsat-darmstadt,SAT,{spacecraft_name:s}-VII-02-CTP_C_EUM_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
+    file_patterns: ['W_XX-EUMETSAT-Darmstadt,SAT,{spacecraft_name:s}-VII-02-CTP_C_EUMT_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
     cached_longitude: data/measurement_data/longitude
     cached_latitude: data/measurement_data/latitude
 
   # EUMETSAT EPSG-SG Visual Infrared Imager Level 2 Cloud Mask and First Guess Cloud Properties files in NetCDF4 format
   nc_vii_l2_icm:
     file_reader: !!python/name:satpy.readers.vii_l2_nc.ViiL2NCFileHandler
-    file_patterns: ['W_xx-eumetsat-darmstadt,SAT,{spacecraft_name:s}-VII-02-ICM_C_EUM_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
+    file_patterns: ['W_XX-EUMETSAT-Darmstadt,SAT,{spacecraft_name:s}-VII-02-ICM_C_EUMT_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
     cached_longitude: data/measurement_data/longitude
     cached_latitude: data/measurement_data/latitude
 
   # EUMETSAT EPSG-SG Visual Infrared Imager Level 2 Optimal Cloud Analysis files in NetCDF4 format
   nc_vii_l2_oca:
     file_reader: !!python/name:satpy.readers.vii_l2_nc.ViiL2NCFileHandler
-    file_patterns: ['W_xx-eumetsat-darmstadt,SAT,{spacecraft_name:s}-VII-02-OCA_C_EUM_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
+    file_patterns: ['W_XX-EUMETSAT-Darmstadt,SAT,{spacecraft_name:s}-VII-02-OCA_C_EUMT_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
     cached_longitude: data/measurement_data/longitude
     cached_latitude: data/measurement_data/latitude
 
   # EUMETSAT EPSG-SG Visual Infrared Imager Level 2 Total Precipitable Water (from VII visible/near-infrared) files in NetCDF4 format
   nc_vii_l2_wvv:
     file_reader: !!python/name:satpy.readers.vii_l2_nc.ViiL2NCFileHandler
-    file_patterns: ['W_xx-eumetsat-darmstadt,SAT,{spacecraft_name:s}-VII-02-WVV_C_EUM_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
+    file_patterns: ['W_XX-EUMETSAT-Darmstadt,SAT,{spacecraft_name:s}-VII-02-WVV_C_EUMT_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
     cached_longitude: data/measurement_data/longitude
     cached_latitude: data/measurement_data/latitude
     interpolate: False
@@ -49,13 +50,13 @@ file_types:
   # EUMETSAT EPSG-SG Visual Infrared Imager Level 2 Total Precipitable Water (from VII thermal infra-red) files in NetCDF4 format
   nc_vii_l2_wvi:
     file_reader: !!python/name:satpy.readers.vii_l2_nc.ViiL2NCFileHandler
-    file_patterns: ['W_xx-eumetsat-darmstadt,SAT,{spacecraft_name:s}-VII-02-WVI_C_EUM_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
+    file_patterns: ['W_XX-EUMETSAT-Darmstadt,SAT,{spacecraft_name:s}-VII-02-WVI_C_EUMT_{creation_time:%Y%m%d%H%M%S}_{mission_type:s}_{environment:s}_{sensing_start_time:%Y%m%d%H%M%S}_{sensing_end_time:%Y%m%d%H%M%S}_{disposition_mode:s}_{processing_mode:s}____.nc']
     cached_longitude: data/measurement_data/longitude
     cached_latitude: data/measurement_data/latitude
     interpolate: False
-    orthorect: False
+    #orthorect: False
 
-datasets:
+ datasets:
 
 # --- Coordinates ---
   # TODO Coordinates on tie points are kept for test purposes
@@ -116,210 +117,210 @@ datasets:
     name: cs_confidence
     file_type: [nc_vii_l2_cld, nc_vii_l2_icm]
     file_key: data/measurement_data/cs_confidence
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: cloud_area_fraction
 
   flag_cm:
     name: flag_cm
     file_type: [nc_vii_l2_cld, nc_vii_l2_icm]
     file_key: data/measurement_data/flag_cm
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: cloud_mask_classification
 
   surface_type:
     name: surface_type
     file_type: [nc_vii_l2_cld, nc_vii_l2_icm]
     file_key: data/measurement_data/surface_type
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: surface_type
 
   ctp_o2:
     name: ctp_o2
     file_type: nc_vii_l2_ctp
     file_key: data/measurement_data/ctp_o2
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: air_pressure_at_cloud_top
 
   log10_ctp_o2_err:
     name: log10_ctp_o2_err
     file_type: nc_vii_l2_ctp
     file_key: data/measurement_data/log10_ctp_o2_err
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: air_pressure_at_cloud_top
 
   log10_cot_o2:
     name: log10_cot_o2
     file_type: nc_vii_l2_ctp
     file_key: data/measurement_data/log10_cot_o2
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: cloud_optical_depth
 
   log10_cot_o2_err:
     name: log10_cot_o2_err
     file_type: nc_vii_l2_ctp
     file_key: data/measurement_data/log10_cot_o2_err
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: cloud_optical_depth
 
   vii_ch_sel1:
     name: vii_ch_sel1
     file_type: nc_vii_l2_icm
     file_key: data/measurement_data/vii_ch_sel1
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: toa_outgoing_radiance_per_unit_wavelength
 
   vii_ch_sel2:
     name: vii_ch_sel2
     file_type: nc_vii_l2_icm
     file_key: data/measurement_data/vii_ch_sel2
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: toa_outgoing_radiance_per_unit_wavelength
 
   vii_ch_sel3:
     name: vii_ch_sel3
     file_type: nc_vii_l2_icm
     file_key: data/measurement_data/vii_ch_sel3
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: toa_outgoing_radiance_per_unit_wavelength
 
   flag_cph:
     name: flag_cph
     file_type: nc_vii_l2_icm
     file_key: data/measurement_data/flag_cph
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: thermodynamic_phase_of_cloud_water_particles_at_cloud_top
 
   log10_cot_fg:
     name: log10_cot_fg
     file_type: nc_vii_l2_icm
     file_key: data/measurement_data/log10_cot_fg
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: cloud_optical_depth
 
   log10_err_cot_fg:
     name: log10_err_cot_fg
     file_type: nc_vii_l2_icm
     file_key: data/measurement_data/log10_err_cot_fg
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: cloud_optical_depth
 
   cth_fg:
     name: cth_fg
     file_type: nc_vii_l2_icm
     file_key: data/measurement_data/cth_fg
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: height_at_cloud_top
 
   err_cth_fg:
     name: err_cth_fg
     file_type: nc_vii_l2_icm
     file_key: data/measurement_data/err_cth_fg
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: height_at_cloud_top
 
   moca_model_final:
     name: moca_model_final
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/moca_model_final
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: scene_classification
 
   log10_cot:
     name: log10_cot
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/log10_cot
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: cloud_optical_depth
 
   log10_err_cot:
     name: log10_err_cot
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/log10_err_cot
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: cloud_optical_depth
 
   cre:
     name: cre
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/cre
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: effective_radius_of_cloud_condensed_water_particles_at_cloud_top
 
   log10_err_cre:
     name: log10_err_cre
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/log10_err_cre
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: effective_radius_of_cloud_condensed_water_particles_at_cloud_top
 
   ctp:
     name: ctp
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/ctp
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: air_pressure_at_cloud_top
 
   log10_err_ctp:
     name: log10_err_ctp
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/log10_err_ctp
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: air_pressure_at_cloud_top
 
   ctt:
     name: ctt
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/ctt
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: air_temperature_at_cloud_top
 
   log10_cot2:
     name: log10_cot2
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/log10_cot2
-    coordinates: [lon_pixels2, lat_pixels2]
+    coordinates: [lat_pixels2, lon_pixels2]
     standard_name: cloud_optical_depth
 
   log10_err_cot2:
     name: log10_err_cot2
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/log10_err_cot2
-    coordinates: [lon_pixels2, lat_pixels2]
+    coordinates: [lat_pixels2, lon_pixels2]
     standard_name: cloud_optical_depth
 
   ctp2:
     name: ctp2
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/ctp2
-    coordinates: [lon_pixels2, lat_pixels2]
+    coordinates: [lat_pixels2, lon_pixels2]
     standard_name: air_pressure_at_cloud_top
 
   log10_err_ctp2:
     name: log10_err_ctp2
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/log10_err_ctp2
-    coordinates: [lon_pixels2, lat_pixels2]
+    coordinates: [lat_pixels2, lon_pixels2]
     standard_name: air_pressure_at_cloud_top
 
   ctt2:
     name: ctt2
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/ctt2
-    coordinates: [lon_pixels2, lat_pixels2]
+    coordinates: [lat_pixels2, lon_pixels2]
     standard_name: air_temperature_at_cloud_top
 
   tpw:
     name: tpw
-    file_type: [nc_vii_l2_wvi, nc_vii_l2_wvv]
+    file_type: [nc_vii_l2_wvi nc_vii_l2_wvv]
     file_key: data/measurement_data/tpw
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: mass_of_water_in_air
 
   tpw_err:
     name: tpw_err
     file_type: [nc_vii_l2_wvi, nc_vii_l2_wvv]
     file_key: data/measurement_data/tpw_err
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels_no_orthorect, lon_pixels_no_orthorect]
     standard_name: mass_of_water_in_air
 
 # --- Geometric data ---
@@ -329,28 +330,28 @@ datasets:
     standard_name: solar_zenith_angle
     file_type: [nc_vii_l2_cld, nc_vii_l2_ctp, nc_vii_l2_icm, nc_vii_l2_oca]
     file_key: data/measurement_data/solar_zenith
-    coordinates: [lon_tie_points, lat_tie_points]
+    coordinates: [lat_tie_points, lon_tie_points]
 
   solar_azimuth_tie_points:
     name: solar_azimuth_tie_points
     standard_name: solar_azimuth_angle
     file_type: [nc_vii_l2_cld, nc_vii_l2_ctp, nc_vii_l2_icm, nc_vii_l2_oca]
     file_key: data/measurement_data/solar_azimuth
-    coordinates: [lon_tie_points, lat_tie_points]
+    coordinates: [lat_tie_points, lon_tie_points]
 
   observation_zenith_tie_points:
     name: observation_zenith_tie_points
     standard_name: sensor_zenith_angle
     file_type: [nc_vii_l2_cld, nc_vii_l2_ctp, nc_vii_l2_icm, nc_vii_l2_oca]
     file_key: data/measurement_data/observation_zenith
-    coordinates: [lon_tie_points, lat_tie_points]
+    coordinates: [lat_tie_points, lon_tie_points]
 
   observation_azimuth_tie_points:
     name: observation_azimuth_tie_points
     standard_name: sensor_azimuth_angle
     file_type: [nc_vii_l2_cld, nc_vii_l2_ctp, nc_vii_l2_icm, nc_vii_l2_oca]
     file_key: data/measurement_data/observation_azimuth
-    coordinates: [lon_tie_points, lat_tie_points]
+    coordinates: [lat_tie_points, lon_tie_points]
 
   solar_zenith:
     name: solar_zenith
@@ -358,7 +359,7 @@ datasets:
     file_type: [nc_vii_l2_cld, nc_vii_l2_ctp, nc_vii_l2_icm, nc_vii_l2_oca, nc_vii_l2_wvi, nc_vii_l2_wvv]
     file_key: data/measurement_data/solar_zenith
     interpolate: True
-    coordinates: [lon_pixels_no_orthorect, lat_pixels_no_orthorect]
+    coordinates: [lat_pixels_no_orthorect, lon_pixels_no_orthorect]
 
   solar_azimuth:
     name: solar_azimuth
@@ -366,7 +367,7 @@ datasets:
     file_type: [nc_vii_l2_cld, nc_vii_l2_ctp, nc_vii_l2_icm, nc_vii_l2_oca, nc_vii_l2_wvi, nc_vii_l2_wvv]
     file_key: data/measurement_data/solar_azimuth
     interpolate: True
-    coordinates: [lon_pixels_no_orthorect, lat_pixels_no_orthorect]
+    coordinates: [lat_pixels_no_orthorect, lon_pixels_no_orthorect]
 
   observation_zenith:
     name: observation_zenith
@@ -374,7 +375,7 @@ datasets:
     file_type: [nc_vii_l2_cld, nc_vii_l2_ctp, nc_vii_l2_icm, nc_vii_l2_oca, nc_vii_l2_wvi, nc_vii_l2_wvv]
     file_key: data/measurement_data/observation_zenith
     interpolate: True
-    coordinates: [lon_pixels_no_orthorect, lat_pixels_no_orthorect]
+    coordinates: [lat_pixels_no_orthorect, lon_pixels_no_orthorect]
 
   observation_azimuth:
     name: observation_azimuth
@@ -382,35 +383,35 @@ datasets:
     file_type: [nc_vii_l2_cld, nc_vii_l2_ctp, nc_vii_l2_icm, nc_vii_l2_oca, nc_vii_l2_wvi, nc_vii_l2_wvv]
     file_key: data/measurement_data/observation_azimuth
     interpolate: True
-    coordinates: [lon_pixels_no_orthorect, lat_pixels_no_orthorect]
+    coordinates: [lat_pixels_no_orthorect, lon_pixels_no_orthorect]
 
 # --- Orthorectification data ---
   delta_lat:
     name: delta_lat
     file_type: [nc_vii_l2_ctp, nc_vii_l2_icm, nc_vii_l2_oca]
     file_key: data/measurement_data/delta_lat
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: parallax_delta_latitude
 
   delta_lon:
     name: delta_lon
     file_type: [nc_vii_l2_ctp, nc_vii_l2_icm, nc_vii_l2_oca]
     file_key: data/measurement_data/delta_lon
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: parallax_delta_longitude
 
   delta_lat_cloud2:
     name: delta_lat_cloud2
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/delta_lat_cloud2
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: parallax_delta_latitude
 
   delta_lon_cloud2:
     name: delta_lon_cloud2
     file_type: nc_vii_l2_oca
     file_key: data/measurement_data/delta_lon_cloud2
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: parallax_delta_longitude
 
 # --- Quality Information data ---
@@ -418,19 +419,19 @@ datasets:
     name: log10_j
     file_type: [nc_vii_l2_ctp, nc_vii_l2_oca, nc_vii_l2_wvi, nc_vii_l2_wvv]
     file_key: data/quality_information/log10_j
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: cost_function
 
   flag_ml:
     name: flag_ml
     file_type: nc_vii_l2_ctp
     file_key: data/quality_information/flag_ml
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: cloud_multilayer_classification
 
   qi_forecast:
     name: qi_forecast
     file_type: [nc_vii_l2_wvi, nc_vii_l2_wvv]
     file_key: data/quality_information/qi_forecast
-    coordinates: [lon_pixels, lat_pixels]
+    coordinates: [lat_pixels, lon_pixels]
     standard_name: mass_of_water_in_air

--- a/satpy/tests/reader_tests/test_vii_l2_nc.py
+++ b/satpy/tests/reader_tests/test_vii_l2_nc.py
@@ -47,14 +47,14 @@ class TestViiL2NCFileHandler(unittest.TestCase):
             g1 = nc.createGroup('data')
 
             # Add dimensions to data group
-            g1.createDimension('num_pixels', 10)
-            g1.createDimension('num_lines', 100)
+            g1.createDimension('num_pixels', 100)
+            g1.createDimension('num_lines', 10)
 
             # Create measurement_data group
             g1_2 = g1.createGroup('measurement_data')
 
             # Add variables to data/measurement_data group
-            delta_lat = g1_2.createVariable('delta_lat', np.float32, dimensions=('num_pixels', 'num_lines'))
+            delta_lat = g1_2.createVariable('delta_lat', np.float32, dimensions=('num_lines', 'num_pixels'))
             delta_lat[:] = 0.1
 
         self.reader = ViiL2NCFileHandler(
@@ -82,7 +82,7 @@ class TestViiL2NCFileHandler(unittest.TestCase):
         """Test the functions."""
         # Checks that the _perform_orthorectification function is correctly executed
         variable = xr.DataArray(
-            dims=('num_pixels', 'num_lines'),
+            dims=('num_lines', 'num_pixels'),
             name='test_name',
             attrs={
                 'key_1': 'value_1',


### PR DESCRIPTION


 - [ ] This is essentially the L2 part to PR #1979 concerning the new METimage product format V4A (lat,lon instead of lon,lat)
 - [ ] vii_l2_nc.yaml has been updated so L2 product readers accept the new lat/lon format and have the correct file pattern.  
 - [ ] test_vii_l2_nc.py has also been updated accordingly.

