### PR TITLE
Improve handing of deprecation warnings for deprecated YAML composite recipes

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -425,7 +425,7 @@ class GenericCompositor(CompositeBase):
     def __call__(self, projectables, nonprojectables=None, **attrs):
         """Build the composite."""
         if 'deprecation_warning' in self.attrs:
-            warnings.warn(self.attrs['deprecation_warning'], RuntimeWarning)
+            warnings.warn(self.attrs['deprecation_warning'], UserWarning)
             self.attrs.pop('deprecation_warning', None)
         num = len(projectables)
         mode = attrs.get('mode')

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -426,6 +426,7 @@ class GenericCompositor(CompositeBase):
         """Build the composite."""
         if 'deprecation_warning' in self.attrs:
             warnings.warn(self.attrs['deprecation_warning'], RuntimeWarning)
+            self.attrs.pop('deprecation_warning', None)
         num = len(projectables)
         mode = attrs.get('mode')
         if mode is None:

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -424,6 +424,8 @@ class GenericCompositor(CompositeBase):
 
     def __call__(self, projectables, nonprojectables=None, **attrs):
         """Build the composite."""
+        if 'deprecation_warning' in self.attrs:
+            warnings.warn(self.attrs['deprecation_warning'], RuntimeWarning)
         num = len(projectables)
         mode = attrs.get('mode')
         if mode is None:

--- a/satpy/composites/spectral.py
+++ b/satpy/composites/spectral.py
@@ -176,5 +176,5 @@ class GreenCorrector(SpectralBlender):
         """Set default keyword argument values."""
         warnings.warn(
             "'GreenCorrector' is deprecated, use 'SpectralBlender' instead, or 'HybridGreen' for hybrid green"
-            " correction following Miller et al. (2016).", RuntimeWarning)
+            " correction following Miller et al. (2016).", UserWarning)
         super().__init__(fractions=fractions, *args, **kwargs)

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -16,8 +16,8 @@ modifiers:
 
 composites:
   green:
-    # Deprecated green composite using deprecated class 'GreenCorrector'. Use 'hybrid_green' instead.
-    compositor: !!python/name:satpy.composites.spectral.GreenCorrector
+    # Deprecated composite name. Use the equivalent 'hybrid_green' instead.
+    compositor: !!python/name:satpy.composites.spectral.HybridGreen
     # FUTURE: Set a wavelength...see what happens. Dependency finding
     #         probably wouldn't work.
     prerequisites:
@@ -30,10 +30,10 @@ composites:
     standard_name: toa_bidirectional_reflectance
 
   green_true_color_reproduction:
-    # Deprecated green composite using deprecated class 'GreenCorrector'. Use 'reproduced_green' instead.
+    # Deprecated composite name. Use the equivalent 'reproduced_green' instead.
     # JMA True Color Reproduction green band
     # http://www.jma.go.jp/jma/jma-eng/satellite/introduction/TCR.html
-    compositor: !!python/name:satpy.composites.spectral.GreenCorrector
+    compositor: !!python/name:satpy.composites.spectral.SpectralBlender
     fractions: [0.6321, 0.2928, 0.0751]
     prerequisites:
       - name: B02
@@ -45,8 +45,8 @@ composites:
     standard_name: none
 
   green_nocorr:
-    # Deprecated green composite using deprecated class 'GreenCorrector'. Use 'hybrid_green_nocorr' instead.
-    compositor: !!python/name:satpy.composites.spectral.GreenCorrector
+    # Deprecated composite name. Use the equivalent 'hybrid_green_nocorr' instead.
+    compositor: !!python/name:satpy.composites.spectral.HybridGreen
     # FUTURE: Set a wavelength...see what happens. Dependency finding
     #         probably wouldn't work.
     prerequisites:

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -16,7 +16,7 @@ modifiers:
 
 composites:
   green:
-    # Deprecated composite name. Use the equivalent 'hybrid_green' instead.
+    deprecation_warning: "'green' is a deprecated composite. Use the equivalent 'hybrid_green' instead."
     compositor: !!python/name:satpy.composites.spectral.HybridGreen
     # FUTURE: Set a wavelength...see what happens. Dependency finding
     #         probably wouldn't work.
@@ -30,9 +30,9 @@ composites:
     standard_name: toa_bidirectional_reflectance
 
   green_true_color_reproduction:
-    # Deprecated composite name. Use the equivalent 'reproduced_green' instead.
     # JMA True Color Reproduction green band
     # http://www.jma.go.jp/jma/jma-eng/satellite/introduction/TCR.html
+    deprecation_warning: "'green_true_color_reproduction' is a deprecated composite. Use the equivalent 'reproduced_green' instead."
     compositor: !!python/name:satpy.composites.spectral.SpectralBlender
     fractions: [0.6321, 0.2928, 0.0751]
     prerequisites:
@@ -45,7 +45,7 @@ composites:
     standard_name: none
 
   green_nocorr:
-    # Deprecated composite name. Use the equivalent 'hybrid_green_nocorr' instead.
+    deprecation_warning: "'green_nocorr' is a deprecated composite. Use the equivalent 'hybrid_green_nocorr' instead."
     compositor: !!python/name:satpy.composites.spectral.HybridGreen
     # FUTURE: Set a wavelength...see what happens. Dependency finding
     #         probably wouldn't work.

--- a/satpy/etc/composites/ami.yaml
+++ b/satpy/etc/composites/ami.yaml
@@ -2,35 +2,35 @@ sensor_name: visir/ami
 
 composites:
   green_raw:
-    # Deprecated green composite using deprecated class 'GreenCorrector'. Use 'hybrid_green_raw' instead.
-    compositor: !!python/name:satpy.composites.spectral.GreenCorrector
+    # Deprecated composite name. Use the equivalent 'hybrid_green_raw' instead.
+    compositor: !!python/name:satpy.composites.spectral.HybridGreen
     prerequisites:
       - name: VI005
         modifiers: [sunz_corrected]
       - name: VI008
         modifiers: [sunz_corrected]
     standard_name: toa_bidirectional_reflectance
-    fractions: [0.85, 0.15]
+    fraction: 0.15
 
   green:
-    # Deprecated green composite using deprecated class 'GreenCorrector'. Use 'hybrid_green' instead.
-    compositor: !!python/name:satpy.composites.spectral.GreenCorrector
+    # Deprecated composite name. Use the equivalent 'hybrid_green' instead.
+    compositor: !!python/name:satpy.composites.spectral.HybridGreen
     prerequisites:
       - name: VI005
         modifiers: [sunz_corrected, rayleigh_corrected]
       - name: VI008
         modifiers: [sunz_corrected]
     standard_name: toa_bidirectional_reflectance
-    fractions: [0.85, 0.15]
+    fraction: 0.15
 
   green_nocorr:
-    # Deprecated green composite using deprecated class 'GreenCorrector'. Use 'hybrid_green_nocorr' instead.
-    compositor: !!python/name:satpy.composites.spectral.GreenCorrector
+    # Deprecated  composite name. Use the equivalent 'hybrid_green_nocorr' instead.
+    compositor: !!python/name:satpy.composites.spectral.HybridGreen
     prerequisites:
       - name: VI005
       - name: VI008
     standard_name: toa_reflectance
-    fractions: [0.85, 0.15]
+    fraction: 0.15
 
   hybrid_green_raw:
     compositor: !!python/name:satpy.composites.spectral.HybridGreen

--- a/satpy/etc/composites/ami.yaml
+++ b/satpy/etc/composites/ami.yaml
@@ -2,7 +2,7 @@ sensor_name: visir/ami
 
 composites:
   green_raw:
-    # Deprecated composite name. Use the equivalent 'hybrid_green_raw' instead.
+    deprecation_warning: "'green_raw' is a deprecated composite. Use the equivalent 'hybrid_green_raw' instead."
     compositor: !!python/name:satpy.composites.spectral.HybridGreen
     prerequisites:
       - name: VI005
@@ -13,7 +13,7 @@ composites:
     fraction: 0.15
 
   green:
-    # Deprecated composite name. Use the equivalent 'hybrid_green' instead.
+    deprecation_warning: "'green' is a deprecated composite. Use the equivalent 'hybrid_green' instead."
     compositor: !!python/name:satpy.composites.spectral.HybridGreen
     prerequisites:
       - name: VI005
@@ -24,7 +24,7 @@ composites:
     fraction: 0.15
 
   green_nocorr:
-    # Deprecated  composite name. Use the equivalent 'hybrid_green_nocorr' instead.
+    deprecation_warning: "'green_nocorr' is a deprecated composite. Use the equivalent 'hybrid_green_nocorr' instead."
     compositor: !!python/name:satpy.composites.spectral.HybridGreen
     prerequisites:
       - name: VI005

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -316,10 +316,8 @@ def fake_area():
 @pytest.fixture
 def fake_dataset_pair(fake_area):
     """Return a fake pair of 2×2 datasets."""
-    ds1 = xr.DataArray(
-            da.full((2, 2), 8, chunks=2, dtype=np.float32), attrs={"area": fake_area})
-    ds2 = xr.DataArray(
-            da.full((2, 2), 4, chunks=2, dtype=np.float32), attrs={"area": fake_area})
+    ds1 = xr.DataArray(da.full((2, 2), 8, chunks=2, dtype=np.float32), attrs={"area": fake_area})
+    ds2 = xr.DataArray(da.full((2, 2), 4, chunks=2, dtype=np.float32), attrs={"area": fake_area})
     return (ds1, ds2)
 
 
@@ -497,21 +495,11 @@ class TestMultiFiller(unittest.TestCase):
         from satpy.composites import MultiFiller
         comp = MultiFiller(name='fill_test')
         attrs = {"units": "K"}
-        a = xr.DataArray(
-                np.array([1, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]),
-                attrs=attrs.copy())
-        b = xr.DataArray(
-                np.array([np.nan, 2, 3, np.nan, np.nan, np.nan, np.nan]),
-                attrs=attrs.copy())
-        c = xr.DataArray(
-                np.array([np.nan, 22, 3, np.nan, np.nan, np.nan, 7]),
-                attrs=attrs.copy())
-        d = xr.DataArray(
-                np.array([np.nan, np.nan, np.nan, np.nan, np.nan, 6, np.nan]),
-                attrs=attrs.copy())
-        e = xr.DataArray(
-                np.array([np.nan, np.nan, np.nan, np.nan, 5, np.nan, np.nan]),
-                attrs=attrs.copy())
+        a = xr.DataArray(np.array([1, np.nan, np.nan, np.nan, np.nan, np.nan, np.nan]), attrs=attrs.copy())
+        b = xr.DataArray(np.array([np.nan, 2, 3, np.nan, np.nan, np.nan, np.nan]), attrs=attrs.copy())
+        c = xr.DataArray(np.array([np.nan, 22, 3, np.nan, np.nan, np.nan, 7]), attrs=attrs.copy())
+        d = xr.DataArray(np.array([np.nan, np.nan, np.nan, np.nan, np.nan, 6, np.nan]), attrs=attrs.copy())
+        e = xr.DataArray(np.array([np.nan, np.nan, np.nan, np.nan, 5, np.nan, np.nan]), attrs=attrs.copy())
         expected = xr.DataArray(np.array([1, 2, 3, np.nan, 5, 6, 7]))
         res = comp([a, b, c], optional_datasets=[d, e])
         np.testing.assert_allclose(res.data, expected.data)
@@ -1010,6 +998,13 @@ class TestGenericCompositor(unittest.TestCase):
         self.assertIsNone(res.attrs['wavelength'])
         self.assertEqual(res.attrs['mode'], 'LA')
         self.assertEqual(res.attrs['resolution'], 333)
+
+    def test_deprecation_warning(self):
+        """Test deprecation warning for dcprecated composite recipes."""
+        warning_message = 'foo is a deprecated composite. Use composite bar instead.'
+        self.comp.attrs['deprecation_warning'] = warning_message
+        with pytest.warns(RuntimeWarning, match=warning_message):
+            self.comp([self.all_valid])
 
 
 class TestAddBands(unittest.TestCase):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -1003,7 +1003,7 @@ class TestGenericCompositor(unittest.TestCase):
         """Test deprecation warning for dcprecated composite recipes."""
         warning_message = 'foo is a deprecated composite. Use composite bar instead.'
         self.comp.attrs['deprecation_warning'] = warning_message
-        with pytest.warns(RuntimeWarning, match=warning_message):
+        with pytest.warns(UserWarning, match=warning_message):
             self.comp([self.all_valid])
 
 


### PR DESCRIPTION
This PR makes the old deprecated composite YAML recipes point to the new green correction classes introduced in PR2280. This is done in order to avoid the deprecations warnings that are currently thrown when all composite YAML recipes are being initialized, meaning that the warnings are shown even if the deprecated composites are not loaded.

I also added the possibility to throw deprecation warnings for given composite YAML recipe by introducing the key `deprecation_warning`. If this key is defined in the YAML recipe a runtime deprecation warning will be thrown in the `__call__` method of `GenericCompositor`. I initially implemented this in the `SpectralBlender` class which would cover all cases dealt with in this PR,  but then I lifted it out to `Generic Compositor` in order to open up this potentially useful feature to all composites.

 - [x] Closes #2363 
 - [x] Tests added 
