### PR TITLE
Add some project urls for pypi display

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -137,6 +137,12 @@ setup(name=NAME,
                    "Programming Language :: Python",
                    "Topic :: Scientific/Engineering"],
       url="https://github.com/pytroll/satpy",
+      download_url="https://pypi.python.org/pypi/satpy",
+      project_urls={
+            "Bug Tracker": "https://github.com/pytroll/satpy/issues",
+            "Documentation": "https://satpy.readthedocs.io/en/stable/",
+            "Source Code": "https://github.com/pytroll/satpy",
+        },
       packages=find_packages(),
       # Always use forward '/', even on Windows
       # See https://setuptools.readthedocs.io/en/latest/userguide/datafiles.html#data-files-support


### PR DESCRIPTION
This PR add some project urls for the sidebar on pypi to look a bit better (like numpy):

![173516495-f0a42c8b-cc8b-440a-9b9d-3f232ffc3346](https://user-images.githubusercontent.com/167802/212890255-94627675-b8dc-4fbb-baf6-bff249f8ad9e.png)

