### PR TITLE
Fix re-loading of StaticImageCompositor composites in special cases

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1187,7 +1187,7 @@ class StaticImageCompositor(GenericCompositor, DataDownloadMixin):
     """
 
     def __init__(self, name, filename=None, url=None, known_hash=None, area=None,
-                 **kwargs):
+                 sensor=None, **kwargs):
         """Collect custom configuration values.
 
         Args:
@@ -1241,6 +1241,7 @@ class StaticImageCompositor(GenericCompositor, DataDownloadMixin):
 
         super(StaticImageCompositor, self).__init__(name, **kwargs)
         cache_keys = self.register_data_files([])
+        self.attrs['sensor'] = sensor
         self._cache_key = cache_keys[0]
 
     @staticmethod
@@ -1300,7 +1301,7 @@ class StaticImageCompositor(GenericCompositor, DataDownloadMixin):
             if self.area is None:
                 raise AttributeError("Area definition needs to be configured")
             img.attrs['area'] = self.area
-        img.attrs['sensor'] = None
+        img.attrs['sensor'] = self.attrs['sensor']
         img.attrs['mode'] = ''.join(img.bands.data)
         img.attrs.pop('modifiers', None)
         img.attrs.pop('calibration', None)

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -419,12 +419,14 @@ composites:
   _night_background:
     compositor: !!python/name:satpy.composites.StaticImageCompositor
     standard_name: night_background
+    sensor: 'viirs'
     url: "https://neo.gsfc.nasa.gov/archive/blackmarble/2016/global/BlackMarble_2016_01deg_geo.tif"
     known_hash: "sha256:146c116962677ae113d9233374715686737ff97141a77cc5da69a9451315a685"  # optional
 
   _night_background_hires:
     compositor: !!python/name:satpy.composites.StaticImageCompositor
     standard_name: night_background
+    sensor: 'viirs'
     url: "https://neo.gsfc.nasa.gov/archive/blackmarble/2016/global/BlackMarble_2016_3km_geo.tif"
     known_hash: "sha256:e915ef2a20d84e2a59e1547d3ad564463ad4bcf22bfa02e0e0b8ed1cd722e9c0"  # optional
 
@@ -505,3 +507,12 @@ composites:
       - wavelength: 0.64
       - wavelength: 1.61
     standard_name: cimss_cloud_type
+
+  natural_color_raw_with_night_ir:
+    compositor: !!python/name:satpy.composites.DayNightCompositor
+    standard_name: natural_color_with_night_ir
+    lim_low: 80
+    lim_high: 90
+    prerequisites:
+      - natural_color_raw
+      - cloudtop


### PR DESCRIPTION
As mentioned in my comment on #2242, re-loading a composite with no pre-requisites fails if the user hasn't loaded any satellite data first:
```
# Example with SEVIRI, substitute whatever data you have
scn = Scene(['D:/sat_data/SEV/MSG3-SEVI-MSG15-0100-NA-20160326144242.057000000Z-NA.nat'], reader='seviri_l1b_native')
scn.load(["_night_background"])
print("LOADED")
scn.load(["_night_background"])
print("LOADED AGAIN")
```
In the above code, the second `load` command will fail with an error as for the `_night_background` composite the `sensor` will be `None`.

In this PR, I fix the problem by - optionally - allowing a `sensor` to be passed to `StaticImageCompositor` via the YAML file. This will then be stored in the composite and prevents the error described above.

 - [ ] Partially closes #2242
 - [ ] Tests added
