### PR TITLE
Fix ABI L2 to only convert reflectances to percentages

### DIFF
--- a/satpy/readers/abi_l2_nc.py
+++ b/satpy/readers/abi_l2_nc.py
@@ -43,7 +43,7 @@ class NC_ABI_L2(NC_ABI_BASE):
         self._remove_problem_attrs(variable)
 
         # convert to satpy standard units
-        if variable.attrs['units'] == '1' and key['calibration'] != 'counts':
+        if variable.attrs['units'] == '1' and key['calibration'] == 'reflectance':
             variable *= 100.0
             variable.attrs['units'] = '%'
 


### PR DESCRIPTION
This is an add-on to #2607 where I realized after merging that the `if` statement (copied from the L1b reader) would be applied to any non-count data with units of `"1"`. For L1b this is really only reflectances I think, but for L2 this could be many many other products. This PR changes this to be specifically `calibration == "reflectance"` which I think is safe enough for now.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
