### PR TITLE
Fix ratio sharpening not sharing invalid mask between bands

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -929,7 +929,6 @@ class RatioSharpenedRGB(GenericCompositor):
             raise ValueError("RatioSharpenedRGB.high_resolution_band must "
                              "be one of ['red', 'green', 'blue', None]. Not "
                              "'{}'".format(self.high_resolution_color))
-        kwargs.setdefault('common_channel_mask', False)
         super(RatioSharpenedRGB, self).__init__(*args, **kwargs)
 
     def __call__(self, datasets, optional_datasets=None, **info):


### PR DESCRIPTION
Fixes a bug introduced in #2240 where I refactored the duplicate masking behavior because it was already handled in the parent class, GenericCompositor. However, I didn't change the default for the ratio sharpening class to enable this behavior in the parent class so it wasn't being done at all. The tests were not complex enough to pick up this mistake but have been updated in this PR.

The behavior I'm talking about is where a mask is created of the NaN locations in each band, merged, and then applied to all the bands. Without this, you get strange colors where one band has missing data but another doesn't. This is especially necessary on the edges of resampled data where different resolution may "stretch" further geographically than other bands.

 - [x] Closes https://github.com/ssec/polar2grid/issues/556 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

