### PR TITLE
Add a new fire RGB using both L1 and L2 data.

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -736,3 +736,52 @@ composites:
       - name: green_nocorr
       - name: C01
     standard_name: true_color_reproduction_color_stretch
+
+
+  tcr_night_ir:
+    # JMA True Color Reproduction complete composite with corrected and uncorrected blend.
+    # http://www.jma.go.jp/jma/jma-eng/satellite/introduction/TCR.html
+    # Blended at night with the `cloudtop` composite.
+    compositor: !!python/name:satpy.composites.DayNightCompositor
+    lim_low: 82.
+    lim_high: 90.
+    prerequisites:
+      - true_color_reproduction
+      - cloudtop
+
+  true_color_flames:
+      compositor: !!python/name:satpy.composites.BackgroundCompositor
+      standard_name: true_color_flames
+      prerequisites:
+        - fire_rgb_masked_alpha
+        - tcr_night_ir
+
+  multi_fires:
+      compositor: !!python/name:satpy.composites.MultiFireCompositor
+      standard_name: multi_fires
+      prerequisites:
+        - Power
+
+  fire_rgb_masked_alpha:
+      compositor: !!python/name:satpy.composites.MaskingCompositor
+      standard_name: fire_power_masked_alpha_col
+      conditions:
+        - method: isnan
+          transparency: 100
+        - method: less
+          value: 2
+          transparency: 100
+        - method: less
+          value: 70
+          transparency: 99
+        - method: less
+          value: 150
+          transparency: 90
+        - method: less
+          value: 220
+          transparency: 30
+      prerequisites:
+        # Composite
+        - name: multi_fires
+        # Data used in masking
+        - name: multi_fires

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -1173,3 +1173,20 @@ enhancements:
          stretch: crude
          min_stretch: [0,0,0]
          max_stretch: [1,1,1]
+
+  fire_power_masked_alpha_col:
+    standard_name: fire_power_masked_alpha_col
+    operations:
+      - name: colorize
+        method: !!python/name:satpy.enhancements.colorize
+        kwargs:
+          palettes:
+            - { colors: ylorrd, min_value: 0, max_value: 250, reverse: true}
+
+  multi_fires:
+    standard_name: multi_fires
+    operations:
+      - name: stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs:
+         stretch: crude


### PR DESCRIPTION
This PR creates a new composite that blends L1 data with an L2 product to highlight regions with fires.
Thus far, it combines GOES/ABI `true_color_reproduction` L1 data with the L2 `FDCC` product that contains fire radiative power.

Example output:
![Untitled](https://github.com/pytroll/satpy/assets/13449576/3f2e0eb3-c03f-4b22-8308-e2c2bf2597f8)

right now, it doesn't look great. We need some better method to blend the edges of the fire with the background data. I've tried to do this in the maskingcompositor by defining various thresholds, but they're obviously not right yet.

 - [ ] Tests added
 - [ ] Fully documented
