### PR TITLE
Fix for bug regarding masking of good scan lines with seviri hrit reader introduced by #1693

### DIFF
--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -948,7 +948,7 @@ def _create_bad_quality_lines_mask(line_validity, line_geometric_quality, line_r
             Quality flags with shape (nlines,).
 
     Returns:
-        numpy.ndarray
+        numpy.ndarray: Indicating if the scan line is bad.
     """
     # Based on missing (2) or corrupted (3) data
     line_mask = line_validity >= 2
@@ -977,5 +977,5 @@ def mask_bad_quality(data, line_validity, line_geometric_quality, line_radiometr
     """
     line_mask = _create_bad_quality_lines_mask(line_validity, line_geometric_quality, line_radiometric_quality)
     line_mask = line_mask[:, np.newaxis]
-    data = data.where(line_mask, np.nan).astype(np.float32)
+    data = data.where(~line_mask, np.nan).astype(np.float32)
     return data

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -300,7 +300,7 @@ class HRITMSGPrologueFileHandler(HRITMSGPrologueEpilogueBase):
 
     def __init__(self, filename, filename_info, filetype_info, calib_mode='nominal',
                  ext_calib_coefs=None, include_raw_metadata=False,
-                 mda_max_array_size=None, fill_hrv=None):
+                 mda_max_array_size=None, fill_hrv=None, mask_bad_quality_scan_lines=None):
         """Initialize the reader."""
         super(HRITMSGPrologueFileHandler, self).__init__(filename, filename_info,
                                                          filetype_info,
@@ -373,7 +373,7 @@ class HRITMSGEpilogueFileHandler(HRITMSGPrologueEpilogueBase):
 
     def __init__(self, filename, filename_info, filetype_info, calib_mode='nominal',
                  ext_calib_coefs=None, include_raw_metadata=False,
-                 mda_max_array_size=None, fill_hrv=None):
+                 mda_max_array_size=None, fill_hrv=None, mask_bad_quality_scan_lines=None):
         """Initialize the reader."""
         super(HRITMSGEpilogueFileHandler, self).__init__(filename, filename_info,
                                                          filetype_info,

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -496,8 +496,7 @@ class TestHRITMSGCalibration(TestFileHandlerCalibrationBase):
         fh = file_handler
 
         res = fh._mask_bad_quality(expected)
-        print(res)
         new_data = np.zeros_like(expected.data).astype('float32')
         new_data[:, :] = np.nan
         expected = expected.copy(data=new_data)
-        xr.testing.assert_allclose(res, expected)
+        xr.testing.assert_equal(res, expected)

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -415,8 +415,8 @@ class TestHRITMSGCalibration(TestFileHandlerCalibrationBase):
         mda = {
             'image_segment_line_quality': {
                 'line_validity': np.array([3, 3]),
-                'line_radiometric_quality': np.array([3, 3]),
-                'line_geometric_quality': np.array([3, 3])
+                'line_radiometric_quality': np.array([4, 4]),
+                'line_geometric_quality': np.array([4, 4])
             },
         }
 
@@ -496,6 +496,7 @@ class TestHRITMSGCalibration(TestFileHandlerCalibrationBase):
         fh = file_handler
 
         res = fh._mask_bad_quality(expected)
+        print(res)
         new_data = np.zeros_like(expected.data).astype('float32')
         new_data[:, :] = np.nan
         expected = expected.copy(data=new_data)

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit_setup.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit_setup.py
@@ -162,8 +162,8 @@ def get_fake_mda(nlines, ncols, start_time):
         'image_segment_line_quality': {
             'line_mean_acquisition': tline,
             'line_validity': np.full(nlines, 3),
-            'line_radiometric_quality': np.full(nlines, 3),
-            'line_geometric_quality': np.full(nlines, 3)
+            'line_radiometric_quality': np.full(nlines, 4),
+            'line_geometric_quality': np.full(nlines, 4)
         }
     }
 

--- a/satpy/tests/reader_tests/test_seviri_l1b_nc.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_nc.py
@@ -59,7 +59,8 @@ class TestNCSEVIRIFileHandler(TestFileHandlerCalibrationBase):
         """
         acq_time_day = np.repeat([1, 1], 11).reshape(2, 11)
         acq_time_msec = np.repeat([1000, 2000], 11).reshape(2, 11)
-        quality = np.repeat([0, 3], 11).reshape(2, 11)
+        line_validity = np.repeat([3, 3], 11).reshape(2, 11)
+        line_geom_radio_quality = np.repeat([4, 4], 11).reshape(2, 11)
         orbit_poly_start_day, orbit_poly_start_msec = to_cds_time(
             np.array([datetime(2019, 12, 31, 18),
                       datetime(2019, 12, 31, 22)],
@@ -93,15 +94,15 @@ class TestNCSEVIRIFileHandler(TestFileHandlerCalibrationBase):
                 ),
                 'channel_data_visir_data_line_validity': (
                     ('num_rows_vis_ir', 'channels_vis_ir_dim'),
-                    quality
+                    line_validity
                 ),
                 'channel_data_visir_data_line_geometric_quality': (
                     ('num_rows_vis_ir', 'channels_vis_ir_dim'),
-                    quality
+                    line_geom_radio_quality
                 ),
                 'channel_data_visir_data_line_radiometric_quality': (
                     ('num_rows_vis_ir', 'channels_vis_ir_dim'),
-                    quality
+                    line_geom_radio_quality
                 ),
                 'orbit_polynomial_x': (
                     ('orbit_polynomial_dim_row',


### PR DESCRIPTION
The refactor of `mask_bad_scan_lines` from `np.choose` to `dataarray.where` inverted the logic of the line mask which lead to good scan lines being masked.

Furthermore this fixes an undiscovered bug regarding the optional line masking in the hrit reader introduced in in PR 1693 where the corresponding reader kwarg was not recognized.

This is a fix which should return the hrit reader to work the same as before #1693.

Notes/Todos:
- during the search for the bug I noticed the second bug mentioned above. It is fixed but there obviously is no unit test which is why the bug was not discovered earlier. I will check how this is tested with other reader_kwargs and make another PR so this fix does not have to wait for it.
- I am embarrassed to say that in #1693 I reused the quality flag setup of the tests which was already there even though I thought the different line masking cases were severly undertested. I will have another look but I think the masking logic is not completely right (this obviously also depends on which flags the user thinks are still considered good). So there should be tests for more different flag combinations.