### PR TITLE
Documentation correction: Not all built-in compositors derive from GenericCompositor

### DIFF
--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -14,12 +14,12 @@ Built-in Compositors
 
 .. py:currentmodule:: satpy.composites
 
-There are several built-in compositors available in SatPy.
-All of them use the :class:`GenericCompositor` base class
+There are many built-in compositors available in Satpy.
+The majority use the :class:`GenericCompositor` base class
 which handles various image modes (`L`, `LA`, `RGB`, and
 `RGBA` at the moment) and updates attributes.
 
-The below sections summarize the composites that come with SatPy and
+The below sections summarize the composites that come with Satpy and
 show basic examples of creating and using them with an existing
 :class:`~satpy.scene.Scene` object. It is recommended that any composites
 that are used repeatedly be configured in YAML configuration files.
@@ -59,6 +59,12 @@ is generated.  To get an image out of the above composite::
 This part is called `enhancement`, and is covered in more detail in
 :doc:`enhancements`.
 
+Single channel composites can also be generated with the
+:class:`GenericCompositor`, but in some cases, the
+:class:`SingleBandCompositor` may be more appropriate.  For example,
+the :class:`GenericCompositor` removes attributes such as ``units``
+because they are typically not meaningful for an RGB image.  Such attributes
+are retained in the :class:`SingleBandCompositor`.
 
 DifferenceCompositor
 --------------------
@@ -492,7 +498,7 @@ Enhancing the images
 After the composite is defined and created, it needs to be converted
 to an image.  To do this, it is necessary to describe how the data
 values are mapped to values stored in the image format.  This
-procedure is called ``stretching``, and in SatPy it is implemented by
+procedure is called ``stretching``, and in Satpy it is implemented by
 ``enhancements``.
 
 The first step is to convert the composite to an
@@ -553,7 +559,7 @@ the file) as::
    the default, in case the default should change in future versions of
    Satpy.
 
-More examples can be found in SatPy source code directory
+More examples can be found in Satpy source code directory
 ``satpy/etc/enhancements/generic.yaml``.
 
 See the :doc:`enhancements` documentation for more information on


### PR DESCRIPTION
Fix an incorrect statement in the documentation alleging that all compositors are derived from the GenericCompositor.  This isn't true. Also add a paragraph on why one might want to use SingleBandCompositor.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

