### PR TITLE
Rename ABI "night_microphysics_abi" composite to "night_microphysics"

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -555,6 +555,22 @@ composites:
       - name: C13
     standard_name: night_microphysics
 
+  night_microphysics_eum:
+    description: >
+      Nighttime Microphysics RGB following the EUMETSAT recipe
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: C15
+          - name: C14
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: C14
+          - name: C07
+      - name: C14
+    standard_name: night_microphysics
+
   fire_temperature_awips:
     description: >
       Fire Temperature RGB, for GOESR: NASA, NOAA

--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -537,7 +537,7 @@ composites:
           - name: C13
     standard_name: snow
 
-  night_microphysics_abi:
+  night_microphysics:
     description: >
       Nighttime Microphysics RGB, for GOESR: NASA, NOAA
     references:


### PR DESCRIPTION
A simple change with a big difference. The default `night_microphysics` recipe results in the ABI C14 channel being used, but NASA/NOAA/CIRA recommend using C13. This changes the final result a decent amount. The enhancement crude stretch was already changed a long time ago to match the CIRA Quick Guide:

https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_NtMicroRGB_Final_20191206.pdf

But I didn't realize that asking for `night_microphysics` would give you the C14 version of the composite. This C13 version was only available via the name `night_microphysics_abi`. This PR changes the name of that composite so it is the main and only night_microphysics loaded for ABI data.

CC @kathys @graemely @scottlindstrom for any thoughts or disagreement with this being the new default in our Geo2Grid project.

Looking at the differences it is kind of like you add a shadow effect to the red regions of the image.

### Old Night Micro

![image](https://github.com/pytroll/satpy/assets/1828519/c248d8e9-4b85-49ef-8b5e-0a1664bc5a37)

### New Night Micro

![image](https://github.com/pytroll/satpy/assets/1828519/73b2d687-ac52-49ae-9c47-3cc006a7e78d)



 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
