### PR TITLE
Fix MODIS reader tests failing with new geotiepoints

### DIFF
--- a/satpy/readers/hdfeos_base.py
+++ b/satpy/readers/hdfeos_base.py
@@ -243,7 +243,7 @@ class HDFEOSBaseFileReader(BaseFileHandler):
         # we still need to convert integers to floats
         if scale_factor is not None and not is_category:
             if add_offset is not None and add_offset != 0:
-                data = data - add_offset
+                data = data - np.float32(add_offset)
             data = data * np.float32(scale_factor)
 
         if good_mask is not None:


### PR DESCRIPTION
The new version of python-geotiepoints implements MODIS interpolation in Cython. In addition to being faster, it adds some more strict-ness/rigidity to what data types can be passed to a function. To simplify the code in geotiepoints, when the user passes more than one array they must all be the same data type (ex. all 32-bit floats or all 64-bit floats). In the real world MODIS cases I've never seen an issue with mixing (mismatching) array data types, but the tests in Satpy do introduce this.

In this PR I fix the small issue in the reader which enforces casting to 32-bit floats. In the tests, I wasn't able to force the HDF4 files produced to match the real MODIS data exactly where this casting wouldn't be needed.

Note: I could update geotiepoints to be more flexible...but this seems so much simpler.

CC @gerritholl for #2164 CI failures

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
