### PR TITLE
Fix CLAVR-x configuration in 'awips_tiled' writer to be backwards compatible

### DIFF
--- a/satpy/etc/writers/awips_tiled.yaml
+++ b/satpy/etc/writers/awips_tiled.yaml
@@ -129,6 +129,12 @@ templates:
           physical_element:
             raw_value: CLAVR-x Cloud Type
           units: {}
+        encoding:
+          dtype: int16
+          _Unsigned: "true"
+          scale_factor: 0.5
+          add_offset: 0.0
+          _FillValue: -128
       clavrx_cld_temp_acha:
         reader: clavrx
         name: cld_temp_acha
@@ -153,6 +159,12 @@ templates:
           units: {}
           physical_element:
             raw_value: CLAVR-x Cloud Phase
+        encoding:
+          dtype: int16
+          _Unsigned: "true"
+          scale_factor: 0.5
+          add_offset: 0.0
+          _FillValue: -128
       clavrx_cld_opd_dcomp:
         reader: clavrx
         name: cld_opd_dcomp


### PR DESCRIPTION
@kathys and I were testing some Polar2Grid 3.0 stuff and noticed the category products weren't being displayed properly. The main issue is that the AWIPS visualization client is configured with colormapping based on the old Polar2Grid 2.3 configuration which applied a scale_factor of 0.5 and add_offset of 0.0. This PR fixes the Satpy version of this configuration to match the old Polar2Grid 2.3 configuration so users across the US don't have to update their AWIPS configurations.

CC @joleenf: This means your Cloud Type configuration needs to be updated in your AWIPS configuration to increment cloud type category values by 2 instead of by 1. This will match what GINA and other AWIPS users will expect.

I'm making this a draft PR because we are currently debugging the use of the "micron" units in AWIPS which apparently AWIPS does not understand in any possible way (micrometers, um, µm, etc).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
