### PR TITLE
Optimise the FCI L1c/netcdf_utils by introducing on-demand variables collection and caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ concurrency:
 on: [push, pull_request]
 
 env:
-  CACHE_NUMBER: 0
+  CACHE_NUMBER: 1
 
 jobs:
   lint:

--- a/satpy/_compat.py
+++ b/satpy/_compat.py
@@ -50,7 +50,7 @@ class CachedPropertyBackport:
             raise TypeError(
                 "Cannot use cached_property instance without calling __set_name__ on it.")
         try:
-            cache = instance.__dict__
+            cache = instance.__dict__  # noqa
         except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
             msg = (
                 f"No '__dict__' attribute on {type(instance).__name__!r} "
@@ -88,3 +88,9 @@ except ImportError:
     # numpy <1.20
     from numpy import dtype as DTypeLike  # noqa
     from numpy import ndarray as ArrayLike  # noqa
+
+
+try:
+    from functools import cache  # type: ignore
+except ImportError:
+    from functools import lru_cache as cache  # noqa

--- a/satpy/_compat.py
+++ b/satpy/_compat.py
@@ -50,7 +50,7 @@ class CachedPropertyBackport:
             raise TypeError(
                 "Cannot use cached_property instance without calling __set_name__ on it.")
         try:
-            cache = instance.__dict__  # noqa
+            cache = instance.__dict__
         except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
             msg = (
                 f"No '__dict__' attribute on {type(instance).__name__!r} "
@@ -88,9 +88,3 @@ except ImportError:
     # numpy <1.20
     from numpy import dtype as DTypeLike  # noqa
     from numpy import ndarray as ArrayLike  # noqa
-
-
-try:
-    from functools import cache  # type: ignore
-except ImportError:
-    from functools import lru_cache as cache  # noqa

--- a/satpy/etc/readers/fci_l1c_nc.yaml
+++ b/satpy/etc/readers/fci_l1c_nc.yaml
@@ -18,7 +18,59 @@ file_types:
     file_reader: !!python/name:satpy.readers.fci_l1c_nc.FCIL1cNCFileHandler
     file_patterns: [ '{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+{data_source}-1C-RRAD-FDHSI-{coverage}-{subsetting}-{component1}-BODY-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc' ]
     expected_segments: 40
-
+    required_netcdf_variables:
+    - attr/platform
+    - data/mtg_geos_projection
+    - data/CHANNEL_NAME/measured/start_position_row
+    - data/CHANNEL_NAME/measured/end_position_row
+    - data/CHANNEL_NAME/measured/radiance_to_bt_conversion_coefficient_wavenumber
+    - data/CHANNEL_NAME/measured/radiance_to_bt_conversion_coefficient_a
+    - data/CHANNEL_NAME/measured/radiance_to_bt_conversion_coefficient_b
+    - data/CHANNEL_NAME/measured/radiance_to_bt_conversion_constant_c1
+    - data/CHANNEL_NAME/measured/radiance_to_bt_conversion_constant_c2
+    - data/CHANNEL_NAME/measured/radiance_unit_conversion_coefficient
+    - data/CHANNEL_NAME/measured/channel_effective_solar_irradiance
+    - data/CHANNEL_NAME/measured/effective_radiance
+    - data/CHANNEL_NAME/measured/x
+    - data/CHANNEL_NAME/measured/y
+    - data/CHANNEL_NAME/measured/pixel_quality
+    - data/CHANNEL_NAME/measured/index_map
+    - data/mtg_geos_projection/attr/inverse_flattening
+    - data/mtg_geos_projection/attr/longitude_of_projection_origin
+    - data/mtg_geos_projection/attr/longitude_of_projection_origin
+    - data/mtg_geos_projection/attr/perspective_point_height
+    - data/mtg_geos_projection/attr/perspective_point_height
+    - data/mtg_geos_projection/attr/perspective_point_height
+    - data/mtg_geos_projection/attr/semi_major_axis
+    - data/swath_direction
+    - data/swath_number
+    - index
+    - state/celestial/earth_sun_distance
+    - state/celestial/earth_sun_distance
+    - state/celestial/subsolar_latitude
+    - state/celestial/subsolar_longitude
+    - state/celestial/sun_satellite_distance
+    - state/platform/platform_altitude
+    - state/platform/subsatellite_latitude
+    - state/platform/subsatellite_longitude
+    - time
+    channel_names:
+    - vis_04
+    - vis_05
+    - vis_06
+    - vis_08
+    - vis_09
+    - nir_13
+    - nir_16
+    - nir_22
+    - ir_38
+    - wv_63
+    - wv_73
+    - ir_87
+    - ir_97
+    - ir_105
+    - ir_123
+    - ir_133
 
 datasets:
   vis_04:

--- a/satpy/etc/readers/fci_l1c_nc.yaml
+++ b/satpy/etc/readers/fci_l1c_nc.yaml
@@ -21,20 +21,20 @@ file_types:
     required_netcdf_variables:
     - attr/platform
     - data/mtg_geos_projection
-    - data/CHANNEL_NAME/measured/start_position_row
-    - data/CHANNEL_NAME/measured/end_position_row
-    - data/CHANNEL_NAME/measured/radiance_to_bt_conversion_coefficient_wavenumber
-    - data/CHANNEL_NAME/measured/radiance_to_bt_conversion_coefficient_a
-    - data/CHANNEL_NAME/measured/radiance_to_bt_conversion_coefficient_b
-    - data/CHANNEL_NAME/measured/radiance_to_bt_conversion_constant_c1
-    - data/CHANNEL_NAME/measured/radiance_to_bt_conversion_constant_c2
-    - data/CHANNEL_NAME/measured/radiance_unit_conversion_coefficient
-    - data/CHANNEL_NAME/measured/channel_effective_solar_irradiance
-    - data/CHANNEL_NAME/measured/effective_radiance
-    - data/CHANNEL_NAME/measured/x
-    - data/CHANNEL_NAME/measured/y
-    - data/CHANNEL_NAME/measured/pixel_quality
-    - data/CHANNEL_NAME/measured/index_map
+    - data/{channel_name}/measured/start_position_row
+    - data/{channel_name}/measured/end_position_row
+    - data/{channel_name}/measured/radiance_to_bt_conversion_coefficient_wavenumber
+    - data/{channel_name}/measured/radiance_to_bt_conversion_coefficient_a
+    - data/{channel_name}/measured/radiance_to_bt_conversion_coefficient_b
+    - data/{channel_name}/measured/radiance_to_bt_conversion_constant_c1
+    - data/{channel_name}/measured/radiance_to_bt_conversion_constant_c2
+    - data/{channel_name}/measured/radiance_unit_conversion_coefficient
+    - data/{channel_name}/measured/channel_effective_solar_irradiance
+    - data/{channel_name}/measured/effective_radiance
+    - data/{channel_name}/measured/x
+    - data/{channel_name}/measured/y
+    - data/{channel_name}/measured/pixel_quality
+    - data/{channel_name}/measured/index_map
     - data/mtg_geos_projection/attr/inverse_flattening
     - data/mtg_geos_projection/attr/longitude_of_projection_origin
     - data/mtg_geos_projection/attr/longitude_of_projection_origin
@@ -54,23 +54,24 @@ file_types:
     - state/platform/subsatellite_latitude
     - state/platform/subsatellite_longitude
     - time
-    channel_names:
-    - vis_04
-    - vis_05
-    - vis_06
-    - vis_08
-    - vis_09
-    - nir_13
-    - nir_16
-    - nir_22
-    - ir_38
-    - wv_63
-    - wv_73
-    - ir_87
-    - ir_97
-    - ir_105
-    - ir_123
-    - ir_133
+    variable_name_replacements:
+      channel_name:
+      - vis_04
+      - vis_05
+      - vis_06
+      - vis_08
+      - vis_09
+      - nir_13
+      - nir_16
+      - nir_22
+      - ir_38
+      - wv_63
+      - wv_73
+      - ir_87
+      - ir_97
+      - ir_105
+      - ir_123
+      - ir_133
 
 datasets:
   vis_04:

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -318,10 +318,10 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
         actual_subsat_lon = float(np.nanmean(self._get_aux_data_lut_vector('subsatellite_longitude')))
         actual_subsat_lat = float(np.nanmean(self._get_aux_data_lut_vector('subsatellite_latitude')))
         actual_sat_alt = float(np.nanmean(self._get_aux_data_lut_vector('platform_altitude')))
-
-        nominal_and_proj_subsat_lon = float(self["data/mtg_geos_projection/attr/longitude_of_projection_origin"])
+        mtg_geos_proj = self.get_and_cache_npxr("data/mtg_geos_projection")
+        nominal_and_proj_subsat_lon = float(mtg_geos_proj.longitude_of_projection_origin)
         nominal_and_proj_subsat_lat = 0
-        nominal_and_proj_sat_alt = float(self["data/mtg_geos_projection/attr/perspective_point_height"])
+        nominal_and_proj_sat_alt = float(mtg_geos_proj.perspective_point_height)
 
         orb_param_dict = {
             'orbital_parameters': {
@@ -372,7 +372,7 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
         # get index map
         index_map = self._get_dataset_index_map(_get_channel_name_from_dsname(dsname))
         # subtract minimum of index variable (index_offset)
-        index_map -= np.min(self['index'])
+        index_map -= np.min(self.get_and_cache_npxr('index'))
 
         # get lut values from 1-d vector variable
         lut = self._get_aux_data_lut_vector(_get_aux_data_name_from_dsname(dsname))
@@ -408,11 +408,12 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
         logger.debug('Row/Cols: {} / {}'.format(nlines, ncols))
 
         # Calculate full globe line extent
-        h = float(self["data/mtg_geos_projection/attr/perspective_point_height"])
+        mtg_geos_proj = self.get_and_cache_npxr("data/mtg_geos_projection")
+        h = float(mtg_geos_proj.perspective_point_height)
 
         extents = {}
         for coord in "xy":
-            coord_radian = self["data/{:s}/measured/{:s}".format(channel_name, coord)]
+            coord_radian = self.get_and_cache_npxr("data/{:s}/measured/{:s}".format(channel_name, coord))
 
             # TODO remove this check when old versions of IDPF test data (<v4) are deprecated.
             if coord == "x" and coord_radian.scale_factor > 0:
@@ -475,11 +476,12 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
         if key['resolution'] in self._cache:
             return self._cache[key['resolution']]
 
-        a = float(self["data/mtg_geos_projection/attr/semi_major_axis"])
-        h = float(self["data/mtg_geos_projection/attr/perspective_point_height"])
-        rf = float(self["data/mtg_geos_projection/attr/inverse_flattening"])
-        lon_0 = float(self["data/mtg_geos_projection/attr/longitude_of_projection_origin"])
-        sweep = str(self["data/mtg_geos_projection/attr/sweep_angle_axis"])
+        mtg_geos_proj = self.get_and_cache_npxr("data/mtg_geos_projection")
+        a = float(mtg_geos_proj.semi_major_axis)
+        h = float(mtg_geos_proj.perspective_point_height)
+        rf = float(mtg_geos_proj.inverse_flattening)
+        lon_0 = float(mtg_geos_proj.longitude_of_projection_origin)
+        sweep = str(mtg_geos_proj.sweep_angle_axis)
 
         area_extent, nlines, ncols = self.calc_area_extent(key)
         logger.debug('Calculated area extent: {}'

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -296,7 +296,7 @@ class FCIL1cNCFileHandler(NetCDF4FileHandler):
         res.attrs.update(attrs)
 
         res.attrs["platform_name"] = self._platform_name_translate.get(
-            self["/attr/platform"], self["/attr/platform"])
+            self["attr/platform"], self["attr/platform"])
 
         # remove unpacking parameters for calibrated data
         if key['calibration'] in ['brightness_temperature', 'reflectance']:

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -108,8 +108,8 @@ class NetCDF4FileHandler(BaseFileHandler):
 
         listed_variables = filetype_info.get("required_netcdf_variables")
         channel_names = filetype_info.get("channel_names")
-        if listed_variables and channel_names:
-            self._collect_listed_variables(file_handle, channel_names, listed_variables)
+        if listed_variables:
+            self._collect_listed_variables(file_handle, listed_variables, channel_names=channel_names)
         else:
             self.collect_metadata("", file_handle)
             self.collect_dimensions("", file_handle)
@@ -162,8 +162,8 @@ class NetCDF4FileHandler(BaseFileHandler):
         self.file_content[var_name + "/dimensions"] = var_obj.dimensions
         self._collect_attrs(var_name, var_obj)
 
-    def _collect_listed_variables(self, file_handle, channel_names, listed_variables):
-        for itm in self._get_required_variable_names(channel_names, listed_variables):
+    def _collect_listed_variables(self, file_handle, listed_variables, channel_names=None):
+        for itm in self._get_required_variable_names(listed_variables, channel_names):
             parts = itm.split('/')
             grp = file_handle
             for p in parts[:-1]:
@@ -178,10 +178,10 @@ class NetCDF4FileHandler(BaseFileHandler):
                 self.collect_dimensions(itm, grp)
 
     @staticmethod
-    def _get_required_variable_names(channel_names, listed_variables):
+    def _get_required_variable_names(listed_variables, channel_names):
         variable_names = []
         for var in listed_variables:
-            if 'CHANNEL_NAME' in var:
+            if channel_names and 'CHANNEL_NAME' in var:
                 for ch in channel_names:
                     variable_names.append(var.replace('CHANNEL_NAME', ch))
             else:

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -19,17 +19,13 @@
 
 import logging
 
-try:
-    from functools import cache  # type: ignore
-except ImportError:
-    from functools import lru_cache as cache
-
 import dask.array as da
 import netCDF4
 import numpy as np
 import xarray as xr
 
 from satpy import CHUNK_SIZE
+from satpy._compat import cache
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.utils import np2str
 

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -340,4 +340,4 @@ def _compose_replacement_names(variable_name_replacements, var, variable_names):
         vals = variable_name_replacements[key]
         for val in vals:
             if key in var:
-                variable_names.append(var.replace('{' + key + '}', val))
+                variable_names.append(var.format(**{key: val}))

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -102,7 +102,6 @@ class NetCDF4FileHandler(BaseFileHandler):
             LOG.exception(
                 'Failed reading file %s. Possibly corrupted file', self.filename)
             raise
-
         self.auto_maskandscale = auto_maskandscale
         if hasattr(file_handle, "set_auto_maskandscale"):
             file_handle.set_auto_maskandscale(auto_maskandscale)
@@ -287,3 +286,15 @@ class NetCDF4FileHandler(BaseFileHandler):
             return self[item]
         else:
             return default
+
+    def get_and_cache_npxr(self, var_name):
+        """Get item as numpy-xarray and keep in cache."""
+        if var_name in self.cached_file_content:
+            return self.cached_file_content[var_name]
+
+        v = self.file_content[var_name]
+
+        self.cached_file_content[var_name] = xr.DataArray(
+            v[:], dims=v.dimensions, attrs=v.__dict__, name=v.name)
+
+        return self.cached_file_content[var_name]

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -326,14 +326,18 @@ class NetCDF4FileHandler(BaseFileHandler):
         else:
             return default
 
-    @cache  # noqa
     def get_and_cache_npxr(self, var_name):
         """Get item as numpy-xarray and keep in cache."""
         v = self.file_content[var_name]
-        if isinstance(v, xr.DataArray):
-            return v
-        return xr.DataArray(
-            v[:], dims=v.dimensions, attrs=v.__dict__, name=v.name)
+        return _cache_npxr(v)
+
+
+@cache  # noqa
+def _cache_npxr(v):
+    if isinstance(v, xr.DataArray):
+        return v
+    return xr.DataArray(
+        v[:], dims=v.dimensions, attrs=v.__dict__, name=v.name)
 
 
 def _compose_replacement_names(variable_name_replacements, var, variable_names):

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -293,7 +293,8 @@ class NetCDF4FileHandler(BaseFileHandler):
             return self.cached_file_content[var_name]
 
         v = self.file_content[var_name]
-
+        if isinstance(v, xr.DataArray):
+            return v
         self.cached_file_content[var_name] = xr.DataArray(
             v[:], dims=v.dimensions, attrs=v.__dict__, name=v.name)
 

--- a/satpy/tests/reader_tests/test_fci_l1c_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_nc.py
@@ -19,6 +19,7 @@
 
 import logging
 import os
+from typing import Dict
 from unittest import mock
 
 import dask.array as da
@@ -32,6 +33,8 @@ from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
 
 class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
     """Class for faking the NetCDF4 Filehandler."""
+
+    cached_file_content: Dict[str, xr.DataArray] = {}
 
     def _get_test_calib_for_channel_ir(self, chroot, meas):
         from pyspectral.blackbody import C_SPEED as c

--- a/satpy/tests/reader_tests/test_fci_l1c_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_nc.py
@@ -203,7 +203,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
         data = {}
         attrs = {"platform": "MTI1"}
         for (k, v) in attrs.items():
-            data["/attr/" + k] = v
+            data["attr/" + k] = v
         return data
 
     def get_test_content(self, filename, filename_info, filetype_info):
@@ -356,7 +356,6 @@ class TestFCIL1cNCReaderGoodData(TestFCIL1cNCReader):
             "CHK-BODY--L2P-NC4E_C_EUMT_20170410114442_GTT_DEV_"
             "20170410113934_20170410113942_N__C_0070_0068.nc",
         ]
-
         reader = _get_reader_with_filehandlers(filenames, reader_configs)
         res = reader.load(
             [make_dataid(name=name, calibration="counts") for name in

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -22,6 +22,8 @@ import unittest
 
 import numpy as np
 
+from satpy._compat import cache
+
 try:
     from satpy.readers.netcdf_utils import NetCDF4FileHandler
 except ImportError:
@@ -45,6 +47,7 @@ class FakeNetCDF4FileHandler(NetCDF4FileHandler):
             raise ImportError("Base 'NetCDF4FileHandler' could not be "
                               "imported.")
         super(NetCDF4FileHandler, self).__init__(filename, filename_info, filetype_info)
+        self.get_and_cache_npxr = cache(self._get_and_cache_npxr)
         self.file_content = self.get_test_content(filename, filename_info, filetype_info)
         if extra_file_content:
             self.file_content.update(extra_file_content)

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -235,3 +235,25 @@ class TestNetCDF4FileHandler(unittest.TestCase):
 
         with self.assertRaises(IOError):
             NetCDF4FileHandler("/thisfiledoesnotexist.nc", {}, {})
+
+    def test_get_and_cache_npxr_is_xr(self):
+        """Test that get_and_cache_npxr() returns xr.DataArray."""
+        import xarray as xr
+
+        from satpy.readers.netcdf_utils import NetCDF4FileHandler
+        file_handler = NetCDF4FileHandler('test.nc', {}, {}, cache_handle=True)
+
+        data = file_handler.get_and_cache_npxr('test_group/ds1_f')
+        assert isinstance(data, xr.DataArray)
+
+    def test_get_and_cache_npxr_data_is_cached(self):
+        """Test that the data are cached when get_and_cache_npxr() is called."""
+        from satpy.readers.netcdf_utils import NetCDF4FileHandler
+
+        file_handler = NetCDF4FileHandler('test.nc', {}, {}, cache_handle=True)
+        data = file_handler.get_and_cache_npxr('test_group/ds1_f')
+
+        # Delete the dataset from the file content dict, it should be available from the cache
+        del file_handler.file_content["test_group/ds1_f"]
+        data2 = file_handler.get_and_cache_npxr('test_group/ds1_f')
+        assert np.all(data == data2)

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -164,6 +164,21 @@ class TestNetCDF4FileHandler(unittest.TestCase):
         self.assertIsNone(file_handler.file_handle)
         self.assertEqual(file_handler["ds2_sc"], 42)
 
+    def test_listed_variables(self):
+        """Test that only listed variables/attributes area collected."""
+        from satpy.readers.netcdf_utils import NetCDF4FileHandler
+
+        filetype_info = {
+            'required_netcdf_variables': [
+                'test_group/attr/test_attr_str',
+                'attr/test_attr_str',
+            ]
+        }
+        file_handler = NetCDF4FileHandler('test.nc', {}, filetype_info)
+        assert len(file_handler.file_content) == 2
+        assert 'test_group/attr/test_attr_str' in file_handler.file_content
+        assert 'attr/test_attr_str' in file_handler.file_content
+
     def test_caching(self):
         """Test that caching works as intended."""
         from satpy.readers.netcdf_utils import NetCDF4FileHandler

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -22,8 +22,6 @@ import unittest
 
 import numpy as np
 
-from satpy._compat import cache
-
 try:
     from satpy.readers.netcdf_utils import NetCDF4FileHandler
 except ImportError:
@@ -47,7 +45,6 @@ class FakeNetCDF4FileHandler(NetCDF4FileHandler):
             raise ImportError("Base 'NetCDF4FileHandler' could not be "
                               "imported.")
         super(NetCDF4FileHandler, self).__init__(filename, filename_info, filetype_info)
-        self.get_and_cache_npxr = cache(self._get_and_cache_npxr)
         self.file_content = self.get_test_content(filename, filename_info, filetype_info)
         if extra_file_content:
             self.file_content.update(extra_file_content)

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -179,6 +179,34 @@ class TestNetCDF4FileHandler(unittest.TestCase):
         assert 'test_group/attr/test_attr_str' in file_handler.file_content
         assert 'attr/test_attr_str' in file_handler.file_content
 
+    def test_listed_variables_with_composing(self):
+        """Test that composing for listed variables is performed."""
+        from satpy.readers.netcdf_utils import NetCDF4FileHandler
+
+        filetype_info = {
+            'required_netcdf_variables': [
+                'test_group/{some_parameter}/attr/test_attr_str',
+                'test_group/attr/test_attr_str',
+            ],
+            'variable_name_replacements': {
+                'some_parameter': [
+                    'ds1_f',
+                    'ds1_i',
+                ],
+                'another_parameter': [
+                    'not_used'
+                ],
+            }
+        }
+        file_handler = NetCDF4FileHandler('test.nc', {}, filetype_info)
+        assert len(file_handler.file_content) == 3
+        assert 'test_group/ds1_f/attr/test_attr_str' in file_handler.file_content
+        assert 'test_group/ds1_i/attr/test_attr_str' in file_handler.file_content
+        assert not any('not_used' in var for var in file_handler.file_content)
+        assert not any('some_parameter' in var for var in file_handler.file_content)
+        assert not any('another_parameter' in var for var in file_handler.file_content)
+        assert 'test_group/attr/test_attr_str' in file_handler.file_content
+
     def test_caching(self):
         """Test that caching works as intended."""
         from satpy.readers.netcdf_utils import NetCDF4FileHandler


### PR DESCRIPTION
A first attempt at optimising the NetCDF4FileHandler for faster FCI L1c loading.

Idea: skip the size-based caching at Scene initialisation (`cache_var_size=0`), and instead get and cache variable as numpy-xarrays when needed.

Also only required variables/attributes (listed in the reader YAML) are collected. This reduces the number of collected variables/attributes from 93880 to 2070.

This PR also included a lot of tests for solving the single-threadedness reported in #2186, so we'll be closing it with this PR:
- create file handlers in parallel: slower than single-threaded
- read datasets (`scn.load()` call) in parallel: slower than single-treaded

 - [x] Closes #2186 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
