### PR TITLE
Fix native resampler not working for some chunk sizes

### DIFF
--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -1076,31 +1076,22 @@ def _rechunk_if_nonfactor_chunks(dask_arr, y_size, x_size):
 
 def _replicate(d_arr, repeats):
     """Repeat data pixels by the per-axis factors specified."""
-    # rechunk so new chunks are the same size as old chunks
-    c_size = max(x[0] for x in d_arr.chunks)
+    repeated_chunks = _get_replicated_chunk_sizes(d_arr, repeats)
+    d_arr = d_arr.map_blocks(_repeat_by_factor,
+                             meta=np.array((), dtype=d_arr.dtype),
+                             dtype=d_arr.dtype,
+                             chunks=repeated_chunks)
+    return d_arr
 
-    def _calc_chunks(c, c_size):
-        whole_chunks = [c_size] * int(sum(c) // c_size)
-        remaining = sum(c) - sum(whole_chunks)
-        if remaining:
-            whole_chunks += [remaining]
-        return tuple(whole_chunks)
-    new_chunks = [_calc_chunks(x, int(c_size // repeats[axis]))
-                  for axis, x in enumerate(d_arr.chunks)]
-    d_arr = d_arr.rechunk(new_chunks)
 
+def _get_replicated_chunk_sizes(d_arr, repeats):
     repeated_chunks = []
     for axis, axis_chunks in enumerate(d_arr.chunks):
         factor = repeats[axis]
         if not factor.is_integer():
             raise ValueError("Expand factor must be a whole number")
         repeated_chunks.append(tuple(x * int(factor) for x in axis_chunks))
-    repeated_chunks = tuple(repeated_chunks)
-    d_arr = d_arr.map_blocks(_repeat_by_factor,
-                             meta=np.array((), dtype=d_arr.dtype),
-                             dtype=d_arr.dtype,
-                             chunks=repeated_chunks)
-    return d_arr
+    return tuple(repeated_chunks)
 
 
 def _get_arg_to_pass_for_skipna_handling(**kwargs):

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -140,7 +140,6 @@ defined.
 """
 import hashlib
 import json
-import math
 import os
 import warnings
 from logging import getLogger
@@ -157,6 +156,14 @@ from pyresample.ewa import fornav, ll2cr
 from pyresample.geometry import SwathDefinition
 
 from satpy.utils import PerformanceWarning
+
+try:
+    from math import lcm  # type: ignore
+except ImportError:
+    def lcm(a, b):
+        """Get 'Least Common Multiple' with Python 3.8 compatibility."""
+        from math import gcd
+        return abs(a * b) // gcd(a, b)
 
 try:
     from pyresample.resampler import BaseResampler as PRBaseResampler
@@ -1065,7 +1072,7 @@ def _rechunk_if_nonfactor_chunks(dask_arr, y_size, x_size):
         for chunk_size in dask_arr.chunks[dim_idx]:
             if chunk_size % agg_size != 0:
                 need_rechunk = True
-                new_dim_chunk = math.lcm(chunk_size, agg_size)
+                new_dim_chunk = lcm(chunk_size, agg_size)
                 new_chunks[dim_idx] = new_dim_chunk
     if need_rechunk:
         warnings.warn("Array chunk size is not divisible by aggregation factor. "

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -986,72 +986,6 @@ class NativeResampler(BaseResampler):
                                                      mask_area=mask_area,
                                                      **kwargs)
 
-    @staticmethod
-    def _aggregate(d, y_size, x_size):
-        """Average every 4 elements (2x2) in a 2D array."""
-        if d.ndim != 2:
-            # we can't guarantee what blocks we are getting and how
-            # it should be reshaped to do the averaging.
-            raise ValueError("Can't aggregrate (reduce) data arrays with "
-                             "more than 2 dimensions.")
-        if not (x_size.is_integer() and y_size.is_integer()):
-            raise ValueError("Aggregation factors are not integers")
-        y_size = int(y_size)
-        x_size = int(x_size)
-        d = NativeResampler._rechunk_if_nonfactor_chunks(d, y_size, x_size)
-        new_chunks = (tuple(int(x / y_size) for x in d.chunks[0]),
-                      tuple(int(x / x_size) for x in d.chunks[1]))
-        return da.core.map_blocks(_mean, d, y_size, x_size,
-                                  meta=np.array((), dtype=d.dtype),
-                                  dtype=d.dtype, chunks=new_chunks)
-
-    @staticmethod
-    def _rechunk_if_nonfactor_chunks(dask_arr, y_size, x_size):
-        need_rechunk = False
-        new_chunks = list(dask_arr.chunks)
-        for dim_idx, agg_size in enumerate([y_size, x_size]):
-            if dask_arr.shape[dim_idx] % agg_size != 0:
-                raise ValueError("Aggregation requires arrays with shapes divisible by the factor.")
-            for chunk_size in dask_arr.chunks[dim_idx]:
-                if chunk_size % agg_size != 0:
-                    need_rechunk = True
-                    new_dim_chunk = math.lcm(chunk_size, agg_size)
-                    new_chunks[dim_idx] = new_dim_chunk
-        if need_rechunk:
-            warnings.warn("Array chunk size is not divisible by aggregation factor. "
-                          "Re-chunking to continue native resampling.", PerformanceWarning)
-            dask_arr = dask_arr.rechunk(tuple(new_chunks))
-        return dask_arr
-
-    @staticmethod
-    def _replicate(d_arr, repeats):
-        """Repeat data pixels by the per-axis factors specified."""
-        # rechunk so new chunks are the same size as old chunks
-        c_size = max(x[0] for x in d_arr.chunks)
-
-        def _calc_chunks(c, c_size):
-            whole_chunks = [c_size] * int(sum(c) // c_size)
-            remaining = sum(c) - sum(whole_chunks)
-            if remaining:
-                whole_chunks += [remaining]
-            return tuple(whole_chunks)
-        new_chunks = [_calc_chunks(x, int(c_size // repeats[axis]))
-                      for axis, x in enumerate(d_arr.chunks)]
-        d_arr = d_arr.rechunk(new_chunks)
-
-        repeated_chunks = []
-        for axis, axis_chunks in enumerate(d_arr.chunks):
-            factor = repeats[axis]
-            if not factor.is_integer():
-                raise ValueError("Expand factor must be a whole number")
-            repeated_chunks.append(tuple(x * int(factor) for x in axis_chunks))
-        repeated_chunks = tuple(repeated_chunks)
-        d_arr = d_arr.map_blocks(_repeat_by_factor,
-                                 meta=np.array((), dtype=d_arr.dtype),
-                                 dtype=d_arr.dtype,
-                                 chunks=repeated_chunks)
-        return d_arr
-
     @classmethod
     def _expand_reduce(cls, d_arr, repeats):
         """Expand reduce."""
@@ -1060,12 +994,12 @@ class NativeResampler(BaseResampler):
         if all(x == 1 for x in repeats.values()):
             return d_arr
         if all(x >= 1 for x in repeats.values()):
-            return cls._replicate(d_arr, repeats)
+            return _replicate(d_arr, repeats)
         if all(x <= 1 for x in repeats.values()):
             # reduce
             y_size = 1. / repeats[0]
             x_size = 1. / repeats[1]
-            return cls._aggregate(d_arr, y_size, x_size)
+            return _aggregate(d_arr, y_size, x_size)
         raise ValueError("Must either expand or reduce in both "
                          "directions")
 
@@ -1101,6 +1035,72 @@ class NativeResampler(BaseResampler):
         d_arr = self._expand_reduce(data.data, repeats)
         new_data = xr.DataArray(d_arr, dims=data.dims)
         return update_resampled_coords(data, new_data, target_geo_def)
+
+
+def _aggregate(d, y_size, x_size):
+    """Average every 4 elements (2x2) in a 2D array."""
+    if d.ndim != 2:
+        # we can't guarantee what blocks we are getting and how
+        # it should be reshaped to do the averaging.
+        raise ValueError("Can't aggregrate (reduce) data arrays with "
+                         "more than 2 dimensions.")
+    if not (x_size.is_integer() and y_size.is_integer()):
+        raise ValueError("Aggregation factors are not integers")
+    y_size = int(y_size)
+    x_size = int(x_size)
+    d = _rechunk_if_nonfactor_chunks(d, y_size, x_size)
+    new_chunks = (tuple(int(x / y_size) for x in d.chunks[0]),
+                  tuple(int(x / x_size) for x in d.chunks[1]))
+    return da.core.map_blocks(_mean, d, y_size, x_size,
+                              meta=np.array((), dtype=d.dtype),
+                              dtype=d.dtype, chunks=new_chunks)
+
+
+def _rechunk_if_nonfactor_chunks(dask_arr, y_size, x_size):
+    need_rechunk = False
+    new_chunks = list(dask_arr.chunks)
+    for dim_idx, agg_size in enumerate([y_size, x_size]):
+        if dask_arr.shape[dim_idx] % agg_size != 0:
+            raise ValueError("Aggregation requires arrays with shapes divisible by the factor.")
+        for chunk_size in dask_arr.chunks[dim_idx]:
+            if chunk_size % agg_size != 0:
+                need_rechunk = True
+                new_dim_chunk = math.lcm(chunk_size, agg_size)
+                new_chunks[dim_idx] = new_dim_chunk
+    if need_rechunk:
+        warnings.warn("Array chunk size is not divisible by aggregation factor. "
+                      "Re-chunking to continue native resampling.", PerformanceWarning)
+        dask_arr = dask_arr.rechunk(tuple(new_chunks))
+    return dask_arr
+
+
+def _replicate(d_arr, repeats):
+    """Repeat data pixels by the per-axis factors specified."""
+    # rechunk so new chunks are the same size as old chunks
+    c_size = max(x[0] for x in d_arr.chunks)
+
+    def _calc_chunks(c, c_size):
+        whole_chunks = [c_size] * int(sum(c) // c_size)
+        remaining = sum(c) - sum(whole_chunks)
+        if remaining:
+            whole_chunks += [remaining]
+        return tuple(whole_chunks)
+    new_chunks = [_calc_chunks(x, int(c_size // repeats[axis]))
+                  for axis, x in enumerate(d_arr.chunks)]
+    d_arr = d_arr.rechunk(new_chunks)
+
+    repeated_chunks = []
+    for axis, axis_chunks in enumerate(d_arr.chunks):
+        factor = repeats[axis]
+        if not factor.is_integer():
+            raise ValueError("Expand factor must be a whole number")
+        repeated_chunks.append(tuple(x * int(factor) for x in axis_chunks))
+    repeated_chunks = tuple(repeated_chunks)
+    d_arr = d_arr.map_blocks(_repeat_by_factor,
+                             meta=np.array((), dtype=d_arr.dtype),
+                             dtype=d_arr.dtype,
+                             chunks=repeated_chunks)
+    return d_arr
 
 
 def _get_arg_to_pass_for_skipna_handling(**kwargs):

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -391,6 +391,19 @@ class TestNativeResampler:
         with pytest.raises(ValueError):
             NativeResampler._expand_reduce(self.d_arr, {0: dim0_factor, 1: 1.})
 
+    def test_expand_reduce_agg_rechunk(self):
+        """Test that an incompatible factor for the chunk size is rechunked.
+
+        This can happen when a user chunks their data that makes sense for
+        the overall shape of the array and for their local machine's
+        performance, but the resulting resampling factor does not divide evenly
+        into that chunk size.
+
+        """
+        d_arr = da.zeros((6, 20), chunks=3)
+        new_data = NativeResampler._expand_reduce(d_arr, {0: 0.5, 1: 0.5})
+        assert new_data.shape == (3, 10)
+
     def test_expand_reduce_numpy(self):
         """Test classmethod 'expand_reduce' converts numpy arrays to dask arrays."""
         n_arr = np.zeros((6, 20))

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -22,12 +22,18 @@ import tempfile
 import unittest
 from unittest import mock
 
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+from pyproj import CRS
+
 try:
     from pyresample.ewa import LegacyDaskEWAResampler
 except ImportError:
     LegacyDaskEWAResampler = None
 
-from pyproj import CRS
+from satpy.resample import NativeResampler
 
 
 def get_test_data(input_shape=(100, 50), output_shape=(200, 100), output_proj=None,
@@ -107,9 +113,6 @@ class TestHLResample(unittest.TestCase):
 
     def test_type_preserve(self):
         """Check that the type of resampled datasets is preserved."""
-        import dask.array as da
-        import numpy as np
-        import xarray as xr
         from pyresample.geometry import SwathDefinition
 
         from satpy.resample import resample_dataset
@@ -142,8 +145,6 @@ class TestKDTreeResampler(unittest.TestCase):
     def test_kd_resampling(self, xr_resampler, create_filename, zarr_open,
                            xr_dset, cnc):
         """Test the kd resampler."""
-        import dask.array as da
-
         from satpy.resample import KDTreeResampler
         data, source_area, swath_data, source_swath, target_area = get_test_data()
         mock_dset = mock.MagicMock()
@@ -361,105 +362,91 @@ class TestEWAResampler(unittest.TestCase):
         self.assertEqual(target_area.crs, new_data.coords['crs'].item())
 
 
-class TestNativeResampler(unittest.TestCase):
+class TestNativeResampler:
     """Tests for the 'native' resampling method."""
 
     def test_expand_reduce(self):
         """Test class method 'expand_reduce' basics."""
-        import dask.array as da
-        import numpy as np
-
-        from satpy.resample import NativeResampler
         d_arr = da.zeros((6, 20), chunks=4)
         new_data = NativeResampler._expand_reduce(d_arr, {0: 2., 1: 2.})
-        self.assertEqual(new_data.shape, (12, 40))
+        assert new_data.shape == (12, 40)
         new_data = NativeResampler._expand_reduce(d_arr, {0: .5, 1: .5})
-        self.assertEqual(new_data.shape, (3, 10))
-        self.assertRaises(ValueError, NativeResampler._expand_reduce,
-                          d_arr, {0: 1. / 3, 1: 1.})
+        assert new_data.shape == (3, 10)
+        with pytest.raises(ValueError):
+            NativeResampler._expand_reduce(d_arr, {0: 1. / 3, 1: 1.})
         new_data = NativeResampler._expand_reduce(d_arr, {0: 1., 1: 1.})
-        self.assertEqual(new_data.shape, (6, 20))
-        self.assertIs(new_data, d_arr)
-        self.assertRaises(ValueError, NativeResampler._expand_reduce,
-                          d_arr, {0: 0.333323423, 1: 1.})
-        self.assertRaises(ValueError, NativeResampler._expand_reduce,
-                          d_arr, {0: 1.333323423, 1: 1.})
+        assert new_data.shape == (6, 20)
+        assert new_data is d_arr
+        with pytest.raises(ValueError):
+            NativeResampler._expand_reduce(d_arr, {0: 0.333323423, 1: 1.})
+        with pytest.raises(ValueError):
+            NativeResampler._expand_reduce(d_arr, {0: 1.333323423, 1: 1.})
 
         n_arr = np.zeros((6, 20))
         new_data = NativeResampler._expand_reduce(n_arr, {0: 2., 1: 1.0})
-        self.assertTrue(np.all(new_data.compute()[::2, :] == n_arr))
+        np.testing.assert_equal(new_data.compute()[::2, :], n_arr)
 
     def test_expand_dims(self):
         """Test expanding native resampling with 2D data."""
-        import numpy as np
-
-        from satpy.resample import NativeResampler
         ds1, source_area, _, _, target_area = get_test_data()
         # source geo def doesn't actually matter
         resampler = NativeResampler(source_area, target_area)
         new_data = resampler.resample(ds1)
-        self.assertEqual(new_data.shape, (200, 100))
+        assert new_data.shape == (200, 100)
         new_data2 = resampler.resample(ds1.compute())
-        self.assertTrue(np.all(new_data == new_data2))
-        self.assertIn('y', new_data.coords)
-        self.assertIn('x', new_data.coords)
-        self.assertIn('crs', new_data.coords)
-        self.assertIsInstance(new_data.coords['crs'].item(), CRS)
-        self.assertIn('lambert', new_data.coords['crs'].item().coordinate_operation.method_name.lower())
-        self.assertEqual(new_data.coords['y'].attrs['units'], 'meter')
-        self.assertEqual(new_data.coords['x'].attrs['units'], 'meter')
-        self.assertEqual(target_area.crs, new_data.coords['crs'].item())
+        np.testing.assert_equal(new_data.compute().data, new_data2.compute().data)
+        assert 'y' in new_data.coords
+        assert 'x' in new_data.coords
+        assert 'crs' in new_data.coords
+        assert isinstance(new_data.coords['crs'].item(), CRS)
+        assert 'lambert' in new_data.coords['crs'].item().coordinate_operation.method_name.lower()
+        assert new_data.coords['y'].attrs['units'] == 'meter'
+        assert new_data.coords['x'].attrs['units'] == 'meter'
+        assert target_area.crs == new_data.coords['crs'].item()
 
     def test_expand_dims_3d(self):
         """Test expanding native resampling with 3D data."""
-        import numpy as np
-
-        from satpy.resample import NativeResampler
         ds1, source_area, _, _, target_area = get_test_data(
             input_shape=(3, 100, 50), input_dims=('bands', 'y', 'x'))
         # source geo def doesn't actually matter
         resampler = NativeResampler(source_area, target_area)
         new_data = resampler.resample(ds1)
-        self.assertEqual(new_data.shape, (3, 200, 100))
+        assert new_data.shape == (3, 200, 100)
         new_data2 = resampler.resample(ds1.compute())
-        self.assertTrue(np.all(new_data == new_data2))
-        self.assertIn('y', new_data.coords)
-        self.assertIn('x', new_data.coords)
-        self.assertIn('bands', new_data.coords)
-        np.testing.assert_equal(new_data.coords['bands'].values,
-                                ['R', 'G', 'B'])
-        self.assertIn('crs', new_data.coords)
-        self.assertIsInstance(new_data.coords['crs'].item(), CRS)
-        self.assertIn('lambert', new_data.coords['crs'].item().coordinate_operation.method_name.lower())
-        self.assertEqual(new_data.coords['y'].attrs['units'], 'meter')
-        self.assertEqual(new_data.coords['x'].attrs['units'], 'meter')
-        self.assertEqual(target_area.crs, new_data.coords['crs'].item())
+        np.testing.assert_equal(new_data.compute().data, new_data2.compute().data)
+        assert 'y' in new_data.coords
+        assert 'x' in new_data.coords
+        assert 'bands' in new_data.coords
+        np.testing.assert_equal(new_data.coords['bands'].values, ['R', 'G', 'B'])
+        assert 'crs' in new_data.coords
+        assert isinstance(new_data.coords['crs'].item(), CRS)
+        assert 'lambert' in new_data.coords['crs'].item().coordinate_operation.method_name.lower()
+        assert new_data.coords['y'].attrs['units'] == 'meter'
+        assert new_data.coords['x'].attrs['units'] == 'meter'
+        assert target_area.crs == new_data.coords['crs'].item()
 
     def test_expand_without_dims(self):
         """Test expanding native resampling with no dimensions specified."""
-        import numpy as np
-
-        from satpy.resample import NativeResampler
         ds1, source_area, _, _, target_area = get_test_data(input_dims=None)
         # source geo def doesn't actually matter
         resampler = NativeResampler(source_area, target_area)
         new_data = resampler.resample(ds1)
-        self.assertEqual(new_data.shape, (200, 100))
+        assert new_data.shape == (200, 100)
         new_data2 = resampler.resample(ds1.compute())
-        self.assertTrue(np.all(new_data == new_data2))
-        self.assertIn('crs', new_data.coords)
-        self.assertIsInstance(new_data.coords['crs'].item(), CRS)
-        self.assertIn('lambert', new_data.coords['crs'].item().coordinate_operation.method_name.lower())
-        self.assertEqual(target_area.crs, new_data.coords['crs'].item())
+        np.testing.assert_equal(new_data.compute().data, new_data2.compute().data)
+        assert 'crs' in new_data.coords
+        assert isinstance(new_data.coords['crs'].item(), CRS)
+        assert 'lambert' in new_data.coords['crs'].item().coordinate_operation.method_name.lower()
+        assert target_area.crs == new_data.coords['crs'].item()
 
     def test_expand_without_dims_4D(self):
         """Test expanding native resampling with 4D data with no dimensions specified."""
-        from satpy.resample import NativeResampler
         ds1, source_area, _, _, target_area = get_test_data(
             input_shape=(2, 3, 100, 50), input_dims=None)
         # source geo def doesn't actually matter
         resampler = NativeResampler(source_area, target_area)
-        self.assertRaises(ValueError, resampler.resample, ds1)
+        with pytest.raises(ValueError):
+            resampler.resample(ds1)
 
 
 class TestBilinearResampler(unittest.TestCase):
@@ -471,9 +458,6 @@ class TestBilinearResampler(unittest.TestCase):
     def test_bil_resampling(self, xr_resampler, create_filename,
                             move_existing_caches):
         """Test the bilinear resampler."""
-        import dask.array as da
-        import xarray as xr
-
         from satpy.resample import BilinearResampler
         data, source_area, swath_data, source_swath, target_area = get_test_data()
 
@@ -573,9 +557,6 @@ class TestCoordinateHelpers(unittest.TestCase):
 
     def test_area_def_coordinates(self):
         """Test coordinates being added with an AreaDefinition."""
-        import dask.array as da
-        import numpy as np
-        import xarray as xr
         from pyresample.geometry import AreaDefinition
 
         from satpy.resample import add_crs_xy_coords
@@ -646,8 +627,6 @@ class TestCoordinateHelpers(unittest.TestCase):
 
     def test_swath_def_coordinates(self):
         """Test coordinates being added with an SwathDefinition."""
-        import dask.array as da
-        import xarray as xr
         from pyresample.geometry import SwathDefinition
 
         from satpy.resample import add_crs_xy_coords
@@ -723,8 +702,6 @@ class TestBucketAvg(unittest.TestCase):
 
     def test_compute(self):
         """Test bucket resampler computation."""
-        import dask.array as da
-
         # 1D data
         data = da.ones((5,))
         res = self._compute_mocked_bucket_avg(data, fill_value=2)
@@ -742,7 +719,6 @@ class TestBucketAvg(unittest.TestCase):
     @mock.patch('satpy.resample.PR_USE_SKIPNA', True)
     def test_compute_and_use_skipna_handling(self):
         """Test bucket resampler computation and use skipna handling."""
-        import dask.array as da
         data = da.ones((5,))
 
         self._compute_mocked_bucket_avg(data, fill_value=2, mask_all_nan=True)
@@ -766,7 +742,6 @@ class TestBucketAvg(unittest.TestCase):
     @mock.patch('satpy.resample.PR_USE_SKIPNA', False)
     def test_compute_and_not_use_skipna_handling(self):
         """Test bucket resampler computation and not use skipna handling."""
-        import dask.array as da
         data = da.ones((5,))
 
         self._compute_mocked_bucket_avg(data, fill_value=2, mask_all_nan=True)
@@ -796,8 +771,6 @@ class TestBucketAvg(unittest.TestCase):
     @mock.patch('pyresample.bucket.BucketResampler')
     def test_resample(self, pyresample_bucket):
         """Test bucket resamplers resample method."""
-        import dask.array as da
-        import xarray as xr
         self.bucket.resampler = mock.MagicMock()
         self.bucket.precompute = mock.MagicMock()
         self.bucket.compute = mock.MagicMock()
@@ -861,8 +834,6 @@ class TestBucketSum(unittest.TestCase):
 
     def test_compute(self):
         """Test sum bucket resampler computation."""
-        import dask.array as da
-
         # 1D data
         data = da.ones((5,))
         res = self._compute_mocked_bucket_sum(data)
@@ -879,7 +850,6 @@ class TestBucketSum(unittest.TestCase):
     @mock.patch('satpy.resample.PR_USE_SKIPNA', True)
     def test_compute_and_use_skipna_handling(self):
         """Test bucket resampler computation and use skipna handling."""
-        import dask.array as da
         data = da.ones((5,))
 
         self._compute_mocked_bucket_sum(data, mask_all_nan=True)
@@ -900,7 +870,6 @@ class TestBucketSum(unittest.TestCase):
     @mock.patch('satpy.resample.PR_USE_SKIPNA', False)
     def test_compute_and_not_use_skipna_handling(self):
         """Test bucket resampler computation and not use skipna handling."""
-        import dask.array as da
         data = da.ones((5,))
 
         self._compute_mocked_bucket_sum(data, mask_all_nan=True)
@@ -949,8 +918,6 @@ class TestBucketCount(unittest.TestCase):
 
     def test_compute(self):
         """Test count bucket resampler computation."""
-        import dask.array as da
-
         # 1D data
         data = da.ones((5,))
         res = self._compute_mocked_bucket_count(data)
@@ -983,9 +950,6 @@ class TestBucketFraction(unittest.TestCase):
 
     def test_compute(self):
         """Test fraction bucket resampler computation."""
-        import dask.array as da
-        import numpy as np
-
         self.bucket.resampler = mock.MagicMock()
         data = da.ones((3, 3))
 
@@ -1010,10 +974,6 @@ class TestBucketFraction(unittest.TestCase):
     @mock.patch('pyresample.bucket.BucketResampler')
     def test_resample(self, pyresample_bucket):
         """Test fraction bucket resamplers resample method."""
-        import dask.array as da
-        import numpy as np
-        import xarray as xr
-
         self.bucket.resampler = mock.MagicMock()
         self.bucket.precompute = mock.MagicMock()
         self.bucket.compute = mock.MagicMock()

--- a/satpy/tests/test_resample.py
+++ b/satpy/tests/test_resample.py
@@ -385,9 +385,9 @@ class TestNativeResampler:
         assert new_data.shape == (6, 20)
         assert new_data is self.d_arr
 
-    @pytest.mark.parametrize("dim0_factor", [1. / 3, 0.333323423, 1.333323423])
+    @pytest.mark.parametrize("dim0_factor", [1. / 4, 0.333323423, 1.333323423])
     def test_expand_reduce_aggregate_invalid(self, dim0_factor):
-        """Test classmethod 'expand_reduce' fails when factor is not an integer."""
+        """Test classmethod 'expand_reduce' fails when factor does not divide evenly."""
         with pytest.raises(ValueError):
             NativeResampler._expand_reduce(self.d_arr, {0: dim0_factor, 1: 1.})
 


### PR DESCRIPTION
This PR fixes the issue described in #2245 where a user's chosen chunk size for their data may not be divisible by the aggregation factor, but the overall shape of the array is. There is no reason except avoiding rechunking that this shouldn't work. This PR makes it so rechunking is done if needed.

I also removed the unnecessary rechunking done in the replication step. My hope is that dask will figure out this rechunking automatically and that this won't be needed.

@simonrp84 any testing you can do would be greatly appreciated.

 - [x] Closes #2245 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
