### PR TITLE
Fix some enhancements producing dask arrays wrapped in dask arrays

### DIFF
--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -277,11 +277,6 @@ def _srgb_gamma(arr):
     return da.where(arr < 0.0031308, arr * 12.92, 1.055 * arr ** 0.41666 - 0.055)
 
 
-def _lookup_delayed(luts, band_data):
-    # can't use luts.__getitem__ for some reason
-    return luts[band_data]
-
-
 def lookup(img, **kwargs):
     """Assign values to channels based on a table."""
     luts = np.array(kwargs['luts'], dtype=np.float32) / 255.0
@@ -295,11 +290,7 @@ def _lookup_table(band_data, luts=None, index=-1):
     # NaN/null values will become 0
     lut = luts[:, index] if len(luts.shape) == 2 else luts
     band_data = band_data.clip(0, lut.size - 1).astype(np.uint8)
-
-    new_delay = dask.delayed(_lookup_delayed)(lut, band_data)
-    new_data = da.from_delayed(new_delay, shape=band_data.shape,
-                               dtype=luts.dtype)
-    return new_data
+    return lut[band_data]
 
 
 def colorize(img, **kwargs):
@@ -596,6 +587,6 @@ def btemp_threshold(img, min_in, max_in, threshold, threshold_out=None, **kwargs
 @using_map_blocks
 def _bt_threshold(band_data, threshold, high_coeffs, low_coeffs):
     # expects dask array to be passed
-    return da.where(band_data >= threshold,
+    return np.where(band_data >= threshold,
                     high_coeffs.offset - high_coeffs.factor * band_data,
                     low_coeffs.offset - low_coeffs.factor * band_data)

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -44,7 +44,12 @@ def run_and_check_enhancement(func, data, expected, **kwargs):
     new_keys = set(img.data.attrs.keys()) - {"enhancement_history"}
     assert old_keys == new_keys
 
-    np.testing.assert_allclose(img.data.values, expected, atol=1.e-6, rtol=0)
+    res_data_arr = img.data
+    assert isinstance(res_data_arr, xr.DataArray)
+    assert isinstance(res_data_arr.data, da.Array)
+    res_data = res_data_arr.data.compute()  # mimics what xrimage geotiff writing does
+    assert not isinstance(res_data, da.Array)
+    np.testing.assert_allclose(res_data, expected, atol=1.e-6, rtol=0)
 
 
 def identical_decorator(func):


### PR DESCRIPTION
I noticed while counting the number of dask computations that some enhancements were causing more computations than they used to. This was caused by some of the dask arrays producing dask arrays so the dask arrays were being passed to rasterio during geotiff saving which caused yet another compute.

The issue was that due to the refactoring in #2133, the functions were accidentally doing dask "stuff" (delayed functions or `da.where`) inside a function that was already map_blocks'd. This PR fixes all of that and adds checks to the tests to make sure it hopefully doesn't happen again in the future.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
