### PR TITLE
Deprecate PYTROLL_CHUNK_SIZE and fallback to array.chunk-size config from dask

### DIFF
--- a/benchmarks/abi_l1b_benchmarks.py
+++ b/benchmarks/abi_l1b_benchmarks.py
@@ -47,9 +47,9 @@ class ABIL1B(GeoBenchmarks):
 
     def setup(self):
         """Set up the benchmarks."""
-        import satpy
+        import dask.config
         self.data_files = get_filenames(self.subdir)
-        satpy.CHUNK_SIZE = 2048
+        dask.config.set({"array.chunk-size": "32MiB"})
 
     def time_load_one_channel(self):
         """Time the loading of one channel."""

--- a/benchmarks/ahi_hsd_benchmarks.py
+++ b/benchmarks/ahi_hsd_benchmarks.py
@@ -41,15 +41,15 @@ class HimawariHSD(GeoBenchmarks):
             from satpy.demo import download_typhoon_surigae_ahi
             download_typhoon_surigae_ahi(channels=[1, 2, 3, 4], segments=[4])
         except ImportError:
-            assert len(get_filenames(self.subdir)) == 4
+            assert len(get_filenames(self.subdir)) == 4  # nosec
         download_rsr()
         download_luts(aerosol_type='rayleigh_only')
 
     def setup(self):
         """Set up the benchmarks."""
-        import satpy
+        import dask.config
         self.data_files = get_filenames(self.subdir)
-        satpy.CHUNK_SIZE = 2048
+        dask.config.set({"array.chunk-size": "32MiB"})
 
     def time_load_one_channel(self):
         """Time the loading of one channel."""

--- a/benchmarks/seviri_hrit_benchmarks.py
+++ b/benchmarks/seviri_hrit_benchmarks.py
@@ -41,15 +41,15 @@ class SEVIRIHRIT(GeoBenchmarks):
             from satpy.demo import download_seviri_hrit_20180228_1500
             download_seviri_hrit_20180228_1500()
         except ImportError:
-            assert len(get_filenames(self.subdir)) == 114
+            assert len(get_filenames(self.subdir)) == 114  # nosec
         download_rsr()
         download_luts(aerosol_type='rayleigh_only')
 
     def setup(self):
         """Set up the benchmarks."""
-        import satpy
+        import dask.config
         self.data_files = get_filenames(self.subdir)
-        satpy.CHUNK_SIZE = 2048
+        dask.config.set({"array.chunk-size": "32MiB"})
 
     def time_load_one_channel(self):
         """Time the loading of one channel."""

--- a/benchmarks/viirs_sdr_benchmarks.py
+++ b/benchmarks/viirs_sdr_benchmarks.py
@@ -40,15 +40,15 @@ class VIIRSSDRBenchmarkBase:
                 channels=("I01", "M03", "M04", "M05"),
                 granules=(2, 3, 4))
         except ImportError:
-            assert len(self.get_filenames()) == 6 * 3
+            assert len(self.get_filenames()) == 6 * 3  # nosec
         download_rsr()
         download_luts(aerosol_type='rayleigh_only')
 
     def setup(self, name):
         """Set up the benchmarks."""
-        import satpy
+        import dask.config
         self.data_files = self.get_filenames()
-        satpy.CHUNK_SIZE = 2048
+        dask.config.set({"array.chunk-size": "32MiB"})
 
     def get_filenames(self):
         """Get the data filenames manually."""

--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -580,8 +580,8 @@ One way of implementing a file handler is shown below:
                 self.nc = xr.open_dataset(self.filename,
                                           decode_cf=True,
                                           mask_and_scale=True,
-                                          chunks={'num_columns_vis_ir': CHUNK_SIZE,
-                                                  'num_rows_vis_ir': CHUNK_SIZE})
+                                          chunks={'num_columns_vis_ir': "auto",
+                                                  'num_rows_vis_ir': "auto"})
                 self.nc = self.nc.rename({'num_columns_vir_ir': 'x', 'num_rows_vir_ir': 'y'})
             dataset = self.nc[dataset_info['nc_key']]
             dataset.attrs.update(dataset_info)

--- a/doc/source/dev_guide/remote_file_support.rst
+++ b/doc/source/dev_guide/remote_file_support.rst
@@ -22,7 +22,6 @@ in every reader. This could look like:
 
 .. code-block:: python
 
-    from satpy import CHUNK_SIZE
     from satpy._compat importe cached_property
     from satpy.readers.file_handlers import BaseFileHandler, open_dataset
 
@@ -33,7 +32,7 @@ in every reader. This could look like:
 
         @cached_property
         def nc(self):
-            return open_dataset(self.filename, chunks=CHUNK_SIZE)
+            return open_dataset(self.filename, chunks="auto")
 
         def get_dataset(self):
             # Access the opened dataset

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -50,15 +50,8 @@ by using the following around your code:
     with dask.config.set("array.chunk-size": "32MiB"):
       # your code here
 
-The value of the chunk-size can be given in different ways, see here:
-https://docs.dask.org/en/stable/api.html#dask.utils.parse_bytes
-There are other ways to set dask configuration items, including configuration
-files or environment variables, see here:
-https://docs.dask.org/en/stable/configuration.html
-
-The default value for this parameter is 128MiB, which can translate to chunk
-sizes of 4096x4096 for 8-byte float arrays. Note however that readers might
-interpret this value to create non-square chunks for better performance.
+For more information about chunk sizes in Satpy, please refer to the
+`Data Chunks` section in :doc:`overview`.
 
 .. note::
 

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -43,7 +43,7 @@ Similarly, if you have many workers processing large chunks of data you may
 be using much more memory than you expect. If you limit the number of workers
 *and* the size of the data chunks being processed by each worker you can
 reduce the overall memory usage. Default chunk size can be configured in Satpy
-by setting using the following around your code:
+by using the following around your code:
 
 .. code-block:: python
 

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -43,16 +43,28 @@ Similarly, if you have many workers processing large chunks of data you may
 be using much more memory than you expect. If you limit the number of workers
 *and* the size of the data chunks being processed by each worker you can
 reduce the overall memory usage. Default chunk size can be configured in Satpy
-by setting the following environment variable:
+by setting using the following around your code:
 
-.. code-block:: bash
+.. code-block:: python
 
-    export PYTROLL_CHUNK_SIZE=2048
+    with dask.config.set("array.chunk-size": "32MiB"):
+      # your code here
 
-This could also be set inside python using ``os.environ``, but must be set
-**before** Satpy is imported. This value defaults to 4096, meaning each
-chunk of data will be 4096 rows by 4096 columns. In the future setting this
-value will change to be easier to set in python.
+The value of the chunk-size can be given in different ways, see here:
+https://docs.dask.org/en/stable/api.html#dask.utils.parse_bytes
+There are other ways to set dask configuration items, including configuration
+files or environment variables, see here:
+https://docs.dask.org/en/stable/configuration.html
+
+The default value for this parameter is 128MiB, which can translate to chunk
+sizes of 4096x4096 for 8-byte float arrays. Note however that readers might
+interpret this value to create non-square chunks for better performance.
+
+.. note::
+
+    The PYTROLL_CHUNK_SIZE variable is pending deprecation, so the
+    above-mentioned dask configuration parameter should be used instead.
+
 
 Why multiple CPUs are used even with one worker?
 ------------------------------------------------

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -78,7 +78,7 @@ around your code:
     with dask.config.set("array.chunk-size": "32MiB"):
       # your code here
 
-or by using just:
+Or by using:
 
 .. code-block:: python
 

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -74,12 +74,14 @@ Default chunk size used by Satpy can be configured in by using the following
 around your code:
 
 .. code-block:: python
+
     with dask.config.set("array.chunk-size": "32MiB"):
       # your code here
 
 or by using just:
 
 .. code-block:: python
+
     dask.config.set("array.chunk-size": "32MiB")
 
 At the top of your code.

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -90,7 +90,6 @@ There are other ways to set dask configuration items, including configuration
 files or environment variables, see here:
 https://docs.dask.org/en/stable/configuration.html
 
-
 The value of the chunk-size can be given in different ways, see here:
 https://docs.dask.org/en/stable/api.html#dask.utils.parse_bytes
 

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -112,15 +112,15 @@ the Satpy readers should respect the overall chunk size when it makes sense.
     variable is the square of the legacy variable, multiplied by the size of array data type
     at hand, so for example, for 64-bits floats::
 
-      ``export DASK_ARRAY__CHUNK_SIZE=134217728``
+      export DASK_ARRAY__CHUNK_SIZE=134217728
     
     which is the same as::
       
-      ``export DASK_ARRAY__CHUNK_SIZE="128MiB"``
+      export DASK_ARRAY__CHUNK_SIZE="128MiB"
 
     is equivalent to the deprecated::
 
-      ``export PYTROLL_CHUNK_SIZE=4096``
+      export PYTROLL_CHUNK_SIZE=4096
 
 Reading
 =======

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -70,7 +70,7 @@ dask documentation here: https://docs.dask.org/en/stable/array-chunks.html
 The size of these chunks can have a significant impact on the performance of
 satpy, so to achieve best performance it can be necessary to adjust it.
 
-Default chunk size used by Satpy can be configured in by using the following
+Default chunk size used by Satpy can be configured by using the following
 around your code:
 
 .. code-block:: python

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -95,7 +95,7 @@ The value of the chunk-size can be given in different ways, see here:
 https://docs.dask.org/en/stable/api.html#dask.utils.parse_bytes
 
 The default value for this parameter is 128MiB, which can translate to chunk
-sizes of 4096x4096 for 8-byte float arrays.
+sizes of 4096x4096 for 64-bit float arrays.
 
 Note however that some reader might choose to use a liberal interpretation of
 the chunk size which will not necessarily result in a square chunk, or even to

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -63,7 +63,7 @@ objects, have a look a :doc:`dev_guide/satpy_internals`.
 Data chunks
 -----------
 
-The usage of dask as ground layer for Satpy's operation means that the
+The usage of dask as the foundation for Satpy's operation means that the
 underlying data is chunked, that is cut in smaller pieces that can then be
 processed in parallel. (Information on dask's chunking can be found in the
 dask documentation here: https://docs.dask.org/en/stable/array-chunks.html)

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -65,8 +65,8 @@ Data chunks
 
 The usage of dask as the foundation for Satpy's operation means that the
 underlying data is chunked, that is, cut in smaller pieces that can then be
-processed in parallel. (Information on dask's chunking can be found in the
-dask documentation here: https://docs.dask.org/en/stable/array-chunks.html)
+processed in parallel. Information on dask's chunking can be found in the
+dask documentation here: https://docs.dask.org/en/stable/array-chunks.html
 The size of these chunks can have a significant impact on the performance of
 satpy, so to achieve best performance it can be necessary to adjust it.
 

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -109,9 +109,14 @@ the Satpy readers should respect the overall chunk size when it makes sense.
     ``PYTROLL_CHUNK_SIZE`` environment variable. This is now pending deprecation,
     so an equivalent way to achieve the same result is by using the
     ``DASK_ARRAY__CHUNK_SIZE`` environment variable. The value to assign to the
-    variable is the square of the legacy variable, so for example::
+    variable is the square of the legacy variable, multiplied by the size of array data type
+    at hand, so for example, for 64-bits floats::
 
-      ``export DASK_ARRAY__CHUNK_SIZE=16777216``
+      ``export DASK_ARRAY__CHUNK_SIZE=134217728``
+    
+    which is the same as::
+      
+      ``export DASK_ARRAY__CHUNK_SIZE="128MiB"``
 
     is equivalent to the deprecated::
 

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -84,7 +84,7 @@ Or by using:
 
     dask.config.set("array.chunk-size": "32MiB")
 
-At the top of your code.
+at the top of your code.
 
 There are other ways to set dask configuration items, including configuration
 files or environment variables, see here:

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -104,7 +104,6 @@ data stored as stripes may load much faster if the horizontal striping is kept
 as much as possible instead of cutting the data in square chunks. However,
 the Satpy readers should respect the overall chunk size when it makes sense.
 
-
 .. note::
 
     The legacy way of providing the chunks size in Satpy is the

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -64,7 +64,7 @@ Data chunks
 -----------
 
 The usage of dask as the foundation for Satpy's operation means that the
-underlying data is chunked, that is cut in smaller pieces that can then be
+underlying data is chunked, that is, cut in smaller pieces that can then be
 processed in parallel. (Information on dask's chunking can be found in the
 dask documentation here: https://docs.dask.org/en/stable/array-chunks.html)
 The size of these chunks can have a significant impact on the performance of

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -113,9 +113,9 @@ the Satpy readers should respect the overall chunk size when it makes sense.
     at hand, so for example, for 64-bits floats::
 
       export DASK_ARRAY__CHUNK_SIZE=134217728
-    
+
     which is the same as::
-      
+
       export DASK_ARRAY__CHUNK_SIZE="128MiB"
 
     is equivalent to the deprecated::

--- a/satpy/__init__.py
+++ b/satpy/__init__.py
@@ -17,8 +17,6 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Satpy Package initializer."""
 
-import os
-
 try:
     from satpy.version import version as __version__  # noqa
 except ModuleNotFoundError:
@@ -26,8 +24,6 @@ except ModuleNotFoundError:
         "No module named satpy.version. This could mean "
         "you didn't install 'satpy' properly. Try reinstalling ('pip "
         "install').")
-
-CHUNK_SIZE = int(os.getenv('PYTROLL_CHUNK_SIZE', 4096))
 
 from satpy._config import config  # noqa
 from satpy.dataset import DataID, DataQuery  # noqa

--- a/satpy/readers/aapp_mhs_amsub_l1c.py
+++ b/satpy/readers/aapp_mhs_amsub_l1c.py
@@ -27,12 +27,13 @@ import logging
 import dask.array as da
 import numpy as np
 
-from satpy import CHUNK_SIZE
 from satpy.readers.aapp_l1b import AAPPL1BaseFileHandler, create_xarray
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
 
 
+CHUNK_SIZE = get_legacy_chunk_size()
 LINE_CHUNK = CHUNK_SIZE ** 2 // 90
 
 MHS_AMSUB_CHANNEL_NAMES = ['1', '2', '3', '4', '5']

--- a/satpy/readers/abi_base.py
+++ b/satpy/readers/abi_base.py
@@ -25,13 +25,14 @@ import numpy as np
 import xarray as xr
 from pyresample import geometry
 
-from satpy import CHUNK_SIZE
 from satpy._compat import cached_property
 from satpy.readers import open_file_or_filename
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
 
+CHUNK_SIZE = get_legacy_chunk_size()
 PLATFORM_NAMES = {
     'G16': 'GOES-16',
     'G17': 'GOES-17',

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -67,7 +67,6 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy._compat import cached_property
 from satpy.readers._geos_area import get_area_definition, get_area_extent
 from satpy.readers.file_handlers import BaseFileHandler
@@ -79,7 +78,9 @@ from satpy.readers.utils import (
     np2str,
     unzip_file,
 )
+from satpy.utils import get_legacy_chunk_size
 
+CHUNK_SIZE = get_legacy_chunk_size()
 AHI_CHANNEL_NAMES = ("1", "2", "3", "4", "5",
                      "6", "7", "8", "9", "10",
                      "11", "12", "13", "14", "15", "16")

--- a/satpy/readers/ahi_l1b_gridded_bin.py
+++ b/satpy/readers/ahi_l1b_gridded_bin.py
@@ -40,9 +40,11 @@ import xarray as xr
 from appdirs import AppDirs
 from pyresample import geometry
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.utils import unzip_file
+from satpy.utils import get_legacy_chunk_size
+
+CHUNK_SIZE = get_legacy_chunk_size()
 
 # Hardcoded address of the reflectance and BT look-up tables
 AHI_REMOTE_LUTS = 'http://www.cr.chiba-u.jp/databases/GEO/H8_9/FD/count2tbb_v102.tgz'
@@ -155,7 +157,7 @@ class AHIGriddedFileHandler(BaseFileHandler):
         """Uncompress downloaded LUTs, which are a tarball."""
         import tarfile
         tar = tarfile.open(tarred_file)
-        tar.extractall(outdir)
+        tar.extractall(outdir)  # nosec
         tar.close()
         os.remove(tarred_file)
 

--- a/satpy/readers/ami_l1b.py
+++ b/satpy/readers/ami_l1b.py
@@ -26,13 +26,14 @@ import pyproj
 import xarray as xr
 from pyspectral.blackbody import blackbody_wn_rad2temp as rad2temp
 
-from satpy import CHUNK_SIZE
 from satpy.readers._geos_area import get_area_definition, get_area_extent
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.utils import apply_rad_correction, get_user_calibration_factors
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
 
+CHUNK_SIZE = get_legacy_chunk_size()
 PLATFORM_NAMES = {
     'GK-2A': 'GEO-KOMPSAT-2A',
     'GK-2B': 'GEO-KOMPSAT-2B',

--- a/satpy/readers/amsr2_l2_gaasp.py
+++ b/satpy/readers/amsr2_l2_gaasp.py
@@ -45,11 +45,13 @@ import xarray as xr
 from pyproj import CRS
 from pyresample.geometry import AreaDefinition
 
-from satpy import CHUNK_SIZE
 from satpy._compat import cached_property
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class GAASPFileHandler(BaseFileHandler):

--- a/satpy/readers/ascat_l2_soilmoisture_bufr.py
+++ b/satpy/readers/ascat_l2_soilmoisture_bufr.py
@@ -35,10 +35,12 @@ except ImportError as e:
         """Missing eccodes-python and/or eccodes C-library installation. Use conda to install eccodes.
            Error: """, e)
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger('AscatSoilMoistureBufr')
+
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class AscatSoilMoistureBufr(BaseFileHandler):

--- a/satpy/readers/atms_sdr_hdf5.py
+++ b/satpy/readers/atms_sdr_hdf5.py
@@ -40,11 +40,12 @@ import dask.array as da
 import h5py
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.viirs_atms_sdr_base import DATASET_KEYS, JPSS_SDR_FileHandler
+from satpy.utils import get_legacy_chunk_size
 
 LOG = logging.getLogger(__name__)
 
+CHUNK_SIZE = get_legacy_chunk_size()
 ATMS_CHANNEL_NAMES = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10',
                       '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22']
 

--- a/satpy/readers/avhrr_l1b_gaclac.py
+++ b/satpy/readers/avhrr_l1b_gaclac.py
@@ -36,11 +36,12 @@ from pygac.gac_pod import GACPODReader
 from pygac.lac_klm import LACKLMReader
 from pygac.lac_pod import LACPODReader
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
 
+CHUNK_SIZE = get_legacy_chunk_size()
 
 spacecrafts = {7: "NOAA 15", 3: "NOAA 16", 13: "NOAA 18", 15: "NOAA 19"}
 

--- a/satpy/readers/clavrx.py
+++ b/satpy/readers/clavrx.py
@@ -28,12 +28,13 @@ import numpy as np
 import xarray as xr
 from pyresample import geometry
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.hdf4_utils import SDS, HDF4FileHandler
+from satpy.utils import get_legacy_chunk_size
 
 LOG = logging.getLogger(__name__)
 
+CHUNK_SIZE = get_legacy_chunk_size()
 
 CF_UNITS = {
     'none': '1',

--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -27,13 +27,15 @@ import xarray as xr
 from dask.delayed import delayed
 from pyresample.geometry import SwathDefinition
 
-from satpy import CHUNK_SIZE
 from satpy._compat import cached_property
 from satpy._config import get_config_path
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.xmlformat import XMLFormat
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+
+CHUNK_SIZE = get_legacy_chunk_size()
 
 C1 = 1.191062e-05  # mW/(m2*sr*cm-4)
 C2 = 1.4387863  # K/cm-1

--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -22,13 +22,15 @@ import numpy as np
 import xarray as xr
 from pyresample import geometry
 
-from satpy import CHUNK_SIZE
 from satpy.readers._geos_area import get_geos_area_naming, make_ext
 from satpy.readers.eum_base import get_service_mode
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.resample import get_area_def
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+
+CHUNK_SIZE = get_legacy_chunk_size()
 
 SSP_DEFAULT = 0.0
 

--- a/satpy/readers/generic_image.py
+++ b/satpy/readers/generic_image.py
@@ -35,8 +35,10 @@ import rasterio
 import xarray as xr
 from pyresample import utils
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
+
+CHUNK_SIZE = get_legacy_chunk_size()
 
 BANDS = {1: ['L'],
          2: ['L', 'A'],

--- a/satpy/readers/ghrsst_l2.py
+++ b/satpy/readers/ghrsst_l2.py
@@ -24,8 +24,10 @@ from functools import cached_property
 
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
+
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class GHRSSTL2FileHandler(BaseFileHandler):

--- a/satpy/readers/goes_imager_nc.py
+++ b/satpy/readers/goes_imager_nc.py
@@ -232,12 +232,14 @@ import numpy as np
 import pyresample.geometry
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.goes_imager_hrit import ALTITUDE, EQUATOR_RADIUS, POLE_RADIUS, SPACECRAFTS
 from satpy.readers.utils import bbox, get_geostationary_angle_extent
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+
+CHUNK_SIZE = get_legacy_chunk_size()
 
 # Radiation constants. Source: [VIS]
 C1 = 1.191066E-5  # [mW/(m2-sr-cm-4)]
@@ -1208,7 +1210,7 @@ class GOESCoefficientReader(object):
         from requests.exceptions import MissingSchema
 
         try:
-            response = requests.get(url)
+            response = requests.get(url, timeout=60)
             if response.ok:
                 return response.text
             raise requests.HTTPError

--- a/satpy/readers/grib.py
+++ b/satpy/readers/grib.py
@@ -32,12 +32,13 @@ import xarray as xr
 from pyproj import Proj
 from pyresample import geometry
 
-from satpy import CHUNK_SIZE
 from satpy.dataset import DataQuery
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 LOG = logging.getLogger(__name__)
 
+CHUNK_SIZE = get_legacy_chunk_size()
 
 CF_UNITS = {
     'none': '1',

--- a/satpy/readers/hdf4_utils.py
+++ b/satpy/readers/hdf4_utils.py
@@ -24,11 +24,12 @@ import numpy as np
 import xarray as xr
 from pyhdf.SD import SD, SDC, SDS
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 LOG = logging.getLogger(__name__)
 
+CHUNK_SIZE = get_legacy_chunk_size()
 
 HTYPE_TO_DTYPE = {
     SDC.INT8: np.int8,

--- a/satpy/readers/hdf5_utils.py
+++ b/satpy/readers/hdf5_utils.py
@@ -24,11 +24,12 @@ import h5py
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.utils import np2str
+from satpy.utils import get_legacy_chunk_size
 
 LOG = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class HDF5FileHandler(BaseFileHandler):

--- a/satpy/readers/hdfeos_base.py
+++ b/satpy/readers/hdfeos_base.py
@@ -30,10 +30,12 @@ import xarray as xr
 from pyhdf.error import HDF4Error
 from pyhdf.SD import SD
 
-from satpy import CHUNK_SIZE, DataID
+from satpy import DataID
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 def interpolate(clons, clats, csatz, src_resolution, dst_resolution):

--- a/satpy/readers/hsaf_grib.py
+++ b/satpy/readers/hsaf_grib.py
@@ -31,11 +31,12 @@ import pygrib
 import xarray as xr
 from pyresample import geometry
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 LOG = logging.getLogger(__name__)
 
+CHUNK_SIZE = get_legacy_chunk_size()
 
 CF_UNITS = {
     'none': '1',

--- a/satpy/readers/hsaf_h5.py
+++ b/satpy/readers/hsaf_h5.py
@@ -24,11 +24,12 @@ import h5py
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.resample import get_area_def
+from satpy.utils import get_legacy_chunk_size
 
 LOG = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
 AREA_X_OFFSET = 1211
 AREA_Y_OFFSET = 62
 

--- a/satpy/readers/iasi_l2.py
+++ b/satpy/readers/iasi_l2.py
@@ -26,9 +26,10 @@ import xarray as xr
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.utils import get_legacy_chunk_size
 
+from .netcdf_utils import NetCDF4FsspecFileHandler
+
 CHUNK_SIZE = get_legacy_chunk_size()
 
-from .netcdf_utils import NetCDF4FsspecFileHandler
 
 # Scan timing values taken from
 # http://oiswww.eumetsat.org/WEBOPS/eps-pg/IASI-L1/IASIL1-PG-4ProdOverview.htm

--- a/satpy/readers/iasi_l2.py
+++ b/satpy/readers/iasi_l2.py
@@ -25,8 +25,10 @@ import h5py
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
+
+CHUNK_SIZE = get_legacy_chunk_size()
 
 # Scan timing values taken from
 # http://oiswww.eumetsat.org/WEBOPS/eps-pg/IASI-L1/IASIL1-PG-4ProdOverview.htm

--- a/satpy/readers/iasi_l2_so2_bufr.py
+++ b/satpy/readers/iasi_l2_so2_bufr.py
@@ -98,11 +98,11 @@ except ImportError as e:
         """Missing eccodes-python and/or eccodes C-library installation. Use conda to install eccodes.
            Error: """, e)
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger('IASIL2SO2BUFR')
-
+CHUNK_SIZE = get_legacy_chunk_size()
 data_center_dict = {3: 'METOP-1', 4: 'METOP-2', 5: 'METOP-3'}
 
 

--- a/satpy/readers/li_l2_nc.py
+++ b/satpy/readers/li_l2_nc.py
@@ -34,12 +34,13 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.li_base_nc import LINCFileHandler
 from satpy.resample import get_area_def
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
 LI_GRID_SHAPE = (5568, 5568)
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class LIL2NCFileHandler(LINCFileHandler):

--- a/satpy/readers/maia.py
+++ b/satpy/readers/maia.py
@@ -32,10 +32,11 @@ import h5py
 import numpy as np
 from xarray import DataArray
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class MAIAFileHandler(BaseFileHandler):

--- a/satpy/readers/mirs.py
+++ b/satpy/readers/mirs.py
@@ -26,10 +26,11 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.aux_download import retrieve
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
+CHUNK_SIZE = get_legacy_chunk_size()
 LOG = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 

--- a/satpy/readers/modis_l1b.py
+++ b/satpy/readers/modis_l1b.py
@@ -76,11 +76,12 @@ import logging
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.hdf4_utils import from_sds
 from satpy.readers.hdfeos_base import HDFEOSBaseFileReader, HDFEOSGeoReader
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class HDFEOSBandReader(HDFEOSBaseFileReader):

--- a/satpy/readers/modis_l2.py
+++ b/satpy/readers/modis_l2.py
@@ -50,11 +50,12 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.hdf4_utils import from_sds
 from satpy.readers.hdfeos_base import HDFEOSGeoReader
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class ModisL2HDFFileHandler(HDFEOSGeoReader):

--- a/satpy/readers/msi_safe.py
+++ b/satpy/readers/msi_safe.py
@@ -42,12 +42,12 @@ import numpy as np
 import xarray as xr
 from pyresample import geometry
 
-from satpy import CHUNK_SIZE
 from satpy._compat import cached_property
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
-
+CHUNK_SIZE = get_legacy_chunk_size()
 
 PLATFORMS = {'S2A': "Sentinel-2A",
              'S2B': "Sentinel-2B",

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -160,10 +160,11 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers._geos_area import get_area_definition, get_area_extent, sampling_to_lfac_cfac
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
+CHUNK_SIZE = get_legacy_chunk_size()
 EQUATOR_RADIUS = 6378140.0
 POLE_RADIUS = 6356755.0
 ALTITUDE = 42164000.0 - EQUATOR_RADIUS

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -24,12 +24,13 @@ import netCDF4
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers import open_file_or_filename
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.utils import np2str
+from satpy.utils import get_legacy_chunk_size
 
 LOG = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class NetCDF4FileHandler(BaseFileHandler):

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -34,11 +34,13 @@ import xarray as xr
 from pyproj import CRS
 from pyresample.geometry import AreaDefinition
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.utils import unzip_file
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+
+CHUNK_SIZE = get_legacy_chunk_size()
 
 SENSOR = {'NOAA-19': 'avhrr-3',
           'NOAA-18': 'avhrr-3',

--- a/satpy/readers/olci_nc.py
+++ b/satpy/readers/olci_nc.py
@@ -46,13 +46,14 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy._compat import cached_property
 from satpy.readers import open_file_or_filename
 from satpy.readers.file_handlers import BaseFileHandler
-from satpy.utils import angle2xyz, xyz2angle
+from satpy.utils import angle2xyz, get_legacy_chunk_size, xyz2angle
 
 logger = logging.getLogger(__name__)
+
+CHUNK_SIZE = get_legacy_chunk_size()
 
 PLATFORM_NAMES = {'S3A': 'Sentinel-3A',
                   'S3B': 'Sentinel-3B',

--- a/satpy/readers/safe_sar_l2_ocn.py
+++ b/satpy/readers/safe_sar_l2_ocn.py
@@ -30,10 +30,11 @@ import logging
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class SAFENC(BaseFileHandler):

--- a/satpy/readers/sar_c_safe.py
+++ b/satpy/readers/sar_c_safe.py
@@ -46,10 +46,11 @@ from dask import array as da
 from dask.base import tokenize
 from xarray import DataArray
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 def dictify(r):

--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -185,11 +185,12 @@ import logging
 import xarray as xr
 from pyresample import AreaDefinition
 
-from satpy import CHUNK_SIZE
 from satpy.dataset.dataid import WavelengthRange
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class SatpyCFFileHandler(BaseFileHandler):

--- a/satpy/readers/scmi.py
+++ b/satpy/readers/scmi.py
@@ -48,9 +48,10 @@ import numpy as np
 import xarray as xr
 from pyresample import geometry
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
+CHUNK_SIZE = get_legacy_chunk_size()
 # NetCDF doesn't support multi-threaded reading, trick it by opening
 # as one whole chunk then split it up before we do any calculations
 LOAD_CHUNK_SIZE = int(os.getenv('PYTROLL_LOAD_CHUNK_SIZE', -1))

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -172,10 +172,11 @@ import numpy as np
 import pyproj
 from numpy.polynomial.chebyshev import Chebyshev
 
-from satpy import CHUNK_SIZE
 from satpy.readers.eum_base import issue_revision, time_cds_short
 from satpy.readers.utils import apply_earthsun_distance_correction
+from satpy.utils import get_legacy_chunk_size
 
+CHUNK_SIZE = get_legacy_chunk_size()
 PLATFORM_DICT = {
     'MET08': 'Meteosat-8',
     'MET09': 'Meteosat-9',

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -195,7 +195,6 @@ import xarray as xr
 from pyresample import geometry
 
 import satpy.readers.utils as utils
-from satpy import CHUNK_SIZE
 from satpy._compat import cached_property
 from satpy.readers._geos_area import get_area_definition, get_area_extent, get_geos_area_naming
 from satpy.readers.eum_base import get_service_mode, recarray2dict, time_cds_short
@@ -221,7 +220,9 @@ from satpy.readers.seviri_base import (
     pad_data_horizontally,
 )
 from satpy.readers.seviri_l1b_native_hdr import hrit_epilogue, hrit_prologue, impf_configuration
+from satpy.utils import get_legacy_chunk_size
 
+CHUNK_SIZE = get_legacy_chunk_size()
 logger = logging.getLogger('hrit_msg')
 
 # MSG implementation:

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -34,7 +34,6 @@ import numpy as np
 import xarray as xr
 from pyresample import geometry
 
-from satpy import CHUNK_SIZE
 from satpy._compat import cached_property
 from satpy.readers._geos_area import get_area_definition, get_geos_area_naming
 from satpy.readers.eum_base import get_service_mode, recarray2dict, time_cds_short
@@ -65,8 +64,10 @@ from satpy.readers.seviri_l1b_native_hdr import (
     native_trailer,
 )
 from satpy.readers.utils import reduce_mda
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger('native_msg')
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class NativeMSGFileHandler(BaseFileHandler):

--- a/satpy/readers/seviri_l1b_nc.py
+++ b/satpy/readers/seviri_l1b_nc.py
@@ -22,7 +22,6 @@ import logging
 
 import numpy as np
 
-from satpy import CHUNK_SIZE
 from satpy._compat import cached_property
 from satpy.readers._geos_area import get_area_definition, get_geos_area_naming
 from satpy.readers.eum_base import get_service_mode
@@ -38,8 +37,10 @@ from satpy.readers.seviri_base import (
     get_satpos,
     mask_bad_quality,
 )
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger('nc_msg')
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class NCSEVIRIFileHandler(BaseFileHandler):

--- a/satpy/readers/seviri_l2_bufr.py
+++ b/satpy/readers/seviri_l2_bufr.py
@@ -30,12 +30,12 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers._geos_area import get_geos_area_naming
 from satpy.readers.eum_base import get_service_mode, recarray2dict
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.seviri_base import mpef_product_header
 from satpy.resample import get_area_def
+from satpy.utils import get_legacy_chunk_size
 
 try:
     import eccodes as ec
@@ -43,6 +43,7 @@ except ImportError:
     raise ImportError(
         "Missing eccodes-python and/or eccodes C-library installation. Use conda to install eccodes")
 
+CHUNK_SIZE = get_legacy_chunk_size()
 logger = logging.getLogger('SeviriL2Bufr')
 
 data_center_dict = {55: {'ssp': 'E0415', 'name': '08'}, 56:  {'ssp': 'E0455', 'name': '09'},

--- a/satpy/readers/seviri_l2_grib.py
+++ b/satpy/readers/seviri_l2_grib.py
@@ -29,11 +29,11 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers._geos_area import get_area_definition, get_geos_area_naming
 from satpy.readers.eum_base import get_service_mode
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.seviri_base import PLATFORM_DICT, REPEAT_CYCLE_DURATION, calculate_area_extent
+from satpy.utils import get_legacy_chunk_size
 
 try:
     import eccodes as ec
@@ -41,6 +41,7 @@ except ImportError:
     raise ImportError(
         "Missing eccodes-python and/or eccodes C-library installation. Use conda to install eccodes")
 
+CHUNK_SIZE = get_legacy_chunk_size()
 logger = logging.getLogger(__name__)
 
 

--- a/satpy/readers/slstr_l1b.py
+++ b/satpy/readers/slstr_l1b.py
@@ -27,10 +27,12 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+
+CHUNK_SIZE = get_legacy_chunk_size()
 
 PLATFORM_NAMES = {'S3A': 'Sentinel-3A',
                   'S3B': 'Sentinel-3B'}

--- a/satpy/readers/tropomi_l2.py
+++ b/satpy/readers/tropomi_l2.py
@@ -36,11 +36,12 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.netcdf_utils import NetCDF4FileHandler, netCDF4
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
 DATE_FMT = '%Y-%m-%dT%H:%M:%SZ'
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class TROPOMIL2FileHandler(NetCDF4FileHandler):

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -35,8 +35,8 @@ import xarray as xr
 from pyresample.geometry import AreaDefinition
 
 from satpy import config
-from satpy.utils import get_legacy_chunk_size
 from satpy.readers import FSFile
+from satpy.utils import get_legacy_chunk_size
 
 LOGGER = logging.getLogger(__name__)
 CHUNK_SIZE = get_legacy_chunk_size()

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -33,9 +33,11 @@ import pyproj
 import xarray as xr
 from pyresample.geometry import AreaDefinition
 
-from satpy import CHUNK_SIZE, config
+from satpy import config
+from satpy.utils import get_legacy_chunk_size
 
 LOGGER = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 def np2str(value):

--- a/satpy/readers/vaisala_gld360.py
+++ b/satpy/readers/vaisala_gld360.py
@@ -34,10 +34,11 @@ import dask.array as da
 import pandas as pd
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class VaisalaGLD360TextFileHandler(BaseFileHandler):

--- a/satpy/readers/viirs_compact.py
+++ b/satpy/readers/viirs_compact.py
@@ -38,11 +38,11 @@ import h5py
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.utils import np2str
-from satpy.utils import angle2xyz, lonlat2xyz, xyz2angle, xyz2lonlat
+from satpy.utils import angle2xyz, get_legacy_chunk_size, lonlat2xyz, xyz2angle, xyz2lonlat
 
+CHUNK_SIZE = get_legacy_chunk_size()
 _channels_dict = {"M01": "M1",
                   "M02": "M2",
                   "M03": "M3",

--- a/satpy/readers/viirs_vgac_l1c_nc.py
+++ b/satpy/readers/viirs_vgac_l1c_nc.py
@@ -21,9 +21,10 @@ from datetime import datetime
 import numpy as np
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
+CHUNK_SIZE = get_legacy_chunk_size()
 logger = logging.getLogger(__name__)
 
 

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -155,7 +155,7 @@ from packaging import version
 from pyresample.ewa import fornav, ll2cr
 from pyresample.geometry import SwathDefinition
 
-from satpy.utils import PerformanceWarning
+from satpy.utils import PerformanceWarning, get_legacy_chunk_size
 
 try:
     from math import lcm  # type: ignore
@@ -178,11 +178,11 @@ try:
 except ImportError:
     DaskEWAResampler = LegacyDaskEWAResampler = None
 
-from satpy import CHUNK_SIZE
 from satpy._config import config_search_paths, get_config_path
 
 LOG = getLogger(__name__)
 
+CHUNK_SIZE = get_legacy_chunk_size()
 CACHE_SIZE = 10
 NN_COORDINATES = {'valid_input_index': ('y1', 'x1'),
                   'valid_output_index': ('y2', 'x2'),

--- a/satpy/tests/reader_tests/test_seviri_base.py
+++ b/satpy/tests/reader_tests/test_seviri_base.py
@@ -25,7 +25,6 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from satpy import CHUNK_SIZE
 from satpy.readers.seviri_base import (
     NoValidOrbitParams,
     OrbitPolynomial,
@@ -38,6 +37,9 @@ from satpy.readers.seviri_base import (
     pad_data_horizontally,
     pad_data_vertically,
 )
+from satpy.utils import get_legacy_chunk_size
+
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 def chebyshev4(c, x, domain):

--- a/satpy/tests/reader_tests/test_seviri_l2_grib.py
+++ b/satpy/tests/reader_tests/test_seviri_l2_grib.py
@@ -63,8 +63,10 @@ class Test_SeviriL2GribFileHandler(unittest.TestCase):
     @mock.patch('satpy.readers.seviri_l2_grib.da')
     def test_data_reading(self, da_, xr_):
         """Test the reading of data from the product."""
-        from satpy import CHUNK_SIZE
         from satpy.readers.seviri_l2_grib import REPEAT_CYCLE_DURATION, SeviriL2GribFileHandler
+        from satpy.utils import get_legacy_chunk_size
+        CHUNK_SIZE = get_legacy_chunk_size()
+
         with mock.patch("builtins.open", mock.mock_open()) as mock_file:
             with mock.patch('satpy.readers.seviri_l2_grib.ec', self.ec_):
                 self.reader = SeviriL2GribFileHandler(

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -486,12 +486,26 @@ def test_chunk_size_limit():
     from unittest.mock import patch
 
     from satpy.utils import get_chunk_size_limit
-    with patch("satpy.utils.CHUNK_SIZE", None):
-        assert get_chunk_size_limit(np.uint8) is None
     with patch("satpy.utils.CHUNK_SIZE", 10):
         assert get_chunk_size_limit(np.float64) == 800
     with patch("satpy.utils.CHUNK_SIZE", (10, 20)):
         assert get_chunk_size_limit(np.int32) == 800
+
+
+def test_chunk_size_limit_from_dask_config():
+    """Check the chunk size limit computations."""
+    from unittest.mock import patch
+
+    import dask.config
+
+    from satpy.utils import get_chunk_size_limit
+    with patch("satpy.utils.CHUNK_SIZE", None):
+        original_chunk_size = dask.config.get('array.chunk-size')
+        try:
+            dask.config.set({"array.chunk-size": "1KiB"})
+            assert get_chunk_size_limit(np.uint8) == 1024
+        finally:
+            dask.config.set({"array.chunk-size": original_chunk_size})
 
 
 def test_convert_remote_files_to_fsspec_local_files():

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -30,6 +30,7 @@ import xarray as xr
 
 from satpy.utils import (
     angle2xyz,
+    get_legacy_chunk_size,
     get_satpos,
     import_error_helper,
     lonlat2xyz,
@@ -468,40 +469,32 @@ def _verify_unchanged_chunks(data_arrays: list[xr.DataArray],
         assert data_arr.chunks == orig_arr.chunks
 
 
-def test_chunk_pixel_size():
-    """Check the chunk pixel size computations."""
-    from unittest.mock import patch
-
-    from satpy.utils import get_chunk_pixel_size
-    with patch("satpy.utils.CHUNK_SIZE", None):
-        assert get_chunk_pixel_size() is None
-    with patch("satpy.utils.CHUNK_SIZE", 10):
-        assert get_chunk_pixel_size() == 100
-    with patch("satpy.utils.CHUNK_SIZE", (10, 20)):
-        assert get_chunk_pixel_size() == 200
-
-
 def test_chunk_size_limit():
     """Check the chunk size limit computations."""
     from unittest.mock import patch
 
     from satpy.utils import get_chunk_size_limit
-    with patch("satpy.utils.CHUNK_SIZE", 10):
-        assert get_chunk_size_limit(np.float64) == 800
-    with patch("satpy.utils.CHUNK_SIZE", (10, 20)):
-        assert get_chunk_size_limit(np.int32) == 800
+    with patch("satpy.utils._get_pytroll_chunk_size") as ptc:
+        ptc.return_value = 10
+        assert get_chunk_size_limit(np.int32) == 400
+        assert get_chunk_size_limit() == 800
 
 
 def test_chunk_size_limit_from_dask_config():
     """Check the chunk size limit computations."""
-    from unittest.mock import patch
-
     import dask.config
 
     from satpy.utils import get_chunk_size_limit
-    with patch("satpy.utils.CHUNK_SIZE", None):
-        with dask.config.set({"array.chunk-size": "1KiB"}):
-            assert get_chunk_size_limit(np.uint8) == 1024
+    with dask.config.set({"array.chunk-size": "1KiB"}):
+        assert get_chunk_size_limit(np.uint8) == 1024
+
+
+def test_get_legacy_chunk_size():
+    """Test getting the legacy chunk size."""
+    import dask.config
+    assert get_legacy_chunk_size() == 4096
+    with dask.config.set({"array.chunk-size": "32MiB"}):
+        assert get_legacy_chunk_size() == 2048
 
 
 def test_convert_remote_files_to_fsspec_local_files():

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -500,12 +500,8 @@ def test_chunk_size_limit_from_dask_config():
 
     from satpy.utils import get_chunk_size_limit
     with patch("satpy.utils.CHUNK_SIZE", None):
-        original_chunk_size = dask.config.get('array.chunk-size')
-        try:
-            dask.config.set({"array.chunk-size": "1KiB"})
+        with dask.config.set({"array.chunk-size": "1KiB"}):
             assert get_chunk_size_limit(np.uint8) == 1024
-        finally:
-            dask.config.set({"array.chunk-size": original_chunk_size})
 
 
 def test_convert_remote_files_to_fsspec_local_files():

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -28,6 +28,7 @@ from copy import deepcopy
 from typing import Mapping, Optional
 from urllib.parse import urlparse
 
+import dask.utils
 import numpy as np
 import xarray as xr
 import yaml
@@ -584,6 +585,9 @@ def get_chunk_size_limit(dtype):
     pixel_size = get_chunk_pixel_size()
     if pixel_size is not None:
         return pixel_size * np.dtype(dtype).itemsize
+    dask_chunk_size = dask.config.get("array.chunk-size")
+    if dask_chunk_size is not None:
+        return dask.utils.parse_bytes(dask_chunk_size)
     return None
 
 

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -586,8 +586,12 @@ def get_chunk_size_limit(dtype=float):
     pixel_size = _get_chunk_pixel_size()
     if pixel_size is not None:
         return pixel_size * np.dtype(dtype).itemsize
-    dask_chunk_size = dask.config.get("array.chunk-size", "128MiB")
-    return dask.utils.parse_bytes(dask_chunk_size)
+    return get_dask_chunk_size_in_bytes()
+
+
+def get_dask_chunk_size_in_bytes():
+    """Get the dask configured chunk size in bytes."""
+    return dask.utils.parse_bytes(dask.config.get("array.chunk-size", "128MiB"))
 
 
 def _get_chunk_pixel_size():
@@ -610,9 +614,7 @@ def get_legacy_chunk_size():
 
     import math
 
-    import dask.config
-    from dask.utils import parse_bytes
-    return int(math.sqrt(parse_bytes(dask.config.get("array.chunk-size", "128MiB")) / 8))
+    return int(math.sqrt(get_dask_chunk_size_in_bytes() / 8))
 
 
 def _get_pytroll_chunk_size():

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -605,14 +605,14 @@ def get_legacy_chunk_size():
     """
     chunk_size = _get_pytroll_chunk_size()
 
-    if chunk_size is None:
-        import math
-
-        import dask.config
-        from dask.utils import parse_bytes
-        return int(math.sqrt(parse_bytes(dask.config.get("array.chunk-size", "128MiB")) / 8))
-    else:
+    if chunk_size is not None:
         return chunk_size
+
+    import math
+
+    import dask.config
+    from dask.utils import parse_bytes
+    return int(math.sqrt(parse_bytes(dask.config.get("array.chunk-size", "128MiB")) / 8))
 
 
 def _get_pytroll_chunk_size():

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -31,14 +31,14 @@ from trollimage.xrimage import XRImage
 from trollsift import parser
 from yaml import UnsafeLoader
 
-from satpy import CHUNK_SIZE
 from satpy._config import config_search_paths, get_entry_points_config_dirs, glob_config
 from satpy.aux_download import DataDownloadMixin
 from satpy.plugin_base import Plugin
 from satpy.resample import get_area_def
-from satpy.utils import recursive_dict_update
+from satpy.utils import get_legacy_chunk_size, recursive_dict_update
 
 LOG = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
 
 
 def read_writer_config(config_files, loader=UnsafeLoader):


### PR DESCRIPTION
This PR starts deprecating PYTROLL_CHUNK_SIZE in favour of dask's `array.chunk-size` setting.
This is a first step in migrating the readers to determine chunk size for the data based on the data itself instead of using square chunks by default. For example, data stored as stripes may load much faster if the horizontal striping is kept as much as possible instead of cutting the data in square chunks.
Individual adaptations need to be implemented for each reader in later PRs.

 - [x] Tests added <!-- for all bug fixes or enhancements -->

