### PR TITLE
Fix leftover deprecated nosetest teardown methods

### DIFF
--- a/satpy/tests/reader_tests/test_fy4_base.py
+++ b/satpy/tests/reader_tests/test_fy4_base.py
@@ -36,7 +36,7 @@ class Test_FY4Base:
 
         self.file_type = {'file_type': 'agri_l1_0500m'}
 
-    def teardown(self):
+    def teardown_method(self):
         """Stop wrapping the HDF5 file handler."""
         self.p.stop()
 

--- a/satpy/tests/reader_tests/test_ghi_l1.py
+++ b/satpy/tests/reader_tests/test_ghi_l1.py
@@ -233,7 +233,7 @@ class Test_HDF_GHI_L1_cal:
             'C07': np.array([[0.2, 0.3, 0.4, 0.5, 0.6], [0.7, 0.8, 0.9, 1., np.nan]]),
         }
 
-    def teardown(self):
+    def teardown_method(self):
         """Stop wrapping the HDF5 file handler."""
         self.p.stop()
 

--- a/satpy/tests/reader_tests/test_msu_gsa_l1b.py
+++ b/satpy/tests/reader_tests/test_msu_gsa_l1b.py
@@ -142,7 +142,7 @@ class TestMSUGSABReader:
         files = self.reader.select_files_from_pathnames(filenames)
         self.reader.create_filehandlers(files)
 
-    def teardown(self):
+    def teardown_method(self):
         """Stop wrapping the HDF5 file handler."""
         self.p.stop()
 


### PR DESCRIPTION
I/we must have switched `setup` to `setup_method` in some tests that were using the deprecated nose-style setup methods, but forgot to change the teardown methods too.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
