### PR TITLE
Support reading from S3 for AHI-HSD

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -49,6 +49,7 @@ The following people have made contributions to this project:
 - [Andrea Meraner (ameraner)](https://github.com/ameraner)
 - [Aronne Merrelli (aronnem)](https://github.com/aronnem)
 - [Lucas Meyer (LTMeyer)](https://github.com/LTMeyer)
+- [Zifeng Mo (Isotr0py)](https://github.com/Isotr0py)
 - [Ondrej Nedelcev (nedelceo)](https://github.com/nedelceo)
 - [Oana Nicola](https://github.com/)
 - [Esben S. Nielsen (storpipfugl)](https://github.com/storpipfugl)
@@ -82,4 +83,3 @@ The following people have made contributions to this project:
 - [praerien (praerien)](https://github.com/praerien)
 - [Xin Zhang (zxdawn)](https://github.com/zxdawn)
 - [Yufei Zhu (yufeizhu600)](https://github.com/yufeizhu600)
-- [Zifeng Mo (Isotr0py)](https://github.com/Isotr0py)

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -359,9 +359,9 @@ class AHIHSDFileHandler(BaseFileHandler):
                                                 filetype_info)
 
         self.is_zipped = False
-        if isinstance(self.filename,str):
+        if isinstance(self.filename, str):
             self._unzipped = unzip_file(self.filename, prefix=str(filename_info['segment']).zfill(2))
-        elif isinstance(self.filename,FSFile):
+        elif isinstance(self.filename, FSFile):
             self._unzipped = unzip_FSFile(self.filename, prefix=str(filename_info['segment']).zfill(2))
         # Assume file is not zipped
         if self._unzipped:

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -69,6 +69,7 @@ import xarray as xr
 
 from satpy import CHUNK_SIZE
 from satpy._compat import cached_property
+from satpy.readers import FSFile
 from satpy.readers._geos_area import get_area_definition, get_area_extent
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.utils import (
@@ -78,6 +79,7 @@ from satpy.readers.utils import (
     get_user_calibration_factors,
     np2str,
     unzip_file,
+    unzip_FSFile
 )
 
 AHI_CHANNEL_NAMES = ("1", "2", "3", "4", "5",
@@ -357,7 +359,10 @@ class AHIHSDFileHandler(BaseFileHandler):
                                                 filetype_info)
 
         self.is_zipped = False
-        self._unzipped = unzip_file(self.filename, prefix=str(filename_info['segment']).zfill(2))
+        if isinstance(self.filename,str):
+            self._unzipped = unzip_file(self.filename, prefix=str(filename_info['segment']).zfill(2))
+        elif isinstance(self.filename,FSFile):
+            self._unzipped = unzip_FSFile(self.filename, prefix=str(filename_info['segment']).zfill(2))
         # Assume file is not zipped
         if self._unzipped:
             # But if it is, set the filename to point to unzipped temp file

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -79,7 +79,7 @@ from satpy.readers.utils import (
     get_user_calibration_factors,
     np2str,
     unzip_file,
-    unzip_FSFile
+    unzip_FSFile,
 )
 
 AHI_CHANNEL_NAMES = ("1", "2", "3", "4", "5",

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -69,7 +69,6 @@ import xarray as xr
 
 from satpy import CHUNK_SIZE
 from satpy._compat import cached_property
-from satpy.readers import FSFile
 from satpy.readers._geos_area import get_area_definition, get_area_extent
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.utils import (
@@ -79,7 +78,6 @@ from satpy.readers.utils import (
     get_user_calibration_factors,
     np2str,
     unzip_file,
-    unzip_FSFile,
 )
 
 AHI_CHANNEL_NAMES = ("1", "2", "3", "4", "5",
@@ -359,10 +357,7 @@ class AHIHSDFileHandler(BaseFileHandler):
                                                 filetype_info)
 
         self.is_zipped = False
-        if isinstance(self.filename, str):
-            self._unzipped = unzip_file(self.filename, prefix=str(filename_info['segment']).zfill(2))
-        elif isinstance(self.filename, FSFile):
-            self._unzipped = unzip_FSFile(self.filename, prefix=str(filename_info['segment']).zfill(2))
+        self._unzipped = unzip_file(self.filename, prefix=str(filename_info['segment']).zfill(2))
         # Assume file is not zipped
         if self._unzipped:
             # But if it is, set the filename to point to unzipped temp file

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -312,7 +312,6 @@ def _unzip_FSFile(filename: FSFile, prefix=None):
         content = bz2.decompress(content)
 
     return _write_uncompress_file(content, fdn, filename, tmpfilepath)
-# endregion
 
 
 @contextmanager

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -278,13 +278,13 @@ def _unzip_with_pbzip(filename, tmpfilepath, fdn):
 
 
 def _unzip_with_bz2(filename, tmpfilepath):
-    with bz2.BZ2File(filename) as bz2file:
-        try:
-            content = bz2file.read()
-        except IOError:
-            LOGGER.debug("Failed to unzip bzipped file %s", str(filename))
-            os.remove(tmpfilepath)
-            raise
+    try:
+        bz2file = bz2.BZ2File(bz2.BZ2File(filename))
+        content = bz2file.read()
+    except IOError:
+        LOGGER.debug("Failed to unzip bzipped file %s", str(filename))
+        os.remove(tmpfilepath)
+        raise
     return content
 
 

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -200,7 +200,6 @@ def get_sub_area(area, xslice, yslice):
                           new_area_extent)
 
 
-# region unzip helpers
 def unzip_file(filename: str | FSFile, prefix=None):
     """Unzip the local/remote file ending with 'bz2'.
 

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -27,6 +27,7 @@ from contextlib import closing, contextmanager
 from io import BytesIO
 from shutil import which
 from subprocess import PIPE, Popen  # nosec
+from typing import Union
 
 import numpy as np
 import pyproj
@@ -199,7 +200,7 @@ def get_sub_area(area, xslice, yslice):
                           new_area_extent)
 
 
-def unzip_file(filename: str, prefix=None):
+def unzip_file(filename: Union[str, FSFile], prefix=None):
     """Unzip the local/remote file ending with 'bz2'.
 
     Args:

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -199,7 +199,7 @@ def get_sub_area(area, xslice, yslice):
                           new_area_extent)
 
 
-def unzip_file(filename:str, prefix=None):
+def unzip_file(filename: str, prefix=None):
     """Unzip the file ending with 'bz2'. Initially with pbzip2 if installed or bz2.
 
     Args:
@@ -263,9 +263,10 @@ def unzip_file(filename:str, prefix=None):
 
     return None
 
-def unzip_FSFile(filename:FSFile, prefix=None):
+
+def unzip_FSFile(filename: FSFile, prefix=None):
     """Open and Unzip remote FSFile ending with 'bz2'.
-    
+
     Args:
         filename: The FSFile to unzip.
         prefix (str, optional): If file is one of many segments of data, prefix random filename
@@ -276,7 +277,8 @@ def unzip_FSFile(filename:FSFile, prefix=None):
 
     """
     if str(filename).endswith('bz2'):
-        fdn, tmpfilepath = tempfile.mkstemp(prefix=prefix,dir=config["tmp_dir"])
+        fdn, tmpfilepath = tempfile.mkstemp(prefix=prefix,
+                                            dir=config["tmp_dir"])
         # open file and decompress to memory
         zip_file = filename.open().read()
         content = bz2.decompress(zip_file)

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -200,6 +200,24 @@ def get_sub_area(area, xslice, yslice):
 
 
 def unzip_file(filename: str, prefix=None):
+    """Unzip the local/remote file ending with 'bz2'.
+
+    Args:
+        filename: The local/remote file to unzip.
+        prefix (str, optional): If file is one of many segments of data, prefix random filename
+        for correct sorting. This is normally the segment number.
+
+    Returns:
+        Temporary filename path for decompressed file or None.
+
+    """
+    if isinstance(filename, str):
+        return _unzip_local_file(filename, prefix=prefix)
+    elif isinstance(filename, FSFile):
+        return _unzip_FSFile(filename, prefix=prefix)
+
+
+def _unzip_local_file(filename: str, prefix=None):
     """Unzip the file ending with 'bz2'. Initially with pbzip2 if installed or bz2.
 
     Args:
@@ -211,60 +229,59 @@ def unzip_file(filename: str, prefix=None):
         Temporary filename path for decompressed file or None.
 
     """
-    if os.fspath(filename).endswith('bz2'):
-        fdn, tmpfilepath = tempfile.mkstemp(prefix=prefix,
-                                            dir=config["tmp_dir"])
-        LOGGER.info("Using temp file for BZ2 decompression: %s", tmpfilepath)
-        # try pbzip2
-        pbzip = which('pbzip2')
-        # Run external pbzip2
-        if pbzip is not None:
-            n_thr = os.environ.get('OMP_NUM_THREADS')
-            if n_thr:
-                runner = [pbzip,
-                          '-dc',
-                          '-p'+str(n_thr),
-                          filename]
-            else:
-                runner = [pbzip,
-                          '-dc',
-                          filename]
-            p = Popen(runner, stdout=PIPE, stderr=PIPE)  # nosec
-            stdout = BytesIO(p.communicate()[0])
-            status = p.returncode
-            if status != 0:
-                raise IOError("pbzip2 error '%s', failed, status=%d"
-                              % (filename, status))
-            with closing(os.fdopen(fdn, 'wb')) as ofpt:
-                try:
-                    stdout.seek(0)
-                    shutil.copyfileobj(stdout, ofpt)
-                except IOError:
-                    import traceback
-                    traceback.print_exc()
-                    LOGGER.info("Failed to read bzipped file %s",
-                                str(filename))
-                    os.remove(tmpfilepath)
-                    raise
-            return tmpfilepath
+    if not os.fspath(filename).endswith('bz2'):
+        return None
 
-        # Otherwise, fall back to the original method
-        bz2file = bz2.BZ2File(filename)
+    fdn, tmpfilepath = tempfile.mkstemp(prefix=prefix,
+                                        dir=config["tmp_dir"])
+    LOGGER.info("Using temp file for BZ2 decompression: %s", tmpfilepath)
+    # try pbzip2
+    pbzip = which('pbzip2')
+    # Run external pbzip2
+    if pbzip is not None:
+        n_thr = os.environ.get('OMP_NUM_THREADS')
+        if n_thr:
+            runner = [pbzip,
+                      '-dc',
+                      '-p'+str(n_thr),
+                      filename]
+        else:
+            runner = [pbzip,
+                      '-dc',
+                      filename]
+        p = Popen(runner, stdout=PIPE, stderr=PIPE)  # nosec
+        stdout = BytesIO(p.communicate()[0])
+        status = p.returncode
+        if status != 0:
+            raise IOError("pbzip2 error '%s', failed, status=%d"
+                          % (filename, status))
         with closing(os.fdopen(fdn, 'wb')) as ofpt:
             try:
-                ofpt.write(bz2file.read())
+                stdout.seek(0)
+                shutil.copyfileobj(stdout, ofpt)
             except IOError:
                 import traceback
                 traceback.print_exc()
-                LOGGER.info("Failed to read bzipped file %s", str(filename))
+                LOGGER.info("Failed to read bzipped file %s",
+                            str(filename))
                 os.remove(tmpfilepath)
-                return None
+                raise
         return tmpfilepath
+    # Otherwise, fall back to the original method
+    bz2file = bz2.BZ2File(filename)
+    with closing(os.fdopen(fdn, 'wb')) as ofpt:
+        try:
+            ofpt.write(bz2file.read())
+        except IOError:
+            import traceback
+            traceback.print_exc()
+            LOGGER.info("Failed to read bzipped file %s", str(filename))
+            os.remove(tmpfilepath)
+            return None
+    return tmpfilepath
 
-    return None
 
-
-def unzip_FSFile(filename: FSFile, prefix=None):
+def _unzip_FSFile(filename: FSFile, prefix=None):
     """Open and Unzip remote FSFile ending with 'bz2'.
 
     Args:
@@ -276,24 +293,24 @@ def unzip_FSFile(filename: FSFile, prefix=None):
         Temporary filename path for decompressed file or None.
 
     """
-    if str(filename).endswith('bz2'):
-        fdn, tmpfilepath = tempfile.mkstemp(prefix=prefix,
-                                            dir=config["tmp_dir"])
-        # open file and decompress to memory
-        zip_file = filename.open().read()
-        content = bz2.decompress(zip_file)
-        with closing(os.fdopen(fdn, 'wb')) as ofpt:
-            try:
-                ofpt.write(content)
-            except IOError:
-                import traceback
-                traceback.print_exc()
-                LOGGER.info("Failed to read bzipped file %s", str(filename))
-                os.remove(tmpfilepath)
-                return None
-        return tmpfilepath
+    if not str(filename).endswith('bz2'):
+        return None
 
-    return None
+    fdn, tmpfilepath = tempfile.mkstemp(prefix=prefix,
+                                        dir=config["tmp_dir"])
+    # open file and decompress to memory
+    zip_file = filename.open().read()
+    content = bz2.decompress(zip_file)
+    with closing(os.fdopen(fdn, 'wb')) as ofpt:
+        try:
+            ofpt.write(content)
+        except IOError:
+            import traceback
+            traceback.print_exc()
+            LOGGER.info("Failed to read bzipped file %s", str(filename))
+            os.remove(tmpfilepath)
+            return None
+    return tmpfilepath
 
 
 @contextmanager

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -278,13 +278,13 @@ def _unzip_with_pbzip(filename, tmpfilepath, fdn):
 
 
 def _unzip_with_bz2(filename, tmpfilepath):
-    try:
-        bz2file = bz2.BZ2File(bz2.BZ2File(filename))
-        content = bz2file.read()
-    except IOError:
-        LOGGER.debug("Failed to unzip bzipped file %s", str(filename))
-        os.remove(tmpfilepath)
-        raise
+    with bz2.BZ2File(filename) as bz2file:
+        try:
+            content = bz2file.read()
+        except IOError:
+            LOGGER.debug("Failed to unzip bzipped file %s", str(filename))
+            os.remove(tmpfilepath)
+            raise
     return content
 
 

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -292,8 +292,9 @@ def unzip_FSFile(filename: FSFile, prefix=None):
                 os.remove(tmpfilepath)
                 return None
         return tmpfilepath
-    
+
     return None
+
 
 @contextmanager
 def unzip_context(filename):

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -34,7 +34,7 @@ import xarray as xr
 from pyresample.geometry import AreaDefinition
 
 from satpy import CHUNK_SIZE, config
-from satpy.readers import FSFile, open_file_or_filename
+from satpy.readers import FSFile
 
 LOGGER = logging.getLogger(__name__)
 
@@ -199,7 +199,7 @@ def get_sub_area(area, xslice, yslice):
                           new_area_extent)
 
 
-def unzip_file(filename:str|bytes, prefix=None):
+def unzip_file(filename:str, prefix=None):
     """Unzip the file ending with 'bz2'. Initially with pbzip2 if installed or bz2.
 
     Args:
@@ -211,58 +211,74 @@ def unzip_file(filename:str|bytes, prefix=None):
         Temporary filename path for decompressed file or None.
 
     """
-    fdn, tmpfilepath = tempfile.mkstemp(prefix=prefix,
-                                                dir=config["tmp_dir"])
-    if type(filename) == str:
-        if os.fspath(filename).endswith('bz2'):
-            LOGGER.info("Using temp file for BZ2 decompression: %s", tmpfilepath)
-            # try pbzip2
-            pbzip = which('pbzip2')
-            # Run external pbzip2
-            if pbzip is not None:
-                n_thr = os.environ.get('OMP_NUM_THREADS')
-                if n_thr:
-                    runner = [pbzip,
-                            '-dc',
-                            '-p'+str(n_thr),
-                            filename]
-                else:
-                    runner = [pbzip,
-                            '-dc',
-                            filename]
-                p = Popen(runner, stdout=PIPE, stderr=PIPE)  # nosec
-                stdout = BytesIO(p.communicate()[0])
-                status = p.returncode
-                if status != 0:
-                    raise IOError("pbzip2 error '%s', failed, status=%d"
-                                % (filename, status))
-                with closing(os.fdopen(fdn, 'wb')) as ofpt:
-                    try:
-                        stdout.seek(0)
-                        shutil.copyfileobj(stdout, ofpt)
-                    except IOError:
-                        import traceback
-                        traceback.print_exc()
-                        LOGGER.info("Failed to read bzipped file %s",
-                                    str(filename))
-                        os.remove(tmpfilepath)
-                        raise
-                return tmpfilepath
-
-            # Otherwise, fall back to the original method
-            bz2file = bz2.BZ2File(filename)
+    if os.fspath(filename).endswith('bz2'):
+        fdn, tmpfilepath = tempfile.mkstemp(prefix=prefix,
+                                            dir=config["tmp_dir"])
+        LOGGER.info("Using temp file for BZ2 decompression: %s", tmpfilepath)
+        # try pbzip2
+        pbzip = which('pbzip2')
+        # Run external pbzip2
+        if pbzip is not None:
+            n_thr = os.environ.get('OMP_NUM_THREADS')
+            if n_thr:
+                runner = [pbzip,
+                          '-dc',
+                          '-p'+str(n_thr),
+                          filename]
+            else:
+                runner = [pbzip,
+                          '-dc',
+                          filename]
+            p = Popen(runner, stdout=PIPE, stderr=PIPE)  # nosec
+            stdout = BytesIO(p.communicate()[0])
+            status = p.returncode
+            if status != 0:
+                raise IOError("pbzip2 error '%s', failed, status=%d"
+                              % (filename, status))
             with closing(os.fdopen(fdn, 'wb')) as ofpt:
                 try:
-                    ofpt.write(bz2file.read())
+                    stdout.seek(0)
+                    shutil.copyfileobj(stdout, ofpt)
                 except IOError:
                     import traceback
                     traceback.print_exc()
-                    LOGGER.info("Failed to read bzipped file %s", str(filename))
+                    LOGGER.info("Failed to read bzipped file %s",
+                                str(filename))
                     os.remove(tmpfilepath)
-                    return None
+                    raise
             return tmpfilepath
-    elif type(filename) == FSFile:
-        zip_file = open_file_or_filename(filename).read()
+
+        # Otherwise, fall back to the original method
+        bz2file = bz2.BZ2File(filename)
+        with closing(os.fdopen(fdn, 'wb')) as ofpt:
+            try:
+                ofpt.write(bz2file.read())
+            except IOError:
+                import traceback
+                traceback.print_exc()
+                LOGGER.info("Failed to read bzipped file %s", str(filename))
+                os.remove(tmpfilepath)
+                return None
+        return tmpfilepath
+
+    return None
+
+def unzip_FSFile(filename:FSFile, prefix=None):
+    """Open and Unzip remote FSFile ending with 'bz2'.
+    
+    Args:
+        filename: The FSFile to unzip.
+        prefix (str, optional): If file is one of many segments of data, prefix random filename
+        for correct sorting. This is normally the segment number.
+
+    Returns:
+        Temporary filename path for decompressed file or None.
+
+    """
+    if str(filename).endswith('bz2'):
+        fdn, tmpfilepath = tempfile.mkstemp(prefix=prefix,dir=config["tmp_dir"])
+        # open file and decompress to memory
+        zip_file = filename.open().read()
         content = bz2.decompress(zip_file)
         with closing(os.fdopen(fdn, 'wb')) as ofpt:
             try:
@@ -274,10 +290,8 @@ def unzip_file(filename:str|bytes, prefix=None):
                 os.remove(tmpfilepath)
                 return None
         return tmpfilepath
-    else:
-        os.remove(tmpfilepath)
+    
     return None
-
 
 @contextmanager
 def unzip_context(filename):

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -362,7 +362,7 @@ class TestHelpers(unittest.TestCase):
         new_fname = hf.unzip_file(fsf, prefix=segmentstr)
         mock_bz2_decompress.assert_not_called
         bz2_mock.assert_not_called
-        assert os.path.exists(new_fname) is True
+        assert os.path.exists(new_fname)
         assert os.path.split(new_fname)[1][0:2] == segmentstr
         if os.path.exists(new_fname):
             os.remove(new_fname)
@@ -376,7 +376,7 @@ class TestHelpers(unittest.TestCase):
         new_fname = hf.unzip_file(fsf, prefix=segmentstr)
         mock_bz2_decompress.assert_called
         bz2_mock.assert_called
-        assert os.path.exists(new_fname) is True
+        assert os.path.exists(new_fname)
         assert os.path.split(new_fname)[1][0:2] == segmentstr
         if os.path.exists(new_fname):
             os.remove(new_fname)

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -359,11 +359,11 @@ class TestHelpers(unittest.TestCase):
         segment = 3
         segmentstr = str(segment).zfill(2)
 
-        new_fname = hf.unzip_FSFile(fsf, prefix=segmentstr)
-        assert mock_bz2_decompress.called
-        self.assertEqual(bz2_mock, mock_bz2_decompress.return_value)
-        self.assertTrue(os.path.exists(new_fname))
-        self.assertNotEqual(os.path.split(new_fname)[1][0:2], segmentstr)
+        new_fname = hf.unzip_file(fsf, prefix=segmentstr)
+        mock_bz2_decompress.assert_called
+        assert bz2_mock == mock_bz2_decompress.return_value
+        assert os.path.exists(new_fname) is True
+        assert os.path.split(new_fname)[1][0:2] != segmentstr
         if os.path.exists(new_fname):
             os.remove(new_fname)
 
@@ -372,7 +372,7 @@ class TestHelpers(unittest.TestCase):
         mem_file.commit()
         fsf = FSFile(mem_file)
         new_fname = hf.unzip_file(fsf)
-        self.assertIsNone(new_fname)
+        assert new_fname is None
 
     @mock.patch("os.remove")
     @mock.patch("satpy.readers.utils.unzip_file", return_value='dummy.txt')

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -344,6 +344,36 @@ class TestHelpers(unittest.TestCase):
 
         assert mock_fn_open.read.called
 
+    @mock.patch('bz2.decompress')
+    def test_unzip_FSFile(self,bz2_mock):
+        """Test the bz2 file unzipping techniques."""
+        mock_bz2_open = mock.MagicMock()
+        mock_bz2_open.return_value = b'TEST_DECOMPRESSED'
+
+        # test zipped FSFile
+        mem_fs = MemoryFileSystem()
+        mem_file = MemoryFile(fs=mem_fs, path="{}test.DAT.bz2".format(mem_fs.root_marker), data=b"TEST")
+        mem_file.commit()
+        fsf = FSFile(mem_file)
+
+        segment = 3
+        segmentstr = str(segment).zfill(2)
+
+        new_fname = hf.unzip_FSFile(fsf, prefix=segmentstr)
+        assert mock_bz2_open.called
+        self.assertEqual(bz2_mock,mock_bz2_open.return_value)
+        self.assertTrue(os.path.exists(new_fname))
+        self.assertNotEqual(os.path.split(new_fname)[1][0:2], segmentstr)
+        if os.path.exists(new_fname):
+            os.remove(new_fname)
+
+        # test unzipped FSFile
+        mem_file = MemoryFile(fs=mem_fs, path="{}test.DAT".format(mem_fs.root_marker), data=b"TEST")
+        mem_file.commit()
+        fsf = FSFile(mem_file)
+        new_fname = hf.unzip_file(fsf)
+        self.assertIsNone(new_fname)
+
     @mock.patch("os.remove")
     @mock.patch("satpy.readers.utils.unzip_file", return_value='dummy.txt')
     def test_pro_reading_gets_unzipped_file(self, fake_unzip_file, fake_remove):

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -345,10 +345,10 @@ class TestHelpers(unittest.TestCase):
         assert mock_fn_open.read.called
 
     @mock.patch('bz2.decompress')
-    def test_unzip_FSFile(self,bz2_mock):
-        """Test the bz2 file unzipping techniques."""
-        mock_bz2_open = mock.MagicMock()
-        mock_bz2_open.return_value = b'TEST_DECOMPRESSED'
+    def test_unzip_FSFile(self, bz2_mock):
+        """Test the FSFile bz2 file unzipping techniques."""
+        mock_bz2_decompress = mock.MagicMock()
+        mock_bz2_decompress.return_value = b'TEST_DECOMPRESSED'
 
         # test zipped FSFile
         mem_fs = MemoryFileSystem()
@@ -360,8 +360,8 @@ class TestHelpers(unittest.TestCase):
         segmentstr = str(segment).zfill(2)
 
         new_fname = hf.unzip_FSFile(fsf, prefix=segmentstr)
-        assert mock_bz2_open.called
-        self.assertEqual(bz2_mock,mock_bz2_open.return_value)
+        assert mock_bz2_decompress.called
+        self.assertEqual(bz2_mock, mock_bz2_decompress.return_value)
         self.assertTrue(os.path.exists(new_fname))
         self.assertNotEqual(os.path.split(new_fname)[1][0:2], segmentstr)
         if os.path.exists(new_fname):

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -276,7 +276,7 @@ class TestHelpers(unittest.TestCase):
         mock_popen.return_value = process_mock
 
         bz2_mock = mock.MagicMock()
-        bz2_mock.read.return_value = b'TEST'
+        bz2_mock.__enter__.return_value.read.return_value = b'TEST'
         mock_bz2.return_value = bz2_mock
 
         filename = 'tester.DAT.bz2'
@@ -287,7 +287,7 @@ class TestHelpers(unittest.TestCase):
         with mock.patch(whichstr) as whichmock:
             whichmock.return_value = None
             new_fname = hf.unzip_file(filename, prefix=segmentstr)
-            self.assertTrue(bz2_mock.read.called)
+            self.assertTrue(bz2_mock.__enter__.return_value.read.called)
             self.assertTrue(os.path.exists(new_fname))
             self.assertEqual(os.path.split(new_fname)[1][0:2], segmentstr)
             if os.path.exists(new_fname):

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -304,7 +304,7 @@ class TestHelpers(unittest.TestCase):
 
         filename = 'tester.DAT'
         new_fname = hf.unzip_file(filename)
-        self.assertIsNone(new_fname)
+        assert new_fname is None
 
     @mock.patch('bz2.BZ2File')
     def test_generic_open_BZ2File(self, bz2_mock):

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -287,18 +287,18 @@ class TestHelpers(unittest.TestCase):
         with mock.patch(whichstr) as whichmock:
             whichmock.return_value = None
             new_fname = hf.unzip_file(filename, prefix=segmentstr)
-            self.assertTrue(bz2_mock.__enter__.return_value.read.called)
-            self.assertTrue(os.path.exists(new_fname))
-            self.assertEqual(os.path.split(new_fname)[1][0:2], segmentstr)
+            assert bz2_mock.__enter__.return_value.read.called
+            assert os.path.exists(new_fname)
+            assert os.path.split(new_fname)[1][0:2] == segmentstr
             if os.path.exists(new_fname):
                 os.remove(new_fname)
         # pbzip2 installed without prefix
         with mock.patch(whichstr) as whichmock:
             whichmock.return_value = '/usr/bin/pbzip2'
             new_fname = hf.unzip_file(filename)
-            self.assertTrue(mock_popen.called)
-            self.assertTrue(os.path.exists(new_fname))
-            self.assertNotEqual(os.path.split(new_fname)[1][0:2], segmentstr)
+            assert mock_popen.called
+            assert os.path.exists(new_fname)
+            assert os.path.split(new_fname)[1][0:2] != segmentstr
             if os.path.exists(new_fname):
                 os.remove(new_fname)
 

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -344,7 +344,7 @@ class TestHelpers(unittest.TestCase):
 
         assert mock_fn_open.read.called
 
-    @mock.patch('bz2.decompress')
+    @mock.patch('bz2.decompress', return_value=b'TEST_DECOMPRESSED')
     def test_unzip_FSFile(self, bz2_mock):
         """Test the FSFile bz2 file unzipping techniques."""
         mock_bz2_decompress = mock.MagicMock()
@@ -361,9 +361,9 @@ class TestHelpers(unittest.TestCase):
 
         new_fname = hf.unzip_file(fsf, prefix=segmentstr)
         mock_bz2_decompress.assert_called
-        assert bz2_mock == mock_bz2_decompress.return_value
+        bz2_mock.assert_called
         assert os.path.exists(new_fname) is True
-        assert os.path.split(new_fname)[1][0:2] != segmentstr
+        assert os.path.split(new_fname)[1][0:2] == segmentstr
         if os.path.exists(new_fname):
             os.remove(new_fname)
 


### PR DESCRIPTION
- Add support for reading AHI-HSD data from AWS S3

Since NOAA provides open AHI-HSD data on [noaa-himawari](https://noaa-himawari9.s3.amazonaws.com/index.html), I think it's possible to read remote Himawari data from AWS S3 with just some simple changes on `satpy/readers/util.py`.

Here is my simple test code:
```python
# a simple test code
from satpy import Scene

reader_kwargs = {
    'storage_options': {
        's3': {'anon': True},
        'simple': {
            'cache_storage': '/tmp/s3_cache',
        }
    }
}

filenames = ['simplecache::s3://noaa-himawari9/AHI-L1b-FLDK/2023/03/24/0450/HS_H09_20230324_0450_B0*']
scn = Scene(filenames=filenames, reader='ahi_hsd',reader_kwargs=reader_kwargs)
scn.load(['true_color'])
new_scn = scn.resample(scn.coarsest_area(), resampler='native')
new_scn.save_dataset('true_color', filename='himawari_ahi_truecolor_03240450.png')
```

And the output should be like this:
![himawari_ahi_truecolor_03240450](https://user-images.githubusercontent.com/41363108/227448160-91170b27-9eda-43a5-ac6d-3afddb2a67da.png)
(I resize the output image because the original image is too large to show)

 - [ ] Fully documented
 - [x] Add your name to `AUTHORS.md` if not there already
