### PR TITLE
Add initial Scene/DataTree conversion via `Scene.to_xarray_datatree`

### DIFF
--- a/satpy/_scene_converters.py
+++ b/satpy/_scene_converters.py
@@ -1,0 +1,33 @@
+# Copyright (c) 2023 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Helper functions for converting the Scene object to some other object."""
+from .scene import Scene
+
+try:
+    from datatree import DataTree
+except ImportError:
+    DataTree = None
+
+
+def to_xarray_datatree(scn: Scene, **kwargs) -> DataTree:
+    """Convert this Scene into an Xarray DataTree object."""
+    try:
+        from datatree import DataTree
+    except ImportError as e:
+        raise ImportError("Missing 'xarray-datatree' library required for DataTree conversion") from e
+
+    tree = DataTree()
+    return tree

--- a/satpy/_scene_converters.py
+++ b/satpy/_scene_converters.py
@@ -24,10 +24,8 @@ except ImportError:
 
 def to_xarray_datatree(scn: Scene, **kwargs) -> DataTree:
     """Convert this Scene into an Xarray DataTree object."""
-    try:
-        from datatree import DataTree
-    except ImportError as e:
-        raise ImportError("Missing 'xarray-datatree' library required for DataTree conversion") from e
+    if DataTree is None:
+        raise ImportError("Missing 'xarray-datatree' library required for DataTree conversion")
 
     tree = DataTree()
     return tree

--- a/satpy/_scene_converters.py
+++ b/satpy/_scene_converters.py
@@ -14,6 +14,10 @@
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Helper functions for converting the Scene object to some other object."""
+from __future__ import annotations
+
+from typing import Iterable
+
 import xarray as xr
 
 from .scene import Scene
@@ -24,20 +28,28 @@ except ImportError:
     DataTree = None
 
 
-def to_xarray_datatree(scn: Scene, **kwargs) -> DataTree:
+def to_xarray_datatree(data_arrays: Scene | Iterable[xr.DataArray], **kwargs) -> DataTree:
     """Convert this Scene into an Xarray DataTree object."""
     if DataTree is None:
         raise ImportError("Missing 'xarray-datatree' library required for DataTree conversion")
 
-    datasets = {}
-    for data_arr in scn:
-        sensor_id = data_arr.attrs["sensor"]
-        if isinstance(sensor_id, set):
-            sensor_id = "-".join(sorted(sensor_id))
-        group_id = data_arr.attrs["platform_name"] + "/" + sensor_id
-        if group_id not in datasets:
-            datasets[group_id] = xr.Dataset({
-                data_arr.attrs["name"]: data_arr,
-            })
+    datasets: dict[str, xr.Dataset] = {}
+    for data_arr in data_arrays:
+        group_id = _data_array_to_group_id(data_arr)
+        group_ds = datasets.setdefault(group_id, xr.Dataset())
+        var_name = _data_array_to_variable_name(data_arr)
+        group_ds[var_name] = data_arr
     tree = DataTree.from_dict(datasets)
     return tree
+
+
+def _data_array_to_group_id(data_arr: xr.DataArray) -> str:
+    sensor_id = data_arr.attrs["sensor"]
+    if isinstance(sensor_id, set):
+        sensor_id = "-".join(sorted(sensor_id))
+    group_id = data_arr.attrs["platform_name"] + "/" + sensor_id
+    return group_id
+
+
+def _data_array_to_variable_name(data_arr: xr.DataArray) -> str:
+    return data_arr.attrs["name"]

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1082,10 +1082,10 @@ class Scene:
             dataarrays = [ds for ds in dataarrays if ds is not None]
         return dataarrays
 
-    def to_xarray_datatree(self):
+    def to_xarray_datatree(self, **kwargs):
         """Convert this Scene into an Xarray DataTree object."""
         from ._scene_converters import to_xarray_datatree
-        return to_xarray_datatree(self)
+        return to_xarray_datatree(self, **kwargs)
 
     def images(self):
         """Generate images for all the datasets from the scene."""

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1084,12 +1084,8 @@ class Scene:
 
     def to_xarray_datatree(self):
         """Convert this Scene into an Xarray DataTree object."""
-        try:
-            from datatree import DataTree
-        except ImportError as e:
-            raise ImportError("Missing 'xarray-datatree' library required for DataTree conversion") from e
-        tree = DataTree()
-        return tree
+        from ._scene_converters import to_xarray_datatree
+        return to_xarray_datatree(self)
 
     def images(self):
         """Generate images for all the datasets from the scene."""

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1084,7 +1084,10 @@ class Scene:
 
     def to_xarray_datatree(self):
         """Convert this Scene into an Xarray DataTree object."""
-        from datatree import DataTree
+        try:
+            from datatree import DataTree
+        except ImportError as e:
+            raise ImportError("Missing 'xarray-datatree' library required for DataTree conversion") from e
         tree = DataTree()
         return tree
 

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1082,6 +1082,12 @@ class Scene:
             dataarrays = [ds for ds in dataarrays if ds is not None]
         return dataarrays
 
+    def to_xarray_datatree(self):
+        """Convert this Scene into an Xarray DataTree object."""
+        from datatree import DataTree
+        tree = DataTree()
+        return tree
+
     def images(self):
         """Generate images for all the datasets from the scene."""
         for ds_id, projectable in self._datasets.items():

--- a/satpy/tests/scene_tests/test_conversions.py
+++ b/satpy/tests/scene_tests/test_conversions.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
+import numpy as np
 import pytest
 import xarray as xr
 from dask import array as da
@@ -111,3 +112,25 @@ class TestToDataTree:
         data_tree = scn.to_xarray_datatree()
         assert isinstance(data_tree, DataTree)
         assert len(data_tree) == 0
+
+    def test_single_data_array(self):
+        """Test a Scene with a single DataArray being converted to a DataTree."""
+        from datatree import DataTree
+
+        scn = Scene()
+        data_arr = xr.DataArray(da.zeros((10, 5), dtype=np.float32),
+                                attrs={
+                                    "name": "ds1",
+                                    "sensor": "abi",
+                                    "platform_name": "GOES-16",
+                                })
+        scn["ds1"] = data_arr
+        data_tree = scn.to_xarray_datatree()
+        assert isinstance(data_tree, DataTree)
+        assert len(data_tree) == 1
+        assert "GOES-16" in data_tree
+        assert len(data_tree["GOES-16"]) == 1
+        assert "abi" in data_tree["GOES-16"]
+        assert len(data_tree["GOES-16"]["abi"]) == 1
+        assert "ds1" in data_tree["GOES-16"]["abi"]
+        assert isinstance(data_tree["GOES-16"]["abi"]["ds1"].data, da.Array)

--- a/satpy/tests/scene_tests/test_conversions.py
+++ b/satpy/tests/scene_tests/test_conversions.py
@@ -115,14 +115,16 @@ class TestToDataTree:
         assert len(data_tree) == 0
 
     @pytest.mark.parametrize(
-        ("input_metadatas", "expected_groups"),
+        ("input_metadatas", "kwargs", "expected_groups"),
         [
             ([{"platform_name": "GOES-16", "sensor": "abi", "name": "ds1"}],
+             {},
              {"/": (1, 0), "GOES-16": (1, 0), "GOES-16/abi": (0, 1)}),
             ([
                  {"platform_name": "GOES-16", "sensor": "abi", "name": "ds1"},
                  {"platform_name": "GOES-16", "sensor": "abi", "name": "ds2"},
              ],
+             {},
              {"/": (1, 0), "GOES-16": (1, 0), "GOES-16/abi": (0, 2)}),
             ([
                  {"platform_name": "GOES-16", "sensor": "abi", "name": "ds1"},
@@ -130,17 +132,26 @@ class TestToDataTree:
                  {"platform_name": "GOES-18", "sensor": "abi", "name": "ds3"},
                  {"platform_name": "GOES-18", "sensor": "abi", "name": "ds4"},
              ],
+             {},
              {"/": (2, 0), "GOES-16": (1, 0), "GOES-16/abi": (0, 2), "GOES-18": (1, 0), "GOES-18/abi": (0, 2)}),
             ([
                  {"platform_name": "GOES-16", "sensor": "abi", "name": "ds1"},
                  {"platform_name": "GOES-16", "sensor": "glm", "name": "ds2"},
              ],
+             {},
              {"/": (1, 0), "GOES-16": (2, 0), "GOES-16/abi": (0, 1), "GOES-16/glm": (0, 1)}),
+            ([
+                 {"platform_name": "GOES-16", "sensor": "abi", "name": "ds1"},
+                 {"platform_name": "GOES-16", "sensor": "glm", "name": "ds2"},
+             ],
+             {"group_keys": ("sensor",)},
+             {"/": (2, 0), "abi": (0, 1), "glm": (0, 1)}),
         ],
     )
     def test_basic_groupings(
             self,
             input_metadatas: Iterable[dict],
+            kwargs: dict,
             expected_groups: dict[str, tuple[int, int]]
     ):
         """Test a Scene with a single DataArray being converted to a DataTree."""
@@ -152,7 +163,7 @@ class TestToDataTree:
                                     attrs=input_metadata)
             scn[data_arr.attrs["name"]] = data_arr
 
-        data_tree = scn.to_xarray_datatree()
+        data_tree = scn.to_xarray_datatree(**kwargs)
         assert isinstance(data_tree, DataTree)
 
         for exp_group, (num_child_nodes, num_child_arrs) in expected_groups.items():

--- a/satpy/tests/scene_tests/test_conversions.py
+++ b/satpy/tests/scene_tests/test_conversions.py
@@ -118,10 +118,27 @@ class TestToDataTree:
         ("input_metadatas", "expected_groups"),
         [
             ([{"platform_name": "GOES-16", "sensor": "abi", "name": "ds1"}],
-             {"GOES-16": (1, 0), "GOES-16/abi": (0, 1)}),
+             {"/": (1, 0), "GOES-16": (1, 0), "GOES-16/abi": (0, 1)}),
+            ([
+                 {"platform_name": "GOES-16", "sensor": "abi", "name": "ds1"},
+                 {"platform_name": "GOES-16", "sensor": "abi", "name": "ds2"},
+             ],
+             {"/": (1, 0), "GOES-16": (1, 0), "GOES-16/abi": (0, 2)}),
+            ([
+                 {"platform_name": "GOES-16", "sensor": "abi", "name": "ds1"},
+                 {"platform_name": "GOES-16", "sensor": "abi", "name": "ds2"},
+                 {"platform_name": "GOES-18", "sensor": "abi", "name": "ds3"},
+                 {"platform_name": "GOES-18", "sensor": "abi", "name": "ds4"},
+             ],
+             {"/": (2, 0), "GOES-16": (1, 0), "GOES-16/abi": (0, 2), "GOES-18": (1, 0), "GOES-18/abi": (0, 2)}),
+            ([
+                 {"platform_name": "GOES-16", "sensor": "abi", "name": "ds1"},
+                 {"platform_name": "GOES-16", "sensor": "glm", "name": "ds2"},
+             ],
+             {"/": (1, 0), "GOES-16": (2, 0), "GOES-16/abi": (0, 1), "GOES-16/glm": (0, 1)}),
         ],
     )
-    def test_single_data_array(
+    def test_basic_groupings(
             self,
             input_metadatas: Iterable[dict],
             expected_groups: dict[str, tuple[int, int]]

--- a/satpy/tests/scene_tests/test_conversions.py
+++ b/satpy/tests/scene_tests/test_conversions.py
@@ -16,11 +16,7 @@
 """Unit tests for Scene conversion functionality."""
 from __future__ import annotations
 
-import contextlib
-import sys
 from datetime import datetime
-from importlib import import_module, reload
-from unittest import mock
 
 import pytest
 import xarray as xr
@@ -96,22 +92,11 @@ class TestSceneConversions:
 
 def test_to_datatree_no_datatree(monkeypatch):
     """Test that datatree not being installed causes an exception with a nice message."""
-    with make_module_unimportable("datatree", "satpy.scene"):
-        scn = Scene()
-        with pytest.raises(ImportError, match='xarray-datatree'):
-            scn.to_xarray_datatree()
-
-
-@contextlib.contextmanager
-def make_module_unimportable(module_name_to_remove: str, module_doing_the_importing: str):
-    """Mock sys.modules to make a module unimportable from another module."""
-    with mock.patch.dict(sys.modules):
-        sys.modules[module_name_to_remove] = None  # type: ignore[assignment]
-        if module_doing_the_importing in sys.modules:
-            reload(sys.modules[module_doing_the_importing])
-        else:
-            import_module(module_doing_the_importing)
-        yield None
+    from satpy import _scene_converters
+    monkeypatch.setattr(_scene_converters, "DataTree", None)
+    scn = Scene()
+    with pytest.raises(ImportError, match='xarray-datatree'):
+        scn.to_xarray_datatree()
 
 
 @pytest.mark.skipif(DataTree is None, reason="Optional 'xarray-datatree' library is not installed")

--- a/satpy/tests/scene_tests/test_conversions.py
+++ b/satpy/tests/scene_tests/test_conversions.py
@@ -22,6 +22,12 @@ from dask import array as da
 
 from satpy import Scene
 
+try:
+    from datatree import DataTree
+except ImportError:
+    DataTree = None
+
+
 # NOTE:
 # The following fixtures are not defined in this file, but are used and injected by Pytest:
 # - include_test_etc
@@ -80,3 +86,17 @@ class TestSceneConversions:
         gv_obj = scn.to_geoviews()
         # we assume that if we got something back, geoviews can use it
         assert gv_obj is not None
+
+
+@pytest.mark.skipif(DataTree is None, reason="Optional 'xarray-datatree' library is not installed")
+class TestToDataTree:
+    """Test Scene conversion to an xarray DataTree."""
+
+    def test_empty_scene(self):
+        """Test that an empty Scene can be converted to a DataTree."""
+        from datatree import DataTree
+
+        scn = Scene()
+        data_tree = scn.to_xarray_datatree()
+        assert isinstance(data_tree, DataTree)
+        assert len(data_tree) == 0


### PR DESCRIPTION
Related to #2352, I thought I'd add a `Scene.to_xarray_datatree` method to the Scene. I want to use this as a stepping stone into more DataTree usage in Satpy and see where it takes us. I also wanted a reason to play around with DataTree more and see how it goes.

At the time of writing this is a pretty simple implementation, but also provides a lot of flexibility. When discussing this concept in #2352 I brought up the ideas of "schemes" or predefined tree-structuring methods that users could choose from. For example, "area"-based or "DataID"-based organizing. As I started working on this (TDD for the win!) I realized I could just structure it as "what metadata keys should I use for each 'group'". This means users can select the level of the hierarchy of the tree. For example, group by platform_name and sensor by specifying `group_keys=("platform_name", "sensor")`.

So at this point, this works as described above, but I'm looking for feedback for others. I seem to remember @mraspaud and @gerritholl being part of this conversation and @ghiggi doing some reworking of `Scene.to_xarray_dataset` related to CF compatibility. I'm curious what you guys think of this.

There is still a lot TODO like:

* handling grouping by area. For example, what do I use as the node name? area hash? Area name (if it exists, pyresample 2.0 will have optional names)?.
* handling of other non-string properties including resolution (units?), calibration enum, etc.
* What attributes to define on each group
* Documentation

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
