### PR TITLE
Add MODIS 05 L2 datasets to `modis_l2` reader

### DIFF
--- a/satpy/etc/readers/modis_l2.yaml
+++ b/satpy/etc/readers/modis_l2.yaml
@@ -207,16 +207,6 @@ datasets:
 
 # file contents: https://atmosphere-imager.gsfc.nasa.gov/sites/default/files/ModAtmo/MOD06_L2_CDL_fs.txt
 
-  scan_start_time:
-    name: scan_start_time
-    long_name: TAI time at start of scan replicated across the swath
-    units: seconds since 1993-1-1 00:00:00.0 0
-    file_type: mod06_hdf
-    coordinates: [longitude, latitude]
-    resolution:
-      5000:
-        file_key: Scan_Start_Time
-
   brightness_temperature:
     name: brightness_temperature
     long_name: Observed Brightness Temperature from Averaged Radiances in a 5x5 1-km Pixel Region

--- a/satpy/etc/readers/modis_l2.yaml
+++ b/satpy/etc/readers/modis_l2.yaml
@@ -9,6 +9,11 @@ reader:
   sensors: [modis]
 
 file_types:
+  mod05_hdf:
+    file_patterns:
+    - 'M{platform_indicator:1s}D05_L2.A{start_time:%Y%j.%H%M}.{collection:03d}.{production_time:%Y%j%H%M%S}.hdf'
+    - '{platform_indicator:1s}1.{start_time:%y%j.%H%M}.mod05.hdf'
+    file_reader: !!python/name:satpy.readers.modis_l2.ModisL2HDFFileHandler
   mod35_hdf:
     file_patterns:
     - 'M{platform_indicator:1s}D35_L2.A{start_time:%Y%j.%H%M}.{collection:03d}.{production_time:%Y%j%H%M%S}.hdf'
@@ -74,9 +79,9 @@ datasets:
     name: longitude
     resolution:
       5000:
-        file_type: [mod35_hdf, mod06_hdf, mod06ct_hdf, mod07_hdf]
+        file_type: [mod35_hdf, mod06_hdf, mod06ct_hdf, mod07_hdf, mod05_hdf]
       1000:
-        file_type: [hdf_eos_geo, mod35_hdf, mod06_hdf]
+        file_type: [hdf_eos_geo, mod35_hdf, mod06_hdf, mod05_hdf]
       500:
         file_type: hdf_eos_geo
       250:
@@ -89,9 +94,9 @@ datasets:
     resolution:
       5000:
         # For EUM reduced (thinned) files
-        file_type: [mod35_hdf, mod06_hdf, mod06ct_hdf, mod07_hdf]
+        file_type: [mod35_hdf, mod06_hdf, mod06ct_hdf, mod07_hdf, mod05_hdf]
       1000:
-        file_type: [hdf_eos_geo, mod35_hdf, mod06_hdf]
+        file_type: [hdf_eos_geo, mod35_hdf, mod06_hdf, mod05_hdf]
       500:
         file_type: hdf_eos_geo
       250:
@@ -144,10 +149,73 @@ datasets:
     coordinates: [longitude, latitude]
 
 ##########################
+#Datasets in file mod05_l2
+##########################
+  scan_start_time:
+    name: scan_start_time
+    long_name: TAI time at start of scan replicated across the swath
+    units: seconds since 1993-1-1 00:00:00.0 0
+    file_type: mod05_hdf
+    coordinates: [longitude, latitude]
+    resolution:
+      5000:
+        file_key: Scan_Start_Time
+
+  sensor_zenith:
+    name: sensor_zenith
+    long_name: Sensor Zenith Angle, Cell to Sensor
+    units: degree
+    file_type: mod05_hdf
+    coordinates: [longitude, latitude]
+    resolution:
+      5000:
+        file_key: Sensor_Zenith
+
+  water_vapor_correction_factor:
+    name: water_vapor_correction_factor
+    long_name: Aerosol Correction Factor for Water Vapor - Near Infrared Retrieval
+    units: None
+    file_type: mod05_hdf
+    coordinates: [longitude, latitude]
+    resolution:
+      1000:
+        file_key: Water_Vapor_Correction_Factor
+
+  water_vapor_near_infrared:
+    name: water_vapor_near_infrared
+    long_name: Total Column Precipitable Water Vapor - Near Infrared Retrieval
+    units: cm
+    file_type: mod05_hdf
+    coordinates: [longitude, latitude]
+    resolution:
+      1000:
+        file_key: Water_Vapor_Near_Infrared
+
+  water_vapor_infrared:
+    name: water_vapor_infrared
+    long_name: Total Column Precipitable Water Vapor - Infrared Retrieval
+    units: cm
+    file_type: mod05_hdf
+    coordinates: [longitude, latitude]
+    resolution:
+      5000:
+        file_key: Water_Vapor_Infrared
+
+##########################
 #Datasets in file mod06_l2
 ##########################
 
 # file contents: https://atmosphere-imager.gsfc.nasa.gov/sites/default/files/ModAtmo/MOD06_L2_CDL_fs.txt
+
+  scan_start_time:
+    name: scan_start_time
+    long_name: TAI time at start of scan replicated across the swath
+    units: seconds since 1993-1-1 00:00:00.0 0
+    file_type: mod06_hdf
+    coordinates: [longitude, latitude]
+    resolution:
+      5000:
+        file_key: Scan_Start_Time
 
   brightness_temperature:
     name: brightness_temperature

--- a/satpy/etc/readers/modis_l2.yaml
+++ b/satpy/etc/readers/modis_l2.yaml
@@ -174,7 +174,7 @@ datasets:
   water_vapor_correction_factor:
     name: water_vapor_correction_factor
     long_name: Aerosol Correction Factor for Water Vapor - Near Infrared Retrieval
-    units: None
+    units: "1"
     file_type: mod05_hdf
     coordinates: [longitude, latitude]
     resolution:

--- a/satpy/etc/readers/modis_l2.yaml
+++ b/satpy/etc/readers/modis_l2.yaml
@@ -161,8 +161,8 @@ datasets:
       5000:
         file_key: Scan_Start_Time
 
-  sensor_zenith_angle:
-    name: sensor_zenith_angle
+  satellite_zenith_angle:
+    name: satellite_zenith_angle
     long_name: Sensor Zenith Angle, Cell to Sensor
     units: degree
     file_type: [mod05_hdf, mod06_hdf]

--- a/satpy/etc/readers/modis_l2.yaml
+++ b/satpy/etc/readers/modis_l2.yaml
@@ -165,7 +165,7 @@ datasets:
     name: sensor_zenith_angle
     long_name: Sensor Zenith Angle, Cell to Sensor
     units: degree
-    file_type: mod05_hdf
+    file_type: [mod05_hdf, mod06_hdf]
     coordinates: [longitude, latitude]
     resolution:
       5000:

--- a/satpy/etc/readers/modis_l2.yaml
+++ b/satpy/etc/readers/modis_l2.yaml
@@ -155,14 +155,14 @@ datasets:
     name: scan_start_time
     long_name: TAI time at start of scan replicated across the swath
     units: seconds since 1993-1-1 00:00:00.0 0
-    file_type: mod05_hdf
+    file_type: [mod05_hdf, mod06_hdf]
     coordinates: [longitude, latitude]
     resolution:
       5000:
         file_key: Scan_Start_Time
 
-  sensor_zenith:
-    name: sensor_zenith
+  sensor_zenith_angle:
+    name: sensor_zenith_angle
     long_name: Sensor Zenith Angle, Cell to Sensor
     units: degree
     file_type: mod05_hdf
@@ -206,16 +206,6 @@ datasets:
 ##########################
 
 # file contents: https://atmosphere-imager.gsfc.nasa.gov/sites/default/files/ModAtmo/MOD06_L2_CDL_fs.txt
-
-  scan_start_time:
-    name: scan_start_time
-    long_name: TAI time at start of scan replicated across the swath
-    units: seconds since 1993-1-1 00:00:00.0 0
-    file_type: mod06_hdf
-    coordinates: [longitude, latitude]
-    resolution:
-      5000:
-        file_key: Scan_Start_Time
 
   brightness_temperature:
     name: brightness_temperature


### PR DESCRIPTION
Hi guys, below a couple of product modis05 datasets .  content of water vapor with retrieval in infrared and near infrared bands, correction factor , vza, ad acquisition time datasets (for mod06 and mod05 both)
I think the tests are enough for those that already exist 