### PR TITLE
Fix filter in modis_l2.yaml

### DIFF
--- a/satpy/etc/readers/modis_l2.yaml
+++ b/satpy/etc/readers/modis_l2.yaml
@@ -16,7 +16,7 @@ file_types:
     file_reader: !!python/name:satpy.readers.modis_l2.ModisL2HDFFileHandler
   mod06_hdf:
     file_patterns:
-    - 'M{platform_indicator:1s}D06_L2.A{acquisition_time:%Y%j.%H%M}.{collection:03d}.{production_time:%Y%j%H%M%S}.hdf'
+    - 'M{platform_indicator:1s}D06_L2.A{start_time:%Y%j.%H%M}.{collection:03d}.{production_time:%Y%j%H%M%S}.hdf'
     - '{platform_indicator:1s}1.{start_time:%y%j.%H%M}.mod06.hdf'
     file_reader: !!python/name:satpy.readers.modis_l2.ModisL2HDFFileHandler
   mod06ct_hdf:
@@ -50,7 +50,7 @@ file_types:
   mod07_hdf:
     file_patterns:
       - '{platform_indicator:1s}1.{start_time:%y%j.%H%M}.mod07.hdf'
-      - 'M{platform_indicator:1s}D07_L2.A{acquisition_time:%Y%j.%H%M}.{collection:03d}.{production_time:%Y%j%H%M%S}.hdf'
+      - 'M{platform_indicator:1s}D07_L2.A{start_time:%Y%j.%H%M}.{collection:03d}.{production_time:%Y%j%H%M%S}.hdf'
     file_reader: !!python/name:satpy.readers.modis_l2.ModisL2HDFFileHandler
   mod28_hdf:
     file_patterns:

--- a/satpy/etc/readers/modis_l2.yaml
+++ b/satpy/etc/readers/modis_l2.yaml
@@ -11,7 +11,7 @@ reader:
 file_types:
   mod35_hdf:
     file_patterns:
-    - 'M{platform_indicator:1s}D35_L2.A{acquisition_time:%Y%j.%H%M}.{collection:03d}.{production_time:%Y%j%H%M%S}.hdf'
+    - 'M{platform_indicator:1s}D35_L2.A{start_time:%Y%j.%H%M}.{collection:03d}.{production_time:%Y%j%H%M%S}.hdf'
     - '{platform_indicator:1s}1.{start_time:%y%j.%H%M}.mod35.hdf'
     file_reader: !!python/name:satpy.readers.modis_l2.ModisL2HDFFileHandler
   mod06_hdf:

--- a/satpy/readers/hdfeos_base.py
+++ b/satpy/readers/hdfeos_base.py
@@ -186,10 +186,7 @@ class HDFEOSBaseFileReader(BaseFileHandler):
             return self._start_time_from_filename()
 
     def _start_time_from_filename(self):
-        for fn_key in ("start_time", "acquisition_time"):
-            if fn_key in self.filename_info:
-                return self.filename_info[fn_key]
-        raise RuntimeError("Could not determine file start time")
+        return self.filename_info["start_time"]
 
     @property
     def end_time(self):


### PR DESCRIPTION
I see Issue #2298 and help fix it

This PR replace `acquisition_time` with `start_time`,to make filter have correct result

https://github.com/pytroll/satpy/blob/6dfb9b9353fa64e91a1f7553783abd859042da56/satpy/etc/readers/modis_l2.yaml#L14

+ fix #2298