### PR TITLE
Stop creating dummy files in cwd when testing

### DIFF
--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -344,48 +344,6 @@ class TestHelpers(unittest.TestCase):
 
         assert mock_fn_open.read.called
 
-    def test_generic_open_text(self):
-        """Test the bz2 file unzipping context manager using dummy text data."""
-        dummy_text_data = 'Hello'
-        dummy_text_filename = 'dummy.txt'
-        with open(dummy_text_filename, 'w') as f:
-            f.write(dummy_text_data)
-
-        with hf.generic_open(dummy_text_filename, 'r') as f:
-            read_text_data = f.read()
-
-        assert read_text_data == dummy_text_data
-
-        dummy_text_filename = 'dummy.txt.bz2'
-        with hf.bz2.open(dummy_text_filename, 'wt') as f:
-            f.write(dummy_text_data)
-
-        with hf.generic_open(dummy_text_filename, 'rt') as f:
-            read_text_data = f.read()
-
-        assert read_text_data == dummy_text_data
-
-    def test_generic_open_binary(self):
-        """Test the bz2 file unzipping context manager using dummy binary data."""
-        dummy_binary_data = b'Hello'
-        dummy_binary_filename = 'dummy.dat'
-        with open(dummy_binary_filename, 'wb') as f:
-            f.write(dummy_binary_data)
-
-        with hf.generic_open(dummy_binary_filename, 'rb') as f:
-            read_binary_data = f.read()
-
-        assert read_binary_data == dummy_binary_data
-
-        dummy_binary_filename = 'dummy.dat.bz2'
-        with hf.bz2.open(dummy_binary_filename, 'wb') as f:
-            f.write(dummy_binary_data)
-
-        with hf.generic_open(dummy_binary_filename, 'rb') as f:
-            read_binary_data = f.read()
-
-        assert read_binary_data == dummy_binary_data
-
     @mock.patch("os.remove")
     @mock.patch("satpy.readers.utils.unzip_file", return_value='dummy.txt')
     def test_pro_reading_gets_unzipped_file(self, fake_unzip_file, fake_remove):
@@ -489,3 +447,28 @@ class TestSunEarthDistanceCorrection:
         np.testing.assert_allclose(out_refl, self.raw_refl)
         assert not out_refl.attrs['sun_earth_distance_correction_applied']
         assert isinstance(out_refl.data, da.Array)
+
+
+@pytest.mark.parametrize("data, filename, mode",
+                         [(b"Hello", "dummy.dat", "b"),
+                          ("Hello", "dummy.txt", "t")])
+def test_generic_open_binary(tmp_path, data, filename, mode):
+    """Test the bz2 file unzipping context manager using dummy binary data."""
+    dummy_data = data
+    dummy_filename = os.fspath(tmp_path / filename)
+    with open(dummy_filename, 'w' + mode) as f:
+        f.write(dummy_data)
+
+    with hf.generic_open(dummy_filename, 'r' + mode) as f:
+        read_binary_data = f.read()
+
+    assert read_binary_data == dummy_data
+
+    dummy_filename = os.fspath(tmp_path / (filename + '.bz2'))
+    with hf.bz2.open(dummy_filename, 'w' + mode) as f:
+        f.write(dummy_data)
+
+    with hf.generic_open(dummy_filename, 'r' + mode) as f:
+        read_binary_data = f.read()
+
+    assert read_binary_data == dummy_data

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -28,6 +28,7 @@ import pytest
 
 from satpy.dataset.data_dict import get_key
 from satpy.dataset.dataid import DataID, ModifierTuple, WavelengthRange
+from satpy.readers import find_files_and_readers
 
 # NOTE:
 # The following fixtures are not defined in this file, but are used and injected by Pytest:
@@ -62,6 +63,17 @@ local_id_keys_config = {'name': {
 }
 
 real_import = builtins.__import__
+
+
+@pytest.fixture
+def viirs_file(tmp_path, monkeypatch):
+    """Create a dummy viirs file."""
+    filename = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
+
+    monkeypatch.chdir(tmp_path)
+    # touch the file so it exists on disk
+    open(filename, 'w').close()
+    return filename
 
 
 def make_dataid(**items):
@@ -413,10 +425,10 @@ class TestReaderLoader(unittest.TestCase):
         self.assertEqual(len(list(readers['abi_l1b'].available_dataset_ids)), 0)
 
 
-class TestFindFilesAndReaders(unittest.TestCase):
+class TestFindFilesAndReaders:
     """Test the find_files_and_readers utility function."""
 
-    def setUp(self):
+    def setup_method(self):
         """Wrap HDF5 file handler with our own fake handler."""
         from satpy.readers.viirs_sdr import VIIRSSDRFileHandler
         from satpy.tests.reader_tests.test_viirs_sdr import FakeHDF5FileHandler2
@@ -426,87 +438,50 @@ class TestFindFilesAndReaders(unittest.TestCase):
         self.fake_handler = self.p.start()
         self.p.is_local = True
 
-    def tearDown(self):
+    def teardown_method(self):
         """Stop wrapping the HDF5 file handler."""
         self.p.stop()
 
-    # def test_sensor(self):
-    #     """Test with filenames and sensor specified"""
-    #     from satpy.readers import load_readers
-    #     ri = load_readers(sensor='viirs',
-    #                       filenames=[
-    #                           'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
-    #                       ])
-    #     self.assertListEqual(list(ri.keys()), ['viirs_sdr'])
-    #
-
-    def test_reader_name(self):
+    def test_reader_name(self, viirs_file):
         """Test with default base_dir and reader specified."""
-        from satpy.readers import find_files_and_readers
-        fn = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
-        # touch the file so it exists on disk
-        test_file = open(fn, 'w')
-        try:
-            ri = find_files_and_readers(reader='viirs_sdr')
-            self.assertListEqual(list(ri.keys()), ['viirs_sdr'])
-            self.assertListEqual(ri['viirs_sdr'], [fn])
-        finally:
-            test_file.close()
-            os.remove(fn)
+        ri = find_files_and_readers(reader='viirs_sdr')
+        assert list(ri.keys()) == ['viirs_sdr']
+        assert ri['viirs_sdr'] == [viirs_file]
 
-    def test_reader_other_name(self):
+    def test_reader_other_name(self, monkeypatch, tmp_path):
         """Test with default base_dir and reader specified."""
-        from satpy.readers import find_files_and_readers
-        fn = 'S_NWC_CPP_npp_32505_20180204T1114116Z_20180204T1128227Z.nc'
+        filename = 'S_NWC_CPP_npp_32505_20180204T1114116Z_20180204T1128227Z.nc'
+        monkeypatch.chdir(tmp_path)
         # touch the file so it exists on disk
-        test_file = open(fn, 'w')
-        try:
-            ri = find_files_and_readers(reader='nwcsaf-pps_nc')
-            self.assertListEqual(list(ri.keys()), ['nwcsaf-pps_nc'])
-            self.assertListEqual(ri['nwcsaf-pps_nc'], [fn])
-        finally:
-            test_file.close()
-            os.remove(fn)
+        open(filename, 'w').close()
 
-    def test_reader_name_matched_start_end_time(self):
+        ri = find_files_and_readers(reader='nwcsaf-pps_nc')
+        assert list(ri.keys()) == ['nwcsaf-pps_nc']
+        assert ri['nwcsaf-pps_nc'] == [filename]
+
+    def test_reader_name_matched_start_end_time(self, viirs_file):
         """Test with start and end time matching the filename."""
         from datetime import datetime
 
-        from satpy.readers import find_files_and_readers
-        fn = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
-        # touch the file so it exists on disk
-        test_file = open(fn, 'w')
-        try:
-            ri = find_files_and_readers(reader='viirs_sdr',
-                                        start_time=datetime(2012, 2, 25, 18, 0, 0),
-                                        end_time=datetime(2012, 2, 25, 19, 0, 0),
-                                        )
-            self.assertListEqual(list(ri.keys()), ['viirs_sdr'])
-            self.assertListEqual(ri['viirs_sdr'], [fn])
-        finally:
-            test_file.close()
-            os.remove(fn)
+        ri = find_files_and_readers(reader='viirs_sdr',
+                                    start_time=datetime(2012, 2, 25, 18, 0, 0),
+                                    end_time=datetime(2012, 2, 25, 19, 0, 0),
+                                    )
+        assert list(ri.keys()) == ['viirs_sdr']
+        assert ri['viirs_sdr'] == [viirs_file]
 
-    def test_reader_name_matched_start_time(self):
+    def test_reader_name_matched_start_time(self, viirs_file):
         """Test with start matching the filename.
 
         Start time in the middle of the file time should still match the file.
         """
         from datetime import datetime
 
-        from satpy.readers import find_files_and_readers
-        fn = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
-        # touch the file so it exists on disk
-        test_file = open(fn, 'w')
-        try:
-            ri = find_files_and_readers(reader='viirs_sdr', start_time=datetime(2012, 2, 25, 18, 1, 30))
-            self.assertListEqual(list(ri.keys()), ['viirs_sdr'])
-            self.assertListEqual(ri['viirs_sdr'], [fn])
-        finally:
-            test_file.close()
-            os.remove(fn)
+        ri = find_files_and_readers(reader='viirs_sdr', start_time=datetime(2012, 2, 25, 18, 1, 30))
+        assert list(ri.keys()) == ['viirs_sdr']
+        assert ri['viirs_sdr'] == [viirs_file]
 
-    def test_reader_name_matched_end_time(self):
+    def test_reader_name_matched_end_time(self, viirs_file):
         """Test with end matching the filename.
 
         End time in the middle of the file time should still match the file.
@@ -514,88 +489,47 @@ class TestFindFilesAndReaders(unittest.TestCase):
         """
         from datetime import datetime
 
-        from satpy.readers import find_files_and_readers
-        fn = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
-        # touch the file so it exists on disk
-        test_file = open(fn, 'w')
-        try:
-            ri = find_files_and_readers(reader='viirs_sdr', end_time=datetime(2012, 2, 25, 18, 1, 30))
-            self.assertListEqual(list(ri.keys()), ['viirs_sdr'])
-            self.assertListEqual(ri['viirs_sdr'], [fn])
-        finally:
-            test_file.close()
-            os.remove(fn)
+        ri = find_files_and_readers(reader='viirs_sdr', end_time=datetime(2012, 2, 25, 18, 1, 30))
+        assert list(ri.keys()) == ['viirs_sdr']
+        assert ri['viirs_sdr'] == [viirs_file]
 
-    def test_reader_name_unmatched_start_end_time(self):
+    def test_reader_name_unmatched_start_end_time(self, viirs_file):
         """Test with start and end time matching the filename."""
         from datetime import datetime
 
-        from satpy.readers import find_files_and_readers
-        fn = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
-        # touch the file so it exists on disk
-        test_file = open(fn, 'w')
-        try:
-            self.assertRaises(ValueError, find_files_and_readers,
-                              reader='viirs_sdr',
-                              start_time=datetime(2012, 2, 26, 18, 0, 0),
-                              end_time=datetime(2012, 2, 26, 19, 0, 0),
-                              )
-        finally:
-            test_file.close()
-            os.remove(fn)
+        with pytest.raises(ValueError):
+            find_files_and_readers(reader='viirs_sdr',
+                                   start_time=datetime(2012, 2, 26, 18, 0, 0),
+                                   end_time=datetime(2012, 2, 26, 19, 0, 0))
 
-    def test_no_parameters(self):
+    def test_no_parameters(self, viirs_file):
         """Test with no limiting parameters."""
         from satpy.readers import find_files_and_readers
-        fn = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
-        # touch the file so it exists on disk
-        test_file = open(fn, 'w')
-        try:
-            ri = find_files_and_readers()
-            self.assertListEqual(list(ri.keys()), ['viirs_sdr'])
-            self.assertListEqual(ri['viirs_sdr'], [fn])
-        finally:
-            test_file.close()
-            os.remove(fn)
 
-    def test_bad_sensor(self):
+        ri = find_files_and_readers()
+        assert list(ri.keys()) == ['viirs_sdr']
+        assert ri['viirs_sdr'] == [viirs_file]
+
+    def test_bad_sensor(self, viirs_file):
         """Test bad sensor doesn't find any files."""
-        from satpy.readers import find_files_and_readers
-        fn = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
-        # touch the file so it exists on disk
-        test_file = open(fn, 'w')
-        try:
-            self.assertRaises(ValueError, find_files_and_readers, sensor='i_dont_exist')
-        finally:
-            test_file.close()
-            os.remove(fn)
+        with pytest.raises(ValueError):
+            find_files_and_readers(sensor='i_dont_exist')
 
-    def test_sensor(self):
+    def test_sensor(self, viirs_file):
         """Test that readers for the current sensor are loaded."""
-        from satpy.readers import find_files_and_readers
-        fn = 'SVI01_npp_d20120225_t1801245_e1802487_b01708_c20120226002130255476_noaa_ops.h5'
-        # touch the file so it exists on disk
-        test_file = open(fn, 'w')
-        try:
-            # we can't easily know how many readers satpy has that support
-            # 'viirs' so we just pass it and hope that this works
-            ri = find_files_and_readers(sensor='viirs')
-            self.assertListEqual(list(ri.keys()), ['viirs_sdr'])
-            self.assertListEqual(ri['viirs_sdr'], [fn])
-        finally:
-            test_file.close()
-            os.remove(fn)
+        # we can't easily know how many readers satpy has that support
+        # 'viirs' so we just pass it and hope that this works
+        ri = find_files_and_readers(sensor='viirs')
+        assert list(ri.keys()) == ['viirs_sdr']
+        assert ri['viirs_sdr'] == [viirs_file]
 
     def test_sensor_no_files(self):
         """Test that readers for the current sensor are loaded."""
-        from satpy.readers import find_files_and_readers
-
         # we can't easily know how many readers satpy has that support
         # 'viirs' so we just pass it and hope that this works
-        self.assertRaises(ValueError, find_files_and_readers, sensor='viirs')
-        self.assertEqual(
-                find_files_and_readers(sensor='viirs', missing_ok=True),
-                {})
+        with pytest.raises(ValueError):
+            find_files_and_readers(sensor='viirs')
+        assert find_files_and_readers(sensor='viirs', missing_ok=True) == {}
 
     def test_reader_load_failed(self):
         """Test that an exception is raised when a reader can't be loaded."""
@@ -606,7 +540,8 @@ class TestFindFilesAndReaders(unittest.TestCase):
         # touch the file so it exists on disk
         with mock.patch('yaml.load') as load:
             load.side_effect = yaml.YAMLError("Import problems")
-            self.assertRaises(yaml.YAMLError, find_files_and_readers, reader='viirs_sdr')
+            with pytest.raises(yaml.YAMLError):
+                find_files_and_readers(reader='viirs_sdr')
 
     def test_pending_old_reader_name_mapping(self):
         """Test that requesting pending old reader names raises a warning."""
@@ -615,9 +550,9 @@ class TestFindFilesAndReaders(unittest.TestCase):
             return unittest.skip("Skipping pending deprecated reader tests because "
                                  "no pending deprecated readers.")
         test_reader = sorted(PENDING_OLD_READER_NAMES.keys())[0]
-        with self.assertWarns(FutureWarning):
+        with pytest.warns(FutureWarning):
             valid_reader_names = get_valid_reader_names([test_reader])
-        self.assertEqual(valid_reader_names[0], PENDING_OLD_READER_NAMES[test_reader])
+        assert valid_reader_names[0] == PENDING_OLD_READER_NAMES[test_reader]
 
     def test_old_reader_name_mapping(self):
         """Test that requesting old reader names raises a warning."""
@@ -626,7 +561,7 @@ class TestFindFilesAndReaders(unittest.TestCase):
             return unittest.skip("Skipping deprecated reader tests because "
                                  "no deprecated readers.")
         test_reader = sorted(OLD_READER_NAMES.keys())[0]
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             get_valid_reader_names([test_reader])
 
 


### PR DESCRIPTION
This PR puts the dummy files needed for testing in `tmp_path`
