### PR TITLE
Fix Scene.load modifiers keyword argument having no effect

### DIFF
--- a/satpy/dataset/dataid.py
+++ b/satpy/dataset/dataid.py
@@ -508,7 +508,7 @@ class DataQuery:
     """The data query object.
 
     A DataQuery can be used in Satpy to query for a Dataset. This way
-    a fully qualified DataID can be found even if some of the DataID
+    a fully qualified DataID can be found even if some DataID
     elements are unknown. In this case a `*` signifies something that is
     unknown or not applicable to the requested Dataset.
     """

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1296,7 +1296,7 @@ class Scene:
             del self._datasets[ds_id]
 
     def load(self, wishlist, calibration='*', resolution='*',
-             polarization='*', level='*', generate=True, unload=True,
+             polarization='*', level='*', modifiers='*', generate=True, unload=True,
              **kwargs):
         """Read and generate requested datasets.
 
@@ -1305,35 +1305,37 @@ class Scene:
         or they can not provide certain parameters and the "best" parameter
         will be chosen. For example, if a dataset is available in multiple
         resolutions and no resolution is specified in the wishlist's DataQuery
-        then the highest (smallest number) resolution will be chosen.
+        then the highest (the smallest number) resolution will be chosen.
 
         Loaded `DataArray` objects are created and stored in the Scene object.
 
         Args:
             wishlist (iterable): List of names (str), wavelengths (float),
-                                 DataQuery objects or DataID of the requested
-                                 datasets to load. See `available_dataset_ids()`
-                                 for what datasets are available.
-            calibration (list, str): Calibration levels to limit available
-                                     datasets. This is a shortcut to
-                                     having to list each DataQuery/DataID in
-                                     `wishlist`.
+                DataQuery objects or DataID of the requested datasets to load.
+                See `available_dataset_ids()` for what datasets are available.
+            calibration (list | str): Calibration levels to limit available
+                datasets. This is a shortcut to having to list each
+                DataQuery/DataID in `wishlist`.
             resolution (list | float): Resolution to limit available datasets.
-                                       This is a shortcut similar to
-                                       calibration.
+                This is a shortcut similar to calibration.
             polarization (list | str): Polarization ('V', 'H') to limit
-                                       available datasets. This is a shortcut
-                                       similar to calibration.
+                available datasets. This is a shortcut similar to calibration.
+            modifiers (tuple | str): Modifiers that should be applied to the
+                loaded datasets. This is a shortcut similar to calibration,
+                but only represents a single set of modifiers as a tuple.
+                For example, specifying
+                ``modifiers=('sunz_corrected', 'rayleigh_corrected')`` will
+                attempt to apply both of these modifiers to all loaded
+                datasets in the specified order ('sunz_corrected' first).
             level (list | str): Pressure level to limit available datasets.
-                                Pressure should be in hPa or mb. If an
-                                altitude is used it should be specified in
-                                inverse meters (1/m). The units of this
-                                parameter ultimately depend on the reader.
+                Pressure should be in hPa or mb. If an altitude is used it
+                should be specified in inverse meters (1/m). The units of this
+                parameter ultimately depend on the reader.
             generate (bool): Generate composites from the loaded datasets
-                             (default: True)
-            unload (bool): Unload datasets that were required to generate
-                           the requested datasets (composite dependencies)
-                           but are no longer needed.
+                (default: True)
+            unload (bool): Unload datasets that were required to generate the
+                requested datasets (composite dependencies) but are no longer
+                needed.
 
         """
         if isinstance(wishlist, str):
@@ -1343,6 +1345,7 @@ class Scene:
         query = DataQuery(calibration=calibration,
                           polarization=polarization,
                           resolution=resolution,
+                          modifiers=modifiers,
                           level=level)
         self._update_dependency_tree(needed_datasets, query)
 

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1304,6 +1304,14 @@ class TestSceneLoading:
         assert len(loaded_ids) == 1
         assert loaded_ids[0]['modifiers'] == ('mod1', 'mod2')
 
+    def test_load_modified_with_load_kwarg(self):
+        """Test loading a modified dataset using the ``Scene.load`` keyword argument."""
+        scene = Scene(filenames=['fake1_1.txt'], reader='fake1')
+        scene.load(['ds1'], modifiers=('mod1', 'mod2'))
+        loaded_ids = list(scene._datasets.keys())
+        assert len(loaded_ids) == 1
+        assert loaded_ids[0]['modifiers'] == ('mod1', 'mod2')
+
     def test_load_multiple_modified(self):
         """Test loading multiple modified datasets."""
         scene = Scene(filenames=['fake1_1.txt'], reader='fake1')


### PR DESCRIPTION
As described in the related issue, passing `modifiers=('some_modifier',)` to `Scene.load` has no effect, but it should unless I'm forgetting some conversation where we decided no to do this.

 - [x] Closes #2234  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
