### PR TITLE
Remove mention of fallback to GDAL in geotiff writer

### DIFF
--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -159,9 +159,7 @@ class GeoTIFFWriter(ImageWriter):
     ):
         """Save the image to the given ``filename`` in geotiff_ format.
 
-        Note for faster output and reduced memory usage the ``rasterio``
-        library must be installed. This writer currently falls back to
-        using ``gdal`` directly, but that will be deprecated in the future.
+        Note this writer requires the ``rasterio`` library to be installed.
 
         Args:
             img (xarray.DataArray): Data to save to geotiff.


### PR DESCRIPTION
This bad information came up in the monthly meeting we had today. The geotiff writer does not use GDAL's python bindings directly at all anymore. This PR removes the mention of this and states that `rasterio` is required.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
