### PR TITLE
Change optional rayleigh prerequisites to required for MODIS

### DIFF
--- a/satpy/etc/composites/modis.yaml
+++ b/satpy/etc/composites/modis.yaml
@@ -18,7 +18,6 @@ modifiers:
     prerequisites:
     - name: '1'
       modifiers: [sunz_corrected]
-    prerequisites:
     - satellite_azimuth_angle
     - satellite_zenith_angle
     - solar_azimuth_angle

--- a/satpy/etc/composites/modis.yaml
+++ b/satpy/etc/composites/modis.yaml
@@ -18,7 +18,7 @@ modifiers:
     prerequisites:
     - name: '1'
       modifiers: [sunz_corrected]
-    optional_prerequisites:
+    prerequisites:
     - satellite_azimuth_angle
     - satellite_zenith_angle
     - solar_azimuth_angle


### PR DESCRIPTION
For MODIS data these should never really be optional in my opinion. I noticed this change from @simonrp84 after it started making my upstream tests for Polar2Grid fail because my custom rayleigh corrector (which uses crefl) was pulling in hard requirements and optional requirements.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
