### PR TITLE
Implement modifier for reducing signal as a function of sunz angle

### DIFF
--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -107,11 +107,11 @@ composites:
     compositor: !!python/name:satpy.composites.spectral.NDVIHybridGreen
     prerequisites:
     - name: B02
-      modifiers: [sunz_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected, rayleigh_corrected, sunz_reduced]
     - name: B03
-      modifiers: [sunz_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected, rayleigh_corrected, sunz_reduced]
     - name: B04
-      modifiers: [sunz_corrected]
+      modifiers: [sunz_corrected, sunz_reduced]
     standard_name: toa_bidirectional_reflectance
 
   airmass:
@@ -275,10 +275,10 @@ composites:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
     - name: B03
-      modifiers: [sunz_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected, rayleigh_corrected, sunz_reduced]
     - name: ndvi_hybrid_green
     - name: B01
-      modifiers: [sunz_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected, rayleigh_corrected, sunz_reduced]
     high_resolution_band: red
     standard_name: true_color
 

--- a/satpy/etc/composites/fci.yaml
+++ b/satpy/etc/composites/fci.yaml
@@ -13,11 +13,11 @@ composites:
     limits: [0.15, 0.05]
     prerequisites:
       - name: vis_05
-        modifiers: [sunz_corrected, rayleigh_corrected]
+        modifiers: [sunz_corrected, rayleigh_corrected, sunz_reduced]
       - name: vis_06
-        modifiers: [sunz_corrected, rayleigh_corrected]
+        modifiers: [sunz_corrected, rayleigh_corrected, sunz_reduced]
       - name: vis_08
-        modifiers: [sunz_corrected ]
+        modifiers: [sunz_corrected, sunz_reduced ]
     standard_name: toa_bidirectional_reflectance
 
   ndvi_hybrid_green_raw:
@@ -48,10 +48,10 @@ composites:
       of the ndvi_hybrid_green composites for details.
     prerequisites:
       - name: vis_06
-        modifiers: [sunz_corrected, rayleigh_corrected]
+        modifiers: [sunz_corrected, rayleigh_corrected, sunz_reduced]
       - name: ndvi_hybrid_green
       - name: vis_04
-        modifiers: [sunz_corrected, rayleigh_corrected]
+        modifiers: [sunz_corrected, rayleigh_corrected, sunz_reduced]
     standard_name: true_color
 
   true_color_raw_with_corrected_green:

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -16,6 +16,11 @@ modifiers:
     optional_prerequisites:
       - solar_zenith_angle
 
+  sunz_reduced:
+    modifier: !!python/name:satpy.modifiers.SunZenithReducer
+    optional_prerequisites:
+    - solar_zenith_angle
+
   co2_corrected:
     modifier: !!python/name:satpy.modifiers.CO2Corrector
     prerequisites:

--- a/satpy/modifiers/__init__.py
+++ b/satpy/modifiers/__init__.py
@@ -25,5 +25,6 @@ from .atmosphere import PSPAtmosphericalCorrection  # noqa: F401
 from .atmosphere import PSPRayleighReflectance  # noqa: F401
 from .geometry import EffectiveSolarPathLengthCorrector  # noqa: F401
 from .geometry import SunZenithCorrector  # noqa: F401
+from .geometry import SunZenithReducer  # noqa: F401
 from .spectral import NIREmissivePartFromReflectance  # noqa: F401
 from .spectral import NIRReflectance  # noqa: F401

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -561,9 +561,6 @@ def _sunzen_reduction_ndarray(data: np.ndarray,
                               limit: float,
                               max_sza: float,
                               strength: float) -> np.ndarray:
-    if max_sza is None:
-        raise ValueError("`max_sza` must be defined when using the SunZenithReducer.")
-
     # compute reduction factor (0.0 - 1.0) between limit and maz_sza
     reduction_factor = (sunz - limit) / (max_sza - limit)
     reduction_factor = reduction_factor.clip(0., 1.)

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -235,6 +235,7 @@ def cache_to_zarr_if(
     out old entries. It is up to the user to manage the size of the cache.
 
     """
+
     def _decorator(func: Callable) -> Callable:
         zarr_cacher = ZarrCacheHelper(func,
                                       cache_config_key,
@@ -242,6 +243,7 @@ def cache_to_zarr_if(
                                       sanitize_args_func)
         wrapper = update_wrapper(zarr_cacher, func)
         return wrapper
+
     return _decorator
 
 
@@ -542,3 +544,47 @@ def _sunzen_corr_cos_ndarray(data: np.ndarray,
     # Force "night" pixels to 0 (where SZA is invalid)
     corr[np.isnan(cos_zen)] = 0
     return data * corr
+
+
+def sunzen_reduction(data: da.Array,
+                     sunz: da.Array,
+                     limit: float = 65.,
+                     max_sza: float = 95.,
+                     strength: float = 2.) -> da.Array:
+    """Reduced strength of signal at high sun zenith angles."""
+    return da.map_blocks(_sunzen_reduction_ndarray, data, sunz, limit, max_sza, strength,
+                         meta=np.array((), dtype=data.dtype), chunks=data.chunks)
+
+
+def _sunzen_reduction_ndarray(data: np.ndarray,
+                              sunz: np.ndarray,
+                              limit: float,
+                              max_sza: float,
+                              strength: float) -> np.ndarray:
+    if max_sza is None:
+        raise ValueError("`max_sza` must be defined when using the SunZenithReducer.")
+
+    # compute reduction factor (0.0 - 1.0) between limit and maz_sza
+    reduction_factor = (sunz - limit) / (max_sza - limit)
+    reduction_factor = reduction_factor.clip(0., 1.)
+
+    # invert the reduction factor such that minimum reduction is done at `limit` and gradually increases towards max_sza
+    with np.errstate(invalid='ignore'):  # we expect space pixels to be invalid
+        reduction_factor = 1. - np.log(reduction_factor + 1) / np.log(2)
+
+    # apply non-linearity to the reduction factor for a non-linear reduction of the signal. This can be used for a
+    # slower or faster transision to higher/lower fractions at the ndvi extremes. If strength equals 1.0, this
+    # operation has no effect on the reduction_factor.
+    reduction_factor = reduction_factor ** strength / (
+                reduction_factor ** strength + (1 - reduction_factor) ** strength)
+
+    # compute final correction term, with no reduction for angles < limit
+    corr = np.where(sunz < limit, 1.0, reduction_factor)
+
+    # force "night" pixels to 0 (where SZA is invalid)
+    corr[np.isnan(sunz)] = 0
+
+    # reduce data signal with correction term
+    res = data * corr
+
+    return res

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -548,9 +548,9 @@ def _sunzen_corr_cos_ndarray(data: np.ndarray,
 
 def sunzen_reduction(data: da.Array,
                      sunz: da.Array,
-                     limit: float = 65.,
-                     max_sza: float = 95.,
-                     strength: float = 2.) -> da.Array:
+                     limit: float = 55.,
+                     max_sza: float = 90.,
+                     strength: float = 1.5) -> da.Array:
     """Reduced strength of signal at high sun zenith angles."""
     return da.map_blocks(_sunzen_reduction_ndarray, data, sunz, limit, max_sza, strength,
                          meta=np.array((), dtype=data.dtype), chunks=data.chunks)

--- a/satpy/modifiers/geometry.py
+++ b/satpy/modifiers/geometry.py
@@ -24,7 +24,7 @@ import logging
 import numpy as np
 
 from satpy.modifiers import ModifierBase
-from satpy.modifiers.angles import sunzen_corr_cos
+from satpy.modifiers.angles import sunzen_corr_cos, sunzen_reduction
 from satpy.utils import atmospheric_path_length_correction
 
 logger = logging.getLogger(__name__)
@@ -159,3 +159,42 @@ class EffectiveSolarPathLengthCorrector(SunZenithCorrectorBase):
     def _apply_correction(self, proj, coszen):
         logger.debug("Apply the effective solar atmospheric path length correction method by Li and Shibata")
         return atmospheric_path_length_correction(proj, coszen, limit=self.correction_limit, max_sza=self.max_sza)
+
+
+class SunZenithReducer(SunZenithCorrectorBase):
+    """Reduce signal strength at large sun zenith angles.
+
+    Within a given sunz interval [correction_limit, max_sza] the strength of the signal is reduced following the
+    formula:
+
+      res = signal * reduction_factor
+
+    where reduction_factor is a pixel-level value ranging from 0 to 1 within the sunz interval.
+
+    The `strength` parameter can be used for a non-linear reduction within the sunz interval. A strength larger
+    than 1.0 will decelerate the signal reduction towards the sunz interval extremes, whereas a strength
+    smaller than 1.0 will accelerate the signal reduction towards the sunz interval extremes.
+
+    """
+
+    def __init__(self, correction_limit=60., strength=2.0, **kwargs):
+        """Collect custom configuration values.
+
+        Args:
+            correction_limit (float): Maximum solar zenith angle to apply the correction in degrees. Default 60.
+            strength (float): The strength of the non-linear signal reduction. Default 2.0
+
+        """
+        self.correction_limit = correction_limit
+        self.strength = strength
+        super(SunZenithReducer, self).__init__(**kwargs)
+
+    def _apply_correction(self, proj, coszen):
+        logger.debug("Apply sun-zenith signal reduction")
+        res = proj.copy()
+        sunz = np.rad2deg(np.arccos(coszen.data))
+        res.data = sunzen_reduction(proj.data, sunz,
+                                    limit=self.correction_limit,
+                                    max_sza=self.max_sza,
+                                    strength=self.strength)
+        return res

--- a/satpy/modifiers/geometry.py
+++ b/satpy/modifiers/geometry.py
@@ -190,6 +190,8 @@ class SunZenithReducer(SunZenithCorrectorBase):
         self.correction_limit = correction_limit
         self.strength = strength
         super(SunZenithReducer, self).__init__(max_sza=max_sza, **kwargs)
+        if self.max_sza is None:
+            raise ValueError("`max_sza` must be defined when using the SunZenithReducer.")
 
     def _apply_correction(self, proj, coszen):
         logger.debug("Apply sun-zenith signal reduction")

--- a/satpy/modifiers/geometry.py
+++ b/satpy/modifiers/geometry.py
@@ -177,17 +177,19 @@ class SunZenithReducer(SunZenithCorrectorBase):
 
     """
 
-    def __init__(self, correction_limit=60., strength=2.0, **kwargs):
+    def __init__(self, correction_limit=55., max_sza=90, strength=1.5, **kwargs):
         """Collect custom configuration values.
 
         Args:
-            correction_limit (float): Maximum solar zenith angle to apply the correction in degrees. Default 60.
-            strength (float): The strength of the non-linear signal reduction. Default 2.0
+            correction_limit (float): Solar zenith angle in degrees where to start the signal reduction. Default 60.
+            max_sza (float): Maximum solar zenith angle in degrees where to apply the signal reduction. Beyond
+                             this solar zenith angle the signal will become zero. Default 90.
+            strength (float): The strength of the non-linear signal reduction. Default 1.5
 
         """
         self.correction_limit = correction_limit
         self.strength = strength
-        super(SunZenithReducer, self).__init__(**kwargs)
+        super(SunZenithReducer, self).__init__(max_sza=max_sza, **kwargs)
 
     def _apply_correction(self, proj, coszen):
         logger.debug("Apply sun-zenith signal reduction")

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -156,6 +156,35 @@ class TestSunZenithCorrector:
             comp((sunz_ds2, sunz_sza), test_attr='test')
 
 
+class TestSunZenithReducer:
+    """Test case for the sun zenith reducer."""
+
+    def test_basic_default_provided(self, sunz_ds1, sunz_sza):
+        """Test default settings with sza data available."""
+        from satpy.modifiers.geometry import SunZenithReducer
+        comp = SunZenithReducer(name='sza_reduction_test_default', modifiers=tuple())
+        res = comp((sunz_ds1, sunz_sza), test_attr='test')
+        np.testing.assert_allclose(res.values,
+                                   np.array([[0.00242814, 0.00235669], [0.00245885, 0.00238707]]),
+                                   rtol=1e-5)
+
+    def test_basic_lims_provided(self, sunz_ds1, sunz_sza):
+        """Test custom settings with sza data available."""
+        from satpy.modifiers.geometry import SunZenithReducer
+        comp = SunZenithReducer(name='sza_reduction_test_custom', modifiers=tuple(),
+                                correction_limit=70, max_sza=95, strength=3.0)
+        res = comp((sunz_ds1, sunz_sza), test_attr='test')
+        np.testing.assert_allclose(res.values,
+                                   np.array([[0.01041319, 0.01030033], [0.01046164, 0.01034834]]),
+                                   rtol=1e-5)
+
+    def test_invalid_max_sza(self, sunz_ds1, sunz_sza):
+        """Test invalid max_sza with sza data available."""
+        from satpy.modifiers.geometry import SunZenithReducer
+        with pytest.raises(ValueError):
+            SunZenithReducer(name='sza_reduction_test_invalid', modifiers=tuple(), max_sza=None)
+
+
 class TestNIRReflectance(unittest.TestCase):
     """Test NIR reflectance compositor."""
 

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -159,21 +159,24 @@ class TestSunZenithCorrector:
 class TestSunZenithReducer:
     """Test case for the sun zenith reducer."""
 
-    def test_basic_default_provided(self, sunz_ds1, sunz_sza):
-        """Test default settings with sza data available."""
+    @classmethod
+    def setup_class(cls):
+        """Initialze SunZenithReducer classes that shall be tested."""
         from satpy.modifiers.geometry import SunZenithReducer
-        comp = SunZenithReducer(name='sza_reduction_test_default', modifiers=tuple())
-        res = comp((sunz_ds1, sunz_sza), test_attr='test')
+        cls.default = SunZenithReducer(name='sza_reduction_test_default', modifiers=tuple())
+        cls.custom = SunZenithReducer(name='sza_reduction_test_custom', modifiers=tuple(),
+                                      correction_limit=70, max_sza=95, strength=3.0)
+
+    def test_default_settings(self, sunz_ds1, sunz_sza):
+        """Test default settings with sza data available."""
+        res = self.default((sunz_ds1, sunz_sza), test_attr='test')
         np.testing.assert_allclose(res.values,
                                    np.array([[0.00242814, 0.00235669], [0.00245885, 0.00238707]]),
                                    rtol=1e-5)
 
-    def test_basic_lims_provided(self, sunz_ds1, sunz_sza):
+    def test_custom_settings(self, sunz_ds1, sunz_sza):
         """Test custom settings with sza data available."""
-        from satpy.modifiers.geometry import SunZenithReducer
-        comp = SunZenithReducer(name='sza_reduction_test_custom', modifiers=tuple(),
-                                correction_limit=70, max_sza=95, strength=3.0)
-        res = comp((sunz_ds1, sunz_sza), test_attr='test')
+        res = self.custom((sunz_ds1, sunz_sza), test_attr='test')
         np.testing.assert_allclose(res.values,
                                    np.array([[0.01041319, 0.01030033], [0.01046164, 0.01034834]]),
                                    rtol=1e-5)


### PR DESCRIPTION
This PR Implements a new modifier that reduces the signal within a defined sunz angle interval in order to avoid the excessive white glow at the limb in geostationary VIS/NIR imagery. An example on how to define it and use it is shown below:

```
modifiers:
  sunz_reduced:
    modifier: !!python/name:satpy.modifiers.SunZenithReducer
    correction_limit: 55
    max_sza: 90
    strength: 1.5
    optional_prerequisites:
      - solar_zenith_angle

composites:
   true_color:
    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
    prerequisites:
      - name: vis_06
        modifiers: [sunz_corrected, rayleigh_corrected, sunz_reduced]
      - name: ndvi_hybrid_green
      - name: vis_04
        modifiers: [sunz_corrected, rayleigh_corrected, sunz_reduced]
    standard_name: true_color
```

The ability to reduce the signal as a function of the sunz angle is already implemented as part of e.g. the `SunZenithCorrector` modifier which generally works very well for reducing the correction at high angles. The problem occurs when applying Rayleigh correction on imagery where the sunz correction has been reduced at high angles, since pyspectral assumes regular reflectance data normalized by the sun zenith angle when estimating the Rayleigh contribution. This issue is clearly demonstrated in the examples below:

![image](https://github.com/pytroll/satpy/assets/42137969/975eca8b-f075-4dcf-b09c-14ffc7550d7c)

It was discussed whether the Rayleigh correction can be adapted to account for this, but after another round of investigation and testing I still did not find a proper way to do this. Hence, I suggest to add the proposed modifier and then when users have had a chance to test it, we can see if we can find a better implementation. A better implementation would mean that the user defines the reduction in the sunz correction and then the Rayleigh correction properly accounts for this (meaning that there would be no need for a third modifier).

The results with the modifier implemented here, following the example recipe above looks like this:
![image](https://github.com/pytroll/satpy/assets/42137969/4fce50e4-9556-4b92-ae95-e87af89e42d6)

Another example with the terminator across the disk, without and with the sunz reduction modifier in this PR:
![image](https://github.com/pytroll/satpy/assets/42137969/a6b6a81f-2f17-4aee-92e1-b1945e277857)

The default values for the reduction (`correction_limit: 55, max_sza: 90, strength: 1.5`) have been chosen to give an overall good trade-off in having a nice transition into deep-space at the limb and not loosing too much information at the terminator. Nevertheless these values can of course be modified by any user that want to use the modifier.

As can be seen in the last example the modifier remove some information at the terminator. Nevertheless, it shall be noted that:
- Without the modifier the colors in this area are generally not well represented.
- The effect get's less evident/relevant when blending the composite with a night-time layer
- It should be possible to restore some of the information by reducing the Rayleigh correction at high sunz angles.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
