### PR TITLE
Remove file reading for FCI L1c

### DIFF
--- a/satpy/etc/readers/fci_l1c_nc.yaml
+++ b/satpy/etc/readers/fci_l1c_nc.yaml
@@ -7,7 +7,7 @@ reader:
     Used to read Meteosat Third Generation (MTG) Flexible
     Combined Imager (FCI) L1c data.
   status: Beta for full-disc FDHSI and HRFI, RSS not supported yet
-  supports_fsspec: false
+  supports_fsspec: true
   reader: !!python/name:satpy.readers.yaml_reader.GEOVariableSegmentYAMLReader
   sensors: [ fci ]
 

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -361,10 +361,11 @@ class FCIL1cNCFileHandler(NetCDF4FsspecFileHandler):
         actual_subsat_lon = float(np.nanmean(self._get_aux_data_lut_vector('subsatellite_longitude')))
         actual_subsat_lat = float(np.nanmean(self._get_aux_data_lut_vector('subsatellite_latitude')))
         actual_sat_alt = float(np.nanmean(self._get_aux_data_lut_vector('platform_altitude')))
-        mtg_geos_proj = self.get_and_cache_npxr("data/mtg_geos_projection")
-        nominal_and_proj_subsat_lon = float(mtg_geos_proj.longitude_of_projection_origin)
+        nominal_and_proj_subsat_lon = float(
+            self.get_and_cache_npxr("data/mtg_geos_projection/attr/longitude_of_projection_origin"))
         nominal_and_proj_subsat_lat = 0
-        nominal_and_proj_sat_alt = float(mtg_geos_proj.perspective_point_height)
+        nominal_and_proj_sat_alt = float(
+            self.get_and_cache_npxr("data/mtg_geos_projection/attr/perspective_point_height"))
 
         orb_param_dict = {
             'orbital_parameters': {
@@ -447,8 +448,7 @@ class FCIL1cNCFileHandler(NetCDF4FsspecFileHandler):
         logger.debug('Row/Cols: {} / {}'.format(nlines, ncols))
 
         # Calculate full globe line extent
-        mtg_geos_proj = self.get_and_cache_npxr("data/mtg_geos_projection")
-        h = float(mtg_geos_proj.perspective_point_height)
+        h = float(self.get_and_cache_npxr("data/mtg_geos_projection/attr/perspective_point_height"))
 
         extents = {}
         for coord in "xy":
@@ -515,12 +515,11 @@ class FCIL1cNCFileHandler(NetCDF4FsspecFileHandler):
         if key['resolution'] in self._cache:
             return self._cache[key['resolution']]
 
-        mtg_geos_proj = self.get_and_cache_npxr("data/mtg_geos_projection")
-        a = float(mtg_geos_proj.semi_major_axis)
-        h = float(mtg_geos_proj.perspective_point_height)
-        rf = float(mtg_geos_proj.inverse_flattening)
-        lon_0 = float(mtg_geos_proj.longitude_of_projection_origin)
-        sweep = str(mtg_geos_proj.sweep_angle_axis)
+        a = float(self.get_and_cache_npxr("data/mtg_geos_projection/attr/semi_major_axis"))
+        h = float(self.get_and_cache_npxr("data/mtg_geos_projection/attr/perspective_point_height"))
+        rf = float(self.get_and_cache_npxr("data/mtg_geos_projection/attr/inverse_flattening"))
+        lon_0 = float(self.get_and_cache_npxr("data/mtg_geos_projection/attr/longitude_of_projection_origin"))
+        sweep = str(self.get_and_cache_npxr("data/mtg_geos_projection/attr/sweep_angle_axis"))
 
         area_extent, nlines, ncols = self.calc_area_extent(key)
         logger.debug('Calculated area extent: {}'

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -209,6 +209,9 @@ class NetCDF4FileHandler(BaseFileHandler):
             self.file_content[fc_key] = global_attrs[key] = value
         self.file_content["/attrs"] = global_attrs
 
+    def _get_object_attrs(self, obj):
+        return obj.__dict__
+
     def _collect_attrs(self, name, obj):
         """Collect all the attributes for the provided file object."""
         for key in self._get_object_attrs(obj):
@@ -223,6 +226,9 @@ class NetCDF4FileHandler(BaseFileHandler):
         except ValueError:
             pass
         return value
+
+    def _get_attr(self, obj, key):
+        return getattr(obj, key)
 
     def collect_dimensions(self, name, obj):
         """Collect dimensions."""
@@ -325,10 +331,7 @@ class NetCDF4FileHandler(BaseFileHandler):
         else:
             g = self.file_handle[group]
         v = g[key]
-        try:
-            attrs = dict(v.attrs)
-        except AttributeError:
-            attrs = v.__attrs__
+        attrs = self._get_object_attrs(v)
         x = xr.DataArray(
                 da.from_array(v), dims=v.dimensions, attrs=attrs,
                 name=v.name)

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -358,7 +358,7 @@ class NetCDF4FileHandler(BaseFileHandler):
         else:
             try:
                 val = v[:]
-                val = xr.DataArray(val, dims=v.dimensions, attrs=dict(v.attrs), name=v.name)
+                val = xr.DataArray(val, dims=v.dimensions, attrs=self._get_object_attrs(v), name=v.name)
             except IndexError:
                 # Handle scalars
                 val = v.__array__().item()

--- a/satpy/tests/reader_tests/test_fci_l1c_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_nc.py
@@ -63,13 +63,22 @@ GRID_TYPE_INFO_FOR_TEST_CONTENT = {
 class FakeH5Variable:
     """Class for faking h5netcdf.Variable class."""
 
-    def __init__(self, dims, data, name, attrs=None):
+    def __init__(self, data):
         """Initialize the class."""
-        self.dimensions = dims
+        self.dimensions = ()
+        self.name = "name"
+        self.attrs = {}
+        self.dtype = None
         self._data = data
-        self.name = name
-        self.dtype = data.dtype
-        self.attrs = attrs or {}
+        self._set_meta()
+
+    def _set_meta(self):
+        if hasattr(self._data, "dims"):
+            self.dimensions = self._data.dims
+        if hasattr(self._data, "dtype"):
+            self.dtype = self._data.dtype
+        if hasattr(self._data, "attrs"):
+            self.attrs = self._data.attrs
 
     def __array__(self):
         """Get the array data.."""
@@ -103,23 +112,18 @@ def _get_test_calib_for_channel_ir(data, meas_path):
     from pyspectral.blackbody import C_SPEED as c
     from pyspectral.blackbody import H_PLANCK as h
     from pyspectral.blackbody import K_BOLTZMANN as k
-    data[meas_path + "/radiance_to_bt_conversion_coefficient_wavenumber"] = FakeH5Variable(
-        (), xr.DataArray(955), "name")
-    data[meas_path + "/radiance_to_bt_conversion_coefficient_a"] = FakeH5Variable(
-        (), xr.DataArray(1), "name")
-    data[meas_path + "/radiance_to_bt_conversion_coefficient_b"] = FakeH5Variable(
-        (), xr.DataArray(0.4), "name")
-    data[meas_path + "/radiance_to_bt_conversion_constant_c1"] = FakeH5Variable(
-        (), xr.DataArray(1e11 * 2 * h * c ** 2), "name")
-    data[meas_path + "/radiance_to_bt_conversion_constant_c2"] = FakeH5Variable(
-        (), xr.DataArray(1e2 * h * c / k), "name")
+    data[meas_path + "/radiance_to_bt_conversion_coefficient_wavenumber"] = FakeH5Variable(xr.DataArray(955))
+    data[meas_path + "/radiance_to_bt_conversion_coefficient_a"] = FakeH5Variable(xr.DataArray(1))
+    data[meas_path + "/radiance_to_bt_conversion_coefficient_b"] = FakeH5Variable(xr.DataArray(0.4))
+    data[meas_path + "/radiance_to_bt_conversion_constant_c1"] = FakeH5Variable(xr.DataArray(1e11 * 2 * h * c ** 2))
+    data[meas_path + "/radiance_to_bt_conversion_constant_c2"] = FakeH5Variable(xr.DataArray(1e2 * h * c / k))
     return data
 
 
 def _get_test_calib_for_channel_vis(data, meas):
     data["state/celestial/earth_sun_distance"] = FakeH5Variable(
-        ('x'), xr.DataArray(da.repeat(da.array([149597870.7]), 6000)), "name")
-    data[meas + "/channel_effective_solar_irradiance"] = FakeH5Variable((), xr.DataArray(50), "name")
+        xr.DataArray(da.repeat(da.array([149597870.7]), 6000), dims=("x")))
+    data[meas + "/channel_effective_solar_irradiance"] = FakeH5Variable(xr.DataArray(50))
     return data
 
 
@@ -146,27 +150,29 @@ def _get_test_image_data_for_channel(data, ch_str, n_rows_cols):
         fire_line = da.ones((1, n_rows_cols[1]), dtype="uint16", chunks=1024) * 5000
         data_without_fires = da.ones((n_rows_cols[0] - 1, n_rows_cols[1]), dtype="uint16", chunks=1024)
         d = FakeH5Variable(
-            ("y", "x"),
-            xr.DataArray(da.concatenate([fire_line, data_without_fires], axis=0)),
-            "name",
-            attrs={
-                "valid_range": [0, 8191],
-                "warm_scale_factor": 2,
-                "warm_add_offset": -300,
-                **common_attrs
-            }
+            xr.DataArray(
+                da.concatenate([fire_line, data_without_fires], axis=0),
+                dims=('y', 'x'),
+                attrs={
+                    "valid_range": [0, 8191],
+                    "warm_scale_factor": 2,
+                    "warm_add_offset": -300,
+                    **common_attrs
+                }
+            )
         )
     else:
         d = FakeH5Variable(
-            ("y", "x"),
-            xr.DataArray(da.ones(n_rows_cols, dtype="uint16", chunks=1024)),
-            "name",
-            attrs={
-                "valid_range": [0, 4095],
-                "warm_scale_factor": 1,
-                "warm_add_offset": 0,
-                **common_attrs
-            }
+            xr.DataArray(
+                da.ones(n_rows_cols, dtype="uint16", chunks=1024),
+                dims=("y", "x"),
+                attrs={
+                    "valid_range": [0, 4095],
+                    "warm_scale_factor": 1,
+                    "warm_add_offset": 0,
+                    **common_attrs
+                }
+            )
         )
 
     data[ch_path] = d
@@ -175,21 +181,21 @@ def _get_test_image_data_for_channel(data, ch_str, n_rows_cols):
 
 def _get_test_segment_position_for_channel(data, ch_str, n_rows_cols):
     pos = "data/{:s}/measured/{:s}_position_{:s}"
-    data[pos.format(ch_str, "start", "row")] = FakeH5Variable((), xr.DataArray(1), "name")
-    data[pos.format(ch_str, "start", "column")] = FakeH5Variable((), xr.DataArray(1), "name")
-    data[pos.format(ch_str, "end", "row")] = FakeH5Variable((), xr.DataArray(n_rows_cols[0]), "name")
-    data[pos.format(ch_str, "end", "column")] = FakeH5Variable((), xr.DataArray(n_rows_cols[1]), "name")
+    data[pos.format(ch_str, "start", "row")] = FakeH5Variable(xr.DataArray(1))
+    data[pos.format(ch_str, "start", "column")] = FakeH5Variable(xr.DataArray(1))
+    data[pos.format(ch_str, "end", "row")] = FakeH5Variable(xr.DataArray(n_rows_cols[0]))
+    data[pos.format(ch_str, "end", "column")] = FakeH5Variable(xr.DataArray(n_rows_cols[1]))
 
 
 def _get_test_index_map_for_channel(data, ch_str, n_rows_cols):
     index_map_path = "data/{:s}/measured/index_map".format(ch_str)
-    data[index_map_path] = FakeH5Variable(("y", "x"), xr.DataArray(
-        (da.ones(n_rows_cols)) * 110, dims=("y", "x")), "name")
+    data[index_map_path] = FakeH5Variable(xr.DataArray(
+        (da.ones(n_rows_cols)) * 110, dims=("y", "x")))
 
 
 def _get_test_pixel_quality_for_channel(data, ch_str, n_rows_cols):
     qual_path = "data/{:s}/measured/pixel_quality".format(ch_str)
-    data[qual_path] = FakeH5Variable(("y", "x"), xr.DataArray((da.ones(n_rows_cols)) * 3, dims=("y", "x")), "name")
+    data[qual_path] = FakeH5Variable(xr.DataArray((da.ones(n_rows_cols)) * 3, dims=("y", "x")))
 
 
 def _get_test_geolocation_for_channel(data, ch_str, grid_type, n_rows_cols):
@@ -247,14 +253,13 @@ def _get_test_content_aux_data():
         # skip population of earth_sun_distance as this is already defined for reflectance calculation
         if key == 'earth_sun_distance':
             continue
-        data[value] = FakeH5Variable(
-            ("index"), xr.DataArray(da.arange(indices_dim, dtype="float32"), dims=("index")), "name")
+        data[value] = FakeH5Variable(xr.DataArray(da.arange(indices_dim, dtype="float32"), dims=("index")))
 
     # compute the last data entry to simulate the FCI caching
     # data[list(AUX_DATA.values())[-1]] = data[list(AUX_DATA.values())[-1]].compute()
 
     data['index'] = FakeH5Variable(
-        ("index"), xr.DataArray(da.ones(indices_dim, dtype="uint16") * 100, dims=("index")), "name")
+        xr.DataArray(da.ones(indices_dim, dtype="uint16") * 100, dims=("index")))
     return data
 
 

--- a/satpy/tests/reader_tests/test_fci_l1c_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_nc.py
@@ -186,13 +186,13 @@ def _get_test_segment_position_for_channel(data, ch_str, n_rows_cols):
 
 def _get_test_index_map_for_channel(data, ch_str, n_rows_cols):
     index_map_path = "data/{:s}/measured/index_map".format(ch_str)
-    data[index_map_path] = FakeH5Variable(
+    data[index_map_path] = xr.DataArray(
         (da.ones(n_rows_cols)) * 110, dims=("y", "x"))
 
 
 def _get_test_pixel_quality_for_channel(data, ch_str, n_rows_cols):
     qual_path = "data/{:s}/measured/pixel_quality".format(ch_str)
-    data[qual_path] = FakeH5Variable((da.ones(n_rows_cols)) * 3, dims=("y", "x"))
+    data[qual_path] = xr.DataArray((da.ones(n_rows_cols)) * 3, dims=("y", "x"))
 
 
 def _get_test_geolocation_for_channel(data, ch_str, grid_type, n_rows_cols):
@@ -250,12 +250,12 @@ def _get_test_content_aux_data():
         # skip population of earth_sun_distance as this is already defined for reflectance calculation
         if key == 'earth_sun_distance':
             continue
-        data[value] = FakeH5Variable(da.arange(indices_dim, dtype="float32"), dims=("index"))
+        data[value] = xr.DataArray(da.arange(indices_dim, dtype="float32"), dims=("index"))
 
     # compute the last data entry to simulate the FCI caching
     # data[list(AUX_DATA.values())[-1]] = data[list(AUX_DATA.values())[-1]].compute()
 
-    data['index'] = FakeH5Variable(
+    data['index'] = xr.DataArray(
         da.ones(indices_dim, dtype="uint16") * 100, dims=("index"))
     return data
 


### PR DESCRIPTION
This PR supersedes #2182 in bringing remote file reading for FCI L1c data:

```python
fnames = ["simplecache::s3://satellite-data-fci-test-data-2022/*DEV_20170920112*.nc"]
scn = Scene(reader='fci_l1c_nc', filenames=fnames)
scn.load(['ir_123'])
scn.save_datasets()
```

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
