### PR TITLE
Add warning for SEVIRI native reader in case of bad data

### DIFF
--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -26,6 +26,7 @@ References:
 """
 
 import logging
+import warnings
 from datetime import datetime
 
 import dask.array as da
@@ -294,6 +295,9 @@ class NativeMSGFileHandler(BaseFileHandler):
         self.mda['number_of_columns'] = cols_visir
         self.mda['hrv_number_of_lines'] = int(sec15hd["NumberLinesHRV"]['Value'])
         self.mda['hrv_number_of_columns'] = cols_hrv
+
+        if self.header['15_MAIN_PRODUCT_HEADER']['QQOV']['Value'] == 'NOK':
+            warnings.warn("The quality flag for this file indicates not OK. Use this data with caution!", UserWarning)
 
     def _read_trailer(self):
 

--- a/satpy/readers/seviri_l1b_native_hdr.py
+++ b/satpy/readers/seviri_l1b_native_hdr.py
@@ -713,7 +713,6 @@ class Msg15NativeTrailerRecord(object):
             ('GeometricQuality', self.geometric_quality),
             ('TimelinessAndCompleteness', self.timeliness_and_completeness)
         ]
-
         return record
 
     @property

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -528,7 +528,7 @@ class TestNativeMSGArea(unittest.TestCase):
     """
 
     @staticmethod
-    def create_test_header(earth_model, dataset_id, is_full_disk, is_rapid_scan, good_qual=True):
+    def create_test_header(earth_model, dataset_id, is_full_disk, is_rapid_scan, good_qual='OK'):
         """Create mocked NativeMSGFileHandler.
 
         Contains sufficient attributes for NativeMSGFileHandler.get_area_extent to be able to execute.
@@ -572,15 +572,10 @@ class TestNativeMSGArea(unittest.TestCase):
             n_hrv_cols = n_visir_cols * 3
             n_hrv_lines = n_visir_lines * 3
             ssp_lon = 0
-        # Set quality flag
-        if good_qual:
-            qqov = 'OK'
-        else:
-            qqov = 'NOK'
         header = {
             '15_MAIN_PRODUCT_HEADER': {
                 'QQOV': {'Name': 'QQOV',
-                         'Value': qqov}
+                         'Value': good_qual}
             },
             '15_DATA_HEADER': {
                 'ImageDescription': {
@@ -1385,14 +1380,14 @@ def test_header_warning():
         earth_model=1,
         is_full_disk=True,
         is_rapid_scan=0,
-        good_qual=True
+        good_qual='OK'
     )
     header_bad = TestNativeMSGArea.create_test_header(
         dataset_id=make_dataid(name='VIS006', resolution=3000),
         earth_model=1,
         is_full_disk=True,
         is_rapid_scan=0,
-        good_qual=False
+        good_qual='NOK'
     )
 
     with mock.patch('satpy.readers.seviri_l1b_native.np.fromfile') as fromfile, \
@@ -1406,9 +1401,8 @@ def test_header_warning():
         exp_warning = "The quality flag for this file indicates not OK. Use this data with caution!"
 
         fromfile.return_value = header_good
-        with pytest.warns(None) as warnings:
+        with pytest.warns(None):
             NativeMSGFileHandler('myfile', {}, None)
-            print(warnings)
 
         fromfile.return_value = header_bad
         with pytest.warns(UserWarning, match=exp_warning):

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -528,7 +528,7 @@ class TestNativeMSGArea(unittest.TestCase):
     """
 
     @staticmethod
-    def create_test_header(earth_model, dataset_id, is_full_disk, is_rapid_scan):
+    def create_test_header(earth_model, dataset_id, is_full_disk, is_rapid_scan, good_qual=True):
         """Create mocked NativeMSGFileHandler.
 
         Contains sufficient attributes for NativeMSGFileHandler.get_area_extent to be able to execute.
@@ -572,8 +572,16 @@ class TestNativeMSGArea(unittest.TestCase):
             n_hrv_cols = n_visir_cols * 3
             n_hrv_lines = n_visir_lines * 3
             ssp_lon = 0
-
+        # Set quality flag
+        if good_qual:
+            qqov = 'OK'
+        else:
+            qqov = 'NOK'
         header = {
+            '15_MAIN_PRODUCT_HEADER': {
+                'QQOV': {'Name': 'QQOV',
+                         'Value': qqov}
+            },
             '15_DATA_HEADER': {
                 'ImageDescription': {
                     reference_grid: {
@@ -1368,3 +1376,40 @@ def test_header_type(file_content, exp_header_size):
         fh = NativeMSGFileHandler('myfile', {}, None)
         assert fh.header_type.itemsize == exp_header_size
         assert '15_SECONDARY_PRODUCT_HEADER' in fh.header
+
+
+def test_header_warning():
+    """Test warning is raised for NOK quality flag."""
+    header_good = TestNativeMSGArea.create_test_header(
+        dataset_id=make_dataid(name='VIS006', resolution=3000),
+        earth_model=1,
+        is_full_disk=True,
+        is_rapid_scan=0,
+        good_qual=True
+    )
+    header_bad = TestNativeMSGArea.create_test_header(
+        dataset_id=make_dataid(name='VIS006', resolution=3000),
+        earth_model=1,
+        is_full_disk=True,
+        is_rapid_scan=0,
+        good_qual=False
+    )
+
+    with mock.patch('satpy.readers.seviri_l1b_native.np.fromfile') as fromfile, \
+            mock.patch('satpy.readers.seviri_l1b_native.recarray2dict') as recarray2dict, \
+            mock.patch('satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_memmap') as _get_memmap, \
+            mock.patch('satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer'), \
+            mock.patch("builtins.open", mock.mock_open(read_data=b'FormatName                  : NATIVE')):
+        recarray2dict.side_effect = (lambda x: x)
+        _get_memmap.return_value = np.arange(3)
+
+        exp_warning = "The quality flag for this file indicates not OK. Use this data with caution!"
+
+        fromfile.return_value = header_good
+        with pytest.warns(None) as warnings:
+            NativeMSGFileHandler('myfile', {}, None)
+            print(warnings)
+
+        fromfile.return_value = header_bad
+        with pytest.warns(UserWarning, match=exp_warning):
+            NativeMSGFileHandler('myfile', {}, None)


### PR DESCRIPTION
On occasion, a SEVIRI native file contains bad data in which the digital counts in the file are invalid. This is not picked up by the reader as there's no quality checking.

This PR adds a check for the QQOV flag in the header. In cases where it is NOK a warning is raised to alert the user that the file is likely to contain bad quality data.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
