### PR TITLE
Choose dtype in CategoricalDataCompositor

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -337,14 +337,15 @@ class CategoricalDataCompositor(CompositeBase):
         res = [[20, 40, 30], [50, 30, 10]]
     """
 
-    def __init__(self, name, lut=None, **kwargs):
+    def __init__(self, name, lut=None, dtype=None, **kwargs):
         """Get look-up-table used to recategorize data.
 
         Args:
             lut (list): a list of new categories. The lenght must be greater than the
                         maximum value in the data array that should be recategorized.
+            dtype (Optional[str]): dtype to be used for the new contents.
         """
-        self.lut = np.array(lut)
+        self.lut = np.array(lut, dtype=dtype)
         super(CategoricalDataCompositor, self).__init__(name, **kwargs)
 
     def _update_attrs(self, new_attrs):

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -337,23 +337,28 @@ class CategoricalDataCompositor(CompositeBase):
         res = [[20, 40, 30], [50, 30, 10]]
     """
 
-    def __init__(self, name, lut=None, dtype=None, **kwargs):
+    def __init__(self, name, lut=None, dtype=None, fill_value=None, **kwargs):
         """Get look-up-table used to recategorize data.
 
         Args:
-            lut (list): a list of new categories. The lenght must be greater than the
-                        maximum value in the data array that should be recategorized.
+            lut (list):
+                A list of new categories. The lenght must be greater than the
+                maximum value in the data array that should be recategorized.
+            dtype (dtype, optional):
+                Set this to force the output dtype to be different from the input dtype.
+            fill_value (number):
+                Fill value to set.  This will be defined as an attribute to the data
+                returned when the compositor is called.
         """
-        lut = np.array(lut)
-        self.lut = np.array(
-                lut,
-                dtype=np.result_type(np.min_scalar_type(lut.min()), lut.max()))
-        super(CategoricalDataCompositor, self).__init__(name, **kwargs)
+        self.lut = np.array(lut)
+        self.fill_value = fill_value
+        self.dtype = dtype
+        super().__init__(name, **kwargs)
 
     def _update_attrs(self, new_attrs):
         """Modify name and add LUT."""
         new_attrs['name'] = self.attrs['name']
-        new_attrs['composite_lut'] = list(self.lut)
+        new_attrs['composite_lut'] = self.lut
 
     @staticmethod
     def _getitem(block, lut):
@@ -368,10 +373,12 @@ class CategoricalDataCompositor(CompositeBase):
         if not np.issubdtype(data.dtype, np.integer):
             raise TypeError(f"{type(self).__name__:s} can only be used on "
                             f"integer data, got {data.dtype!s}")
-        res = data.data.map_blocks(self._getitem, self.lut, dtype=data.dtype)
+        res = data.data.map_blocks(self._getitem, self.lut, dtype=self.dtype or data.dtype)
 
         new_attrs = data.attrs.copy()
         self._update_attrs(new_attrs)
+        if self.fill_value is not None:
+            new_attrs["_FillValue"] = self.fill_value
 
         return xr.DataArray(res, dims=data.dims, attrs=new_attrs, coords=data.coords)
 

--- a/satpy/etc/composites/fci.yaml
+++ b/satpy/etc/composites/fci.yaml
@@ -32,13 +32,14 @@ composites:
     standard_name: toa_bidirectional_reflectance
 
   binary_cloud_mask:
-    # This will set all clear pixels to '0', all pixles with cloudy features (meteorological/dust/ash clouds) to '1' and
-    # missing/undefined pixels to 'nan'. This can be used for the the official EUMETSAT cloud mask product (CLM).
+    # This will set all clear pixels to 0, all pixels with cloudy features (meteorological/dust/ash clouds) to 1 and
+    # missing/undefined pixels to fill values. This can be used for the the official EUMETSAT cloud mask product (CLM).
     compositor: !!python/name:satpy.composites.CategoricalDataCompositor
     prerequisites:
       - name: 'cloud_state'
-    lut: [.nan, 0, 1, 1, 1, 1, 1, 1, 0, .nan]
+    lut: [255, 0, 1, 1, 1, 1, 1, 1, 0, 255]
     standard_name: binary_cloud_mask
+    fill_value: 255
 
   true_color:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -863,14 +863,15 @@ class TestCategoricalDataCompositor:
     def test_basic_recategorization(self, categorical_data):
         """Test general functionality of compositor incl. attributes."""
         from satpy.composites import CategoricalDataCompositor
-        lut = [np.nan, 0, 1, 1]
+        lut = [255, 0, 1, 1]
         name = 'bar'
-        comp = CategoricalDataCompositor(name=name, lut=lut)
+        comp = CategoricalDataCompositor(name=name, lut=lut, fill_value=255)
         res = comp([categorical_data])
         assert res.dtype == categorical_data.dtype
-        expected = np.array([[1., 0.], [1., np.nan]])
+        expected = np.array([[1., 0.], [1., 255]])
         np.testing.assert_equal(res.values, expected)
         assert res.attrs["name"] == name
+        assert res.attrs["_FillValue"] == 255
         np.testing.assert_equal(res.attrs['composite_lut'], lut)
 
     def test_too_many_datasets(self, categorical_data):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -853,7 +853,9 @@ class TestCategoricalDataCompositor:
     def categorical_data(self):
         """Create test data."""
         attrs = {'name': 'foo'}
-        data = xr.DataArray(da.from_array([[2., 1.], [3., 0.]]), attrs=attrs,
+        data = xr.DataArray(da.from_array(
+                                np.array([[2, 1], [3, 0]], dtype="uint8")),
+                            attrs=attrs,
                             dims=('y', 'x'), coords={'y': [0, 1], 'x': [0, 1]})
 
         return data
@@ -865,10 +867,10 @@ class TestCategoricalDataCompositor:
         name = 'bar'
         comp = CategoricalDataCompositor(name=name, lut=lut)
         res = comp([categorical_data])
-        res = res.compute()
+        assert res.dtype == categorical_data.dtype
         expected = np.array([[1., 0.], [1., np.nan]])
         np.testing.assert_equal(res.values, expected)
-        np.testing.assert_equal(res.attrs['name'], name)
+        assert res.attrs["name"] == name
         np.testing.assert_equal(res.attrs['composite_lut'], lut)
 
     def test_too_many_datasets(self, categorical_data):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -878,6 +878,17 @@ class TestCategoricalDataCompositor:
         comp = CategoricalDataCompositor(name='foo', lut=lut)
         np.testing.assert_raises(ValueError, comp, [categorical_data, categorical_data])
 
+    def test_respect_dtype(self, categorical_data):
+        """Test that choice of dtype is respected."""
+        from satpy.composites import CategoricalDataCompositor
+        lut = [0, 1, 2, 3]
+        comp = CategoricalDataCompositor(name="mavas", lut=lut, dtype="uint8")
+        res = comp([categorical_data])
+        assert res.dtype == np.uint8
+        comp = CategoricalDataCompositor(name="mavas", lut=lut, dtype="int32")
+        res = comp([categorical_data])
+        assert res.dtype == np.int32
+
 
 class TestGenericCompositor(unittest.TestCase):
     """Test generic compositor."""

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -876,7 +876,8 @@ class TestCategoricalDataCompositor:
         from satpy.composites import CategoricalDataCompositor
         lut = [np.nan, 0, 1, 1]
         comp = CategoricalDataCompositor(name='foo', lut=lut)
-        np.testing.assert_raises(ValueError, comp, [categorical_data, categorical_data])
+        with pytest.raises(ValueError):
+            comp([categorical_data, categorical_data])
 
     def test_respect_dtype(self, categorical_data):
         """Test that choice of dtype is respected."""

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -846,36 +846,37 @@ class TestSingleBandCompositor(unittest.TestCase):
         self.assertEqual(res.attrs['resolution'], 333)
 
 
-class TestCategoricalDataCompositor(unittest.TestCase):
+class TestCategoricalDataCompositor:
     """Test composiotor for recategorization of categorical data."""
 
-    def setUp(self):
+    @pytest.fixture
+    def categorical_data(self):
         """Create test data."""
         attrs = {'name': 'foo'}
         data = xr.DataArray(da.from_array([[2., 1.], [3., 0.]]), attrs=attrs,
                             dims=('y', 'x'), coords={'y': [0, 1], 'x': [0, 1]})
 
-        self.data = data
+        return data
 
-    def test_basic_recategorization(self):
+    def test_basic_recategorization(self, categorical_data):
         """Test general functionality of compositor incl. attributes."""
         from satpy.composites import CategoricalDataCompositor
         lut = [np.nan, 0, 1, 1]
         name = 'bar'
         comp = CategoricalDataCompositor(name=name, lut=lut)
-        res = comp([self.data])
+        res = comp([categorical_data])
         res = res.compute()
         expected = np.array([[1., 0.], [1., np.nan]])
         np.testing.assert_equal(res.values, expected)
         np.testing.assert_equal(res.attrs['name'], name)
         np.testing.assert_equal(res.attrs['composite_lut'], lut)
 
-    def test_too_many_datasets(self):
+    def test_too_many_datasets(self, categorical_data):
         """Test that ValueError is raised if more than one dataset is provided."""
         from satpy.composites import CategoricalDataCompositor
         lut = [np.nan, 0, 1, 1]
         comp = CategoricalDataCompositor(name='foo', lut=lut)
-        np.testing.assert_raises(ValueError, comp, [self.data, self.data])
+        np.testing.assert_raises(ValueError, comp, [categorical_data, categorical_data])
 
 
 class TestGenericCompositor(unittest.TestCase):


### PR DESCRIPTION
When using the CategoricalDataCompositor, allow the user to choose the resulting dtype.  So far, it automatically results in either float64 or int64.  In many cases, this may be a (big) waste of space, and a (much) smaller type is a better choice.  With this PR, a keyword argument `dtype` allows the user to force a different dtype.

 - [x] Closes #2402 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

