### PR TITLE
Add missing test dependencies and update dev environment documentation

### DIFF
--- a/doc/source/dev_guide/index.rst
+++ b/doc/source/dev_guide/index.rst
@@ -44,7 +44,7 @@ automatically reflected in the python environment. We highly recommend making
 a separate conda environment or virtualenv for development. For example, you
 can do this using conda_::
 
-  conda create -n satpy-dev python=3.8
+  conda create -n satpy-dev python=3.11
   conda activate satpy-dev
 
 .. _conda: https://conda.io/
@@ -80,7 +80,7 @@ libraries. If you want to run all Satpy tests you will need to install
 additional dependencies that aren't needed for regular Satpy usage. To install
 them run::
 
-    pip install -e .[tests]
+    pip install -e ".[tests]"
 
 Satpy tests can be executed by running::
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.24.0', 'trollsift',
 test_requires = ['behave', 'h5py', 'netCDF4', 'pyhdf', 'imageio',
                  'rasterio', 'geoviews', 'trollimage', 'fsspec', 'bottleneck',
                  'rioxarray', 'pytest', 'pytest-lazy-fixture', 'defusedxml',
-                 's3fs']
+                 's3fs', 'python-eccodes', 'h5netcdf', 'xarray-datatree',
+                 'skyfield', 'ephem', 'pint-xarray', 'astropy']
 
 extras_require = {
     # Readers:


### PR DESCRIPTION
This PR adds the missing dependecies to `test_requires` in `setup.py` so that all the tests run. Also the recommeded python version in the docs is updated to `python=3.11`.

 - [x] Closes #2471

