### PR TITLE
Added filename pattern for CLASS subscription files.

### DIFF
--- a/satpy/etc/readers/avhrr_l1b_gaclac.yaml
+++ b/satpy/etc/readers/avhrr_l1b_gaclac.yaml
@@ -182,4 +182,6 @@ file_types:
     gac_lac_l1b:
         file_reader: !!python/name:satpy.readers.avhrr_l1b_gaclac.GACLACFile
         #NSS.GHRR.NJ.D95056.S1116.E1303.B0080506.GC
-        file_patterns: ['{creation_site:3s}.{transfer_mode:4s}.{platform_id:2s}.D{start_time:%y%j.S%H%M}.E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}']
+        file_patterns:
+        - '{creation_site:3s}.{transfer_mode:4s}.{platform_id:2s}.D{start_time:%y%j.S%H%M}.E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}'
+        - '{subscription_prefix:10d}.{creation_site:3s}.{transfer_mode:4s}.{platform_id:2s}.D{start_time:%y%j.S%H%M}.E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}'


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
The Scene class would fail to read AVHRR files received through a [CLASS](https://www.avl.class.noaa.gov/saa/products/welcome) subscription because of a numeric prefix to the file name. Fixes issue #2155 .
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

