### PR TITLE
Add enhancement for OLCI to enable mask to be saved. 

### DIFF
--- a/satpy/etc/enhancements/olci.yaml
+++ b/satpy/etc/enhancements/olci.yaml
@@ -1,0 +1,4 @@
+enhancements:
+  mask:
+    name: mask
+    operations: []


### PR DESCRIPTION
This PR adds a new enhancement YAML for OLCI that contains an empty enhancement for the mask dataset, which now enables it to be saved successfully.

 - [ ] Closes #2547 