### PR TITLE
added the CRR-Ph files to the nwcsaf geo yaml file

### DIFF
--- a/satpy/etc/readers/nwcsaf-geo.yaml
+++ b/satpy/etc/readers/nwcsaf-geo.yaml
@@ -35,6 +35,10 @@ file_types:
         file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
         file_patterns: ['S_NWC_CRR_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc']
 
+    nc_nwcsaf_crr-ph:
+        file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
+        file_patterns: ['S_NWC_CRR-Ph_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc']
+
     nc_nwcsaf_ishai:
         file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
         file_patterns: ['S_NWC_iSHAI_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc']
@@ -352,6 +356,48 @@ datasets:
     name: crr_quality
     resolution: 3000
     file_type: nc_nwcsaf_crr
+
+# ---- CRR-Ph products ------------
+
+  crrph_intensity:
+    name: crrph_intensity
+    resolution: 3000
+    file_type: nc_nwcsaf_crr-ph
+
+  crrph_pal:
+    name: crrph_intensity_pal
+    resolution: 3000
+    file_type: nc_nwcsaf_crr-ph
+
+  crrph_accum:
+    name: crrph_accum
+    resolution: 3000
+    file_type: nc_nwcsaf_crr-ph
+
+  crrph_iqf:
+    name: crrph_iqf
+    resolution: 3000
+    file_type: nc_nwcsaf_crr-ph
+
+  crrph_iqf_pal:
+    name: crrph_iqf_pal
+    resolution: 3000
+    file_type: nc_nwcsaf_crr-ph
+
+  crrph_status_flag:
+    name: crrph_status 
+    resolution: 3000
+    file_type: nc_nwcsaf_crr-ph
+
+  crrph_conditions:
+    name: crrph_conditions
+    resolution: 3000
+    file_type: nc_nwcsaf_crr-ph
+
+  crrph_quality:
+    name: crrph_quality
+    resolution: 3000
+    file_type: nc_nwcsaf_crr-ph
 
 # ----iSHAI  products ------------
 

--- a/satpy/etc/readers/nwcsaf-geo.yaml
+++ b/satpy/etc/readers/nwcsaf-geo.yaml
@@ -385,7 +385,7 @@ datasets:
     file_type: nc_nwcsaf_crr-ph
 
   crrph_status_flag:
-    name: crrph_status 
+    name: crrph_status
     resolution: 3000
     file_type: nc_nwcsaf_crr-ph
 


### PR DESCRIPTION
added the CRR-Ph files (including the data products description) to the nwcsaf-geo.yaml file,
as it was missing 

CRR-Ph files can be found with find_files_and_readers
datasets can be loaded 

Cheers,
Ulrich 
