### PR TITLE
Fix coordinate names in Ocean Color CCI reader.

### DIFF
--- a/satpy/readers/oceancolorcci_l3_nc.py
+++ b/satpy/readers/oceancolorcci_l3_nc.py
@@ -84,6 +84,10 @@ class OCCCIFileHandler(NetCDF4FileHandler):
         if '_FillValue' in dataset.attrs:
             dataset.data = da.where(dataset.data == dataset.attrs['_FillValue'], np.nan, dataset.data)
         self._update_attrs(dataset, ds_info)
+        if 'lat' in dataset.dims:
+            dataset = dataset.rename({'lat': 'y'})
+        if 'lon' in dataset.dims:
+            dataset = dataset.rename({'lon': 'x'})
         return dataset
 
     def get_area_def(self, dsid):

--- a/satpy/tests/reader_tests/test_oceancolorcci_l3_nc.py
+++ b/satpy/tests/reader_tests/test_oceancolorcci_l3_nc.py
@@ -32,29 +32,29 @@ def fake_dataset():
     """Create a CLAAS-like test dataset."""
     adg = xr.DataArray(
         [[1.0, 0.47, 4.5, 1.2], [0.2, 0, 1.3, 1.3]],
-        dims=("y", "x")
+        dims=("lat", "lon")
     )
     atot = xr.DataArray(
         [[0.001, 0.08, 23.4, 0.1], [2.1, 1.2, 4.7, 306.]],
-        dims=("y", "x")
+        dims=("lat", "lon")
     )
     kd = xr.DataArray(
         [[0.8, 0.01, 5.34, 1.23], [0.4, 1.0, 3.2, 1.23]],
-        dims=("y", "x")
+        dims=("lat", "lon")
     )
     nobs = xr.DataArray(
         [[5, 118, 5, 100], [0, 15, 0, 1]],
-        dims=("y", "x"),
+        dims=("lat", "lon"),
         attrs={'_FillValue': 0}
     )
     nobs_filt = xr.DataArray(
         [[5, 118, 5, 100], [np.nan, 15, np.nan, 1]],
-        dims=("y", "x"),
+        dims=("lat", "lon"),
         attrs={'_FillValue': 0}
     )
     watcls = xr.DataArray(
         [[12.2, 0.01, 6.754, 5.33], [12.5, 101.5, 103.5, 204.]],
-        dims=("y", "x")
+        dims=("lat", "lon")
     )
     attrs = {
         "geospatial_lon_resolution": "90",


### PR DESCRIPTION
I mistakenly forgot to set the correct coordinate names in the Ocean Color CCI reader. Satpy expects `x` and `y` but I was using `lon` and `lat`.

This PR renames the coordinates within the reader and also fixes the tests so that they use the same coordinate names as the actual data files.
