### PR TITLE
Implements a html representation for the Scene

### DIFF
--- a/satpy/formatting_html.py
+++ b/satpy/formatting_html.py
@@ -50,7 +50,7 @@ def scene_repr(scene):
 
     TODO:
         - streamline loading and combining of css styles. Move _load_static_files function into pyresample
-        - display combined numer of datasets, area name, projection, extent, sensor after object type?
+        - display combined numer of datasets, area name, projection, extent, sensor, start/end time after object type?
         - drop "unecessary" attributes from the datasets?
         - make the area show as tabbed display (attribtues/ map each in tab)?
         - only show resolution and dimensions (number of pixels) for each section if the area definition extent,

--- a/satpy/formatting_html.py
+++ b/satpy/formatting_html.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2010-2022 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Html formatting function for Scene representation in notebooks."""
+
+from functools import lru_cache
+from html import escape
+from importlib.resources import read_binary
+
+from pyresample.formatting_html import area_repr  # , _icon, collapsible_section, STATIC_FILES
+from xarray.core.formatting_html import datavar_section
+
+STATIC_FILES = {"html": [("xarray.static.html", "icons-svg-inline.html")],
+                "css": [("pyresample.static.css", "style.css"), ("xarray.static.css", "style.css")]
+                }
+
+
+@lru_cache(None)
+def _load_static_files():
+    """Lazily load the resource files into memory the first time they are needed."""
+    css = "\n".join([read_binary(package, resource).decode("utf-8") for package, resource in STATIC_FILES["css"]])
+
+    html = "\n".join([read_binary(package, resource).decode("utf-8") for package, resource in STATIC_FILES["html"]])
+
+    return [html, css]
+
+
+def scene_repr(scene):
+    """Html representation of Scene.
+
+    Args:
+        scene (:class:`~satpy.scene.Scene`): Satpy scene.
+
+    Returns:
+        str: Html str
+
+    TODO:
+        - streamline loading and combining of css styles. Move _load_static_files function into pyresample
+        - display combined numer of datasets, area name, projection, extent, sensor after object type?
+        - drop "unecessary" attributes from the datasets?
+        - make the area show as tabbed display (attribtues/ map each in tab)?
+        - only show resolution and dimensions (number of pixels) for each section if the area definition extent,
+          projection (and name) is the same?
+        - for the data variables list not only display channel (dataarray) name but also other DataId info
+          (like spectral range)?
+        - what about composites?
+    """
+    icons_svg, css_style = _load_static_files()
+
+    obj_type = f"satpy.scene.{type(scene).__name__}"
+    header = ("<div class='pyresample-header'>"
+              "<div class='pyresample-obj-type'>"
+              f"{escape(obj_type)}"
+              "</div>"
+              "</div>"
+              )
+
+    html = (
+           f"{icons_svg}<style>{css_style}</style>"
+           f"<pre class='pyresample-text-repr-fallback'>{escape(repr(scene))}</pre>"
+           "<div class='pyresample-wrap' style='display:none'>"
+           )
+
+    html += f"{header}"
+
+    html += "<div class='pyresample-area-sections'>"
+
+    for _, dss in scene.iter_by_area():
+        area = scene[dss[0]].attrs.get("area")
+        html += area_repr(area, include_header=False)
+
+        ds_names = [x.name for x in dss]
+        scn_ds = scene.to_xarray_dataset(ds_names)
+        ds_list = ("<div class='xr-wrap' style='display:none'>"
+                   f"<ul class='xr-sections'>"
+                   f"<li class='xr-section-item'>{datavar_section(scn_ds.data_vars)}</li>"
+                   "</ul></div>")
+
+        html += ds_list  # collapsible_section("Channels", details=ds_list, icon=icon)
+        html += "<hr>"
+
+    html += "</div>"
+
+    return html

--- a/satpy/formatting_html.py
+++ b/satpy/formatting_html.py
@@ -17,18 +17,394 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Html formatting function for Scene representation in notebooks."""
 
+import uuid
 from functools import lru_cache
 from html import escape
 from importlib.resources import read_binary
 
 import toolz
 import xarray as xr
-from pyresample._formatting_html import _icon, area_repr, collapsible_section  # , STATIC_FILES
+from pyresample._formatting_html import _icon, plot_area_def
 from xarray.core.formatting_html import _mapping_section, summarize_vars  # , datavar_section
 
-STATIC_FILES = {"html": [("xarray.static.html", "icons-svg-inline.html")],
-                "css": [("pyresample.static.css", "style.css"), ("xarray.static.css", "style.css")]
+STATIC_FILES = {"html": [("pyresample.static.html", "icons_svg_inline.html")],
+                "css": [("pyresample.static.css", "style.css")]
                 }
+
+css = """
+:root {
+  --xr-font-color0: var(--jp-content-font-color0, rgba(0, 0, 0, 1));
+  --xr-font-color2: var(--jp-content-font-color2, rgba(0, 0, 0, 0.54));
+  --xr-font-color3: var(--jp-content-font-color3, rgba(0, 0, 0, 0.38));
+  --xr-border-color: var(--jp-border-color2, #e0e0e0);
+  --xr-disabled-color: var(--jp-layout-color3, #bdbdbd);
+  --xr-background-color: var(--jp-layout-color0, white);
+  --xr-background-color-row-even: var(--jp-layout-color1, white);
+  --xr-background-color-row-odd: var(--jp-layout-color2, #eeeeee);
+}
+
+html[theme=dark],
+body[data-theme=dark],
+body.vscode-dark {
+  --xr-font-color0: rgba(255, 255, 255, 1);
+  --xr-font-color2: rgba(255, 255, 255, 0.54);
+  --xr-font-color3: rgba(255, 255, 255, 0.38);
+  --xr-border-color: #1F1F1F;
+  --xr-disabled-color: #515151;
+  --xr-background-color: #111111;
+  --xr-background-color-row-even: #111111;
+  --xr-background-color-row-odd: #313131;
+}
+
+.satpy-scene-sections {
+  padding: 0 !important;
+  display: grid;
+  grid-template-columns: 20px 20px 150px auto 20px 20px;
+  width: 1000px;
+}
+
+.satpy-section-name {
+  grid-column: 2 / 3;
+}
+
+.satpy-scene-section-item {
+  display: contents;
+}
+
+.satpy-scene-section-item input {
+  display: none;
+}
+
+.satpy-scene-section-item input:enabled + label {
+  cursor: pointer;
+}
+
+.satpy-scene-section-summary {
+  grid-column: 1 / 4;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.satpy-scene-section-in:checked + label > span {
+  display: none;
+}
+
+.satpy-scene-section-inline-preview {
+  grid-column: 4 / -1
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.satpy-scene-section-details,
+.satpy-scene-section-in:checked ~ .satpy-scene-section-preview {
+  display: none;
+}
+
+.satpy-scene-section-in:checked ~ .satpy-scene-section-details,
+.satpy-scene-section-preview {
+  display: contents;
+  padding: 0;
+  grid-column: 3 / -1;
+}
+
+.satpy-scene-section-area {
+  display: contents;
+}
+
+.satpy-area-name {
+  grid-column: 3;
+  font-weight: bold;
+}
+
+.satpy-area-details {
+  grid-column: 4;
+}
+
+/*show hide css for area def section */
+.satpy-area-attrs,
+.satpy-area-map {
+  display: none;
+}
+
+.satpy-area-attrs-in:checked ~ .satpy-area-attrs,
+.satpy-area-map-in:checked ~ .satpy-area-map {
+  display: block;
+  grid-column: 3 / -1;
+}
+
+.satpy-area-attrs dt {
+  width: 190px;
+  float: left;
+  font-weight: bold;
+  margin-right: 0.5em;
+}
+
+.satpy-area-attrs dt:after {
+  content: ": ";
+}
+
+.satpy-area-attrs dd {
+  all: initial;
+}
+
+.satpy-area-attrs dd:after {
+  clear: left;
+  content: " ";
+  display: block;
+}
+
+.satpy-scene-section-datasets {
+  grid-column: 3 / -1;
+}
+
+.xr-wrap {
+  all: initial;
+}
+
+.xr-wrap {
+  display: block !important;
+  min-width: 300px;
+  max-width: 1000px;
+}
+ .xr-sections {
+  padding-left: 0 !important;
+  display: grid;
+  grid-template-columns: 150px auto auto 1fr 20px 20px;
+}
+
+.xr-section-item {
+  display: contents;
+}
+
+.xr-section-item input {
+  display: none;
+}
+
+.xr-section-item input + label {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-item input:enabled + label {
+  cursor: pointer;
+  color: var(--xr-font-color2);
+}
+
+.xr-section-item input:enabled + label:hover {
+  color: var(--xr-font-color0);
+}
+
+.xr-section-summary {
+  grid-column: 1;
+  color: var(--xr-font-color2);
+  font-weight: 500;
+}
+
+.xr-section-summary > span {
+  display: inline-block;
+  padding-left: 0.5em;
+}
+
+.xr-section-summary-in:disabled + label {
+  color: var(--xr-font-color2);
+}
+
+.xr-section-summary-in + label:before {
+  display: inline-block;
+  content: '►';
+  font-size: 11px;
+  width: 15px;
+  text-align: center;
+}
+
+.xr-section-summary-in:disabled + label:before {
+  color: var(--xr-disabled-color);
+}
+
+.xr-section-summary-in:checked + label:before {
+  content: '▼';
+}
+
+.xr-section-summary-in:checked + label > span {
+  display: none;
+}
+
+.xr-section-summary,
+.xr-section-inline-details {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.xr-section-inline-details {
+  grid-column: 2 / -1;
+}
+
+.xr-section-details {
+  display: none;
+  grid-column: 1 / -1;
+  margin-bottom: 5px;
+}
+
+.xr-section-summary-in:checked ~ .xr-section-details {
+  display: contents;
+}
+
+.xr-sections {
+  padding-left: 0 !important;
+  display: grid;
+  grid-template-columns: 250px auto auto 1fr 20px 20px;
+}
+
+.xr-section-item {
+  display: contents;
+}
+
+.xr-section-item input:enabled + label {
+  cursor: pointer;
+  color: var(--xr-font-color2);
+}
+
+.xr-section-summary,
+.xr-section-inline-details {
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.xr-section-inline-details {
+  margin-bottom: 5px;
+}
+
+.xr-var-list,
+.xr-var-item {
+  display: contents;
+}
+
+.xr-var-item > div,
+.xr-var-item label,
+.xr-var-item > .xr-var-name span {
+  background-color: var(--xr-background-color-row-even);
+  margin-bottom: 0;
+}
+
+.xr-var-item > .xr-var-name:hover span {
+  padding-right: 5px;
+}
+
+.xr-var-list > li:nth-child(odd) > div,
+.xr-var-list > li:nth-child(odd) > label,
+.xr-var-list > li:nth-child(odd) > .xr-var-name span {
+  background-color: var(--xr-background-color-row-odd);
+}
+
+.xr-var-name {
+  grid-column: 1;
+}
+
+.xr-var-dims {
+  grid-column: 2;
+}
+
+.xr-var-dtype {
+  grid-column: 3;
+  text-align: right;
+  color: var(--xr-font-color2);
+}
+
+.xr-var-preview {
+  grid-column: 4;
+}
+
+.xr-var-name,
+.xr-var-dims,
+.xr-var-dtype,
+.xr-preview,
+.xr-attrs dt {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding-right: 10px;
+}
+
+.xr-var-name:hover,
+.xr-var-dims:hover,
+.xr-var-dtype:hover,
+.xr-attrs dt:hover {
+  overflow: visible;
+  width: auto;
+  z-index: 1;
+}
+
+.xr-var-attrs,
+.xr-var-data {
+  display: none;
+  background-color: var(--xr-background-color) !important;
+  padding-bottom: 5px !important;
+}
+
+.xr-var-attrs-in:checked ~ .xr-var-attrs,
+.xr-var-data-in:checked ~ .xr-var-data {
+  display: block;
+}
+
+.xr-var-data > table {
+  float: right;
+}
+
+.xr-var-name span,
+.xr-var-data,
+.xr-attrs {
+  padding-left: 25px !important;
+}
+
+.xr-attrs,
+.xr-var-attrs,
+.xr-var-data {
+  grid-column: 1 / -1;
+}
+
+dl.xr-attrs {
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 125px auto;
+}
+
+.xr-attrs dt,
+.xr-attrs dd {
+  padding: 0;
+  margin: 0;
+  float: left;
+  padding-right: 10px;
+  width: auto;
+}
+
+.xr-attrs dt {
+  font-weight: normal;
+  grid-column: 1;
+}
+
+.xr-attrs dt:hover span {
+  display: inline-block;
+  background: var(--xr-background-color);
+  padding-right: 10px;
+}
+
+.xr-attrs dd {
+  grid-column: 2;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.xr-icon-database,
+.xr-icon-file-text2 {
+  display: inline-block;
+  vertical-align: middle;
+  width: 1em;
+  height: 1.5em !important;
+  stroke-width: 0;
+  stroke: currentColor;
+  fill: currentColor;
+}
+"""
 
 
 @lru_cache(None)
@@ -47,24 +423,61 @@ def attr(attr_name, ds):
     return ds.attrs.get(attr_name)
 
 
-def sensor_section(platform_name, sensor_name, datasets):
+def collapsible_section_satpy(name, inline_details="", details="", n_items=None, enabled=True, collapsed=False,
+                              icon=None):
+    """Create a collapsible section.
+
+    Args:
+      name (str): Name of the section
+      inline_details (str): Information to show when section is collapsed. Default nothing.
+      details (str): Details to show when section is expanded.
+      n_items (int): Number of items in this section.
+      enabled (boolean): Is collapsing enabled. Default True.
+      collapsed (boolean): Is the section collapsed on first show. Default False.
+
+    Returns:
+      str: Html div structure for collapsible section.
+
+    """
+    # "unique" id to expand/collapse the section
+    data_id = "section-" + str(uuid.uuid4())
+
+    has_items = n_items is not None and n_items
+    n_items_span = "" if n_items is None else f" <span>({n_items})</span>"
+    enabled = "" if enabled and has_items else "disabled"
+    collapsed = "" if collapsed or not has_items else "checked"
+    tip = " title='Expand/collapse section'" if enabled else ""
+
+    if icon is None:
+        icon = _icon("icon-database")
+
+    return ("<div class='satpy-scene-section-item'>"
+            f"<input id='{data_id}' class='satpy-scene-section-in' "
+            f"type='checkbox' {enabled} {collapsed}>"
+            f"<label for='{data_id}' class='satpy-scene-section-summary' {tip}>{icon} {name}: {n_items_span}</label>"
+            f"<div class='satpy-scene-section-inline-preview'>{inline_details}</div>"
+            f"<div class='satpy-scene-section-details'>{details}</div>"
+            "</div>"
+            )
+
+
+def sensor_section(platform_name, sensor_name, datasets, number_of_platforms):
     """Generate sensor section."""
     by_area = toolz.groupby(lambda x: x.attrs.get("area").proj_dict.get("proj"), datasets)
 
     sensor_name = sensor_name.upper()
     icon = _icon("icon-satellite")
 
-    section_name = (f"<div>"
-                    f"<a href='https://space.oscar.wmo.int/satellites/view/{platform_name}'>{platform_name}</a>/"
+    section_name = (f"<a href='https://space.oscar.wmo.int/satellites/view/{platform_name}'>{platform_name}</a> / "
                     f"<a href='https://space.oscar.wmo.int/instruments/view/{sensor_name}'>{sensor_name}</a>"
-                    "</div>")
+                    )
 
     section_details = ""
     for proj, ds in by_area.items():
         section_details += resolution_section(proj, ds)
 
-    html = collapsible_section(section_name, details=section_details, icon=icon)
-    # html += "</div>"
+    html = collapsible_section_satpy(section_name, details=section_details, n_items=number_of_platforms, icon=icon)
+
     return html
 
 
@@ -77,16 +490,43 @@ def resolution_section(projection, datasets):
 
     by_resolution = toolz.groupby(resolution, datasets)
 
-    # html = f"<div>{projection}</div>"
-    # modify area representation
-    html = area_repr(datasets[0].attrs.get("area"), include_header=False)
-    #
+    areadefinition = datasets[0].attrs.get("area")
+    proj_dict = areadefinition.proj_dict
+    proj_str = "{{{}}}".format(", ".join(["'%s': '%s'" % (str(k), str(proj_dict[k])) for k in
+                                          sorted(proj_dict.keys())]))
+
+    area_attrs = ("<dl>"
+                  f"<dt>Description</dt><dd>{areadefinition.description}</dd>"
+                  f"<dt>Projection</dt><dd>{proj_str}</dd>"
+                  f"<dt>Extent (ll_x, ll_y, ur_x, ur_y)</dt>"
+                  f"<dd>{tuple(round(x, 4) for x in areadefinition.area_extent)}</dd>"
+                  "</dl>"
+                  )
+
+    area_map = plot_area_def(areadefinition)
+
+    attrs_id = "attrs-" + str(uuid.uuid4())
+    map_id = "map-" + str(uuid.uuid4())
+    attrs_icon = _icon("icon-file-text2")
+    map_icon = _icon("icon-globe")
+
+    html = ("<div class='satpy-scene-section-area'>"
+            f"<div class='satpy-area-name'>{areadefinition.area_id}</div>"
+            f"<div class='satpy-area-details'></div>"
+            f"<input id='{attrs_id}' class='satpy-area-attrs-in' type='checkbox'>"
+            f"<label for='{attrs_id}' title='Show/Hide properties'>{attrs_icon}</label>"
+            f"<input id='{map_id}' class='satpy-area-map-in' type='checkbox'>"
+            f"<label for='{map_id}' title='Show/Hide map'>{map_icon}</label>"
+            f"<div class='satpy-area-attrs'>{area_attrs}</div>"
+            f"<div class='satpy-area-map'>{area_map}</div>"
+            "</div>"
+            )
+
     for res, ds in by_resolution.items():
         ds_dict = {i.attrs['name']: i.rename(i.attrs['name']) for i in ds if i.attrs.get('area') is not None}
         dss = xr.merge(ds_dict.values())
         html += xarray_dataset_repr(dss, "Resolution (x/y): {}".format(res))
 
-    html += "</div>"
     return html
 
 
@@ -103,7 +543,6 @@ def scene_repr(scene):
         - streamline loading and combining of css styles. Move _load_static_files function into pyresample
         - display combined numer of datasets, area name, projection, extent, sensor, start/end time after object type?
         - drop "unecessary" attributes from the datasets?
-        - make the area show as tabbed display (attribtues/ map each in tab)?
         - only show resolution and dimensions (number of pixels) for each section if the area definition extent,
           projection (and name) is the same?
         - for the data variables list not only display channel (dataarray) name but also other DataId info
@@ -111,6 +550,7 @@ def scene_repr(scene):
         - what about composites?
     """
     icons_svg, css_style = _load_static_files()
+    css_style = "\n".join([css, css_style])
 
     obj_type = f"satpy.scene.{type(scene).__name__}"
     header = ("<div class='pyresample-header'>"
@@ -128,17 +568,17 @@ def scene_repr(scene):
            )
 
     html += f"{header}"
+    html += "<ul class='satpy-scene-sections'>"
 
     dslist = list(scene._datasets.values())
-    # scn_by_sensor = toolz.groupby(attr("sensor"), dslist)
     scn_by_sensor = toolz.groupby(lambda x: (x.attrs.get("platform_name"), x.attrs.get("sensor")), dslist)
+    n_platforms = len(list(scn_by_sensor.keys()))
 
     # when more than one platform/sensor collapse section
-
     for (platform, sensor), dss in scn_by_sensor.items():
-        html += sensor_section(platform, sensor, dss)  # simple(scene)
+        html += sensor_section(platform, sensor, dss, n_platforms)
 
-    html += "</div>"
+    html += "</ul></div>"
 
     return html
 
@@ -148,27 +588,12 @@ def xarray_dataset_repr(dataset, ds_name):
     data_variables = _mapping_section(mapping=dataset, name=ds_name, details_func=summarize_vars,
                                       max_items_collapse=15, expand_option_name="display_expand_data_vars")
 
-    ds_list = ("<div class='xr-wrap' style='display:none'>"
+    ds_list = ("<div class='satpy-scene-section-datasets'>"
+               "<div class='xr-wrap' style='display:none'>"
                f"<ul class='xr-sections'>"
                f"<li class='xr-section-item'>{data_variables}</li>"
-               "</ul></div>")
+               "</ul></div>"
+               "</div>"
+               )
 
     return ds_list
-
-
-def simple(scene):
-    """Generate old scene repr."""
-    html = ""
-    html += "<div class='pyresample-area-sections'>"
-
-    for _, dss in scene.iter_by_area():
-        area = scene[dss[0]].attrs.get("area")
-        html += area_repr(area, include_header=False)
-
-        ds_names = [x.name for x in dss]
-        scn_ds = scene.to_xarray_dataset(ds_names)
-        html += xarray_dataset_repr(scn_ds, "Data Variables")
-        # collapsible_section("Channels", details=ds_list, icon=icon)
-        html += "<hr>"
-
-    return html

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -32,6 +32,7 @@ from satpy.composites import IncompatibleAreas
 from satpy.composites.config_loader import load_compositor_configs_for_sensors
 from satpy.dataset import DataID, DataQuery, DatasetDict, combine_metadata, dataset_walker, replace_anc
 from satpy.dependency_tree import DependencyTree
+from satpy.formatting_html import scene_repr
 from satpy.node import CompositorNode, MissingDependencies, ReaderNode
 from satpy.readers import load_readers
 from satpy.resample import get_area_def, prepare_resampler, resample_dataset
@@ -516,6 +517,10 @@ class Scene:
         """Generate a nice print out for the scene."""
         res = (str(proj) for proj in self._datasets.values())
         return "\n".join(res)
+
+    def _repr_html_(self):
+        """Html representation of Scene for notebooks."""
+        return scene_repr(self)
 
     def __iter__(self):
         """Iterate over the datasets."""


### PR DESCRIPTION
While many users use Satpy in automated scripts in a more interactive workflow in Jupyter notebooks printing the Scene just outputs a concatenated list of the string representation of xarray DataArrays.
In my opinion this does not give a good overview of the Scene and what is contained in it.

Inspired by the xarray html representation of Datasets and DataArrays (in fact for some parts I reused code/css from xarray, more about that below) I implemented a html representation for the Scene.

The Scene can potentially contain data from different platforms/sensors with different areas, resolutions and extents. The current implementation tries to capture this and give a somewhat structured overview of the Scene resulting in the following design idea:
- it lists the contained data by platform/sensor first (collapsible)
- for each platform/sensor it lists the data by area definition (projection)
- for each area definition (projection) the area properties and a map overview is included which can be folded out followed by the contained xarray DataArrays by resolution (here the html representation of xarray Datasets is reused)

# Collapsed view
![satpy_scene_repr_html_folded](https://user-images.githubusercontent.com/12115839/184142993-4f297cba-7bb8-449d-b6ca-df6be81845a4.png)

# Uncollapsed view
![satpy_scene_repr_html_unfolded](https://user-images.githubusercontent.com/12115839/184143011-5484a893-cbac-4cc4-aa61-6692f196298e.png)

# In progress "features"
- Add some information e.g. number of data items, etc. to the headers when sections area collapsed
- Add other information other than dataset name from DataId to each data item row?

# Todos
Right now this mixes in some code/css from https://github.com/pytroll/pyresample/pull/450 because when I started working on this I thought that I might reuse the html representation of the area definition. Turns out I wanted it to look
a little different in the html view of the Scene :-D. Apart from that I duplicated some code/css from xarray for the display of the data (this also leads to a little display bug when somewhere in the notebook another xarray object is shown). So obvious todos are:
- refactor css
    - refactor xarray code/css to use satpy css class names
    - seperate pyresample code/css completely from satpy
- refactor the formatting code

# Design questions and ideas
Obviously "design" is always opinionated so some of my questions/ideas are:
- Does it make sense to list by platform/sensor, area/projection, resolution or should it be something different?
- How do you feel about the layout/look?
- One thing that I did not cover yet is: what to do if there are different extents? One thing I am probably going to implement is to also show the extent with the area attributes when it is the same for all data items, which should cover the most basic situation.
- Is there something missing that would be informative to show?
- Should there be an option to activate showing available but not yet loaded datasets based on the reader (greyed out)? This would make it a lot easier for users to get the dataset names interactively and also see what is supported.
- in https://github.com/pytroll/pyresample/pull/450 @djhoese suggested to maybe move the css/icon html inline. Haven't done that in https://github.com/pytroll/pyresample/pull/450 yet but tried it out here. It does have some advantages (not needing extra files/directories in the repo, no loading function). I didn't really test if the caching as done in xarray and which I reused is better performance wise when more than one Scene is view in a notebook.
- other things/ideas?

Another note: while I got it looking and working the way I wanted it the css/html probably is a mess (haven't done any in a long time). So if there are any html/css wizards out there help is appreciated :-).
