### PR TITLE
Fix automatic reader table not listing readers with missing dependencies

### DIFF
--- a/doc/source/_static/main.js
+++ b/doc/source/_static/main.js
@@ -1,5 +1,6 @@
 $(document).ready( function () {
     $('table.datatable').DataTable( {
-    "paging": false
+    "paging": false,
+    "dom": 'lfitp'
 } );
 } );

--- a/doc/source/reader_table.py
+++ b/doc/source/reader_table.py
@@ -20,6 +20,11 @@
 
 from satpy.readers import available_readers
 
+try:
+    from yaml import BaseLoader
+except ImportError:
+    from yaml import BaseLoader  # type: ignore
+
 
 def rst_table_row(columns=None):
     """Create one row for a rst table.
@@ -72,7 +77,7 @@ def generate_reader_table():
     table = [rst_table_header("Satpy Readers", header=["Description", "Reader name", "Status", "fsspec support"],
                               widths=[45, 25, 30, 30])]
 
-    reader_configs = available_readers(as_dict=True)
+    reader_configs = available_readers(as_dict=True, yaml_loader=BaseLoader)
     for rc in reader_configs:
         table.append(rst_table_row([rc.get("long_name", "").rstrip("\n"), rc.get("name", ""),
                                     rc.get("status", ""), rc.get("supports_fsspec", "false")]))

--- a/doc/source/reader_table.py
+++ b/doc/source/reader_table.py
@@ -18,12 +18,9 @@
 # along with satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Module for autogenerating reader table from config files."""
 
-from satpy.readers import available_readers
+from yaml import BaseLoader
 
-try:
-    from yaml import BaseLoader
-except ImportError:
-    from yaml import BaseLoader  # type: ignore
+from satpy.readers import available_readers
 
 
 def rst_table_row(columns=None):

--- a/satpy/composites/config_loader.py
+++ b/satpy/composites/config_loader.py
@@ -25,11 +25,7 @@ from functools import lru_cache, update_wrapper
 from typing import Callable, Iterable
 
 import yaml
-
-try:
-    from yaml import UnsafeLoader
-except ImportError:
-    from yaml import Loader as UnsafeLoader  # type: ignore
+from yaml import UnsafeLoader
 
 import satpy
 from satpy import DataID, DataQuery

--- a/satpy/plugin_base.py
+++ b/satpy/plugin_base.py
@@ -20,11 +20,7 @@
 import logging
 
 import yaml
-
-try:
-    from yaml import UnsafeLoader
-except ImportError:
-    from yaml import Loader as UnsafeLoader  # type: ignore
+from yaml import UnsafeLoader
 
 from satpy._config import config_search_paths
 from satpy.utils import recursive_dict_update

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -26,11 +26,7 @@ from datetime import datetime, timedelta
 from functools import total_ordering
 
 import yaml
-
-try:
-    from yaml import UnsafeLoader
-except ImportError:
-    from yaml import Loader as UnsafeLoader  # type: ignore
+from yaml import UnsafeLoader
 
 from satpy._config import config_search_paths, get_entry_points_config_dirs, glob_config
 

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -370,7 +370,7 @@ def get_valid_reader_names(reader):
     return new_readers
 
 
-def available_readers(as_dict=False):
+def available_readers(as_dict=False, yaml_loader=UnsafeLoader):
     """Available readers based on current configuration.
 
     Args:
@@ -385,7 +385,7 @@ def available_readers(as_dict=False):
     readers = []
     for reader_configs in configs_for_reader():
         try:
-            reader_info = read_reader_config(reader_configs)
+            reader_info = read_reader_config(reader_configs, loader=yaml_loader)
         except (KeyError, IOError, yaml.YAMLError):
             LOG.debug("Could not import reader config from: %s", reader_configs)
             LOG.debug("Error loading YAML", exc_info=True)

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -371,11 +371,13 @@ def available_readers(as_dict=False, yaml_loader=UnsafeLoader):
 
     Args:
         as_dict (bool): Optionally return reader information as a dictionary.
-                        Default: False
+                        Default: False.
+        yaml_loader (Optional[Union[yaml.BaseLoader, yaml.FullLoader, yaml.UnsafeLoader]]):
+            The yaml loader type. Default: ``yaml.UnsafeLoader``.
 
-    Returns: List of available reader names. If `as_dict` is `True` then
-             a list of dictionaries including additionally reader information
-             is returned.
+    Returns:
+        Union[list[str], list[dict]]: List of available reader names. If `as_dict` is `True` then
+        a list of dictionaries including additionally reader information is returned.
 
     """
     readers = []
@@ -450,12 +452,12 @@ def find_files_and_readers(start_time=None, end_time=None, base_dir=None,
         missing_ok (bool): If False (default), raise ValueError if no files
                             are found.  If True, return empty dictionary if no
                             files are found.
-        fs (FileSystem): Optional, instance of implementation of
-                         fsspec.spec.AbstractFileSystem (strictly speaking,
-                         any object of a class implementing ``.glob`` is
-                         enough).  Defaults to searching the local filesystem.
+        fs (:class:`fsspec.spec.AbstractFileSystem`): Optional, instance of implementation of
+            :class:`fsspec.spec.AbstractFileSystem` (strictly speaking, any object of a class implementing
+            ``.glob`` is enough).  Defaults to searching the local filesystem.
 
-    Returns: Dictionary mapping reader name string to list of filenames
+    Returns:
+        dict: Dictionary mapping reader name string to list of filenames
 
     """
     reader_files = {}

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -26,22 +26,16 @@ from abc import ABCMeta, abstractmethod
 from collections import OrderedDict, deque
 from contextlib import suppress
 from fnmatch import fnmatch
+from functools import cached_property
 from weakref import WeakValueDictionary
 
 import numpy as np
 import xarray as xr
 import yaml
-
-try:
-    from yaml import UnsafeLoader
-except ImportError:
-    from yaml import Loader as UnsafeLoader  # type: ignore
-
-from functools import cached_property
-
 from pyresample.boundary import AreaDefBoundary, Boundary
 from pyresample.geometry import AreaDefinition, StackedAreaDefinition, SwathDefinition
 from trollsift.parser import globify, parse
+from yaml import UnsafeLoader
 
 from satpy import DatasetDict
 from satpy.aux_download import DataDownloadMixin

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -691,6 +691,7 @@ class TestYAMLFiles(unittest.TestCase):
 
         reader_names = available_readers(yaml_loader=yaml.BaseLoader)
         self.assertIn('abi_l1b', reader_names)  # needs netcdf4
+        self.assertIn('viirs_l1b', reader_names)
         self.assertEqual(len(reader_names), len(list(glob_config('readers/*.yaml'))))
 
 

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -31,14 +31,9 @@ from urllib.parse import urlparse
 import numpy as np
 import xarray as xr
 import yaml
-from yaml import BaseLoader
+from yaml import BaseLoader, UnsafeLoader
 
 from satpy import CHUNK_SIZE
-
-try:
-    from yaml import UnsafeLoader
-except ImportError:
-    from yaml import Loader as UnsafeLoader  # type: ignore
 
 _is_logging_on = False
 TRACE_LEVEL = 5

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -29,14 +29,9 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 import yaml
-
-try:
-    from yaml import UnsafeLoader
-except ImportError:
-    from yaml import Loader as UnsafeLoader  # type: ignore
-
 from trollimage.xrimage import XRImage
 from trollsift import parser
+from yaml import UnsafeLoader
 
 from satpy import CHUNK_SIZE
 from satpy._config import config_search_paths, get_entry_points_config_dirs, glob_config

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ except ImportError:
     pass
 
 requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.24.0', 'trollsift',
-            'trollimage >1.10.1', 'pykdtree', 'pyyaml', 'xarray >=0.10.1, !=0.13.0',
+            'trollimage >1.10.1', 'pykdtree', 'pyyaml >=5.1', 'xarray >=0.10.1, !=0.13.0',
             'dask[array] >=0.17.1', 'pyproj>=2.2', 'zarr', 'donfig', 'appdirs',
             'pooch', 'pyorbital']
 

--- a/utils/convert_to_ninjotiff.py
+++ b/utils/convert_to_ninjotiff.py
@@ -30,16 +30,11 @@ import argparse
 import os
 
 import yaml
+from yaml import UnsafeLoader
 
 from satpy import Scene
 from satpy.pyresample import get_area_def
 from satpy.utils import debug_on
-
-try:
-    from yaml import UnsafeLoader
-except ImportError:
-    from yaml import Loader as UnsafeLoader  # type: ignore
-
 
 debug_on()
 


### PR DESCRIPTION
This makes a minor modification to the `available_readers` function to be able to pass a yaml loader type.
Based on this for reader table generation when `BasicLoader` is passed reader classes are not instantiated and thus readers with missing dependencies in the RTD build environment are now included in the reader table.

 - [x] Closes #2189 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
