### PR TITLE
Remove use of deprecated setuptools_scm_git_archive build package

### DIFF
--- a/.github/workflows/deploy-sdist.yaml
+++ b/.github/workflows/deploy-sdist.yaml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-        with:
-          fetch-tags: true
 
       - name: Create sdist
         shell: bash -l {0}

--- a/.github/workflows/deploy-sdist.yaml
+++ b/.github/workflows/deploy-sdist.yaml
@@ -1,6 +1,8 @@
 name: Deploy sdist
 
 on:
+  push:
+  pull_request:
   release:
     types:
       - published
@@ -12,10 +14,14 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+        with:
+          fetch-tags: true
 
       - name: Create sdist
         shell: bash -l {0}
-        run: python setup.py sdist
+        run: |
+          python -m pip install -q build
+          python -m build -s
 
       - name: Publish package to PyPI
         if: github.event.action == 'published'

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,5 +7,10 @@ include LICENSE.txt
 include README.rst
 include AUTHORS.md
 include CHANGELOG.md
+include SECURITY.md
+include CITATION
 include satpy/version.py
+include pyproject.toml
+include setup.py
+include setup.cfg
 global-exclude *.py[cod]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,11 @@
-include doc/Makefile
-include doc/source/*
-include doc/examples/*.py
+prune *
+exclude *
+graft doc
+recursive-exclude doc/build *
+graft satpy
 include LICENSE.txt
 include README.rst
+include AUTHORS.md
+include CHANGELOG.md
 include satpy/version.py
+global-exclude *.py[cod]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2", 'setuptools_scm_git_archive']
+requires = ["setuptools>=60", "wheel", "setuptools_scm[toml]>=8.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -22,14 +22,6 @@ from glob import glob
 
 from setuptools import find_packages, setup
 
-try:
-    # HACK: https://github.com/pypa/setuptools_scm/issues/190#issuecomment-351181286
-    # Stop setuptools_scm from including all repository files
-    import setuptools_scm.integration
-    setuptools_scm.integration.find_files = lambda _: []
-except ImportError:
-    pass
-
 requires = ['numpy >=1.13', 'pillow', 'pyresample >=1.24.0', 'trollsift',
             'trollimage >=1.20', 'pykdtree', 'pyyaml >=5.1', 'xarray >=0.10.1, !=0.13.0',
             'dask[array] >=0.17.1', 'pyproj>=2.2', 'zarr', 'donfig', 'appdirs',


### PR DESCRIPTION
In my Polar2Grid project I install Satpy from source. I noticed today that CI was failing because Satpy is still using the deprecated setuptools_scm_git_archive utility package. The functionality of this package has been merged into setuptools_scm and is no longer needed. It now fails because setuptools_scm (the newest version) no longer includes modules that that package was importing.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
