### PR TITLE
Fix warning when CF-writing a Scene with SwathDefinition area 

### DIFF
--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -733,7 +733,7 @@ class CFWriter(Writer):
     def _try_to_get_crs(new_data):
         """Try to get a CRS from attributes."""
         if "area" in new_data.attrs:
-            if isinstance(new_data.attrs["area"], AreaDefinition):
+            if isinstance(new_data.attrs["area"], (AreaDefinition, SwathDefinition)):
                 return new_data.attrs["area"].crs
             # at least one test case passes an area of type str
             logger.warning(

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -735,10 +735,7 @@ class CFWriter(Writer):
         if "area" in new_data.attrs:
             if isinstance(new_data.attrs["area"], AreaDefinition):
                 return new_data.attrs["area"].crs
-            elif isinstance(new_data.attrs["area"], SwathDefinition):
-                pass   # This is just used to avoid log a warning for SwathDefinition
-            else:
-                # at least one test case passes an area of type str
+            if not isinstance(new_data.attrs["area"], SwathDefinition):
                 logger.warning(
                     f"Could not tell CRS from area of type {type(new_data.attrs['area']).__name__:s}. "
                     "Assuming projected CRS.")

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -733,12 +733,15 @@ class CFWriter(Writer):
     def _try_to_get_crs(new_data):
         """Try to get a CRS from attributes."""
         if "area" in new_data.attrs:
-            if isinstance(new_data.attrs["area"], (AreaDefinition, SwathDefinition)):
+            if isinstance(new_data.attrs["area"], AreaDefinition):
                 return new_data.attrs["area"].crs
-            # at least one test case passes an area of type str
-            logger.warning(
-                f"Could not tell CRS from area of type {type(new_data.attrs['area']).__name__:s}. "
-                "Assuming projected CRS.")
+            elif isinstance(new_data.attrs["area"], SwathDefinition):
+                pass   # This is just used to avoid log a warning for SwathDefinition
+            else:
+                # at least one test case passes an area of type str
+                logger.warning(
+                    f"Could not tell CRS from area of type {type(new_data.attrs['area']).__name__:s}. "
+                    "Assuming projected CRS.")
         if "crs" in new_data.coords:
             return new_data.coords["crs"].item()
 


### PR DESCRIPTION
 This PR fixes an annoying erroneous warning occurring when writing with the CFWriter a satpy Scene to disk.


