### PR TITLE
Fix rayleigh correction not handling angles as required inputs

### DIFF
--- a/satpy/modifiers/atmosphere.py
+++ b/satpy/modifiers/atmosphere.py
@@ -74,12 +74,12 @@ class PSPRayleighReflectance(ModifierBase):
         Uses pyspectral.
         """
         from pyspectral.rayleigh import Rayleigh
-        if not optional_datasets or len(optional_datasets) != 4:
+        projectables = projectables + (optional_datasets or [])
+        if len(projectables) != 6:
             vis, red = self.match_data_arrays(projectables)
             sata, satz, suna, sunz = get_angles(vis)
         else:
-            vis, red, sata, satz, suna, sunz = self.match_data_arrays(
-                projectables + optional_datasets)
+            vis, red, sata, satz, suna, sunz = self.match_data_arrays(projectables)
             # First make sure the two azimuth angles are in the range 0-360:
             sata = sata % 360.
             suna = suna % 360.


### PR DESCRIPTION
This fixes an issue identified by Dmitry on slack. This was an accidental bug introduced in #2454. I tested things in this way with the CREFL rayleigh correction that I use in Polar2Grid but not with the pyspectral rayleigh correction. The pyspectral/PSP version of the modifier does not properly handle angles being provided as hard requirements (`prerequisites`) instead of optionals (`optional_prerequisites`).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

