### PR TITLE
Allow using s3 files for AMI reader

### DIFF
--- a/satpy/etc/readers/ami_l1b.yaml
+++ b/satpy/etc/readers/ami_l1b.yaml
@@ -8,7 +8,7 @@ reader:
     `here <https://nmsc.kma.go.kr/enhome/html/base/cmm/selectPage.do?page=satellite.gk2a.intro>`_.
   sensors: [ami]
   status: Beta
-  supports_fsspec: false
+  supports_fsspec: true
   default_channels:
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
   # file pattern keys to sort files by with 'satpy.utils.group_files'

--- a/satpy/readers/ami_l1b.py
+++ b/satpy/readers/ami_l1b.py
@@ -26,6 +26,7 @@ import pyproj
 import xarray as xr
 from pyspectral.blackbody import blackbody_wn_rad2temp as rad2temp
 
+from satpy.readers import open_file_or_filename
 from satpy.readers._geos_area import get_area_definition, get_area_extent
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.utils import apply_rad_correction, get_user_calibration_factors
@@ -93,7 +94,8 @@ class AMIL1bNetCDF(BaseFileHandler):
                  user_calibration=None):
         """Open the NetCDF file with xarray and prepare the Dataset for reading."""
         super(AMIL1bNetCDF, self).__init__(filename, filename_info, filetype_info)
-        self.nc = xr.open_dataset(self.filename,
+        f_obj = open_file_or_filename(self.filename)
+        self.nc = xr.open_dataset(f_obj,
                                   decode_cf=True,
                                   mask_and_scale=False,
                                   chunks={'dim_image_x': CHUNK_SIZE, 'dim_image_y': CHUNK_SIZE})

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -1448,5 +1448,5 @@ def _should_use_compression_keyword():
     versions = _get_backend_versions()
     return (
         versions["libnetcdf"] >= Version("4.9.0") and
-        versions["xarray"] >= Version("2023.8")
+        versions["xarray"] >= Version("2023.9")
     )


### PR DESCRIPTION
This PR allow using s3 files for AMI reader.
No tests where added as I see this as a mere refactoring.

Example usage:

```python
from satpy import Scene

storage_options = {'anon': True}
filenames = ['s3://noaa-gk2a-pds/AMI/L1B/FD/202308/21/06/gk2a_ami_*0600.nc']
scn = Scene(filenames=filenames, reader='ami_l1b', reader_kwargs={'storage_options': storage_options})
scn.load(["true_color"])

newscn = scn.resample(resampler="native")

newscn.save_datasets()

```

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->


works also like this, but the above version is preferred.

```python
import fsspec
from satpy.readers import FSFile
from satpy import Scene

filename = 'noaa-gk2a-pds/AMI/L1B/FD/202308/21/06/gk2a_ami_*0600.nc'
the_files = fsspec.open_files("simplecache::s3://" + filename, s3={'anon': True})
fs_files = [FSFile(open_file) for open_file in the_files]

scn = Scene(filenames=fs_files, reader='ami_l1b')
scn.load(["true_color"])

newscn = scn.resample(resampler="native")

newscn.save_datasets()
```
