### PR TITLE
Fix Adaptive DNB composite bug introduced from refactoring

### DIFF
--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -644,6 +644,9 @@ def _get_cumul_bin_info_for_tile(
     # current tile)
     calculated_row = num_row_tile - 1 + weight_row
     calculated_col = num_col_tile - 1 + weight_col
+    if calculated_row < 0 or calculated_col < 0:
+        # don't allow negative indexes (out of bounds)
+        return None, None
 
     try:
         bin_info = all_bin_information[calculated_row][calculated_col]

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -206,7 +206,7 @@ class TestVIIRSComposites:
             exp_unique = [0.00000000e+00, 1.00446703e-01, 1.64116082e-01,
                           2.09233451e-01, 1.43916324e+02, 2.03528498e+02,
                           2.49270516e+02]
-            np.testing.assert_allclose(nonnan_unique, exp_unique)
+        np.testing.assert_allclose(nonnan_unique, exp_unique)
 
     def test_snow_age(self, area):
         """Test the 'snow_age' compositor."""


### PR DESCRIPTION
This fixes a bug I introduced when contributing to @simonrp84's #2124 PR when I refactored the VIIRS composites module. One simplification I did resulted in allowing negative indices to be used when accessing data when they were actually supposed to be considered out of bounds.

I haven't added a test for this explicitly because the difference it makes with our test dataset seems to be extremely small (0.9989 to 0.9990) and even in real world cases I didn't see anything obvious. The only reason I caught this is because of some automated testing I have in Polar2Grid which compared two images and it discovered that some pixels had changed.

Otherwise, this PR also fixes a few issues discovered in the tests (name changes and one expected data not being checked).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->

