### PR TITLE
Fix experimental dependency stdlibc++ issues in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,8 @@ jobs:
       - name: Install unstable dependencies
         if: matrix.experimental == true
         shell: bash -l {0}
+        # We must get LD_PRELOAD for stdlibc++ or else the manylinux wheels
+        # may break the conda-forge libraries trying to use newer glibc versions
         run: |
           python -m pip install \
           --index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple/ \
@@ -105,6 +107,8 @@ jobs:
           git+https://github.com/pydata/bottleneck \
           git+https://github.com/pydata/xarray \
           git+https://github.com/astropy/astropy;
+          LD_PRELOAD=$(python -c "import sys; print(sys.prefix)")/lib/libstdc++.so
+          echo "LD_PRELOAD=${LD_PRELOAD}" >> $GITHUB_ENV
 
       - name: Install satpy
         shell: bash -l {0}
@@ -114,6 +118,7 @@ jobs:
       - name: Run unit tests
         shell: bash -l {0}
         run: |
+          export LD_PRELOAD=${{ env.LD_PRELOAD }};
           pytest --cov=satpy satpy/tests --cov-report=xml --cov-report=
 
       - name: Upload unittest coverage to Codecov
@@ -133,6 +138,7 @@ jobs:
       - name: Run behaviour tests
         shell: bash -l {0}
         run: |
+          export LD_PRELOAD=${{ env.LD_PRELOAD }};
           coverage run --source=satpy -m behave satpy/tests/features --tags=-download
           coverage xml
 


### PR DESCRIPTION
See https://github.com/rasterio/rasterio/issues/2591 for more detailed debugging.

The shortest answer I can give is that unstable wheels built for PyPI are typically built with a manylinux container using the system glibcxx (stdlibc++.so) which is relatively old. Conda-forge packages are built with a conda-forge-specific glibcxx which is much newer. If the wheels are installed and imported before a conda-forge package that uses stdlibc++.so then it will load the system .so and when the conda-forge package is imported it will reuse the already loaded but *OLDER* .so.

This is my attempt at forcing our CI to load the conda-forge libstdc++ no matter what.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
