### PR TITLE
Fix incorrect rows_per_scan in 'acspo' reader

### DIFF
--- a/satpy/readers/acspo.py
+++ b/satpy/readers/acspo.py
@@ -33,9 +33,9 @@ LOG = logging.getLogger(__name__)
 
 
 ROWS_PER_SCAN = {
-    'MODIS': 10,
-    'VIIRS': 16,
-    'AVHRR': None,
+    'modis': 10,
+    'viirs': 16,
+    'avhrr': None,
 }
 
 

--- a/satpy/tests/reader_tests/test_acspo.py
+++ b/satpy/tests/reader_tests/test_acspo.py
@@ -152,3 +152,4 @@ class TestACSPOReader:
             assert d.shape == DEFAULT_FILE_SHAPE
             assert d.dims == ("y", "x")
             assert d.attrs["sensor"] == "viirs"
+            assert d.attrs["rows_per_scan"] == 16


### PR DESCRIPTION
In #2114 I updated the ACSPO reader so the `sensor_name` attribute was lowercase, but I didn't update the reader's internal dictionary mapping sensor name to rows per scan. This meant that the file handler was always returning "0" rows per scan. This made the EWA resampling results look bad. This PR fixes the case of this internal dictionary.

 - [x] Closes https://github.com/ssec/polar2grid/issues/498 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

