### PR TITLE
Add true color RGB for FCI

### DIFF
--- a/satpy/etc/composites/fci.yaml
+++ b/satpy/etc/composites/fci.yaml
@@ -11,3 +11,14 @@ composites:
       - name: 'cloud_state'
     lut: [.nan, 0, 1, 1, 1, 1, 1, 1, 0, .nan]
     standard_name: binary_cloud_mask
+
+  true_color:
+    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
+    prerequisites:
+      - name: vis_06
+        modifiers: [sunz_corrected, rayleigh_corrected]
+      - name: vis_05
+        modifiers: [sunz_corrected, rayleigh_corrected]
+      - name: vis_04
+        modifiers: [sunz_corrected, rayleigh_corrected]
+    standard_name: true_color


### PR DESCRIPTION
Add a true color RGB for FCI.

 - [ ] Closes #xxxx
 - [ ] Tests added 
 - [ ] Fully documented 

Marking as draft because I don't know if it looks right...

`true_color_raw` (was already supported):

![201709201220-MTG-I1-fci-mtg_fci_fdss_1km-true_color_raw](https://user-images.githubusercontent.com/500246/184915173-e7288d1a-de11-4e91-b679-7ad88459c894.jpg)

The `true_color` with this PR looks like:

![201709201220-MTG-I1-fci-mtg_fci_fdss_1km-true_color](https://user-images.githubusercontent.com/500246/184915222-573037e0-cfa6-4ec4-94a1-efc63034cc86.jpg)

I find it quite dark, compared to, for example, MODIS true color images such as [visible in EOSDIS](https://worldview.earthdata.nasa.gov/?v=-100.47848594224924,-33.7358947568389,93.19932560790274,65.8266052431611&t=2022-08-16-T14%3A35%3A09Z), but I wouldn't know what to do differently on the Satpy side of things, so maybe this is due to the test data or perhaps this is expected.

This is with pyspectral-0.11.1.dev3+g6948a7a (latest main).