### PR TITLE
Fix dataid attribute access in JMA HRIT readers

### DIFF
--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -388,7 +388,7 @@ class HRITJMAFileHandler(HRITFileHandler):
         self._check_sensor_platform_consistency(info['sensor'])
 
         # Calibrate and mask space pixels
-        res = self._mask_space(self.calibrate(res, key.calibration))
+        res = self._mask_space(self.calibrate(res, key["calibration"]))
 
         # Add scanline acquisition time
         res.coords['acq_time'] = ('y', self.acq_time)

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -24,6 +24,8 @@ import dask.array as da
 import numpy as np
 from xarray import DataArray
 
+from satpy.tests.utils import make_dataid
+
 
 class TestHRITJMAFileHandler(unittest.TestCase):
     """Test the HRITJMAFileHandler."""
@@ -271,9 +273,7 @@ class TestHRITJMAFileHandler(unittest.TestCase):
         mda = self._get_mda(loff=1375.0, coff=1375.0, nlines=275, ncols=1375,
                             segno=1, numseg=10)
         reader = self._get_reader(mda=mda)
-
-        key = mock.MagicMock()
-        key.calibration = 'reflectance'
+        key = make_dataid(name="VIS", calibration="reflectance")
 
         base_get_dataset.return_value = DataArray(da.ones((275, 1375),
                                                           chunks=1024),


### PR DESCRIPTION
JMA HRIT readers still use dataid attribute access, which was removed in 0.41.0. Use key access instead. 

A mock in the unit test was masking the problem...

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Tests added <!-- for all bug fixes or enhancements -->

