### PR TITLE
satpy_cf_nc reader to support reading variables with the same name with different resolutions from two files

### DIFF
--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -286,12 +286,9 @@ class SatpyCFFileHandler(BaseFileHandler):
         if key in ['name', 'modifiers']:
             return True
         elif key == 'wavelength':
-            if _ds_id_dict[key] != WavelengthRange.from_cf(data.attrs[key]):
-                return False
+            return _ds_id_dict[key] == WavelengthRange.from_cf(data.attrs[key])
         else:
-            if data.attrs[key] != _ds_id_dict[key]:
-                return False
-        return True
+            return data.attrs[key] == _ds_id_dict[key]
 
     def _dataid_attrs_equal(self, ds_id, data):
         _ds_id_dict = ds_id.to_dict()

--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -293,7 +293,7 @@ class SatpyCFFileHandler(BaseFileHandler):
                 return False
         return True
 
-    def _attrs_equal(self, ds_id, data):
+    def _dataid_attrs_equal(self, ds_id, data):
         _ds_id_dict = ds_id.to_dict()
         for key in _ds_id_dict:
             try:
@@ -311,7 +311,7 @@ class SatpyCFFileHandler(BaseFileHandler):
         name = ds_info.get('nc_store_name', ds_id['name'])
         file_key = ds_info.get('file_key', name)
         data = nc[file_key]
-        if not self._attrs_equal(ds_id, data):
+        if not self._dataid_attrs_equal(ds_id, data):
             return
         if name != ds_id['name']:
             data = data.rename(ds_id['name'])

--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -282,15 +282,22 @@ class SatpyCFFileHandler(BaseFileHandler):
             self.fix_modifier_attr(ds_info)
             yield True, ds_info
 
+    def _compare_attr(self, _ds_id_dict, key, data):
+        if key in ['name', 'modifiers']:
+            return True
+        elif key == 'wavelength':
+            if _ds_id_dict[key] != WavelengthRange.from_cf(data.attrs[key]):
+                return False
+        else:
+            if data.attrs[key] != _ds_id_dict[key]:
+                return False
+        return True
+
     def _attrs_equal(self, ds_id, data):
         _ds_id_dict = ds_id.to_dict()
         for key in _ds_id_dict:
             try:
-                if key in ['name', 'modifiers']:
-                    continue
-                elif key == 'wavelength' and ds_id[key] != WavelengthRange.from_cf(data.attrs[key]):
-                    return False
-                elif data.attrs[key] != ds_id[key]:
+                if not self._compare_attr(_ds_id_dict, key, data):
                     return False
             except KeyError:
                 pass

--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -306,8 +306,7 @@ class SatpyCFFileHandler(BaseFileHandler):
         nc = xr.open_dataset(self.filename, engine=self.engine,
                              chunks={'y': CHUNK_SIZE, 'x': CHUNK_SIZE})
         name = ds_info.get('nc_store_name', ds_id['name'])
-        file_key = ds_info.get('file_key', name)
-        data = nc[file_key]
+        data = nc[ds_info.get('file_key', name)]
         if not self._dataid_attrs_equal(ds_id, data):
             return
         if name != ds_id['name']:

--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -285,20 +285,15 @@ class SatpyCFFileHandler(BaseFileHandler):
     def _attrs_equal(self, ds_id, data):
         _ds_id_dict = ds_id.to_dict()
         for key in _ds_id_dict:
-            if key in ['name', 'modifiers']:
-                continue
-            if key == 'wavelength':
-                try:
-                    if ds_id[key] != WavelengthRange.from_cf(data.attrs[key]):
-                        return False
-                except KeyError:
-                    pass
-            else:
-                try:
-                    if data.attrs[key] != ds_id[key]:
-                        return False
-                except KeyError:
-                    pass
+            try:
+                if key in ['name', 'modifiers']:
+                    continue
+                elif key == 'wavelength' and ds_id[key] != WavelengthRange.from_cf(data.attrs[key]):
+                    return False
+                elif data.attrs[key] != ds_id[key]:
+                    return False
+            except KeyError:
+                pass
         return True
 
     def get_dataset(self, ds_id, ds_info):

--- a/satpy/tests/reader_tests/test_satpy_cf_nc.py
+++ b/satpy/tests/reader_tests/test_satpy_cf_nc.py
@@ -479,7 +479,7 @@ class TestCFReader:
         data = _cf_scene
         assert reader._attrs_equal(ds_id, data['image0']) is False
         ds_id_wavelength = DataID(default_id_keys_config, name='image0', resolution=1000, modifiers=(),
-                         wavelength=WavelengthRange(min=0.1, central=0.63, max=1000, unit='µm'))
+                                  wavelength=WavelengthRange(min=0.1, central=0.63, max=1000, unit='µm'))
         assert reader._attrs_equal(ds_id_wavelength, data['image0']) is False
         ds_id_key_error = DataID(default_id_keys_config, name='image0', resolution=1000)
         del data['image0'].attrs['resolution']

--- a/satpy/tests/reader_tests/test_satpy_cf_nc.py
+++ b/satpy/tests/reader_tests/test_satpy_cf_nc.py
@@ -468,3 +468,19 @@ class TestCFReader:
         scn_.unload()
         scn_.load(['solar_zenith_angle'], resolution=371)
         assert scn_['solar_zenith_angle'].attrs['resolution'] == 371
+
+    def test_attrs_equal_non_equal(self, _cf_scene):
+        """Check that attrs return False on non equal attribute and handles missing keys."""
+        from satpy.dataset.dataid import DataID, default_id_keys_config
+        reader = SatpyCFFileHandler('filename',
+                                    {},
+                                    {'filetype': 'info'})
+        ds_id = DataID(default_id_keys_config, name='image0', resolution=999, modifiers=())
+        data = _cf_scene
+        assert reader._attrs_equal(ds_id, data['image0']) is False
+        ds_id_wavelength = DataID(default_id_keys_config, name='image0', resolution=1000, modifiers=(),
+                         wavelength=WavelengthRange(min=0.1, central=0.63, max=1000, unit='µm'))
+        assert reader._attrs_equal(ds_id_wavelength, data['image0']) is False
+        ds_id_key_error = DataID(default_id_keys_config, name='image0', resolution=1000)
+        del data['image0'].attrs['resolution']
+        assert reader._attrs_equal(ds_id_key_error, data['image0']) is True

--- a/satpy/tests/reader_tests/test_satpy_cf_nc.py
+++ b/satpy/tests/reader_tests/test_satpy_cf_nc.py
@@ -68,28 +68,28 @@ def _cf_scene_i():
     print(lat_i.shape)
     print(len(y_visir_i), len(x_visir_i))
     lat_i = xr.DataArray(lat_i,
-                       dims=('y', 'x'),
-                       coords={'y': y_visir_i, 'x': x_visir_i},
-                       attrs={
-                           'name': 'lat',
-                           'standard_name': 'latitude',
-                           'modifiers': np.array([])
-                       })
+                         dims=('y', 'x'),
+                         coords={'y': y_visir_i, 'x': x_visir_i},
+                         attrs={
+                             'name': 'lat',
+                             'standard_name': 'latitude',
+                             'modifiers': np.array([])
+                         })
     lon_i = xr.DataArray(lon_i,
-                       dims=('y', 'x'),
-                       coords={'y': y_visir_i, 'x': x_visir_i},
-                       attrs={
-                           'name': 'lon',
-                           'standard_name': 'longitude',
-                           'modifiers': np.array([])
-                       })
+                         dims=('y', 'x'),
+                         coords={'y': y_visir_i, 'x': x_visir_i},
+                         attrs={
+                             'name': 'lon',
+                             'standard_name': 'longitude',
+                             'modifiers': np.array([])
+                         })
 
     solar_zenith_angle_i = xr.DataArray(data_visir_i,
-                          dims=('y', 'x'),
-                          coords={'y': y_visir_i, 'x': x_visir_i},
-                          attrs={'name': 'solar_zenith_angle',
-                                 'coordinates': 'lat lon',
-                                 'resolution': 371})
+                                        dims=('y', 'x'),
+                                        coords={'y': y_visir_i, 'x': x_visir_i},
+                                        attrs={'name': 'solar_zenith_angle',
+                                               'coordinates': 'lat lon',
+                                               'resolution': 371})
 
     scene = Scene()
     scene.attrs['sensor'] = ['avhrr-1', 'avhrr-2', 'avhrr-3']
@@ -213,11 +213,11 @@ def _cf_scene():
                                })
 
     solar_zenith_angle = xr.DataArray(data_visir,
-                          dims=('y', 'x'),
-                          coords={'y': y_visir, 'x': x_visir},
-                          attrs={'name': 'solar_zenith_angle',
-                                 'coordinates': 'lat lon',
-                                 'resolution': 742})
+                                      dims=('y', 'x'),
+                                      coords={'y': y_visir, 'x': x_visir},
+                                      attrs={'name': 'solar_zenith_angle',
+                                             'coordinates': 'lat lon',
+                                             'resolution': 742})
 
     # for swath testing
     area = SwathDefinition(lons=lon, lats=lat)
@@ -249,6 +249,7 @@ def _nc_filename(tmp_path):
     now = datetime.utcnow()
     filename = f'testingcfwriter{now:%Y%j%H%M%S}-viirs-mband-20201007075915-20201007080744.nc'
     return str(tmp_path / filename)
+
 
 @pytest.fixture
 def _nc_filename_i(tmp_path):
@@ -434,10 +435,10 @@ class TestCFReader:
                                 flatten_attrs=True,
                                 pretty=True)
         _cf_scene_i.save_datasets(writer='cf',
-                                filename=_nc_filename_i,
-                                engine='h5netcdf',
-                                flatten_attrs=True,
-                                pretty=True)
+                                  filename=_nc_filename_i,
+                                  engine='h5netcdf',
+                                  flatten_attrs=True,
+                                  pretty=True)
         scn_ = Scene(reader='satpy_cf_nc',
                      filenames=[_nc_filename, _nc_filename_i])
         scn_.load(['solar_zenith_angle'])

--- a/satpy/tests/reader_tests/test_satpy_cf_nc.py
+++ b/satpy/tests/reader_tests/test_satpy_cf_nc.py
@@ -38,7 +38,7 @@ def _cf_scene_i():
     tstart = datetime(2019, 4, 1, 12, 0)
     tend = datetime(2019, 4, 1, 12, 15)
 
-    data_visir_i = np.array([[1, 2, 3 ,4], [5, 6, 7, 8],
+    data_visir_i = np.array([[1, 2, 3, 4], [5, 6, 7, 8],
                              [9, 10, 11, 12], [13, 14, 15, 16]])
     lat_i = 33.0 * np.array([np.arange(1, 2.1, 1/3), np.arange(3, 4.1, 1/3),
                              np.arange(5, 6.1, 1/3), np.arange(7, 8.1, 1/3)])
@@ -452,10 +452,10 @@ class TestCFReader:
     def test_write_and_read_from_two_files(self, _cf_scene_m, _cf_scene_i, _nc_filename, _nc_filename_i):
         """Save two datasets with different resolution and read the solar_zenith_angle again."""
         _cf_scene_m.save_datasets(writer='cf',
-                                filename=_nc_filename,
-                                engine='h5netcdf',
-                                flatten_attrs=True,
-                                pretty=True)
+                                 filename=_nc_filename,
+                                 engine='h5netcdf',
+                                 flatten_attrs=True,
+                                 pretty=True)
         _cf_scene_i.save_datasets(writer='cf',
                                   filename=_nc_filename_i,
                                   engine='h5netcdf',

--- a/satpy/tests/reader_tests/test_satpy_cf_nc.py
+++ b/satpy/tests/reader_tests/test_satpy_cf_nc.py
@@ -111,6 +111,7 @@ def _cf_scene_i():
             scene[key].attrs.update(common_attrs)
     return scene
 
+
 @pytest.fixture(scope="session")
 def _cf_scene():
     tstart = datetime(2019, 4, 1, 12, 0)
@@ -256,6 +257,7 @@ def _nc_filename_i(tmp_path):
     now = datetime.utcnow()
     filename = f'testingcfwriter{now:%Y%j%H%M%S}-viirs-iband-20201007075915-20201007080744.nc'
     return str(tmp_path / filename)
+
 
 class TestCFReader:
     """Test case for CF reader."""

--- a/satpy/tests/reader_tests/test_satpy_cf_nc.py
+++ b/satpy/tests/reader_tests/test_satpy_cf_nc.py
@@ -469,7 +469,7 @@ class TestCFReader:
         scn_.load(['solar_zenith_angle'], resolution=371)
         assert scn_['solar_zenith_angle'].attrs['resolution'] == 371
 
-    def test_attrs_equal_non_equal(self, _cf_scene):
+    def test_dataid_attrs_equal_non_equal(self, _cf_scene):
         """Check that attrs return False on non equal attribute and handles missing keys."""
         from satpy.dataset.dataid import DataID, default_id_keys_config
         reader = SatpyCFFileHandler('filename',
@@ -477,10 +477,10 @@ class TestCFReader:
                                     {'filetype': 'info'})
         ds_id = DataID(default_id_keys_config, name='image0', resolution=999, modifiers=())
         data = _cf_scene
-        assert reader._attrs_equal(ds_id, data['image0']) is False
+        assert reader._dataid_attrs_equal(ds_id, data['image0']) is False
         ds_id_wavelength = DataID(default_id_keys_config, name='image0', resolution=1000, modifiers=(),
                                   wavelength=WavelengthRange(min=0.1, central=0.63, max=1000, unit='µm'))
-        assert reader._attrs_equal(ds_id_wavelength, data['image0']) is False
+        assert reader._dataid_attrs_equal(ds_id_wavelength, data['image0']) is False
         ds_id_key_error = DataID(default_id_keys_config, name='image0', resolution=1000)
         del data['image0'].attrs['resolution']
-        assert reader._attrs_equal(ds_id_key_error, data['image0']) is True
+        assert reader._dataid_attrs_equal(ds_id_key_error, data['image0']) is True

--- a/satpy/tests/reader_tests/test_satpy_cf_nc.py
+++ b/satpy/tests/reader_tests/test_satpy_cf_nc.py
@@ -452,10 +452,10 @@ class TestCFReader:
     def test_write_and_read_from_two_files(self, _cf_scene_m, _cf_scene_i, _nc_filename, _nc_filename_i):
         """Save two datasets with different resolution and read the solar_zenith_angle again."""
         _cf_scene_m.save_datasets(writer='cf',
-                                 filename=_nc_filename,
-                                 engine='h5netcdf',
-                                 flatten_attrs=True,
-                                 pretty=True)
+                                  filename=_nc_filename,
+                                  engine='h5netcdf',
+                                  flatten_attrs=True,
+                                  pretty=True)
         _cf_scene_i.save_datasets(writer='cf',
                                   filename=_nc_filename_i,
                                   engine='h5netcdf',


### PR DESCRIPTION
I have VIIRS I-band and M-band data it different files created with the satpy_cf_nc writer. When reading back the data the reader can not differentiate between two variables having the same name, like solar_zenith_angle, with different resolution.

 - [X] Closes #2286  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
