### PR TITLE
Drop support for Python 3.8 and add 3.11 tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,10 +40,10 @@ jobs:
       fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         experimental: [false]
         include:
-          - python-version: "3.9"
+          - python-version: "3.11"
             os: "ubuntu-latest"
             experimental: true
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -40,10 +40,6 @@ the base Satpy installation.
     Satpy's interfaces are not guaranteed stable and may change until version
     1.0 when backwards compatibility will be a main focus.
 
-.. versionchanged:: 0.20.0
-
-    Dropped Python 2 support.
-
 .. _project: http://github.com/pytroll/satpy
 
 

--- a/setup.py
+++ b/setup.py
@@ -166,7 +166,7 @@ setup(name=NAME,
                               ]},
       zip_safe=False,
       install_requires=requires,
-      python_requires='>=3.8',
+      python_requires='>=3.9',
       extras_require=extras_require,
       entry_points=entry_points,
       )


### PR DESCRIPTION
Drop support for Python 3.8 and add tests for Python 3.11.  Remove a note that Python 2 support was dropped as this information is no longer relevant except for historians.


