### PR TITLE
Add support for compressed FSFiles to HRIT readers

### DIFF
--- a/satpy/etc/readers/jami_hrit.yaml
+++ b/satpy/etc/readers/jami_hrit.yaml
@@ -24,6 +24,7 @@ file_types:
         - 'IMG_DK{area:02d}VIS_{start_time:%Y%m%d%H%M}_{segment:03d}'
         - 'IMG_DK{area:02d}VIS_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT1_{start_time:%Y%m%d_%H%M}_DK{area:02d}VIS'
+        - 'HRIT_MTSAT1_{start_time:%Y%m%d_%H%M}_DK{area:02d}VIS.gz'
 
     hrit_ir1:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
@@ -31,6 +32,7 @@ file_types:
         - 'IMG_DK{area:02d}IR1_{start_time:%Y%m%d%H%M}_{segment:03d}'
         - 'IMG_DK{area:02d}IR1_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT1_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR1'
+        - 'HRIT_MTSAT1_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR1.gz'
 
     hrit_ir2:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
@@ -38,6 +40,7 @@ file_types:
         - 'IMG_DK{area:02d}IR2_{start_time:%Y%m%d%H%M}_{segment:03d}'
         - 'IMG_DK{area:02d}IR2_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT1_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR2'
+        - 'HRIT_MTSAT1_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR2.gz'
 
     hrit_ir3:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
@@ -45,6 +48,7 @@ file_types:
         - 'IMG_DK{area:02d}IR3_{start_time:%Y%m%d%H%M}_{segment:03d}'
         - 'IMG_DK{area:02d}IR3_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT1_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR3'
+        - 'HRIT_MTSAT1_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR3.gz'
 
 
     hrit_ir4:
@@ -53,6 +57,7 @@ file_types:
         - 'IMG_DK{area:02d}IR4_{start_time:%Y%m%d%H%M}_{segment:03d}'
         - 'IMG_DK{area:02d}IR4_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT1_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR4'
+        - 'HRIT_MTSAT1_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR4.gz'
 
 datasets:
   VIS:

--- a/satpy/etc/readers/mtsat2-imager_hrit.yaml
+++ b/satpy/etc/readers/mtsat2-imager_hrit.yaml
@@ -23,30 +23,35 @@ file_types:
         file_patterns:
         - 'IMG_DK{area:02d}VIS_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}VIS'
+        - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}VIS.gz'
 
     hrit_ir1:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
         file_patterns:
         - 'IMG_DK{area:02d}IR1_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR1'
+        - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR1.gz'
 
     hrit_ir2:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
         file_patterns:
         - 'IMG_DK{area:02d}IR2_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR2'
+        - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR2.gz'
 
     hrit_ir3:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
         file_patterns:
         - 'IMG_DK{area:02d}IR3_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR3'
+        - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR3.gz'
 
     hrit_ir4:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler
         file_patterns:
         - 'IMG_DK{area:02d}IR4_{start_time:%Y%m%d%H%M}'
         - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR4'
+        - 'HRIT_MTSAT2_{start_time:%Y%m%d_%H%M}_DK{area:02d}IR4.gz'
 
     hrit_vis_seg:
         file_reader: !!python/name:satpy.readers.hrit_jma.HRITJMAFileHandler

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -706,7 +706,7 @@ class FSFile(os.PathLike):
 
         This is read-only.
         """
-        if self._file_handle and self._file_handle.compression:
+        if self._file_handle and hasattr(self._file_handle, "compression") and self._file_handle.compression:
             return self._file_handle.open()
         try:
             return self._fs.open(self._file, *args, **kwargs)

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -680,6 +680,7 @@ class FSFile(os.PathLike):
             fs (fsspec filesystem, optional)
                 Object implementing the fsspec filesystem protocol.
         """
+        self._file_handle = file
         try:
             self._file = file.path
             self._fs = file.fs
@@ -704,6 +705,8 @@ class FSFile(os.PathLike):
 
         This is read-only.
         """
+        if self._file_handle.compression:
+            return self._file_handle.open()
         try:
             return self._fs.open(self._file, *args, **kwargs)
         except AttributeError:

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -711,6 +711,12 @@ class FSFile(os.PathLike):
         except AttributeError:
             return open(self._file, *args, **kwargs)
 
+    def _update_with_fs_open_kwargs(self, user_kwargs):
+        """Complement keyword arguments for opening a file via file system."""
+        kwargs = user_kwargs.copy()
+        kwargs.update(self._fs_open_kwargs)
+        return kwargs
+
     def __lt__(self, other):
         """Implement ordering.
 
@@ -747,12 +753,6 @@ class FSFile(os.PathLike):
         except TypeError:  # fsspec < 0.8.8 for CachingFileSystem
             fshash = hash(pickle.dumps(self._fs))  # nosec B403
         return hash(self._file) ^ fshash
-
-    def _update_with_fs_open_kwargs(self, user_kwargs):
-        """Complement keyword arguments for opening a file via file system."""
-        kwargs = user_kwargs.copy()
-        kwargs.update(self._fs_open_kwargs)
-        return kwargs
 
 
 def _get_fs_open_kwargs(file):

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -680,11 +680,12 @@ class FSFile(os.PathLike):
             fs (fsspec filesystem, optional)
                 Object implementing the fsspec filesystem protocol.
         """
-        self._file_handle = file
         try:
+            self._file_handle = file
             self._file = file.path
             self._fs = file.fs
         except AttributeError:
+            self._file_handle = None
             self._file = file
             self._fs = fs
 
@@ -705,7 +706,7 @@ class FSFile(os.PathLike):
 
         This is read-only.
         """
-        if self._file_handle.compression:
+        if self._file_handle and self._file_handle.compression:
             return self._file_handle.open()
         try:
             return self._fs.open(self._file, *args, **kwargs)

--- a/satpy/readers/hrit_base.py
+++ b/satpy/readers/hrit_base.py
@@ -356,8 +356,7 @@ class HRITSegment:
         self.bpp = mda['number_of_bits_per_pixel']
         self.compressed = mda['compression_flag_for_data'] == 1
         self.offset = mda['total_header_length']
-        self.bzipped = os.fspath(filename).endswith('.bz2')
-        self.gzipped = os.fspath(filename).endswith('.gz')
+        self.zipped = os.fspath(filename).endswith('.bz2')
 
     def read_data(self):
         """Read the data."""

--- a/satpy/readers/hrit_base.py
+++ b/satpy/readers/hrit_base.py
@@ -356,7 +356,8 @@ class HRITSegment:
         self.bpp = mda['number_of_bits_per_pixel']
         self.compressed = mda['compression_flag_for_data'] == 1
         self.offset = mda['total_header_length']
-        self.zipped = os.fspath(filename).endswith('.bz2')
+        self.bzipped = os.fspath(filename).endswith('.bz2')
+        self.gzipped = os.fspath(filename).endswith('.gz')
 
     def read_data(self):
         """Read the data."""
@@ -367,12 +368,13 @@ class HRITSegment:
         return data
 
     def _read_data_from_file(self):
-        # check, if 'filename' is a file on disk,
-        #  or a file like obj, possibly residing already in memory
-        try:
-            return self._read_data_from_disk()
-        except (FileNotFoundError, AttributeError):
+        if self._is_file_like():
             return self._read_file_like()
+        return self._read_data_from_disk()
+
+    def _is_file_like(self):
+        from satpy.readers import FSFile
+        return isinstance(self.filename, FSFile)
 
     def _read_data_from_disk(self):
         # For reading the image data, unzip_context is faster than generic_open

--- a/satpy/readers/hrit_base.py
+++ b/satpy/readers/hrit_base.py
@@ -43,6 +43,7 @@ import xarray as xr
 from pyresample import geometry
 
 import satpy.readers.utils as utils
+from satpy.readers import FSFile
 from satpy.readers.eum_base import time_cds_short
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.seviri_base import dec10216
@@ -372,7 +373,6 @@ class HRITSegment:
         return self._read_data_from_disk()
 
     def _is_file_like(self):
-        from satpy.readers import FSFile
         return isinstance(self.filename, FSFile)
 
     def _read_data_from_disk(self):

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -83,6 +83,25 @@ JMA HRIT data contain the scanline acquisition time for only a subset of scanlin
 the remaining scanlines are computed using linear interpolation. This is what you'll find in the
 ``acq_time`` coordinate of the dataset.
 
+Compression
+-----------
+
+Gzip-compressed MTSAT files can be decompressed on the fly using
+:class:`~satpy.readers.FSFile`:
+
+.. code-block:: python
+
+    import fsspec
+    from satpy import Scene
+    from satpy.readers import FSFile
+
+    filename = "/data/HRIT_MTSAT1_20090101_0630_DK01IR1.gz"
+    open_file = fsspec.open(filename, compression="gzip")
+    fs_file = FSFile(open_file)
+    scn = Scene([fs_file], reader="jami_hrit")
+    scn.load(["IR1"])
+
+
 .. _JMA HRIT - Mission Specific Implementation: http://www.jma.go.jp/jma/jma-eng/satellite/introduction/4_2HRIT.pdf
 .. _JAMI/Imager sample data: https://www.data.jma.go.jp/mscweb/en/operation/hrit_sample.html
 .. _AHI sample data: https://www.data.jma.go.jp/mscweb/en/himawari89/space_segment/sample_hrit.html

--- a/satpy/tests/reader_tests/test_hrit_base.py
+++ b/satpy/tests/reader_tests/test_hrit_base.py
@@ -18,6 +18,7 @@
 """The HRIT base reader tests package."""
 
 import bz2
+import gzip
 import os
 import unittest
 from datetime import datetime
@@ -157,6 +158,14 @@ def stub_bzipped_hrit_file(tmp_path):
 
 
 @pytest.fixture
+def stub_gzipped_hrit_file(tmp_path):
+    """Create a stub gzipped hrit file."""
+    filename = tmp_path / "some_hrit_file.gz"
+    create_stub_hrit(filename, open_fun=gzip.open)
+    return filename
+
+
+@pytest.fixture
 def stub_compressed_hrit_file(tmp_path):
     """Create a stub compressed hrit file."""
     filename = tmp_path / "some_hrit_file.C_"
@@ -240,6 +249,17 @@ class TestHRITFileHandler:
     def test_read_band_bzipped2_filepath(self, stub_bzipped_hrit_file):
         """Test reading a single band from a bzipped file."""
         self.reader.filename = stub_bzipped_hrit_file
+
+        res = self.reader.read_band('VIS006', None)
+        assert res.compute().shape == (464, 3712)
+
+    def test_read_band_gzip_stream(self, stub_gzipped_hrit_file):
+        """Test reading a single band from a gzip stream."""
+        import fsspec
+        filename = stub_gzipped_hrit_file
+
+        fs_file = fsspec.open(filename, compression="gzip")
+        self.reader.filename = FSFile(fs_file)
 
         res = self.reader.read_band('VIS006', None)
         assert res.compute().shape == (464, 3712)


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Add support for compressed FSFiles to HRIT readers, in particular for MTSAT. Usage example:

```python
import fsspec
from satpy import Scene
from satpy.readers import FSFile

open_file = fsspec.open("HRIT_MTSAT1_20090101_0630_DK01IR1.gz", compression="gzip")
fs_file = FSFile(open_file)
scn = Scene([fs_file], reader="jami_hrit")
scn.load(["IR1"])
```


<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
