### PR TITLE
Fix argument name in DayNightComposite example document

### DIFF
--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -173,7 +173,7 @@ In the case below, the image shows its day portion and day/night
 transition with night portion blacked-out instead of transparent::
 
     >>> from satpy.composites import DayNightCompositor
-    >>> compositor = DayNightCompositor("dnc", lim_low=85., lim_high=88., day_night="day_only", need_alpha=False)
+    >>> compositor = DayNightCompositor("dnc", lim_low=85., lim_high=88., day_night="day_only", include_alpha=False)
     >>> composite = compositor([local_scene['true_color'])
 
 RealisticColors


### PR DESCRIPTION
This fixes an argument name in the example documentation for `DayNightComposite`. This wrong value in the example caused me a headache in figuring out since it did not throw an error but also did not do the expected behavior. I found in the API doc for `DayNightComposite` that `need_alpha=False` was supposed to be `include_alpha=False`.



