### PR TITLE
Fix ABI L2 reader to produce reflectances as percentages

### DIFF
--- a/satpy/readers/abi_l2_nc.py
+++ b/satpy/readers/abi_l2_nc.py
@@ -41,6 +41,12 @@ class NC_ABI_L2(NC_ABI_BASE):
         variable.attrs.update(key.to_dict())
         self._update_data_arr_with_filename_attrs(variable)
         self._remove_problem_attrs(variable)
+
+        # convert to satpy standard units
+        if variable.attrs['units'] == '1' and key['calibration'] != 'counts':
+            variable *= 100.0
+            variable.attrs['units'] = '%'
+
         return variable
 
     def _update_data_arr_with_filename_attrs(self, variable):


### PR DESCRIPTION
As discussed on slack, this data handling has been broken for a long time (since creation?). Basically the CMIP Level 2 files are solar zenith correction versions of the L1b bands. Satpy expects reflectances to be 0 to ~100 (%), but in ABI files they are 0 to ~1. This PR fixes this.

CC @yufeizhu600

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
