### PR TITLE
Drop default compression in CF Writer

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -1403,6 +1403,21 @@ class TestEncodingKwarg:
             assert f["test-array"].encoding["complevel"] == expected["complevel"]
 
 
+class TestEncodingAttribute(TestEncodingKwarg):
+    """Test CF writer with 'encoding' dataset attribute."""
+
+    @pytest.fixture
+    def scene_with_encoding(self, scene, encoding):
+        """Create scene with a dataset providing the 'encoding' attribute."""
+        scene["test-array"].encoding = encoding["test-array"]
+        return scene
+
+    def test_encoding_attribute(self, scene_with_encoding, filename, expected):
+        """Test 'encoding' dataset attribute."""
+        scene_with_encoding.save_datasets(filename=filename, writer='cf')
+        self._assert_encoding_as_expected(filename, expected)
+
+
 def _get_compression_params(complevel):
     params = {"complevel": complevel}
     if _should_use_compression_keyword():

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -26,7 +26,11 @@ from datetime import datetime
 from unittest import mock
 
 import numpy as np
+import pytest
+import xarray as xr
+from packaging.version import Version
 
+from satpy import Scene
 from satpy.tests.utils import make_dsq
 
 try:
@@ -38,6 +42,7 @@ except ImportError:
 # The following fixtures are not defined in this file, but are used and injected by Pytest:
 # - tmp_path
 # - caplog
+# - request
 
 
 class TempFile(object):
@@ -87,26 +92,6 @@ class TestCFWriter(unittest.TestCase):
                 expected_prereq = ("DataQuery(name='hej')")
                 self.assertEqual(f['test-array'].attrs['prerequisites'],
                                  expected_prereq)
-
-    def test_save_with_compression(self):
-        """Test saving an array with compression."""
-        import xarray as xr
-
-        from satpy import Scene
-        scn = Scene()
-        start_time = datetime(2018, 5, 30, 10, 0)
-        end_time = datetime(2018, 5, 30, 10, 15)
-        with mock.patch('satpy.writers.cf_writer.xr.Dataset') as xrdataset,\
-                mock.patch('satpy.writers.cf_writer.make_time_bounds'):
-            scn['test-array'] = xr.DataArray([1, 2, 3],
-                                             attrs=dict(start_time=start_time,
-                                                        end_time=end_time,
-                                                        prerequisites=[make_dsq(name='hej')]))
-
-            comp = {'zlib': True, 'complevel': 9}
-            scn.save_datasets(filename='bla', writer='cf', compression=comp)
-            ars, kws = xrdataset.call_args_list[1]
-            self.assertDictEqual(ars[0]['test-array'].encoding, comp)
 
     def test_save_array_coords(self):
         """Test saving array with coordinates."""
@@ -402,30 +387,6 @@ class TestCFWriter(unittest.TestCase):
             with xr.open_dataset(filename, decode_cf=True) as f:
                 bounds_exp = np.array([[start_timeA, end_timeA]], dtype='datetime64[m]')
                 np.testing.assert_array_equal(f['time_bnds'], bounds_exp)
-
-    def test_encoding_kwarg(self):
-        """Test 'encoding' keyword argument."""
-        import xarray as xr
-
-        from satpy import Scene
-        scn = Scene()
-        start_time = datetime(2018, 5, 30, 10, 0)
-        end_time = datetime(2018, 5, 30, 10, 15)
-        scn['test-array'] = xr.DataArray([1, 2, 3],
-                                         attrs=dict(start_time=start_time,
-                                                    end_time=end_time))
-        with TempFile() as filename:
-            encoding = {'test-array': {'dtype': 'int8',
-                                       'scale_factor': 0.1,
-                                       'add_offset': 0.0,
-                                       '_FillValue': 3}}
-            scn.save_datasets(filename=filename, encoding=encoding, writer='cf')
-            with xr.open_dataset(filename, mask_and_scale=False) as f:
-                np.testing.assert_array_equal(f['test-array'][:], [10, 20, 30])
-                self.assertEqual(f['test-array'].attrs['scale_factor'], 0.1)
-                self.assertEqual(f['test-array'].attrs['_FillValue'], 3)
-                # check that dtype behave as int8
-                self.assertEqual(np.iinfo(f['test-array'][:].dtype).max, 127)
 
     def test_unlimited_dims_kwarg(self):
         """Test specification of unlimited dimensions."""
@@ -1368,3 +1329,94 @@ class EncodingUpdateTest(unittest.TestCase):
 
         # User-defined encoding may not be altered
         self.assertDictEqual(kwargs['encoding'], {'bar': {'chunksizes': (1, 1, 1)}})
+
+
+class TestEncodingKwarg:
+    """Test CF writer with 'encoding' keyword argument."""
+
+    @pytest.fixture
+    def scene(self):
+        """Create a fake scene."""
+        scn = Scene()
+        attrs = {
+            "start_time": datetime(2018, 5, 30, 10, 0),
+            "end_time": datetime(2018, 5, 30, 10, 15)
+        }
+        scn['test-array'] = xr.DataArray([1, 2, 3], attrs=attrs)
+        return scn
+
+    @pytest.fixture(params=[True, False])
+    def compression_on(self, request):
+        """Get compression options."""
+        return request.param
+
+    @pytest.fixture
+    def encoding(self, compression_on):
+        """Get encoding."""
+        enc = {
+            'test-array': {
+                'dtype': 'int8',
+                'scale_factor': 0.1,
+                'add_offset': 0.0,
+                '_FillValue': 3,
+            }
+        }
+        if compression_on:
+            comp_params = _get_compression_params(complevel=7)
+            enc["test-array"].update(comp_params)
+        return enc
+
+    @pytest.fixture
+    def filename(self, tmp_path):
+        """Get output filename."""
+        return str(tmp_path / "test.nc")
+
+    @pytest.fixture
+    def complevel_exp(self, compression_on):
+        """Get expected compression level."""
+        if compression_on:
+            return 7
+        return 0
+
+    @pytest.fixture
+    def expected(self, complevel_exp):
+        """Get expectated file contents."""
+        return {
+            "data": [10, 20, 30],
+            "scale_factor": 0.1,
+            "fill_value": 3,
+            "dtype": np.int8,
+            "complevel": complevel_exp
+        }
+
+    def test_encoding_kwarg(self, scene, encoding, filename, expected):
+        """Test 'encoding' keyword argument."""
+        scene.save_datasets(filename=filename, encoding=encoding, writer='cf')
+        self._assert_encoding_as_expected(filename, expected)
+
+    def _assert_encoding_as_expected(self, filename, expected):
+        with xr.open_dataset(filename, mask_and_scale=False) as f:
+            np.testing.assert_array_equal(f['test-array'][:], expected["data"])
+            assert f['test-array'].attrs['scale_factor'] == expected["scale_factor"]
+            assert f['test-array'].attrs['_FillValue'] == expected["fill_value"]
+            assert f['test-array'].dtype == expected["dtype"]
+            assert f["test-array"].encoding["complevel"] == expected["complevel"]
+
+
+def _get_compression_params(complevel):
+    params = {"complevel": complevel}
+    if _should_use_compression_keyword():
+        params["compression"] = "zlib"
+    else:
+        params["zlib"] = True
+    return params
+
+
+def _should_use_compression_keyword():
+    clib_version = _get_netcdf4_clib_version()
+    return clib_version >= Version("4.9.0")
+
+
+def _get_netcdf4_clib_version():
+    import netCDF4
+    return Version(netCDF4.__netcdf4libversion__)

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -592,7 +592,7 @@ def _handle_dataarray_name(original_name, numeric_name_prefix):
         else:
             warnings.warn(
                 'Invalid NetCDF dataset name: {} starts with a digit.'.format(name),
-                stacklevel=2
+                stacklevel=5
             )
     return original_name, name
 
@@ -823,7 +823,7 @@ class CFWriter(Writer):
             if ds.dtype not in CF_DTYPES:
                 warnings.warn(
                     'Dtype {} not compatible with {}.'.format(str(ds.dtype), CF_VERSION),
-                    stacklevel=2
+                    stacklevel=3
                 )
             # we may be adding attributes, coordinates, or modifying the
             # structure of attributes
@@ -946,7 +946,7 @@ def _check_backend_versions():
             "Backend version mismatch. Compression might fail or be ignored "
             "silently. Recommended: All versions below or above "
             "netCDF4-1.6.0/libnetcdf-4.9.0/xarray-2022.12.0.",
-            stacklevel=2
+            stacklevel=3
         )
 
 

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -71,14 +71,15 @@ Dataset encoding can be specified in two ways:
 
     >>> my_encoding = {
     ...    'my_dataset_1': {
-    ...        'zlib': True,
+    ...        'compression': 'zlib',
     ...        'complevel': 9,
     ...        'scale_factor': 0.01,
     ...        'add_offset': 100,
     ...        'dtype': np.int16
     ...     },
     ...    'my_dataset_2': {
-    ...        'zlib': False
+    ...        'compression': None,
+    ...        'dtype': np.float64
     ...     }
     ... }
     >>> scn.save_datasets(writer='cf', filename='encoding_test.nc', encoding=my_encoding)
@@ -86,10 +87,18 @@ Dataset encoding can be specified in two ways:
 
 2) Via the ``encoding`` attribute of the datasets in a scene. For example
 
-    >>> scn['my_dataset'].encoding = {'zlib': False}
+    >>> scn['my_dataset'].encoding = {'compression': 'zlib'}
     >>> scn.save_datasets(writer='cf', filename='encoding_test.nc')
 
 See the `xarray encoding documentation`_ for all encoding options.
+
+.. note::
+
+    Since netCDF4-1.6.0/libnetcdf-4.9.0/xarray-2022.12.0 the "zlib" keyword
+    argument is deprecated in favour of "compression". Make sure that the
+    versions of these modules are all above or all below that reference. If all
+    versions are above, use the "compression" keyword. If all of them are below,
+    use the "zlib" keyword. Else compression might fail or be ignored silently.
 
 
 Attribute Encoding

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -793,17 +793,6 @@ class CFWriter(Writer):
             new_data.attrs.pop(satpy_attr)
         new_data.attrs.pop('_last_resampler', None)
 
-    @staticmethod
-    def update_encoding(dataset, to_netcdf_kwargs):
-        """Update encoding info (deprecated)."""
-        warnings.warn(
-            'CFWriter.update_encoding is deprecated. '
-            'Use satpy.writers.cf_writer.update_encoding instead.',
-            DeprecationWarning,
-            stacklevel=2
-        )
-        return update_encoding(dataset, to_netcdf_kwargs)
-
     def save_dataset(self, dataset, filename=None, fill_value=None, **kwargs):
         """Save the *dataset* to a given *filename*."""
         return self.save_datasets([dataset], filename, **kwargs)

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -94,11 +94,18 @@ See the `xarray encoding documentation`_ for all encoding options.
 
 .. note::
 
-    Since netCDF4-1.6.0/libnetcdf-4.9.0/xarray-2022.12.0 the "zlib" keyword
-    argument is deprecated in favour of "compression". Make sure that the
-    versions of these modules are all above or all below that reference. If all
-    versions are above, use the "compression" keyword. If all of them are below,
-    use the "zlib" keyword. Else compression might fail or be ignored silently.
+    Chunk-based compression can be spezified with the ``compression`` keyword
+    since
+
+        .. code::
+
+            netCDF4-1.6.0
+            libnetcdf-4.9.0
+            xarray-2022.12.0
+
+    The ``zlib`` keyword is deprecated. Make sure that the versions of
+    these modules are all above or all below that reference. Otherwise,
+    compression might fail or be ignored silently.
 
 
 Attribute Encoding

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -145,11 +145,11 @@ import logging
 import warnings
 from collections import OrderedDict, defaultdict
 from datetime import datetime
-from distutils.version import LooseVersion
 
 import numpy as np
 import xarray as xr
 from dask.base import tokenize
+from packaging.version import Version
 from pyresample.geometry import AreaDefinition, SwathDefinition
 from xarray.coding.times import CFDatetimeCoder
 
@@ -199,7 +199,7 @@ CF_VERSION = 'CF-1.7'
 def create_grid_mapping(area):
     """Create the grid mapping instance for `area`."""
     import pyproj
-    if LooseVersion(pyproj.__version__) < LooseVersion('2.4.1'):
+    if Version(pyproj.__version__) < Version('2.4.1'):
         # technically 2.2, but important bug fixes in 2.4.1
         raise ImportError("'cf' writer requires pyproj 2.4.1 or greater")
     # let pyproj do the heavily lifting


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->

Drop default compression in CF Writer and delegate this to the user (via encoding keyword argument or dataset attribute). This closes #2244. Also, update documentation to use the new `compression` keyword instead of `zlib`, which closes #2386 .

I played around a bit with different combinations of backend versions (netCDF4, libnetcdf, xarray) and noticed that the keyword choice also depends on the underlying libnetcdf. If `libnetcdf<4.9.0` only `zlib` works and `compression` is silently ignored. This is the case in our CI environment where`eccodes` currently requires `libnetcdf-4.8`.

In order to make users aware of that, I added a little section in the documentation and issued a user warning if the backend versions don't match. 

Waiting for https://github.com/pytroll/satpy/pull/2391 to fix flake8 errors.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
