### PR TITLE
Fix plugins not working with new versions of setuptools

### DIFF
--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Satpy Configuration directory and file handling."""
+from __future__ import annotations
 
 import ast
 import glob
@@ -24,7 +25,18 @@ import os
 import sys
 from collections import OrderedDict
 from importlib.metadata import entry_points
-from importlib.resources import files as impr_files  # type: ignore
+from pathlib import Path
+
+try:
+    from importlib.resources import files as impr_files  # type: ignore
+except ImportError:
+    # Python 3.8
+    def impr_files(module_name: str) -> Path:
+        """Get path to module as a backport for Python 3.8."""
+        from importlib.resources import path as impr_path
+
+        with impr_path(module_name, "__init__.py") as pkg_init_path:
+            return pkg_init_path.parent
 
 import appdirs
 from donfig import Config

--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -123,12 +123,21 @@ def get_entry_points_config_dirs(name, include_config_path=True):
     """Get the config directories for all entry points of given name."""
     dirs = []
     for entry_point in entry_points().get(name, []):
-        new_dir = str(impr_files(entry_point.module) / "etc")
+        module = _entry_point_module(entry_point)
+        new_dir = str(impr_files(module) / "etc")
         if not dirs or dirs[-1] != new_dir:
             dirs.append(new_dir)
     if include_config_path:
         dirs.extend(config.get('config_path')[::-1])
     return dirs
+
+
+def _entry_point_module(entry_point):
+    try:
+        return entry_point.module
+    except AttributeError:
+        # Python 3.8
+        return entry_point.value.split(":")[0].strip()
 
 
 def config_search_paths(filename, search_dirs=None, **kwargs):

--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -23,9 +23,10 @@ import logging
 import os
 import sys
 from collections import OrderedDict
+from importlib.metadata import entry_points
+from importlib.resources import files as impr_files  # type: ignore
 
 import appdirs
-import pkg_resources
 from donfig import Config
 
 LOG = logging.getLogger(__name__)
@@ -109,9 +110,8 @@ def get_config_path_safe():
 def get_entry_points_config_dirs(name, include_config_path=True):
     """Get the config directories for all entry points of given name."""
     dirs = []
-    for entry_point in pkg_resources.iter_entry_points(name):
-        package_name = entry_point.module_name.split('.', 1)[0]
-        new_dir = os.path.join(entry_point.dist.module_path, package_name, 'etc')
+    for entry_point in entry_points().get(name, []):
+        new_dir = str(impr_files(entry_point.module) / "etc")
         if not dirs or dirs[-1] != new_dir:
             dirs.append(new_dir)
     if include_config_path:

--- a/satpy/composites/config_loader.py
+++ b/satpy/composites/config_loader.py
@@ -209,6 +209,8 @@ def _load_config(composite_configs):
 
     comp_config_helper = _CompositeConfigHelper(sensor_compositors, id_keys)
     configured_composites = conf.get('composites', {})
+    if any("viirs.yaml" in config for config in composite_configs):
+        print(configured_composites)
     comp_config_helper.parse_config(configured_composites, composite_configs)
     return sensor_compositors, sensor_modifiers, id_keys
 
@@ -275,6 +277,8 @@ def load_compositor_configs_for_sensor(sensor_name: str) -> tuple[dict[str, dict
     composite_configs = config_search_paths(
         os.path.join("composites", config_filename),
         search_dirs=paths, check_exists=True)
+    print(paths)
+    print(composite_configs)
     if not composite_configs:
         logger.debug("No composite config found called %s",
                      config_filename)

--- a/satpy/composites/config_loader.py
+++ b/satpy/composites/config_loader.py
@@ -209,8 +209,6 @@ def _load_config(composite_configs):
 
     comp_config_helper = _CompositeConfigHelper(sensor_compositors, id_keys)
     configured_composites = conf.get('composites', {})
-    if any("viirs.yaml" in config for config in composite_configs):
-        print(configured_composites)
     comp_config_helper.parse_config(configured_composites, composite_configs)
     return sensor_compositors, sensor_modifiers, id_keys
 
@@ -277,8 +275,6 @@ def load_compositor_configs_for_sensor(sensor_name: str) -> tuple[dict[str, dict
     composite_configs = config_search_paths(
         os.path.join("composites", config_filename),
         search_dirs=paths, check_exists=True)
-    print(paths)
-    print(composite_configs)
     if not composite_configs:
         logger.debug("No composite config found called %s",
                      config_filename)

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -138,9 +138,10 @@ def _get_entry_points_and_etc_paths(
             parts = [part.strip() for part in entry_point_value.split("=")]
             ep_name = parts[0]
             ep_value = parts[1]
+            ep_module = ep_value.split(":")[0].strip()
             ep = EntryPoint(name=ep_name, group=ep_group, value=ep_value)
             entry_points[ep_group].append(ep)
-            entry_point_module_paths[ep.module] = module_path  # type: ignore
+            entry_point_module_paths[ep_module] = module_path
     return etc_path, entry_points, entry_point_module_paths
 
 

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -22,11 +22,11 @@ import contextlib
 import os
 import sys
 import unittest
+from importlib.metadata import EntryPoint
 from pathlib import Path
 from typing import Callable, Iterator
 from unittest import mock
 
-import pkg_resources
 import pytest
 
 import satpy
@@ -115,34 +115,45 @@ def fake_plugin_etc_path(
     package is installed and has made a satpy plugin available.
 
     """
-    etc_path, entry_points = _get_entry_point_list(tmp_path, entry_point_names)
+    etc_path, entry_points, module_paths = _get_entry_points_and_etc_paths(tmp_path, entry_point_names)
     fake_iter_entry_points = _create_fake_iter_entry_points(entry_points)
-    with mock.patch('satpy._config.pkg_resources.iter_entry_points', fake_iter_entry_points):
+    fake_importlib_files = _create_fake_importlib_files(module_paths)
+    with mock.patch('satpy._config.entry_points', fake_iter_entry_points), \
+            mock.patch('satpy._config.impr_files', fake_importlib_files):
         yield etc_path
 
 
-def _get_entry_point_list(
+def _get_entry_points_and_etc_paths(
         tmp_path: Path,
         entry_point_names: dict[str, list[str]]
-) -> tuple[Path, dict[str, list[pkg_resources.EntryPoint]]]:
-    dist_obj = pkg_resources.Distribution.from_filename('satpy_plugin-0.0.0-py3.8.egg')
-    etc_path = tmp_path / "satpy_plugin" / "etc"
+) -> tuple[Path, dict[str, list[EntryPoint]], dict[str, Path]]:
+    module_path = tmp_path / "satpy_plugin"
+    etc_path = module_path / "etc"
     etc_path.mkdir(parents=True, exist_ok=True)
-    entry_points: dict[str, list[pkg_resources.EntryPoint]] = {}
-    for entry_point_name, entry_point_values in entry_point_names.items():
-        entry_points[entry_point_name] = []
+    entry_points: dict[str, list[EntryPoint]] = {}
+    entry_point_module_paths: dict[str, Path] = {}
+    for ep_group, entry_point_values in entry_point_names.items():
+        entry_points[ep_group] = []
         for entry_point_value in entry_point_values:
-            ep = pkg_resources.EntryPoint.parse(entry_point_value)
-            ep.dist = dist_obj
-            ep.dist.module_path = tmp_path  # type: ignore
-            entry_points[entry_point_name].append(ep)
-    return etc_path, entry_points
+            parts = [part.strip() for part in entry_point_value.split("=")]
+            ep_name = parts[0]
+            ep_value = parts[1]
+            ep = EntryPoint(name=ep_name, group=ep_group, value=ep_value)
+            entry_points[ep_group].append(ep)
+            entry_point_module_paths[ep.module] = module_path  # type: ignore
+    return etc_path, entry_points, entry_point_module_paths
 
 
-def _create_fake_iter_entry_points(entry_points: dict[str, list[pkg_resources.EntryPoint]]) -> Callable[[str], list]:
-    def _fake_iter_entry_points(desired_entry_point_name: str) -> list:
-        return entry_points.get(desired_entry_point_name, [])
+def _create_fake_iter_entry_points(entry_points: dict[str, list[EntryPoint]]) -> Callable[[], dict[str, EntryPoint]]:
+    def _fake_iter_entry_points() -> dict:
+        return entry_points
     return _fake_iter_entry_points
+
+
+def _create_fake_importlib_files(module_paths: dict[str, Path]) -> Callable[[str], Path]:
+    def _fake_importlib_files(module_name: str) -> Path:
+        return module_paths[module_name]
+    return _fake_importlib_files
 
 
 @pytest.fixture


### PR DESCRIPTION
See https://github.com/pypa/setuptools/issues/3527 for details. Bottom line is that `pkg_resources` is kind of deprecated and Satpy was using undocumented function like the `.dist.module_path` property. This PR updates Satpy to use importlib which has the necessary functionality as of Python 3.8 and is the minimum version of Python that Satpy supports. This also should fix the CI issues in https://github.com/pytroll/satpy-composites-plugin-example/pull/2.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
