### PR TITLE
Update AGRI reader to deal with invalid `valid_range` HDF attribute

### DIFF
--- a/satpy/readers/agri_l1.py
+++ b/satpy/readers/agri_l1.py
@@ -143,11 +143,13 @@ class HDF_AGRI_L1(HDF5FileHandler):
         elif calibration == 'radiance':
             raise NotImplementedError("Calibration to radiance is not supported.")
         # Apply range limits, but not for counts or we convert to float!
-        if calibration != 'counts':
+        if calibration != 'counts' and calibration is not None:
             data = data.where((data >= min(data.attrs['valid_range'])) &
                               (data <= max(data.attrs['valid_range'])))
         else:
             data.attrs['_FillValue'] = data.attrs['FillValue'].item()
+        if calibration is None:
+            data = data.where(data != data.attrs['FillValue'].item())
         return data
 
     def calibrate_to_reflectance(self, data, channel_index, ds_info):

--- a/satpy/readers/agri_l1.py
+++ b/satpy/readers/agri_l1.py
@@ -143,7 +143,7 @@ class HDF_AGRI_L1(HDF5FileHandler):
         elif calibration == 'radiance':
             raise NotImplementedError("Calibration to radiance is not supported.")
         # Apply range limits, but not for counts or we convert to float!
-        if calibration != 'counts' and calibration is not None:
+        if calibration not in ['counts', None]:
             data = data.where((data >= min(data.attrs['valid_range'])) &
                               (data <= max(data.attrs['valid_range'])))
         else:

--- a/satpy/readers/agri_l1.py
+++ b/satpy/readers/agri_l1.py
@@ -148,7 +148,6 @@ class HDF_AGRI_L1(HDF5FileHandler):
                               (data <= max(data.attrs['valid_range'])))
         else:
             data.attrs['_FillValue'] = data.attrs['FillValue'].item()
-        if calibration is None:
             data = data.where(data != data.attrs['FillValue'].item())
         return data
 

--- a/satpy/readers/agri_l1.py
+++ b/satpy/readers/agri_l1.py
@@ -148,7 +148,8 @@ class HDF_AGRI_L1(HDF5FileHandler):
                               (data <= max(data.attrs['valid_range'])))
         else:
             data.attrs['_FillValue'] = data.attrs['FillValue'].item()
-            data = data.where(data != data.attrs['FillValue'].item())
+        if calibration is None:
+            data = data.where(data != data.attrs['_FillValue'])
         return data
 
     def calibrate_to_reflectance(self, data, channel_index, ds_info):

--- a/satpy/readers/agri_l1.py
+++ b/satpy/readers/agri_l1.py
@@ -235,10 +235,16 @@ class HDF_AGRI_L1(HDF5FileHandler):
     def start_time(self):
         """Get the start time."""
         start_time = self['/attr/Observing Beginning Date'] + 'T' + self['/attr/Observing Beginning Time'] + 'Z'
-        return datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%S.%fZ')
+        try:
+            return datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%S.%fZ')
+        except ValueError:
+            return datetime.strptime(start_time, '%Y-%m-%dT%H:%M:%SZ')
 
     @property
     def end_time(self):
         """Get the end time."""
         end_time = self['/attr/Observing Ending Date'] + 'T' + self['/attr/Observing Ending Time'] + 'Z'
-        return datetime.strptime(end_time, '%Y-%m-%dT%H:%M:%S.%fZ')
+        try:
+            return datetime.strptime(end_time, '%Y-%m-%dT%H:%M:%S.%fZ')
+        except ValueError:
+            return datetime.strptime(end_time, '%Y-%m-%dT%H:%M:%SZ')

--- a/satpy/tests/reader_tests/test_agri_l1.py
+++ b/satpy/tests/reader_tests/test_agri_l1.py
@@ -226,7 +226,7 @@ class Test_HDF_AGRI_L1_cal:
 
     yaml_file = "agri_l1.yaml"
 
-    def setup(self):
+    def setup_method(self):
         """Wrap HDF5 file handler with our own fake handler."""
         from satpy._config import config_search_paths
         from satpy.readers.agri_l1 import HDF_AGRI_L1
@@ -253,17 +253,16 @@ class Test_HDF_AGRI_L1_cal:
                     14: np.array([[0.2, 0.3, 0.4, 0.5, 0.6], [0.7, 0.8, 0.9, 1., np.nan]])
                     }
 
-    def teardown(self):
+    def teardown_method(self):
         """Stop wrapping the HDF5 file handler."""
         self.p.stop()
 
     def test_times_correct(self):
         """Test that the reader handles the two possible time formats correctly."""
         reader = self._create_reader_for_resolutions(1000)
-        timestamp_ms = reader.start_time.timestamp()
+        np.testing.assert_almost_equal(reader.start_time.microsecond, 807000)
         reader = self._create_reader_for_resolutions(2000)
-        timestamp_noms = reader.start_time.timestamp()
-        np.testing.assert_almost_equal(timestamp_ms - timestamp_noms, 0.807)
+        np.testing.assert_almost_equal(reader.start_time.microsecond, 0)
 
     def test_fy4a_channels_are_loaded_with_right_resolution(self):
         """Test all channels are loaded with the right resolution."""


### PR DESCRIPTION
While trying to reproduce #2163 I discovered that the `valid_range` attribute for the azimuth angles stored in the AGRI L1 data files is incorrect. The `valid_range` is given as -180 -> 180 degrees but the data is in the range 0 -> 360 degrees.

This PR removes the check for data within the `valid_range` if the calibration is set to `None`, which is only the case for angles datasets.

Fixes #2163 