### PR TITLE
remove setuptools_scm_git_archive from requirement

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,1 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true)$
 ref-names: $Format:%D$

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -25,7 +25,6 @@ dependencies:
   - rioxarray
   - setuptools
   - setuptools_scm
-  - setuptools_scm_git_archive
   - sphinx
   - sphinx_rtd_theme
   - sphinxcontrib-apidoc

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,3 @@
-[options]
-setup_requires =
-    setuptools_scm
-
 [bdist_rpm]
 requires=h5py pyresample python2-numexpr pyhdf xarray dask h5netcdf
 release=1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [options]
 setup_requires =
     setuptools_scm
-    setuptools_scm_git_archive
 
 [bdist_rpm]
 requires=h5py pyresample python2-numexpr pyhdf xarray dask h5netcdf


### PR DESCRIPTION
The package's functionality is now found in setuptools_scm (see https://github.com/pytroll/satpy/issues/2549 and
https://github.com/Changaco/setuptools_scm_git_archive ).

Minimal changes done:
1. Remove setuptools_scm_git_archive from setup.cfg and doc/rtd_environment.yml
2. Change the content of .git_archival.txt according to https://setuptools-scm.readthedocs.io/en/latest/usage/#builtin-mechanisms-for-obtaining-version-numbers

fixes #2549

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #2549
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
