### PR TITLE
Fix warnings from NWCSAF reader

### DIFF
--- a/satpy/etc/readers/nwcsaf-pps_nc.yaml
+++ b/satpy/etc/readers/nwcsaf-pps_nc.yaml
@@ -85,6 +85,24 @@ datasets:
     name: cma_extended_pal
     file_type: nc_nwcsaf_cma
 
+  cma_conditions:
+    name: cma_conditions
+    file_type: nc_nwcsaf_cma
+    coordinates: [lon, lat]
+    standard_name: cma_conditions
+
+  cma_quality:
+    name: cma_quality
+    file_type: nc_nwcsaf_cma
+    coordinates: [lon, lat]
+    standard_name: cma_quality
+
+  cma_status_flag:
+    name: cma_status_flag
+    file_type: nc_nwcsaf_cma
+    coordinates: [lon, lat]
+    standard_name: cma_status_flag
+
   cmaprob:
     name: cmaprob
     file_type: nc_nwcsaf_cmaprob
@@ -313,5 +331,23 @@ datasets:
   cmic_quality:
     name: [cmic_quality, cpp_quality]
     file_key: quality
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
+    coordinates: [lon, lat]
+
+  cmic_dcwp:
+    name: cmic_dcwp
+    file_key: dcwp
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
+    coordinates: [lon, lat]
+
+  cmic_dcre:
+    name: cmic_dcre
+    file_key: dcre
+    file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
+    coordinates: [lon, lat]
+
+  cmic_dcot:
+    name: cmic_dcot
+    file_key: dcot
     file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
     coordinates: [lon, lat]


### PR DESCRIPTION
Added ancillary datasets to nwcsaf-pps yaml file. This will remove the warnings of this type:

```
[2023-06-12 12:58:33,423 WARNING  satpy.readers.yaml_reader] Can't load ancillary dataset cmic_dcwp 
```

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
