### PR TITLE
Update FCI L1c reader to work with remote file systems

### DIFF
--- a/satpy/etc/readers/fci_l1c_nc.yaml
+++ b/satpy/etc/readers/fci_l1c_nc.yaml
@@ -7,7 +7,7 @@ reader:
     Used to read Meteosat Third Generation (MTG) Flexible
     Combined Imager (FCI) L1c data.
   status: Beta for FDHSI, HRFI not supported yet
-  supports_fsspec: false
+  supports_fsspec: true
   reader: !!python/name:satpy.readers.yaml_reader.GEOVariableSegmentYAMLReader
   sensors: [ fci ]
 

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -254,7 +254,6 @@ class FCIL1cNCFileHandler(NetCDF4FsspecFileHandler):
 
         attrs = dict(data.attrs.items()).copy()
         info = info.copy()
-
         data = xr.DataArray(
             da.array(data), dims=data.dimensions, attrs=attrs, name=data.name)
 
@@ -357,16 +356,21 @@ class FCIL1cNCFileHandler(NetCDF4FsspecFileHandler):
         grp_path = self.get_channel_measured_group_path(_get_channel_name_from_dsname(dsname))
         dv_path = grp_path + "/index_map"
         data = self[dv_path]
-
+        attrs = dict(data.attrs.items()).copy()
+        data = xr.DataArray(
+            da.array(data), dims=data.dimensions, attrs=attrs, name=data.name)
         data = data.where(data != data.attrs.get('_FillValue', 65535))
         return data
 
     def _get_aux_data_lut_vector(self, aux_data_name):
         """Load the lut vector of an auxiliary variable."""
         lut = self[AUX_DATA[aux_data_name]]
+        attrs = dict(lut.attrs.items()).copy()
+        lut = xr.DataArray(
+            da.array(lut), dims=lut.dimensions, attrs=attrs, name=lut.name)
 
         fv = default_fillvals.get(lut.dtype.str[1:], np.nan)
-        lut = da.where(lut != fv, lut, np.nan)
+        lut = lut.where(lut != fv)
 
         return lut
 

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -255,7 +255,7 @@ class FCIL1cNCFileHandler(NetCDF4FsspecFileHandler):
         attrs = dict(data.attrs.items()).copy()
         info = info.copy()
         data = xr.DataArray(
-            da.array(data), dims=data.dimensions, attrs=attrs, name=data.name)
+            da.from_array(data), dims=data.dimensions, attrs=attrs, name=data.name)
 
         fv = attrs.pop(
             "FillValue",
@@ -348,7 +348,7 @@ class FCIL1cNCFileHandler(NetCDF4FsspecFileHandler):
         data = self[dv_path]
         attrs = dict(data.attrs.items()).copy()
         data = xr.DataArray(
-            da.array(data), dims=data.dimensions, attrs=attrs, name=data.name)
+            da.from_array(data), dims=data.dimensions, attrs=attrs, name=data.name)
         return data
 
     def _get_dataset_index_map(self, dsname):
@@ -358,7 +358,7 @@ class FCIL1cNCFileHandler(NetCDF4FsspecFileHandler):
         data = self[dv_path]
         attrs = dict(data.attrs.items()).copy()
         data = xr.DataArray(
-            da.array(data), dims=data.dimensions, attrs=attrs, name=data.name)
+            da.from_array(data), dims=data.dimensions, attrs=attrs, name=data.name)
         data = data.where(data != data.attrs.get('_FillValue', 65535))
         return data
 
@@ -367,7 +367,7 @@ class FCIL1cNCFileHandler(NetCDF4FsspecFileHandler):
         lut = self[AUX_DATA[aux_data_name]]
         attrs = dict(lut.attrs.items()).copy()
         lut = xr.DataArray(
-            da.array(lut), dims=lut.dimensions, attrs=attrs, name=lut.name)
+            da.from_array(lut), dims=lut.dimensions, attrs=attrs, name=lut.name)
 
         fv = default_fillvals.get(lut.dtype.str[1:], np.nan)
         lut = lut.where(lut != fv)

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -20,7 +20,6 @@
 import logging
 
 import dask.array as da
-import h5netcdf
 import netCDF4
 import numpy as np
 import xarray as xr
@@ -313,11 +312,13 @@ class NetCDF4FsspecFileHandler(NetCDF4FileHandler):
     """NetCDF4 file handler using fsspec to read files remotely."""
 
     def _get_file_handle(self):
+        import h5netcdf
         f_obj = open_file_or_filename(self.filename)
         return h5netcdf.File(f_obj, 'r')
 
     def _check_variable_type(self, var, cache_var_size):
-        return (isinstance(var, h5netcdf.Variable)
+        from h5netcdf import Variable
+        return (isinstance(var, Variable)
                 and isinstance(var.dtype, np.dtype)  # vlen may be str
                 and np.prod(var.shape) * var.dtype.itemsize < cache_var_size)
 


### PR DESCRIPTION
This PR adapts the FCI L1c reader so that it is able to read data from remote locations using `fsspec`.

```python
fnames = ["simplecache::s3://satellite-data-fci-test-data-2022/*DEV_20170920112*.nc"]
scn = Scene(reader='fci_l1c_nc', filenames=fnames)
scn.load(['ir_123'])
scn.save_datasets()
```

See the [documentation](https://satpy.readthedocs.io/en/stable/remote_reading.html) for more information on accessing remote data.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
