### PR TITLE
Remove usage of open_rasterio in some readers

### DIFF
--- a/satpy/readers/generic_image.py
+++ b/satpy/readers/generic_image.py
@@ -75,7 +75,16 @@ class GenericImageFileHandler(BaseFileHandler):
         if hasattr(dataset, 'crs') and dataset.crs is not None:
             self.area = utils.get_area_def_from_raster(dataset)
 
-        data = xr.open_rasterio(dataset, chunks=(1, CHUNK_SIZE, CHUNK_SIZE))
+        data = xr.open_dataset(self.finfo["filename"], engine="rasterio",
+                               chunks={"band": 1, "y": CHUNK_SIZE, "x": CHUNK_SIZE}, mask_and_scale=False)["band_data"]
+        if hasattr(dataset, "nodatavals"):
+            # The nodata values for the raster bands
+            # copied from https://github.com/pydata/xarray/blob/v2023.03.0/xarray/backends/rasterio_.py#L322-L326
+            nodatavals = tuple(
+                np.nan if nodataval is None else nodataval for nodataval in dataset.nodatavals
+            )
+            data.attrs["nodatavals"] = nodatavals
+
         attrs = data.attrs.copy()
 
         # Rename to Satpy convention

--- a/satpy/readers/msi_safe.py
+++ b/satpy/readers/msi_safe.py
@@ -35,13 +35,12 @@ L1B format description for the files read here:
 """
 
 import logging
-import xml.etree.ElementTree as ET
 
 import dask.array as da
+import defusedxml.ElementTree as ET
 import numpy as np
-import rioxarray
+import xarray as xr
 from pyresample import geometry
-from xarray import DataArray
 
 from satpy import CHUNK_SIZE
 from satpy._compat import cached_property
@@ -84,7 +83,7 @@ class SAFEMSIL1C(BaseFileHandler):
         return proj
 
     def _read_from_file(self, key):
-        proj = rioxarray.open_rasterio(self.filename, chunks=CHUNK_SIZE)
+        proj = xr.open_dataset(self.filename, engine="rasterio", chunks=CHUNK_SIZE)["band_data"]
         proj = proj.squeeze("band")
         if key["calibration"] == "reflectance":
             return self._mda.calibrate_to_reflectances(proj, self._channel)
@@ -215,7 +214,7 @@ class SAFEMSIMDXML(SAFEMSIXMLMetadata):
 
 def _fill_swath_edges(angles):
     """Fill gaps at edges of swath."""
-    darr = DataArray(angles, dims=['y', 'x'])
+    darr = xr.DataArray(angles, dims=['y', 'x'])
     darr = darr.bfill('x')
     darr = darr.ffill('x')
     darr = darr.bfill('y')
@@ -330,7 +329,7 @@ class SAFEMSITileMDXML(SAFEMSIXMLMetadata):
 
         res = self.interpolate_angles(angles, key['resolution'])
 
-        proj = DataArray(res, dims=['y', 'x'])
+        proj = xr.DataArray(res, dims=['y', 'x'])
         proj.attrs = info.copy()
         proj.attrs['units'] = 'degrees'
         proj.attrs['platform_name'] = self.platform_name

--- a/satpy/readers/sar_c_safe.py
+++ b/satpy/readers/sar_c_safe.py
@@ -41,7 +41,6 @@ from threading import Lock
 import defusedxml.ElementTree as ET
 import numpy as np
 import rasterio
-import rioxarray
 import xarray as xr
 from dask import array as da
 from dask.base import tokenize
@@ -585,7 +584,8 @@ class SAFEGRD(BaseFileHandler):
             data.attrs.update(info)
 
         else:
-            data = rioxarray.open_rasterio(self.filename, chunks=(1, CHUNK_SIZE, CHUNK_SIZE)).squeeze()
+            data = xr.open_dataset(self.filename, engine="rasterio",
+                                   chunks={"band": 1, "y": CHUNK_SIZE, "x": CHUNK_SIZE})["band_data"].squeeze()
             data = data.assign_coords(x=np.arange(len(data.coords['x'])),
                                       y=np.arange(len(data.coords['y'])))
             data = self._calibrate_and_denoise(data, key)

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -209,8 +209,7 @@ class TestGenericImage(unittest.TestCase):
 
         dataset = reader.get_dataset(foo, {})
         self.assertTrue(isinstance(dataset, xr.DataArray))
-        self.assertIn('crs', dataset.attrs)
-        self.assertIn('transform', dataset.attrs)
+        self.assertIn('spatial_ref', dataset.coords)
         self.assertTrue(np.all(np.isnan(dataset.data[:, :10, :10].compute())))
 
     def test_GenericImageFileHandler_masking_only_integer(self):

--- a/satpy/tests/reader_tests/test_msi_safe.py
+++ b/satpy/tests/reader_tests/test_msi_safe.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Module for testing the satpy.readers.msi_safe module."""
-import unittest
 import unittest.mock as mock
 from io import BytesIO, StringIO
 
@@ -863,10 +862,10 @@ mtd_l1c_xml = """<?xml version="1.0" encoding="UTF-8" standalone="no"?>
 """  # noqa
 
 
-class TestMTDXML(unittest.TestCase):
+class TestMTDXML:
     """Test the SAFE MTD XML file handler."""
 
-    def setUp(self):
+    def setup_method(self):
         """Set up the test case."""
         from satpy.readers.msi_safe import SAFEMSIMDXML, SAFEMSITileMDXML
         filename_info = dict(observation_time=None, dtile_number=None, fmission_id="S2A")
@@ -973,7 +972,7 @@ class TestSAFEMSIL1C:
         """Set up the test."""
         from satpy.readers.msi_safe import SAFEMSITileMDXML
         self.filename_info = dict(observation_time=None, fmission_id="S2A", band_name="B01", dtile_number=None)
-        self.fake_data = xr.DataArray([[[0, 1], [65534, 65535]]], dims=["band", "x", "y"])
+        self.fake_data = xr.Dataset({"band_data": xr.DataArray([[[0, 1], [65534, 65535]]], dims=["band", "x", "y"])})
         self.tile_mda = mock.create_autospec(SAFEMSITileMDXML)(BytesIO(mtd_tile_xml),
                                                                self.filename_info, mock.MagicMock())
 
@@ -989,6 +988,6 @@ class TestSAFEMSIL1C:
                            mask_saturated=mask_saturated)
         self.jp2_fh = SAFEMSIL1C("somefile", self.filename_info, mock.MagicMock(), mda, self.tile_mda)
 
-        with mock.patch("satpy.readers.msi_safe.rioxarray.open_rasterio", return_value=self.fake_data):
+        with mock.patch("xarray.open_dataset", return_value=self.fake_data):
             res = self.jp2_fh.get_dataset(make_dataid(name="B01", calibration=calibration), info=dict())
             np.testing.assert_allclose(res, expected)

--- a/satpy/tests/reader_tests/test_sar_c_safe.py
+++ b/satpy/tests/reader_tests/test_sar_c_safe.py
@@ -59,22 +59,26 @@ class TestSAFEGRD(unittest.TestCase):
         assert self.test_fh.noise == self.noisefh
         self.mocked_rio_open.assert_called()
 
-    @mock.patch('rioxarray.open_rasterio')
-    def test_read_calibrated_natural(self, mocked_rioxarray_open):
+    @mock.patch('xarray.open_dataset')
+    def test_read_calibrated_natural(self, mocked_xarray_open):
         """Test the calibration routines."""
         calibration = mock.MagicMock()
         calibration.name = "sigma_nought"
-        mocked_rioxarray_open.return_value = xr.DataArray(da.from_array(np.array([[0, 1], [2, 3]])), dims=['y', 'x'])
+        mocked_xarray_open.return_value.__getitem__.return_value = xr.DataArray(da.from_array(np.array([[0, 1],
+                                                                                                        [2, 3]])),
+                                                                                dims=['y', 'x'])
         xarr = self.test_fh.get_dataset(DataQuery(name="measurement", polarization="vv",
                                                   calibration=calibration, quantity='natural'), info=dict())
         np.testing.assert_allclose(xarr, [[np.nan, 2], [5, 10]])
 
-    @mock.patch('rioxarray.open_rasterio')
-    def test_read_calibrated_dB(self, mocked_rioxarray_open):
+    @mock.patch('xarray.open_dataset')
+    def test_read_calibrated_dB(self, mocked_xarray_open):
         """Test the calibration routines."""
         calibration = mock.MagicMock()
         calibration.name = "sigma_nought"
-        mocked_rioxarray_open.return_value = xr.DataArray(da.from_array(np.array([[0, 1], [2, 3]])), dims=['y', 'x'])
+        mocked_xarray_open.return_value.__getitem__.return_value = xr.DataArray(da.from_array(np.array([[0, 1],
+                                                                                                        [2, 3]])),
+                                                                                dims=['y', 'x'])
         xarr = self.test_fh.get_dataset(DataQuery(name="measurement", polarization="vv",
                                                   calibration=calibration, quantity='dB'), info=dict())
         np.testing.assert_allclose(xarr, [[np.nan, 3.0103], [6.9897, 10]])


### PR DESCRIPTION
`xr.open_rasterio` is deprecated and will be removed in the next xarray release. This PR should remove usage of that function.

