### PR TITLE
Document behaviour on default enhancement

### DIFF
--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -536,6 +536,23 @@ the file) as::
           kwargs:
             gamma: [1.7, 1.7, 1.7]
 
+.. warning::
+   If you define a composite with no matching enhancement, Satpy will by
+   default apply a crude stretch enhancement.  If you want no enhancement
+   at all (maybe you are enhancing a composite based on
+   :class:`DayNightCompositor` where the components have their own
+   enhancements defined), you need to define an enhancement that does
+   nothing::
+
+      enhancements:
+        day_x:
+          standard_name: day_x
+          operations: []
+
+   It is recommended to define an enhancement even if you intend to use
+   the default, in case the default should change in future versions of
+   Satpy.
+
 More examples can be found in SatPy source code directory
 ``satpy/etc/enhancements/generic.yaml``.
 

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -538,11 +538,11 @@ the file) as::
 
 .. warning::
    If you define a composite with no matching enhancement, Satpy will by
-   default apply a crude stretch enhancement.  If you want no enhancement
-   at all (maybe you are enhancing a composite based on
-   :class:`DayNightCompositor` where the components have their own
-   enhancements defined), you need to define an enhancement that does
-   nothing::
+   default apply the :func:`~trollimage.xrimage.XRImage.stretch_linear` enhancement with
+   cutoffs of 0.5% and 99.5%.  If you want no enhancement at all (maybe you
+   are enhancing a composite based on :class:`DayNightCompositor` where
+   the components have their own enhancements defined), you need to define
+   an enhancement that does nothing::
 
       enhancements:
         day_x:


### PR DESCRIPTION
Document Satpys behaviour on applying a default enhancement if no enhancement is defined, and document on how to avoid this enhancement from being applied.  Also add a recommendation to always define an enhancement even if using the default.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
