### PR TITLE
Add Himawari areas to the default area def list.

### DIFF
--- a/satpy/etc/areas.yaml
+++ b/satpy/etc/areas.yaml
@@ -300,21 +300,21 @@ himawari_ahi_fes_1km:
     lower_left_xy: [-5500000.0355, -5500000.0355]
     upper_right_xy: [5500000.0355, 5500000.0355]
 
-  himawari_ahi_fes_2km:
-    description:
-      Himawari-8/9 full disk area definition at 2km resolution
-    projection:
-      proj: geos
-      lon_0: 140.7
-      a: 6378137.0
-      rf: 298.257024882273
-      h: 35785863.0
-    shape:
-      height: 5500
-      width: 5500
-    area_extent:
-      lower_left_xy: [ -5499999.9012, -5499999.9012 ]
-      upper_right_xy: [ 5499999.9012, 5499999.9012 ]
+himawari_ahi_fes_2km:
+  description:
+    Himawari-8/9 full disk area definition at 2km resolution
+  projection:
+    proj: geos
+    lon_0: 140.7
+    a: 6378137.0
+    rf: 298.257024882273
+    h: 35785863.0
+  shape:
+    height: 5500
+    width: 5500
+  area_extent:
+    lower_left_xy: [ -5499999.9012, -5499999.9012 ]
+    upper_right_xy: [ 5499999.9012, 5499999.9012 ]
 
 
 # Regional

--- a/satpy/etc/areas.yaml
+++ b/satpy/etc/areas.yaml
@@ -268,6 +268,54 @@ msg_seviri_iodc_48km:
     lower_left_xy: [-5570248.686685662, -5567248.28340708]
     upper_right_xy: [5567248.28340708,   5570248.686685662]
 
+himawari_ahi_fes_500m:
+  description:
+    Himawari-8/9 full disk area definition at 500m resolution
+  projection:
+    proj: geos
+    lon_0: 140.7
+    a: 6378137.0
+    rf: 298.257024882273
+    h: 35785863.0
+  shape:
+    height: 22000
+    width: 22000
+  area_extent:
+    lower_left_xy: [-5499999.9684, -5499999.9684]
+    upper_right_xy: [5499999.9684, 5499999.9684]
+
+himawari_ahi_fes_1km:
+  description:
+    Himawari-8/9 full disk area definition at 1km resolution
+  projection:
+    proj: geos
+    lon_0: 140.7
+    a: 6378137.0
+    rf: 298.257024882273
+    h: 35785863.0
+  shape:
+    height: 11000
+    width: 11000
+  area_extent:
+    lower_left_xy: [-5500000.0355, -5500000.0355]
+    upper_right_xy: [5500000.0355, 5500000.0355]
+
+  himawari_ahi_fes_2km:
+    description:
+      Himawari-8/9 full disk area definition at 2km resolution
+    projection:
+      proj: geos
+      lon_0: 140.7
+      a: 6378137.0
+      rf: 298.257024882273
+      h: 35785863.0
+    shape:
+      height: 5500
+      width: 5500
+    area_extent:
+      lower_left_xy: [ -5499999.9012, -5499999.9012 ]
+      upper_right_xy: [ 5499999.9012, 5499999.9012 ]
+
 
 # Regional
 


### PR DESCRIPTION
I noticed that the Himawari full disk areas are missing from `areas.yaml`. This PR adds the 500m, 1km and 2km full disk areas to the YAML.
