### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Automatically update CI actions. To all the reviewers, I just thought you'd like to see this as an example of what can/should be done in other repositories. Go to the repositories "Settings" -> "Code security and analysis" -> Enable "Dependabot version updates" -> Set the `package-ecosystem` to `github-actions` -> Make a PR.
