### PR TITLE
Add ability to export Scene's dependency tree to a graphviz dot format

### DIFF
--- a/satpy/dependency_tree.py
+++ b/satpy/dependency_tree.py
@@ -145,6 +145,21 @@ class Tree:
         """Render the dependency tree as a string."""
         return self._root.display()
 
+    def to_graphviz(self, *args, node_kwargs=None, **kwargs):
+        """Generate a graphviz 'DiGraph' object representation of this tree.
+
+        All arguments and keyword arguments are passed directly to
+        :class:`graphviz.DiGraph` except for ``node_kwargs`` which is passed
+        to each child node.
+
+        """
+        import graphviz
+        kwargs.setdefault("strict", True)
+        graph = graphviz.Digraph(*args, **kwargs)
+        node_kwargs = node_kwargs or {}
+        self._root.to_graphviz(graph, **node_kwargs)
+        return graph
+
 
 class DependencyTree(Tree):
     """Structure to discover and store `Dataset` dependencies.

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -154,6 +154,15 @@ class Node:
                         res.append(sub_child)
         return res
 
+    def to_graphviz(self, graph, **node_kwargs) -> str:
+        """Add nodes and edges to the provided graphviz graph."""
+        node_name = str(self.name)
+        graph.node(node_name, **node_kwargs)
+        for child in self.children:
+            child_node_name = child.to_graphviz(graph, **node_kwargs)
+            graph.edge(node_name, child_node_name)
+        return node_name
+
 
 class CompositorNode(Node):
     """Implementation of a compositor-specific node."""


### PR DESCRIPTION
This is a proof of concept for something that might be useful. The idea was to create a way to semi-easily convert a series of Satpy dependency relationships into a graphviz graph. Not sure how useful it is, but I wanted to try it. Here's a basic graph for the ABI `true_color`.

![test_graph3](https://user-images.githubusercontent.com/1828519/201542633-c2b08bc9-dffa-46b1-9a13-bcf3c3bf08f9.svg)

I think this could be cleaned up to treat modifiers differently and shorten the size of each bubble.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

