### PR TITLE
Add support for temporal composites

### DIFF
--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -333,7 +333,7 @@ with the :func:`satpy.multiscene.timeseries` function::
     ...         group_keys=["repeat_cycle_in_day"])
     >>> ms.load(["vis_06"])
     >>> sc = ms.blend(blend_function=satpy.multiscene.timeseries)
-    >>> comp = temporal([sc["vis_06"]])
+    >>> comp = temporal([sc["vis_06"]]*3)  # pass three times: same source for each timestep
 
 When defining a time-dependent composite in a configuration file (see below)
 it should be loaded directly from the :class:`~satpy.multiscene.MultiScene`, but will be

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -304,6 +304,43 @@ categories representing clear sky (cat1/cat5), cloudy features (cat2-cat4) and m
     >>> compositor = CategoricalDataCompositor('binary_cloud_mask', lut=lut)
     >>> composite = compositor([cloud_type])  # 0 - cat1/cat5, 1 - cat2/cat3/cat4, nan - cat0
 
+Time-dependent compositors
+--------------------------
+
+.. versionadded:: 0.43
+
+.. warning::
+
+   Time-dependent compositors are experimental.
+
+The built-in compositor :class:`TemporalRGB` creates an RGB consisting of
+three timesteps from the same channel.  When creating the compositor, the
+user must define the times using a :class:`~satpy.DataQuery`::
+
+    >>> temporal = TemporalRGB(
+    ...     "temporal_rgb",
+    ...     [DataQuery(wavelength=0.6, time=0),
+    ...      DataQuery(wavelength=0.6, time="-10 min"),
+    ...      DataQuery(wavelength=0.6, time="-20 min")])
+
+When calling the compositor, it should be passed a dataset that has a
+time dimension.  This can be obtained by blending a :class:`satpy.multiscene.MultiScene`
+with the :func:`satpy.multiscene.timeseries` function::
+
+    >>> ms = MultiScene.from_files(
+    ...         glob("/media/nas/x21308/MTG_test_data/2022_05_MTG_Testdata/RC007[012]/*BODY*.nc"),
+    ...         reader="fci_l1c_nc",
+    ...         group_keys=["repeat_cycle_in_day"])
+    >>> ms.load(["vis_06"])
+    >>> sc = ms.blend(blend_function=satpy.multiscene.timeseries)
+    >>> comp = temporal([sc["vis_06"]])
+
+When defining a time-dependent composite in a configuration file (see below)
+it should be loaded directly from the :class:`~satpy.multiscene.MultiScene`, but will be
+available only after timeseries blending::
+
+    >>> ms.load(["temporal_rgb_vis06"])
+    >>> sc = ms.blend(blend_function=timeseries)
 
 Creating composite configuration files
 ======================================

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1701,3 +1701,28 @@ class LongitudeMaskingCompositor(SingleBandCompositor):
 
         masked_projectable = projectable.where(lon_min_max)
         return super().__call__([masked_projectable], **info)
+
+
+class MissingTime(Exception):
+    """Raised when temporal composite building lacks time dimension."""
+
+
+class BaseTemporalCompositor(CompositeBase):
+    """Compositors combining multiple time steps.
+
+    Base class for compositors that combine inputs from two or more time steps.
+    """
+
+    def __call__(self, projectables, nonprojectables=None, **info):
+        """Build the composite."""
+        self._check_time_dimension(projectables)
+        return super().__call__(projectables, nonprojectables, **info)
+
+    def _check_time_dimension(self, projectables):
+        """Make sure all projectables have a time dimension."""
+        for projectable in projectables:
+            if "time" not in projectable.dims:
+                raise MissingTime(
+                    "Creating temporal composite needs time dimensions. "
+                    "Typically, this comes from starting with a MultiScene "
+                    "and then performing timeseries blending.")

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1770,6 +1770,7 @@ class TemporalRGB(BaseTemporalCompositor):
 
     def __call__(self, projectables, optional_datasets=None, **info):
         """Build the composite."""
+        projectables = self.match_data_arrays(projectables)
         self._check_time_dimension(projectables)
         new_projectables = self._apply_temporal_prerequisites(projectables)
         # need to drop the time coordinate, otherwise we can't concatenate

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1722,7 +1722,7 @@ class BaseTemporalCompositor(CompositeBase):
     the generation should work.
     """
 
-    def __init__(self, name, prerequisites, optional_prerequisites, **kwargs):
+    def __init__(self, name, prerequisites, optional_prerequisites=None, **kwargs):
         """Initialise a temporal compositor."""
         self._ensure_prerequisites_have_times(prerequisites)
         super().__init__(name, prerequisites, optional_prerequisites, **kwargs)
@@ -1766,7 +1766,11 @@ class BaseTemporalCompositor(CompositeBase):
 
 
 class TemporalRGB(BaseTemporalCompositor):
-    """Make an RGB where different timesteps of the same channel go in different bands."""
+    """Make an RGB where different timesteps of the same channel go in different bands.
+
+    See the note in the parent class :class:`BaseTemporalCompositor` for
+    usage instructions.
+    """
 
     def __call__(self, projectables, optional_datasets=None, **info):
         """Build the composite."""

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1760,7 +1760,7 @@ class BaseTemporalCompositor(CompositeBase):
         ref_time = projectables[0]["time"][-1]
         new_projectables = []
         for (dq, proj) in zip(self.attrs["prerequisites"], projectables):
-            new_da = proj.sel(time=ref_time+pd.Timedelta(dq["time"]))
+            new_da = proj.sel(time=ref_time+pd.Timedelta(dq["time"]), method='nearest')
             new_projectables.append(new_da)
         return new_projectables
 

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -22,6 +22,7 @@ import warnings
 
 import dask.array as da
 import numpy as np
+import pandas as pd
 import xarray as xr
 from trollimage.colormap import Colormap
 
@@ -245,6 +246,16 @@ class CompositeBase:
                       "'{}'".format(self.attrs['name']))
             raise IncompatibleAreas("Areas are different")
 
+    def _concat_datasets(self, projectables, mode):
+        try:
+            data = xr.concat(projectables, 'bands', coords='minimal')
+            data['bands'] = list(mode)
+        except ValueError as e:
+            LOG.debug("Original exception for incompatible areas: {}".format(str(e)))
+            raise IncompatibleAreas
+
+        return data
+
 
 class DifferenceCompositor(CompositeBase):
     """Make the difference of two data arrays."""
@@ -396,16 +407,6 @@ class GenericCompositor(CompositeBase):
         if 'bands' in data_arr.coords and isinstance(data_arr.coords['bands'][0].item(), str):
             return ''.join(data_arr.coords['bands'].values)
         return cls.modes[data_arr.sizes['bands']]
-
-    def _concat_datasets(self, projectables, mode):
-        try:
-            data = xr.concat(projectables, 'bands', coords='minimal')
-            data['bands'] = list(mode)
-        except ValueError as e:
-            LOG.debug("Original exception for incompatible areas: {}".format(str(e)))
-            raise IncompatibleAreas
-
-        return data
 
     def _get_sensors(self, projectables):
         sensor = set()
@@ -1711,12 +1712,20 @@ class BaseTemporalCompositor(CompositeBase):
     """Compositors combining multiple time steps.
 
     Base class for compositors that combine inputs from two or more time steps.
+
+    To use this, the user must start with a :class:`MultiScene` and load the
+    temporal composite from there.  Composite generation will fail due to missing
+    temporal information in the containing scenes, but it will add the temporal
+    composite to the scene wishlists.  Now we run ``MultiScene.blend(timeseries)``,
+    which will create DataArrays with a time dimension.  After blending, the
+    blend method tries again to generate the composites, and on this second run
+    the generation should work.
     """
 
-    def __call__(self, projectables, nonprojectables=None, **info):
-        """Build the composite."""
-        self._check_time_dimension(projectables)
-        return super().__call__(projectables, nonprojectables, **info)
+    def __init__(self, name, prerequisites, optional_prerequisites, **kwargs):
+        """Initialise a temporal compositor."""
+        self._ensure_prerequisites_have_times(prerequisites)
+        super().__init__(name, prerequisites, optional_prerequisites, **kwargs)
 
     def _check_time_dimension(self, projectables):
         """Make sure all projectables have a time dimension."""
@@ -1726,3 +1735,47 @@ class BaseTemporalCompositor(CompositeBase):
                     "Creating temporal composite needs time dimensions. "
                     "Typically, this comes from starting with a MultiScene "
                     "and then performing timeseries blending.")
+
+    def _ensure_prerequisites_have_times(self, prerequisites):
+        """Make sure all prerequisites have times defined."""
+        for preq in prerequisites:
+            if "time" not in preq.to_dict():
+                raise KeyError(
+                    "In a temporal composite, all prerequisites should have "
+                    "time information defined.  Time information is missing for "
+                    f"{preq!s}")
+
+    def _apply_temporal_prerequisites(self, projectables):
+        """Apply temporal prerequisites.
+
+        The generic Satpy composite loading logic does not understand time
+        dependencies.  When :meth:`MultiScene.blend` reruns the composite
+        loading for a composite combining the same channel for three time
+        steps, we will be passed the same 3-D data array three times.
+
+        This method matches the temporal prerequisites as defined in the
+        compositor with the time dimension associated with the dataarrays.
+        """
+        # reference time is the newest time
+        ref_time = projectables[0]["time"][-1]
+        new_projectables = []
+        for (dq, proj) in zip(self.attrs["prerequisites"], projectables):
+            new_da = proj.sel(time=ref_time+pd.Timedelta(dq["time"]))
+            new_projectables.append(new_da)
+        return new_projectables
+
+
+class TemporalRGB(BaseTemporalCompositor):
+    """Make an RGB where different timesteps of the same channel go in different bands."""
+
+    def __call__(self, projectables, optional_datasets=None, **info):
+        """Build the composite."""
+        self._check_time_dimension(projectables)
+        new_projectables = self._apply_temporal_prerequisites(projectables)
+        # need to drop the time coordinate, otherwise we can't concatenate
+        # the bands
+        dataset = self._concat_datasets(
+            [proj.drop_vars("time") for proj in new_projectables], "RGB")
+        dataset.attrs.update(self.attrs)
+        dataset.attrs.update(info)
+        return dataset

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -642,3 +642,20 @@ composites:
       - wavelength: 3.9
       - wavelength: 6.2
       - wavelength: 1.6
+
+  temporal_rgb_vis06:
+    description: >
+      An RGB to highlight changes at 0.64 µm. To use this, start with a
+      MultiScene containing three scenes that are 10 minutes apart, such
+      as three subsequent FCI or ABI FD scenes. Load the composite from
+      the MultiScene, then apply timeseries blending. The resulting Scene
+      should have the composites.
+    compositor: !!python/name:satpy.composites.TemporalRGB
+    prerequisites:
+      - wavelength: 0.64
+        time: 0
+      - wavelength: 0.64
+        time: -10 min
+      - wavelength: 0.64
+        time: -20 min
+    standard_name: temporal_rgb_vis06

--- a/satpy/multiscene/_multiscene.py
+++ b/satpy/multiscene/_multiscene.py
@@ -360,7 +360,7 @@ class MultiScene(object):
             new_scn[ds_id] = blend_function(datasets)
 
         new_scn._wishlist = self.first_scene.wishlist.copy()
-        # without copying this, there is a KeyError in dependency_tree.trunk
+        # without copying the dependency tree, there is a KeyError in dependency_tree.trunk
         new_scn._dependency_tree = self.first_scene._dependency_tree.copy()
         new_scn.generate_possible_composites(True)
         return new_scn

--- a/satpy/multiscene/_multiscene.py
+++ b/satpy/multiscene/_multiscene.py
@@ -359,6 +359,10 @@ class MultiScene(object):
             datasets = [scn[ds_id] for scn in self.scenes if ds_id in scn]
             new_scn[ds_id] = blend_function(datasets)
 
+        new_scn._wishlist = self.first_scene.wishlist.copy()
+        # without copying this, there is a KeyError in dependency_tree.trunk
+        new_scn._dependency_tree = self.first_scene._dependency_tree.copy()
+        new_scn.generate_possible_composites(True)
         return new_scn
 
     def group(self, groups):

--- a/satpy/multiscene/_multiscene.py
+++ b/satpy/multiscene/_multiscene.py
@@ -359,11 +359,18 @@ class MultiScene(object):
             datasets = [scn[ds_id] for scn in self.scenes if ds_id in scn]
             new_scn[ds_id] = blend_function(datasets)
 
-        new_scn._wishlist = self.first_scene.wishlist.copy()
+        new_scn._wishlist = self._shared_wishlist()
         # without copying the dependency tree, there is a KeyError in dependency_tree.trunk
         new_scn._dependency_tree = self.first_scene._dependency_tree.copy()
         new_scn.generate_possible_composites(True)
         return new_scn
+
+    def _shared_wishlist(self):
+        """Get shared wishlist."""
+        shared_wishlist = self.scenes[0]._wishlist
+        for scene in self.scenes[1:]:
+            shared_wishlist &= scene._wishlist
+        return shared_wishlist
 
     def group(self, groups):
         """Group datasets from the multiple scenes.

--- a/satpy/tests/multiscene_tests/test_temporal_composites.py
+++ b/satpy/tests/multiscene_tests/test_temporal_composites.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2023 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for loading temporal composites."""
+
+import datetime
+
+import numpy as np
+import pytest
+import xarray as xr
+
+from satpy.composites import GenericCompositor
+
+composite_definition = """sensor_name: visir
+
+composites:
+  temporal:
+    compositor: !!python/name:satpy.tests.multiscene_tests.test_temporal_composites._TemporalCompositor
+    prerequisites:
+      - name: ir
+        time: 0
+      - name: ir
+        time: -10 min
+      - name: ir
+        time: -20 min
+    standard_name: temporal
+"""
+
+
+class _TemporalCompositor(GenericCompositor):
+    """Dummy temporal compositor class."""
+
+
+@pytest.fixture
+def fake_config(tmp_path):
+    """Make a configuration path with a temporal composite definition."""
+    confdir = tmp_path / "etc"
+    conffile = tmp_path / "etc" / "composites" / "visir.yaml"
+    conffile.parent.mkdir(parents=True)
+    with conffile.open(mode="wt", encoding="ascii") as fp:
+        fp.write(composite_definition)
+    return confdir
+
+
+@pytest.fixture
+def fake_dataset():
+    """Create minimalle fake Satpy CF NC dataset."""
+    ds = xr.Dataset()
+    nx = ny = 4
+    ds["ir"] = xr.DataArray(
+            np.zeros((nx, ny)),
+            attrs={"sensor": "visir"})
+    return ds
+
+
+@pytest.fixture
+def fake_files(tmp_path, fake_dataset):
+    """Make fake files for the Satpy CF reader."""
+    start_time = datetime.datetime(2050, 5, 3, 12, 0, 0)
+    delta = datetime.timedelta(minutes=10)
+    n_timesteps = 5
+    ofs = []
+    for i in range(n_timesteps):
+        begin = start_time + i*delta
+        end = start_time + (i+1)*delta
+        of = tmp_path / f"Meteosat99-imager-{begin:%Y%m%d%H%M%S}-{end:%Y%m%d%H%M%S}.nc"
+        fd = fake_dataset.copy()
+        fd["ir"][...] = i
+        fd["ir"].attrs["start_time"] = f"{start_time:%Y-%m-%dT%H:%M:%S}"
+        fd.to_netcdf(of)
+        ofs.append(of)
+    return ofs
+
+
+def test_load_temporal_composite(fake_files, fake_config):
+    """Test loading a temporal composite."""
+    from satpy import config
+    from satpy.multiscene import MultiScene, timeseries
+    with config.set(config_path=[fake_config]):
+        ms = MultiScene.from_files(fake_files, reader="satpy_cf_nc")
+        ms.load(["temporal"])
+        sc = ms.blend(blend_function=timeseries)
+        assert sc["temporal"].shape == (5, 3, 4, 4)
+        # first two should be fill values as conditions not met
+        assert np.isnan(sc["temporal"][0:2, ...]).all()
+        np.testing.assert_array_equal(sc["temporal"][2, 0, :, :], np.full((4, 4), 0))
+        np.testing.assert_array_equal(sc["temporal"][3, 1, :, :], np.full((4, 4), 2))
+        np.testing.assert_array_equal(sc["temporal"][4, 2, :, :], np.full((4, 4), 4))

--- a/satpy/tests/multiscene_tests/test_temporal_composites.py
+++ b/satpy/tests/multiscene_tests/test_temporal_composites.py
@@ -22,7 +22,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from satpy.composites import GenericCompositor
+from satpy.composites import BaseTemporalCompositor, GenericCompositor
 
 composite_definition = """sensor_name: visir
 
@@ -40,8 +40,11 @@ composites:
 """
 
 
-class _TemporalCompositor(GenericCompositor):
+class _TemporalCompositor(BaseTemporalCompositor, GenericCompositor):
     """Dummy temporal compositor class."""
+
+    def __call__(self, *args, **kwargs):
+        return super().__call__(*args, **kwargs)
 
 
 @pytest.fixture

--- a/satpy/tests/multiscene_tests/test_temporal_composites.py
+++ b/satpy/tests/multiscene_tests/test_temporal_composites.py
@@ -67,10 +67,11 @@ def fake_files(tmp_path, fake_dataset):
     start_time = datetime.datetime(2050, 5, 3, 12, 0, 0)
     delta = datetime.timedelta(minutes=10)
     n_timesteps = 5
+    offsets = [-2.2, 1.3, 0.5, -0.9, 0.7]
     ofs = []
     for i in range(n_timesteps):
-        begin = start_time + i*delta
-        end = start_time + (i+1)*delta
+        begin = start_time + i*delta + datetime.timedelta(seconds=offsets[i])
+        end = start_time + (i+1)*delta + datetime.timedelta(seconds=offsets[i])
         of = tmp_path / f"Meteosat99-imager-{begin:%Y%m%d%H%M%S}-{end:%Y%m%d%H%M%S}.nc"
         fd = fake_dataset.copy()
         fd["ir"][...] = i


### PR DESCRIPTION
Add a framework for temporal composites.

Current status
===

Implementation:
---

Draft.

When loading a temporal composite from a multiscene, the first iteration is failing as expected, because time dimension information is missing.  The `MultiScene` blend function then calls `generate_possible_composites` after timeseries blending, and the composite is loaded.

See below for a list of open tasks.

Unit tests
---

Passing.

Documentation
---

Present.


 - [x] Closes #1748 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Fix implementation
 - [ ] Don't throw a warning for every single scene
 - [ ] Disambiguate between "needs resampling" and "needs blending", as the latter is going to be very rare and such a message will just confuse users
 - [x] Add functionality to handle the temporal component of the prerequisites
 - [x] Add one or more composites that use the new temporal rgb compositor (this also helps as documentation).
 - [x] Add time tolerances or slicing, for the (common) case where start times are not rounded
