### PR TITLE
Fix angle caching not handling a specific type of irregular chunking

### DIFF
--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -314,7 +314,9 @@ def _chunks_are_irregular(chunks_tuple: tuple) -> bool:
     is when all chunks are the same size (except for the last one).
 
     """
-    return any(len(set(chunks[:-1])) > 1 for chunks in chunks_tuple)
+    if any(len(set(chunks[:-1])) > 1 for chunks in chunks_tuple):
+        return True
+    return any(chunks[-1] > chunks[0] for chunks in chunks_tuple)
 
 
 def _geo_dask_to_data_array(arr: da.Array) -> xr.DataArray:

--- a/satpy/tests/modifier_tests/test_angles.py
+++ b/satpy/tests/modifier_tests/test_angles.py
@@ -104,6 +104,10 @@ def _get_angle_test_data_odd_chunks():
     return _get_angle_test_data(chunks=((2, 1, 2), (1, 1, 2, 1)))
 
 
+def _get_angle_test_data_odd_chunks2():
+    return _get_angle_test_data(chunks=((1, 4), (2, 3)))
+
+
 def _similar_sat_pos_datetime(orig_data, lon_offset=0.04):
     # change data slightly
     new_data = orig_data.copy()
@@ -226,6 +230,7 @@ class TestAngleGeneration:
             (_get_angle_test_data, 9, ((2, 2, 1), (2, 2, 1))),
             (_get_stacked_angle_test_data, 3, ((5,), (2, 2, 1))),
             (_get_angle_test_data_odd_chunks, 9, ((2, 1, 2), (1, 1, 2, 1))),
+            (_get_angle_test_data_odd_chunks2, 4, ((1, 4), (2, 3))),
             (_get_angle_test_data_rgb, 9, ((2, 2, 1), (2, 2, 1))),
             (_get_angle_test_data_rgb_nodims, 9, ((2, 2, 1), (2, 2, 1))),
         ])


### PR DESCRIPTION
In #2483 @simonrp84 ran into a case where chunks where the last chunk is larger than the first chunk fail to save to zarr in dask, but are supposed to be caught and rechunked automatically by Satpy. They weren't being rechunked which was causing an error. This PR fixes that.

 - [x] Closes #2483 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

