### PR TITLE
Fix "p_id" to be compatible with Himawari-9

### DIFF
--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -505,7 +505,7 @@ class AHIHSDFileHandler(BaseFileHandler):
 
         pdict['a_name'] = self.observation_area
         pdict['a_desc'] = "AHI {} area".format(self.observation_area)
-        pdict['p_id'] = 'geosh8'
+        pdict['p_id'] = f'geosh{self.basic_info["satellite"][0].decode()[-1]}'
 
         return get_area_definition(pdict, aex)
 

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -311,6 +311,9 @@ class TestAHIHSDFileHandler:
                 ref_mask = np.logical_not(get_geostationary_mask(fh.area).compute())
                 np.testing.assert_equal(mask, ref_mask)
 
+                # Make sure proj_id is correct
+                assert fh.area.proj_id == f'geosh{FAKE_BASIC_INFO["satellite"][-1]}'
+
     def test_time_properties(self):
         """Test start/end/scheduled time properties."""
         with _fake_hsd_handler() as fh:


### PR DESCRIPTION
The Projection ID (`"p_id"`) of this reader was fixed to `"geosh8"`, assuming only input of the Himawari-8 satellite. However, it was modified to `"geosh8"` for the Himawari-8 and `"geosh9"` for the Himawari-9.