### PR TITLE
Fix palette images for float data

### DIFF
--- a/doc/source/enhancements.rst
+++ b/doc/source/enhancements.rst
@@ -147,7 +147,25 @@ Ocean and Sea Ice SAF (OSISAF) GHRSST product::
 The RGB color values will be interpolated to give a smooth result. This is
 contrary to using the palettize enhancement.
 
-The above examples are just two different ways to apply colors to images with
+If the source dataset already defines a palette, this can be applied directly.
+This requires that the palette is listed as an auxiliary variable and loaded
+as such by the reader.  To apply such a palette directly, pass the ``dataset``
+keyword.  For example::
+
+    - name: colorize
+      method: !!python/name:satpy.enhancements.colorize
+      kwargs:
+        palettes:
+          - dataset: ctth_alti_pal
+            color_scale: 255
+
+.. warning::
+   If the source data have a valid range defined, one should **not** define
+   ``min_value`` and ``max_value`` in the enhancement configuration!  If
+   those are defined and differ from the values in the valid range, the
+   colors will be wrong.
+
+The above examples are just three different ways to apply colors to images with
 Satpy. There is a wealth of other options for how to declare a colormap, please
 see :func:`~satpy.enhancements.create_colormap` for more inspiration.
 

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -431,7 +431,14 @@ def create_colormap(palette, img=None):
     **From an auxiliary variable**
 
     If the colormap is defined in the same dataset as the data to which the
-    colormap shall be applied,
+    colormap shall be applied, this can be indicated with
+    ``{'dataset': 'palette_variable'}``, where ``'palette_variable'`` is the
+    name of the variable containing the palette.  This variable must be an
+    auxiliary variable to the dataset to which the colours are applied.  When
+    using this, it is important that one should **not** set ``min_value`` and
+    ``max_value`` as those will be taken from the ``valid_range`` attribute
+    on the dataset and if those differ from ``min_value`` and ``max_value``,
+    the resulting colors will not match the ones in the palette.
 
     **Color Scale**
 

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -395,8 +395,8 @@ enhancements:
         palettes:
           - dataset: ctth_alti_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
+            min_value: -2000
+            max_value: 25000
 
   cloud_top_pressure:
     standard_name: cloud_top_pressure

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -359,8 +359,8 @@ enhancements:
         palettes:
           - dataset: ct_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
+            # NB: setting min_value and max_value that differ from the valid_range in the data
+            # will result in wrong colors.  It's safer to not set min_value and max_value at all.
 
   cloudmask:
     standard_name: cloudmask
@@ -371,8 +371,6 @@ enhancements:
         palettes:
           - dataset: cma_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   cloudmask_probability:
     standard_name: cloudmask_probability
@@ -383,8 +381,6 @@ enhancements:
         palettes:
           - dataset: cmaprob_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   cloud_top_height:
     standard_name: cloud_top_height
@@ -395,8 +391,6 @@ enhancements:
         palettes:
           - dataset: ctth_alti_pal
             color_scale: 255
-            min_value: -2000
-            max_value: 25000
 
   cloud_top_pressure:
     standard_name: cloud_top_pressure
@@ -407,8 +401,6 @@ enhancements:
         palettes:
           - dataset: ctth_pres_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   cloud_top_temperature:
     standard_name: cloud_top_temperature
@@ -419,8 +411,6 @@ enhancements:
         palettes:
           - dataset: ctth_tempe_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   cloud_top_phase:
     standard_name: cloud_top_phase
@@ -431,8 +421,6 @@ enhancements:
         palettes:
           - dataset: cmic_phase_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   cloud_drop_effective_radius:
     standard_name: cloud_drop_effective_radius
@@ -443,8 +431,6 @@ enhancements:
         palettes:
           - dataset: cmic_reff_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   cloud_optical_thickness:
     standard_name: cloud_optical_thickness
@@ -455,8 +441,6 @@ enhancements:
         palettes:
           - dataset: cmic_cot_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   cloud_liquid_water_path:
     standard_name: cloud_liquid_water_path
@@ -467,8 +451,6 @@ enhancements:
         palettes:
           - dataset: cmic_lwp_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   cloud_ice_water_path:
     standard_name: cloud_ice_water_path
@@ -479,8 +461,6 @@ enhancements:
         palettes:
           - dataset: cmic_iwp_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   precipitation_probability:
     standard_name: precipitation_probability
@@ -491,8 +471,6 @@ enhancements:
         palettes:
           - dataset: pc_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   convective_rain_rate:
     standard_name: convective_rain_rate
@@ -503,8 +481,6 @@ enhancements:
         palettes:
           - dataset: crr_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   convective_precipitation_hourly_accumulation:
     standard_name: convective_precipitation_hourly_accumulation
@@ -515,8 +491,6 @@ enhancements:
         palettes:
           - dataset: crr_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   total_precipitable_water:
     standard_name: total_precipitable_water
@@ -527,8 +501,6 @@ enhancements:
         palettes:
           - dataset: ishai_tpw_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   showalter_index:
     standard_name: showalter_index
@@ -539,8 +511,6 @@ enhancements:
         palettes:
           - dataset: ishai_shw_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   lifted_index:
     standard_name: lifted_index
@@ -551,8 +521,6 @@ enhancements:
         palettes:
           - dataset: ishai_li_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   convection_initiation_prob30:
     standard_name: convection_initiation_prob30
@@ -563,8 +531,6 @@ enhancements:
         palettes:
           - dataset: ci_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   convection_initiation_prob60:
     standard_name: convection_initiation_prob60
@@ -575,8 +541,6 @@ enhancements:
         palettes:
           - dataset: ci_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   convection_initiation_prob90:
     standard_name: convection_initiation_prob90
@@ -587,8 +551,6 @@ enhancements:
         palettes:
           - dataset: ci_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   rdt_cell_type:
     standard_name: rdt_cell_type
@@ -599,8 +561,6 @@ enhancements:
         palettes:
           - dataset: MapCellCatType_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   asii_prob:
     standard_name: asii_prob
@@ -611,8 +571,6 @@ enhancements:
         palettes:
           - dataset: asii_turb_prob_pal
             color_scale: 255
-            min_value: 0
-            max_value: 255
 
   day_microphysics_ahi:
     standard_name: day_microphysics_ahi

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -567,4 +567,6 @@ def test_producing_mode_p(fake_area, tmp_path, data):
     im = get_enhanced_image(sc[comp])
     assert im.mode == "P"
     np.testing.assert_array_equal(im.data.coords["bands"], ["P"])
-    np.testing.assert_array_equal(im.data.sel(bands="P"), fake_alti)
+    np.testing.assert_allclose(
+            im.data.sel(bands="P"),
+            ((fake_alti - rng[0]) * (255/np.ptp(rng))).round())

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -502,27 +502,27 @@ def fake_area():
 
 
 _nwcsaf_props = {
-     'cma': ('cma_pal', 'cloudmask', 'CMA'),
-     'ct': ('ct_pal', 'cloudtype', 'CT'),
-     'ctth_alti': ('ctth_alti_pal', 'cloud_top_height', 'CTTH'),
-     'ctth_pres': ('ctth_pres_pal', 'cloud_top_pressure', 'CTTH'),
-     'ctth_tempe': ('ctth_tempe_pal', 'cloud_top_temperature', 'CTTH'),
-     'cmic_phase': ('cmic_phase_pal', 'cloud_top_phase', 'CMIC'),
-     'cmic_reff': ('cmic_reff_pal', 'cloud_drop_effective_radius', 'CMIC'),
-     'cmic_cot': ('cmic_cot_pal', 'cloud_optical_thickness', 'CMIC'),
-     'cmic_lwp': ('cmic_lwp_pal', 'cloud_liquid_water_path', 'CMIC'),
-     'cmic_iwp': ('cmic_iwp_pal', 'cloud_ice_water_path', 'CMIC'),
-     'pc': ('pc_pal', 'precipitation_probability', 'PC'),
-     'crr': ('crr_pal', 'convective_rain_rate', 'CRR'),
-     'crr_accum': ('crr_pal', 'convective_precipitation_hourly_accumulation', 'CRR'),
-     'ishai_tpw': ('ishai_tpw_pal', 'total_precipitable_water', 'iSHAI'),
-     'ishai_shw': ('ishai_shw_pal', 'showalter_index', 'iSHAI'),
-     'ishai_li': ('ishai_li_pal', 'lifted_index', 'iSHAI'),
-     'ci_prob30': ('ci_pal', 'convection_initiation_prob30', 'CI'),
-     'ci_prob60': ('ci_pal', 'convection_initiation_prob60', 'CI'),
-     'ci_prob90': ('ci_pal', 'convection_initiation_prob90', 'CI'),
-     'asii_turb_trop_prob': ('asii_turb_prob_pal', 'asii_prob', 'ASII-NG'),
-     'MapCellCatType': ('MapCellCatType_pal', 'rdt_cell_type', 'RDT-CW')}
+     'cma': ('cma_pal', 'cloudmask', 'CMA', "uint8"),
+     'ct': ('ct_pal', 'cloudtype', 'CT', "uint8"),
+     'ctth_alti': ('ctth_alti_pal', 'cloud_top_height', 'CTTH', "float64"),
+     'ctth_pres': ('ctth_pres_pal', 'cloud_top_pressure', 'CTTH', "float64"),
+     'ctth_tempe': ('ctth_tempe_pal', 'cloud_top_temperature', 'CTTH', "float64"),
+     'cmic_phase': ('cmic_phase_pal', 'cloud_top_phase', 'CMIC', "uint8"),
+     'cmic_reff': ('cmic_reff_pal', 'cloud_drop_effective_radius', 'CMIC', "float64"),
+     'cmic_cot': ('cmic_cot_pal', 'cloud_optical_thickness', 'CMIC', "float64"),
+     'cmic_lwp': ('cmic_lwp_pal', 'cloud_liquid_water_path', 'CMIC', "float64"),
+     'cmic_iwp': ('cmic_iwp_pal', 'cloud_ice_water_path', 'CMIC', "float64"),
+     'pc': ('pc_pal', 'precipitation_probability', 'PC', "uint8"),
+     'crr': ('crr_pal', 'convective_rain_rate', 'CRR', "uint8"),
+     'crr_accum': ('crr_pal', 'convective_precipitation_hourly_accumulation', 'CRR', "uint8"),
+     'ishai_tpw': ('ishai_tpw_pal', 'total_precipitable_water', 'iSHAI', "float64"),
+     'ishai_shw': ('ishai_shw_pal', 'showalter_index', 'iSHAI', "float64"),
+     'ishai_li': ('ishai_li_pal', 'lifted_index', 'iSHAI', "float64"),
+     'ci_prob30': ('ci_pal', 'convection_initiation_prob30', 'CI', "float64"),
+     'ci_prob60': ('ci_pal', 'convection_initiation_prob60', 'CI', "float64"),
+     'ci_prob90': ('ci_pal', 'convection_initiation_prob90', 'CI', "float64"),
+     'asii_turb_trop_prob': ('asii_turb_prob_pal', 'asii_prob', 'ASII-NG', "float64"),
+     'MapCellCatType': ('MapCellCatType_pal', 'rdt_cell_type', 'RDT-CW', "uint8")}
 
 
 @pytest.mark.parametrize(
@@ -537,7 +537,8 @@ def test_producing_mode_p(fake_area, tmp_path, data):
     from satpy.writers import get_enhanced_image
 
     from ... import Scene
-    (palette, comp, label) = _nwcsaf_props[data]
+    (palette, comp, label, dtp) = _nwcsaf_props[data]
+    rng = (0, 100) if dtp == "uint8" else (-100, 1000)
     fk = tmp_path / f"S_NWC_{label:s}_MSG2_MSG-N-VISIR_20220124T094500Z.nc"
     # create a minimally fake netCDF file, otherwise satpy won't load the
     # composite
@@ -554,13 +555,14 @@ def test_producing_mode_p(fake_area, tmp_path, data):
     sc[palette] = xr.DataArray(
             da.tile(da.arange(256), [3, 1]).T,
             dims=("pal02_colors", "pal_RGB"))
-    fake_alti = da.full((2, 2), 8, chunks=2, dtype="uint8")
+    fake_alti = da.linspace(rng[0], rng[1], 4, chunks=2, dtype=dtp).reshape(2, 2)
     sc[data] = xr.DataArray(
             fake_alti,
             dims=("y", "x"),
             attrs={
                 "area": fake_area,
-                "ancillary_variables": [sc[palette]]})
+                "ancillary_variables": [sc[palette]],
+                "valid_range": rng})
     sc.load([comp])
     im = get_enhanced_image(sc[comp])
     assert im.mode == "P"

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -501,35 +501,43 @@ def fake_area():
     return create_area_def("wingertsberg", 4087, area_extent=[-2_000, -2_000, 2_000, 2_000], shape=(2, 2))
 
 
+_nwcsaf_props = {
+     'cma': ('cma_pal', 'cloudmask', 'CMA'),
+     'ct': ('ct_pal', 'cloudtype', 'CT'),
+     'ctth_alti': ('ctth_alti_pal', 'cloud_top_height', 'CTTH'),
+     'ctth_pres': ('ctth_pres_pal', 'cloud_top_pressure', 'CTTH'),
+     'ctth_tempe': ('ctth_tempe_pal', 'cloud_top_temperature', 'CTTH'),
+     'cmic_phase': ('cmic_phase_pal', 'cloud_top_phase', 'CMIC'),
+     'cmic_reff': ('cmic_reff_pal', 'cloud_drop_effective_radius', 'CMIC'),
+     'cmic_cot': ('cmic_cot_pal', 'cloud_optical_thickness', 'CMIC'),
+     'cmic_lwp': ('cmic_lwp_pal', 'cloud_liquid_water_path', 'CMIC'),
+     'cmic_iwp': ('cmic_iwp_pal', 'cloud_ice_water_path', 'CMIC'),
+     'pc': ('pc_pal', 'precipitation_probability', 'PC'),
+     'crr': ('crr_pal', 'convective_rain_rate', 'CRR'),
+     'crr_accum': ('crr_pal', 'convective_precipitation_hourly_accumulation', 'CRR'),
+     'ishai_tpw': ('ishai_tpw_pal', 'total_precipitable_water', 'iSHAI'),
+     'ishai_shw': ('ishai_shw_pal', 'showalter_index', 'iSHAI'),
+     'ishai_li': ('ishai_li_pal', 'lifted_index', 'iSHAI'),
+     'ci_prob30': ('ci_pal', 'convection_initiation_prob30', 'CI'),
+     'ci_prob60': ('ci_pal', 'convection_initiation_prob60', 'CI'),
+     'ci_prob90': ('ci_pal', 'convection_initiation_prob90', 'CI'),
+     'asii_turb_trop_prob': ('asii_turb_prob_pal', 'asii_prob', 'ASII-NG'),
+     'MapCellCatType': ('MapCellCatType_pal', 'rdt_cell_type', 'RDT-CW')}
+
+
 @pytest.mark.parametrize(
-        "data,palette,comp,label",
-        [("cma", "cma_pal", "cloudmask", "CMA"),
-         ("ct", "ct_pal", "cloudtype", "CT"),
-         ("ctth_alti", "ctth_alti_pal", "cloud_top_height", "CTTH"),
-         ("ctth_pres", "ctth_pres_pal", "cloud_top_pressure", "CTTH"),
-         ("ctth_tempe", "ctth_tempe_pal", "cloud_top_temperature", "CTTH"),
-         ("cmic_phase", "cmic_phase_pal", "cloud_top_phase", "CMIC"),
-         ("cmic_reff", "cmic_reff_pal", "cloud_drop_effective_radius", "CMIC"),
-         ("cmic_cot", "cmic_cot_pal", "cloud_optical_thickness", "CMIC"),
-         ("cmic_lwp", "cmic_lwp_pal", "cloud_liquid_water_path", "CMIC"),
-         ("cmic_iwp", "cmic_iwp_pal", "cloud_ice_water_path", "CMIC"),
-         ("pc", "pc_pal", "precipitation_probability", "PC"),
-         ("crr", "crr_pal", "convective_rain_rate", "CRR"),
-         ("crr_accum", "crr_pal", "convective_precipitation_hourly_accumulation", "CRR"),
-         ("ishai_tpw", "ishai_tpw_pal", "total_precipitable_water", "iSHAI"),
-         ("ishai_shw", "ishai_shw_pal", "showalter_index", "iSHAI"),
-         ("ishai_li", "ishai_li_pal", "lifted_index", "iSHAI"),
-         ("ci_prob30", "ci_pal", "convection_initiation_prob30", "CI"),
-         ("ci_prob60", "ci_pal", "convection_initiation_prob60", "CI"),
-         ("ci_prob90", "ci_pal", "convection_initiation_prob90", "CI"),
-         ("asii_turb_trop_prob", "asii_turb_prob_pal", "asii_prob", "ASII-NG"),
-         ("MapCellCatType", "MapCellCatType_pal", "rdt_cell_type", "RDT-CW"),
-         ])
-def test_producing_mode_p(fake_area, tmp_path, data, palette, comp, label):
+        "data",
+        ['cma', 'ct', 'ctth_alti', 'ctth_pres', 'ctth_tempe', 'cmic_phase',
+            'cmic_reff', 'cmic_cot', 'cmic_lwp', 'cmic_iwp', 'pc', 'crr',
+            'crr_accum', 'ishai_tpw', 'ishai_shw', 'ishai_li', 'ci_prob30',
+            'ci_prob60', 'ci_prob90', 'asii_turb_trop_prob', 'MapCellCatType']
+        )
+def test_producing_mode_p(fake_area, tmp_path, data):
     """Test producing mode p with  palettizer and ancillary variables."""
     from satpy.writers import get_enhanced_image
 
     from ... import Scene
+    (palette, comp, label) = _nwcsaf_props[data]
     fk = tmp_path / f"S_NWC_{label:s}_MSG2_MSG-N-VISIR_20220124T094500Z.nc"
     # create a minimally fake netCDF file, otherwise satpy won't load the
     # composite


### PR DESCRIPTION
Fix broken palette images for those datasets where the valid range is not 0 to 255.  When defining a composite with a palettize enhancement where the palette is read from the source file, one **should not** set `min_value` and `max_value` in the enhancement configuration!  If those are set and differ from the values defined in `valid_range` in the dataset to which the palette is being applied, the images will be wrong.  If `min_value` and `max_value` are set at all, they have to be equal to the values defined in `valid_range`, or the resulting colours will be wrong.  The correct and safe thing to do is to not set `min_value` and `max_value` at all.

 - [x] Closes #2371 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
