### PR TITLE
Fix Scene not handling DataArrays with 'sensor' set to None

### DIFF
--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -181,8 +181,6 @@ class Scene:
                 sensor_names.add(data_arr.attrs["sensor"])
             elif isinstance(data_arr.attrs["sensor"], set):
                 sensor_names.update(data_arr.attrs["sensor"])
-            else:
-                raise TypeError("Unexpected type in sensor collection")
         return sensor_names
 
     @property

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1521,6 +1521,43 @@ class TestSceneLoading:
         available_comp_ids = scene.available_composite_ids()
         assert make_cid(name='static_image') in available_comp_ids
 
+    def test_available_when_sensor_none_in_preloaded_dataarrays(self):
+        """Test Scene available composites when existing loaded arrays have sensor set to None.
+
+        Some readers or composites (ex. static images) don't have a sensor and
+        developers choose to set it to `None`. This test makes sure this
+        doesn't break available composite IDs.
+
+        """
+        scene = Scene(filenames=['fake1_1.txt'], reader='fake1')
+        scene['my_data'] = xr.DataArray(
+            da.zeros((2, 2)),
+            attrs={
+                "name": "my_data",
+                "sensor": None,
+            })
+        available_comp_ids = scene.available_composite_ids()
+        assert make_cid(name='static_image') in available_comp_ids
+
+    def test_load_when_sensor_none_in_preloaded_dataarrays(self):
+        """Test Scene loading when existing loaded arrays have sensor set to None.
+
+        Some readers or composites (ex. static images) don't have a sensor and
+        developers choose to set it to `None`. This test makes sure this
+        doesn't break loading.
+
+        """
+        scene = Scene(filenames=['fake1_1.txt'], reader='fake1')
+        scene['my_data'] = xr.DataArray(
+            da.zeros((2, 2)),
+            attrs={
+                "name": "my_data",
+                "sensor": None,
+            })
+        scene.load(["static_image"])
+        assert "static_image" in scene
+        assert "my_data" in scene
+
     def test_compute_pass_through(self):
         """Test pass through of xarray compute."""
         import numpy as np

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -179,7 +179,8 @@ class FakeCompositor(GenericCompositor):
 
     def __call__(self, projectables, nonprojectables=None, **kwargs):
         """Produce test compositor data depending on modifiers and input data provided."""
-        projectables = self.match_data_arrays(projectables)
+        if projectables:
+            projectables = self.match_data_arrays(projectables)
         if nonprojectables:
             self.match_data_arrays(nonprojectables)
         info = self.attrs.copy()
@@ -194,8 +195,12 @@ class FakeCompositor(GenericCompositor):
             raise ValueError("Not enough prerequisite datasets passed")
 
         info.update(kwargs)
-        info['area'] = projectables[0].attrs['area']
-        dim_sizes = projectables[0].sizes
+        if projectables:
+            info['area'] = projectables[0].attrs['area']
+            dim_sizes = projectables[0].sizes
+        else:
+            # static_image
+            dim_sizes = {'y': 4, 'x': 5}
         return DataArray(data=da.zeros((dim_sizes['y'], dim_sizes['x'], 3)),
                          attrs=info,
                          dims=['y', 'x', 'bands'],


### PR DESCRIPTION
Back when I rewrote the composite loading to happen at Scene.load time, I had added a check to make sure `.attrs['sensor']` in DataArrays contained in the Scene were never set to `None`. I don't remember explicitly why I check this and apparently it was never tested (removing the relevant line of code doesn't cause any failures).

This PR addresses the issue described in #2264 where it turns out that there isn't a strong reason not to support sensor set to None. This PR required updated parts of the fake reader/composite code used by the tests because it turns out I was never loading the `static_image` composite (only using it in available_X_ids/names checks).

 - [x] Closes #2264 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

