### PR TITLE
force setuptools_scm[toml]>=6.2,<8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2", 'setuptools_scm_git_archive']
+requires = ["setuptools>=45", "wheel", "setuptools_scm[toml]>=6.2,<8", 'setuptools_scm_git_archive']
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]


### PR DESCRIPTION
This fixes the current pip install issue from PyPI described in Issue 2576

 - [ ] Closes #2576
