### PR TITLE
Add helper-function for reading SEVIRI L1.5 Native header.

### DIFF
--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -593,8 +593,8 @@ def _jma_true_color_reproduction(img_data, platform=None):
     The conversion matrices for this are supplied per-platform.
     The matrices are computed using the method described in the paper:
     'True Color Imagery Rendering for Himawari-8 with a Color Reproduction Approach
-     Based on the CIE XYZ Color System'
-    DOI:10.2151/jmsj.2018-049
+    Based on the CIE XYZ Color System' (:doi:`10.2151/jmsj.2018-049`).
+
     """
     # Conversion matrix dictionaries specifying sensor and platform.
     ccm_dict = {'himawari-8': np.array([[1.1629, 0.1539, -0.2175],

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -140,6 +140,7 @@ from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger('native_msg')
 CHUNK_SIZE = get_legacy_chunk_size()
+ASCII_STARTSWITH = b'FormatName                  : NATIVE'
 
 
 class NativeMSGFileHandler(BaseFileHandler):
@@ -875,7 +876,7 @@ def get_available_channels(header):
 
 def has_archive_header(filename):
     """Check whether the file includes an ASCII archive header."""
-    ascii_startswith = b'FormatName                  : NATIVE'
+    ascii_startswith = ASCII_STARTSWITH
     with open(filename, mode='rb') as istream:
         return istream.read(36) == ascii_startswith
 

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -876,9 +876,8 @@ def get_available_channels(header):
 
 def has_archive_header(filename):
     """Check whether the file includes an ASCII archive header."""
-    ascii_startswith = ASCII_STARTSWITH
     with open(filename, mode='rb') as istream:
-        return istream.read(36) == ascii_startswith
+        return istream.read(36) == ASCII_STARTSWITH
 
 
 def read_header(filename):

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -188,18 +188,10 @@ class NativeMSGFileHandler(BaseFileHandler):
         # Read header, prepare dask-array, read trailer and initialize image boundaries
         # Available channels are known only after the header has been read
         self.header_type = get_native_header(has_archive_header(self.filename))
-        # self.header_type = get_native_header(self.has_archive_header(self.filename))
         self._read_header()
         self.dask_array = da.from_array(self._get_memmap(), chunks=(CHUNK_SIZE,))
         self._read_trailer()
         self.image_boundaries = ImageBoundaries(self.header, self.trailer, self.mda)
-
-    # @staticmethod
-    # def has_archive_header(filename):
-    #     """Check whether the file includes an ASCII archive header."""
-    #     ascii_startswith = b'FormatName                  : NATIVE'
-    #     with open(filename, mode='rb') as istream:
-    #         return istream.read(36) == ascii_startswith
 
     @property
     def nominal_start_time(self):

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1406,23 +1406,20 @@ def test_header_warning():
             NativeMSGFileHandler('myfile', {}, None)
 
 
-def test_has_archive_header_true():
-    """Test that the file includes an ASCII archive header."""
-    starts_with = ASCII_STARTSWITH
+@pytest.mark.parametrize(
+    "starts_with, expected",
+    [(ASCII_STARTSWITH, True),
+     (b'invalid_startswith', False)]
+)
+def test_has_archive_header(starts_with, expected):
+    """Test if the file includes an ASCII archive header."""
     with mock.patch("builtins.open", mock.mock_open(read_data=starts_with)):
-        assert has_archive_header('filename')
-
-
-def test_has_archive_header_false():
-    """Test that the file does not include an ASCII archive header."""
-    starts_with = b'This does not match with ASCII_STARTSWITH'
-    with mock.patch("builtins.open", mock.mock_open(read_data=starts_with)):
-        assert not has_archive_header('filename')
+        assert has_archive_header('filename') == expected
 
 
 def test_read_header():
     """Test that reading header returns the header correctly converted to a dictionary."""
-    expected_dict = {'SatelliteId': 324, 'NominalLongitude': 0.0, 'SatelliteStatus': 1}
+    expected = {'SatelliteId': 324, 'NominalLongitude': 0.0, 'SatelliteStatus': 1}
 
     dtypes = np.dtype([
         ('SatelliteId', np.uint16),
@@ -1433,5 +1430,5 @@ def test_read_header():
 
     with mock.patch('satpy.readers.seviri_l1b_native.np.fromfile') as fromfile:
         fromfile.return_value = hdr_data
-        actual_dict = recarray2dict(hdr_data)
-    unittest.TestCase().assertDictEqual(expected_dict, actual_dict)
+        actual = recarray2dict(hdr_data)
+    unittest.TestCase().assertDictEqual(actual, expected)

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -684,7 +684,7 @@ class TestNativeMSGArea(unittest.TestCase):
             fh.image_boundaries = ImageBoundaries(header, trailer, fh.mda)
             calc_area_def = fh.get_area_def(dataset_id)
 
-        return (calc_area_def, expected_area_def)
+        return calc_area_def, expected_area_def
 
     # Earth model 1 tests
     def test_earthmodel1_visir_fulldisk(self):
@@ -707,7 +707,6 @@ class TestNativeMSGArea(unittest.TestCase):
                                    np.array(expected['Area extent 0']))
         np.testing.assert_allclose(np.array(calculated.defs[1].area_extent),
                                    np.array(expected['Area extent 1']))
-
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.defs[0].area_id, expected['Area ID'])
@@ -729,10 +728,8 @@ class TestNativeMSGArea(unittest.TestCase):
         calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL1_VISIR_RAPIDSCAN
         )
-
         np.testing.assert_allclose(np.array(calculated.area_extent),
                                    np.array(expected['Area extent']))
-
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.area_id, expected['Area ID'])
@@ -742,10 +739,8 @@ class TestNativeMSGArea(unittest.TestCase):
         calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL1_VISIR_RAPIDSCAN_FILL
         )
-
         np.testing.assert_allclose(np.array(calculated.area_extent),
                                    np.array(expected['Area extent']))
-
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.area_id, expected['Area ID'])
@@ -755,10 +750,8 @@ class TestNativeMSGArea(unittest.TestCase):
         calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN
         )
-
         np.testing.assert_allclose(np.array(calculated.area_extent),
                                    np.array(expected['Area extent']))
-
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.area_id, expected['Area ID'])
@@ -768,10 +761,8 @@ class TestNativeMSGArea(unittest.TestCase):
         calculated, expected = self.prepare_area_defs(
             TEST_AREA_EXTENT_EARTHMODEL1_HRV_RAPIDSCAN_FILL
         )
-
         np.testing.assert_allclose(np.array(calculated.area_extent),
                                    np.array(expected['Area extent']))
-
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.area_id, expected['Area ID'])
@@ -865,7 +856,6 @@ class TestNativeMSGArea(unittest.TestCase):
         )
         np.testing.assert_allclose(np.array(calculated.area_extent),
                                    np.array(expected['Area extent']))
-
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.area_id, expected['Area ID'])
@@ -877,7 +867,6 @@ class TestNativeMSGArea(unittest.TestCase):
         )
         np.testing.assert_allclose(np.array(calculated.area_extent),
                                    np.array(expected['Area extent']))
-
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.area_id, expected['Area ID'])
@@ -889,7 +878,6 @@ class TestNativeMSGArea(unittest.TestCase):
         )
         np.testing.assert_allclose(np.array(calculated.area_extent),
                                    np.array(expected['Area extent']))
-
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.area_id, expected['Area ID'])
@@ -901,7 +889,6 @@ class TestNativeMSGArea(unittest.TestCase):
         )
         np.testing.assert_allclose(np.array(calculated.area_extent),
                                    np.array(expected['Area extent']))
-
         self.assertEqual(calculated.width, expected['Number of columns'])
         self.assertEqual(calculated.height, expected['Number of rows'])
         self.assertEqual(calculated.area_id, expected['Area ID'])
@@ -977,7 +964,7 @@ class TestNativeMSGArea(unittest.TestCase):
             fh.trailer = trailer
             calc_is_roi = fh.is_roi()
 
-        return (calc_is_roi, expected_is_roi)
+        return calc_is_roi, expected_is_roi
 
     def test_is_roi_fulldisk(self):
         """Test check for region of interest with FES data."""
@@ -1310,7 +1297,7 @@ class TestNativeMSGPadder(unittest.TestCase):
         padder._final_shape = final_shape
         calc_padded_data = padder.pad_data(dataset)
 
-        return (calc_padded_data, expected_padded_data)
+        return calc_padded_data, expected_padded_data
 
     def test_padder_rss_roi(self):
         """Test padder for RSS and ROI data (applies to both VISIR and HRV)."""
@@ -1442,8 +1429,8 @@ def test_read_header():
         ('NominalLongitude', np.float32),
         ('SatelliteStatus', np.uint8)
     ])
-
     hdr_data = np.array([(324, 0.0, 1)], dtype=dtypes)
+
     with mock.patch('satpy.readers.seviri_l1b_native.np.fromfile') as fromfile:
         fromfile.return_value = hdr_data
         actual_dict = recarray2dict(hdr_data)

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1415,21 +1415,21 @@ def test_header_warning():
 
 
 def test_has_archive_header_true():
-    """Test that the  file includes an ASCII archive header."""
+    """Test that the file includes an ASCII archive header."""
     starts_with = b'FormatName                  : NATIVE'
     with mock.patch("builtins.open", mock.mock_open(read_data=starts_with)):
         assert open("path/to/open").read(36) == ASCII_STARTSWITH
 
 
 def test_has_archive_header_false():
-    """Test that the  file includes an ASCII archive header."""
-    starts_with = b'This does not match ASCII_STARTSWITH'
+    """Test that the file does not include an ASCII archive header."""
+    starts_with = b'This does not match with ASCII_STARTSWITH'
     with mock.patch("builtins.open", mock.mock_open(read_data=starts_with)):
         assert not open("path/to/open").read(36) == ASCII_STARTSWITH
 
 
 def test_read_header():
-    """Test reading header returns the header correctly converted to a dictionary."""
+    """Test that reading header returns the header correctly converted to a dictionary."""
     expected_dict = {'SatelliteId': 324, 'NominalLongitude': 0.0, 'SatelliteStatus': 1}
 
     dtypes = np.dtype([

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -31,12 +31,17 @@ import pytest
 import xarray as xr
 
 from satpy.readers.eum_base import recarray2dict, time_cds_short
-from satpy.readers.seviri_l1b_native import ImageBoundaries, NativeMSGFileHandler, Padder, get_available_channels
+from satpy.readers.seviri_l1b_native import (
+    ASCII_STARTSWITH,
+    ImageBoundaries,
+    NativeMSGFileHandler,
+    Padder,
+    get_available_channels,
+    has_archive_header,
+)
 from satpy.tests.reader_tests.test_seviri_base import ORBIT_POLYNOMIALS, ORBIT_POLYNOMIALS_INVALID
 from satpy.tests.reader_tests.test_seviri_l1b_calibration import TestFileHandlerCalibrationBase
 from satpy.tests.utils import assert_attrs_equal, make_dataid
-
-ASCII_STARTSWITH = b'FormatName                  : NATIVE'
 
 CHANNEL_INDEX_LIST = ['VIS006', 'VIS008', 'IR_016', 'IR_039',
                       'WV_062', 'WV_073', 'IR_087', 'IR_097',
@@ -1416,16 +1421,16 @@ def test_header_warning():
 
 def test_has_archive_header_true():
     """Test that the file includes an ASCII archive header."""
-    starts_with = b'FormatName                  : NATIVE'
+    starts_with = ASCII_STARTSWITH
     with mock.patch("builtins.open", mock.mock_open(read_data=starts_with)):
-        assert open("path/to/open").read(36) == ASCII_STARTSWITH
+        assert has_archive_header('filename')
 
 
 def test_has_archive_header_false():
     """Test that the file does not include an ASCII archive header."""
     starts_with = b'This does not match with ASCII_STARTSWITH'
     with mock.patch("builtins.open", mock.mock_open(read_data=starts_with)):
-        assert not open("path/to/open").read(36) == ASCII_STARTSWITH
+        assert not has_archive_header('filename')
 
 
 def test_read_header():


### PR DESCRIPTION
This PR introduces a helper function `read_header` in `seviri_l1b_native`-module. A need for this arises from EUM Helpdesk user inquiries, occurring every now and then, for asking how to read or get the header of the file for checking that their implementations in another software is correct.

The usage of the new feature is very simple:
```
from satpy.readers.seviri_l1b_native import read_header
hdr = read_header('MSG4-SEVI-MSG15-0100-NA-20210302124244.185000000Z-NA.nat')
print(hdr['15_DATA_HEADER']['SatelliteStatus']['SatelliteDefinition'])
```

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented
