### PR TITLE
Fix SEVIRI native reader failing when missing main header

### DIFF
--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -370,13 +370,16 @@ class NativeMSGFileHandler(BaseFileHandler):
         self.mda['hrv_number_of_lines'] = int(sec15hd["NumberLinesHRV"]['Value'])
         self.mda['hrv_number_of_columns'] = cols_hrv
 
-        if self.header['15_MAIN_PRODUCT_HEADER']['QQOV']['Value'] == 'NOK':
-            warnings.warn(
-                "The quality flag for this file indicates not OK. "
-                "Use this data with caution!",
-                UserWarning,
-                stacklevel=2
-            )
+        if '15_MAIN_PRODUCT_HEADER' not in self.header:
+            logger.info("Quality flag check was not possible due to missing 15_MAIN_PRODUCT_HEADER.")
+        else:
+            if self.header['15_MAIN_PRODUCT_HEADER']['QQOV']['Value'] == 'NOK':
+                warnings.warn(
+                    "The quality flag for this file indicates not OK. "
+                    "Use this data with caution!",
+                    UserWarning,
+                    stacklevel=2
+                )
 
     def _read_trailer(self):
 

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -372,14 +372,13 @@ class NativeMSGFileHandler(BaseFileHandler):
 
         if '15_MAIN_PRODUCT_HEADER' not in self.header:
             logger.info("Quality flag check was not possible due to missing 15_MAIN_PRODUCT_HEADER.")
-        else:
-            if self.header['15_MAIN_PRODUCT_HEADER']['QQOV']['Value'] == 'NOK':
-                warnings.warn(
-                    "The quality flag for this file indicates not OK. "
-                    "Use this data with caution!",
-                    UserWarning,
-                    stacklevel=2
-                )
+        elif self.header['15_MAIN_PRODUCT_HEADER']['QQOV']['Value'] == 'NOK':
+            warnings.warn(
+                "The quality flag for this file indicates not OK. "
+                "Use this data with caution!",
+                UserWarning,
+                stacklevel=2
+            )
 
     def _read_trailer(self):
 

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1423,6 +1423,14 @@ def test_header_warning():
         with pytest.warns(UserWarning, match=exp_warning):
             NativeMSGFileHandler('myfile', {}, None)
 
+        # check that without Main Header the code doesn't crash
+        header_missing = header_good.copy()
+        header_missing.pop('15_MAIN_PRODUCT_HEADER')
+        fromfile.return_value = header_missing
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            NativeMSGFileHandler('myfile', {}, None)
+
 
 @pytest.mark.parametrize(
     "starts_with, expected",


### PR DESCRIPTION
This PR fixes a bug introduced by https://github.com/pytroll/satpy/pull/2198 (cc @simonrp84 ) that causes the SEVIRI reader to fail for files that do not have a `15_MAIN_PRODUCT_HEADER` -this header is read, optionally, here:
https://github.com/pytroll/satpy/blob/f44473f905fa07615f4f17e5b41657645a3ce7d1/satpy/readers/seviri_l1b_native_hdr.py#L84-L86
Files that do not contain the archive header were missing the `15_MAIN_PRODUCT_HEADER`, which was causing a `KeyError`.

After this PR, an info log message is issued specifying that the quality check could not be performed in case of the missing header.
 - [x] Tests added <!-- for all bug fixes or enhancements -->
