### PR TITLE
Fix bug hashing the angles derivation using the NWCSAF reader

### DIFF
--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -535,7 +535,15 @@ the :func:`xarray.open_dataset` function in a custom file handler is a much
 better idea.
 
 .. note::
-   Be careful about the data types of the datasets your reader is returning.
+   Be careful about the data types of the dataset attributes your reader is
+   returning.  JSON is used internally in Satpy to serialize the function
+   arguments so we can hash them and then use that hash as the filename for the
+   cached results. Numpy types don't serialize into JSON, therefore please make
+   sure the attributes being set upon reading does not contain numpy scalar
+   types.
+
+.. note::
+   Also, be careful about the data types of the datasets your reader is returning.
    It is easy to let the data be coerced into double precision floats (`np.float64`). At the
    moment, satellite instruments are rarely measuring in a resolution greater
    than what can be encoded in 16 bits. As such, to preserve processing power,

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -265,8 +265,9 @@ def _sanitize_observer_look_args(*args):
         if isinstance(arg, datetime):
             new_args.append(STATIC_EARTH_INERTIAL_DATETIME)
         elif isinstance(arg, (float, np.float64, np.float32)):
-            # round floating point numbers to nearest tenth
-            # Hashing numpy float types doesn't seem to work:
+            # Round floating point numbers to nearest tenth. Numpy types don't
+            # serialize into JSON which is needed for hashing, thus the casting
+            # to float here:
             new_args.append(float(round(arg, 1)))
         elif _is_chunk_tuple(arg) and _chunks_are_irregular(arg):
             new_chunks = _regular_chunks_from_irregular_chunks(arg)

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2021 Satpy developers
+# Copyright (c) 2021-2023 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -266,7 +266,8 @@ def _sanitize_observer_look_args(*args):
             new_args.append(STATIC_EARTH_INERTIAL_DATETIME)
         elif isinstance(arg, (float, np.float64, np.float32)):
             # round floating point numbers to nearest tenth
-            new_args.append(round(arg, 1))
+            # Hashing numpy float types doesn't seem to work:
+            new_args.append(float(round(arg, 1)))
         elif _is_chunk_tuple(arg) and _chunks_are_irregular(arg):
             new_chunks = _regular_chunks_from_irregular_chunks(arg)
             new_args.append(new_chunks)

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -171,7 +171,7 @@ class NcNWCSAF(BaseFileHandler):
             gdal_params = dict(elt.strip("+").split("=") for elt in self.nc.attrs["gdal_projection"].split())
             variable.attrs["orbital_parameters"] = dict(
                 satellite_nominal_altitude=float(gdal_params["h"]),
-                satellite_nominal_longitude=self.nc.attrs["sub-satellite_longitude"],
+                satellite_nominal_longitude=float(self.nc.attrs["sub-satellite_longitude"]),
                 satellite_nominal_latitude=0)
 
     def _get_varname_in_file(self, info, info_type="file_key"):

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2017-2022 Satpy developers
+# Copyright (c) 2017-2023 Satpy developers
 #
 # This file is part of satpy.
 #

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2018-2022 Satpy developers
+# Copyright (c) 2018-2023 Satpy developers
 #
 # This file is part of satpy.
 #

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -279,6 +279,9 @@ class TestNcNWCSAFGeo:
         dsid = {'name': 'ct'}
         var = nwcsaf_geo_ct_filehandler.get_dataset(dsid, {})
         assert "orbital_parameters" in var.attrs
+        for param in var.attrs['orbital_parameters']:
+            assert isinstance(var.attrs['orbital_parameters'][param], (float, int))
+
         assert var.attrs["orbital_parameters"]["satellite_nominal_altitude"] == NOMINAL_ALTITUDE
         assert var.attrs["orbital_parameters"]["satellite_nominal_longitude"] == NOMINAL_LONGITUDE
         assert var.attrs["orbital_parameters"]["satellite_nominal_latitude"] == 0


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
The new NWCSAF cloud products reader now includes orbital parameters so satz angles can be derived without habving to also load the raw channels. However, one of the parameters in the attributes are numpy float32 which is not JSON serializable and then an exception is thrown, see #2366 .

Instead of casting the variable when reading perhaps it is better to fix the sanitize function in the `angles.py` module? This is what is currently suggested.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Closes #2366  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
