### PR TITLE
Document alternative for get_min/max_area

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -316,6 +316,8 @@ class Scene:
     def max_area(self, datasets=None):
         """Get highest resolution area for the provided datasets. Deprecated.
 
+        Deprecated.  Use :meth:`finest_area` instead.
+
         Args:
             datasets (iterable): Datasets whose areas will be compared. Can
                                  be either `xarray.DataArray` objects or
@@ -341,6 +343,8 @@ class Scene:
 
     def min_area(self, datasets=None):
         """Get lowest resolution area for the provided datasets. Deprecated.
+
+        Deprecated.  Use :meth:`coarsest_area` instead.
 
         Args:
             datasets (iterable): Datasets whose areas will be compared. Can


### PR DESCRIPTION
In the docstrings for get_min_area and get_max_area, do not only write
that they are deprecated, but also write what should be used instead.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
