### PR TITLE
Add time coverage attrs for TROPOMI L2

### DIFF
--- a/satpy/readers/tropomi_l2.py
+++ b/satpy/readers/tropomi_l2.py
@@ -30,6 +30,7 @@ http://www.tropomi.eu/data-products/level-2-products
 """
 
 import logging
+from datetime import datetime
 
 import dask.array as da
 import numpy as np
@@ -39,6 +40,7 @@ from satpy import CHUNK_SIZE
 from satpy.readers.netcdf_utils import NetCDF4FileHandler, netCDF4
 
 logger = logging.getLogger(__name__)
+DATE_FMT = '%Y-%m-%dT%H:%M:%SZ'
 
 
 class TROPOMIL2FileHandler(NetCDF4FileHandler):
@@ -58,6 +60,16 @@ class TROPOMIL2FileHandler(NetCDF4FileHandler):
     def platform_shortname(self):
         """Get platform shortname."""
         return self.filename_info['platform_shortname']
+
+    @property
+    def time_coverage_start(self):
+        """Get time_coverage_start."""
+        return datetime.strptime(self['/attr/time_coverage_start'], DATE_FMT)
+
+    @property
+    def time_coverage_end(self):
+        """Get time_coverage_end."""
+        return datetime.strptime(self['/attr/time_coverage_end'], DATE_FMT)
 
     @property
     def sensor(self):
@@ -164,6 +176,8 @@ class TROPOMIL2FileHandler(NetCDF4FileHandler):
             'sensor': self.sensor,
             'start_time': self.start_time,
             'end_time': self.end_time,
+            'time_coverage_start': self.time_coverage_start,
+            'time_coverage_end': self.time_coverage_end,
         })
 
         return metadata

--- a/satpy/tests/reader_tests/test_tropomi_l2.py
+++ b/satpy/tests/reader_tests/test_tropomi_l2.py
@@ -20,7 +20,7 @@
 
 import os
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest import mock
 
 import numpy as np
@@ -46,8 +46,8 @@ class FakeNetCDF4FileHandlerTL2(FakeNetCDF4FileHandler):
 
         if filetype_info['file_type'] == 'tropomi_l2':
             file_content = {
-                '/attr/time_coverage_start': dt_s.strftime('%Y-%m-%dT%H:%M:%S.000Z'),
-                '/attr/time_coverage_end': dt_e.strftime('%Y-%m-%dT%H:%M:%S.000Z'),
+                '/attr/time_coverage_start': (dt_s+timedelta(minutes=22)).strftime('%Y-%m-%dT%H:%M:%SZ'),
+                '/attr/time_coverage_end': (dt_e-timedelta(minutes=22)).strftime('%Y-%m-%dT%H:%M:%SZ'),
                 '/attr/platform_shortname': 'S5P',
                 '/attr/sensor': 'TROPOMI',
             }
@@ -141,6 +141,8 @@ class TestTROPOMIL2Reader(unittest.TestCase):
         for d in ds.values():
             self.assertEqual(d.attrs['platform_shortname'], 'S5P')
             self.assertEqual(d.attrs['sensor'], 'tropomi')
+            self.assertEqual(d.attrs['time_coverage_start'], datetime(2018, 7, 9, 17, 25, 34))
+            self.assertEqual(d.attrs['time_coverage_end'], datetime(2018, 7, 9, 18, 23, 4))
             self.assertIn('area', d.attrs)
             self.assertIsNotNone(d.attrs['area'])
             self.assertIn('y', d.dims)


### PR DESCRIPTION
- [x] Tests added <!-- for all bug fixes or enhancements -->

The `time_coverage_start` and `time_coverage_end` attributes are important for TROPOMI L2 data. I have added these two attributes as property.

Note that  `time_coverage_start` and `time_coverage_end` are not as same as start_time and end_time shown in the filename. Here's an example:

```
filename: S5P_PAL__L2__NO2____20210721T154634_20210721T172804_19540_02_020301_20211107T185715.nc

  // global attributes:
  :time_coverage_start = "2021-07-21T16:08:09Z";
  :time_coverage_end = "2021-07-21T17:06:32Z";
```