### PR TITLE
Fix gap between day/night-only composites

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -731,7 +731,7 @@ class DayNightCompositor(GenericCompositor):
 
         return coszen.clip(0, 1)
 
-    def _get_data_for_single_side_product(self, foreground_data, coszen):
+    def _get_data_for_single_side_product(self, foreground_data, weights):
         # Only one portion (day or night) is selected. One composite is requested.
         # Add alpha band to single L/RGB composite to make the masked-out portion transparent when needed
         # L -> LA
@@ -739,19 +739,19 @@ class DayNightCompositor(GenericCompositor):
         if self.include_alpha:
             foreground_data = add_alpha_bands(foreground_data)
         else:
-            coszen = self._mask_coszen(coszen)
+            weights = self._mask_weights(weights)
 
-        day_data, night_data = self._weight_single_side_data(foreground_data, coszen)
-        return day_data, night_data, coszen
+        day_data, night_data = self._weight_single_side_data(foreground_data, weights)
+        return day_data, night_data, weights
 
-    def _mask_coszen(self, coszen):
+    def _mask_weights(self, weights):
         if "day" in self.day_night:
-            return da.where(coszen != 0, coszen, np.nan).compute()
-        return da.where(coszen != 1, coszen, np.nan).compute()
+            return da.where(weights != 0, weights, np.nan).compute()
+        return da.where(weights != 1, weights, np.nan).compute()
 
-    def _weight_single_side_data(self, foreground_data, coszen):
+    def _weight_single_side_data(self, foreground_data, weights):
         if self.include_alpha:
-            weight = coszen if "day" in self.day_night else (1 - coszen)
+            weight = weights if "day" in self.day_night else (1 - weights)
             foreground_data[-1, :, :] = foreground_data[-1, :, :] * weight
         if "day" in self.day_night:
             return foreground_data, 0

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -750,10 +750,11 @@ class DayNightCompositor(GenericCompositor):
         return da.where(coszen != 1, coszen, np.nan).compute()
 
     def _weight_single_side_data(self, foreground_data, coszen):
+        if self.include_alpha:
+            weight = coszen if "day" in self.day_night else (1 - coszen)
+            foreground_data[-1, :, :] = foreground_data[-1, :, :] * weight
         if "day" in self.day_night:
-            foreground_data[-1, :, :] = foreground_data[-1, :, :] * coszen
             return foreground_data, 0
-        foreground_data[-1, :, :] = foreground_data[-1, :, :] * (1 - coszen)
         return 0, foreground_data
 
     def _get_data_for_combined_product(self, day_data, night_data):

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -726,12 +726,12 @@ class DayNightCompositor(GenericCompositor):
             # Determine the composite position
             if "day" in self.day_night:
                 foreground_data[-1, :, :] = foreground_data[-1, :, :] * coszen
-                day_portion = foreground_data
-                night_portion = 0
+                day_data = foreground_data
+                night_data = 0
             else:
                 foreground_data[-1, :, :] = foreground_data[-1, :, :] * (1 - coszen)
-                night_portion = foreground_data
-                day_portion = 0
+                night_data = foreground_data
+                day_data = 0
 
         else:
             # Both day and night portions are selected. Two composites are requested. Get the second one merged.
@@ -758,11 +758,12 @@ class DayNightCompositor(GenericCompositor):
             day_data = foreground_data
             night_data = background_data
 
+        if "only" not in self.day_night or self.include_alpha is False:
             # Blend the two images together
-            day_portion = coszen * day_data
-            night_portion = (1 - coszen) * night_data
+            day_data = coszen * day_data
+            night_data = (1 - coszen) * night_data
 
-        data = night_portion + day_portion
+        data = night_data + day_data
         data.attrs = attrs
 
         # Split to separate bands so the mode is correct

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -456,8 +456,9 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=False)
         res = comp((self.data_a, self.sza))
         res = res.compute()
-        expected_red_channel = np.array([[0., 0.22122352], [np.nan, np.nan]])
-        np.testing.assert_allclose(res.values[0], expected_red_channel)
+        expected_channel_data = np.array([[0., 0.22122352], [np.nan, np.nan]])
+        for i in range(3):
+            np.testing.assert_allclose(res.values[i], expected_channel_data)
         assert res.shape[0] == 3
 
     def test_day_only_area_with_alpha(self):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -394,8 +394,9 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="day_night")
         res = comp((self.data_a, self.data_b))
         res = res.compute()
-        expected = np.array([[0., 0.33164983], [0.66835017, 1.]])
-        np.testing.assert_allclose(res.values[0], expected)
+        expected_channel = np.array([[0., 0.33164983], [0.66835017, 1.]])
+        for i in range(3):
+            np.testing.assert_allclose(res.values[i], expected_channel)
 
     def test_night_only_sza_with_alpha(self):
         """Test compositor with night portion with alpha band when SZA data is included."""
@@ -435,8 +436,8 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=False)
         res = comp((self.data_b),)
         res = res.compute()
-        expected = np.array([np.nan, np.nan])
-        np.testing.assert_allclose(res.values[0], expected)
+        expected = np.array([[np.nan, 0.], [0.5, 1]])
+        np.testing.assert_allclose(res.values, expected)
         assert res.ndim == 2
 
     def test_day_only_sza_with_alpha(self):
@@ -456,7 +457,7 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=False)
         res = comp((self.data_a, self.sza))
         res = res.compute()
-        expected_channel_data = np.array([[0., 0.22122352], [np.nan, np.nan]])
+        expected_channel_data = np.array([[0., 0.33164983], [0.66835017, 1.]])
         for i in range(3):
             np.testing.assert_allclose(res.values[i], expected_channel_data)
         assert res.shape[0] == 3

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -456,7 +456,7 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=False)
         res = comp((self.data_a, self.sza))
         res = res.compute()
-        expected_red_channel = np.array([[0., 0.33164983], [np.nan, np.nan]])
+        expected_red_channel = np.array([[0., 0.22122352], [np.nan, np.nan]])
         np.testing.assert_allclose(res.values[0], expected_red_channel)
         assert res.shape[0] == 3
 

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -413,17 +413,17 @@ class TestDayNightCompositor(unittest.TestCase):
         """Test compositor with night portion without alpha band when SZA data is included."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=False)
-        res = comp((self.data_b, self.sza))
+        res = comp((self.data_a, self.sza))
         res = res.compute()
-        expected = np.array([[np.nan, 0.], [0.5, 1.]])
+        expected = np.array([[0., 0.11042631], [0.66835017, 1.]])
         np.testing.assert_allclose(res.values[0], expected)
-        assert res.shape[0] == 3
+        assert 'A' not in res.bands
 
     def test_night_only_area_with_alpha(self):
         """Test compositor with night portion with alpha band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=True)
-        res = comp((self.data_b),)
+        res = comp((self.data_b,))
         res = res.compute()
         expected_l_channel = np.array([[np.nan, 0.], [0.5, 1.]])
         expected_alpha = np.array([[np.nan, 0.], [0., 0.]])
@@ -434,11 +434,11 @@ class TestDayNightCompositor(unittest.TestCase):
         """Test compositor with night portion without alpha band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=False)
-        res = comp((self.data_b),)
+        res = comp((self.data_b,))
         res = res.compute()
-        expected = np.array([[np.nan, 0.], [0.5, 1]])
-        np.testing.assert_allclose(res.values, expected)
-        assert res.ndim == 2
+        expected = np.array([[np.nan, 0.], [0., 0.]])
+        np.testing.assert_allclose(res.values[0], expected)
+        assert 'A' not in res.bands
 
     def test_day_only_sza_with_alpha(self):
         """Test compositor with day portion with alpha band when SZA data is included."""
@@ -457,16 +457,16 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=False)
         res = comp((self.data_a, self.sza))
         res = res.compute()
-        expected_channel_data = np.array([[0., 0.33164983], [0.66835017, 1.]])
+        expected_channel_data = np.array([[0., 0.22122352], [0., 0.]])
         for i in range(3):
             np.testing.assert_allclose(res.values[i], expected_channel_data)
-        assert res.shape[0] == 3
+        assert 'A' not in res.bands
 
     def test_day_only_area_with_alpha(self):
         """Test compositor with day portion with alpha_band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=True)
-        res = comp((self.data_a),)
+        res = comp((self.data_a, ))
         res = res.compute()
         expected_l_channel = np.array([[0., 0.33164983], [0.66835017, 1.]])
         expected_alpha = np.array([[1., 1.], [1., 1.]])
@@ -488,11 +488,11 @@ class TestDayNightCompositor(unittest.TestCase):
         """Test compositor with day portion without alpha_band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=False)
-        res = comp((self.data_a),)
+        res = comp((self.data_a,))
         res = res.compute()
-        expected = np.array([0., 0.33164983])
+        expected = np.array([[0., 0.33164983], [0.66835017, 1.]])
         np.testing.assert_allclose(res.values[0], expected)
-        assert res.ndim == 2
+        assert 'A' not in res.bands
 
 
 class TestFillingCompositor(unittest.TestCase):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -422,7 +422,7 @@ class TestDayNightCompositor(unittest.TestCase):
         """Test compositor with night portion with alpha band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=True)
-        res = comp(self.data_b)
+        res = comp((self.data_b),)
         res = res.compute()
         expected_l_channel = np.array([[np.nan, 0.], [0.5, 1.]])
         expected_alpha = np.array([[np.nan, 0.], [0., 0.]])
@@ -433,7 +433,7 @@ class TestDayNightCompositor(unittest.TestCase):
         """Test compositor with night portion without alpha band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=False)
-        res = comp(self.data_b)
+        res = comp((self.data_b),)
         res = res.compute()
         expected = np.array([np.nan, np.nan])
         np.testing.assert_allclose(res.values[0], expected)
@@ -465,7 +465,7 @@ class TestDayNightCompositor(unittest.TestCase):
         """Test compositor with day portion with alpha_band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=True)
-        res = comp(self.data_a)
+        res = comp((self.data_a),)
         res = res.compute()
         expected_l_channel = np.array([[0., 0.33164983], [0.66835017, 1.]])
         expected_alpha = np.array([[1., 1.], [1., 1.]])
@@ -476,7 +476,7 @@ class TestDayNightCompositor(unittest.TestCase):
         """Test compositor with day portion with alpha_band when SZA data is not provided and there is missing data."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=True)
-        res = comp(self.data_b)
+        res = comp((self.data_b,))
         res = res.compute()
         expected_l_channel = np.array([[np.nan, 0.], [0.5, 1.]])
         expected_alpha = np.array([[np.nan, 1.], [1., 1.]])
@@ -487,7 +487,7 @@ class TestDayNightCompositor(unittest.TestCase):
         """Test compositor with day portion without alpha_band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
         comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=False)
-        res = comp(self.data_a)
+        res = comp((self.data_a),)
         res = res.compute()
         expected = np.array([0., 0.33164983])
         np.testing.assert_allclose(res.values[0], expected)

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -421,8 +421,10 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=True)
         res = comp(self.data_b)
         res = res.compute()
-        expected = np.array([[np.nan, np.nan], [np.nan, np.nan]])
-        np.testing.assert_allclose(res.values[0], expected)
+        expected_l_channel = np.array([[np.nan, 0.], [0.5, 1.]])
+        expected_alpha = np.array([[np.nan, 0.], [0., 0.]])
+        np.testing.assert_allclose(res.values[0], expected_l_channel)
+        np.testing.assert_allclose(res.values[-1], expected_alpha)
 
     def test_night_only_area_without_alpha(self):
         """Test compositor with night portion without alpha band when SZA data is not provided."""
@@ -439,8 +441,10 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=True)
         res = comp((self.data_a, self.sza))
         res = res.compute()
-        expected = np.array([[0., 0.22122352], [np.nan, np.nan]])
-        np.testing.assert_allclose(res.values[0], expected)
+        expected_red_channel = np.array([[0., 0.33164983], [0.66835017, 1.]])
+        expected_alpha = np.array([[1., 0.66703944], [0., 0.]])
+        np.testing.assert_allclose(res.values[0], expected_red_channel)
+        np.testing.assert_allclose(res.values[-1], expected_alpha)
 
     def test_day_only_sza_without_alpha(self):
         """Test compositor with day portion without alpha band when SZA data is included."""
@@ -448,8 +452,9 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=False)
         res = comp((self.data_a, self.sza))
         res = res.compute()
-        expected = np.array([[0., 0.22122352], [np.nan, np.nan]])
-        np.testing.assert_allclose(res.values[0], expected)
+        expected_red_channel = np.array([[0., 0.33164983], [np.nan, np.nan]])
+        np.testing.assert_allclose(res.values[0], expected_red_channel)
+        assert res.shape[0] == 3
 
     def test_day_only_area_with_alpha(self):
         """Test compositor with day portion with alpha_band when SZA data is not provided."""

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -403,8 +403,10 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="night_only", include_alpha=True)
         res = comp((self.data_b, self.sza))
         res = res.compute()
-        expected = np.array([[np.nan, 0.], [0.5, 1.]])
-        np.testing.assert_allclose(res.values[0], expected)
+        expected_red_channel = np.array([[np.nan, 0.], [0.5, 1.]])
+        expected_alpha = np.array([[0., 0.33296056], [1., 1.]])
+        np.testing.assert_allclose(res.values[0], expected_red_channel)
+        np.testing.assert_allclose(res.values[-1], expected_alpha)
 
     def test_night_only_sza_without_alpha(self):
         """Test compositor with night portion without alpha band when SZA data is included."""
@@ -414,6 +416,7 @@ class TestDayNightCompositor(unittest.TestCase):
         res = res.compute()
         expected = np.array([[np.nan, 0.], [0.5, 1.]])
         np.testing.assert_allclose(res.values[0], expected)
+        assert res.shape[0] == 3
 
     def test_night_only_area_with_alpha(self):
         """Test compositor with night portion with alpha band when SZA data is not provided."""
@@ -434,6 +437,7 @@ class TestDayNightCompositor(unittest.TestCase):
         res = res.compute()
         expected = np.array([np.nan, np.nan])
         np.testing.assert_allclose(res.values[0], expected)
+        assert res.ndim == 2
 
     def test_day_only_sza_with_alpha(self):
         """Test compositor with day portion with alpha band when SZA data is included."""
@@ -462,8 +466,10 @@ class TestDayNightCompositor(unittest.TestCase):
         comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=True)
         res = comp(self.data_a)
         res = res.compute()
-        expected = np.array([[0., 0.33164983], [0.66835017, 1.]])
-        np.testing.assert_allclose(res.values[0], expected)
+        expected_l_channel = np.array([[0., 0.33164983], [0.66835017, 1.]])
+        expected_alpha = np.array([[1., 1.], [1., 1.]])
+        np.testing.assert_allclose(res.values[0], expected_l_channel)
+        np.testing.assert_allclose(res.values[-1], expected_alpha)
 
     def test_day_only_area_without_alpha(self):
         """Test compositor with day portion without alpha_band when SZA data is not provided."""
@@ -473,6 +479,7 @@ class TestDayNightCompositor(unittest.TestCase):
         res = res.compute()
         expected = np.array([0., 0.33164983])
         np.testing.assert_allclose(res.values[0], expected)
+        assert res.ndim == 2
 
 
 class TestFillingCompositor(unittest.TestCase):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -472,6 +472,17 @@ class TestDayNightCompositor(unittest.TestCase):
         np.testing.assert_allclose(res.values[0], expected_l_channel)
         np.testing.assert_allclose(res.values[-1], expected_alpha)
 
+    def test_day_only_area_with_alpha_and_missing_data(self):
+        """Test compositor with day portion with alpha_band when SZA data is not provided and there is missing data."""
+        from satpy.composites import DayNightCompositor
+        comp = DayNightCompositor(name='dn_test', day_night="day_only", include_alpha=True)
+        res = comp(self.data_b)
+        res = res.compute()
+        expected_l_channel = np.array([[np.nan, 0.], [0.5, 1.]])
+        expected_alpha = np.array([[np.nan, 1.], [1., 1.]])
+        np.testing.assert_allclose(res.values[0], expected_l_channel)
+        np.testing.assert_allclose(res.values[-1], expected_alpha)
+
     def test_day_only_area_without_alpha(self):
         """Test compositor with day portion without alpha_band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor


### PR DESCRIPTION
This PR was inspired by the discussion in https://github.com/pytroll/satpy/pull/2358#issuecomment-1400650541

With the current Satpy `main` there is discontinuity between a pair of day-only and night-only composites causing a dark band between them when stacked (in this case in Gimp using the mode "Merge"):

![current_merged](https://user-images.githubusercontent.com/3170788/218482557-5ff1a301-502c-409b-975b-3188798a2653.png)

The two composites were done using `DayNightCompositor` with `day_night: {day,night}_only` and `include_alpha: True`.

With the version of this PR, the result of stacking the two sub-composites is the following:

![new_merged](https://user-images.githubusercontent.com/3170788/218484060-2b4810ca-c4c8-4a63-847e-f7b9695fc5e9.png)

The change introduced here is that *only* the transparency is adjusted on the SZA transition zone, while previously also the image date were changed. The scaling of image data caused stacking/blending outside of Satpy to in essence scale the data twice: once in Satpy and the other time when weighing the data with the transparencies of the overlapping images.

 - [x] Tests added (and adjusted)
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
