### PR TITLE
Add a blend method to create temporal RGB from MultiScene

### DIFF
--- a/satpy/multiscene/__init__.py
+++ b/satpy/multiscene/__init__.py
@@ -1,4 +1,4 @@
 """Functions and classes related to MultiScene functionality."""
 
-from ._blend_funcs import stack, timeseries  # noqa
+from ._blend_funcs import stack, temporal_rgb, timeseries  # noqa
 from ._multiscene import MultiScene  # noqa

--- a/satpy/multiscene/_blend_funcs.py
+++ b/satpy/multiscene/_blend_funcs.py
@@ -178,3 +178,22 @@ def timeseries(datasets):
     res = xr.concat(expanded_ds, dim="time")
     res.attrs = combine_metadata(*[x.attrs for x in expanded_ds])
     return res
+
+
+def temporal_rgb(
+        data_arrays: Sequence[xr.DataArray],
+        weights: Optional[Sequence[xr.DataArray]] = None,
+        combine_times: bool = True,
+        blend_type: str = 'select_with_weights'
+) -> xr.DataArray:
+    """Combine a series of datasets as a temporal RGB.
+
+    The first dataset is used as the Red component of the new composite, the second as Green and the third as Blue.
+    All the other datasets are discarded.
+    """
+    from satpy.composites import GenericCompositor
+
+    compositor = GenericCompositor("temporal_composite")
+    composite = compositor((data_arrays[0], data_arrays[1], data_arrays[2]), attrs=data_arrays[2].attrs)
+
+    return composite


### PR DESCRIPTION
In #1748 we've discussed composites with temporal dependency. This is one attempt on one of the ideas.

```python
import glob
from satpy import MultiScene
from satpy import Scene
from satpy.multiscene import temporal_rgb

# Three sets of data in ascending time order (latest last)
fnames = []
fnames.append(glob.glob('/data/*202305100800*))
fnames.append(glob.glob('/data/*202305100830*))
fnames.append(glob.glob('/data/*202305100855*))

scenes = [Scene(filenames=files, reader='seviri_l1b_hrit') for files in fnames]
mscn = MultiScene(scenes)
mscn.load(['HRV'])
mscn2 = mscn.resample('euron1', resampler='gradient_search')
blended = mscn2.blend(blend_function=temporal_rgb)
blended.save_datasets(base_dir='/tmp')

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
