### PR TITLE
Change logic for ninjogeotiff gradient/axisintercept tags

### DIFF
--- a/satpy/tests/writer_tests/test_ninjogeotiff.py
+++ b/satpy/tests/writer_tests/test_ninjogeotiff.py
@@ -28,7 +28,7 @@ import xarray as xr
 from pyresample import create_area_def
 
 from satpy import Scene
-from satpy.writers import get_enhanced_image
+from satpy.writers import get_enhanced_image, to_image
 
 try:
     from math import prod
@@ -53,7 +53,7 @@ def _get_fake_da(lo, hi, shp, dtype="f4"):
     This is more or less a 2d linspace: it'll return a 2-d dask array of shape
     ``shp``, lowest value is ``lo``, highest value is ``hi``.
     """
-    return da.arange(lo, hi, (hi-lo)/prod(shp), chunks=50, dtype=dtype).reshape(shp)
+    return da.linspace(lo, hi, prod(shp), dtype=dtype).reshape(shp)
 
 
 @pytest.fixture(scope="module")
@@ -204,6 +204,23 @@ def test_image_small_mid_atlantic_K_L(test_area_tiny_eqc_sphere):
 
 
 @pytest.fixture(scope="module")
+def test_image_small_mid_atlantic_L_no_quantity(test_area_tiny_eqc_sphere):
+    """Get a small test image, mode L, over Atlantic, with non-quantitywvalues.
+
+    This could be the case, for example, for vis_with_night_ir.
+    """
+    arr = xr.DataArray(
+        _get_fake_da(0, 273, test_area_tiny_eqc_sphere.shape + (1,)),
+        dims=("y", "x", "bands"),
+        attrs={
+            "name": "test-small-mid-atlantic",
+            "start_time": datetime.datetime(1985, 8, 13, 13, 0),
+            "area": test_area_tiny_eqc_sphere,
+            "units": "N/A"})
+    return get_enhanced_image(arr)
+
+
+@pytest.fixture(scope="module")
 def test_image_large_asia_RGB(test_area_small_eqc_wgs84):
     """Get a large-ish test image in mode RGB, over Asia."""
     arr = xr.DataArray(
@@ -230,7 +247,7 @@ def test_image_small_arctic_P(test_area_tiny_stereographic_wgs84):
             "start_time": datetime.datetime(2027, 8, 2, 8, 20),
             "area": test_area_tiny_stereographic_wgs84,
             "mode": "P"})
-    return get_enhanced_image(arr)
+    return to_image(arr)
 
 
 @pytest.fixture(scope="module")
@@ -489,9 +506,9 @@ def test_write_and_read_file(test_image_small_mid_atlantic_L, tmp_path):
     assert tgs["ninjo_FileName"] == fn
     assert tgs["ninjo_DataSource"] == "dowsing rod"
     np.testing.assert_allclose(float(tgs["ninjo_Gradient"]),
-                               0.4653780307919959)
+                               0.46771654391851947)
     np.testing.assert_allclose(float(tgs["ninjo_AxisIntercept"]),
-                               -79.86837954904149)
+                               -79.86771951938239)
 
 
 def test_write_and_read_file_RGB(test_image_large_asia_RGB, tmp_path):
@@ -542,8 +559,8 @@ def test_write_and_read_file_LA(test_image_latlon, tmp_path):
     tgs = src.tags()
     assert tgs["ninjo_FileName"] == fn
     assert tgs["ninjo_DataSource"] == "dowsing rod"
-    np.testing.assert_allclose(float(tgs["ninjo_Gradient"]), 0.30816176470588236)
-    np.testing.assert_allclose(float(tgs["ninjo_AxisIntercept"]), -49.603125)
+    np.testing.assert_allclose(float(tgs["ninjo_Gradient"]), 0.31058823679007746)
+    np.testing.assert_allclose(float(tgs["ninjo_AxisIntercept"]), -49.6)
     assert tgs["ninjo_PhysicValue"] == "Reflectance"
     assert tgs["ninjo_TransparentPixel"] == "-1"  # meaning not set
 
@@ -574,6 +591,8 @@ def test_write_and_read_file_P(test_image_small_arctic_P, tmp_path):
     tgs = src.tags()
     assert tgs["ninjo_FileName"] == fn
     assert tgs["ninjo_DataSource"] == "dowsing rod"
+    assert "ninjo_Gradient" not in tgs
+    assert "ninjo_AxisIntercept" not in tgs
 
 
 def test_write_and_read_file_units(
@@ -609,9 +628,9 @@ def test_write_and_read_file_units(
     assert tgs["ninjo_FileName"] == fn
     assert tgs["ninjo_DataSource"] == "dowsing rod"
     np.testing.assert_allclose(float(tgs["ninjo_Gradient"]),
-                               0.465379, rtol=1e-5)
+                               0.467717, rtol=1e-5)
     np.testing.assert_allclose(float(tgs["ninjo_AxisIntercept"]),
-                               -79.86838)
+                               -79.86771)
     fn2 = os.fspath(tmp_path / "test2.tif")
     with caplog.at_level(logging.WARNING):
         ngtw.save_dataset(
@@ -631,6 +650,33 @@ def test_write_and_read_file_units(
     assert ("Writing F to ninjogeotiff headers, but "
             "data attributes have unit K. "
             "No conversion applied.") in caplog.text
+
+
+def test_write_and_read_no_quantity(
+        test_image_small_mid_atlantic_L_no_quantity, tmp_path):
+    """Test that no scale/offset written if no valid units present."""
+    import rasterio
+
+    from satpy.writers.ninjogeotiff import NinJoGeoTIFFWriter
+    fn = os.fspath(tmp_path / "test.tif")
+    ngtw = NinJoGeoTIFFWriter()
+    ngtw.save_dataset(
+        test_image_small_mid_atlantic_L_no_quantity.data,
+        filename=fn,
+        blockxsize=128,
+        blockysize=128,
+        compress="lzw",
+        predictor=2,
+        PhysicUnit="N/A",
+        PhysicValue="N/A",
+        SatelliteNameID=6400014,
+        ChannelID=900015,
+        DataType="GORN",
+        DataSource="dowsing rod")
+    src = rasterio.open(fn)
+    tgs = src.tags()
+    assert "ninjo_Gradient" not in tgs.keys()
+    assert "ninjo_AxisIntercept" not in tgs.keys()
 
 
 def test_write_and_read_via_scene(test_image_small_mid_atlantic_L, tmp_path):
@@ -810,7 +856,6 @@ def test_get_max_gray_value_RGB(ntg2):
     assert ntg2.get_max_gray_value() == 255
 
 
-@pytest.mark.xfail(reason="Needs GeoTIFF P fixes, see GH#1844")
 def test_get_max_gray_value_P(ntg3):
     """Test getting max gray value for mode P."""
     assert ntg3.get_max_gray_value().compute().item() == 10

--- a/satpy/tests/writer_tests/test_ninjogeotiff.py
+++ b/satpy/tests/writer_tests/test_ninjogeotiff.py
@@ -652,8 +652,9 @@ def test_write_and_read_file_units(
             "No conversion applied.") in caplog.text
 
 
+@pytest.mark.parametrize("unit", ["N/A", "1", ""])
 def test_write_and_read_no_quantity(
-        test_image_small_mid_atlantic_L_no_quantity, tmp_path):
+        test_image_small_mid_atlantic_L_no_quantity, tmp_path, unit):
     """Test that no scale/offset written if no valid units present."""
     import rasterio
 
@@ -667,7 +668,7 @@ def test_write_and_read_no_quantity(
         blockysize=128,
         compress="lzw",
         predictor=2,
-        PhysicUnit="N/A",
+        PhysicUnit=unit,
         PhysicValue="N/A",
         SatelliteNameID=6400014,
         ChannelID=900015,

--- a/satpy/writers/ninjogeotiff.py
+++ b/satpy/writers/ninjogeotiff.py
@@ -78,7 +78,7 @@ and only if the image has mode ``L`` or ``LA`` and ``PhysicUnit`` is not set
 to ``"N/A"``.  In other words, to suppress those tags for images with mode
 ``L`` or ``LA`` (for example, for the composite ``vis_with_ir``, where the
 physical interpretation of individual pixels is lost), one should set
-``PhysicUnit`` to ``"N/A"`` or ``"n/a"``.
+``PhysicUnit`` to ``"N/A"``, ``"n/a"``, ``"1"``, or ``""`` (empty string).
 """
 
 import copy
@@ -236,7 +236,7 @@ class NinJoGeoTIFFWriter(GeoTIFFWriter):
 
     def _check_include_scale_offset(self, image, unit):
         """Check if scale-offset tags should be included."""
-        if image.mode.startswith("L") and unit.lower() != "n/a":
+        if image.mode.startswith("L") and unit.lower() not in ("n/a", "1", ""):
             return True
         return False
 

--- a/satpy/writers/ninjogeotiff.py
+++ b/satpy/writers/ninjogeotiff.py
@@ -17,13 +17,12 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Writer for GeoTIFF images with tags for the NinJo visualization tool.
 
-The next version of NinJo (release expected spring 2022) will be able
-to read standard GeoTIFF images, with required metadata encoded as a set
-of XML tags in the GDALMetadata TIFF tag.  Each of the XML tags must be
-prepended with ``'NINJO_'``.  For NinJo delivery, these GeoTIFF files
-supersede the old NinJoTIFF format.  The :class:`NinJoGeoTIFFWriter`
-therefore supersedes the old Satpy NinJoTIFF writer and the pyninjotiff
-package.
+Starting with NinJo 7, NinJo is able to read standard GeoTIFF images,
+with required metadata encoded as a set of XML tags in the GDALMetadata
+TIFF tag.  Each of the XML tags must be prepended with ``'NINJO_'``.
+For NinJo delivery, these GeoTIFF files supersede the old NinJoTIFF
+format.  The :class:`NinJoGeoTIFFWriter` therefore supersedes the old
+Satpy NinJoTIFF writer and the pyninjotiff package.
 
 The reference documentation for valid NinJo tags and their meaning is
 contained in `NinJoPedia`_.  Since this page is not in the public web,
@@ -70,6 +69,16 @@ their functionality has become redundant.  This applies to
 Instead, pass those values in source units to the
 :func:`~satpy.enhancements.stretch` enhancement with the ``min_stretch``
 and ``max_stretch`` arguments.
+
+For images where the pixel value corresponds directly to a physical value,
+NinJo has a functionality to read the corresponding quantity (example:
+brightness temperature or reflectance).  To make this possible, the writer
+adds the tags ``Gradient`` and ``AxisIntercept``.  Those tags are added if
+and only if the image has mode ``L`` or ``LA`` and ``PhysicUnit`` is not set
+to ``"N/A"``.  In other words, to suppress those tags for images with mode
+``L`` or ``LA`` (for example, for the composite ``vis_with_ir``, where the
+physical interpretation of individual pixels is lost), one should set
+``PhysicUnit`` to ``"N/A"`` or ``"n/a"``.
 """
 
 import copy
@@ -91,6 +100,8 @@ class NinJoGeoTIFFWriter(GeoTIFFWriter):
     For information, see module docstring and documentation for
     :meth:`~NinJoGeoTIFFWriter.save_image`.
     """
+
+    scale_offset_tag_names = ("ninjo_Gradient", "ninjo_AxisIntercept")
 
     def save_image(
             self, image, filename=None, fill_value=None,
@@ -149,7 +160,8 @@ class NinJoGeoTIFFWriter(GeoTIFFWriter):
                 "Temperature", PhysicUnit is set to "C", but data attributes
                 incidate the data have unit "K", then the writer will adapt the
                 header ``ninjo_AxisIntercept`` such that data are interpreted
-                in units of "C".
+                in units of "C".  If PhysicUnit is set to "N/A", no
+                AxisIntercept and Gradient tags will be written.
             PhysicValue (str)
                 NinJo label for quantity (example: "temperature")
 
@@ -192,7 +204,9 @@ class NinJoGeoTIFFWriter(GeoTIFFWriter):
             overviews_minsize=overviews_minsize,
             overviews_resampling=overviews_resampling,
             tags={**(tags or {}), **ninjo_tags},
-            scale_offset_tags=None if image.mode.startswith("RGB") else ("ninjo_Gradient", "ninjo_AxisIntercept"),
+            scale_offset_tags=(self.scale_offset_tag_names
+                               if self._check_include_scale_offset(image, PhysicUnit)
+                               else None),
             **gdal_opts)
 
     def _fix_units(self, image, quantity, unit):
@@ -219,6 +233,12 @@ class NinJoGeoTIFFWriter(GeoTIFFWriter):
                     "No conversion applied.")
 
         return image
+
+    def _check_include_scale_offset(self, image, unit):
+        """Check if scale-offset tags should be included."""
+        if image.mode.startswith("L") and unit.lower() != "n/a":
+            return True
+        return False
 
 
 class NinJoTagGenerator:


### PR DESCRIPTION
In the ninjogeotiff writer, change the logic for deciding whether to set the tags AxisIntercept and Gradient.  Previously, those were always set, unless the image had mode RGB or RGBA.  With this change, those tags are set only if the image has mode L and LA and PhysicUnit is not set to N/A.

This commit also makes a small bugfix in a data fixture in the test routine, that leads to a few reference values changing slightly.  This reflects no change in functionality, but only between the fixtures and the test functions.

Adapt documentation to reflect that NinJo 7 is now out and about.

 - [x] Closes #2490 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

