### PR TITLE
Enhanced selecting with weights (PR 2275) to handle composites. Added…

### DIFF
--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -139,13 +139,13 @@ def set_weights_to_zero_where_invalid(datasets, weights):
                 weights[i] = xr.where(dataset[0] == dataset.attrs["_FillValue"], 0, weights[i])
             except KeyError:
                 weights[i] = xr.where(dataset[0].isnull(), 0, weights[i])
-    else:
-        for i, dataset in enumerate(datasets):
-            try:
-                weights[i] = xr.where(dataset == dataset.attrs["_FillValue"], 0, weights[i])
-            except KeyError:
-                weights[i] = xr.where(dataset.isnull(), 0, weights[i])
+    return weights
 
+    for i, dataset in enumerate(datasets):
+        try:
+            weights[i] = xr.where(dataset == dataset.attrs["_FillValue"], 0, weights[i])
+        except KeyError:
+            weights[i] = xr.where(dataset.isnull(), 0, weights[i])
     return weights
 
 

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -139,7 +139,7 @@ def set_weights_to_zero_where_invalid(datasets, weights):
                 weights[i] = xr.where(dataset[0] == dataset.attrs["_FillValue"], 0, weights[i])
             except KeyError:
                 weights[i] = xr.where(dataset[0].isnull(), 0, weights[i])
-    return weights
+        return weights
 
     for i, dataset in enumerate(datasets):
         try:

--- a/satpy/multiscene.py
+++ b/satpy/multiscene.py
@@ -60,11 +60,10 @@ def stack(datasets, weights=None, combine_times=True, blend_type=1):
     Other blend_types will fallback to stacking the datasets without weights applied.
 
     """
-    if weights:
-        if blend_type == 1:
-           return _stack_selected(datasets, weights, combine_times)
-        elif blend_type == 2:
-           return _stack_blended(datasets, weights, combine_times)
+    if weights and blend_type == 1:
+        return _stack_selected(datasets, weights, combine_times)
+    if weights and blend_type == 2:
+        return _stack_blended(datasets, weights, combine_times)
 
     base = datasets[0].copy()
     for dataset in datasets[1:]:
@@ -93,14 +92,14 @@ def _stack_blended(datasets, weights, combine_times):
     for n in range(1, len(weights)):
         total += weights[n]
 
-    datasets0=[]
+    datasets0 = []
     for n in range(0, len(datasets)):
         weights[n] /= total
         datasets0.append(datasets[n].fillna(0))
         # RGB composite
         if dims[0] == 'bands':
             for b in [0, 1, 2]:
-               datasets0[n][b] *= weights[n]
+                datasets0[n][b] *= weights[n]
         # Single channel
         else:
             datasets0[n] *= weights[n]


### PR DESCRIPTION
… true blending with weights for single channels and composites.

<!-- Describe what your PR does, and why -->
Multiscene blending revisited

The code of PR 2275 appeared first in Satpy 0.40.
I was mislead by its titel as this was actually
about selecting (choosing) pixels with weights.

This has been developed by Adam for combining 'ct'
data of GEO and LEO satellites up north. My use of the
code was for multipass images of LEOs with identical
sensors. I have enhanced PR 2275 to handle composites.

I added a function for true blending of overlapping
datasets. This also works with common RGB composites.

I propose this naming:

default)
multiscene "stacking"  
(the original way, datasets put on top of each other)

1)
multiscene "selecting" with weights 
(pixel with highest weight is selected from one dataset)

2)
multiscene "blending" with weights 
(pixels blended,  more than one dataset may contribute)

"Stacking" is the default. When working with multiscene and
a list with weights is provided the user has an additional
way to select case 1) or 2) (and maybe future options ...?).
This is handled by integer keyword argument 'blending_type'.

For 1) I propose to document/use the weighting function
w = 180 - satellite_zenith_angle

For 2) I propose a function similar to the flight track
dispersion formula as used in the German 'AzB'
 
         weights=[]
            for s in new_mscn.scenes:
                w = s['satellite_zenith_angle']
                w = w / w.max(dim = ['x', 'y'])
                w = (1. - w*w)
                weights.append(w*w)

Where new_mscn is the multiscene resampled to the area.
This will certainly not work for 'ct', 'cma' type data.

NOTE: I'm absolutely new to this array stuff and will
certainly not be able to write meaningful tests. I just
hope that Adam's tests for PR 2275 can be used somehow.

![NOAA20-20230213-NIG-0214-night_overview-westminster-multi-blended](https://user-images.githubusercontent.com/101883219/219333041-4fac9ce6-dd41-4f63-b1fd-ea87ce62dff7.jpg)
![NOAA20-20230213-NIG-0214-night_overview-westminster-multi-selected](https://user-images.githubusercontent.com/101883219/219333051-5a31cda3-cd71-4c91-9fb6-ad672193d4ac.jpg)
![NOAA20-20230213-NIG-0214-night_overview-westminster-multi-stacked](https://user-images.githubusercontent.com/101883219/219333058-ff6500e4-5002-4530-9e14-041fb335adb6.jpg)


Cheers,
Ernst
