### PR TITLE
Convert TestYAMLFiles to pytest

### DIFF
--- a/satpy/tests/enhancement_tests/test_ahi.py
+++ b/satpy/tests/enhancement_tests/test_ahi.py
@@ -22,10 +22,10 @@ import numpy as np
 import xarray as xr
 
 
-class TestAHIEnhancement():
+class TestAHIEnhancement:
     """Test the AHI enhancement functions."""
 
-    def setup(self):
+    def setup_method(self):
         """Create test data."""
         data = da.arange(-100, 1000, 110).reshape(2, 5)
         rgb_data = np.stack([data, data, data])

--- a/satpy/tests/reader_tests/test_fy4_base.py
+++ b/satpy/tests/reader_tests/test_fy4_base.py
@@ -28,7 +28,7 @@ from satpy.tests.reader_tests.test_agri_l1 import FakeHDF5FileHandler2
 class Test_FY4Base:
     """Tests for the FengYun4 base class for the components missed by AGRI/GHI tests."""
 
-    def setup(self):
+    def setup_method(self):
         """Initialise the tests."""
         self.p = mock.patch.object(FY4Base, '__bases__', (FakeHDF5FileHandler2,))
         self.fake_handler = self.p.start()

--- a/satpy/tests/reader_tests/test_ghi_l1.py
+++ b/satpy/tests/reader_tests/test_ghi_l1.py
@@ -211,7 +211,7 @@ class Test_HDF_GHI_L1_cal:
 
     yaml_file = "ghi_l1.yaml"
 
-    def setup(self):
+    def setup_method(self):
         """Wrap HDF5 file handler with our own fake handler."""
         from satpy._config import config_search_paths
         from satpy.readers.fy4_base import FY4Base

--- a/satpy/tests/reader_tests/test_msi_safe.py
+++ b/satpy/tests/reader_tests/test_msi_safe.py
@@ -969,7 +969,7 @@ class TestMTDXML(unittest.TestCase):
 class TestSAFEMSIL1C:
     """Test case for image reading (jp2k)."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the test."""
         from satpy.readers.msi_safe import SAFEMSITileMDXML
         self.filename_info = dict(observation_time=None, fmission_id="S2A", band_name="B01", dtile_number=None)

--- a/satpy/tests/reader_tests/test_msu_gsa_l1b.py
+++ b/satpy/tests/reader_tests/test_msu_gsa_l1b.py
@@ -126,7 +126,7 @@ class TestMSUGSABReader:
 
     yaml_file = "msu_gsa_l1b.yaml"
 
-    def setup(self):
+    def setup_method(self):
         """Wrap HDF5 file handler with our own fake handler."""
         from satpy._config import config_search_paths
         from satpy.readers import load_reader

--- a/satpy/tests/reader_tests/test_oceancolorcci_l3_nc.py
+++ b/satpy/tests/reader_tests/test_oceancolorcci_l3_nc.py
@@ -132,7 +132,7 @@ def fake_file_dict(fake_dataset, tmp_path):
 class TestOCCCIReader:
     """Test the Ocean Color reader."""
 
-    def setup(self):
+    def setup_method(self):
         """Set up the reader tests."""
         from satpy._config import config_search_paths
 


### PR DESCRIPTION
This should hopefully fix some leaking monkeypatch modifications. My theory based on the failures seen in the unstable/test environment is that this monkeypatch'd import was being used in other tests besides the one it was implemented in (tracebacks include the `real_import` name). It may not be the actual solution to the failures in the experimental environment, but it is a start.

CC @BENR0

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
