### PR TITLE
Fix 3d effect enhancement

### DIFF
--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -534,13 +534,12 @@ def three_d_effect(img, **kwargs):
                        [-w, 1, w],
                        [-w, 0, w]])
     mode = kwargs.get('convolve_mode', 'same')
-
     return _three_d_effect(img.data, kernel=kernel, mode=mode)
 
 
 @exclude_alpha
 @on_separate_bands
-@using_map_blocks
+@on_dask_array
 def _three_d_effect(band_data, kernel=None, mode=None, index=None):
     del index
 

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -63,10 +63,11 @@ class TestEnhancementStretch:
         crefl_data /= 5.605
         crefl_data[0, 0] = np.nan  # one bad value for testing
         crefl_data[0, 1] = 0.
-        self.ch1 = xr.DataArray(data, dims=('y', 'x'), attrs={'test': 'test'})
-        self.ch2 = xr.DataArray(crefl_data, dims=('y', 'x'), attrs={'test': 'test'})
+        self.ch1 = xr.DataArray(da.from_array(data, chunks=2), dims=('y', 'x'), attrs={'test': 'test'})
+        self.ch2 = xr.DataArray(da.from_array(crefl_data, chunks=2), dims=('y', 'x'), attrs={'test': 'test'})
         rgb_data = np.stack([data, data, data])
-        self.rgb = xr.DataArray(rgb_data, dims=('bands', 'y', 'x'),
+        self.rgb = xr.DataArray(da.from_array(rgb_data, chunks=(3, 2, 2)),
+                                dims=('bands', 'y', 'x'),
                                 coords={'bands': ['R', 'G', 'B']})
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
This PR fixes the 3d effect enhancement that was wrongly converted in dc28b1d50bdd4adb91d782dbc3cf3c474638e0f5 to use map_block where it should be delayed.

Also, the enhancement tests are now running on dask array-based DataArray for more realism.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #2173 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

