### PR TITLE
Adds use of GCPDefinition instead of SwathDefinition to Modis L1b reader

### DIFF
--- a/satpy/etc/readers/modis_l1b.yaml
+++ b/satpy/etc/readers/modis_l1b.yaml
@@ -403,11 +403,29 @@ datasets:
     name: '36'
     resolution: 1000
     calibration: [brightness_temperature, radiance]
-    coordinates: [longitude, latitude]
+    coordinates: [longitude, latitude, longitude_tiepoints, latitude_tiepoints]
     wavelength:
     - 14.085
     - 14.235
     - 14.385
+
+  longitude_tiepoints:
+    name: longitude_tiepoints
+    resolution:
+     1000:
+        file_type: hdf_eos_data_1000m
+    file_key: Longitude
+    standard_name: longitude_tiepoints
+    units: degree
+
+  latitude_tiepoints:
+    name: latitude_tiepoints
+    resolution:
+      1000:
+        file_type: hdf_eos_data_1000m
+    file_key: Latitude
+    standard_name: latitude_tiepoints
+    units: degree
 
   longitude:
     name: longitude

--- a/satpy/readers/hdfeos_base.py
+++ b/satpy/readers/hdfeos_base.py
@@ -296,6 +296,8 @@ class HDFEOSGeoReader(HDFEOSBaseFileReader):
     DATASET_NAMES = {
         'longitude': 'Longitude',
         'latitude': 'Latitude',
+        'longitude_tiepoints': 'Longitude',
+        'latitude_tiepoints': 'Latitude',
         'satellite_azimuth_angle': ('SensorAzimuth', 'Sensor_Azimuth'),
         'satellite_zenith_angle': ('SensorZenith', 'Sensor_Zenith'),
         'solar_azimuth_angle': ('SolarAzimuth', 'SolarAzimuth'),
@@ -393,6 +395,8 @@ class HDFEOSGeoReader(HDFEOSBaseFileReader):
             # otherwise use the default name for this variable
             data = self._load_ds_by_name(dataset_name)
         if resolution != self.geo_resolution:
+            if dataset_name in ["longitude_tiepoints", "latitude_tiepoints"]:
+                return data
             if in_file_dataset_name is not None:
                 # they specified a custom variable name but
                 # we don't know how to interpolate this yet

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -774,6 +774,12 @@ class FileYAMLReader(AbstractYAMLReader, DataDownloadMixin):
             lons, lats = self._get_lons_lats_from_coords(coords)
             sdef = self._make_swath_definition_from_lons_lats(lons, lats)
             return sdef
+        if len(coords) == 4:
+            lons_tiepoints, lats_tiepoints = coords[2::]
+            lons, lats = self._get_lons_lats_from_coords(coords[0:2])
+            sdef = self._make_tiepoints_definition_from_lons_lats_and_gcps(lons, lats, lons_tiepoints,
+                                                                           lats_tiepoints)
+            return sdef
         if len(coords) != 0:
             raise NameError("Don't know what to do with coordinates " + str(
                 coords))
@@ -800,6 +806,37 @@ class FileYAMLReader(AbstractYAMLReader, DataDownloadMixin):
             sdef = None
         if sdef is None:
             sdef = SwathDefinition(lons, lats)
+            sensor_str = '_'.join(self.info['sensors'])
+            shape_str = '_'.join(map(str, lons.shape))
+            sdef.name = "{}_{}_{}_{}".format(sensor_str, shape_str,
+                                             lons.attrs.get('name', lons.name),
+                                             lats.attrs.get('name', lats.name))
+            if key is not None:
+                FileYAMLReader._coords_cache[key] = sdef
+        return sdef
+
+    def _make_tiepoints_definition_from_lons_lats_and_gcps(self, lons, lats, lons_tiepoints, lats_tiepoints):
+        """Make a swath definition instance from lons and lats.
+
+        Args:
+            lons (xarray.DataArray): Interpolated Longitudes.
+            lats (xarray.DataArray): Interpolated Latitudes.
+            lons_tiepoints (xarray.DataArray): Longitude tiepoints.
+            lats_tiepoints (xarray.DataArray): Latitude tiepoints.
+
+        Returns:
+            pyresample.geometry.GCPDefinition
+
+        """
+        from pyresample.geometry import GCPDefinition
+        key = None
+        try:
+            key = (lons.data.name, lats.data.name)
+            sdef = FileYAMLReader._coords_cache.get(key)
+        except AttributeError:
+            sdef = None
+        if sdef is None:
+            sdef = GCPDefinition(lons, lats, {"longitude": lons_tiepoints, "latitude": lats_tiepoints})
             sensor_str = '_'.join(self.info['sensors'])
             shape_str = '_'.join(map(str, lons.shape))
             sdef.name = "{}_{}_{}_{}".format(sensor_str, shape_str,


### PR DESCRIPTION
These changes introduce the use of `GCPDefinition` (`SwathDefinition` with ground control points https://github.com/pytroll/pyresample/pull/476) for the Modis L1b reader.

This should be used as a base for discussion of how/where `SwathDefinitions`/ `GCPDefinitions` should be created reader/`FileYAMLReader`. Currently if `get_area_def` is not implemented in the reader a `SwathDefinition` is created in the `FileYAMLReader` as a "fallback" in a kind of way.

Possible Questions:

- change `get_area_def` to `get_area` in the reader to make it clearer that this should be used for creation of `AreaDefinitions` as well as `SwathDefinitions` (with control points).
- refactor the logic of `FileYAMLReader` and readers how to create `SwathDefinitions` with ground control points and interpolation?
	- e.g. should it be necessary to include tiepoints as a variable and add it to the coordinates keyword for the other datasets in the yaml file of the reader (as is done here)? Alternatively introduction of a "depends_on"/"requires" keyword which can be used to indicate that full lat/lons depend on tiepoints?

...


 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->