### PR TITLE
Add section to FAQ to describe how `generate=False` may speed up RGBs

### DIFF
--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -29,12 +29,12 @@ load your composite:
     scn.load(['true_color'], generate=False)
     scn_res = scn.resample(...)
 
-By default, `generate=True` which means that Satpy will create as many
+By default, ``generate=True`` which means that Satpy will create as many
 composites as it can with the available data. In some cases this could
 a lot of intermediate products (ex. rayleigh corrected data using dynamically
 generated angles for each band resolution) that will then need to be
 resampled.
-By setting `generate=False`, Satpy will only load the necessary dependencies
+By setting ``generate=False``, Satpy will only load the necessary dependencies
 from the reader, but not attempt generating any composites or applying any
 modifiers. In these cases this can save a lot of time and memory as only one
 resolution of the input data have to be processed. Note that this option has

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -13,7 +13,7 @@ an issue on GitHub or talk to us on the Slack team or mailing list. See the
     :local:
 
 
-How can I speed up image production for composites that need resampling?
+How can I speed up creation of composites that need resampling?
 ------------------------------------------------------------------------
 
 Satpy performs some initial image generation on the fly, but for composites
@@ -29,11 +29,20 @@ load your composite:
     scn.load(['true_color'], generate=False)
     scn_res = scn.resample(...)
 
-By default, `generate=True` which means that Satpy will compute some initial
-information about the scene at *each* spatial resolution.
-By setting `generate=False`, Satpy will only compute this information when the
-final image is generated. This can save a lot of time, and can result in images
-being generated up to 3x faster.
+By default, `generate=True` which means that Satpy will create as many
+composites as it can with the available data. In some cases this could
+a lot of intermediate products (ex. rayleigh corrected data using dynamically
+generated angles for each band resolution) that will then need to be
+resampled.
+By setting `generate=False`, Satpy will only load the necessary dependencies
+from the reader, but not attempt generating any composites or applying any
+modifiers. In these cases this can save a lot of time and memory as only one
+resolution of the input data have to be processed. Note that this option has
+no effect when only loading data directly from readers (ex. IR/visible bands
+directly from the files) and where no composites or modifiers are used. Also
+note that in cases where most of your composite
+inputs are already at the same resolution and you are only generating a limited
+number of composites, ``generate=False`` may actually hurt performance.
 
 
 Why is Satpy slow on my powerful machine?

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -18,9 +18,9 @@ How can I speed up creation of composites that need resampling?
 
 Satpy performs some initial image generation on the fly, but for composites
 that need resampling (like the ``true_color`` composite for GOES/ABI) the data
-must be resampled to a common grid before the final image can be producted, as
+must be resampled to a common grid before the final image can be produced, as
 the input channels are at differing spatial resolutions. In such cases, you may
-see a substantial performance improvement by passing `generate=False` when you
+see a substantial performance improvement by passing ``generate=False`` when you
 load your composite:
 
 .. code-block:: python
@@ -30,7 +30,7 @@ load your composite:
     scn_res = scn.resample(...)
 
 By default, ``generate=True`` which means that Satpy will create as many
-composites as it can with the available data. In some cases this could
+composites as it can with the available data. In some cases this could mean
 a lot of intermediate products (ex. rayleigh corrected data using dynamically
 generated angles for each band resolution) that will then need to be
 resampled.

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -12,6 +12,30 @@ an issue on GitHub or talk to us on the Slack team or mailing list. See the
     :depth: 1
     :local:
 
+
+How can I speed up image production for composites that need resampling?
+------------------------------------------------------------------------
+
+Satpy performs some initial image generation on the fly, but for composites
+that need resampling (like the ``true_color`` composite for GOES/ABI) the data
+must be resampled to a common grid before the final image can be producted, as
+the input channels are at differing spatial resolutions. In such cases, you may
+see a substantial performance improvement by passing `generate=False` when you
+load your composite:
+
+.. code-block:: python
+
+    scn = Scene(filenames=filenames, reader='abi_l1b')
+    scn.load(['true_color'], generate=False)
+    scn_res = scn.resample(...)
+
+By default, `generate=True` which means that Satpy will compute some initial
+information about the scene at *each* spatial resolution.
+By setting `generate=False`, Satpy will only compute this information when the
+final image is generated. This can save a lot of time, and can result in images
+being generated up to 3x faster.
+
+
 Why is Satpy slow on my powerful machine?
 -----------------------------------------
 


### PR DESCRIPTION
Based on a comment from @djhoese on slack, I added `generate=False` to some of my `load` calls. This resulted in a massive speed up when generating composites, with processing going nearly three times faster than with the `generate=True` option (default).

In this PR, I add a short section to the FAQ docs to describe how adding `generate=False` may help users produce images more rapidly. Am not sure if I've described it right, or whether I've missed anything out, so there's probably scope for improving the text.

 - [x] Fully documented
