### PR TITLE
Adapt unit test between categorical and continuous

### DIFF
--- a/satpy/dataset/__init__.py
+++ b/satpy/dataset/__init__.py
@@ -19,7 +19,5 @@
 
 from .anc_vars import dataset_walker, replace_anc  # noqa
 from .data_dict import DatasetDict, get_key  # noqa
-from .dataid import (  # noqa
-    DataID, DataQuery, ModifierTuple, WavelengthRange, create_filtered_query
-)
+from .dataid import DataID, DataQuery, ModifierTuple, WavelengthRange, create_filtered_query  # noqa
 from .metadata import combine_metadata  # noqa

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -567,6 +567,9 @@ def test_producing_mode_p(fake_area, tmp_path, data):
     im = get_enhanced_image(sc[comp])
     assert im.mode == "P"
     np.testing.assert_array_equal(im.data.coords["bands"], ["P"])
-    np.testing.assert_allclose(
-            im.data.sel(bands="P"),
-            ((fake_alti - rng[0]) * (255/np.ptp(rng))).round())
+    if dtp == "float64":
+        np.testing.assert_allclose(
+                im.data.sel(bands="P"),
+                ((fake_alti - rng[0]) * (255/np.ptp(rng))).round())
+    else:
+        np.testing.assert_allclose(im.data.sel(bands="P"), fake_alti)


### PR DESCRIPTION
Adapt unit test for pmode imagery to test the different behaviour expected for float or int data.

This doesn't actually fix any bug, because the fix for #2376 turns out to be in trollimage, where it's fixed by https://github.com/pytroll/trollimage/pull/123.  However, I think it's still useful to test for this in satpy because of the closely tied interface between the two.

Depends on https://github.com/pytroll/trollimage/pull/123.

Also changes the spelling of an import in `dataset/__init__.py` to make isort happy.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
