### PR TITLE
Repair CF writer tests failing with libnetcdf >= 4.9.0

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -29,11 +29,9 @@ from unittest import mock
 import numpy as np
 import pytest
 import xarray as xr
-from packaging.version import Version
 
 from satpy import Scene
 from satpy.tests.utils import make_dsq
-from satpy.writers.cf_writer import _get_backend_versions
 
 try:
     from pyproj import CRS
@@ -1450,5 +1448,8 @@ def _get_compression_params(complevel):
 
 
 def _should_use_compression_keyword():
-    versions = _get_backend_versions()
-    return versions["libnetcdf"] >= Version("4.9.0")
+    # libnetcdf >= 4.9.0 supports the "compression" keyword argument,
+    # but xarray silently ignores it at the moment. See
+    # https://github.com/pydata/xarray/issues/7388. Once that issue is resolved,
+    # check libnetcdf version here.
+    return False

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -1450,5 +1450,12 @@ def _get_compression_params(complevel):
 
 
 def _should_use_compression_keyword():
+    # xarray currently ignores the "compression" keyword, see
+    # https://github.com/pydata/xarray/issues/7388. There's already an open
+    # PR, so we assume that this will be fixed in the next minor release
+    # (current release is 2023.02). If not, tests will fail and remind us.
     versions = _get_backend_versions()
-    return versions["libnetcdf"] >= Version("4.9.0")
+    return (
+        versions["libnetcdf"] >= Version("4.9.0") and
+        versions["xarray"] >= Version("2023.03")
+    )

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -29,9 +29,11 @@ from unittest import mock
 import numpy as np
 import pytest
 import xarray as xr
+from packaging.version import Version
 
 from satpy import Scene
 from satpy.tests.utils import make_dsq
+from satpy.writers.cf_writer import _get_backend_versions
 
 try:
     from pyproj import CRS
@@ -1448,8 +1450,5 @@ def _get_compression_params(complevel):
 
 
 def _should_use_compression_keyword():
-    # libnetcdf >= 4.9.0 supports the "compression" keyword argument,
-    # but xarray silently ignores it at the moment. See
-    # https://github.com/pydata/xarray/issues/7388. Once that issue is resolved,
-    # check libnetcdf version here.
-    return False
+    versions = _get_backend_versions()
+    return versions["libnetcdf"] >= Version("4.9.0")


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
CF writer tests fail with `libnetcdf4 >= 4.9.0`, because they use the `compression` keyword argument, which is ignored by xarray (https://github.com/pydata/xarray/issues/7388). To fix this, tie usage of the `compression` keyword to the xarray version. There's already an open PR, so we can assume that this will be fixed in the next minor release (`xarray >= 2023.03`).

My bad, sorry I missed that in #2390 .
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

