### PR TITLE
Remove DataID attribute access in seviri_l2_grib reader

### DIFF
--- a/satpy/readers/seviri_l2_grib.py
+++ b/satpy/readers/seviri_l2_grib.py
@@ -65,8 +65,8 @@ class SeviriL2GribFileHandler(BaseFileHandler):
 
     def get_area_def(self, dataset_id):
         """Return the area definition for a dataset."""
-        self._area_dict['column_step'] = dataset_id.resolution
-        self._area_dict['line_step'] = dataset_id.resolution
+        self._area_dict['column_step'] = dataset_id["resolution"]
+        self._area_dict['line_step'] = dataset_id["resolution"]
 
         area_extent = calculate_area_extent(self._area_dict)
 

--- a/satpy/tests/reader_tests/test_seviri_l2_grib.py
+++ b/satpy/tests/reader_tests/test_seviri_l2_grib.py
@@ -168,7 +168,8 @@ class Test_SeviriL2GribFileHandler(unittest.TestCase):
                 with mock.patch('satpy.readers.seviri_l2_grib.calculate_area_extent',
                                 mock.Mock(name='calculate_area_extent')) as cae:
                     with mock.patch('satpy.readers.seviri_l2_grib.get_area_definition', mock.Mock()) as gad:
-                        self.reader.get_area_def(mock.Mock(resolution=400.))
+                        dataset_id = make_dataid(name='dummmy', resolution=400.)
+                        self.reader.get_area_def(dataset_id)
                         # Asserts that calculate_area_extent has been called with the correct arguments
                         expected_args = ({'center_point': 500, 'east': 1, 'west': 1000, 'south': 1, 'north': 1200,
                                          'column_step': 400., 'line_step': 400.},)


### PR DESCRIPTION
The recently merged PR https://github.com/pytroll/satpy/pull/2396, removed the DataID attribute access and modified affected readers accordingly. However, two instances in the `seviri_l2_grib` reader were not modified leading to failure when using this reader with the current main. This PR resolves this issue.

The initial commit fixed the attribute access, but broke the reader's unit test since a mocked `DataID` was used, which lead to `TypeError` since the mock object was not subscriptable. This was resolved by using `make_dataid` for the test instead.


