### PR TITLE
Fix ici after mws merge

### DIFF
--- a/satpy/etc/readers/ici_l1b_nc.yaml
+++ b/satpy/etc/readers/ici_l1b_nc.yaml
@@ -12,7 +12,7 @@ reader:
     name:
       required: true
     frequency_double_sideband:
-      type: !!python/name:satpy.readers.aapp_mhs_amsub_l1c.FrequencyDoubleSideBand
+      type: !!python/name:satpy.readers.pmw_channels_definitions.FrequencyDoubleSideBand
     polarization:
       enum:
         - H

--- a/satpy/etc/readers/mws_l1b_nc.yaml
+++ b/satpy/etc/readers/mws_l1b_nc.yaml
@@ -493,22 +493,6 @@ datasets:
             - mws_lon
             - mws_lat
 
-# --- Land surface data ---
-    surface_type:
-        name: surface_type
-        standard_name: surface_type
-        file_type: mws_l1b_nc
-        coordinates:
-            - mws_lon
-            - mws_lat
-    terrain_elevation:
-        name: terrain_elevation
-        standard_name: terrain_elevation
-        file_type: mws_l1b_nc
-        coordinates:
-            - mws_lon
-            - mws_lat
-
 
 file_types:
     mws_l1b_nc:


### PR DESCRIPTION
When supporting MWS in #2120 the use of the `FrequencyDoubleSideBand` type was moved to another module. I/we forgot to update the yaml file for ICI, so the code stopped working as is for ICI.
This PR fixes this.

In addition I had not tested that the code is not able to handle the ancillary datasets like surface type and terrain yet. So I removed this from the yaml file. Reading such datasets is considered of less importance at the moment. We could add an issue on that, but I would rather take that when (and if) a need appears.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
