### PR TITLE
Fix readthedocs creating a dirty git environment

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,5 +13,8 @@ build:
   os: "ubuntu-20.04"
   tools:
     python: "mambaforge-4.10"
+  jobs:
+    pre_install:
+      - git update-index --assume-unchanged doc/rtd_environment.yml doc/source/conf.py
 conda:
   environment: doc/rtd_environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -18,7 +18,5 @@ build:
       - git fetch --tags
     pre_install:
       - git update-index --assume-unchanged doc/rtd_environment.yml doc/source/conf.py
-    # post_install:
-    #  - python -m pip install --no-deps -e .
 conda:
   environment: doc/rtd_environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,11 +14,11 @@ build:
   tools:
     python: "mambaforge-4.10"
   jobs:
+    post_checkout:
+      - git fetch --tags
     pre_install:
-      - git status
       - git update-index --assume-unchanged doc/rtd_environment.yml doc/source/conf.py
-      - git status
-    post_install:
-      - python -m pip install --no-deps -e .
+    # post_install:
+    #  - python -m pip install --no-deps -e .
 conda:
   environment: doc/rtd_environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,6 +15,7 @@ build:
     python: "mambaforge-4.10"
   jobs:
     pre_install:
+      - git status
       - git update-index --assume-unchanged doc/rtd_environment.yml doc/source/conf.py
 conda:
   environment: doc/rtd_environment.yml

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,5 +17,8 @@ build:
     pre_install:
       - git status
       - git update-index --assume-unchanged doc/rtd_environment.yml doc/source/conf.py
+      - git status
+    post_install:
+      - python -m pip install --no-deps -e .
 conda:
   environment: doc/rtd_environment.yml


### PR DESCRIPTION
Our version numbers are messed up in multiple ways, but this should get us closer.

https://docs.readthedocs.io/en/latest/build-customization.html#avoid-having-a-dirty-git-index

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
