### PR TITLE
Specify target branch in CI badge URL

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Satpy
 =====
 
 .. image:: https://github.com/pytroll/satpy/workflows/CI/badge.svg?branch=main
-    :target: https://github.com/pytroll/satpy/actions?query=workflow%3A%22CI%22
+    :target: https://github.com/pytroll/satpy/actions?query=workflow%3A%22CI%22+branch%3Amain
 
 .. image:: https://coveralls.io/repos/github/pytroll/satpy/badge.svg?branch=main
     :target: https://coveralls.io/github/pytroll/satpy?branch=main


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
I noticed that the CI badge is red if the CI pipeline in one of the pull requests is red. To fix this, specify the target branch (`main`) in the badge URL.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

