### PR TITLE
Add initial support for EUMETSAT's climatological calibration

### DIFF
--- a/satpy/dataset/__init__.py
+++ b/satpy/dataset/__init__.py
@@ -19,7 +19,5 @@
 
 from .anc_vars import dataset_walker, replace_anc  # noqa
 from .data_dict import DatasetDict, get_key  # noqa
-from .dataid import (  # noqa
-    DataID, DataQuery, ModifierTuple, WavelengthRange, create_filtered_query
-)
+from .dataid import DataID, DataQuery, ModifierTuple, WavelengthRange, create_filtered_query  # noqa
 from .metadata import combine_metadata  # noqa

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -383,7 +383,7 @@ def get_cds_time(days, msecs):
 
     time = (CDS_EPOCH.astype('datetime64[ms]') +
             days.astype('timedelta64[D]') + msecs.astype('timedelta64[ms]'))
-    time = np.where(time == CDS_EPOCH,  np.datetime64("NaT"), time)
+    time = np.where(time == CDS_EPOCH, np.datetime64("NaT"), time)
 
     if len(time) == 1:
         return time[0]

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -398,6 +398,10 @@ def load_eumclim_nc(fname, ref_time):
     try:
         with Dataset(fname, 'r') as fid:
             jul_time = jdays(ref_time)
+            min_tdiff = np.min(abs(jul_time - fid['julian_time']))
+            if min_tdiff > 1:
+                warnings.warn("Closest EUMCLIM calibration coefficients differ from image time by more than one day.",
+                              UserWarning)
             jul_idx = np.argmin(abs(jul_time - fid['julian_time']))
 
             eum_coef = {}

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -401,7 +401,7 @@ def load_eumclim_nc(fname, ref_time):
             jul_idx = np.argmin(abs(jul_time - fid['julian_time']))
 
             eum_coef = {}
-            for chan in EUMCLIM_COEF_MAP.keys():
+            for chan in EUMCLIM_COEF_MAP:
                 eum_coef[chan] = {'gain': float(fid[f'b_{EUMCLIM_COEF_MAP[chan]}'][jul_idx]),
                                   'offset': float(fid[f'a_{EUMCLIM_COEF_MAP[chan]}'][jul_idx])}
     except OSError:

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -371,13 +371,41 @@ def get_cds_time(days, msecs):
         days = np.array([days], dtype='int64')
         msecs = np.array([msecs], dtype='int64')
 
-    time = np.datetime64('1958-01-01').astype('datetime64[ms]') + \
-        days.astype('timedelta64[D]') + msecs.astype('timedelta64[ms]')
+    time = (np.datetime64('1958-01-01').astype('datetime64[ms]') +
+            days.astype('timedelta64[D]') + msecs.astype('timedelta64[ms]'))
     time[time == np.datetime64('1958-01-01 00:00')] = np.datetime64("NaT")
 
     if len(time) == 1:
         return time[0]
     return time
+
+
+def load_eumclim_nc(fname, ref_time):
+    """Load EUMETSAT climate calibration values from netCDF4."""
+    from netCDF4 import Dataset
+    from pyorbital.astronomy import jdays
+
+    try:
+        with Dataset(fname, 'r') as fid:
+            jul_time = jdays(ref_time)
+            jul_idx = np.argmin(abs(jul_time - fid['julian_time']))
+
+            coef_map = {'WV_062': 'IR062',
+                        'WV_073': 'IR073',
+                        'IR_087': 'IR087',
+                        'IR_097': 'IR097',
+                        'IR_108': 'IR108',
+                        'IR_120': 'IR120',
+                        'IR_134': 'IR134'}
+
+            eum_coef = {}
+            for chan in coef_map.keys():
+                eum_coef[chan] = {'gain': float(fid[f'b_{coef_map[chan]}'][jul_idx]),
+                                  'offset': float(fid[f'a_{coef_map[chan]}'][jul_idx])}
+    except OSError:
+        raise OSError(f'Error: EUM calibration file {fname} does not exist.')
+
+    return eum_coef
 
 
 def add_scanline_acq_time(dataset, acq_time):
@@ -552,19 +580,20 @@ class SEVIRICalibrationHandler:
     calibration algorithm.
     """
 
-    def __init__(self, platform_id, channel_name, coefs, calib_mode, scan_time):
+    def __init__(self, platform_id, channel_name, coefs, calib_mode, scan_time, calib_file=None):
         """Initialize the calibration handler."""
         self._platform_id = platform_id
         self._channel_name = channel_name
         self._coefs = coefs
         self._calib_mode = calib_mode.upper()
+        self._calib_file = calib_file
         self._scan_time = scan_time
         self._algo = SEVIRICalibrationAlgorithm(
             platform_id=self._platform_id,
             scan_time=self._scan_time
         )
 
-        valid_modes = ('NOMINAL', 'GSICS')
+        valid_modes = ('NOMINAL', 'GSICS', 'EUMCLIM')
         if self._calib_mode not in valid_modes:
             raise ValueError(
                 'Invalid calibration mode: {}. Choose one of {}'.format(
@@ -696,9 +725,9 @@ class OrbitPolynomial:
     def __eq__(self, other):
         """Test equality of two orbit polynomials."""
         return (
-            np.array_equal(self.coefs, np.array(other.coefs)) and
-            self.start_time == other.start_time and
-            self.end_time == other.end_time
+                np.array_equal(self.coefs, np.array(other.coefs)) and
+                self.start_time == other.start_time and
+                self.end_time == other.end_time
         )
 
 

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -55,6 +55,7 @@ from satpy.readers.seviri_base import (
     dec10216,
     get_cds_time,
     get_satpos,
+    load_eumclim_nc,
     pad_data_horizontally,
     pad_data_vertically,
 )
@@ -94,14 +95,15 @@ class NativeMSGFileHandler(BaseFileHandler):
     """
 
     def __init__(self, filename, filename_info, filetype_info,
-                 calib_mode='nominal', fill_disk=False, ext_calib_coefs=None,
-                 include_raw_metadata=False, mda_max_array_size=100):
+                 calib_mode='nominal', calib_file=None, fill_disk=False,
+                 ext_calib_coefs=None, include_raw_metadata=False, mda_max_array_size=100):
         """Initialize the reader."""
         super(NativeMSGFileHandler, self).__init__(filename,
                                                    filename_info,
                                                    filetype_info)
         self.platform_name = None
         self.calib_mode = calib_mode
+        self.calib_file = calib_file
         self.ext_calib_coefs = ext_calib_coefs or {}
         self.fill_disk = fill_disk
         self.include_raw_metadata = include_raw_metadata
@@ -119,6 +121,12 @@ class NativeMSGFileHandler(BaseFileHandler):
         self.dask_array = da.from_array(self._get_memmap(), chunks=(CHUNK_SIZE,))
         self._read_trailer()
         self.image_boundaries = ImageBoundaries(self.header, self.trailer, self.mda)
+
+        # Read the EUMETSAT climate calibration coefficients if available
+        if self.calib_mode == 'EUMCLIM':
+            self.eumclim_cal_coef = load_eumclim_nc(self.calib_file, self.observation_start_time)
+        else:
+            self.eumclim_cal_coef = {}
 
     def _has_archive_header(self):
         """Check whether the file includes an ASCII archive header."""
@@ -541,6 +549,15 @@ class NativeMSGFileHandler(BaseFileHandler):
         logger.debug("Calibration time " + str(datetime.now() - tic))
         return res
 
+    def _sort_ext_eum_coefs(self):
+        """Merge the external and eumetsat calibration dicts.
+
+        From: https://stackoverflow.com/questions/2365921/merging-python-dictionaries
+        """
+        output = {k: self.ext_calib_coefs[k] for k in self.ext_calib_coefs}
+        output.update({k: self.eumclim_cal_coef[k] for k in self.eumclim_cal_coef if k not in self.ext_calib_coefs})
+        return output
+
     def _get_calib_coefs(self, channel_name):
         """Get coefficients for calibration from counts to radiance."""
         # even though all the channels may not be present in the file,
@@ -554,6 +571,13 @@ class NativeMSGFileHandler(BaseFileHandler):
             'RadiometricProcessing']['MPEFCalFeedback']
         radiance_types = self.header['15_DATA_HEADER']['ImageDescription'][
                 'Level15ImageProduction']['PlannedChanProcessing']
+
+        # Merge potential external and EUMETSAT climatology coefficients
+        if self.calib_mode == 'EUMCLIM':
+            tmp_dict = self._sort_ext_eum_coefs()
+        else:
+            tmp_dict = self.ext_calib_coefs
+
         return create_coef_dict(
             coefs_nominal=(
                 coefs_nominal['CalSlope'][band_idx],
@@ -563,7 +587,7 @@ class NativeMSGFileHandler(BaseFileHandler):
                 coefs_gsics['GSICSCalCoeff'][band_idx],
                 coefs_gsics['GSICSOffsetCount'][band_idx]
             ),
-            ext_coefs=self.ext_calib_coefs.get(channel_name, {}),
+            ext_coefs=tmp_dict.get(channel_name, {}),
             radiance_type=radiance_types[band_idx]
         )
 

--- a/satpy/tests/reader_tests/test_seviri_base.py
+++ b/satpy/tests/reader_tests/test_seviri_base.py
@@ -27,6 +27,7 @@ import xarray as xr
 
 from satpy import CHUNK_SIZE
 from satpy.readers.seviri_base import (
+    EUMCLIM_COEF_MAP,
     NoValidOrbitParams,
     OrbitPolynomial,
     OrbitPolynomialFinder,
@@ -35,16 +36,41 @@ from satpy.readers.seviri_base import (
     get_cds_time,
     get_padding_area,
     get_satpos,
+    load_eumclim_nc,
     pad_data_horizontally,
     pad_data_vertically,
 )
+
+DUMMY_DATA = {'time': np.array([2458861.145949074,
+                               2458861.1563657406,
+                               2458861.1667824076])}
+for val in EUMCLIM_COEF_MAP:
+    DUMMY_DATA[f'{val}_gain'] = np.random.uniform(size=3)
+    DUMMY_DATA[f'{val}_offset'] = np.random.uniform(size=3)
+
+
+@pytest.fixture()
+def make_dummy_ncdf(tmp_path):
+    """Make a dummy netCDF file for coefficient testing."""
+    from netCDF4 import Dataset
+
+    fname = f'{tmp_path}/MSG1-COEFs.nc'
+    with Dataset(fname, 'w') as fid:
+        fid.createDimension('time', 3)
+        fid.createVariable('julian_time', np.float64, ('time',))[:] = DUMMY_DATA['time']
+        for val in EUMCLIM_COEF_MAP:
+            fid.createVariable(f'a_{EUMCLIM_COEF_MAP[val]}', np.float32, ('time',))[:] = DUMMY_DATA[f'{val}_offset']
+            fid.createVariable(f'b_{EUMCLIM_COEF_MAP[val]}', np.float32, ('time',))[:] = DUMMY_DATA[f'{val}_gain']
+
+    print(fname)
+    return fname
 
 
 def chebyshev4(c, x, domain):
     """Evaluate 4th order Chebyshev polynomial."""
     start_x, end_x = domain
     t = (x - 0.5 * (end_x + start_x)) / (0.5 * (end_x - start_x))
-    return c[0] + c[1]*t + c[2]*(2*t**2 - 1) + c[3]*(4*t**3 - 3*t) - 0.5*c[0]
+    return c[0] + c[1] * t + c[2] * (2 * t ** 2 - 1) + c[3] * (4 * t ** 3 - 3 * t) - 0.5 * c[0]
 
 
 class SeviriBaseTest(unittest.TestCase):
@@ -53,10 +79,10 @@ class SeviriBaseTest(unittest.TestCase):
     def test_dec10216(self):
         """Test the dec10216 function."""
         res = dec10216(np.array([255, 255, 255, 255, 255], dtype=np.uint8))
-        exp = (np.ones((4, )) * 1023).astype(np.uint16)
+        exp = (np.ones((4,)) * 1023).astype(np.uint16)
         np.testing.assert_equal(res, exp)
         res = dec10216(np.array([1, 1, 1, 1, 1], dtype=np.uint8))
-        exp = np.array([4,  16,  64, 257], dtype=np.uint16)
+        exp = np.array([4, 16, 64, 257], dtype=np.uint16)
         np.testing.assert_equal(res, exp)
 
     def test_chebyshev(self):
@@ -71,19 +97,19 @@ class SeviriBaseTest(unittest.TestCase):
     def test_get_cds_time(self):
         """Test the get_cds_time function."""
         # Scalar
-        self.assertEqual(get_cds_time(days=21246, msecs=12*3600*1000),
+        self.assertEqual(get_cds_time(days=21246, msecs=12 * 3600 * 1000),
                          np.datetime64('2016-03-03 12:00'))
 
         # Array
         days = np.array([21246, 21247, 21248])
-        msecs = np.array([12*3600*1000, 13*3600*1000 + 1, 14*3600*1000 + 2])
+        msecs = np.array([12 * 3600 * 1000, 13 * 3600 * 1000 + 1, 14 * 3600 * 1000 + 2])
         expected = np.array([np.datetime64('2016-03-03 12:00:00.000'),
                              np.datetime64('2016-03-04 13:00:00.001'),
                              np.datetime64('2016-03-05 14:00:00.002')])
         np.testing.assert_equal(get_cds_time(days=days, msecs=msecs), expected)
 
         days = 21246
-        msecs = 12*3600*1000
+        msecs = 12 * 3600 * 1000
         expected = np.datetime64('2016-03-03 12:00:00.000')
         np.testing.assert_equal(get_cds_time(days=days, msecs=msecs), expected)
 
@@ -113,7 +139,7 @@ class SeviriBaseTest(unittest.TestCase):
         west_bound = 13
         final_size = (1, 20)
         res = pad_data_horizontally(data, final_size, east_bound, west_bound)
-        expected = np.array([[np.nan, np.nan, np.nan,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,
+        expected = np.array([[np.nan, np.nan, np.nan, 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
                               np.nan, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]])
         np.testing.assert_equal(res, expected)
 
@@ -127,7 +153,7 @@ class SeviriBaseTest(unittest.TestCase):
         res = pad_data_vertically(data, final_size, south_bound, north_bound)
         expected = np.zeros(final_size)
         expected[:] = np.nan
-        expected[south_bound-1:north_bound] = 0.
+        expected[south_bound - 1:north_bound] = 0.
         np.testing.assert_equal(res, expected)
 
     @staticmethod
@@ -147,6 +173,41 @@ class SeviriBaseTest(unittest.TestCase):
         res = get_padding_area(shape, dtype)
         expected = da.full(shape, 0, dtype=dtype, chunks=CHUNK_SIZE)
         np.testing.assert_array_equal(res, expected)
+
+
+class TestEumClimCoef:
+    """Test loading of EUM climatological calibration coefficients."""
+
+    def test_load_eumclim_nc_badfile(self):
+        """Test case where no data file is found."""
+        with pytest.raises(OSError):
+            load_eumclim_nc('/nodir/nonsensefile.nc', datetime(2000, 1, 1, 12, 0, 0))
+
+    def test_load_eumclim_nc_pastfile(self, make_dummy_ncdf):
+        """Test we get first value if we specify time in distant past."""
+        with pytest.warns(UserWarning):
+            retval = load_eumclim_nc(make_dummy_ncdf, datetime(1900, 1, 1, 12, 0, 0))
+        np.testing.assert_allclose(retval['WV_073']['gain'], DUMMY_DATA['WV_073_gain'][0])
+        np.testing.assert_allclose(retval['IR_120']['offset'], DUMMY_DATA['IR_120_offset'][0])
+
+    def test_load_eumclim_nc_futurefile(self, make_dummy_ncdf):
+        """Test we get last value if we specify time in distant past."""
+        with pytest.warns(UserWarning):
+            retval = load_eumclim_nc(make_dummy_ncdf, datetime(2040, 1, 1, 12, 0, 0))
+        np.testing.assert_allclose(retval['WV_073']['gain'], DUMMY_DATA['WV_073_gain'][-1])
+        np.testing.assert_allclose(retval['IR_120']['offset'], DUMMY_DATA['IR_120_offset'][-1])
+
+    def test_load_eumclim_nc_goodfile(self, make_dummy_ncdf):
+        """Test we get correct value when we pass appropriate times."""
+        retval = load_eumclim_nc(make_dummy_ncdf, datetime(2020, 1, 12, 15, 36, 0))
+        np.testing.assert_allclose(retval['WV_073']['gain'], DUMMY_DATA['WV_073_gain'][0])
+        np.testing.assert_allclose(retval['IR_120']['offset'], DUMMY_DATA['IR_120_offset'][0])
+        retval = load_eumclim_nc(make_dummy_ncdf, datetime(2020, 1, 12, 15, 46, 0))
+        np.testing.assert_allclose(retval['WV_073']['gain'], DUMMY_DATA['WV_073_gain'][1])
+        np.testing.assert_allclose(retval['IR_120']['offset'], DUMMY_DATA['IR_120_offset'][1])
+        retval = load_eumclim_nc(make_dummy_ncdf, datetime(2020, 1, 12, 15, 56, 0))
+        np.testing.assert_allclose(retval['WV_073']['gain'], DUMMY_DATA['WV_073_gain'][2])
+        np.testing.assert_allclose(retval['IR_120']['offset'], DUMMY_DATA['IR_120_offset'][2])
 
 
 ORBIT_POLYNOMIALS = {
@@ -279,13 +340,13 @@ class TestOrbitPolynomialFinder:
         [
             # Contiguous validity intervals (that's the norm)
             (
-                ORBIT_POLYNOMIALS_SYNTH,
-                datetime(2005, 12, 31, 12, 15),
-                OrbitPolynomial(
-                    coefs=(2.0, 2.1, 2.2),
-                    start_time=np.datetime64('2005-12-31 12:00'),
-                    end_time=np.datetime64('2005-12-31 18:00')
-                )
+                    ORBIT_POLYNOMIALS_SYNTH,
+                    datetime(2005, 12, 31, 12, 15),
+                    OrbitPolynomial(
+                        coefs=(2.0, 2.1, 2.2),
+                        start_time=np.datetime64('2005-12-31 12:00'),
+                        end_time=np.datetime64('2005-12-31 18:00')
+                    )
             ),
             # No interval enclosing the given timestamp, but closest interval
             # not too far away


### PR DESCRIPTION
EUMETSAT are working on long-term calibration coefficients for SEVIRI, which will be available as external files specifying the gain and offset for each satellite over their lifetime.

This PR adds initial support for these calibration coefficients as an additional calibration method, `EUMCLIM`. Currently, I've only added support for the `native` reader, as this is the data format for historical images on the data store and eoportal. I will also add support to the HRIT and netCDF readers at a later point, as this should be reasonably straightforward.

This is a draft for now as I need to add the docs.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
