### PR TITLE
Fix failure creating directory if it already exists.

### DIFF
--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -649,7 +649,7 @@ class Writer(Plugin, DataDownloadMixin):
         dirname = os.path.dirname(output_filename)
         if dirname and not os.path.isdir(dirname):
             LOG.info("Creating output directory: {}".format(dirname))
-            os.makedirs(dirname)
+            os.makedirs(dirname, exist_ok=True)
         return output_filename
 
     def save_datasets(self, datasets, compute=True, **kwargs):


### PR DESCRIPTION
The satpy writers code is set up to create the output directory if it doesn't already exist. Which works well in most cases.

However, for use cases where the user submits a large number of jobs to a parallel processing queue (like slurm) this can cause issues if one job creates the directory *after* another job checks if the dir exists but *before* it creates the directory.
This situation results in the following error:

```
Traceback (most recent call last):
  File "/home/users/srproud/Scripts/Visualise/Proc_Him_Volc.py", line 43, in <module>
    scn.save_dataset(compo[0], filename=outf1, fill_value=0)
  File "/home/users/srproud/Software/satpy/satpy/scene.py", line 1133, in save_dataset
    return writer.save_dataset(self[dataset_id],
  File "/home/users/srproud/Software/satpy/satpy/writers/__init__.py", line 813, in save_dataset
    return self.save_image(img, filename=filename, compute=compute, fill_value=fill_value, **kwargs)
  File "/home/users/srproud/Software/satpy/satpy/writers/simple_image.py", line 64, in save_image
    filename = filename or self.get_filename(**img.data.attrs)
  File "/home/users/srproud/Software/satpy/satpy/writers/__init__.py", line 652, in get_filename
    os.makedirs(dirname)
  File "/home/users/srproud/miniconda3/lib/python3.9/os.py", line 225, in makedirs
    mkdir(name, mode)
FileExistsError: [Errno 17] File exists: '/gws/nopw/j04/nerc_avmet/out//true_color_nocorr'
```

This PR fixes the problem by adding the `exist_ok=True` argument to `os.makedirs`.