### PR TITLE
Add SEVIRI level 2 AMV BUFR

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -81,3 +81,4 @@ The following people have made contributions to this project:
 - [praerien (praerien)](https://github.com/praerien)
 - [Xin Zhang (zxdawn)](https://github.com/zxdawn)
 - [Yufei Zhu (yufeizhu600)](https://github.com/yufeizhu600)
+- [Manuel Carranza (manucarran)](https://github.com/manucarran)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,6 +18,7 @@ The following people have made contributions to this project:
 - Guido della Bruna - meteoswiss
 - [Pierre de Buyl (pdebuyl)](https://github.com/pdebuyl)
 - [Eric Bruning (deeplycloudy)](https://github.com/deeplycloudy)
+- [Manuel Carranza (manucarran)](https://github.com/manucarran)
 - [Lorenzo Clementi (loreclem)](https://github.com/loreclem)
 - [Colin Duff (ColinDuff)](https://github.com/ColinDuff)
 - [Radar, Satellite and Nowcasting Division (meteoswiss-mdr)](https://github.com/meteoswiss-mdr)
@@ -81,4 +82,3 @@ The following people have made contributions to this project:
 - [praerien (praerien)](https://github.com/praerien)
 - [Xin Zhang (zxdawn)](https://github.com/zxdawn)
 - [Yufei Zhu (yufeizhu600)](https://github.com/yufeizhu600)
-- [Manuel Carranza (manucarran)](https://github.com/manucarran)

--- a/satpy/etc/readers/seviri_l2_bufr.yaml
+++ b/satpy/etc/readers/seviri_l2_bufr.yaml
@@ -53,7 +53,10 @@ file_types:
 
   seviri_l2_bufr_amv:
     file_reader: !!python/name:satpy.readers.seviri_l2_bufr.SeviriL2BufrFileHandler
-    file_patterns: ['AMVBUFRProd_{start_time:%Y%m%d%H%M%S}Z_00_{server:s}_{satellite:s}_{mission:s}_{subsat:s}']
+    file_patterns:
+        - 'AMVBUFRProd_{start_time:%Y%m%d%H%M%S}Z_00_{server:s}_{satellite:s}_{mission:s}_{subsat:s}'
+        - '{spacecraft:s}-SEVI-MSGAMVE-{loc1:s}-{loc2:s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{time1:%Y%m%d%H%M%S}-{ord1:s}.bfr'
+        - '{spacecraft:s}-SEVI-MSGAMVE-{loc1:s}-{loc2:s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{time1:%Y%m%d%H%M%S}-{ord1:s}'
 
 datasets:
 

--- a/satpy/etc/readers/seviri_l2_bufr.yaml
+++ b/satpy/etc/readers/seviri_l2_bufr.yaml
@@ -3,7 +3,7 @@ reader:
   short_name: SEVIRI l2 BUFR
   long_name: MSG (Meteosat 8 to 11) Level 2 products in BUFR format
   description: SEVIRI L2 BUFR Product Reader
-  status: Alpha, AMV BUFR products not supported yet
+  status: Alpha
   supports_fsspec: false
   sensors: [seviri]
   default_channels: []
@@ -51,13 +51,17 @@ file_types:
         - '{spacecraft:s}-SEVI-MSGTOZN-{loc1:s}-{loc2:s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{time1:%Y%m%d%H%M%S}-{ord1:s}.bfr'
         - '{spacecraft:s}-SEVI-MSGTOZN-{loc1:s}-{loc2:s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{time1:%Y%m%d%H%M%S}-{ord1:s}'
 
+  seviri_l2_bufr_amv:
+    file_reader: !!python/name:satpy.readers.seviri_l2_bufr.SeviriL2BufrFileHandler
+    file_patterns: ['AMVBUFRProd_{start_time:%Y%m%d%H%M%S}Z_00_{server:s}_{satellite:s}_{mission:s}_{subsat:s}']
+
 datasets:
 
   latitude:
     name: latitude
     key: 'latitude'
-    resolution: [48006.450653072,9001.209497451]
-    file_type: [seviri_l2_bufr_asr,seviri_l2_bufr_cla,seviri_l2_bufr_csr,seviri_l2_bufr_gii,seviri_l2_bufr_thu,seviri_l2_bufr_toz]
+    resolution: [48006.450653072,9001.209497451,72009.675979608]
+    file_type: [seviri_l2_bufr_asr,seviri_l2_bufr_cla,seviri_l2_bufr_csr,seviri_l2_bufr_gii,seviri_l2_bufr_thu,seviri_l2_bufr_toz,seviri_l2_bufr_amv]
     standard_name: latitude
     units: degree_north
     fill_value: -1.e+100
@@ -65,8 +69,8 @@ datasets:
   longitude:
     name: longitude
     key: 'longitude'
-    resolution: [48006.450653072,9001.209497451]
-    file_type: [seviri_l2_bufr_asr,seviri_l2_bufr_cla,seviri_l2_bufr_csr,seviri_l2_bufr_gii,seviri_l2_bufr_thu,seviri_l2_bufr_toz]
+    resolution: [48006.450653072,9001.209497451,72009.675979608]
+    file_type: [seviri_l2_bufr_asr,seviri_l2_bufr_cla,seviri_l2_bufr_csr,seviri_l2_bufr_gii,seviri_l2_bufr_thu,seviri_l2_bufr_toz,seviri_l2_bufr_amv]
     standard_name: longitude
     units: degree_east
     fill_value: -1.e+100
@@ -1149,3 +1153,40 @@ datasets:
        - longitude
        - latitude
     fill_value: 0
+
+  # ---- AMV products ------------
+  speed:
+    name: speed
+    key: '#1#windSpeed'
+    resolution: 72009.675979608
+    file_type: seviri_l2_bufr_amv
+    standard_name: wind_speed
+    units: m s-1
+    fill_value: -1.e+100
+    coordinates:
+       - longitude
+       - latitude
+
+  direction:
+    name: direction
+    key: '#1#windDirection'
+    resolution: 72009.675979608
+    file_type: seviri_l2_bufr_amv
+    standard_name: wind_to_direction
+    units: deg
+    fill_value: -1.e+100
+    coordinates:
+       - longitude
+       - latitude
+
+  pressure:
+    name: pressure
+    key: '#1#pressure'
+    resolution: 72009.675979608
+    file_type: seviri_l2_bufr_amv
+    standard_name: wind_pressure
+    units: Pa
+    fill_value: -1.e+100
+    coordinates:
+       - longitude
+       - latitude

--- a/satpy/readers/seviri_l2_bufr.py
+++ b/satpy/readers/seviri_l2_bufr.py
@@ -105,8 +105,8 @@ class SeviriL2BufrFileHandler(BaseFileHandler):
             self.mpef_header['RectificationLongitude'] = f'E{int(rectification_longitude * 10):04d}'
 
         self.with_adef = with_area_definition
-        if filetype_info['file_type'] == 'seviri_l2_bufr_amv':
-            logging.info("AMV BUFR data cannot be loaded with an area definition. Setting self.with_def = False.")
+        if self.with_adef and filetype_info['file_type'] == 'seviri_l2_bufr_amv':
+            logging.warning("AMV BUFR data cannot be loaded with an area definition. Setting self.with_def = False.")
             self.with_adef = False
 
         self.seg_size = seg_size_dict[filetype_info['file_type']]

--- a/satpy/readers/seviri_l2_bufr.py
+++ b/satpy/readers/seviri_l2_bufr.py
@@ -50,7 +50,8 @@ data_center_dict = {55: {'ssp': 'E0415', 'name': '08'}, 56:  {'ssp': 'E0455', 'n
 
 seg_size_dict = {'seviri_l2_bufr_asr': 16, 'seviri_l2_bufr_cla': 16,
                  'seviri_l2_bufr_csr': 16, 'seviri_l2_bufr_gii': 3,
-                 'seviri_l2_bufr_thu': 16, 'seviri_l2_bufr_toz': 3}
+                 'seviri_l2_bufr_thu': 16, 'seviri_l2_bufr_toz': 3,
+                 'seviri_l2_bufr_amv': 1}
 
 
 class SeviriL2BufrFileHandler(BaseFileHandler):

--- a/satpy/readers/seviri_l2_bufr.py
+++ b/satpy/readers/seviri_l2_bufr.py
@@ -51,7 +51,7 @@ data_center_dict = {55: {'ssp': 'E0415', 'name': '08'}, 56:  {'ssp': 'E0455', 'n
 seg_size_dict = {'seviri_l2_bufr_asr': 16, 'seviri_l2_bufr_cla': 16,
                  'seviri_l2_bufr_csr': 16, 'seviri_l2_bufr_gii': 3,
                  'seviri_l2_bufr_thu': 16, 'seviri_l2_bufr_toz': 3,
-                 'seviri_l2_bufr_amv': 1}
+                 'seviri_l2_bufr_amv': 24}
 
 
 class SeviriL2BufrFileHandler(BaseFileHandler):
@@ -105,6 +105,10 @@ class SeviriL2BufrFileHandler(BaseFileHandler):
             self.mpef_header['RectificationLongitude'] = f'E{int(rectification_longitude * 10):04d}'
 
         self.with_adef = with_area_definition
+        if filetype_info['file_type'] == 'seviri_l2_bufr_amv':
+            logging.info("AMV BUFR data cannot be loaded with an area definition. Setting self.with_def = False.")
+            self.with_adef = False
+
         self.seg_size = seg_size_dict[filetype_info['file_type']]
 
     @property

--- a/satpy/tests/reader_tests/test_seviri_l2_bufr.py
+++ b/satpy/tests/reader_tests/test_seviri_l2_bufr.py
@@ -125,7 +125,7 @@ class SeviriL2BufrData:
         from satpy.readers.seviri_l2_bufr import SeviriL2BufrFileHandler
         self.buf1 = ec.codes_bufr_new_from_samples('BUFR4_local_satellite')
         ec.codes_set(self.buf1, 'unpack', 1)
-        # write the bufr test data twice as we want to read in and the concatenate the data in the reader
+        # write the bufr test data twice as we want to read in and then concatenate the data in the reader
         # 55 id corresponds to METEOSAT 8`
         ec.codes_set(self.buf1, 'satelliteIdentifier', 55)
         ec.codes_set_array(self.buf1, 'latitude', LAT)
@@ -255,3 +255,27 @@ class TestSeviriL2BufrReader:
 
         ad = bufr_obj.fh.get_area_def(None)
         assert ad == AREA_DEF_FES
+
+
+class SeviriL2AMVBufrData:
+    """Mock SEVIRI L2 AMV BUFR data."""
+
+    @unittest.skipIf(sys.platform.startswith('win'), "'eccodes' not supported on Windows")
+    def __init__(self, filename):
+        """Initialize by mocking test data for testing the SEVIRI L2 BUFR reader."""
+        from satpy.readers.seviri_l2_bufr import SeviriL2BufrFileHandler
+
+        with mock.patch('satpy.readers.seviri_l2_bufr.np.fromfile'):
+            self.fh = SeviriL2BufrFileHandler(filename, FILENAME_INFO2,
+                                              filetype_info={'file_type': 'seviri_l2_bufr_amv'},
+                                              with_area_definition=True)
+
+
+class TestSeviriL2AMVBufrReader:
+    """Test SEVIRI L2 BUFR Reader for AMV data."""
+
+    @staticmethod
+    def test_amv_with_area_def():
+        """Test that AMV data can not be loaded with an area definition."""
+        bufr_obj = SeviriL2AMVBufrData('AMVBUFRProd_20201110124500Z_00_OMPEFS04_MET11_FES_E0000')
+        assert bufr_obj.fh.with_adef is False


### PR DESCRIPTION
This pull request has been created in order to add the missing SEVIRI level 2 AMV BUFR products to the corresponding satpy reader. The unit test file for the SEVIRI level 2 BUFR products has been updated in order to test the correct behaviour of the reader with AMV BUFR products (because these do not use the area definition).

As far as I see, there is no specific documentation to update for the SEVIRI level 2 BUFR reader.

- [x] It addresses [Seviri L2 BUFR reader fails to read RSS Regional Instability Index and Atmospheric Motion Vectors #1768](https://github.com/pytroll/satpy/issues/1768)
- [x] Tests added
- [x] Passes `flake8 satpy`
- [x] Fully documented
- [x] Add your name to `AUTHORS.md` if not there already