### PR TITLE
Fix NUCAPS reader compatibility with new versions of xarray

### DIFF
--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -358,12 +358,14 @@ def _remove_data_at_pressure_levels(datasets_loaded, plevels_ds, pressure_levels
 
 def _get_pressure_level_condition(plevels_ds, pressure_levels):
     if pressure_levels is True:
-        cond = None
-    elif len(pressure_levels) == 2:
+        return None
+    if len(pressure_levels) == 2:
         cond = (plevels_ds >= pressure_levels[0]) & (plevels_ds <= pressure_levels[1])
     else:
         cond = plevels_ds == pressure_levels
-    return cond
+    # convert dask-based DataArray to a computed numpy-based DataArray to
+    # avoid unknown shapes of dask arrays when this condition is used for masking
+    return cond.compute()
 
 
 def _mask_data_below_surface_pressure(datasets_loaded, dataset_keys):


### PR DESCRIPTION
First noticed in https://github.com/pytroll/satpy/pull/2416, the unreleased version of xarray doesn't like using boolean dask arrays to mask/drop data of other arrays since it creates DataArrays of unknown shapes. The simple workaround in the NUCAPS reader is to just compute the small condition array/mask and then use it.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
