### PR TITLE
Fix ancillary variable confusion after resampling

### DIFF
--- a/satpy/dataset/anc_vars.py
+++ b/satpy/dataset/anc_vars.py
@@ -17,7 +17,7 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Utilities for dealing with ancillary variables."""
 
-from .dataid import DataID
+from .dataid import DataID, default_id_keys_config
 
 
 def dataset_walker(datasets):
@@ -39,7 +39,11 @@ def replace_anc(dataset, parent_dataset):
     """Replace *dataset* the *parent_dataset*'s `ancillary_variables` field."""
     if parent_dataset is None:
         return
-    id_keys = parent_dataset.attrs.get('_satpy_id_keys', dataset.attrs.get('_satpy_id_keys'))
+    id_keys = parent_dataset.attrs.get(
+            '_satpy_id_keys',
+            dataset.attrs.get(
+                '_satpy_id_keys',
+                default_id_keys_config))
     current_dataid = DataID(id_keys, **dataset.attrs)
     for idx, ds in enumerate(parent_dataset.attrs['ancillary_variables']):
         if current_dataid == DataID(id_keys, **ds.attrs):

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1796,6 +1796,35 @@ class TestSceneResampling:
         new_scene = scene.resample(dst_area)
         assert new_scene['comp20'] is new_scene['comp19'].attrs['ancillary_variables'][0]
 
+    def test_resample_multi_ancillary(self):
+        """Test that multiple ancillary variables are retained after resampling.
+
+        This test corresponds to GH#2329
+        """
+        from pyresample import create_area_def
+        sc = Scene()
+        n = 5
+        ar = create_area_def("a", 4087, resolution=1000, center=(0, 0), shape=(n, n))
+        sc["test"] = xr.DataArray(
+            np.arange(n*n).reshape(n, n),
+            dims=("y", "x"),
+            attrs={
+                "area": ar,
+                "name": "test",
+                "ancillary_variables": [
+                    xr.DataArray(
+                        np.arange(n*n).reshape(n, n)*i,
+                        dims=("y", "x"),
+                        attrs={
+                            "name": f"anc{i:d}",
+                            "area": ar})
+                        for i in range(2)]})
+        subset = create_area_def("b", 4087, resolution=800, center=(0, 0),
+                                 shape=(n-1, n-1))
+        ls = sc.resample(subset)
+        assert ([av.attrs["name"] for av in sc["test"].attrs["ancillary_variables"]] ==
+                [av.attrs["name"] for av in ls["test"].attrs["ancillary_variables"]])
+
     def test_resample_reduce_data(self):
         """Test that the Scene reducing data does not affect final output."""
         from pyresample.geometry import AreaDefinition

--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -1805,20 +1805,17 @@ class TestSceneResampling:
         sc = Scene()
         n = 5
         ar = create_area_def("a", 4087, resolution=1000, center=(0, 0), shape=(n, n))
+        anc_vars = [xr.DataArray(
+            np.arange(n*n).reshape(n, n)*i,
+            dims=("y", "x"),
+            attrs={"name": f"anc{i:d}", "area": ar}) for i in range(2)]
         sc["test"] = xr.DataArray(
             np.arange(n*n).reshape(n, n),
             dims=("y", "x"),
             attrs={
                 "area": ar,
                 "name": "test",
-                "ancillary_variables": [
-                    xr.DataArray(
-                        np.arange(n*n).reshape(n, n)*i,
-                        dims=("y", "x"),
-                        attrs={
-                            "name": f"anc{i:d}",
-                            "area": ar})
-                        for i in range(2)]})
+                "ancillary_variables": anc_vars})
         subset = create_area_def("b", 4087, resolution=800, center=(0, 0),
                                  shape=(n-1, n-1))
         ls = sc.resample(subset)


### PR DESCRIPTION
Fix ancillary variable confusion after resampling.

Previously, `replace_anc()` was only looking at `_satpy_id_keys` in the variable attributes.  When this was not set, it would use `None` for constructing the `DataID`s used for comparison.  When we pass `None` as ID keys to `DataID`, the `DataID` becomes empty: `DataID()`, such that a comparison always evaluates to True.  As a consequence, instead of replacing the "correct" of N ancillary variables, it would replace the first one N times and the other ones not at all.

In this PR, I am taking the `default_id_keys_config` if no `_satpy_id_keys` are set in the variable attributes.

I'm not sure if `_satpy_id_keys` is supposed to be always set (possibly to `default_id_keys_config`, or if it is expected that it is not always set.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #2329 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Closes #2330 
 - [x] Tests added <!-- for all bug fixes or enhancements -->

