### PR TITLE
fix write multiple channels mitiff writer

### DIFF
--- a/satpy/tests/writer_tests/test_mitiff.py
+++ b/satpy/tests/writer_tests/test_mitiff.py
@@ -772,6 +772,8 @@ class TestMITIFFWriter(unittest.TestCase):
                     self.fail("Not a valid channel description i the given key.")
         self.assertTrue(found_table_calibration, "Table_calibration is not found in the imagedescription.")
         self.assertEqual(number_of_calibrations, 6)
+        pillow_tif = Image.open(os.path.join(self.base_dir, filename))
+        self.assertEqual(pillow_tif.n_frames, 6)
         self._read_back_mitiff_and_check(os.path.join(self.base_dir, filename), expected)
 
     def test_save_dataset_with_calibration_one_dataset(self):

--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -724,6 +724,7 @@ class MITIFFWriter(ImageWriter):
             Image.fromarray(data.astype(np.uint8)).save(tmp_gen_filename, compression='tiff_deflate',
                                                         compress_level=9, tiffinfo=tiffinfo)
         else:
+            mitiff_frames = []
             for _cn_i, _cn in enumerate(self.channel_order[kwargs['sensor']]):
                 for band in datasets['bands']:
                     if band == _cn:
@@ -736,6 +737,8 @@ class MITIFFWriter(ImageWriter):
                                                     self.mitiff_config[kwargs['sensor']][cn]['min-val'],
                                                     self.mitiff_config[kwargs['sensor']][cn]['max-val'])
 
-                        Image.fromarray(data.astype(np.uint8)).save(tmp_gen_filename, compression='tiff_deflate',
-                                                                    compress_level=9, tiffinfo=tiffinfo)
+                        mitiff_frames.append(Image.fromarray(data.astype(np.uint8), mode='L'))
+
                         break
+            mitiff_frames[0].save(tmp_gen_filename, save_all=True, append_images=mitiff_frames[1:],
+                                  compression='tiff_deflate', compress_level=9, tiffinfo=tiffinfo)


### PR DESCRIPTION
When a datasets contains more than 1 channel the channel was overwritten by the last.
Fix this so that channels are appended.

 - [X] Closes #2349 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [X] Add your name to `AUTHORS.md` if not there already
