### PR TITLE
Add decimal rounding to geostationary area utilities for better consistency

### DIFF
--- a/satpy/readers/_geos_area.py
+++ b/satpy/readers/_geos_area.py
@@ -54,10 +54,15 @@ def make_ext(ll_x, ur_x, ll_y, ur_y, h):
         aex: An area extent for the scene
 
     """
-    aex = (np.deg2rad(ll_x) * h, np.deg2rad(ll_y) * h,
-           np.deg2rad(ur_x) * h, np.deg2rad(ur_y) * h)
-
-    return aex
+    ll_x = np.deg2rad(ll_x)
+    ll_y = np.deg2rad(ll_y)
+    ur_x = np.deg2rad(ur_x)
+    ur_y = np.deg2rad(ur_y)
+    ll_x = np.round(ll_x, 7)
+    ur_x = np.round(ur_x, 7)
+    ll_y = np.round(ll_y, 7)
+    ur_y = np.round(ur_y, 7)
+    return ll_x * h, ll_y * h, ur_x * h, ur_y * h
 
 
 def get_area_extent(pdict):

--- a/satpy/readers/_geos_area.py
+++ b/satpy/readers/_geos_area.py
@@ -41,7 +41,7 @@ def get_xy_from_linecol(line, col, offsets, factors):
     return x__, y__
 
 
-def make_ext(ll_x, ur_x, ll_y, ur_y, h):
+def make_ext(ll_x, ur_x, ll_y, ur_y, h, round=False):
     """Create the area extent from computed ll and ur.
 
     Args:
@@ -50,6 +50,8 @@ def make_ext(ll_x, ur_x, ll_y, ur_y, h):
         ll_y: The lower left y coordinate (m)
         ur_y: The upper right y coordinate (m)
         h: The satellite altitude above the Earth's surface
+        round: Round values by 7 decimal places to avoid inconsistencies
+            with floating point calculations.
     Returns:
         aex: An area extent for the scene
 
@@ -58,14 +60,15 @@ def make_ext(ll_x, ur_x, ll_y, ur_y, h):
     ll_y = np.deg2rad(ll_y)
     ur_x = np.deg2rad(ur_x)
     ur_y = np.deg2rad(ur_y)
-    ll_x = np.round(ll_x, 7)
-    ur_x = np.round(ur_x, 7)
-    ll_y = np.round(ll_y, 7)
-    ur_y = np.round(ur_y, 7)
+    if round:
+        ll_x = np.round(ll_x, 7)
+        ur_x = np.round(ur_x, 7)
+        ll_y = np.round(ll_y, 7)
+        ur_y = np.round(ur_y, 7)
     return ll_x * h, ll_y * h, ur_x * h, ur_y * h
 
 
-def get_area_extent(pdict):
+def get_area_extent(pdict, round=False):
     """Get the area extent seen by a geostationary satellite.
 
     Args:
@@ -77,6 +80,8 @@ def get_area_extent(pdict):
             coff: Column offset factor
             loff: Line offset factor
             scandir: 'N2S' for standard (N->S), 'S2N' for inverse (S->N)
+        round: Round values by 7 decimal places to avoid inconsistencies
+            with floating point calculations.
     Returns:
         aex: An area extent for the scene
 
@@ -108,7 +113,7 @@ def get_area_extent(pdict):
         ur_y *= -1
 
     # Convert degrees to radians and create area extent
-    aex = make_ext(ll_x=ll_x, ur_x=ur_x, ll_y=ll_y, ur_y=ur_y, h=pdict['h'])
+    aex = make_ext(ll_x=ll_x, ur_x=ur_x, ll_y=ll_y, ur_y=ur_y, h=pdict['h'], round=round)
 
     return aex
 

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -504,7 +504,7 @@ class AHIHSDFileHandler(BaseFileHandler):
 
         pdict['loff'] = pdict['loff'] + (self.segment_number * pdict['nlines'])
 
-        aex = get_area_extent(pdict)
+        aex = get_area_extent(pdict, round=True)
 
         pdict['a_name'] = self.observation_area
         pdict['a_desc'] = "AHI {} area".format(self.observation_area)

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -148,8 +148,10 @@ class TestAHIHSDNavigation(unittest.TestCase):
             self.assertEqual(proj_dict['lon_0'], 140.7)
             self.assertEqual(proj_dict['proj'], 'geos')
             self.assertEqual(proj_dict['units'], 'm')
-            np.testing.assert_allclose(area_def.area_extent, (592000.0038256242, 4132000.0267018233,
-                                                              1592000.0102878273, 5132000.033164027))
+            np.testing.assert_allclose(
+                area_def.area_extent,
+                (591998.374436, 4132000.35695, 1591998.530108, 5132000.512622)
+            )
 
     @mock.patch('satpy.readers.ahi_hsd.np2str')
     @mock.patch('satpy.readers.ahi_hsd.np.fromfile')
@@ -196,8 +198,9 @@ class TestAHIHSDNavigation(unittest.TestCase):
             self.assertEqual(proj_dict['lon_0'], 140.7)
             self.assertEqual(proj_dict['proj'], 'geos')
             self.assertEqual(proj_dict['units'], 'm')
-            np.testing.assert_allclose(area_def.area_extent, (-5500000.035542117, -3300000.021325271,
-                                                              5500000.035542117, -2200000.0142168473))
+            np.testing.assert_allclose(
+                area_def.area_extent,
+                (-5500000.856196, -3300000.513718, 5500000.856196, -2200000.342478))
 
 
 @pytest.fixture


### PR DESCRIPTION
As discussed a little in #2560, the AHI HSD reader (which uses the geos utilities) produces inconsistent area extents between resolutions (usually not between time steps). In the ABI readers I put extra work into rounding the calculations so that they produced the same output between resolutions. I did a quick test at a few points in the geos utilities to see if something similar could be done for AHI.

The numbers going in to these calculations are all pretty simple and float friendly (ex. `0.5`), but then there is a `2**16` thrown in there, then I tried rounding some things and it didn't really change much. It wasn't until I rounded extents near the `np.deg2rad` that things started being a little more consistent. For AHI I saw the best results rounding after `np.deg2rad` and found that rounding to 7 decimal places was still producing consistent results. What I don't like is changing the number of decimal places can change the results of the Y dimension 10s of meters for each segment.

Anyway, here's the results of this PR:

```
Area ID: FLDK
Description: AHI FLDK area
Projection ID: geosh8
Projection: {'a': '6378137', 'h': '35785863', 'lon_0': '140.7', 'no_defs': 'None', 'proj': 'geos', 'rf': '298.257024882273', 'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'}
Number of columns: 11000
Number of rows: 11000
Area extent: (-5500000.8562, -5500000.8562, 5500000.8562, 5500000.8562)
Area ID: FLDK
Description: AHI FLDK area
Projection ID: geosh8
Projection: {'a': '6378137', 'h': '35785863', 'lon_0': '140.7', 'no_defs': 'None', 'proj': 'geos', 'rf': '298.257024882273', 'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'}
Number of columns: 22000
Number of rows: 22000
Area extent: (-5500000.8562, -5500000.8562, 5500000.8562, 5500000.8562)
Area ID: FLDK
Description: AHI FLDK area
Projection ID: geosh8
Projection: {'a': '6378137', 'h': '35785863', 'lon_0': '140.7', 'no_defs': 'None', 'proj': 'geos', 'rf': '298.257024882273', 'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'}
Number of columns: 5500
Number of rows: 5500
Area extent: (-5500000.8562, -5500000.8562, 5500000.8562, 5500000.8562)
```

And for the record, here's what `main` produces:

```
Area ID: FLDK
Description: AHI FLDK area
Projection ID: geosh8
Projection: {'a': '6378137', 'h': '35785863', 'lon_0': '140.7', 'no_defs': 'None', 'proj': 'geos', 'rf': '298.257024882273', 'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'}
Number of columns: 11000
Number of rows: 11000
Area extent: (-5500000.0355, -5500000.0355, 5500000.0355, 5500000.0355)
Area ID: FLDK
Description: AHI FLDK area
Projection ID: geosh8
Projection: {'a': '6378137', 'h': '35785863', 'lon_0': '140.7', 'no_defs': 'None', 'proj': 'geos', 'rf': '298.257024882273', 'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'}
Number of columns: 22000
Number of rows: 22000
Area extent: (-5499999.9684, -5499999.9684, 5499999.9684, 5499999.9684)
Area ID: FLDK
Description: AHI FLDK area
Projection ID: geosh8
Projection: {'a': '6378137', 'h': '35785863', 'lon_0': '140.7', 'no_defs': 'None', 'proj': 'geos', 'rf': '298.257024882273', 'type': 'crs', 'units': 'm', 'x_0': '0', 'y_0': '0'}
Number of columns: 5500
Number of rows: 5500
Area extent: (-5499999.9012, -5499999.9012, 5499999.9012, 5499999.9012)
```

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
