### PR TITLE
Fix VIIRS L1B I-band angle names being inconsistent with VIIRS SDR

### DIFF
--- a/satpy/etc/readers/viirs_l1b.yaml
+++ b/satpy/etc/readers/viirs_l1b.yaml
@@ -185,7 +185,7 @@ datasets:
     coordinates: [i_lon, i_lat]
     file_type: vl1bi
   I_SOLZ:
-    name: i_solar_zenith_angle
+    name: solar_zenith_angle
     standard_name: solar_zenith_angle
     resolution: 371
     units: degrees
@@ -193,7 +193,7 @@ datasets:
     file_type: vgeoi
     file_key: geolocation_data/solar_zenith
   I_SOLA:
-    name: i_solar_azimuth_angle
+    name: solar_azimuth_angle
     standard_name: solar_azimuth_angle
     resolution: 371
     units: degrees
@@ -201,7 +201,7 @@ datasets:
     file_type: vgeoi
     file_key: geolocation_data/solar_azimuth
   I_SENZ:
-    name: i_satellite_zenith_angle
+    name: satellite_zenith_angle
     standard_name: sensor_zenith_angle
     resolution: 371
     units: degrees
@@ -209,7 +209,7 @@ datasets:
     file_type: vgeoi
     file_key: geolocation_data/sensor_zenith
   I_SENA:
-    name: i_satellite_azimuth_angle
+    name: satellite_azimuth_angle
     standard_name: sensor_azimuth_angle
     resolution: 371
     units: degrees

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -742,34 +742,6 @@ class FileYAMLReader(AbstractYAMLReader, DataDownloadMixin):
         """Load the area definition of *dsid*."""
         return _load_area_def(dsid, file_handlers)
 
-    def _get_coordinates_for_dataset_key(self, dsid):
-        """Get the coordinate dataset keys for *dsid*."""
-        ds_info = self.all_ids[dsid]
-        cids = []
-        for cinfo in ds_info.get('coordinates', []):
-            if not isinstance(cinfo, dict):
-                cinfo = {'name': cinfo}
-
-            for key in self._co_keys:
-                if key == 'name':
-                    continue
-                if key in ds_info:
-                    if ds_info[key] is not None:
-                        cinfo[key] = ds_info[key]
-            cid = DataQuery.from_dict(cinfo)
-
-            cids.append(self.get_dataset_key(cid))
-
-        return cids
-
-    def _get_coordinates_for_dataset_keys(self, dsids):
-        """Get all coordinates."""
-        coordinates = {}
-        for dsid in dsids:
-            cids = self._get_coordinates_for_dataset_key(dsid)
-            coordinates.setdefault(dsid, []).extend(cids)
-        return coordinates
-
     def _get_file_handlers(self, dsid):
         """Get the file handler to load this dataset."""
         ds_info = self.all_ids[dsid]
@@ -780,6 +752,21 @@ class FileYAMLReader(AbstractYAMLReader, DataDownloadMixin):
                            "'%s'", ds_info['file_type'], dsid['name'])
         else:
             return self.file_handlers[filetype]
+
+    def _load_dataset_area(self, dsid, file_handlers, coords, **kwargs):
+        """Get the area for *dsid*."""
+        try:
+            return self._load_area_def(dsid, file_handlers, **kwargs)
+        except NotImplementedError:
+            if any(x is None for x in coords):
+                logger.warning(
+                    "Failed to load coordinates for '{}'".format(dsid))
+                return None
+
+            area = self._make_area_from_coords(coords)
+            if area is None:
+                logger.debug("No coordinates found for %s", str(dsid))
+            return area
 
     def _make_area_from_coords(self, coords):
         """Create an appropriate area with the given *coords*."""
@@ -821,21 +808,6 @@ class FileYAMLReader(AbstractYAMLReader, DataDownloadMixin):
             if key is not None:
                 FileYAMLReader._coords_cache[key] = sdef
         return sdef
-
-    def _load_dataset_area(self, dsid, file_handlers, coords, **kwargs):
-        """Get the area for *dsid*."""
-        try:
-            return self._load_area_def(dsid, file_handlers, **kwargs)
-        except NotImplementedError:
-            if any(x is None for x in coords):
-                logger.warning(
-                    "Failed to load coordinates for '{}'".format(dsid))
-                return None
-
-            area = self._make_area_from_coords(coords)
-            if area is None:
-                logger.debug("No coordinates found for %s", str(dsid))
-            return area
 
     def _load_dataset_with_area(self, dsid, coords, **kwargs):
         """Load *dsid* and its area if available."""
@@ -964,6 +936,34 @@ class FileYAMLReader(AbstractYAMLReader, DataDownloadMixin):
         self._load_ancillary_variables(all_datasets, **kwargs)
 
         return datasets
+
+    def _get_coordinates_for_dataset_keys(self, dsids):
+        """Get all coordinates."""
+        coordinates = {}
+        for dsid in dsids:
+            cids = self._get_coordinates_for_dataset_key(dsid)
+            coordinates.setdefault(dsid, []).extend(cids)
+        return coordinates
+
+    def _get_coordinates_for_dataset_key(self, dsid):
+        """Get the coordinate dataset keys for *dsid*."""
+        ds_info = self.all_ids[dsid]
+        cids = []
+        for cinfo in ds_info.get('coordinates', []):
+            if not isinstance(cinfo, dict):
+                cinfo = {'name': cinfo}
+
+            for key in self._co_keys:
+                if key == 'name':
+                    continue
+                if key in ds_info:
+                    if ds_info[key] is not None:
+                        cinfo[key] = ds_info[key]
+            cid = DataQuery.from_dict(cinfo)
+
+            cids.append(self.get_dataset_key(cid))
+
+        return cids
 
 
 def _load_area_def(dsid, file_handlers):

--- a/satpy/tests/reader_tests/test_viirs_l1b.py
+++ b/satpy/tests/reader_tests/test_viirs_l1b.py
@@ -272,6 +272,29 @@ class TestVIIRSL1BReaderDay:
             assert v.attrs['area'].lats.attrs['rows_per_scan'] == 2
             assert v.attrs['sensor'] == "viirs"
 
+    def test_load_i_band_angles(self):
+        """Test loading all M bands as radiances."""
+        from satpy.readers import load_reader
+        from satpy.tests.utils import make_dataid
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([
+            'VL1BI_snpp_d20161130_t012400_c20161130054822.nc',
+            'VL1BM_snpp_d20161130_t012400_c20161130054822.nc',
+            'VGEOI_snpp_d20161130_t012400_c20161130054822.nc',
+            'VGEOM_snpp_d20161130_t012400_c20161130054822.nc',
+        ])
+        r.create_filehandlers(loadables)
+        datasets = r.load([
+            make_dataid(name='satellite_zenith_angle'),
+            make_dataid(name='satellite_azimuth_angle'),
+            make_dataid(name='solar_azimuth_angle'),
+            make_dataid(name='solar_zenith_angle'),
+        ])
+        assert len(datasets) == 4
+        for v in datasets.values():
+            assert v.attrs['resolution'] == 371
+            assert v.attrs['sensor'] == "viirs"
+
     def test_load_dnb_radiance(self):
         """Test loading the main DNB dataset."""
         from satpy.readers import load_reader


### PR DESCRIPTION
While looking into #2258, it was pointed out that the I-band angle datasets in the `viirs_l1b` reader don't match the names in the `viirs_sdr` reader. This PR fixes that as well as refactors some of the yaml_reader.py to follow a top-to-bottom reading strategy (I got annoyed while debugging something).

 - [x] Closes #2258 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

