### PR TITLE
Add suppression of AttributeError when trying to close the netcdf file.

### DIFF
--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -113,7 +113,7 @@ class FciL2CommonFunctions(object):
 
     def __del__(self):
         """Close the NetCDF file that may still be open."""
-        with suppress(OSError):
+        with suppress(AttributeError, OSError):
             self.nc.close()
 
 


### PR DESCRIPTION
This PR adds the suppression of `AttributeError` when trying to close the netcdf file in the FCI L2 NetCDF reader, in case the file was never opened. The lack of this suppression has lead to occasional failures of the reader during routine reading/monitoring of FCI L2 test data.

 - [x] Closes #2269
