### PR TITLE
Add Getting Help section to documentation

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -53,7 +53,7 @@ Getting Help
 Having trouble installing or using Satpy? Feel free to ask questions at
 any of the contact methods for the PyTroll group
 `here <https://pytroll.github.io/#getting-in-touch>`_ or file an issue on
-Satpy's GitHub page `here <https://github.com/pytroll/satpy/issues>`_.
+`Satpy's GitHub page <https://github.com/pytroll/satpy/issues>`_.
 
 Documentation
 =============

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -50,7 +50,10 @@ the base Satpy installation.
 Getting Help
 ============
 
-Having trouble installing or using Satpy? Feel free to ask questions and any of the contact methods for the PyTroll group `here <https://pytroll.github.io/#getting-in-touch>`_ or file an issue on Satpy's GitHub page `here <https://github.com/pytroll/satpy/issues>`_.
+Having trouble installing or using Satpy? Feel free to ask questions at
+any of the contact methods for the PyTroll group
+`here <https://pytroll.github.io/#getting-in-touch>`_ or file an issue on
+Satpy's GitHub page `here <https://github.com/pytroll/satpy/issues>`_.
 
 Documentation
 =============

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -46,6 +46,15 @@ the base Satpy installation.
 
 .. _project: http://github.com/pytroll/satpy
 
+
+Getting Help
+============
+
+Having trouble installing or using Satpy? Feel free to ask questions and any of the contact methods for the PyTroll group `here <https://pytroll.github.io/#getting-in-touch>`_ or file an issue on Satpy's GitHub page `here <https://github.com/pytroll/satpy/issues>`_.
+
+Documentation
+=============
+
 .. toctree::
     :maxdepth: 2
 


### PR DESCRIPTION
I get too many emails directly sent to me for help. After looking I realized that there isn't a very obvious spot in the documentation that says "this is how you ask for help". But maybe I missed something. At least this addition is more direct.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
