### PR TITLE
Improve flexibility of olci level2 reader 

### DIFF
--- a/satpy/etc/readers/olci_l2.yaml
+++ b/satpy/etc/readers/olci_l2.yaml
@@ -356,10 +356,8 @@ datasets:
     name: chl_nn
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: algal_pigment_concentration
-        units: "lg(re mg.m-3)"
+    standard_name: algal_pigment_concentration
+    units: "lg(re mg.m-3)"
     coordinates: [longitude, latitude]
     file_type: esa_l2_chl_nn
     nc_key: CHL_NN
@@ -368,10 +366,8 @@ datasets:
     name: iop_nn
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: cdm_absorption_coefficient
-        units: "lg(re m-l)"
+    standard_name: cdm_absorption_coefficient
+    units: "lg(re m-l)"
     coordinates: [longitude, latitude]
     file_type: esa_l2_iop_nn
     nc_key: ADG443_NN
@@ -380,10 +376,8 @@ datasets:
     name: trsp
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: diffuse_attenuation_coefficient
-        units: "lg(re m-l)"
+    standard_name: diffuse_attenuation_coefficient
+    units: "lg(re m-l)"
     coordinates: [longitude, latitude]
     file_type: esa_l2_trsp
     nc_key: KD490_M07
@@ -392,10 +386,8 @@ datasets:
     name: tsm_nn
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: total_suspended_matter_concentration
-        units: "lg(re g.m-3)"
+    standard_name: total_suspended_matter_concentration
+    units: "lg(re g.m-3)"
     coordinates: [longitude, latitude]
     file_type: esa_l2_tsm_nn
     nc_key: TSM_NN
@@ -412,10 +404,8 @@ datasets:
     name: iwv
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: integrated_water_vapour_column
-        units: "kg.m-2"
+    standard_name: integrated_water_vapour_column
+    units: "kg.m-2"
     coordinates: [longitude, latitude]
     file_type: esa_l2_iwv
     nc_key: IWV
@@ -424,10 +414,8 @@ datasets:
     name: iwv_unc
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: uncertainty_estimate_integrated_water_vapour_column
-        units: "kg.m-2"
+    standard_name: uncertainty_estimate_integrated_water_vapour_column
+    units: "kg.m-2"
     coordinates: [longitude, latitude]
     file_type: esa_l2_iwv
     nc_key: IWV_unc
@@ -436,9 +424,7 @@ datasets:
     name: otci
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: terrestrial_chlorophyll_index
+    standard_name: terrestrial_chlorophyll_index
     coordinates: [longitude, latitude]
     file_type: esa_l2_otci
     nc_key: OTCI
@@ -447,9 +433,7 @@ datasets:
     name: otci_unc
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: uncertainty_estimate_terrestrial_chlorophyll_index
+    standard_name: uncertainty_estimate_terrestrial_chlorophyll_index
     coordinates: [longitude, latitude]
     file_type: esa_l2_otci
     nc_key: OTCI_unc
@@ -458,9 +442,7 @@ datasets:
     name: otci_quality_flags
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: quality_flags_for_terrestrial_chlorophyll_index
+    standard_name: quality_flags_for_terrestrial_chlorophyll_index
     coordinates: [longitude, latitude]
     file_type: esa_l2_otci
     nc_key: OTCI_quality_flags
@@ -469,9 +451,7 @@ datasets:
     name: gifapar
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: green_instantaneous_fraction_of_absorbed_photosynthetically_available_radiation
+    standard_name: green_instantaneous_fraction_of_absorbed_photosynthetically_available_radiation
     coordinates: [longitude, latitude]
     file_type: esa_l2_gifapar
     nc_key: GIFAPAR
@@ -480,9 +460,7 @@ datasets:
     name: gifapar_unc
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: uncertainty_in_green_instantaneous_fraction_of_absorbed_photosynthetically_available_radiation
+    standard_name: uncertainty_in_green_instantaneous_fraction_of_absorbed_photosynthetically_available_radiation
     coordinates: [longitude, latitude]
     file_type: esa_l2_gifapar
     nc_key: GIFAPAR_unc
@@ -491,10 +469,8 @@ datasets:
     name: rc_gifapar_oa10
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: rectified_reflectance_for_band_oa10
-        units: 'mW.m-2.sr-1.nm-1'
+    standard_name: rectified_reflectance_for_band_oa10
+    units: 'mW.m-2.sr-1.nm-1'
     coordinates: [longitude, latitude]
     file_type: esa_l2_rc_gifapar
     nc_key: RC681
@@ -503,10 +479,8 @@ datasets:
     name: rc_gifapar_oa10_unc
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: ucnertainty_in_rectified_reflectance_for_band_oa10
-        units: 'mW.m-2.sr-1.nm-1'
+    standard_name: ucnertainty_in_rectified_reflectance_for_band_oa10
+    units: 'mW.m-2.sr-1.nm-1'
     coordinates: [longitude, latitude]
     file_type: esa_l2_rc_gifapar
     nc_key: RC681_unc
@@ -515,10 +489,8 @@ datasets:
     name: rc_gifapar_oa17
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: rectified_reflectance_for_band_oa17
-        units: 'mW.m-2.sr-1.nm-1'
+    standard_name: rectified_reflectance_for_band_oa17
+    units: 'mW.m-2.sr-1.nm-1'
     coordinates: [longitude, latitude]
     file_type: esa_l2_rc_gifapar
     nc_key: RC865
@@ -527,10 +499,8 @@ datasets:
     name: rc_gifapar_oa17_unc
     sensor: olci
     resolution: 300
-    calibration:
-      reflectance:
-        standard_name: ucnertainty_in_rectified_reflectance_for_band_oa17
-        units: 'mW.m-2.sr-1.nm-1'
+    standard_name: ucnertainty_in_rectified_reflectance_for_band_oa17
+    units: 'mW.m-2.sr-1.nm-1'
     coordinates: [longitude, latitude]
     file_type: esa_l2_rc_gifapar
     nc_key: RC865_unc

--- a/satpy/etc/readers/olci_l2.yaml
+++ b/satpy/etc/readers/olci_l2.yaml
@@ -367,7 +367,7 @@ datasets:
     sensor: olci
     resolution: 300
     standard_name: cdm_absorption_coefficient
-    units: "lg(re m-l)"
+    units: "lg(re m-1)"
     coordinates: [longitude, latitude]
     file_type: esa_l2_iop_nn
     nc_key: ADG443_NN
@@ -377,7 +377,7 @@ datasets:
     sensor: olci
     resolution: 300
     standard_name: diffuse_attenuation_coefficient
-    units: "lg(re m-l)"
+    units: "lg(re m-1)"
     coordinates: [longitude, latitude]
     file_type: esa_l2_trsp
     nc_key: KD490_M07


### PR DESCRIPTION
This PR adds some flexibility to the olci l2 reader. In particular, it adds the the possibility to un-log10 the data which has units like `lg(re mg.m-3)` and lets the user provide its own mask items.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
