### PR TITLE
Add fsspec functionality to `viirs_sdr` reader

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -779,7 +779,15 @@ def _get_compression(file):
 
 
 def open_file_or_filename(unknown_file_thing):
-    """Try to open the *unknown_file_thing*, otherwise return the filename."""
+    """Try to open the provided file "thing" if needed, otherwise return the filename or Path.
+
+    This wraps the logic of getting something like an fsspec OpenFile object
+    that is not directly supported by most reading libraries and making it
+    usable. If a :class:`pathlib.Path` object or something that is not
+    open-able is provided then that object is passed along. In the case of
+    fsspec OpenFiles their ``.open()`` method is called and the result returned.
+
+    """
     if isinstance(unknown_file_thing, pathlib.Path):
         f_obj = unknown_file_thing
     else:

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -22,6 +22,7 @@ import logging
 import os
 import pickle  # nosec B403
 import warnings
+import pathlib
 from datetime import datetime, timedelta
 from functools import total_ordering
 
@@ -779,8 +780,11 @@ def _get_compression(file):
 
 def open_file_or_filename(unknown_file_thing):
     """Try to open the *unknown_file_thing*, otherwise return the filename."""
-    try:
-        f_obj = unknown_file_thing.open()
-    except AttributeError:
+    if isinstance(unknown_file_thing, (pathlib.WindowsPath, pathlib.PosixPath)):
         f_obj = unknown_file_thing
+    else:
+        try:
+            f_obj = unknown_file_thing.open()
+        except AttributeError:
+            f_obj = unknown_file_thing
     return f_obj

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -20,9 +20,9 @@ from __future__ import annotations
 
 import logging
 import os
+import pathlib
 import pickle  # nosec B403
 import warnings
-import pathlib
 from datetime import datetime, timedelta
 from functools import total_ordering
 
@@ -780,7 +780,7 @@ def _get_compression(file):
 
 def open_file_or_filename(unknown_file_thing):
     """Try to open the *unknown_file_thing*, otherwise return the filename."""
-    if isinstance(unknown_file_thing, (pathlib.WindowsPath, pathlib.PosixPath)):
+    if isinstance(unknown_file_thing, pathlib.Path):
         f_obj = unknown_file_thing
     else:
         try:

--- a/satpy/readers/hdf5_utils.py
+++ b/satpy/readers/hdf5_utils.py
@@ -24,10 +24,10 @@ import h5py
 import numpy as np
 import xarray as xr
 
+from satpy.readers import open_file_or_filename
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.utils import np2str
 from satpy.utils import get_legacy_chunk_size
-from satpy.readers import open_file_or_filename
 
 LOG = logging.getLogger(__name__)
 CHUNK_SIZE = get_legacy_chunk_size()

--- a/satpy/readers/hdf5_utils.py
+++ b/satpy/readers/hdf5_utils.py
@@ -27,6 +27,7 @@ import xarray as xr
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.utils import np2str
 from satpy.utils import get_legacy_chunk_size
+from satpy.readers import open_file_or_filename
 
 LOG = logging.getLogger(__name__)
 CHUNK_SIZE = get_legacy_chunk_size()
@@ -43,7 +44,8 @@ class HDF5FileHandler(BaseFileHandler):
         self._attrs_cache = {}
 
         try:
-            file_handle = h5py.File(self.filename, "r")
+            f_obj = open_file_or_filename(self.filename)
+            file_handle = h5py.File(f_obj, "r")
         except IOError:
             LOG.exception(
                 "Failed reading file %s. Possibly corrupted file", self.filename)
@@ -73,7 +75,8 @@ class HDF5FileHandler(BaseFileHandler):
 
     def get_reference(self, name, key):
         """Get reference."""
-        with h5py.File(self.filename, "r") as hf:
+        f_obj = open_file_or_filename(self.filename)
+        with h5py.File(f_obj, "r") as hf:
             return self._get_reference(hf, hf[name].attrs[key])
 
     def _get_reference(self, hf, ref):
@@ -97,7 +100,8 @@ class HDF5FileHandler(BaseFileHandler):
         val = self.file_content[key]
         if isinstance(val, h5py.Dataset):
             # these datasets are closed and inaccessible when the file is closed, need to reopen
-            dset = h5py.File(self.filename, "r")[key]
+            f_obj = open_file_or_filename(self.filename)
+            dset = h5py.File(f_obj, "r")[key]
             dset_data = da.from_array(dset, chunks=CHUNK_SIZE)
             attrs = self._attrs_cache.get(key, dset.attrs)
             if dset.ndim == 2:

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -977,7 +977,7 @@ def _local_file(tmp_path_factory, filename: str) -> Iterator[Path]:
     tmp_path = tmp_path_factory.mktemp("local_files")
     local_filename = tmp_path / filename
     local_filename.touch()
-    return local_filename
+    yield local_filename
 
 
 @pytest.fixture(scope="module")

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -23,7 +23,6 @@ import os
 import sys
 import unittest
 import warnings
-from contextlib import suppress
 from pathlib import Path
 from typing import Iterator
 from unittest import mock
@@ -978,8 +977,7 @@ def _local_file(tmp_path_factory, filename: str) -> Iterator[Path]:
     tmp_path = tmp_path_factory.mktemp("local_files")
     local_filename = tmp_path / filename
     local_filename.touch()
-    yield local_filename
-    local_filename.unlink()
+    return local_filename
 
 
 @pytest.fixture(scope="module")
@@ -1007,9 +1005,7 @@ def local_zip_file(local_filename2):
     zip_file = zipfile.ZipFile(zip_name, "w", zipfile.ZIP_DEFLATED)
     zip_file.write(local_filename2)
     zip_file.close()
-    yield zip_name
-    with suppress(PermissionError):
-        zip_name.unlink()
+    return zip_name
 
 
 class TestFSFile:
@@ -1131,9 +1127,7 @@ def local_netcdf_filename(tmp_path_factory):
     ds["var1"] = xr.DataArray(np.zeros((10, 10), dtype=np.int16), dims=("y", "x"))
     ds.to_netcdf(filename)
 
-    yield str(filename)
-    with suppress(PermissionError):
-        filename.unlink()
+    return str(filename)
 
 
 @pytest.fixture(scope="module")
@@ -1188,9 +1182,7 @@ def local_hdf5_filename(tmp_path_factory):
     h.create_dataset("var1", data=np.zeros((10, 10), dtype=np.int16))
     h.close()
 
-    yield str(filename)
-    with suppress(PermissionError):
-        filename.unlink()
+    return str(filename)
 
 
 @pytest.fixture(scope="module")

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -1132,7 +1132,8 @@ def local_netcdf_filename(tmp_path_factory):
     ds.to_netcdf(filename)
 
     yield str(filename)
-    filename.unlink()
+    with suppress(PermissionError):
+        filename.unlink()
 
 
 @pytest.fixture(scope="module")
@@ -1188,7 +1189,8 @@ def local_hdf5_filename(tmp_path_factory):
     h.close()
 
     yield str(filename)
-    filename.unlink()
+    with suppress(PermissionError):
+        filename.unlink()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Adds to #1439 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

Add the option to read AWS S3 files in the `viirs_sdr` reader, similarly to the `abi_l1b` version, [as described in the documentation](https://satpy.readthedocs.io/en/stable/remote_reading.html#using-a-single-reader).
h5py also is fine with the return of `satpy.readers.open_file_or_filename`.
(Thanks to @ajelenak for the inspiration in his [jupyter notebook](https://gist.github.com/ajelenak/db0d9bf14b7ea4c48acf20249e189c80)).
Though I am not sure where to properly document the added functionality.

Cheers,
martin
