### PR TITLE
Make caching warn if some of the args are unhashable

### DIFF
--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -248,7 +248,8 @@ def _hash_args(*args, unhashable_types=DEFAULT_UNCACHE_TYPES):
     hashable_args = []
     for arg in args:
         if isinstance(arg, unhashable_types):
-            raise TypeError(f"Unhashable type in function signature ({type(arg)}), cannot be cached.")
+            warnings.warn(f"Unhashable type in function signature ({type(arg)}), cannot be cached.", stacklevel=2)
+            continue
         if isinstance(arg, HASHABLE_GEOMETRIES):
             arg = hash(arg)
         elif isinstance(arg, datetime):

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -250,7 +250,7 @@ def _hash_args(*args, unhashable_types=DEFAULT_UNCACHE_TYPES):
     hashable_args = []
     for arg in args:
         if isinstance(arg, unhashable_types):
-            continue
+            raise TypeError(f"Unhashable type in function signature ({type(arg)}), cannot be cached.")
         if isinstance(arg, HASHABLE_GEOMETRIES):
             arg = hash(arg)
         elif isinstance(arg, datetime):

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -163,8 +163,6 @@ class ZarrCacheHelper:
 
     def _get_should_cache_and_cache_dir(self, args, cache_dir: Optional[str]) -> tuple[bool, str]:
         should_cache: bool = satpy.config.get(self._cache_config_key, False)
-        can_cache = not any(isinstance(arg, self._uncacheable_arg_types) for arg in args)
-        should_cache = should_cache and can_cache
         cache_dir = self._get_cache_dir_from_config(cache_dir)
         return should_cache, cache_dir
 

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -138,42 +138,44 @@ class ZarrCacheHelper:
 
     def __call__(self, *args, cache_dir: Optional[str] = None) -> Any:
         """Call the decorated function."""
-        sanitized_args = self._sanitize_args_func(*args) if self._sanitize_args_func is not None else args
-        should_cache, cache_dir = self._get_should_cache_and_cache_dir(sanitized_args, cache_dir)
-        if should_cache:
-            try:
-                arg_hash = _hash_args(*sanitized_args, unhashable_types=self._uncacheable_arg_types)
-            except TypeError as err:
-                warnings.warn("Cannot cache function because of unhashable argument: " + str(err), stacklevel=2)
-                should_cache = False
-
+        should_cache: bool = satpy.config.get(self._cache_config_key, False)
         if not should_cache:
             return self._func(*args)
 
-        zarr_fn = self._zarr_pattern(arg_hash)
-        zarr_format = os.path.join(cache_dir, zarr_fn)
+        try:
+            return self._cache_and_read(args, cache_dir)
+        except TypeError as err:
+            warnings.warn("Cannot cache function because of unhashable argument: " + str(err), stacklevel=2)
+            return self._func(*args)
+
+    def _cache_and_read(self, args, cache_dir):
+        sanitized_args = self._sanitize_args_func(*args) if self._sanitize_args_func is not None else args
+
+        zarr_format = self._get_zarr_format(sanitized_args, cache_dir)
         zarr_paths = glob(zarr_format.format("*"))
 
         if not zarr_paths:
             # use sanitized arguments
-            args_to_use = sanitized_args
-            res = self._func(*args_to_use)
-            self._warn_if_irregular_input_chunks(args, args_to_use)
-            self._cache_results(res, zarr_format)
+            self._warn_if_irregular_input_chunks(args, sanitized_args)
+            res_to_cache = self._func(*(sanitized_args))
+            self._cache_results(res_to_cache, zarr_format)
 
         # if we did any caching, let's load from the zarr files, so that future calls have the same name
         # re-calculate the cached paths
         zarr_paths = sorted(glob(zarr_format.format("*")))
         if not zarr_paths:
             raise RuntimeError("Data was cached to disk but no files were found")
+
         new_chunks = _get_output_chunks_from_func_arguments(args)
         res = tuple(da.from_zarr(zarr_path, chunks=new_chunks) for zarr_path in zarr_paths)
         return res
 
-    def _get_should_cache_and_cache_dir(self, args, cache_dir: Optional[str]) -> tuple[bool, str]:
-        should_cache: bool = satpy.config.get(self._cache_config_key, False)
+    def _get_zarr_format(self, sanitized_args, cache_dir):
+        arg_hash = _hash_args(*sanitized_args, unhashable_types=self._uncacheable_arg_types)
+        zarr_filename = self._zarr_pattern(arg_hash)
         cache_dir = self._get_cache_dir_from_config(cache_dir)
-        return should_cache, cache_dir
+        zarr_format = os.path.join(cache_dir, zarr_filename)
+        return zarr_format
 
     @staticmethod
     def _get_cache_dir_from_config(cache_dir: Optional[str]) -> str:

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -161,7 +161,7 @@ class ZarrCacheHelper:
             self._warn_if_irregular_input_chunks(args, args_to_use)
             self._cache_results(res, zarr_format)
 
-        # if we did any caching, let's load from the zarr files
+        # if we did any caching, let's load from the zarr files, so that future calls have the same name
         # re-calculate the cached paths
         zarr_paths = sorted(glob(zarr_format.format("*")))
         if not zarr_paths:

--- a/satpy/tests/modifier_tests/test_angles.py
+++ b/satpy/tests/modifier_tests/test_angles.py
@@ -322,6 +322,18 @@ class TestAngleGeneration:
                 satpy.config.set(cache_lonlats=True, cache_dir=str(tmp_path)):
             _fake_func((5, 5), ((5,), (5,)))
 
+    def test_caching_with_array_in_args_fails(self, tmp_path):
+        """Test that trying to cache with non-dask arrays fails."""
+        from satpy.modifiers.angles import cache_to_zarr_if
+
+        @cache_to_zarr_if("cache_lonlats")
+        def _fake_func(array):
+            return array + 1
+
+        with pytest.raises(TypeError), \
+                satpy.config.set(cache_lonlats=True, cache_dir=str(tmp_path)):
+            _fake_func(da.zeros(100))
+
     def test_no_cache_dir_fails(self, tmp_path):
         """Test that 'cache_dir' not being set fails."""
         from satpy.modifiers.angles import _get_sensor_angles_from_sat_pos, get_angles

--- a/satpy/tests/modifier_tests/test_angles.py
+++ b/satpy/tests/modifier_tests/test_angles.py
@@ -322,7 +322,7 @@ class TestAngleGeneration:
                 satpy.config.set(cache_lonlats=True, cache_dir=str(tmp_path)):
             _fake_func((5, 5), ((5,), (5,)))
 
-    def test_caching_with_array_in_args_fails(self, tmp_path):
+    def test_caching_with_array_in_args_warns(self, tmp_path):
         """Test that trying to cache with non-dask arrays fails."""
         from satpy.modifiers.angles import cache_to_zarr_if
 
@@ -333,6 +333,18 @@ class TestAngleGeneration:
         with pytest.warns(UserWarning), \
                 satpy.config.set(cache_lonlats=True, cache_dir=str(tmp_path)):
             _fake_func(da.zeros(100))
+
+    def test_caching_with_array_in_args_does_not_warn_when_caching_is_not_enabled(self, tmp_path, recwarn):
+        """Test that trying to cache with non-dask arrays fails."""
+        from satpy.modifiers.angles import cache_to_zarr_if
+
+        @cache_to_zarr_if("cache_lonlats")
+        def _fake_func(array):
+            return array + 1
+
+        with satpy.config.set(cache_lonlats=False, cache_dir=str(tmp_path)):
+            _fake_func(da.zeros(100))
+        assert len(recwarn) == 0
 
     def test_no_cache_dir_fails(self, tmp_path):
         """Test that 'cache_dir' not being set fails."""

--- a/satpy/tests/modifier_tests/test_angles.py
+++ b/satpy/tests/modifier_tests/test_angles.py
@@ -330,7 +330,7 @@ class TestAngleGeneration:
         def _fake_func(array):
             return array + 1
 
-        with pytest.raises(TypeError), \
+        with pytest.warns(UserWarning), \
                 satpy.config.set(cache_lonlats=True, cache_dir=str(tmp_path)):
             _fake_func(da.zeros(100))
 


### PR DESCRIPTION
This PR make the caching decorator fail if one of the arguments in unhashable where it was silently ignoring it previously and not caching.

 - [x] Tests added <!-- for all bug fixes or enhancements -->

