### PR TITLE
Add config option for temporary directory

### DIFF
--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -260,6 +260,20 @@ correction.
 
 .. _component_configuration:
 
+
+Temporary Directory
+^^^^^^^^^^^^^^^^^^^
+
+* **Environment variable**: ``SATPY_TMP_DIR``
+* **YAML/Config Key**: ``tmp_dir``
+* **Default**: `tempfile.gettempdir()`_
+
+Directory where Satpy creates temporary files, for example decompressed
+input files. Default depends on the operating system.
+
+.. _tempfile.gettempdir(): https://docs.python.org/3/library/tempfile.html?highlight=gettempdir#tempfile.gettempdir
+
+
 Component Configuration
 -----------------------
 

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -258,9 +258,6 @@ as part of the :func:`~satpy.modifiers.angles.get_angles` and
 used by multiple modifiers and composites including the default rayleigh
 correction.
 
-.. _component_configuration:
-
-
 Temporary Directory
 ^^^^^^^^^^^^^^^^^^^
 
@@ -273,6 +270,8 @@ input files. Default depends on the operating system.
 
 .. _tempfile.gettempdir(): https://docs.python.org/3/library/tempfile.html?highlight=gettempdir#tempfile.gettempdir
 
+
+.. _component_configuration:
 
 Component Configuration
 -----------------------

--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -23,6 +23,7 @@ import glob
 import logging
 import os
 import sys
+import tempfile
 from collections import OrderedDict
 from importlib.metadata import entry_points
 from pathlib import Path
@@ -49,6 +50,7 @@ PACKAGE_CONFIG_PATH = os.path.join(BASE_PATH, 'etc')
 
 _satpy_dirs = appdirs.AppDirs(appname='satpy', appauthor='pytroll')
 _CONFIG_DEFAULTS = {
+    'tmp_dir': tempfile.gettempdir(),
     'cache_dir': _satpy_dirs.user_cache_dir,
     'cache_lonlats': False,
     'cache_sensor_angles': False,

--- a/satpy/readers/ahi_l1b_gridded_bin.py
+++ b/satpy/readers/ahi_l1b_gridded_bin.py
@@ -163,14 +163,15 @@ class AHIGriddedFileHandler(BaseFileHandler):
         """Download the LUTs needed for count->Refl/BT conversion."""
         import pathlib
         import shutil
-        import tempfile
+
+        from satpy import config
 
         # Check that the LUT directory exists
         pathlib.Path(self.lut_dir).mkdir(parents=True, exist_ok=True)
 
         logger.info("Download AHI LUTs files and store in directory %s",
                     self.lut_dir)
-        tempdir = tempfile.gettempdir()
+        tempdir = config["tmp_dir"]
         fname = os.path.join(tempdir, 'tmp.tgz')
         # Download the LUTs
         self._download_luts(fname)

--- a/satpy/readers/hrit_base.py
+++ b/satpy/readers/hrit_base.py
@@ -34,7 +34,6 @@ from contextlib import contextmanager, nullcontext
 from datetime import timedelta
 from io import BytesIO
 from subprocess import PIPE, Popen  # nosec B404
-from tempfile import gettempdir
 
 import dask
 import dask.array as da
@@ -43,6 +42,7 @@ import xarray as xr
 from pyresample import geometry
 
 import satpy.readers.utils as utils
+from satpy import config
 from satpy.readers import FSFile
 from satpy.readers.eum_base import time_cds_short
 from satpy.readers.file_handlers import BaseFileHandler
@@ -337,7 +337,7 @@ def _read_data(filename, mda):
 def decompressed(filename):
     """Decompress context manager."""
     try:
-        new_filename = decompress(filename, gettempdir())
+        new_filename = decompress(filename, config["tmp_dir"])
     except IOError as err:
         logger.error("Unpacking failed: %s", str(err))
         raise

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -33,7 +33,7 @@ import pyproj
 import xarray as xr
 from pyresample.geometry import AreaDefinition
 
-from satpy import CHUNK_SIZE
+from satpy import CHUNK_SIZE, config
 
 LOGGER = logging.getLogger(__name__)
 
@@ -211,7 +211,8 @@ def unzip_file(filename, prefix=None):
 
     """
     if os.fspath(filename).endswith('bz2'):
-        fdn, tmpfilepath = tempfile.mkstemp(prefix=prefix)
+        fdn, tmpfilepath = tempfile.mkstemp(prefix=prefix,
+                                            dir=config["tmp_dir"])
         LOGGER.info("Using temp file for BZ2 decompression: %s", tmpfilepath)
         # try pbzip2
         pbzip = which('pbzip2')

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -486,6 +486,12 @@ class TestConfigObject:
         assert _is_writable(satpy.config["tmp_dir"])
 
 
+def test_is_writable():
+    """Test writable directory check."""
+    assert _is_writable(os.getcwd())
+    assert not _is_writable("/foo/bar")
+
+
 def _is_writable(directory):
     import tempfile
     try:

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -480,21 +480,19 @@ class TestConfigObject:
         with satpy.config.set(config_path='/single/string/paths/are/bad'):
             pytest.raises(ValueError, satpy._config.get_config_path_safe)
 
-    def test_defaults(self):
-        """Check default config."""
+    def test_tmp_dir_is_writable(self):
+        """Check that the default temporary directory is writable."""
         import satpy
-        keys_exp = {
-            'tmp_dir',
-            'cache_dir',
-            'cache_lonlats',
-            'cache_sensor_angles',
-            'config_path',
-            'data_dir',
-            'demo_data_dir',
-            'download_aux',
-            'sensor_angles_position_preference',
-        }
-        assert set(satpy.config.to_dict().keys()) == keys_exp
+        assert _is_writable(satpy.config["tmp_dir"])
+
+
+def _is_writable(directory):
+    import tempfile
+    try:
+        with tempfile.TemporaryFile(dir=directory):
+            return True
+    except OSError:
+        return False
 
 
 def _os_specific_multipaths():

--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -480,6 +480,22 @@ class TestConfigObject:
         with satpy.config.set(config_path='/single/string/paths/are/bad'):
             pytest.raises(ValueError, satpy._config.get_config_path_safe)
 
+    def test_defaults(self):
+        """Check default config."""
+        import satpy
+        keys_exp = {
+            'tmp_dir',
+            'cache_dir',
+            'cache_lonlats',
+            'cache_sensor_angles',
+            'config_path',
+            'data_dir',
+            'demo_data_dir',
+            'download_aux',
+            'sensor_angles_position_preference',
+        }
+        assert set(satpy.config.to_dict().keys()) == keys_exp
+
 
 def _os_specific_multipaths():
     exp_paths = ['/my/configs1', '/my/configs2', '/my/configs3']


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Add config option `tmp_dir` for a temporary directory. That is, for example, where decompressed input files are stored. Default: `tempfile.gettempdir()`

The test is pretty weak, but I didn't see a way for a meaningful test, except "the code I wrote is the code I wrote". Let me know if you have a better idea.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
