### PR TITLE
Add "neutral_resolution_band" kwarg to RatioSharpenedRGB/SelfSharpenedRGB

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1114,7 +1114,7 @@ class RatioSharpenedRGB(GenericCompositor):
 
         return bands['red'], bands['green'], bands['blue'], new_attrs
 
-    def _sharpen_bands_with_high_res(self, bands, high_res):
+    def _sharpen_bands_with_high_res(self, bands, high_res): 
         ratio = da.map_blocks(
             _get_sharpening_ratio,
             high_res.data,

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1047,7 +1047,8 @@ class RatioSharpenedRGB(GenericCompositor):
         R_hi -  500m resolution - shape=(4000, 4000)
 
     To avoid the green band getting involved in calculating ratio or sharpening,
-    specify it by "neutral_resolution_band: green" in YAML config file. Then::
+    specify it by "neutral_resolution_band: green" in YAML config file. Therefore,
+    only blue band will get sharpened::
 
         ratio = R_hi / R_lo
         new_R = R_hi

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1109,27 +1109,27 @@ class RatioSharpenedRGB(GenericCompositor):
             high_res = None
 
         bands = {'red': low_res_red, 'green': low_res_green, 'blue': low_res_blue}
-        self._sharpen_bands_with_high_res(bands, high_res)
+        if high_res is not None:
+            self._sharpen_bands_with_high_res(bands, high_res)
 
         return bands['red'], bands['green'], bands['blue'], new_attrs
 
     def _sharpen_bands_with_high_res(self, bands, high_res):
-        if high_res is not None:
-            ratio = da.map_blocks(
-                _get_sharpening_ratio,
-                high_res.data,
-                bands[self.high_resolution_color].data,
-                meta=np.array((), dtype=high_res.dtype),
-                dtype=high_res.dtype,
-                chunks=high_res.chunks,
-            )
+        ratio = da.map_blocks(
+            _get_sharpening_ratio,
+            high_res.data,
+            bands[self.high_resolution_color].data,
+            meta=np.array((), dtype=high_res.dtype),
+            dtype=high_res.dtype,
+            chunks=high_res.chunks,
+        )
 
-            bands[self.high_resolution_color] = high_res
+        bands[self.high_resolution_color] = high_res
 
-            with xr.set_options(keep_attrs=True):
-                for color in bands.keys():
-                    if color != self.neutral_resolution_color and color != self.high_resolution_color:
-                        bands[color] = bands[color] * ratio
+        with xr.set_options(keep_attrs=True):
+            for color in bands.keys():
+                if color != self.neutral_resolution_color and color != self.high_resolution_color:
+                    bands[color] = bands[color] * ratio
 
     def _combined_sharpened_info(self, info, new_attrs):
         combined_info = {}

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1109,6 +1109,11 @@ class RatioSharpenedRGB(GenericCompositor):
             high_res = None
 
         bands = {'red': low_res_red, 'green': low_res_green, 'blue': low_res_blue}
+        self._sharpen_bands_with_high_res(bands, high_res)
+
+        return bands['red'], bands['green'], bands['blue'], new_attrs
+
+    def _sharpen_bands_with_high_res(self, bands, high_res):
         if high_res is not None:
             ratio = da.map_blocks(
                 _get_sharpening_ratio,
@@ -1125,8 +1130,6 @@ class RatioSharpenedRGB(GenericCompositor):
                 for color in bands.keys():
                     if color != self.neutral_resolution_color and color != self.high_resolution_color:
                         bands[color] = bands[color] * ratio
-
-        return bands['red'], bands['green'], bands['blue'], new_attrs
 
     def _combined_sharpened_info(self, info, new_attrs):
         combined_info = {}

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1105,19 +1105,21 @@ class RatioSharpenedRGB(GenericCompositor):
             new_attrs.setdefault('resolution', high_res.attrs['resolution'])
             colors = ['red', 'green', 'blue', None]
             low_resolution_index = colors.index(self.high_resolution_color)
-            high_resolution_index = low_resolution_index
             neutral_resolution_index = colors.index(self.neutral_resolution_color)
-            neutral_res = datasets[neutral_resolution_index] if neutral_resolution_index is not None else None
+            neutral_res = datasets[neutral_resolution_index] if self.neutral_resolution_color is not None else None
 
         else:
             LOG.debug("No sharpening band specified for ratio sharpening")
             high_res = None
             neutral_res = None
             low_resolution_index = 0
-            high_resolution_index = 0
             neutral_resolution_index = 0
 
         if high_res is not None:
+            bands = locals()
+            colors = ['red', 'green', 'blue']
+            bands["low_res_" + self.high_resolution_color] = high_res
+            colors.remove(self.high_resolution_color)
             low_res = (low_res_red, low_res_green, low_res_blue)[low_resolution_index]
             ratio = da.map_blocks(
                 _get_sharpening_ratio,
@@ -1129,27 +1131,16 @@ class RatioSharpenedRGB(GenericCompositor):
             )
             with xr.set_options(keep_attrs=True):
                 if neutral_res is not None:
-                    if high_resolution_index == 0:
-                        low_res_red = high_res
-                        low_res_green = neutral_res if neutral_resolution_index == 1 else low_res_green * ratio
-                        low_res_blue = neutral_res if neutral_resolution_index == 2 else low_res_blue * ratio
+                    if low_resolution_index != neutral_resolution_index:
+                        colors.remove(self.neutral_resolution_color)
 
-                    elif high_resolution_index == 1:
-                        low_res_red = neutral_res if neutral_resolution_index == 0 else low_res_red * ratio
-                        low_res_green = high_res
-                        low_res_blue = neutral_res if neutral_resolution_index == 2 else low_res_blue * ratio
+                for color in colors:
+                    bands["low_res_" + color] = bands["low_res_" + color] * ratio
 
-                    elif high_resolution_index == 2:
-                        low_res_red = neutral_res if neutral_resolution_index == 0 else low_res_red * ratio
-                        low_res_green = neutral_res if neutral_resolution_index == 1 else low_res_green * ratio
-                        low_res_blue = high_res
+            return bands["low_res_red"], bands["low_res_green"], bands["low_res_blue"], new_attrs
 
-                else:
-                    low_res_red = high_res if high_resolution_index == 0 else low_res_red * ratio
-                    low_res_green = high_res if high_resolution_index == 1 else low_res_green * ratio
-                    low_res_blue = high_res if high_resolution_index == 2 else low_res_blue * ratio
-
-        return low_res_red, low_res_green, low_res_blue, new_attrs
+        else:
+            return low_res_red, low_res_green, low_res_blue, new_attrs
 
     def _combined_sharpened_info(self, info, new_attrs):
         combined_info = {}

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1039,7 +1039,7 @@ class RatioSharpenedRGB(GenericCompositor):
         new_G = G * ratio
         new_B = B * ratio
 
-    In some cases, there could be another high resolution band::
+    In some cases, there could be multiple high resolution bands::
 
         R_lo -  1000m resolution - shape=(2000, 2000)
         G_hi - 500m resolution - shape=(4000, 4000)

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1047,8 +1047,8 @@ class RatioSharpenedRGB(GenericCompositor):
         R_hi -  500m resolution - shape=(4000, 4000)
 
     To avoid the green band getting involved in calculating ratio or sharpening,
-    specify it by "neutral_resolution_band: green" in YAML config file. Therefore,
-    only blue band will get sharpened::
+    add "neutral_resolution_band: green" in the YAML config file. This way
+    only the blue band will get sharpened::
 
         ratio = R_hi / R_lo
         new_R = R_hi

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1114,7 +1114,7 @@ class RatioSharpenedRGB(GenericCompositor):
 
         return bands['red'], bands['green'], bands['blue'], new_attrs
 
-    def _sharpen_bands_with_high_res(self, bands, high_res): 
+    def _sharpen_bands_with_high_res(self, bands, high_res):
         ratio = da.map_blocks(
             _get_sharpening_ratio,
             high_res.data,

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1039,7 +1039,7 @@ class RatioSharpenedRGB(GenericCompositor):
         new_G = G * ratio
         new_B = B * ratio
 
-    In some cases, there could be another high resolution band:
+    In some cases, there could be another high resolution band::
 
         R_lo -  1000m resolution - shape=(2000, 2000)
         G_hi - 500m resolution - shape=(4000, 4000)
@@ -1047,7 +1047,7 @@ class RatioSharpenedRGB(GenericCompositor):
         R_hi -  500m resolution - shape=(4000, 4000)
 
     To avoid the green band getting involved in calculating ratio or sharpening,
-    specify it by "neutral_resolution_band: green" in YAML config file. Then:
+    specify it by "neutral_resolution_band: green" in YAML config file. Then::
 
         ratio = R_hi / R_lo
         new_R = R_hi

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1060,7 +1060,7 @@ class RatioSharpenedRGB(GenericCompositor):
     def __init__(self, *args, **kwargs):
         """Instanciate the ration sharpener."""
         self.high_resolution_color = kwargs.pop("high_resolution_band", "red")
-        self.neutral_resolution_color = kwargs.pop("neutral_resolution_band", "red")
+        self.neutral_resolution_color = kwargs.pop("neutral_resolution_band", None)
         if self.high_resolution_color not in ['red', 'green', 'blue', None]:
             raise ValueError("RatioSharpenedRGB.high_resolution_band must "
                              "be one of ['red', 'green', 'blue', None]. Not "
@@ -1103,15 +1103,12 @@ class RatioSharpenedRGB(GenericCompositor):
             if 'rows_per_scan' in high_res.attrs:
                 new_attrs.setdefault('rows_per_scan', high_res.attrs['rows_per_scan'])
             new_attrs.setdefault('resolution', high_res.attrs['resolution'])
-            colors = ['red', 'green', 'blue']
+            colors = ['red', 'green', 'blue', None]
             low_resolution_index = colors.index(self.high_resolution_color)
             high_resolution_index = low_resolution_index
-            if self.neutral_resolution_color is not None:
-                neutral_resolution_index = colors.index(self.neutral_resolution_color)
-                neutral_res = datasets[neutral_resolution_index]
-            else:
-                neutral_res = None
-                neutral_resolution_index = 0
+            neutral_resolution_index = colors.index(self.neutral_resolution_color)
+            neutral_res = datasets[neutral_resolution_index] if neutral_resolution_index is not None else None
+
         else:
             LOG.debug("No sharpening band specified for ratio sharpening")
             high_res = None

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1108,9 +1108,8 @@ class RatioSharpenedRGB(GenericCompositor):
             LOG.debug("No sharpening band specified for ratio sharpening")
             high_res = None
 
+        bands = {'red': low_res_red, 'green': low_res_green, 'blue': low_res_blue}
         if high_res is not None:
-            bands = {'red': low_res_red, 'green': low_res_green, 'blue': low_res_blue}
-
             ratio = da.map_blocks(
                 _get_sharpening_ratio,
                 high_res.data,
@@ -1128,8 +1127,7 @@ class RatioSharpenedRGB(GenericCompositor):
                         bands[color] = bands[color] * ratio
                 return bands['red'], bands['green'], bands['blue'], new_attrs
 
-        else:
-            return low_res_red, low_res_green, low_res_blue, new_attrs
+        return bands['red'], bands['green'], bands['blue'], new_attrs
 
     def _combined_sharpened_info(self, info, new_attrs):
         combined_info = {}

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1125,7 +1125,6 @@ class RatioSharpenedRGB(GenericCompositor):
                 for color in bands.keys():
                     if color != self.neutral_resolution_color and color != self.high_resolution_color:
                         bands[color] = bands[color] * ratio
-                return bands['red'], bands['green'], bands['blue'], new_attrs
 
         return bands['red'], bands['green'], bands['blue'], new_attrs
 

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -31,7 +31,6 @@ from pyresample import AreaDefinition
 
 import satpy
 
-
 # NOTE:
 # The following fixtures are not defined in this file, but are used and injected by Pytest:
 # - tmp_path

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -184,11 +184,15 @@ class TestRatioSharpenedCompositors(unittest.TestCase):
                                            (-2000, -2000, 2000, 2000))
         self.ds4_big = ds4
 
-    def test_bad_color(self):
+    def test_high_bad_color(self):
         """Test that only valid band colors can be provided."""
         from satpy.composites import RatioSharpenedRGB
-        self.assertRaises(ValueError, RatioSharpenedRGB, name='true_color', high_resolution_band='bad',
-                          neutral_resolution_band='bad')
+        self.assertRaises(ValueError, RatioSharpenedRGB, name='true_color', high_resolution_band='bad')
+
+    def test_neutral_bad_color(self):
+        """Test that only valid band colors can be provided."""
+        from satpy.composites import RatioSharpenedRGB
+        self.assertRaises(ValueError, RatioSharpenedRGB, name='true_color', neutral_resolution_band='bad')
 
     def test_match_data_arrays(self):
         """Test that all areas have to be the same resolution."""
@@ -217,10 +221,10 @@ class TestRatioSharpenedCompositors(unittest.TestCase):
         res = comp((self.ds1, self.ds2, self.ds3), optional_datasets=(self.ds4,))
         self.assertEqual(res.shape, (3, 2, 2))
 
-    def test_basic_red(self):
-        """Test that basic high resolution red can be passed."""
+    def test_basic_red_no_neutral(self):
+        """Test that basic high resolution red with no neutral band can be passed."""
         from satpy.composites import RatioSharpenedRGB
-        comp = RatioSharpenedRGB(name='true_color')
+        comp = RatioSharpenedRGB(name='true_color', neutral_resolution_band=None)
         res = comp((self.ds1, self.ds2, self.ds3), optional_datasets=(self.ds4,))
         res = res.values
         self.assertEqual(res.shape, (3, 2, 2))
@@ -229,7 +233,7 @@ class TestRatioSharpenedCompositors(unittest.TestCase):
         np.testing.assert_allclose(res[2], np.array([[0.8, 0.8], [np.nan, 4.0]], dtype=np.float64))
 
     def test_basic_red_neutral_green(self):
-        """Test that basic high resolution red can be passed."""
+        """Test that basic high resolution red with green neutral band can be passed."""
         from satpy.composites import RatioSharpenedRGB
         comp = RatioSharpenedRGB(name='true_color', neutral_resolution_band='green')
         res = comp((self.ds1, self.ds2, self.ds3), optional_datasets=(self.ds4,))
@@ -238,6 +242,50 @@ class TestRatioSharpenedCompositors(unittest.TestCase):
         np.testing.assert_allclose(res[0], self.ds4.values)
         np.testing.assert_allclose(res[1], np.array([[3.0, 3.0], [np.nan, 3.0]], dtype=np.float64))
         np.testing.assert_allclose(res[2], np.array([[0.8, 0.8], [np.nan, 4.0]], dtype=np.float64))
+
+    def test_high_green_no_neutral(self):
+        """Test that high resolution green with no neutral band can be passed."""
+        from satpy.composites import RatioSharpenedRGB
+        comp = RatioSharpenedRGB(name='true_color', high_resolution_band='green', neutral_resolution_band=None)
+        res = comp((self.ds1, self.ds2, self.ds3), optional_datasets=(self.ds4,))
+        res = res.values
+        self.assertEqual(res.shape, (3, 2, 2))
+        np.testing.assert_allclose(res[0], np.array([[5/3, 5/3], [np.nan, 0.0]], dtype=np.float64))
+        np.testing.assert_allclose(res[1], np.array([[1.0, 1.0], [np.nan, 1.0]], dtype=np.float64))
+        np.testing.assert_allclose(res[2], np.array([[4/3, 4/3], [np.nan, 4/3]], dtype=np.float64))
+
+    def test_high_green_neutral_blue(self):
+        """Test that high resolution green with blue neutral band can be passed."""
+        from satpy.composites import RatioSharpenedRGB
+        comp = RatioSharpenedRGB(name='true_color', high_resolution_band='green', neutral_resolution_band='blue')
+        res = comp((self.ds1, self.ds2, self.ds3), optional_datasets=(self.ds4,))
+        res = res.values
+        self.assertEqual(res.shape, (3, 2, 2))
+        np.testing.assert_allclose(res[0], np.array([[5/3, 5/3], [np.nan, 0.0]], dtype=np.float64))
+        np.testing.assert_allclose(res[1], np.array([[1.0, 1.0], [np.nan, 1.0]], dtype=np.float64))
+        np.testing.assert_allclose(res[2], np.array([[4.0, 4.0], [np.nan, 4.0]], dtype=np.float64))
+
+    def test_high_blue_no_neutral(self):
+        """Test that high resolution blue with no neutral band can be passed."""
+        from satpy.composites import RatioSharpenedRGB
+        comp = RatioSharpenedRGB(name='true_color', high_resolution_band='blue', neutral_resolution_band=None)
+        res = comp((self.ds1, self.ds2, self.ds3), optional_datasets=(self.ds4,))
+        res = res.values
+        self.assertEqual(res.shape, (3, 2, 2))
+        np.testing.assert_allclose(res[0], np.array([[1.25, 1.25], [np.nan, 0.0]], dtype=np.float64))
+        np.testing.assert_allclose(res[1], np.array([[0.75, 0.75], [np.nan, 0.75]], dtype=np.float64))
+        np.testing.assert_allclose(res[2], np.array([[1.0, 1.0], [np.nan, 1.0]], dtype=np.float64))
+
+    def test_high_blue_neutral_red(self):
+        """Test that high resolution blue with red neutral band can be passed."""
+        from satpy.composites import RatioSharpenedRGB
+        comp = RatioSharpenedRGB(name='true_color', high_resolution_band='blue', neutral_resolution_band='red')
+        res = comp((self.ds1, self.ds2, self.ds3), optional_datasets=(self.ds4,))
+        res = res.values
+        self.assertEqual(res.shape, (3, 2, 2))
+        np.testing.assert_allclose(res[0], np.array([[5.0, 5.0], [np.nan, 0.0]], dtype=np.float64))
+        np.testing.assert_allclose(res[1], np.array([[0.75, 0.75], [np.nan, 0.75]], dtype=np.float64))
+        np.testing.assert_allclose(res[2], np.array([[1.0, 1.0], [np.nan, 1.0]], dtype=np.float64))
 
     def test_self_sharpened_no_high_res(self):
         """Test for exception when no high res band is specified."""

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -31,7 +31,6 @@ from pyresample import AreaDefinition
 
 import satpy
 
-
 # NOTE:
 # The following fixtures are not defined in this file, but are used and injected by Pytest:
 # - tmp_path
@@ -202,7 +201,7 @@ class TestRatioSharpenedCompositors:
 
     def test_match_data_arrays(self):
         """Test that all areas have to be the same resolution."""
-        from satpy.composites import RatioSharpenedRGB, IncompatibleAreas
+        from satpy.composites import IncompatibleAreas, RatioSharpenedRGB
         comp = RatioSharpenedRGB(name='true_color')
         with pytest.raises(IncompatibleAreas):
             comp((self.ds1, self.ds2, self.ds3), optional_datasets=(self.ds4_big,))

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -187,7 +187,8 @@ class TestRatioSharpenedCompositors(unittest.TestCase):
     def test_bad_color(self):
         """Test that only valid band colors can be provided."""
         from satpy.composites import RatioSharpenedRGB
-        self.assertRaises(ValueError, RatioSharpenedRGB, name='true_color', high_resolution_band='bad')
+        self.assertRaises(ValueError, RatioSharpenedRGB, name='true_color', high_resolution_band='bad',
+                          neutral_resolution_band='bad')
 
     def test_match_data_arrays(self):
         """Test that all areas have to be the same resolution."""
@@ -225,6 +226,17 @@ class TestRatioSharpenedCompositors(unittest.TestCase):
         self.assertEqual(res.shape, (3, 2, 2))
         np.testing.assert_allclose(res[0], self.ds4.values)
         np.testing.assert_allclose(res[1], np.array([[0.6, 0.6], [np.nan, 3.0]], dtype=np.float64))
+        np.testing.assert_allclose(res[2], np.array([[0.8, 0.8], [np.nan, 4.0]], dtype=np.float64))
+
+    def test_basic_red_neutral_green(self):
+        """Test that basic high resolution red can be passed."""
+        from satpy.composites import RatioSharpenedRGB
+        comp = RatioSharpenedRGB(name='true_color', neutral_resolution_band='green')
+        res = comp((self.ds1, self.ds2, self.ds3), optional_datasets=(self.ds4,))
+        res = res.values
+        self.assertEqual(res.shape, (3, 2, 2))
+        np.testing.assert_allclose(res[0], self.ds4.values)
+        np.testing.assert_allclose(res[1], np.array([[3.0, 3.0], [np.nan, 3.0]], dtype=np.float64))
         np.testing.assert_allclose(res[2], np.array([[0.8, 0.8], [np.nan, 4.0]], dtype=np.float64))
 
     def test_self_sharpened_no_high_res(self):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -209,10 +209,10 @@ class TestRatioSharpenedCompositors:
 
     def test_more_than_three_datasets(self):
         """Test that only 3 datasets can be passed."""
-        from satpy.composites import SelfSharpenedRGB
-        comp = SelfSharpenedRGB(name='true_color', high_resolution_band=None)
+        from satpy.composites import RatioSharpenedRGB
+        comp = RatioSharpenedRGB(name='true_color')
         with pytest.raises(ValueError):
-            comp((self.ds1, self.ds2, self.ds3))
+            comp((self.ds1, self.ds2, self.ds3, self.ds1), optional_datasets=(self.ds4_big,))
 
     def test_self_sharpened_no_high_res(self):
         """Test for exception when no high_res band is specified."""

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -187,18 +187,16 @@ class TestRatioSharpenedCompositors:
         self.ds4_big = ds4_big
 
     @pytest.mark.parametrize(
-        "init_kwarg",
+        "init_kwargs",
         [
-            "bad",
-            "bad"
+            {'name': "true_color", "high_resolution_band": "bad", "neutral_resolution_band": "bad"},
         ]
     )
-    def test_bad_colors(self, init_kwarg):
+    def test_bad_colors(self, init_kwargs):
         """Test that only valid band colors can be provided."""
         from satpy.composites import RatioSharpenedRGB
         with pytest.raises(ValueError):
-            RatioSharpenedRGB(name='true_color', high_resolution_band="red", neutral_resolution_band=init_kwarg)
-            RatioSharpenedRGB(name='true_color', high_resolution_band=init_kwarg, neutral_resolution_band="red")
+            RatioSharpenedRGB(**init_kwargs)
 
     @pytest.mark.parametrize(
         "exp",

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -194,7 +194,7 @@ class TestRatioSharpenedCompositors:
     )
     def test_high_bad_color(self, exp):
         """Test that only valid band colors can be provided."""
-        from satpy.composites import RatioSharpenedRGB, SelfSharpenedRGB
+        from satpy.composites import RatioSharpenedRGB
         with pytest.raises(exp):
             RatioSharpenedRGB(name='true_color', high_resolution_band="bad", neutral_resolution_band="red")
 
@@ -206,7 +206,7 @@ class TestRatioSharpenedCompositors:
     )
     def test_neutral_bad_color(self, exp):
         """Test that only valid band colors can be provided."""
-        from satpy.composites import RatioSharpenedRGB, SelfSharpenedRGB
+        from satpy.composites import RatioSharpenedRGB
         with pytest.raises(exp):
             RatioSharpenedRGB(name='true_color', high_resolution_band="red", neutral_resolution_band="bad")
 
@@ -218,7 +218,7 @@ class TestRatioSharpenedCompositors:
     )
     def test_match_data_arrays(self, exp):
         """Test that all areas have to be the same resolution."""
-        from satpy.composites import RatioSharpenedRGB, SelfSharpenedRGB
+        from satpy.composites import RatioSharpenedRGB
         comp = RatioSharpenedRGB(name='true_color')
         with pytest.raises(exp):
             comp((self.ds1, self.ds2, self.ds3), optional_datasets=(self.ds4_big,))
@@ -231,7 +231,7 @@ class TestRatioSharpenedCompositors:
     )
     def test_more_than_three_datasets(self, exp):
         """Test that only 3 datasets can be passed."""
-        from satpy.composites import RatioSharpenedRGB, SelfSharpenedRGB
+        from satpy.composites import SelfSharpenedRGB
         comp = SelfSharpenedRGB(name='true_color', high_resolution_band=None)
         with pytest.raises(exp):
             comp((self.ds1, self.ds2, self.ds3))
@@ -244,7 +244,7 @@ class TestRatioSharpenedCompositors:
     )
     def test_self_sharpened_no_high_res(self, exp):
         """Test for exception when no high_res band is specified."""
-        from satpy.composites import RatioSharpenedRGB, SelfSharpenedRGB
+        from satpy.composites import SelfSharpenedRGB
         comp = SelfSharpenedRGB(name='true_color', high_resolution_band=None)
         with pytest.raises(exp):
             comp((self.ds1, self.ds2, self.ds3))

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -187,28 +187,18 @@ class TestRatioSharpenedCompositors:
         self.ds4_big = ds4_big
 
     @pytest.mark.parametrize(
-        "exp",
+        "init_kwarg",
         [
-            ValueError,
+            "bad",
+            "bad"
         ]
     )
-    def test_high_bad_color(self, exp):
+    def test_bad_colors(self, init_kwarg):
         """Test that only valid band colors can be provided."""
         from satpy.composites import RatioSharpenedRGB
-        with pytest.raises(exp):
-            RatioSharpenedRGB(name='true_color', high_resolution_band="bad", neutral_resolution_band="red")
-
-    @pytest.mark.parametrize(
-        "exp",
-        [
-            ValueError,
-        ]
-    )
-    def test_neutral_bad_color(self, exp):
-        """Test that only valid band colors can be provided."""
-        from satpy.composites import RatioSharpenedRGB
-        with pytest.raises(exp):
-            RatioSharpenedRGB(name='true_color', high_resolution_band="red", neutral_resolution_band="bad")
+        with pytest.raises(ValueError):
+            RatioSharpenedRGB(name='true_color', high_resolution_band="red", neutral_resolution_band=init_kwarg)
+            RatioSharpenedRGB(name='true_color', high_resolution_band=init_kwarg, neutral_resolution_band="red")
 
     @pytest.mark.parametrize(
         "exp",


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Current RatioSharpenedRGB/SelfSharpenedRGB compositor is based on one assumption: there's only one high-res band. However in some composites, like 'false_red_color' of VIIRS, there could be a second high-res band. And it will be wrongfully sharpened in current compositor. So this PR will fix it by adding a new kwarg called "neutral_resolution_band". 

Here's a comparison.

The current one
**R: I02            -- 375m            -- another high-res band (no need for sharpening but still got it)
G: M05/I01 -- 750m/375m -- high-res band (calculate ratio)
B: M04          -- 750m            -- low-res band (need sharpening)**
```
  false_red_color:
    compositor: !!python/name:satpy.composites.RatioSharpenedRGB
    prerequisites:
    - name: I02
      modifiers: [sunz_corrected_iband]
    - name: M05
      modifiers: [sunz_corrected, rayleigh_corrected]
    - name: M04
      modifiers: [sunz_corrected, rayleigh_corrected]
    optional_prerequisites:
    - name: I01
      modifiers: [sunz_corrected_iband, rayleigh_corrected_iband]
    standard_name: crefl
    high_resolution_band: green

```
(100% enlarged)
![image](https://github.com/pytroll/satpy/assets/72339781/833d94fe-ffc7-4428-b81c-2f17acfc0570)
(100% enlarged -- I02)
![image](https://github.com/pytroll/satpy/assets/72339781/188911fc-06c5-4178-bfa4-eb76eb2cc502)


This PR
**R: I02         -- 375m            -- another high-res band (marked as "neutral_resolution_band" so won't get involved)
G: M05/I01 -- 750m/375m -- high-res band (calculate ratio)
B: M15       -- 750m            -- low-res band (need sharpening)**
```
  false_red_color:
    compositor: !!python/name:satpy.composites.RatioSharpenedRGB
    prerequisites:
    - name: I02
      modifiers: [sunz_corrected_iband]
    - name: M05
      modifiers: [sunz_corrected, rayleigh_corrected]
    - name: M04
      modifiers: [sunz_corrected, rayleigh_corrected]
    optional_prerequisites:
    - name: I01
      modifiers: [sunz_corrected_iband, rayleigh_corrected_iband]
    standard_name: crefl
    high_resolution_band: green
    neutral_resolution_band: red
```
(100% enlarged)
![image](https://github.com/pytroll/satpy/assets/72339781/6d845679-eebd-43ab-8d41-b401518ecfd0)
(100% enlarged -- I02)
![image](https://github.com/pytroll/satpy/assets/72339781/4faf8f3c-c3b2-4e3c-b082-138f11a85b0d)


Additionally, if there's no high-resolution file provided, a non-sharpened, low-res image will come out instead.
**R: I02         -- 375m
G: M05  -- 750m
B: M15       -- 750m**
```
  false_red_color:
    compositor: !!python/name:satpy.composites.RatioSharpenedRGB
    prerequisites:
    - name: I02
      modifiers: [sunz_corrected_iband]
    - name: M05
      modifiers: [sunz_corrected, rayleigh_corrected]
    - name: M04
      modifiers: [sunz_corrected, rayleigh_corrected]
    optional_prerequisites:
    - name: I01
      modifiers: [sunz_corrected_iband, rayleigh_corrected_iband]
    standard_name: crefl
    high_resolution_band: green
    neutral_resolution_band: red
```
![image](https://github.com/pytroll/satpy/assets/72339781/67a031df-ecac-45b3-b6c5-3c433b68ff31)

Note that "neutral_resolution_band" should be considered as a complementary to "high_resolution_band". So only when the high-resolution file is given and "high_resolution_band" is set, this kwarg takes effect.



 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
