### PR TITLE
Fix Scene storage options not being used if no other reader_kwargs are passed

### DIFF
--- a/satpy/tests/test_scene.py
+++ b/satpy/tests/test_scene.py
@@ -657,13 +657,13 @@ class TestScene:
                 Scene(filenames=filenames, reader_kwargs=reader_kwargs)
                 open_files.assert_called_once_with(filenames)
 
-    def test_storage_options_from_reader_kwargs_single_dict(self):
+    @pytest.mark.parametrize("reader_kwargs", [{}, {'reader_opt': 'foo'}])
+    def test_storage_options_from_reader_kwargs_single_dict(self, reader_kwargs):
         """Test getting storage options from reader kwargs.
 
         Case where a single dict is given for all readers with some common storage options.
         """
         filenames = ["s3://data-bucket/file1", "s3://data-bucket/file2", "s3://data-bucket/file3"]
-        reader_kwargs = {'reader_opt': 'foo'}
         expected_reader_kwargs = reader_kwargs.copy()
         storage_options = {'option1': '1'}
         reader_kwargs['storage_options'] = storage_options

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -660,9 +660,12 @@ def get_storage_options_from_reader_kwargs(reader_kwargs):
 def _get_storage_dictionary_options(reader_kwargs):
     storage_opt_dict = {}
     shared_storage_options = reader_kwargs.pop("storage_options", {})
+    if not reader_kwargs:
+        # no other reader kwargs
+        return shared_storage_options
     for reader_name, rkwargs in reader_kwargs.items():
         if not isinstance(rkwargs, dict):
-            # reader kwargs are not per-reader, return a single dictonary of storage options
+            # reader kwargs are not per-reader, return a single dictionary of storage options
             return shared_storage_options
         if shared_storage_options:
             # set base storage options if there are any


### PR DESCRIPTION
The tests added in #2335 weren't robust enough. This fixes the issues identified in #2381.

 - [x] Closes #2381 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

CC @simonrp84 
