### PR TITLE
Update condition of xarray version in CF writer tests

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -1457,5 +1457,5 @@ def _should_use_compression_keyword():
     versions = _get_backend_versions()
     return (
         versions["libnetcdf"] >= Version("4.9.0") and
-        versions["xarray"] >= Version("2023.03")
+        versions["xarray"] >= Version("2023.04")
     )


### PR DESCRIPTION
These tests were originally fixed by @sfinkens in https://github.com/pytroll/satpy/pull/2412, but it assumed that the related xarray PR (https://github.com/pydata/xarray/pull/7551) would be included in the next xarray release (2023.3.0) but it wasn't so now the tests are failing again. This PR bumps the xarray version check.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
