### PR TITLE
Fix Scene modifying user-provided reader_kwargs

### DIFF
--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -22,6 +22,7 @@ import os
 import random
 import string
 import unittest
+from copy import deepcopy
 from datetime import datetime
 from unittest import mock
 
@@ -666,20 +667,20 @@ class TestScene:
         expected_reader_kwargs = reader_kwargs.copy()
         storage_options = {'option1': '1'}
         reader_kwargs['storage_options'] = storage_options
+        orig_reader_kwargs = deepcopy(reader_kwargs)
         with mock.patch('satpy.scene.load_readers') as load_readers:
             with mock.patch('fsspec.open_files') as open_files:
                 Scene(filenames=filenames, reader_kwargs=reader_kwargs)
                 call_ = load_readers.mock_calls[0]
                 assert call_.kwargs['reader_kwargs'] == expected_reader_kwargs
                 open_files.assert_called_once_with(filenames, **storage_options)
+                assert reader_kwargs == orig_reader_kwargs
 
     def test_storage_options_from_reader_kwargs_per_reader(self):
         """Test getting storage options from reader kwargs.
 
         Case where each reader have their own storage options.
         """
-        from copy import deepcopy
-
         filenames = {
             "reader1": ["s3://data-bucket/file1"],
             "reader2": ["s3://data-bucket/file2"],
@@ -697,6 +698,7 @@ class TestScene:
         reader_kwargs['reader1']['storage_options'] = storage_options_1
         reader_kwargs['reader2']['storage_options'] = storage_options_2
         reader_kwargs['reader3']['storage_options'] = storage_options_3
+        orig_reader_kwargs = deepcopy(reader_kwargs)
 
         with mock.patch('satpy.scene.load_readers') as load_readers:
             with mock.patch('fsspec.open_files') as open_files:
@@ -706,6 +708,7 @@ class TestScene:
                 assert mock.call(filenames["reader1"], **storage_options_1) in open_files.mock_calls
                 assert mock.call(filenames["reader2"], **storage_options_2) in open_files.mock_calls
                 assert mock.call(filenames["reader3"], **storage_options_3) in open_files.mock_calls
+                assert reader_kwargs == orig_reader_kwargs
 
 
 def _create_coarest_finest_data_array(shape, area_def, attrs=None):

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -26,6 +26,7 @@ import logging
 import os
 import warnings
 from contextlib import contextmanager
+from copy import deepcopy
 from typing import Mapping, Optional
 from urllib.parse import urlparse
 
@@ -658,11 +659,12 @@ def get_storage_options_from_reader_kwargs(reader_kwargs):
     """Read and clean storage options from reader_kwargs."""
     if reader_kwargs is None:
         return None, None
-    storage_options = reader_kwargs.pop('storage_options', None)
-    storage_opt_dict = _get_storage_dictionary_options(reader_kwargs)
+    new_reader_kwargs = deepcopy(reader_kwargs)  # don't modify user provided dict
+    storage_options = new_reader_kwargs.pop('storage_options', None)
+    storage_opt_dict = _get_storage_dictionary_options(new_reader_kwargs)
     storage_options = _merge_storage_options(storage_options, storage_opt_dict)
 
-    return storage_options, reader_kwargs
+    return storage_options, new_reader_kwargs
 
 
 def _get_storage_dictionary_options(reader_kwargs):

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import contextlib
 import datetime
 import logging
-import os
 import warnings
 from contextlib import contextmanager
 from copy import deepcopy
@@ -45,13 +44,6 @@ logger = logging.getLogger(__name__)
 
 class PerformanceWarning(Warning):
     """Warning raised when there is a possible performance impact."""
-
-
-def ensure_dir(filename):
-    """Check if the dir of f exists, otherwise create it."""
-    directory = os.path.dirname(filename)
-    if directory and not os.path.isdir(directory):
-        os.makedirs(directory)
 
 
 def debug_on(deprecation_warnings=True):
@@ -660,29 +652,23 @@ def get_storage_options_from_reader_kwargs(reader_kwargs):
     if reader_kwargs is None:
         return None, None
     new_reader_kwargs = deepcopy(reader_kwargs)  # don't modify user provided dict
-    storage_options = new_reader_kwargs.pop('storage_options', None)
-    storage_opt_dict = _get_storage_dictionary_options(new_reader_kwargs)
-    storage_options = _merge_storage_options(storage_options, storage_opt_dict)
-
+    storage_options = _get_storage_dictionary_options(new_reader_kwargs)
     return storage_options, new_reader_kwargs
 
 
 def _get_storage_dictionary_options(reader_kwargs):
     storage_opt_dict = {}
-    for k, v in reader_kwargs.items():
-        if isinstance(v, dict):
-            storage_opt_dict[k] = v.pop('storage_options', None)
-
+    shared_storage_options = reader_kwargs.pop("storage_options", {})
+    for reader_name, rkwargs in reader_kwargs.items():
+        if not isinstance(rkwargs, dict):
+            # reader kwargs are not per-reader, return a single dictonary of storage options
+            return shared_storage_options
+        if shared_storage_options:
+            # set base storage options if there are any
+            storage_opt_dict[reader_name] = shared_storage_options.copy()
+        if isinstance(rkwargs, dict) and "storage_options" in rkwargs:
+            storage_opt_dict.setdefault(reader_name, {}).update(rkwargs.pop('storage_options'))
     return storage_opt_dict
-
-
-def _merge_storage_options(storage_options, storage_opt_dict):
-    if storage_opt_dict:
-        if storage_options:
-            storage_opt_dict['storage_options'] = storage_options
-        storage_options = storage_opt_dict
-
-    return storage_options
 
 
 @contextmanager


### PR DESCRIPTION
While working with the `MultiScene` I noticed that only the first Scene creation was working and failing on the second because `reader_kwargs` passed by me were being modified by the Scene. This is the simplest fix I could think of for fixing this.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
