### PR TITLE
Add tmp_path to the list of fixtures use in test_readers.py

### DIFF
--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -33,6 +33,7 @@ from satpy.readers import find_files_and_readers
 # NOTE:
 # The following fixtures are not defined in this file, but are used and injected by Pytest:
 # - monkeypatch
+# - tmp_path
 
 # clear the config dir environment variable so it doesn't interfere
 os.environ.pop("PPP_CONFIG_DIR", None)


### PR DESCRIPTION
This PR adds `tmp_path` to the list of fixtures use in test_readers.py
