### PR TITLE
Add additional logging information about enhancements being used

### DIFF
--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -241,6 +241,19 @@ enhancements:
         # alphabetically first
         np.testing.assert_allclose(img.data.values[0], ds.data / 20.0)
 
+    def test_enhance_bad_query_value(self):
+        """Test Enhancer doesn't fail when query includes bad values."""
+        from xarray import DataArray
+
+        from satpy.writers import Enhancer, get_enhanced_image
+        ds = DataArray(np.arange(1, 11.).reshape((2, 5)),
+                       attrs=dict(name=["I", "am", "invalid"], sensor='test_sensor2', mode='L'),
+                       dims=['y', 'x'])
+        e = Enhancer()
+        assert e.enhancement_tree is not None
+        with pytest.raises(KeyError, match="No .* found for None"):
+            get_enhanced_image(ds, enhance=e)
+
 
 class TestEnhancerUserConfigs(_BaseCustomEnhancementConfigTests):
     """Test `Enhancer` functionality when user's custom configurations are present."""

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -1067,6 +1067,7 @@ class EnhancementDecisionTree(DecisionTree):
                     if not enhancement_section:
                         LOG.debug("Config '{}' has no '{}' section or it is empty".format(config_file, self.prefix))
                         continue
+                    LOG.debug(f"Adding enhancement configuration from file: {config_file}")
                     conf = recursive_dict_update(conf, enhancement_section)
             elif isinstance(config_file, dict):
                 conf = recursive_dict_update(conf, config_file)
@@ -1150,11 +1151,11 @@ class Enhancer(object):
         """Apply the enhancements."""
         enh_kwargs = self.enhancement_tree.find_match(**info)
 
-        LOG.debug("Enhancement configuration options: %s" %
-                  (str(enh_kwargs['operations']), ))
+        backup_id = f"<name={info.get('name')}, calibration={info.get('calibration')}>"
+        data_id = info.get("_satpy_id", backup_id)
+        LOG.debug(f"Data for {data_id} will be enhanced with options:\n\t{enh_kwargs['operations']}")
         for operation in enh_kwargs['operations']:
             fun = operation['method']
             args = operation.get('args', [])
             kwargs = operation.get('kwargs', {})
             fun(img, *args, **kwargs)
-        # img.enhance(**enh_kwargs)

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -403,7 +403,7 @@ def get_enhanced_image(dataset, enhance=None, overlay=None, decorate=None,
         dataset (xarray.DataArray): Data to be enhanced and converted to an image.
         enhance (bool or Enhancer): Whether to automatically enhance
             data to be more visually useful and to fit inside the file
-            format being saved to. By default this will default to using
+            format being saved to. By default, this will default to using
             the enhancement configuration files found using the default
             :class:`~satpy.writers.Enhancer` class. This can be set to
             `False` so that no enhancments are performed. This can also
@@ -662,7 +662,7 @@ class Writer(Plugin, DataDownloadMixin):
         Args:
             datasets (iterable): Iterable of `xarray.DataArray` objects to
                                  save using this writer.
-            compute (bool): If `True` (default), compute all of the saves to
+            compute (bool): If `True` (default), compute all the saves to
                             disk. If `False` then the return value is either
                             a :doc:`dask:delayed` object or two lists to
                             be passed to a :func:`dask.array.store` call.
@@ -672,7 +672,7 @@ class Writer(Plugin, DataDownloadMixin):
 
         Returns:
             Value returned depends on `compute` keyword argument. If
-            `compute` is `True` the value is the result of a either a
+            `compute` is `True` the value is the result of either a
             :func:`dask.array.store` operation or a :doc:`dask:delayed`
             compute, typically this is `None`. If `compute` is `False` then
             the result is either a :doc:`dask:delayed` object that can be
@@ -725,7 +725,7 @@ class Writer(Plugin, DataDownloadMixin):
             If `compute` is `False` then the returned value is either a
             :doc:`dask:delayed` object that can be computed using
             `delayed.compute()` or a tuple of (source, target) that should be
-            passed to :func:`dask.array.store`. If target is provided the the
+            passed to :func:`dask.array.store`. If target is provided the
             caller is responsible for calling `target.close()` if the target
             has this method.
 
@@ -760,7 +760,7 @@ class ImageWriter(Writer):
                 Base destination directories for all created files.
             enhance (bool or Enhancer): Whether to automatically enhance
                 data to be more visually useful and to fit inside the file
-                format being saved to. By default this will default to using
+                format being saved to. By default, this will default to using
                 the enhancement configuration files found using the default
                 :class:`~satpy.writers.Enhancer` class. This can be set to
                 `False` so that no enhancments are performed. This can also
@@ -903,7 +903,7 @@ class DecisionTree(object):
             decision_dicts (dict): Dictionary of dictionaries. Each
                 sub-dictionary contains key/value pairs that can be
                 matched from the `find_match` method. Sub-dictionaries
-                can include additional keys outside of the ``match_keys``
+                can include additional keys outside the ``match_keys``
                 provided to act as the "result" of a query. The keys of
                 the root dict are arbitrary.
             match_keys (list): Keys of the provided dictionary to use for
@@ -1023,9 +1023,10 @@ class DecisionTree(object):
         """
         try:
             match = self._find_match(self._tree, self._match_keys, query_dict)
-        except (KeyError, IndexError, ValueError):
+        except (KeyError, IndexError, ValueError, TypeError):
             LOG.debug("Match exception:", exc_info=True)
             LOG.error("Error when finding matching decision section")
+            match = None
 
         if match is None:
             # only possible if no default section was provided


### PR DESCRIPTION
This comes from a request by @kathys in P2G: https://github.com/ssec/polar2grid/issues/502

The main idea is that there isn't a lot of logged information about custom enhancement YAML locations being used. I have also found that Satpy doesn't log as much information as I'd like about what product/dataset is being currently enhanced. This PR tries to improve this and looks like:

```
[2022-08-29 14:46:32,772] : PID 719348 : DEBUG    : satpy.writers : add_config_to_tree : Adding enhancement configuration from file: /home/davidh/repos/git/satpy/satpy/etc/enhancements/generic.yaml
[2022-08-29 14:46:32,818] : PID 719348 : DEBUG    : satpy.writers : add_config_to_tree : Adding enhancement configuration from file: /home/davidh/repos/git/polar2grid/etc/enhancements/generic.yaml
[2022-08-29 14:46:32,841] : PID 719348 : DEBUG    : satpy.writers : add_config_to_tree : Adding enhancement configuration from file: /home/davidh/repos/git/satpy/satpy/etc/enhancements/abi.yaml
[2022-08-29 14:46:32,846] : PID 719348 : DEBUG    : satpy.writers : add_config_to_tree : Adding enhancement configuration from file: /home/davidh/repos/git/polar2grid/etc/enhancements/abi.yaml
[2022-08-29 14:46:32,846] : PID 719348 : DEBUG    : satpy.writers : apply : Data for DataID(name='C08', wavelength=WavelengthRange(min=5.77, central=6.185, max=6.6, unit='µm'), resolution=2000, calibration=<calibration.brightness_temperature>, modifiers=()) will be enhanced with options:
        [{'name': 'colorize', 'method': <function colorize at 0x7f2297d8cca0>, 'kwargs': {'palettes': [{'filename': 'colormaps/abi_l2_modified_cloud_top.cmap', 'min_value': 280.0, 'max_value': 180.0}]}}]
```

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
