### PR TITLE
Update himawari8/9 JMA True Color Reproduction composite

### DIFF
--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -70,8 +70,7 @@ composites:
     standard_name: toa_bidirectional_reflectance
 
   reproduced_green:
-    # JMA True Color Reproduction green band
-    # http://www.jma.go.jp/jma/jma-eng/satellite/introduction/TCR.html
+    # JMA True Color Reproduction corrected green band.
     compositor: !!python/name:satpy.composites.spectral.SpectralBlender
     fractions: [0.6321, 0.2928, 0.0751]
     prerequisites:
@@ -312,6 +311,8 @@ composites:
       - true_color_reproduction_corr
       - true_color_reproduction_uncorr
 
+  true_color_reproduction_corr:
+    # JMA True Color Reproduction corrected composite.
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
       - name: B03

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -304,7 +304,7 @@ composites:
     # JMA True Color Reproduction complete composite with corrected and uncorrected blend.
     # http://www.jma.go.jp/jma/jma-eng/satellite/introduction/TCR.html
     compositor: !!python/name:satpy.composites.DayNightCompositor
-    standard_name: non_enhanced_crude_stretch_1
+    standard_name: true_color_reproduction
     lim_low: 73.
     lim_high: 85.
     prerequisites:
@@ -320,7 +320,7 @@ composites:
       - name: reproduced_green
       - name: B01
         modifiers: [sunz_corrected, rayleigh_corrected]
-    standard_name: true_color_reproduction
+    standard_name: true_color_reproduction_color_stretch
 
   true_color_reproduction_uncorr:
     # JMA True Color Reproduction uncorrected composite.
@@ -329,7 +329,7 @@ composites:
       - name: B03
       - name: reproduced_green_uncorr
       - name: B01
-    standard_name: true_color_reproduction
+    standard_name: true_color_reproduction_color_stretch
 
 #  true_color_reducedsize_land:
 #    compositor: !!python/name:satpy.composites.GenericCompositor

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -83,6 +83,16 @@ composites:
       modifiers: [sunz_corrected]
     standard_name: none
 
+  reproduced_green_uncorr:
+    # JMA True Color Reproduction uncorrected green band.
+    compositor: !!python/name:satpy.composites.spectral.SpectralBlender
+    fractions: [0.6321, 0.2928, 0.0751]
+    prerequisites:
+    - name: B02
+    - name: B03
+    - name: B04
+    standard_name: none
+
   hybrid_green_nocorr:
     compositor: !!python/name:satpy.composites.spectral.HybridGreen
     # FUTURE: Set a wavelength...see what happens. Dependency finding
@@ -309,6 +319,15 @@ composites:
       - name: reproduced_green
       - name: B01
         modifiers: [sunz_corrected, rayleigh_corrected]
+    standard_name: true_color_reproduction
+
+  true_color_reproduction_uncorr:
+    # JMA True Color Reproduction uncorrected composite.
+    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
+    prerequisites:
+      - name: B03
+      - name: reproduced_green_uncorr
+      - name: B01
     standard_name: true_color_reproduction
 
 #  true_color_reducedsize_land:

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -292,8 +292,16 @@ composites:
     standard_name: true_color
 
   true_color_reproduction:
-    # JMA True Color Reproduction
+    # JMA True Color Reproduction complete composite with corrected and uncorrected blend.
     # http://www.jma.go.jp/jma/jma-eng/satellite/introduction/TCR.html
+    compositor: !!python/name:satpy.composites.DayNightCompositor
+    standard_name: non_enhanced_crude_stretch_1
+    lim_low: 73.
+    lim_high: 85.
+    prerequisites:
+      - true_color_reproduction_corr
+      - true_color_reproduction_uncorr
+
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
       - name: B03

--- a/satpy/etc/enhancements/ahi.yaml
+++ b/satpy/etc/enhancements/ahi.yaml
@@ -19,7 +19,7 @@ enhancements:
         method: !!python/name:satpy.enhancements.stretch
         kwargs:
          stretch: log
-         min_stretch: [3.,3.,3.]
+         min_stretch: [3.,3.,3.] # tweak min/max values for desired contrast
          max_stretch: [150., 150., 150.]
 
   true_color_reproduction:

--- a/satpy/etc/enhancements/ahi.yaml
+++ b/satpy/etc/enhancements/ahi.yaml
@@ -15,11 +15,9 @@ enhancements:
     operations:
       - name: color
         method: !!python/name:satpy.enhancements.ahi.jma_true_color_reproduction
-      - name: cira_stretch
-        method: !!python/name:satpy.enhancements.cira_stretch
       - name: stretch
         method: !!python/name:satpy.enhancements.stretch
         kwargs:
-          stretch: crude
-          min_stretch: [0.08, 0.08, 0.08]
-          max_stretch: [.93, .90, .90]
+         stretch: log
+         min_stretch: [3.,3.,3.]
+         max_stretch: [150., 150., 150.]

--- a/satpy/etc/enhancements/ahi.yaml
+++ b/satpy/etc/enhancements/ahi.yaml
@@ -21,3 +21,13 @@ enhancements:
          stretch: log
          min_stretch: [3.,3.,3.]
          max_stretch: [150., 150., 150.]
+
+  true_color_reproduction:
+    standard_name: true_color_reproduction
+    operations:
+      - name: stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs:
+         stretch: crude
+         min_stretch: [0,0,0]
+         max_stretch: [1,1,1]

--- a/satpy/etc/enhancements/ahi.yaml
+++ b/satpy/etc/enhancements/ahi.yaml
@@ -10,8 +10,8 @@ enhancements:
           min_stretch: [-26.2, -43.2, 243.9]
           max_stretch: [0.6, 6.7, 208.5]
 
-  true_color_reproduction:
-    standard_name: true_color_reproduction
+  true_color_reproduction_color_stretch:
+    standard_name: true_color_reproduction_color_stretch
     operations:
       - name: color
         method: !!python/name:satpy.enhancements.ahi.jma_true_color_reproduction


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->
This update aligns the `true_color_reproduction` composite closer towards JMA. This includes:

- adding an uncorrected blend at the terminator with day/night compositor
- removal of cira_strech and using default log stretch with custom min/max values for color balance and contrast.

![TCR_202212122100](https://user-images.githubusercontent.com/57386258/208288642-bb5c0e5d-5910-40f1-bae3-b2babfc1a8d7.png)

![TCR_202212130220](https://user-images.githubusercontent.com/57386258/208288503-192dc6c7-ca0e-449f-b64b-4fa24a1dd410.png)

![TCR_202212130840](https://user-images.githubusercontent.com/57386258/208288687-c3c522a3-3951-44fa-9c8b-aaf4a97c5696.png)
