### PR TITLE
Update MODIS composites with specific channel for Rayleigh correction

### DIFF
--- a/satpy/etc/composites/modis.yaml
+++ b/satpy/etc/composites/modis.yaml
@@ -11,6 +11,22 @@ modifiers:
     - name: solar_azimuth_angle
     - name: solar_zenith_angle
 
+  rayleigh_corrected:
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: rayleigh_only
+    prerequisites:
+    - name: '1'
+      modifiers: [sunz_corrected]
+    optional_prerequisites:
+    - satellite_azimuth_angle
+    - satellite_zenith_angle
+    - solar_azimuth_angle
+    - solar_zenith_angle
+
+
+
+
 composites:
   true_color_uncorrected:
     compositor: !!python/name:satpy.composites.GenericCompositor

--- a/satpy/etc/composites/modis.yaml
+++ b/satpy/etc/composites/modis.yaml
@@ -24,9 +24,6 @@ modifiers:
     - solar_azimuth_angle
     - solar_zenith_angle
 
-
-
-
 composites:
   true_color_uncorrected:
     compositor: !!python/name:satpy.composites.GenericCompositor


### PR DESCRIPTION
Currently, the `rayleigh_corrected` modifier in `visir.yaml` requires a wavelength of `0.67μm`. This can be a problem for MODIS as it has a band with an upper wavelength matching this value as well as several other bands with similar wavelengths.
This can produce errors such as:
`Too many possible datasets to load for DataQuery(wavelength=0.67, modifiers=(), calibration='reflectance')`

This PR adds a MODIS-specific Rayleigh modifier that directly specifies which channel to use by name rather than by wavelength, which resolves the issue.