### PR TITLE
Refactor HRIT readers to be smarter about compression and reading data

### DIFF
--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -17,8 +17,6 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Interface for BaseFileHandlers."""
 
-from abc import ABCMeta
-
 import numpy as np
 import xarray as xr
 from pyresample.geometry import SwathDefinition
@@ -46,7 +44,7 @@ def open_dataset(filename, *args, **kwargs):
     return xr.open_dataset(f_obj, *args, **kwargs)
 
 
-class BaseFileHandler(metaclass=ABCMeta):
+class BaseFileHandler:
     """Base file handler."""
 
     def __init__(self, filename, filename_info, filetype_info):

--- a/satpy/readers/hrit_base.py
+++ b/satpy/readers/hrit_base.py
@@ -321,10 +321,10 @@ class HRITFileHandler(BaseFileHandler):
     def _memmap_data(self, shape, dtype):
         # For reading the image data, unzip_context is faster than generic_open
         with utils.unzip_context(self.filename) as fn:
-            return np.memmap(fn, mode='r',
-                             offset=self.mda['total_header_length'],
-                             dtype=dtype,
-                             shape=shape)
+            return np.fromfile(fn,
+                               offset=self.mda['total_header_length'],
+                               dtype=dtype,
+                               count=np.prod(shape))
 
     def _read_file_or_file_like(self, shape, dtype):
         # filename is likely to be a file-like object, already in memory

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -414,8 +414,7 @@ def dec10216(inbuf):
     arr16_1 = ((arr10_1 & 63) << 4) + (arr10_2 >> 4)
     arr16_2 = ((arr10_2 & 15) << 6) + (arr10_3 >> 2)
     arr16_3 = ((arr10_3 & 3) << 8) + arr10_4
-    arr16 = da.stack([arr16_0, arr16_1, arr16_2, arr16_3], axis=-1).ravel()
-    arr16 = da.rechunk(arr16, arr16.shape[0])
+    arr16 = np.stack([arr16_0, arr16_1, arr16_2, arr16_3], axis=-1).ravel()
 
     return arr16
 

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -23,7 +23,7 @@ import os
 import shutil
 import tempfile
 import warnings
-from contextlib import closing
+from contextlib import closing, contextmanager
 from io import BytesIO
 from shutil import which
 from subprocess import PIPE, Popen  # nosec
@@ -202,6 +202,7 @@ def unzip_file(filename, prefix=None):
     """Unzip the file ending with 'bz2'. Initially with pbzip2 if installed or bz2.
 
     Args:
+        filename: The file to unzip.
         prefix (str, optional): If file is one of many segments of data, prefix random filename
         for correct sorting. This is normally the segment number.
 
@@ -261,8 +262,9 @@ def unzip_file(filename, prefix=None):
     return None
 
 
-class unzip_context():
-    """Context manager for uncompressing a .bz2 file on the fly.
+@contextmanager
+def unzip_context(filename):
+    """Context manager for decompressing a .bz2 file on the fly.
 
     Uses `unzip_file`. Removes the uncompressed file on exit of the context manager.
 
@@ -270,51 +272,31 @@ class unzip_context():
     compressed.
 
     """
-
-    def __init__(self, filename):
-        """Keep original filename."""
-        self.input_filename = filename
-
-    def __enter__(self):
-        """Uncompress file if necessary and return the relevant filename for the file handler."""
-        unzipped = unzip_file(self.input_filename)
-        if unzipped is not None:
-            self.unzipped_filename = unzipped
-            return unzipped
-        else:
-            self.unzipped_filename = None
-            return self.input_filename
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        """Remove temporary file."""
-        if self.unzipped_filename is not None:
-            os.remove(self.unzipped_filename)
+    unzipped = unzip_file(filename)
+    if unzipped is not None:
+        yield unzipped
+        os.remove(unzipped)
+    else:
+        yield filename
 
 
-class generic_open():
-    """Context manager for opening either a regular file or a bzip2 file."""
+@contextmanager
+def generic_open(filename, *args, **kwargs):
+    """Context manager for opening either a regular file or a bzip2 file.
 
-    def __init__(self, filename, *args, **kwargs):
-        """Keep filename and mode."""
-        self.filename = filename
-        self.open_args = args
-        self.open_kwargs = kwargs
+    Returns a file-like object.
+    """
+    if os.fspath(filename).endswith('.bz2'):
+        fp = bz2.open(filename, *args, **kwargs)
+    else:
+        try:
+            fp = filename.open(*args, **kwargs)
+        except AttributeError:
+            fp = open(filename, *args, **kwargs)
 
-    def __enter__(self):
-        """Return a file-like object."""
-        if os.fspath(self.filename).endswith('.bz2'):
-            self.fp = bz2.open(self.filename, *self.open_args, **self.open_kwargs)
-        else:
-            if hasattr(self.filename, "open"):
-                self.fp = self.filename.open(*self.open_args, **self.open_kwargs)
-            else:
-                self.fp = open(self.filename, *self.open_args, **self.open_kwargs)
+    yield fp
 
-        return self.fp
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        """Close the file handler."""
-        self.fp.close()
+    fp.close()
 
 
 def bbox(img):

--- a/satpy/tests/reader_tests/test_goes_imager_nc.py
+++ b/satpy/tests/reader_tests/test_goes_imager_nc.py
@@ -34,7 +34,6 @@ class GOESNCBaseFileHandlerTest(unittest.TestCase):
 
     @mock.patch('satpy.readers.goes_imager_nc.xr')
     @mock.patch.multiple('satpy.readers.goes_imager_nc.GOESNCBaseFileHandler',
-                         __abstractmethods__=set(),
                          _get_sector=mock.MagicMock())
     def setUp(self, xr_):
         """Set up the tests."""

--- a/satpy/tests/reader_tests/test_hrit_base.py
+++ b/satpy/tests/reader_tests/test_hrit_base.py
@@ -20,7 +20,6 @@
 import os
 import unittest
 from datetime import datetime
-from io import BytesIO
 from tempfile import NamedTemporaryFile, gettempdir
 from unittest import mock
 
@@ -94,11 +93,11 @@ def new_get_hd(instance, hdr_info):
     instance.mda['total_header_length'] = 12
 
 
-class TestHRITFileHandler(unittest.TestCase):
+class TestHRITFileHandler:
     """Test the HRITFileHandler."""
 
     @mock.patch('satpy.readers.hrit_base.np.fromfile')
-    def setUp(self, fromfile):
+    def setup(self, fromfile):
         """Set up the hrit file handler for testing."""
         m = mock.mock_open()
         fromfile.return_value = np.array([(1, 2)], dtype=[('total_header_length', int),
@@ -137,21 +136,21 @@ class TestHRITFileHandler(unittest.TestCase):
     def test_get_xy_from_linecol(self):
         """Test get_xy_from_linecol."""
         x__, y__ = self.reader.get_xy_from_linecol(0, 0, (10, 10), (5, 5))
-        self.assertEqual(-131072, x__)
-        self.assertEqual(-131072, y__)
+        assert -131072 == x__
+        assert -131072 == y__
         x__, y__ = self.reader.get_xy_from_linecol(10, 10, (10, 10), (5, 5))
-        self.assertEqual(0, x__)
-        self.assertEqual(0, y__)
+        assert x__ == 0
+        assert y__ == 0
         x__, y__ = self.reader.get_xy_from_linecol(20, 20, (10, 10), (5, 5))
-        self.assertEqual(131072, x__)
-        self.assertEqual(131072, y__)
+        assert 131072 == x__
+        assert 131072 == y__
 
     def test_get_area_extent(self):
         """Test getting the area extent."""
         res = self.reader.get_area_extent((20, 20), (10, 10), (5, 5), 33)
         exp = (-71717.44995740513, -71717.44995740513,
                79266.655216079365, 79266.655216079365)
-        self.assertTupleEqual(res, exp)
+        assert res == exp
 
     def test_get_area_def(self):
         """Test getting an area definition."""
@@ -159,37 +158,43 @@ class TestHRITFileHandler(unittest.TestCase):
         area = self.reader.get_area_def('VIS06')
         proj_dict = area.proj_dict
         a, b = proj4_radius_parameters(proj_dict)
-        self.assertEqual(a, 6378169.0)
-        self.assertEqual(b, 6356583.8)
-        self.assertEqual(proj_dict['h'], 35785831.0)
-        self.assertEqual(proj_dict['lon_0'], 44.0)
-        self.assertEqual(proj_dict['proj'], 'geos')
-        self.assertEqual(proj_dict['units'], 'm')
-        self.assertEqual(area.area_extent,
-                         (-77771774058.38356, -77771774058.38356,
-                          30310525626438.438, 3720765401003.719))
+        assert a == 6378169.0
+        assert b == 6356583.8
+        assert proj_dict['h'] == 35785831.0
+        assert proj_dict['lon_0'] == 44.0
+        assert proj_dict['proj'] == 'geos'
+        assert proj_dict['units'] == 'm'
+        assert area.area_extent == (-77771774058.38356, -77771774058.38356,
+                                    30310525626438.438, 3720765401003.719)
 
-    @mock.patch('satpy.readers.hrit_base.np.memmap')
-    def test_read_band_filepath(self, memmap):
+    def stub_hrit_file(self, filename, open_fun=open):
+        """Create a stub hrit file."""
+        nbits = self.reader.mda['number_of_bits_per_pixel']
+        arr = np.random.randint(0, 256,
+                                size=int((464 * 3712 * nbits) / 8),
+                                dtype=np.uint8)
+        with open_fun(filename, mode="wb") as fd:
+            fd.write(b" " * self.reader.mda['total_header_length'])
+            bytes_data = arr.tobytes()
+            fd.write(bytes_data)
+
+    def test_read_band_filepath(self, tmp_path):
         """Test reading a single band from a filepath."""
-        nbits = self.reader.mda['number_of_bits_per_pixel']
-        memmap.return_value = np.random.randint(0, 256,
-                                                size=int((464 * 3712 * nbits) / 8),
-                                                dtype=np.uint8)
-        res = self.reader.read_band('VIS006', None)
-        self.assertEqual(res.compute().shape, (464, 3712))
+        filename = tmp_path / "some_hrit_file"
+        self.stub_hrit_file(filename)
+        self.reader.filename = filename
 
-    @mock.patch('satpy.readers.FSFile.open')
-    def test_read_band_FSFile(self, fsfile_open):
-        """Test reading a single band from a FSFile."""
-        nbits = self.reader.mda['number_of_bits_per_pixel']
-        self.reader.filename = FSFile(self.reader.filename)  # convert str to FSFile
-        fsfile_open.return_value = BytesIO(
-            np.random.randint(
-                0, 256,
-                size=int((464 * 3712 * nbits) / 8) + self.reader.mda['total_header_length'],
-                dtype=np.uint8
-            ).tobytes()
-        )
         res = self.reader.read_band('VIS006', None)
-        self.assertEqual(res.compute().shape, (464, 3712))
+        assert res.compute().shape == (464, 3712)
+
+    def test_read_band_FSFile(self, tmp_path):
+        """Test reading a single band from a filepath."""
+        import fsspec
+        filename = tmp_path / "some_hrit_file"
+        self.stub_hrit_file(filename)
+
+        fs_file = fsspec.open(filename)
+        self.reader.filename = FSFile(fs_file)
+
+        res = self.reader.read_band('VIS006', None)
+        assert res.compute().shape == (464, 3712)

--- a/satpy/tests/reader_tests/test_hrit_base.py
+++ b/satpy/tests/reader_tests/test_hrit_base.py
@@ -17,6 +17,7 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """The HRIT base reader tests package."""
 
+import bz2
 import os
 import unittest
 from datetime import datetime
@@ -24,6 +25,7 @@ from tempfile import NamedTemporaryFile, gettempdir
 from unittest import mock
 
 import numpy as np
+import pytest
 
 from satpy.readers import FSFile
 from satpy.readers.hrit_base import HRITFileHandler, decompress, get_xritdecompress_cmd, get_xritdecompress_outfile
@@ -80,58 +82,107 @@ class TestHRITDecompress(unittest.TestCase):
         self.assertEqual(res, os.path.join('.', 'bla.__'))
 
 
+# From a compressed msg hrit file.
+# uncompressed data field length 17223680
+# compressed data field length 1578312
+mda = {'file_type': 0, 'total_header_length': 6198, 'data_field_length': 17223680, 'number_of_bits_per_pixel': 10,
+       'number_of_columns': 3712, 'number_of_lines': 464, 'compression_flag_for_data': 0,
+       'projection_name': b'GEOS(+000.0)                    ',
+       'cfac': -13642337, 'lfac': -13642337, 'coff': 1856, 'loff': 1856,
+       'annotation_header': b'H-000-MSG4__-MSG4________-VIS006___-000001___-202208180730-C_',
+       'cds_p_field': 64, 'timestamp': (23605, 27911151), 'GP_SC_ID': 324,
+       'spectral_channel_id': 1,
+       'segment_sequence_number': 1, 'planned_start_segment_number': 1, 'planned_end_segment_number': 8,
+       'data_field_representation': 3,
+       'image_segment_line_quality': np.array([(1, (0, 0), 1, 1, 0)] * 464,
+                                              dtype=[('line_number_in_grid', '>i4'),
+                                                     ('line_mean_acquisition', [('days', '>u2'),
+                                                                                ('milliseconds', '>u4')]),
+                                                     ('line_validity', 'u1'),
+                                                     ('line_radiometric_quality', 'u1'),
+                                                     ('line_geometric_quality', 'u1')]),
+       'projection_parameters': {'a': 6378169.0, 'b': 6356583.8, 'h': 35785831.0, 'SSP_longitude': 0.0},
+       'orbital_parameters': {}}
+
+mda_compressed = mda.copy()
+mda_compressed["data_field_length"] = 1578312
+mda_compressed['compression_flag_for_data'] = 1
+
+
 def new_get_hd(instance, hdr_info):
     """Generate some metadata."""
-    instance.mda = {'spectral_channel_id': 1}
-    instance.mda.setdefault('number_of_bits_per_pixel', 10)
+    if os.fspath(instance.filename).endswith(".C_"):
+        instance.mda = mda_compressed.copy()
+    else:
+        instance.mda = mda.copy()
 
-    instance.mda['projection_parameters'] = {'a': 6378169.00,
-                                             'b': 6356583.80,
-                                             'h': 35785831.00,
-                                             'SSP_longitude': 0.0}
-    instance.mda['orbital_parameters'] = {}
-    instance.mda['total_header_length'] = 12
+
+def new_get_hd_compressed(instance, hdr_info):
+    """Generate some metadata."""
+    instance.mda = mda.copy()
+    instance.mda['compression_flag_for_data'] = 1
+    instance.mda['data_field_length'] = 1578312
+
+
+@pytest.fixture
+def stub_hrit_file(tmp_path):
+    """Create a stub hrit file."""
+    filename = tmp_path / "some_hrit_file"
+    create_stub_hrit(filename)
+    return filename
+
+
+def create_stub_hrit(filename, open_fun=open, meta=mda):
+    """Create a stub hrit file."""
+    nbits = meta['number_of_bits_per_pixel']
+    lines = meta['number_of_lines']
+    cols = meta['number_of_columns']
+    total_bits = lines * cols * nbits
+    arr = np.random.randint(0, 256,
+                            size=int(total_bits / 8),
+                            dtype=np.uint8)
+    with open_fun(filename, mode="wb") as fd:
+        fd.write(b" " * meta['total_header_length'])
+        bytes_data = arr.tobytes()
+        fd.write(bytes_data)
+    return filename
+
+
+@pytest.fixture
+def stub_bzipped_hrit_file(tmp_path):
+    """Create a stub bzipped hrit file."""
+    filename = tmp_path / "some_hrit_file.bz2"
+    create_stub_hrit(filename, open_fun=bz2.open)
+    return filename
+
+
+@pytest.fixture
+def stub_compressed_hrit_file(tmp_path):
+    """Create a stub compressed hrit file."""
+    filename = tmp_path / "some_hrit_file.C_"
+    create_stub_hrit(filename, meta=mda_compressed)
+    return filename
 
 
 class TestHRITFileHandler:
     """Test the HRITFileHandler."""
 
-    @mock.patch('satpy.readers.hrit_base.np.fromfile')
-    def setup_method(self, method, fromfile):
+    def setup_method(self, method):
         """Set up the hrit file handler for testing."""
         del method
-        m = mock.mock_open()
-        fromfile.return_value = np.array([(1, 2)], dtype=[('total_header_length', int),
-                                                          ('hdr_id', int)])
 
-        with mock.patch('satpy.readers.hrit_base.open', m, create=True) as newopen, \
-             mock.patch('satpy.readers.utils.open', m, create=True) as utilopen, \
-             mock.patch.object(HRITFileHandler, '_get_hd', new=new_get_hd):
-
-            newopen.return_value.__enter__.return_value.tell.return_value = 1
-            FAKE_DATA_LARGE_ENOUGH_FOR_TESTING = bytes([0]*8192)
-            utilopen.return_value.__enter__.return_value.read.return_value = FAKE_DATA_LARGE_ENOUGH_FOR_TESTING
+        with mock.patch.object(HRITFileHandler, '_get_hd', new=new_get_hd):
             self.reader = HRITFileHandler('filename',
                                           {'platform_shortname': 'MSG3',
                                            'start_time': datetime(2016, 3, 3, 0, 0)},
                                           {'filetype': 'info'},
                                           [mock.MagicMock(), mock.MagicMock(),
                                            mock.MagicMock()])
-            ncols = 3712
-            nlines = 464
-            nbits = 10
-            self.reader.mda['number_of_bits_per_pixel'] = nbits
-            self.reader.mda['number_of_lines'] = nlines
-            self.reader.mda['number_of_columns'] = ncols
-            self.reader.mda['data_field_length'] = nlines * ncols * nbits
+
             self.reader.mda['cfac'] = 5
             self.reader.mda['lfac'] = 5
             self.reader.mda['coff'] = 10
             self.reader.mda['loff'] = 10
-            self.reader.mda['projection_parameters'] = {}
-            self.reader.mda['projection_parameters']['a'] = 6378169.0
-            self.reader.mda['projection_parameters']['b'] = 6356583.8
-            self.reader.mda['projection_parameters']['h'] = 35785831.0
             self.reader.mda['projection_parameters']['SSP_longitude'] = 44
 
     def test_get_xy_from_linecol(self):
@@ -168,31 +219,17 @@ class TestHRITFileHandler:
         assert area.area_extent == (-77771774058.38356, -77771774058.38356,
                                     30310525626438.438, 3720765401003.719)
 
-    def stub_hrit_file(self, filename, open_fun=open):
-        """Create a stub hrit file."""
-        nbits = self.reader.mda['number_of_bits_per_pixel']
-        arr = np.random.randint(0, 256,
-                                size=int((464 * 3712 * nbits) / 8),
-                                dtype=np.uint8)
-        with open_fun(filename, mode="wb") as fd:
-            fd.write(b" " * self.reader.mda['total_header_length'])
-            bytes_data = arr.tobytes()
-            fd.write(bytes_data)
-
-    def test_read_band_filepath(self, tmp_path):
+    def test_read_band_filepath(self, stub_hrit_file):
         """Test reading a single band from a filepath."""
-        filename = tmp_path / "some_hrit_file"
-        self.stub_hrit_file(filename)
-        self.reader.filename = filename
+        self.reader.filename = stub_hrit_file
 
         res = self.reader.read_band('VIS006', None)
         assert res.compute().shape == (464, 3712)
 
-    def test_read_band_FSFile(self, tmp_path):
+    def test_read_band_FSFile(self, stub_hrit_file):
         """Test reading a single band from an FSFile."""
         import fsspec
-        filename = tmp_path / "some_hrit_file"
-        self.stub_hrit_file(filename)
+        filename = stub_hrit_file
 
         fs_file = fsspec.open(filename)
         self.reader.filename = FSFile(fs_file)
@@ -200,13 +237,38 @@ class TestHRITFileHandler:
         res = self.reader.read_band('VIS006', None)
         assert res.compute().shape == (464, 3712)
 
-    def test_read_band_bzipped2_filepath(self, tmp_path):
+    def test_read_band_bzipped2_filepath(self, stub_bzipped_hrit_file):
         """Test reading a single band from a bzipped file."""
-        import bz2
-        filename = tmp_path / "some_hrit_file.bz2"
-        self.stub_hrit_file(filename, open_fun=bz2.open)
-
-        self.reader.filename = filename
+        self.reader.filename = stub_bzipped_hrit_file
 
         res = self.reader.read_band('VIS006', None)
         assert res.compute().shape == (464, 3712)
+
+
+def fake_decompress(infile, outdir='.'):
+    """Fake decompression."""
+    filename = os.fspath(infile)[:-3]
+    return create_stub_hrit(filename)
+
+
+class TestHRITFileHandlerCompressed:
+    """Test the HRITFileHandler with compressed segments."""
+
+    def test_read_band_filepath(self, stub_compressed_hrit_file):
+        """Test reading a single band from a filepath."""
+        filename = stub_compressed_hrit_file
+
+        with mock.patch("satpy.readers.hrit_base.decompress", side_effect=fake_decompress) as mock_decompress:
+            with mock.patch.object(HRITFileHandler, '_get_hd', side_effect=new_get_hd, autospec=True) as get_hd:
+                self.reader = HRITFileHandler(filename,
+                                              {'platform_shortname': 'MSG3',
+                                               'start_time': datetime(2016, 3, 3, 0, 0)},
+                                              {'filetype': 'info'},
+                                              [mock.MagicMock(), mock.MagicMock(),
+                                               mock.MagicMock()])
+
+                res = self.reader.read_band('VIS006', None)
+                assert get_hd.call_count == 1
+                assert mock_decompress.call_count == 0
+                assert res.compute().shape == (464, 3712)
+                assert mock_decompress.call_count == 1

--- a/satpy/tests/reader_tests/test_hrit_base.py
+++ b/satpy/tests/reader_tests/test_hrit_base.py
@@ -188,13 +188,24 @@ class TestHRITFileHandler:
         assert res.compute().shape == (464, 3712)
 
     def test_read_band_FSFile(self, tmp_path):
-        """Test reading a single band from a filepath."""
+        """Test reading a single band from an FSFile."""
         import fsspec
         filename = tmp_path / "some_hrit_file"
         self.stub_hrit_file(filename)
 
         fs_file = fsspec.open(filename)
         self.reader.filename = FSFile(fs_file)
+
+        res = self.reader.read_band('VIS006', None)
+        assert res.compute().shape == (464, 3712)
+
+    def test_read_band_bzipped2_filepath(self, tmp_path):
+        """Test reading a single band from a bzipped file."""
+        import bz2
+        filename = tmp_path / "some_hrit_file.bz2"
+        self.stub_hrit_file(filename, open_fun=bz2.open)
+
+        self.reader.filename = filename
 
         res = self.reader.read_band('VIS006', None)
         assert res.compute().shape == (464, 3712)

--- a/satpy/tests/reader_tests/test_hrit_base.py
+++ b/satpy/tests/reader_tests/test_hrit_base.py
@@ -97,8 +97,9 @@ class TestHRITFileHandler:
     """Test the HRITFileHandler."""
 
     @mock.patch('satpy.readers.hrit_base.np.fromfile')
-    def setup(self, fromfile):
+    def setup_method(self, method, fromfile):
         """Set up the hrit file handler for testing."""
+        del method
         m = mock.mock_open()
         fromfile.return_value = np.array([(1, 2)], dtype=[('total_header_length', int),
                                                           ('hdr_id', int)])

--- a/satpy/tests/reader_tests/test_safe_sar_l2_ocn.py
+++ b/satpy/tests/reader_tests/test_safe_sar_l2_ocn.py
@@ -29,8 +29,6 @@ class TestSAFENC(unittest.TestCase):
     """Test various SAFE SAR L2 OCN file handlers."""
 
     @mock.patch('satpy.readers.safe_sar_l2_ocn.xr')
-    @mock.patch.multiple('satpy.readers.safe_sar_l2_ocn.SAFENC',
-                         __abstractmethods__=set())
     def setUp(self, xr_):
         """Set up the tests."""
         from satpy.readers.safe_sar_l2_ocn import SAFENC

--- a/satpy/tests/test_file_handlers.py
+++ b/satpy/tests/test_file_handlers.py
@@ -47,8 +47,6 @@ class TestBaseFileHandler(unittest.TestCase):
 
     def setUp(self):
         """Set up the test."""
-        self._old_set = BaseFileHandler.__abstractmethods__
-        BaseFileHandler._abstractmethods__ = set()
         self.fh = BaseFileHandler(
             'filename', {'filename_info': 'bla'}, 'filetype_info')
 
@@ -190,10 +188,6 @@ class TestBaseFileHandler(unittest.TestCase):
         filename = Path('/bla/bla.nc')
         bfh = BaseFileHandler(filename, {'filename_info': 'bla'}, 'filetype_info')
         assert isinstance(bfh.filename, Path)
-
-    def tearDown(self):
-        """Tear down the test."""
-        BaseFileHandler.__abstractmethods__ = self._old_set
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
HRIT readers are reading data eagerly and unpacking files when it might not be needed. This PR fixes them to be lazier.

 - [x] Closes #2183 
 - [x] Tests added <!-- for all bug fixes or enhancements -->

