### PR TITLE
Fix eccodes package names in setup.py, update documentation for setting up development environment.

### DIFF
--- a/doc/source/dev_guide/index.rst
+++ b/doc/source/dev_guide/index.rst
@@ -68,6 +68,12 @@ should be run from the root of the cloned Satpy repository (where the
 You can now edit the python files in your cloned repository and have them
 immediately reflected in your conda environment.
 
+All the required dependencies for a full development environment, i.e. running the
+tests and building the documentation, can be installed with::
+
+    conda install eccodes
+    pip install -e ".[all]"
+
 Running tests
 =============
 
@@ -80,6 +86,7 @@ libraries. If you want to run all Satpy tests you will need to install
 additional dependencies that aren't needed for regular Satpy usage. To install
 them run::
 
+    conda install eccodes
     pip install -e ".[tests]"
 
 Satpy tests can be executed by running::
@@ -115,8 +122,12 @@ Documentation
 =============
 
 Satpy's documentation is built using Sphinx. All documentation lives in the
-``doc/`` directory of the project repository. After editing the source files
-there the documentation can be generated locally::
+``doc/`` directory of the project repository. For building the documentation,
+additional packages are needed. These can be installed with ::
+
+    pip install -e ".[all]".
+
+After editing the source files there the documentation can be generated locally::
 
     cd doc
     make html

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.24.0', 'trollsift',
 test_requires = ['behave', 'h5py', 'netCDF4', 'pyhdf', 'imageio',
                  'rasterio', 'geoviews', 'trollimage', 'fsspec', 'bottleneck',
                  'rioxarray', 'pytest', 'pytest-lazy-fixture', 'defusedxml',
-                 's3fs', 'python-eccodes', 'h5netcdf', 'xarray-datatree',
+                 's3fs', 'eccodes', 'h5netcdf', 'xarray-datatree',
                  'skyfield', 'ephem', 'pint-xarray', 'astropy']
 
 extras_require = {
@@ -62,8 +62,8 @@ extras_require = {
     'seviri_l1b_hrit': ['pyorbital >= 1.3.1'],
     'seviri_l1b_native': ['pyorbital >= 1.3.1'],
     'seviri_l1b_nc': ['pyorbital >= 1.3.1', 'netCDF4 >= 1.1.8'],
-    'seviri_l2_bufr': ['eccodes-python'],
-    'seviri_l2_grib': ['eccodes-python'],
+    'seviri_l2_bufr': ['eccodes'],
+    'seviri_l2_grib': ['eccodes'],
     'hsaf_grib': ['pygrib'],
     'remote_reading': ['fsspec'],
     'insat_3d': ['xarray-datatree'],


### PR DESCRIPTION
This PR fixes the package names for `eccodes` in `setup.py`. Old package names `eccodes-python` and `python-eccodes` are deprecated, see:

https://pypi.org/project/eccodes-python/
https://confluence.ecmwf.int/display/UDOC/How+to+install+ecCodes+with+Python+bindings+in+conda+-+ecCodes+FAQ

For added confusion both `eccodes` and `python-eccodes` are available in conda-forge and can be installed, but the new installation of the package should be:
```
conda install eccodes
pip install eccodes
```
The `conda` installation installs the C/Fortran library and the command line tools, `pip` installs the python bindings to this `eccodes`-library. For this reason the documentation is also updated to reflect the correct procedure.

The new docs built without warnings on my machine.
