### PR TITLE
Fix VIIRS EDR Active Fires reader for new format and fix fine/coarse 1D swath handling

### DIFF
--- a/satpy/readers/viirs_edr_active_fires.py
+++ b/satpy/readers/viirs_edr_active_fires.py
@@ -92,12 +92,12 @@ class VIIRSActiveFiresFileHandler(NetCDF4FileHandler):
     @property
     def sensor_name(self):
         """Name of sensor for this file."""
-        return self["sensor"].lower()
+        return self["/attr/instrument_name"].lower()
 
     @property
     def platform_name(self):
         """Name of platform/satellite for this file."""
-        return self["platform_name"]
+        return self["/attr/satellite_name"]
 
 
 class VIIRSActiveFiresTextFileHandler(BaseFileHandler):

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -275,7 +275,8 @@ class Scene:
         def _key_func(swath_def: SwathDefinition) -> tuple:
             attrs = getattr(swath_def.lons, "attrs", {})
             lon_ds_name = attrs.get("name")
-            return swath_def.shape[1], swath_def.shape[0], lon_ds_name
+            rev_shape = swath_def.shape[::-1]
+            return rev_shape + (lon_ds_name,)
         return compare_func(swath_defs, key=_key_func)
 
     def _gather_all_areas(self, datasets):

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -61,8 +61,8 @@ class FakeModFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
         """Mimic reader input file content."""
         file_content = {}
         file_content['/attr/data_id'] = "AFMOD"
-        file_content['satellite_name'] = "npp"
-        file_content['sensor'] = 'VIIRS'
+        file_content['/attr/satellite_name'] = "NPP"
+        file_content['/attr/instrument_name'] = 'VIIRS'
 
         file_content['Fire Pixels/FP_latitude'] = DEFAULT_LATLON_FILE_DATA
         file_content['Fire Pixels/FP_longitude'] = DEFAULT_LATLON_FILE_DATA
@@ -87,8 +87,8 @@ class FakeImgFiresNetCDF4FileHandler(FakeNetCDF4FileHandler):
         """Mimic reader input file content."""
         file_content = {}
         file_content['/attr/data_id'] = "AFIMG"
-        file_content['satellite_name'] = "npp"
-        file_content['sensor'] = 'VIIRS'
+        file_content['/attr/satellite_name'] = "NPP"
+        file_content['/attr/instrument_name'] = 'VIIRS'
 
         file_content['Fire Pixels/FP_latitude'] = DEFAULT_LATLON_FILE_DATA
         file_content['Fire Pixels/FP_longitude'] = DEFAULT_LATLON_FILE_DATA

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -17,6 +17,7 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Unit tests for scene.py."""
 
+import math
 import os
 import random
 import string
@@ -709,7 +710,7 @@ class TestScene:
 
 def _create_coarest_finest_data_array(shape, area_def, attrs=None):
     data_arr = xr.DataArray(
-        da.arange(shape[0] * shape[1]).reshape(shape),
+        da.arange(math.prod(shape)).reshape(shape),
         attrs={
             'area': area_def,
         })
@@ -735,8 +736,12 @@ def _create_coarsest_finest_area_def(shape, extents):
 
 def _create_coarsest_finest_swath_def(shape, extents, name_suffix):
     from pyresample import SwathDefinition
-    lons_arr = da.repeat(da.linspace(extents[0], extents[2], shape[1], dtype=np.float32)[None, :], shape[0], axis=0)
-    lats_arr = da.repeat(da.linspace(extents[1], extents[3], shape[0], dtype=np.float32)[:, None], shape[1], axis=1)
+    if len(shape) == 1:
+        lons_arr = da.linspace(extents[0], extents[2], shape[0], dtype=np.float32)
+        lats_arr = da.linspace(extents[1], extents[3], shape[0], dtype=np.float32)
+    else:
+        lons_arr = da.repeat(da.linspace(extents[0], extents[2], shape[1], dtype=np.float32)[None, :], shape[0], axis=0)
+        lats_arr = da.repeat(da.linspace(extents[1], extents[3], shape[0], dtype=np.float32)[:, None], shape[1], axis=1)
     lons_data_arr = xr.DataArray(lons_arr, attrs={"name": f"longitude{name_suffix}"})
     lats_data_arr = xr.DataArray(lats_arr, attrs={"name": f"latitude1{name_suffix}"})
     return SwathDefinition(lons_data_arr, lats_data_arr)
@@ -754,6 +759,8 @@ class TestFinestCoarsestArea:
              _create_coarsest_finest_area_def((4, 10), (-1000.0, -1500.0, 1000.0, 1500.0))),
             (_create_coarsest_finest_swath_def((2, 5), (1000.0, 1500.0, -1000.0, -1500.0), "1"),
              _create_coarsest_finest_swath_def((4, 10), (1000.0, 1500.0, -1000.0, -1500.0), "1")),
+            (_create_coarsest_finest_swath_def((5,), (1000.0, 1500.0, -1000.0, -1500.0), "1"),
+             _create_coarsest_finest_swath_def((10,), (1000.0, 1500.0, -1000.0, -1500.0), "1")),
         ]
     )
     def test_coarsest_finest_area_different_shape(self, coarse_area, fine_area):


### PR DESCRIPTION
Apparently I never tested my last changes to this reader against real files. The instrument and satellite attribute names were not what I expected. This PR fixes them.

See https://github.com/ssec/polar2grid/issues/458

 - [x] Closes https://github.com/ssec/polar2grid/issues/458 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

