### PR TITLE
Reorganize seviri_l2_grib.yaml file for easier reading.

### DIFF
--- a/satpy/etc/readers/seviri_l2_grib.yaml
+++ b/satpy/etc/readers/seviri_l2_grib.yaml
@@ -1,7 +1,7 @@
 reader:
   name: seviri_l2_grib
   short_name: SEVIRI L2 GRIB
-  long_name: MSG (Meteosat 8 to 11) Level 2 products in GRIB2 format
+  long_name: MSG (Meteosat 8 to 11) SEVIRI Level 2 products in GRIB2 format
   description: Reader for EUMETSAT MSG SEVIRI L2 files in GRIB format.
   status: Nominal
   supports_fsspec: false
@@ -10,33 +10,8 @@ reader:
 
 
 file_types:
-  # EUMETSAT MSG SEVIRI L2 Cloud Mask files in GRIB format
-  grib_seviri_clm:
-    file_reader: !!python/name:satpy.readers.seviri_l2_grib.SeviriL2GribFileHandler
-    file_patterns:
-        - 'CLMEncProd_{start_time:%Y%m%d%H%M%S}Z_00_{server:8s}_{spacecraft:5s}_{scan_mode:3s}_{sub_sat:5s}'
-        - '{spacecraft:4s}-SEVI-MSGCLMK-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}'
-        - '{spacecraft:4s}-SEVI-MSGCLMK-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
-        - '{spacecraft:4s}-SEVI-MSGCLMK-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-NA.grb'
 
-  # EUMETSAT MSG SEVIRI L2 Optimal Cloud Analysis files in GRIB format
-  grib_seviri_oca:
-    file_reader: !!python/name:satpy.readers.seviri_l2_grib.SeviriL2GribFileHandler
-    file_patterns:
-        - 'OCAEncProd_{start_time:%Y%m%d%H%M%S}Z_00_{server:8s}_{spacecraft:5s}_{scan_mode:3s}_{sub_sat:5s}'
-        - '{spacecraft:4s}-SEVI-MSGOCAE-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}'
-        - '{spacecraft:4s}-SEVI-MSGOCAE-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
-        - '{spacecraft:4s}-SEVI-MSGOCAE-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-NA.grb'
-
-  # EUMETSAT MSG SEVIRI L2 Active Fire Monitoring files in GRIB format
-  grib_seviri_fir:
-    file_reader: !!python/name:satpy.readers.seviri_l2_grib.SeviriL2GribFileHandler
-    file_patterns:
-      - 'FIREncProd_{start_time:%Y%m%d%H%M%S}Z_00_{server:8s}_{spacecraft:5s}_{scan_mode:3s}_{sub_sat:5s}'
-      - '{spacecraft:4s}-SEVI-MSGFIRG-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}'
-      - '{spacecraft:4s}-SEVI-MSGFIRG-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
-      - '{spacecraft:4s}-SEVI-MSGFIRG-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-NA.grb'
-
+  # EUMETSAT MSG SEVIRI L2 Aerosol Properties over Sea product
   grib_seviri_aes:
     file_reader: !!python/name:satpy.readers.seviri_l2_grib.SeviriL2GribFileHandler
     file_patterns:
@@ -45,6 +20,16 @@ file_types:
       - '{spacecraft:4s}-SEVI-MSGAESE-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
       - '{spacecraft:4s}-SEVI-MSGAESE-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-NA.grb'
 
+  # EUMETSAT MSG SEVIRI L2 Cloud Mask product
+  grib_seviri_clm:
+    file_reader: !!python/name:satpy.readers.seviri_l2_grib.SeviriL2GribFileHandler
+    file_patterns:
+      - 'CLMEncProd_{start_time:%Y%m%d%H%M%S}Z_00_{server:8s}_{spacecraft:5s}_{scan_mode:3s}_{sub_sat:5s}'
+      - '{spacecraft:4s}-SEVI-MSGCLMK-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}'
+      - '{spacecraft:4s}-SEVI-MSGCLMK-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
+      - '{spacecraft:4s}-SEVI-MSGCLMK-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-NA.grb'
+
+  # EUMETSAT MSG SEVIRI L2 Cloud Top Height product
   grib_seviri_cth:
     file_reader: !!python/name:satpy.readers.seviri_l2_grib.SeviriL2GribFileHandler
     file_patterns:
@@ -53,6 +38,8 @@ file_types:
       - '{spacecraft:4s}-SEVI-MSGCLTH-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
       - '{spacecraft:4s}-SEVI-MSGCLTH-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-NA.grb'
 
+  # EUMETSAT MSG SEVIRI L2 Clear-Sky Reflectance Map product
+  # https://www.eumetsat.int/media/38309
   grib_seviri_crm:
     file_reader: !!python/name:satpy.readers.seviri_l2_grib.SeviriL2GribFileHandler
     file_patterns:
@@ -61,6 +48,18 @@ file_types:
       - '{spacecraft:4s}-SEVI-MSGCRMN-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
       - '{spacecraft:4s}-SEVI-MSGCRMN-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-NA.grb'
 
+  # EUMETSAT MSG SEVIRI L2 Active Fire Monitoring product
+  # https://www.eumetsat.int/media/38051
+  grib_seviri_fir:
+    file_reader: !!python/name:satpy.readers.seviri_l2_grib.SeviriL2GribFileHandler
+    file_patterns:
+      - 'FIREncProd_{start_time:%Y%m%d%H%M%S}Z_00_{server:8s}_{spacecraft:5s}_{scan_mode:3s}_{sub_sat:5s}'
+      - '{spacecraft:4s}-SEVI-MSGFIRG-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}'
+      - '{spacecraft:4s}-SEVI-MSGFIRG-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
+      - '{spacecraft:4s}-SEVI-MSGFIRG-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-NA.grb'
+
+  # EUMETSAT MSG SEVIRI L2 Multi-Sensor Precipitation Estimate product
+  # https://www.eumetsat.int/media/38623
   grib_seviri_mpe:
     file_reader: !!python/name:satpy.readers.seviri_l2_grib.SeviriL2GribFileHandler
     file_patterns:
@@ -69,8 +68,69 @@ file_types:
       - '{spacecraft:4s}-SEVI-MSGMPEG-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
       - '{spacecraft:4s}-SEVI-MSGMPEG-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-NA.grb'
 
+  # EUMETSAT MSG SEVIRI L2 Optimal Cloud Analysis product
+  # https://www.eumetsat.int/media/45999
+  grib_seviri_oca:
+    file_reader: !!python/name:satpy.readers.seviri_l2_grib.SeviriL2GribFileHandler
+    file_patterns:
+      - 'OCAEncProd_{start_time:%Y%m%d%H%M%S}Z_00_{server:8s}_{spacecraft:5s}_{scan_mode:3s}_{sub_sat:5s}'
+      - '{spacecraft:4s}-SEVI-MSGOCAE-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}'
+      - '{spacecraft:4s}-SEVI-MSGOCAE-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
+      - '{spacecraft:4s}-SEVI-MSGOCAE-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-NA.grb'
+
+
 datasets:
 
+  # EUMETSAT MSG SEVIRI L2 Aerosol Properties over Sea product
+  aerosol_optical_thickness_vis06:
+    name: aerosol_optical_thickness_vis06
+    long_name: Aerosol optical Thickness at 0.6um
+    standard_name: atmosphere_absorption_optical_thickness_due_to_ambient_aerosol
+    resolution: 9001.209497451
+    file_type: grib_seviri_aes
+    parameter_number: 20
+    units: "1"
+
+  aerosol_optical_thickness_vis08:
+    name: aerosol_optical_thickness_vis08
+    long_name: Aerosol optical Thickness at 0.8um
+    standard_name: atmosphere_absorption_optical_thickness_due_to_ambient_aerosol
+    resolution: 9001.209497451
+    file_type: grib_seviri_aes
+    parameter_number: 21
+    units: "1"
+
+  aerosol_optical_thickness_vis16:
+    name: aerosol_optical_thickness_vis16
+    long_name: Aerosol optical Thickness at 1.6um
+    standard_name: atmosphere_absorption_optical_thickness_due_to_ambient_aerosol
+    resolution: 9001.209497451
+    file_type: grib_seviri_aes
+    parameter_number: 22
+    units: "1"
+
+  angstroem_coefficient:
+    name: angstroem_coefficient
+    long_name: Angstroem Coefficient
+    standard_name: aerosol_angstrom_exponent
+    resolution: 9001.209497451
+    file_type: grib_seviri_aes
+    parameter_number: 23
+    units: "1"
+
+  aes_quality:
+    name: aes_quality
+    long_name: AES Product Quality Flag
+    standard_name: quality_flag
+    resolution: 9001.209497451
+    file_type: grib_seviri_aes
+    parameter_number: 192
+    units: "1"
+    flag_values: [0, 1, 2, 3]
+    flag_meanings: ['clear sky over water','clear sky over land', 'cloudy', 'no data' ]
+
+
+  # EUMETSAT MSG SEVIRI L2 Cloud Mask product
   cloud_mask:
     name: cloud_mask
     long_name: Cloud Classification
@@ -82,6 +142,130 @@ datasets:
     flag_values: [0, 1, 2, 3]
     flag_meanings: ['clear sky over water','clear sky over land', 'cloudy', 'no data' ]
 
+
+  # EUMETSAT MSG SEVIRI L2 Cloud Top Height product
+  cloud_top_height:
+    name: cloud_top_height
+    long_name: Cloud Top Height
+    standard_name: height_at_cloud_top
+    resolution: 9001.209497451
+    file_type: grib_seviri_cth
+    parameter_number: 2
+    units: m
+
+  cloud_top_quality:
+    name: cloud_top_quality
+    long_name: CTH Product Quality Flag
+    standard_name: height_at_cloud_top quality_flag
+    resolution: 9001.209497451
+    file_type: grib_seviri_cth
+    parameter_number: 3
+    units: "1"
+    flag_values: [0, 1]
+    flag_meanings: ['good quality retreival','poor quality retreival' ]
+
+
+  # EUMETSAT MSG SEVIRI L2 Clear-Sky Reflectance Map product
+  vis_refl_06:
+    name: vis_refl_06
+    long_name: TOA Bidirectional Reflectance at 0.6um (7 days average)
+    standard_name: toa_bidirectional_reflectance
+    resolution: 3000.403165817
+    wavelength: [0.56, 0.635, 0.71]
+    file_type: grib_seviri_crm
+    parameter_number: 9
+    units: "%"
+
+  vis_refl_08:
+    name: vis_refl_08
+    long_name: TOA Bidirectional Reflectance at 0.8um (7 days average)
+    standard_name: toa_bidirectional_reflectance
+    resolution: 3000.403165817
+    wavelength: [0.74, 0.81, 0.88]
+    file_type: grib_seviri_crm
+    parameter_number: 10
+    units: "%"
+
+  vis_refl_16:
+    name: vis_refl_16
+    long_name: TOA Bidirectional Reflectance at 1.6um (7 days average)
+    standard_name: toa_bidirectional_reflectance
+    resolution: 3000.403165817
+    wavelength: [1.5, 1.64, 1.78]
+    file_type: grib_seviri_crm
+    parameter_number: 11
+    units: "%"
+
+  nir_refl_39:
+    name: nir_refl_39
+    long_name: TOA Bidirectional Reflectance at 3.9um (7 days average)
+    standard_name: toa_bidirectional_reflectance
+    resolution: 3000.403165817
+    wavelength: [3.48, 3.92, 4.36]
+    file_type: grib_seviri_crm
+    parameter_number: 12
+    units: "%"
+
+  num_accumulations:
+    name: num_accumulations
+    long_name: CRM Product Number of Accumulations
+    standard_name: number_of_accumulations
+    resolution: 3000.403165817
+    file_type: grib_seviri_crm
+    parameter_number: 6
+    units: "1"
+
+  solar_zenith_angle:
+    name: solar_zenith_angle
+    long_name: Solar Zenith Angle (7 days average)
+    standard_name: solar_zenith_angle
+    resolution: 3000.403165817
+    file_type: grib_seviri_crm
+    parameter_number: 7
+    units: degrees
+
+  relative_azimuth_angle:
+    name: relative_azimuth_angle
+    long_name: Relative Azimuth Angle (7 days average)
+    standard_name: relative_sensor_azimuth_angle
+    resolution: 3000.403165817
+    file_type: grib_seviri_crm
+    parameter_number: 8
+    units: degrees
+
+
+  # EUMETSAT MSG SEVIRI L2 Active Fire Monitoring product
+  active_fires:
+    name: active_fires
+    long_name: Active Fire Classification
+    standard_name: active_fire_classification
+    resolution: 3000.403165817
+    file_type: grib_seviri_fir
+    parameter_number: 9
+    units: "1"
+    flag_values: [0, 1, 2, 3]
+    flag_meanings: ['no fire','possible fire', 'probable fire', 'missing' ]
+
+  fire_probability:
+    name: fire_probability
+    long_name: Fire Probability
+    standard_name: fire_probability
+    resolution: 3000.403165817
+    file_type: grib_seviri_fir
+    parameter_number: 192
+    units: "%"
+
+  # EUMETSAT MSG SEVIRI L2 Multi-Sensor Precipitation Estimate product
+  instantaneous_rain_rate:
+    name: instantaneous_rain_rate
+    long_name: MPE Product Instantaneous Rain Rate
+    standard_name: rainfall_rate
+    resolution: 3000.403165817
+    file_type: grib_seviri_mpe
+    parameter_number: 1
+    units: "kg m-2 s-1"
+
+  # EUMETSAT MSG SEVIRI L2 Optimal Cloud Analysis product
   pixel_scene_type:
     name: pixel_scene_type
     long_name: Cloud Type
@@ -191,166 +375,3 @@ datasets:
     file_type: grib_seviri_oca
     parameter_number: 40
     units: Pa
-
-  fire_probability:
-    name: fire_probability
-    long_name: Fire Probability
-    standard_name: fire_probability
-    resolution: 3000.403165817
-    file_type: grib_seviri_fir
-    parameter_number: 192
-    units: "%"
-
-  active_fires:
-    name: active_fires
-    long_name: Active Fire Classification
-    standard_name: active_fire_classification
-    resolution: 3000.403165817
-    file_type: grib_seviri_fir
-    parameter_number: 9
-    units: "1"
-    flag_values: [0, 1, 2, 3]
-    flag_meanings: ['no fire','possible fire', 'probable fire', 'missing' ]
-
-  aerosol_optical_thickness_vis06:
-    name: aerosol_optical_thickness_vis06
-    long_name: Aerosol optical Thickness at 0.6um
-    standard_name: atmosphere_absorption_optical_thickness_due_to_ambient_aerosol
-    resolution: 9001.209497451
-    file_type: grib_seviri_aes
-    parameter_number: 20
-    units: "1"
-
-  aerosol_optical_thickness_vis08:
-    name: aerosol_optical_thickness_vis08
-    long_name: Aerosol optical Thickness at 0.8um
-    standard_name: atmosphere_absorption_optical_thickness_due_to_ambient_aerosol
-    resolution: 9001.209497451
-    file_type: grib_seviri_aes
-    parameter_number: 21
-    units: "1"
-
-  aerosol_optical_thickness_vis16:
-    name: aerosol_optical_thickness_vis16
-    long_name: Aerosol optical Thickness at 1.6um
-    standard_name: atmosphere_absorption_optical_thickness_due_to_ambient_aerosol
-    resolution: 9001.209497451
-    file_type: grib_seviri_aes
-    parameter_number: 22
-    units: "1"
-
-  angstroem_coefficient:
-    name: angstroem_coefficient
-    long_name: Angstroem Coefficient
-    standard_name: aerosol_angstrom_exponent
-    resolution: 9001.209497451
-    file_type: grib_seviri_aes
-    parameter_number: 23
-    units: "1"
-
-  aes_quality:
-    name: aes_quality
-    long_name: AES Product Quality Flag
-    standard_name: quality_flag
-    resolution: 9001.209497451
-    file_type: grib_seviri_aes
-    parameter_number: 192
-    units: "1"
-    flag_values: [0, 1, 2, 3]
-    flag_meanings: ['clear sky over water','clear sky over land', 'cloudy', 'no data' ]
-
-  cloud_top_height:
-    name: cloud_top_height
-    long_name: Cloud Top Height
-    standard_name: height_at_cloud_top
-    resolution: 9001.209497451
-    file_type: grib_seviri_cth
-    parameter_number: 2
-    units: m
-
-  cloud_top_quality:
-    name: cloud_top_quality
-    long_name: CTH Product Quality Flag
-    standard_name: height_at_cloud_top quality_flag
-    resolution: 9001.209497451
-    file_type: grib_seviri_cth
-    parameter_number: 3
-    units: "1"
-    flag_values: [0, 1]
-    flag_meanings: ['good quality retreival','poor quality retreival' ]
-
-  vis_refl_06:
-    name: vis_refl_06
-    long_name: TOA Bidirectional Reflectance at 0.6um (7 days average)
-    standard_name: toa_bidirectional_reflectance
-    resolution: 3000.403165817
-    wavelength: [0.56, 0.635, 0.71]
-    file_type: grib_seviri_crm
-    parameter_number: 9
-    units: "%"
-
-  vis_refl_08:
-    name: vis_refl_08
-    long_name: TOA Bidirectional Reflectance at 0.8um (7 days average)
-    standard_name: toa_bidirectional_reflectance
-    resolution: 3000.403165817
-    wavelength: [0.74, 0.81, 0.88]
-    file_type: grib_seviri_crm
-    parameter_number: 10
-    units: "%"
-
-  vis_refl_16:
-    name: vis_refl_16
-    long_name: TOA Bidirectional Reflectance at 1.6um (7 days average)
-    standard_name: toa_bidirectional_reflectance
-    resolution: 3000.403165817
-    wavelength: [1.5, 1.64, 1.78]
-    file_type: grib_seviri_crm
-    parameter_number: 11
-    units: "%"
-
-  nir_refl_39:
-    name: nir_refl_39
-    long_name: TOA Bidirectional Reflectance at 3.9um (7 days average)
-    standard_name: toa_bidirectional_reflectance
-    resolution: 3000.403165817
-    wavelength: [3.48, 3.92, 4.36]
-    file_type: grib_seviri_crm
-    parameter_number: 12
-    units: "%"
-
-  num_accumulations:
-    name: num_accumulations
-    long_name: CRM Product Number of Accumulations
-    standard_name: number_of_accumulations
-    resolution: 3000.403165817
-    file_type: grib_seviri_crm
-    parameter_number: 6
-    units: "1"
-
-  solar_zenith_angle:
-    name: solar_zenith_angle
-    long_name: Solar Zenith Angle (7 days average)
-    standard_name: solar_zenith_angle
-    resolution: 3000.403165817
-    file_type: grib_seviri_crm
-    parameter_number: 7
-    units: degrees
-
-  relative_azimuth_angle:
-    name: relative_azimuth_angle
-    long_name: Relative Azimuth Angle (7 days average)
-    standard_name: relative_sensor_azimuth_angle
-    resolution: 3000.403165817
-    file_type: grib_seviri_crm
-    parameter_number: 8
-    units: degrees
-
-  instantaneous_rain_rate:
-    name: instantaneous_rain_rate
-    long_name: MPE Product Instantaneous Rain Rate
-    standard_name: rainfall_rate
-    resolution: 3000.403165817
-    file_type: grib_seviri_mpe
-    parameter_number: 1
-    units: "kg m-2 s-1"


### PR DESCRIPTION
This small PR re-orders the `files_types` and `datasets` in `seviri_l2_grib.yaml`-file in aplhabetical order in order to find things easier. 

Also, comments are added for clarity and resource links added for product guides, if available.

Tested with `pytest` for `test_seviri_l2_grib.py`, which runs OK.