### PR TITLE
Change platform name for EPIC (DSCOVR) to upper case.

### DIFF
--- a/satpy/readers/epic_l1b_h5.py
+++ b/satpy/readers/epic_l1b_h5.py
@@ -69,7 +69,7 @@ class DscovrEpicL1BH5FileHandler(HDF5FileHandler):
         super(DscovrEpicL1BH5FileHandler, self).__init__(filename, filename_info, filetype_info)
 
         self.sensor = 'epic'
-        self.platform_name = 'dscovr'
+        self.platform_name = 'DSCOVR'
 
     @property
     def start_time(self):

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -1448,5 +1448,5 @@ def _should_use_compression_keyword():
     versions = _get_backend_versions()
     return (
         versions["libnetcdf"] >= Version("4.9.0") and
-        versions["xarray"] >= Version("2023.10")
+        versions["xarray"] >= Version("2023.11")
     )


### PR DESCRIPTION
In a recent [pyspectral PR](https://github.com/pytroll/pyspectral/pull/200) I added spectral response functions for EPIC. @adybbroe mentioned that the platform name in that PR should be upper case. The same is true in satpy, so here I make a PR to correct the platform name to the WMO standard name.