### PR TITLE
Don't use deprecated distutils module.

### DIFF
--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -145,11 +145,11 @@ import logging
 import warnings
 from collections import OrderedDict, defaultdict
 from datetime import datetime
-from distutils.version import LooseVersion
 
 import numpy as np
 import xarray as xr
 from dask.base import tokenize
+from packaging.version import Version
 from pyresample.geometry import AreaDefinition, SwathDefinition
 from xarray.coding.times import CFDatetimeCoder
 
@@ -199,7 +199,7 @@ CF_VERSION = 'CF-1.7'
 def create_grid_mapping(area):
     """Create the grid mapping instance for `area`."""
     import pyproj
-    if LooseVersion(pyproj.__version__) < LooseVersion('2.4.1'):
+    if Version(pyproj.__version__) < Version('2.4.1'):
         # technically 2.2, but important bug fixes in 2.4.1
         raise ImportError("'cf' writer requires pyproj 2.4.1 or greater")
     # let pyproj do the heavily lifting

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ except ImportError:
 requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.24.0', 'trollsift',
             'trollimage >=1.20', 'pykdtree', 'pyyaml >=5.1', 'xarray >=0.10.1, !=0.13.0',
             'dask[array] >=0.17.1', 'pyproj>=2.2', 'zarr', 'donfig', 'appdirs',
-            'pooch', 'pyorbital']
+            'packaging', 'pooch', 'pyorbital']
 
 test_requires = ['behave', 'h5py', 'netCDF4', 'pyhdf', 'imageio',
                  'rasterio', 'geoviews', 'trollimage', 'fsspec', 'bottleneck',


### PR DESCRIPTION
`satpy/writers/cf_writer.py` still uses the deprecated distutils which will be removed in Python 3.12.

From [What’s New In Python 3.10](https://docs.python.org/3/whatsnew/3.10.html#distutils-deprecated):
> The entire `distutils` package is deprecated, to be removed in Python 3.12. Its functionality for specifying package builds has already been completely replaced by third-party packages `setuptools` and `packaging`, and most other commonly used APIs are available elsewhere in the standard library (such as [`platform`](https://docs.python.org/3/library/platform.html#module-platform), [`shutil`](https://docs.python.org/3/library/shutil.html#module-shutil), [`subprocess`](https://docs.python.org/3/library/subprocess.html#module-subprocess) or [`sysconfig`](https://docs.python.org/3/library/sysconfig.html#module-sysconfig)). There are no plans to migrate any other functionality from distutils, and applications that are using other functions should plan to make private copies of the code. Refer to [PEP 632](https://peps.python.org/pep-0632/) for discussion.

[Porting from Distutils](https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html#prefer-setuptools) suggests using [`packaging.version`](https://packaging.pypa.io/en/latest/version.html) instead of `distutils.version`.