### PR TITLE
Add an argument to the compositor to switch alpha band on/off in DayNightCompositor

### DIFF
--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -166,10 +166,11 @@ provides only a day product with night portion masked-out::
 
 By default, the image under `day_only` or `night_only` flag will come out
 with an alpha band to display its transparency. It could be changed by
-setting `need_alpha` to False if there's no need for that alpha band.
+setting `include_alpha` to False if there's no need for that alpha band.
 In such cases, it is recommended to use it together with `fill_value=0`
-when saving to geotiff. In the case below, the image shows its day portion
-and day/night transition with night portion blacked-out instead of transparent::
+when saving to geotiff to get a single-band image with black background.
+In the case below, the image shows its day portion and day/night
+transition with night portion blacked-out instead of transparent::
 
     >>> from satpy.composites import DayNightCompositor
     >>> compositor = DayNightCompositor("dnc", lim_low=85., lim_high=88., day_night="day_only", need_alpha=False)

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -146,7 +146,7 @@ They can be defined when initializing the compositor::
  - include_alpha (bool): This only affects the "day only" or "night only" result.
                          True means an alpha band will be added to the output image for transparency.
                          False means the output is a single-band image with undesired pixels being masked out
-                         (replaced with NaNs).					   
+                         (replaced with NaNs).
 
 Usage (with default values)::
 

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -130,7 +130,7 @@ first composite will be placed on the day-side of the scene, and the
 second one on the night side.  The transition from day to night is
 done by calculating solar zenith angle (SZA) weighed average of the
 two composites.  The SZA can optionally be given as third dataset, and
-if not given, the angles will be calculated.  Three arguments are used
+if not given, the angles will be calculated.  Four arguments are used
 to generate the image (default values shown in the example below).
 They can be defined when initializing the compositor::
 
@@ -143,6 +143,9 @@ They can be defined when initializing the compositor::
  - day_night (string): "day_night" means both day and night portions will be kept
                        "day_only" means only day portion will be kept
                        "night_only" means only night portion will be kept
+ - need_alpha (bool): This only affects "day only" or "night only" result
+                      True means an alpha band will be added to the output image for transparency
+                      False means the output is just a single-band image with masked-out area					   
 
 Usage (with default values)::
 
@@ -158,6 +161,16 @@ provides only a day product with night portion masked-out::
 
     >>> from satpy.composites import DayNightCompositor
     >>> compositor = DayNightCompositor("dnc", lim_low=85., lim_high=88., day_night="day_only")
+    >>> composite = compositor([local_scene['true_color'])
+
+By default, the image under `day_only` or `night_only` flag will come out
+with an alpha band to display its transparency. It could be changed by
+setting `need_alpha` to False if there's no need for that alpha band.
+In the case below, the image shows its day portion and day/night transition
+with night portion blacked-out instead of transparent:
+
+    >>> from satpy.composites import DayNightCompositor
+    >>> compositor = DayNightCompositor("dnc", lim_low=85., lim_high=88., day_night="day_only", need_alpha=False)
     >>> composite = compositor([local_scene['true_color'])
 
 RealisticColors

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -143,9 +143,10 @@ They can be defined when initializing the compositor::
  - day_night (string): "day_night" means both day and night portions will be kept
                        "day_only" means only day portion will be kept
                        "night_only" means only night portion will be kept
- - need_alpha (bool): This only affects "day only" or "night only" result
-                      True means an alpha band will be added to the output image for transparency
-                      False means the output is just a single-band image with masked-out area					   
+ - include_alpha (bool): This only affects the "day only" or "night only" result.
+                         True means an alpha band will be added to the output image for transparency.
+                         False means the output is a single-band image with undesired pixels being masked out
+                         (replaced with NaNs).					   
 
 Usage (with default values)::
 

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -167,8 +167,9 @@ provides only a day product with night portion masked-out::
 By default, the image under `day_only` or `night_only` flag will come out
 with an alpha band to display its transparency. It could be changed by
 setting `need_alpha` to False if there's no need for that alpha band.
-In the case below, the image shows its day portion and day/night transition
-with night portion blacked-out instead of transparent:
+In such cases, it is recommended to use it together with `fill_value=0`
+when saving to geotiff. In the case below, the image shows its day portion
+and day/night transition with night portion blacked-out instead of transparent::
 
     >>> from satpy.composites import DayNightCompositor
     >>> compositor = DayNightCompositor("dnc", lim_low=85., lim_high=88., day_night="day_only", need_alpha=False)

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -657,7 +657,7 @@ class DayNightCompositor(GenericCompositor):
     of the image (night or day). See the documentation below for more details.
     """
 
-    def __init__(self, name, lim_low=85., lim_high=88., day_night="day_night", **kwargs):
+    def __init__(self, name, lim_low=85., lim_high=88., day_night="day_night", need_alpha=True, **kwargs):
         """Collect custom configuration values.
 
         Args:
@@ -673,6 +673,7 @@ class DayNightCompositor(GenericCompositor):
         self.lim_low = lim_low
         self.lim_high = lim_high
         self.day_night = day_night
+        self.need_alpha = need_alpha
         super(DayNightCompositor, self).__init__(name, **kwargs)
 
     def __call__(self, projectables, **kwargs):
@@ -703,7 +704,8 @@ class DayNightCompositor(GenericCompositor):
             # Add alpha band to single L/RGB composite to make the masked-out portion transparent
             # L -> LA
             # RGB -> RGBA
-            foreground_data = add_alpha_bands(foreground_data)
+            if self.need_alpha:
+                foreground_data = add_alpha_bands(foreground_data)
 
             # No need to replace missing channel data with zeros
             # Get metadata

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -710,6 +710,9 @@ class DayNightCompositor(GenericCompositor):
             # RGB -> RGBA
             if self.include_alpha:
                 foreground_data = add_alpha_bands(foreground_data)
+
+            # Use coszen to determine the undesired pixels and replace the coszen of these pixels with NaN.
+            # They will be passed to subsequent calculation and therefore make sure those pixels being masked-out.
             if "day" in self.day_night:
                 coszen = da.where(coszen != 0, coszen, np.nan).compute()
             else:

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -716,8 +716,8 @@ class DayNightCompositor(GenericCompositor):
             attrs = foreground_data.attrs.copy()
 
             # Determine the composite position
-            day_data = foreground_data if "day" in self.day_night else 0
-            night_data = foreground_data if "night" in self.day_night else 0
+            day_data = foreground_data if "day" in self.day_night else np.nan
+            night_data = foreground_data if "night" in self.day_night else np.nan
 
         else:
             # Both day and night portions are selected. Two composites are requested. Get the second one merged.
@@ -747,7 +747,13 @@ class DayNightCompositor(GenericCompositor):
         # Blend the two images together
         day_portion = coszen * day_data
         night_portion = (1 - coszen) * night_data
-        data = night_portion + day_portion
+        if "and" in self.day_night:
+            data = night_portion + day_portion
+        else:
+            if "day" in self.day_night:
+                data = day_portion
+            else:
+                data = night_portion
         data.attrs = attrs
 
         # Split to separate bands so the mode is correct

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -710,14 +710,18 @@ class DayNightCompositor(GenericCompositor):
             # RGB -> RGBA
             if self.include_alpha:
                 foreground_data = add_alpha_bands(foreground_data)
+            if "day" in self.day_night:
+                coszen = da.where(coszen != 0, coszen, np.nan).compute()
+            else:
+                coszen = da.where(coszen != 1, coszen, np.nan).compute()
 
             # No need to replace missing channel data with zeros
             # Get metadata
             attrs = foreground_data.attrs.copy()
 
             # Determine the composite position
-            day_data = foreground_data if "day" in self.day_night else np.nan
-            night_data = foreground_data if "night" in self.day_night else np.nan
+            day_data = foreground_data if "day" in self.day_night else 0
+            night_data = foreground_data if "night" in self.day_night else 0
 
         else:
             # Both day and night portions are selected. Two composites are requested. Get the second one merged.
@@ -747,13 +751,7 @@ class DayNightCompositor(GenericCompositor):
         # Blend the two images together
         day_portion = coszen * day_data
         night_portion = (1 - coszen) * night_data
-        if "and" in self.day_night:
-            data = night_portion + day_portion
-        else:
-            if "day" in self.day_night:
-                data = day_portion
-            else:
-                data = night_portion
+        data = night_portion + day_portion
         data.attrs = attrs
 
         # Split to separate bands so the mode is correct

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -668,6 +668,9 @@ class DayNightCompositor(GenericCompositor):
             day_night (string): "day_night" means both day and night portions will be kept
                                 "day_only" means only day portion will be kept
                                 "night_only" means only night portion will be kept
+            need_alpha (bool): This only affects "day only" or "night only" result
+                               True means an alpha band will be added to the output image for transparency
+                               False means the output is just a single-band image with masked-out area
 
         """
         self.lim_low = lim_low
@@ -701,7 +704,7 @@ class DayNightCompositor(GenericCompositor):
 
         if "only" in self.day_night:
             # Only one portion (day or night) is selected. One composite is requested.
-            # Add alpha band to single L/RGB composite to make the masked-out portion transparent
+            # Add alpha band to single L/RGB composite to make the masked-out portion transparent when needed
             # L -> LA
             # RGB -> RGBA
             if self.need_alpha:

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -668,9 +668,9 @@ class DayNightCompositor(GenericCompositor):
             day_night (string): "day_night" means both day and night portions will be kept
                                 "day_only" means only day portion will be kept
                                 "night_only" means only night portion will be kept
-            need_alpha (bool): This only affects "day only" or "night only" result
-                               True means an alpha band will be added to the output image for transparency
-                               False means the output is just a single-band image with masked-out area
+            include_alpha (bool): This only affects the "day only" or "night only" result.
+                               True means an alpha band will be added to the output image for transparency.
+                               False means the output is a single-band image with undesired pixels being masked out (replaced with NaNs).
 
         """
         self.lim_low = lim_low

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -669,8 +669,9 @@ class DayNightCompositor(GenericCompositor):
                                 "day_only" means only day portion will be kept
                                 "night_only" means only night portion will be kept
             include_alpha (bool): This only affects the "day only" or "night only" result.
-                               True means an alpha band will be added to the output image for transparency.
-                               False means the output is a single-band image with undesired pixels being masked out (replaced with NaNs).
+                                  True means an alpha band will be added to the output image for transparency.
+                                  False means the output is a single-band image with undesired pixels being masked out
+                                   (replaced with NaNs).
 
         """
         self.lim_low = lim_low

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -657,7 +657,7 @@ class DayNightCompositor(GenericCompositor):
     of the image (night or day). See the documentation below for more details.
     """
 
-    def __init__(self, name, lim_low=85., lim_high=88., day_night="day_night", need_alpha=True, **kwargs):
+    def __init__(self, name, lim_low=85., lim_high=88., day_night="day_night", include_alpha=True, **kwargs):
         """Collect custom configuration values.
 
         Args:
@@ -677,7 +677,7 @@ class DayNightCompositor(GenericCompositor):
         self.lim_low = lim_low
         self.lim_high = lim_high
         self.day_night = day_night
-        self.need_alpha = need_alpha
+        self.include_alpha = include_alpha
         super(DayNightCompositor, self).__init__(name, **kwargs)
 
     def __call__(self, projectables, **kwargs):
@@ -708,7 +708,7 @@ class DayNightCompositor(GenericCompositor):
             # Add alpha band to single L/RGB composite to make the masked-out portion transparent when needed
             # L -> LA
             # RGB -> RGBA
-            if self.need_alpha:
+            if self.include_alpha:
                 foreground_data = add_alpha_bands(foreground_data)
 
             # No need to replace missing channel data with zeros

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -671,7 +671,7 @@ class DayNightCompositor(GenericCompositor):
             include_alpha (bool): This only affects the "day only" or "night only" result.
                                   True means an alpha band will be added to the output image for transparency.
                                   False means the output is a single-band image with undesired pixels being masked out
-                                   (replaced with NaNs).
+                                  (replaced with NaNs).
 
         """
         self.lim_low = lim_low

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -402,7 +402,7 @@ class TestDayNightCompositor(unittest.TestCase):
     def test_night_only_sza_with_alpha(self):
         """Test compositor with night portion with alpha band when SZA data is included."""
         from satpy.composites import DayNightCompositor
-        comp = DayNightCompositor(name='dn_test', day_night="night_only", need_alpha=True)
+        comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=True)
         res = comp((self.data_b, self.sza))
         res = res.compute()
         expected = np.array([[np.nan, 0.], [0.5, 1.]])
@@ -411,7 +411,7 @@ class TestDayNightCompositor(unittest.TestCase):
     def test_night_only_sza_without_alpha(self):
         """Test compositor with night portion without alpha band when SZA data is included."""
         from satpy.composites import DayNightCompositor
-        comp = DayNightCompositor(name='dn_test', day_night="night_only", need_alpha=False)
+        comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=False)
         res = comp((self.data_b, self.sza))
         res = res.compute()
         expected = np.array([[np.nan, 0.], [0.5, 1.]])
@@ -420,7 +420,7 @@ class TestDayNightCompositor(unittest.TestCase):
     def test_night_only_area_with_alpha(self):
         """Test compositor with night portion with alpha band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
-        comp = DayNightCompositor(name='dn_test', day_night="night_only", need_alpha=True)
+        comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=True)
         res = comp(self.data_b)
         res = res.compute()
         expected = np.array([[np.nan, 0.], [0., 0.]])
@@ -429,7 +429,7 @@ class TestDayNightCompositor(unittest.TestCase):
     def test_night_only_area_without_alpha(self):
         """Test compositor with night portion without alpha band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
-        comp = DayNightCompositor(name='dn_test', day_night="night_only", need_alpha=False)
+        comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=False)
         res = comp(self.data_b)
         res = res.compute()
         expected = np.array([np.nan, 0.])
@@ -438,7 +438,7 @@ class TestDayNightCompositor(unittest.TestCase):
     def test_day_only_sza_with_alpha(self):
         """Test compositor with day portion with alpha band when SZA data is included."""
         from satpy.composites import DayNightCompositor
-        comp = DayNightCompositor(name='dn_test', day_night="day_only", need_alpha=True)
+        comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=True)
         res = comp((self.data_a, self.sza))
         res = res.compute()
         expected = np.array([[0., 0.22122352], [0., 0.]])
@@ -447,7 +447,7 @@ class TestDayNightCompositor(unittest.TestCase):
     def test_day_only_sza_without_alpha(self):
         """Test compositor with day portion without alpha band when SZA data is included."""
         from satpy.composites import DayNightCompositor
-        comp = DayNightCompositor(name='dn_test', day_night="day_only", need_alpha=False)
+        comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=False)
         res = comp((self.data_a, self.sza))
         res = res.compute()
         expected = np.array([[0., 0.22122352], [0., 0.]])
@@ -456,7 +456,7 @@ class TestDayNightCompositor(unittest.TestCase):
     def test_day_only_area_with_alpha(self):
         """Test compositor with day portion with alpha_band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
-        comp = DayNightCompositor(name='dn_test', day_night="day_only", need_alpha=True)
+        comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=True)
         res = comp(self.data_a)
         res = res.compute()
         expected = np.array([[0., 0.33164983], [0.66835017, 1.]])
@@ -465,7 +465,7 @@ class TestDayNightCompositor(unittest.TestCase):
     def test_day_only_area_without_alpha(self):
         """Test compositor with day portion without alpha_band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
-        comp = DayNightCompositor(name='dn_test', day_night="day_only", need_alpha=False)
+        comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=False)
         res = comp(self.data_a)
         res = res.compute()
         expected = np.array([0., 0.33164983])

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -432,7 +432,7 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=False)
         res = comp(self.data_b)
         res = res.compute()
-        expected = np.array([[np.nan, np.nan]])
+        expected = np.array([np.nan, np.nan])
         np.testing.assert_allclose(res.values[0], expected)
 
     def test_day_only_sza_with_alpha(self):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -421,7 +421,7 @@ class TestDayNightCompositor(unittest.TestCase):
         """Test compositor with night portion with alpha band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test', day_night="night_only", need_alpha=True)
-        res = comp((self.data_b))
+        res = comp(self.data_b)
         res = res.compute()
         expected = np.array([[np.nan, 0.], [0., 0.]])
         np.testing.assert_allclose(res.values[0], expected)
@@ -430,9 +430,9 @@ class TestDayNightCompositor(unittest.TestCase):
         """Test compositor with night portion without alpha band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test', day_night="night_only", need_alpha=False)
-        res = comp((self.data_b))
+        res = comp(self.data_b)
         res = res.compute()
-        expected = np.array([[np.nan, 0.], [0., 0.]])
+        expected = np.array([np.nan, 0.])
         np.testing.assert_allclose(res.values[0], expected)
 
     def test_day_only_sza_with_alpha(self):
@@ -457,7 +457,7 @@ class TestDayNightCompositor(unittest.TestCase):
         """Test compositor with day portion with alpha_band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test', day_night="day_only", need_alpha=True)
-        res = comp((self.data_a))
+        res = comp(self.data_a)
         res = res.compute()
         expected = np.array([[0., 0.33164983], [0.66835017, 1.]])
         np.testing.assert_allclose(res.values[0], expected)
@@ -466,9 +466,9 @@ class TestDayNightCompositor(unittest.TestCase):
         """Test compositor with day portion without alpha_band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test', day_night="day_only", need_alpha=False)
-        res = comp((self.data_a))
+        res = comp(self.data_a)
         res = res.compute()
-        expected = np.array([[0., 0.33164983], [0.66835017, 1.]])
+        expected = np.array([0., 0.33164983])
         np.testing.assert_allclose(res.values[0], expected)
 
 

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -432,7 +432,7 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=False)
         res = comp(self.data_b)
         res = res.compute()
-        expected = np.array([[np.nan, np.nan], [np.nan, 0]])
+        expected = np.array([[np.nan, np.nan]])
         np.testing.assert_allclose(res.values[0], expected)
 
     def test_day_only_sza_with_alpha(self):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -423,7 +423,7 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=True)
         res = comp(self.data_b)
         res = res.compute()
-        expected = np.array([[np.nan, 0.], [0., 0.]])
+        expected = np.array([[np.nan, np.nan], [np.nan, np.nan]])
         np.testing.assert_allclose(res.values[0], expected)
 
     def test_night_only_area_without_alpha(self):
@@ -432,7 +432,7 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=False)
         res = comp(self.data_b)
         res = res.compute()
-        expected = np.array([np.nan, 0.])
+        expected = np.array([[np.nan, np.nan], [np.nan, 0]])
         np.testing.assert_allclose(res.values[0], expected)
 
     def test_day_only_sza_with_alpha(self):
@@ -441,7 +441,7 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=True)
         res = comp((self.data_a, self.sza))
         res = res.compute()
-        expected = np.array([[0., 0.22122352], [0., 0.]])
+        expected = np.array([[0., 0.22122352], [np.nan, np.nan]])
         np.testing.assert_allclose(res.values[0], expected)
 
     def test_day_only_sza_without_alpha(self):
@@ -450,7 +450,7 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=False)
         res = comp((self.data_a, self.sza))
         res = res.compute()
-        expected = np.array([[0., 0.22122352], [0., 0.]])
+        expected = np.array([[0., 0.22122352], [np.nan, np.nan]])
         np.testing.assert_allclose(res.values[0], expected)
 
     def test_day_only_area_with_alpha(self):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -399,37 +399,73 @@ class TestDayNightCompositor(unittest.TestCase):
         expected = np.array([[0., 0.33164983], [0.66835017, 1.]])
         np.testing.assert_allclose(res.values[0], expected)
 
-    def test_night_only_sza(self):
-        """Test compositor with night portion when SZA data is included."""
+    def test_night_only_sza_with_alpha(self):
+        """Test compositor with night portion with alpha band when SZA data is included."""
         from satpy.composites import DayNightCompositor
-        comp = DayNightCompositor(name='dn_test', day_night="night_only")
+        comp = DayNightCompositor(name='dn_test', day_night="night_only", need_alpha=True)
         res = comp((self.data_b, self.sza))
         res = res.compute()
         expected = np.array([[np.nan, 0.], [0.5, 1.]])
         np.testing.assert_allclose(res.values[0], expected)
 
-    def test_night_only_area(self):
-        """Test compositor with night portion when SZA data is not provided."""
+    def test_night_only_sza_without_alpha(self):
+        """Test compositor with night portion without alpha band when SZA data is included."""
         from satpy.composites import DayNightCompositor
-        comp = DayNightCompositor(name='dn_test', day_night="night_only")
+        comp = DayNightCompositor(name='dn_test', day_night="night_only", need_alpha=False)
+        res = comp((self.data_b, self.sza))
+        res = res.compute()
+        expected = np.array([[np.nan, 0.], [0.5, 1.]])
+        np.testing.assert_allclose(res.values[0], expected)
+
+    def test_night_only_area_with_alpha(self):
+        """Test compositor with night portion with alpha band when SZA data is not provided."""
+        from satpy.composites import DayNightCompositor
+        comp = DayNightCompositor(name='dn_test', day_night="night_only", need_alpha=True)
         res = comp((self.data_b))
         res = res.compute()
         expected = np.array([[np.nan, 0.], [0., 0.]])
         np.testing.assert_allclose(res.values[0], expected)
 
-    def test_day_only_sza(self):
-        """Test compositor with day portion when SZA data is included."""
+    def test_night_only_area_without_alpha(self):
+        """Test compositor with night portion without alpha band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
-        comp = DayNightCompositor(name='dn_test', day_night="day_only")
+        comp = DayNightCompositor(name='dn_test', day_night="night_only", need_alpha=False)
+        res = comp((self.data_b))
+        res = res.compute()
+        expected = np.array([[np.nan, 0.], [0., 0.]])
+        np.testing.assert_allclose(res.values[0], expected)
+
+    def test_day_only_sza_with_alpha(self):
+        """Test compositor with day portion with alpha band when SZA data is included."""
+        from satpy.composites import DayNightCompositor
+        comp = DayNightCompositor(name='dn_test', day_night="day_only", need_alpha=True)
         res = comp((self.data_a, self.sza))
         res = res.compute()
         expected = np.array([[0., 0.22122352], [0., 0.]])
         np.testing.assert_allclose(res.values[0], expected)
 
-    def test_day_only_area(self):
-        """Test compositor with day portion when SZA data is not provided."""
+    def test_day_only_sza_without_alpha(self):
+        """Test compositor with day portion without alpha band when SZA data is included."""
         from satpy.composites import DayNightCompositor
-        comp = DayNightCompositor(name='dn_test', day_night="day_only")
+        comp = DayNightCompositor(name='dn_test', day_night="day_only", need_alpha=False)
+        res = comp((self.data_a, self.sza))
+        res = res.compute()
+        expected = np.array([[0., 0.22122352], [0., 0.]])
+        np.testing.assert_allclose(res.values[0], expected)
+
+    def test_day_only_area_with_alpha(self):
+        """Test compositor with day portion with alpha_band when SZA data is not provided."""
+        from satpy.composites import DayNightCompositor
+        comp = DayNightCompositor(name='dn_test', day_night="day_only", need_alpha=True)
+        res = comp((self.data_a))
+        res = res.compute()
+        expected = np.array([[0., 0.33164983], [0.66835017, 1.]])
+        np.testing.assert_allclose(res.values[0], expected)
+
+    def test_day_only_area_without_alpha(self):
+        """Test compositor with day portion without alpha_band when SZA data is not provided."""
+        from satpy.composites import DayNightCompositor
+        comp = DayNightCompositor(name='dn_test', day_night="day_only", need_alpha=False)
         res = comp((self.data_a))
         res = res.compute()
         expected = np.array([[0., 0.33164983], [0.66835017, 1.]])


### PR DESCRIPTION
This PR is a solution for #2357. It only takes effect in "day only" or "night only" mode.

 - [ ] Closes #2357 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
