### PR TITLE
Refactor colormap creation

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -54,6 +54,6 @@ dependencies:
   - xarray-datatree
   - pip:
     - trollsift
-    - trollimage
+    - trollimage>=1.20
     - pyspectral
     - pyorbital

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -535,7 +535,11 @@ class ColormapCompositor(GenericCompositor):
 
         """
         squeezed_palette = np.asanyarray(palette).squeeze() / 255.0
-        cmap = Colormap.from_xrda(palette, dtype, info)
+        cmap = Colormap.from_array_with_metadata(
+                palette,
+                dtype,
+                color_scale=255,
+                **info)
 
         return cmap, squeezed_palette
 

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -455,7 +455,7 @@ def create_colormap(palette):
     if 'min_value' in palette and 'max_value' in palette:
         cmap.set_range(palette["min_value"], palette["max_value"])
     elif 'min_value' in palette or 'max_value' in palette:
-        raise ValueError("Both 'min_value' and 'max_value' must be specified")
+        raise ValueError("Both 'min_value' and 'max_value' must be specified (or neither)")
 
     return cmap
 

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -28,6 +28,7 @@ import dask
 import dask.array as da
 import numpy as np
 import xarray as xr
+from trollimage.colormap import Colormap
 from trollimage.xrimage import XRImage
 
 from satpy._compat import ArrayLike
@@ -439,14 +440,13 @@ def create_colormap(palette):
     # are colors between 0-255 or 0-1
     color_scale = palette.get('color_scale', 255)
     if fname:
-        cmap = _create_colormap_from_file(fname, palette, color_scale)
+        if not os.path.exists(fname):
+            fname = get_config_path(fname)
+        cmap = Colormap.from_file(fname, palette.get("colormap_mode", None), color_scale)
     elif isinstance(colors, (tuple, list)):
-        cmap = _create_colormap_from_sequence(colors, palette, color_scale)
+        cmap = Colormap.from_sequence_of_colors(colors, palette.get("values", None), color_scale)
     elif isinstance(colors, str):
-        import copy
-
-        from trollimage import colormap
-        cmap = copy.copy(getattr(colormap, colors))
+        cmap = Colormap.from_name(colors)
     else:
         raise ValueError("Unknown colormap format: {}".format(palette))
 
@@ -458,64 +458,6 @@ def create_colormap(palette):
         raise ValueError("Both 'min_value' and 'max_value' must be specified")
 
     return cmap
-
-
-def _create_colormap_from_sequence(colors, palette, color_scale):
-    from trollimage.colormap import Colormap
-    cmap = []
-    values = palette.get('values', None)
-    for idx, color in enumerate(colors):
-        if values is not None:
-            value = values[idx]
-        else:
-            value = idx / float(len(colors) - 1)
-        if color_scale != 1:
-            color = tuple(elem / float(color_scale) for elem in color)
-        cmap.append((value, tuple(color)))
-    return Colormap(*cmap)
-
-
-def _create_colormap_from_file(filename, palette, color_scale):
-    from trollimage.colormap import Colormap
-    data = _read_colormap_data_from_file(filename)
-    cols = data.shape[1]
-    default_modes = {
-        3: 'RGB',
-        4: 'VRGB',
-        5: 'VRGBA'
-    }
-    default_mode = default_modes.get(cols)
-    mode = palette.setdefault('colormap_mode', default_mode)
-    if mode is None or len(mode) != cols:
-        raise ValueError(
-            "Unexpected colormap shape for mode '{}'".format(mode))
-    rows = data.shape[0]
-    if mode[0] == 'V':
-        colors = data[:, 1:]
-        if color_scale != 1:
-            colors = data[:, 1:] / float(color_scale)
-        values = data[:, 0]
-    else:
-        colors = data
-        if color_scale != 1:
-            colors = colors / float(color_scale)
-        values = np.arange(rows) / float(rows - 1)
-    return Colormap(*zip(values, colors))
-
-
-def _read_colormap_data_from_file(filename):
-    if not os.path.exists(filename):
-        filename = get_config_path(filename)
-    ext = os.path.splitext(filename)[1]
-    if ext in (".npy", ".npz"):
-        file_content = np.load(filename)
-        if ext == ".npz":
-            # .npz is a collection
-            # assume position list-like and get the first element
-            file_content = file_content["arr_0"]
-        return file_content
-    # CSV
-    return np.loadtxt(filename, delimiter=",")
 
 
 def three_d_effect(img, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ except ImportError:
     pass
 
 requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.24.0', 'trollsift',
-            'trollimage >1.20', 'pykdtree', 'pyyaml >=5.1', 'xarray >=0.10.1, !=0.13.0',
+            'trollimage >=1.20', 'pykdtree', 'pyyaml >=5.1', 'xarray >=0.10.1, !=0.13.0',
             'dask[array] >=0.17.1', 'pyproj>=2.2', 'zarr', 'donfig', 'appdirs',
             'pooch', 'pyorbital']
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ except ImportError:
     pass
 
 requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.24.0', 'trollsift',
-            'trollimage >1.10.1', 'pykdtree', 'pyyaml >=5.1', 'xarray >=0.10.1, !=0.13.0',
+            'trollimage >1.20', 'pykdtree', 'pyyaml >=5.1', 'xarray >=0.10.1, !=0.13.0',
             'dask[array] >=0.17.1', 'pyproj>=2.2', 'zarr', 'donfig', 'appdirs',
             'pooch', 'pyorbital']
 


### PR DESCRIPTION
Refactor colormap creation.  Move functionality to trollimage where appropriate, and in particular where it's duplicated. 

Bump trollimage version to 1.20 due to the requirement of https://github.com/pytroll/trollimage/pull/117.

 - [x] Closes #2308
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
