### PR TITLE
Add reader for DSCOVR EPIC L1b data in HDF5 format.

### DIFF
--- a/satpy/etc/composites/epic.yaml
+++ b/satpy/etc/composites/epic.yaml
@@ -1,0 +1,40 @@
+sensor_name: visir/epic
+
+modifiers:
+  sunz_corrected:
+    modifier: !!python/name:satpy.modifiers.SunZenithCorrector
+    optional_prerequisites:
+    - solar_zenith_angle
+
+  rayleigh_corrected:
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: rayleigh_only
+    prerequisites:
+    - name: B680
+      modifiers: [sunz_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
+composites:
+  true_color:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: B680
+        modifiers: [sunz_corrected, rayleigh_corrected]
+      - name: B551
+        modifiers: [sunz_corrected, rayleigh_corrected]
+      - name: B443
+        modifiers: [sunz_corrected, rayleigh_corrected]
+    standard_name: true_color
+
+  true_color_raw:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: B680
+      - name: B551
+      - name: B443
+    standard_name: true_color

--- a/satpy/etc/enhancements/epic.yaml
+++ b/satpy/etc/enhancements/epic.yaml
@@ -1,0 +1,10 @@
+enhancements:
+  true_color:
+    standard_name:   true_color
+    operations:
+    - name: stretch
+      method: !!python/name:satpy.enhancements.stretch
+      kwargs:
+        stretch: crude
+        min_stretch: [0, 0, 0]
+        max_stretch: [100, 100, 100]

--- a/satpy/etc/readers/epic_l1b_h5.yaml
+++ b/satpy/etc/readers/epic_l1b_h5.yaml
@@ -13,7 +13,7 @@ reader:
 
 file_types:
     h5_std:
-        file_reader: !!python/name:satpy.readers.epic_l1b_h5.DSCOVREPICL1BH5FileHandler
+        file_reader: !!python/name:satpy.readers.epic_l1b_h5.DscovrEpicL1BH5FileHandler
         file_patterns: [
           "{sensor:4s}_1b_{nominal_time:%Y%m%d%H%M%S}_{version:2s}.h5"
         ]

--- a/satpy/etc/readers/epic_l1b_h5.yaml
+++ b/satpy/etc/readers/epic_l1b_h5.yaml
@@ -1,0 +1,216 @@
+reader:
+  name: epic_l1b_h5
+  short_name: DSCOVR_EPIC_L1b
+  long_name: DSCOVR EPIC L1b hdf5
+  description: >
+    Reader for level 1b data produced by DSCOVR's EPIC sensor.
+    For documentation see: https://cmr.earthdata.nasa.gov/search/concepts/C1667168435-LARC_ASDC.html.
+  status: Beta
+  supports_fsspec: false
+  sensors: [epic]
+  default_channels: [B317, B325, B340, B388, B443, B551, B680, B688, B764, B780]
+  reader: !!python/name:satpy.readers.yaml_reader.GEOFlippableFileYAMLReader
+
+file_types:
+    h5_std:
+        file_reader: !!python/name:satpy.readers.epic_l1b_h5.DSCOVREPICL1BH5FileHandler
+        file_patterns: [
+          "{sensor:4s}_1b_{nominal_time:%Y%m%d%H%M%S}_{version:2s}.h5"
+        ]
+
+
+datasets:
+  B317:
+    name: B317
+    wavelength: [0.3174, 0.3175, 0.3176]
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: count
+    file_type: h5_std
+    file_key: Band317nm/Image
+
+  B325:
+    name: B325
+    wavelength: [0.3249, 0.325, 0.3251]
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: count
+    file_type: h5_std
+    file_key: Band325nm/Image
+
+  B340:
+    name: B340
+    wavelength: [0.3397, 0.340, 0.3403]
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: count
+    file_type: h5_std
+    file_key: Band340nm/Image
+
+  B388:
+    name: B388
+    wavelength: [0.3877, 0.388, 0.3883]
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: count
+    file_type: h5_std
+    file_key: Band388nm/Image
+
+  B443:
+    name: B443
+    wavelength: [0.442, 0.443, 0.444]
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: count
+    file_type: h5_std
+    file_key: Band443nm/Image
+
+  B551:
+    name: B551
+    wavelength: [0.550, 0.551, 0.552]
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: count
+    file_type: h5_std
+    file_key: Band551nm/Image
+
+  B680:
+    name: B680
+    wavelength: [0.678, 0.680, 0.682]
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: count
+    file_type: h5_std
+    file_key: Band680nm/Image
+
+  B688:
+    name: B688
+    wavelength: [0.6773, 0.6875, 0.6777]
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: count
+    file_type: h5_std
+    file_key: Band688nm/Image
+
+  B764:
+    name: B764
+    wavelength: [0.7638, 0.764, 0.7642]
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: count
+    file_type: h5_std
+    file_key: Band764nm/Image
+
+  B780:
+    name: B780
+    wavelength: [0.7792, 0.7795, 0.7798]
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: count
+    file_type: h5_std
+    file_key: Band780nm/Image
+
+
+  longitude:
+    name: longitude
+    standard_name: longitude
+    long_name: "Longitude"
+    units: degree
+    file_type: h5_std
+    file_key: Band688nm/Geolocation/Earth/Longitude
+
+  latitude:
+    name: latitude
+    standard_name: latitude
+    long_name: "Latitude"
+    units: degree
+    file_type: h5_std
+    file_key: Band688nm/Geolocation/Earth/Latitude
+
+  solar_zenith_angle:
+    name: solar_zenith_angle
+    standard_name: solar_zenith_angle
+    long_name: "Solar zenith angle"
+    units: degree
+    file_type: h5_std
+    file_key: Band688nm/Geolocation/Earth/SunAngleZenith
+
+  solar_azimuth_angle:
+    name: solar_azimuth_angle
+    standard_name: solar_azimuth_angle
+    long_name: "Solar azimuth angle"
+    units: degree
+    file_type: h5_std
+    file_key: Band688nm/Geolocation/Earth/SunAngleAzimuth
+
+  satellite_zenith_angle:
+    name: satellite_zenith_angle
+    standard_name: sensor_zenith_angle
+    long_name: "Satellite zenith angle"
+    units: degree
+    file_type: h5_std
+    file_key: Band688nm/Geolocation/Earth/ViewAngleZenith
+
+  satellite_azimuth_angle:
+    name: satellite_azimuth_angle
+    standard_name: sensor_azimuth_angle
+    long_name: "Satellite azimuth angle"
+    units: degree
+    file_type: h5_std
+    file_key: Band688nm/Geolocation/Earth/ViewAngleAzimuth
+
+  satellite_refraction_angle:
+    name:   satellite_refraction_angle
+    standard_name:   satellite_refraction_angle
+    long_name: "Satellite refraction angle"
+    units: degree
+    file_type: h5_std
+    file_key: Band688nm/Geolocation/Earth/ViewAngleRefraction
+
+  earth_mask:
+    name:     earth_mask
+    standard_name:     earth_mask
+    long_name: "Satellite refraction angle"
+    units: degree
+    file_type: h5_std
+    file_key: Band688nm/Geolocation/Earth/Mask

--- a/satpy/readers/epic_l1b_h5.py
+++ b/satpy/readers/epic_l1b_h5.py
@@ -1,4 +1,42 @@
-"""File handler for DSCOVR EPIC L1B data in hdf5 format."""
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""File handler for DSCOVR EPIC L1B data in hdf5 format.
+
+The ``epic_l1b_h5`` reader reads and calibrates EPIC L1B image data in hdf5 format.
+
+This reader supports all image and most ancillary datasets.
+Once the reader is initialised:
+
+`` scn = Scene([epic_filename], reader='epic_l1b_h5')``
+
+Channels can be loaded with the 'B' prefix and their wavelength in nanometers:
+
+``scn.load(['B317', 'B688'])``
+
+while ancillary data can be loaded by its name:
+
+``scn.load(['solar_zenith_angle'])``
+
+Note that ancillary dataset names use common standards and not the dataset names in the file.
+By default, channel data is loaded as calibrated reflectances, but counts data is also available.
+
+"""
+
 import logging
 from datetime import datetime
 

--- a/satpy/readers/epic_l1b_h5.py
+++ b/satpy/readers/epic_l1b_h5.py
@@ -61,12 +61,12 @@ CALIB_COEFS = {'B317': 1.216e-4,
                'B780': 1.435e-5}
 
 
-class DSCOVREPICL1BH5FileHandler(HDF5FileHandler):
+class DscovrEpicL1BH5FileHandler(HDF5FileHandler):
     """File handler for DSCOVR EPIC L1b data."""
 
     def __init__(self, filename, filename_info, filetype_info):
         """Init filehandler."""
-        super(DSCOVREPICL1BH5FileHandler, self).__init__(filename, filename_info, filetype_info)
+        super(DscovrEpicL1BH5FileHandler, self).__init__(filename, filename_info, filetype_info)
 
         self.sensor = 'EPIC'
         self.platform_name = 'DSCOVR'

--- a/satpy/readers/epic_l1b_h5.py
+++ b/satpy/readers/epic_l1b_h5.py
@@ -68,8 +68,8 @@ class DscovrEpicL1BH5FileHandler(HDF5FileHandler):
         """Init filehandler."""
         super(DscovrEpicL1BH5FileHandler, self).__init__(filename, filename_info, filetype_info)
 
-        self.sensor = 'EPIC'
-        self.platform_name = 'DSCOVR'
+        self.sensor = 'epic'
+        self.platform_name = 'dscovr'
 
     @property
     def start_time(self):

--- a/satpy/tests/reader_tests/test_epic_l1b_h5.py
+++ b/satpy/tests/reader_tests/test_epic_l1b_h5.py
@@ -54,7 +54,7 @@ def make_fake_hdf_epic(fname):
     g4 = g3.create_group('Earth')
     g4.create_dataset('SunAngleZenith', shape=(100, 100), dtype=np.float32, data=sza_data)
     g4.create_dataset('ViewAngleAzimuth', shape=(100, 100), dtype=np.float32, data=vaa_data)
-    g4.create_dataset('Mask', shape=(100, 100), dtype=np.int, data=mas_data)
+    g4.create_dataset('Mask', shape=(100, 100), dtype=int, data=mas_data)
     g4.create_dataset('Latitude', shape=(100, 100), dtype=np.float32, data=lat_data)
     g4.create_dataset('Longitude', shape=(100, 100), dtype=np.float32, data=lon_data)
 

--- a/satpy/tests/reader_tests/test_epic_l1b_h5.py
+++ b/satpy/tests/reader_tests/test_epic_l1b_h5.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""The epic_l1b_h5 reader tests package."""
+
+import os
+import tempfile
+
+import h5py
+import numpy as np
+import pytest
+
+from satpy.readers.epic_l1b_h5 import CALIB_COEFS
+
+b317_data = np.random.uniform(low=0, high=5200, size=(100, 100))
+b688_data = np.random.uniform(low=0, high=5200, size=(100, 100))
+sza_data = np.random.uniform(low=0, high=100, size=(100, 100))
+vaa_data = np.random.uniform(low=-180, high=180, size=(100, 100))
+lon_data = np.random.uniform(low=-90, high=90, size=(100, 100))
+lat_data = np.random.uniform(low=-180, high=180, size=(100, 100))
+mas_data = np.random.choice([0, 1], size=(100, 100))
+
+
+@pytest.fixture()
+def setup_hdf5_file(tmp_path):
+    """Create temp hdf5 files."""
+    fn = tmp_path / "epic_1b_20150613120251_03.h5"
+    make_fake_hdf_epic(fn)
+    return fn
+
+
+def make_fake_hdf_epic(fname):
+    """Make a fake HDF5 file for EPIC data testing."""
+    fid = h5py.File(fname, 'w')
+    g1 = fid.create_group('Band317nm')
+    g1.create_dataset('Image', shape=(100, 100), dtype=np.float32, data=b317_data)
+    g2 = fid.create_group('Band688nm')
+    g2.create_dataset('Image', shape=(100, 100), dtype=np.float32, data=b688_data)
+    g3 = g2.create_group('Geolocation')
+    g4 = g3.create_group('Earth')
+    g4.create_dataset('SunAngleZenith', shape=(100, 100), dtype=np.float32, data=sza_data)
+    g4.create_dataset('ViewAngleAzimuth', shape=(100, 100), dtype=np.float32, data=vaa_data)
+    g4.create_dataset('Mask', shape=(100, 100), dtype=np.int, data=mas_data)
+    g4.create_dataset('Latitude', shape=(100, 100), dtype=np.float32, data=lat_data)
+    g4.create_dataset('Longitude', shape=(100, 100), dtype=np.float32, data=lon_data)
+
+    fid.attrs.create('begin_time', '2015-06-13 12:00:37')
+    fid.attrs.create('end_time', '2015-06-13 12:05:01')
+    fid.close()
+
+
+class TestEPICL1bReader:
+    """Test the EPIC L1b HDF5 reader."""
+
+    def setup_method(self):
+        """Set up the tests."""
+        from satpy._config import config_search_paths
+
+        self.yaml_file = "epic_l1b_h5.yaml"
+
+        self.filename_test = os.path.join(
+            tempfile.gettempdir(),
+            "epic_1b_20150613120251_03.h5",
+        )
+        self.reader_configs = config_search_paths(os.path.join('readers', self.yaml_file))
+
+    def test_times(self, setup_hdf5_file):
+        """Test start and end times load properly."""
+        from datetime import datetime
+
+        from satpy.readers import load_reader
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([setup_hdf5_file])
+        r.create_filehandlers(loadables)
+
+        assert r.start_time == datetime(2015, 6, 13, 12, 0, 37)
+        assert r.end_time == datetime(2015, 6, 13, 12, 5, 1)
+
+    def test_calibration(self, setup_hdf5_file):
+        """Test that data is correctly calibrated."""
+        from satpy.readers import load_reader
+        from satpy.tests.utils import make_dsq
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([setup_hdf5_file])
+        r.create_filehandlers(loadables)
+
+        # Test counts calibration
+        ds = r.load([make_dsq(name='B317', calibration='counts')])
+        np.testing.assert_allclose(ds['B317'].data, b317_data)
+
+        # Test conversion to reflectance
+        ds = r.load([make_dsq(name='B317', calibration='reflectance')])
+        np.testing.assert_allclose(ds['B317'].data, b317_data * CALIB_COEFS['B317'] * 100., rtol=1e-5)
+
+        # Test nonsense calibration
+        with pytest.raises(KeyError):
+            r.load([make_dsq(name='B317', calibration='potatoes')])
+
+    def test_load_ancillary(self, setup_hdf5_file):
+        """Test that ancillary datasets load correctly."""
+        from satpy.readers import load_reader
+        from satpy.tests.utils import make_dsq
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([setup_hdf5_file])
+        r.create_filehandlers(loadables)
+
+        # Load sza
+        ds = r.load([make_dsq(name='solar_zenith_angle'),
+                     make_dsq(name='satellite_azimuth_angle'),
+                     make_dsq(name='latitude'),
+                     make_dsq(name='longitude'),
+                     make_dsq(name='earth_mask')])
+
+        np.testing.assert_allclose(ds['solar_zenith_angle'].data, sza_data)
+        np.testing.assert_allclose(ds['satellite_azimuth_angle'].data, vaa_data)
+        np.testing.assert_allclose(ds['latitude'].data, lat_data)
+        np.testing.assert_allclose(ds['longitude'].data, lon_data)
+        np.testing.assert_allclose(ds['earth_mask'].data, mas_data)


### PR DESCRIPTION
This PR adds a reader for [DSCOVR EPIC](https://epic.gsfc.nasa.gov/) data at level 1B, which is in HDF5 format. Level 1A and level 2+ data are not supported by this reader.

I have also added two composites, `true_color` and `true_color_raw`. But note that the `true_color` composite may not look as expected as DSCOVR is in a very different orbit to most sensors and hence gives an unusual view of the Earth with many high zenith angles.

An example `true_color_raw` image:
![true_col_raw](https://user-images.githubusercontent.com/13449576/212350356-85dafc35-06e2-4980-af4f-c46d4662d6de.png)


 - [x] Tests added
 - [x] Fully documented
