### PR TITLE
Remove DataID attribute access

### DIFF
--- a/satpy/dataset/dataid.py
+++ b/satpy/dataset/dataid.py
@@ -407,7 +407,7 @@ class DataID(dict):
                           stacklevel=2)
             return self[key]
         else:
-            return super().__getattr__(key)
+            raise AttributeError(f"'{type(self).__name__:s}' object has no attribute '{key:s}'")
 
     def __deepcopy__(self, memo=None):
         """Copy this object.

--- a/satpy/dataset/dataid.py
+++ b/satpy/dataset/dataid.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# Copyright (c) 2015-2021 Satpy developers
+# Copyright (c) 2015-2023 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -19,7 +17,6 @@
 
 import logging
 import numbers
-import warnings
 from collections import namedtuple
 from contextlib import suppress
 from copy import copy, deepcopy
@@ -399,15 +396,6 @@ class DataID(dict):
             else:
                 res_dict[key] = value
         return res_dict
-
-    def __getattr__(self, key):
-        """Support old syntax for getting items."""
-        if key in self._id_keys:
-            warnings.warn('Attribute access to DataIDs is deprecated, use key access instead.',
-                          stacklevel=2)
-            return self[key]
-        else:
-            raise AttributeError(f"'{type(self).__name__:s}' object has no attribute '{key:s}'")
 
     def __deepcopy__(self, memo=None):
         """Copy this object.

--- a/satpy/readers/abi_l2_nc.py
+++ b/satpy/readers/abi_l2_nc.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-#
-# Copyright (c) 2019 Satpy developers
+# Copyright (c) 2019-2023 Satpy developers
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -38,7 +35,7 @@ class NC_ABI_L2(NC_ABI_BASE):
         """Load a dataset."""
         var = info['file_key']
         if self.filetype_info['file_type'] == 'abi_l2_mcmip':
-            var += "_" + key.name
+            var += "_" + key["name"]
         LOG.debug('Reading in get_dataset %s.', var)
         variable = self[var]
         variable.attrs.update(key.to_dict())

--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-#
-# Copyright (c) 2019 Satpy developers
+# Copyright (c) 2019-2023 Satpy developers
 #
 # satpy is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -252,7 +249,7 @@ class FciL2NCFileHandler(FciL2CommonFunctions, BaseFileHandler):
         # as fallback until all L2PF test files are correctly formatted.
         rf = float(self._projection.attrs.get('inverse_flattening', 298.257223563))
 
-        res = dataset_id.resolution
+        res = dataset_id["resolution"]
 
         area_naming_input_dict = {'platform_name': 'mtg',
                                   'instrument_name': 'fci',
@@ -360,7 +357,7 @@ class FciL2NCSegmentFileHandler(FciL2CommonFunctions, BaseFileHandler):
             AreaDefinition: A pyresample AreaDefinition object containing the area definition.
 
         """
-        res = dataset_id.resolution
+        res = dataset_id["resolution"]
 
         area_naming_input_dict = {'platform_name': 'mtg',
                                   'instrument_name': 'fci',

--- a/satpy/readers/seviri_l2_grib.py
+++ b/satpy/readers/seviri_l2_grib.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-#
-# Copyright (c) 2019-2020 Satpy developers
+# Copyright (c) 2019-2023 Satpy developers
 #
 # satpy is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -111,7 +108,7 @@ class SeviriL2GribFileHandler(BaseFileHandler):
 
                 if parameter_number == dataset_info['parameter_number']:
 
-                    self._res = dataset_id.resolution
+                    self._res = dataset_id["resolution"]
                     self._read_attributes(gid)
 
                     # Read the missing value

--- a/satpy/tests/test_dataset.py
+++ b/satpy/tests/test_dataset.py
@@ -953,3 +953,10 @@ def test_wavelength_range_cf_roundtrip():
 
     assert WavelengthRange.from_cf(wr.to_cf()) == wr
     assert WavelengthRange.from_cf([str(item) for item in wr]) == wr
+
+
+def test_attributeerror():
+    """Test that DataID attribute access gives correct AttributeError."""
+    did = DataID({})
+    with pytest.raises(AttributeError, match="'DataID' object has no attribute 'unknown'"):
+        did.unknown

--- a/satpy/tests/test_dataset.py
+++ b/satpy/tests/test_dataset.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# Copyright (c) 2015-2022 Satpy developers
+# Copyright (c) 2015-2023 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -686,7 +684,7 @@ class TestIDQueryInteractions(unittest.TestCase):
                        resolution=3000.403165817, calibration="counts", modifiers=())]
         dq = DataQuery(wavelength=0.8)
         res, distances = dq.sort_dataids(dids)
-        assert res[0].name == "HRV"
+        assert res[0]["name"] == "HRV"
 
 
 def test_frequency_quadruple_side_band_class_method_convert():
@@ -953,10 +951,3 @@ def test_wavelength_range_cf_roundtrip():
 
     assert WavelengthRange.from_cf(wr.to_cf()) == wr
     assert WavelengthRange.from_cf([str(item) for item in wr]) == wr
-
-
-def test_attributeerror():
-    """Test that DataID attribute access gives correct AttributeError."""
-    did = DataID({})
-    with pytest.raises(AttributeError, match="'DataID' object has no attribute 'unknown'"):
-        did.unknown

--- a/satpy/tests/test_dependency_tree.py
+++ b/satpy/tests/test_dependency_tree.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-# Copyright (c) 2020 Satpy developers
+# Copyright (c) 2020-2023 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -219,7 +217,7 @@ class TestMultipleSensors(unittest.TestCase):
         self.dependency_tree.populate_with_keys({'comp1'})
         comp_nodes = self.dependency_tree.trunk()
         self.assertEqual(len(comp_nodes), 1)
-        self.assertEqual(comp_nodes[0].name.resolution, 500)
+        self.assertEqual(comp_nodes[0].name["resolution"], 500)
 
     def test_modifier_loaded_sensor_order(self):
         """Test that a modifier is loaded from the first alphabetical sensor."""


### PR DESCRIPTION
Remove the `__getattr__` implementation on DataID, that was implementing a deprecated way to access information from DataID objects.  From now on, only key access is possible.

 - [x] Closes #2395<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests adapted <!-- for all bug fixes or enhancements -->
