### PR TITLE
Fix nwcsaf pps palettes

### DIFF
--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -264,7 +264,7 @@ class NcNWCSAF(BaseFileHandler):
         variable.attrs['palette_meanings'] = [int(val)
                                               for val in variable.attrs['palette_meanings'].split()]
 
-        if fill_value not in variable.attrs['palette_meanings']:
+        if fill_value not in variable.attrs['palette_meanings'] and 'fill_value_color' in variable.attrs:
             variable.attrs['palette_meanings'] = [fill_value] + variable.attrs['palette_meanings']
             variable = xr.DataArray(da.vstack((np.array(variable.attrs['fill_value_color']), variable.data)),
                                     coords=variable.coords, dims=variable.dims, attrs=variable.attrs)

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -256,13 +256,16 @@ class NcNWCSAF(BaseFileHandler):
         except KeyError:
             scale = 1
             offset = 0
+            fill_value = 255
         else:
             scale = so_dataset.attrs['scale_factor']
             offset = so_dataset.attrs['add_offset']
+            fill_value = so_dataset.attrs['_FillValue']
         variable.attrs['palette_meanings'] = [int(val)
                                               for val in variable.attrs['palette_meanings'].split()]
-        if variable.attrs['palette_meanings'][0] == 1:
-            variable.attrs['palette_meanings'] = [0] + variable.attrs['palette_meanings']
+
+        if fill_value not in variable.attrs['palette_meanings']:
+            variable.attrs['palette_meanings'] = [fill_value] + variable.attrs['palette_meanings']
             variable = xr.DataArray(da.vstack((np.array(variable.attrs['fill_value_color']), variable.data)),
                                     coords=variable.coords, dims=variable.dims, attrs=variable.attrs)
         val, idx = np.unique(variable.attrs['palette_meanings'], return_index=True)

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -168,7 +168,7 @@ def create_cot_variable(nc_file, var_name):
     var[:] = COT_ARRAY
     var.attrs["scale_factor"] = COT_SCALE
     var.attrs["add_offset"] = COT_OFFSET
-
+    var.attrs["_FillValue"] = 65535
 
 @pytest.fixture
 def nwcsaf_pps_cpp_filehandler(nwcsaf_pps_cpp_filename):


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Fix the palettes for the PPS NWCSAF products by adding fill_value_color when relevant (available and not included).
