### PR TITLE
Fix Sar lon/lat interpolator for scipy deprecation

### DIFF
--- a/satpy/readers/sar_c_safe.py
+++ b/satpy/readers/sar_c_safe.py
@@ -479,17 +479,22 @@ class XMLArray:
         return interpolate_xarray_linear(xpoints, ypoints, self.data, shape, chunks=chunks)
 
 
-def interpolate_xarray(xpoints, ypoints, values, shape, kind='cubic',
+def interpolate_xarray(xpoints, ypoints, values, shape,
                        blocksize=CHUNK_SIZE):
     """Interpolate, generating a dask array."""
+    from scipy.interpolate import RectBivariateSpline
+
     vchunks = range(0, shape[0], blocksize)
     hchunks = range(0, shape[1], blocksize)
 
-    token = tokenize(blocksize, xpoints, ypoints, values, kind, shape)
+    token = tokenize(blocksize, xpoints, ypoints, values, shape)
     name = 'interpolate-' + token
 
-    from scipy.interpolate import interp2d
-    interpolator = interp2d(xpoints, ypoints, values, kind=kind)
+    spline = RectBivariateSpline(xpoints, ypoints, values.T)
+
+    def interpolator(xnew, ynew):
+        """Interpolator function."""
+        return spline(xnew, ynew).T
 
     dskx = {(name, i, j): (interpolate_slice,
                            slice(vcs, min(vcs + blocksize, shape[0])),

--- a/satpy/readers/sar_c_safe.py
+++ b/satpy/readers/sar_c_safe.py
@@ -585,7 +585,7 @@ class SAFEGRD(BaseFileHandler):
             data.attrs.update(info)
 
         else:
-            data = rioxarray.open_rasterio(self.filename, lock=False, chunks=(1, CHUNK_SIZE, CHUNK_SIZE)).squeeze()
+            data = rioxarray.open_rasterio(self.filename, chunks=(1, CHUNK_SIZE, CHUNK_SIZE)).squeeze()
             data = data.assign_coords(x=np.arange(len(data.coords['x'])),
                                       y=np.arange(len(data.coords['y'])))
             data = self._calibrate_and_denoise(data, key)


### PR DESCRIPTION
The interp2d function is marked for deprecation starting with scipy v1.10.0 and will be removed in v1.12.0. So this PR replaces it.
