### PR TITLE
Fix amsub_l1c_aapp.yaml frequency handling pointers 

### DIFF
--- a/satpy/etc/readers/amsub_l1c_aapp.yaml
+++ b/satpy/etc/readers/amsub_l1c_aapp.yaml
@@ -13,9 +13,9 @@ reader:
     name:
       required: true
     frequency_double_sideband:
-      type: !!python/name:satpy.readers.aapp_mhs_amsub_l1c.FrequencyDoubleSideBand
+      type: !!python/name:satpy.readers.pmw_channels_definitions.FrequencyDoubleSideBand
     frequency_range:
-      type: !!python/name:satpy.readers.aapp_mhs_amsub_l1c.FrequencyRange
+      type: !!python/name:satpy.readers.pmw_channels_definitions.FrequencyRange
     resolution:
     polarization:
       enum:


### PR DESCRIPTION
The script
```python 
import satpy
from satpy.utils import debug_on; debug_on()
readers = satpy.available_readers()
```
fails at the reader `amsub_l1c_aapp` with
```
[DEBUG: 2022-12-05 14:36:44 : satpy.readers.yaml_reader] Reading ('/tcenas/home/andream/code/satpy_latest/satpy/satpy/etc/readers/amsub_l1c_aapp.yaml',)
[DEBUG: 2022-12-05 14:36:44 : satpy.readers] Could not import reader config from: ['/tcenas/home/andream/code/satpy_latest/satpy/satpy/etc/readers/amsub_l1c_aapp.yaml']
[DEBUG: 2022-12-05 14:36:44 : satpy.readers] Error loading YAML
Traceback (most recent call last):
  File "/tcenas/home/andream/code/satpy_latest/satpy/satpy/readers/__init__.py", line 386, in available_readers
    reader_info = read_reader_config(reader_configs, loader=yaml_loader)

[.......]

  File "/tcenas/home/andream/anaconda3/envs/trolldev_latest/lib/python3.9/site-packages/yaml/constructor.py", line 560, in find_python_name
    raise ConstructorError("while constructing a Python object", mark,
yaml.constructor.ConstructorError: while constructing a Python object
cannot find 'FrequencyDoubleSideBand' in the module 'satpy.readers.aapp_mhs_amsub_l1c'
  in "/tcenas/home/andream/code/satpy_latest/satpy/satpy/etc/readers/amsub_l1c_aapp.yaml", line 16, column 13
```

Seems that a change to point to the correct classes has been forgotten during the refactoring in https://github.com/pytroll/satpy/pull/2120 (see e.g. commit https://github.com/pytroll/satpy/commit/e7b4e63a00831d3154105be6d1cf44927102b6e6 doing this change on other yaml files).

This PR fixes the broken pointers.