### PR TITLE
Add resolution-based chunking to ABI L1b reader

### DIFF
--- a/satpy/etc/readers/abi_l1b.yaml
+++ b/satpy/etc/readers/abi_l1b.yaml
@@ -25,16 +25,19 @@ file_types:
     # "suffix" is an arbitrary suffix that may be added during third-party testing (see PR #1380)
     c01:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
+        resolution: 1000
         file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C01_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc{nc_version}',
                         '{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C01_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-{chid:6d}_0.nc{nc_version}',
                         '{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C01_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}_{suffix}.nc{nc_version}']
     c02:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
+        resolution: 500
         file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C02_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc{nc_version}',
                         '{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C02_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-{chid:6d}_0.nc{nc_version}',
                         '{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C02_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}_{suffix}.nc{nc_version}']
     c03:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
+        resolution: 1000
         file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C03_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc{nc_version}',
                         '{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C03_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-{chid:6d}_0.nc{nc_version}',
                         '{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C03_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}_{suffix}.nc{nc_version}']
@@ -44,6 +47,7 @@ file_types:
                         '{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C04_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}_{suffix}.nc{nc_version}']
     c05:
         file_reader: !!python/name:satpy.readers.abi_l1b.NC_ABI_L1B
+        resolution: 1000
         file_patterns: ['{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C05_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc{nc_version}',
                         '{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C05_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}-{chid:6d}_0.nc{nc_version}',
                         '{system_environment:2s}_{mission_id:3s}-L1b-{observation_type:3s}{scene_abbr:s}-{scan_mode:2s}C05_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}_{suffix}.nc{nc_version}']

--- a/satpy/readers/abi_base.py
+++ b/satpy/readers/abi_base.py
@@ -23,7 +23,7 @@ from datetime import datetime
 
 import numpy as np
 import xarray as xr
-from pyresample.geometry import AreaDefinition
+from pyresample import geometry
 
 from satpy._compat import cached_property
 from satpy.readers import open_file_or_filename
@@ -212,7 +212,7 @@ class NC_ABI_BASE(BaseFileHandler):
                      "fi": float(fi),
                      "pm": float(pm)}
 
-        ll_area_def = AreaDefinition(
+        ll_area_def = geometry.AreaDefinition(
             self.nc.attrs.get("orbital_slot", "abi_geos"),
             self.nc.attrs.get("spatial_resolution", "ABI file area"),
             "abi_latlon",
@@ -262,7 +262,7 @@ class NC_ABI_BASE(BaseFileHandler):
                      "units": "m",
                      "sweep": sweep_axis}
 
-        fg_area_def = AreaDefinition(
+        fg_area_def = geometry.AreaDefinition(
             self.nc.attrs.get("orbital_slot", "abi_geos"),
             self.nc.attrs.get("spatial_resolution", "ABI file area"),
             "abi_fixed_grid",

--- a/satpy/readers/abi_base.py
+++ b/satpy/readers/abi_base.py
@@ -140,7 +140,7 @@ class NC_ABI_BASE(BaseFileHandler):
                 new_fill = fill
             else:
                 new_fill = np.nan
-            data = data.where(data != fill, np.float32(new_fill))
+            data = data.where(data != fill, new_fill)
         if factor != 1 and item in ("x", "y"):
             # be more precise with x/y coordinates
             # see get_area_def for more information

--- a/satpy/readers/abi_base.py
+++ b/satpy/readers/abi_base.py
@@ -66,7 +66,7 @@ class NC_ABI_BASE(BaseFileHandler):
 
         from satpy.utils import get_dask_chunk_size_in_bytes
         chunk_size_for_high_res = math.sqrt(get_dask_chunk_size_in_bytes() / 4)  # 32-bit floats
-        chunk_size_for_high_res = np.round(chunk_size_for_high_res / (4 * 226)) * (4 * 226)
+        chunk_size_for_high_res = np.round(max(chunk_size_for_high_res / (4 * 226), 1)) * (4 * 226)
         low_res_factor = int(self.filetype_info.get("resolution", 2000) // 500)
         res_chunk_bytes = int(chunk_size_for_high_res / low_res_factor) * 4
         import dask

--- a/satpy/readers/abi_base.py
+++ b/satpy/readers/abi_base.py
@@ -23,7 +23,7 @@ from datetime import datetime
 
 import numpy as np
 import xarray as xr
-from pyresample import geometry
+from pyresample.geometry import AreaDefinition
 
 from satpy._compat import cached_property
 from satpy.readers import open_file_or_filename
@@ -212,7 +212,7 @@ class NC_ABI_BASE(BaseFileHandler):
                      "fi": float(fi),
                      "pm": float(pm)}
 
-        ll_area_def = geometry.AreaDefinition(
+        ll_area_def = AreaDefinition(
             self.nc.attrs.get("orbital_slot", "abi_geos"),
             self.nc.attrs.get("spatial_resolution", "ABI file area"),
             "abi_latlon",
@@ -262,7 +262,7 @@ class NC_ABI_BASE(BaseFileHandler):
                      "units": "m",
                      "sweep": sweep_axis}
 
-        fg_area_def = geometry.AreaDefinition(
+        fg_area_def = AreaDefinition(
             self.nc.attrs.get("orbital_slot", "abi_geos"),
             self.nc.attrs.get("spatial_resolution", "ABI file area"),
             "abi_fixed_grid",

--- a/satpy/readers/abi_base.py
+++ b/satpy/readers/abi_base.py
@@ -139,18 +139,13 @@ class NC_ABI_BASE(BaseFileHandler):
             if is_int(data) and is_int(factor) and is_int(offset):
                 new_fill = fill
             else:
-                new_fill = np.nan
+                new_fill = np.float32(np.nan)
             data = data.where(data != fill, new_fill)
         if factor != 1 and item in ("x", "y"):
             # be more precise with x/y coordinates
             # see get_area_def for more information
             data = data * np.round(float(factor), 6) + np.round(float(offset), 6)
         elif factor != 1:
-            # make sure the factor is a 64-bit float
-            # can't do this in place since data is most likely uint16
-            # and we are making it a 64-bit float
-            if not is_int(factor):
-                factor = np.float32(factor)
             data = data * np.float32(factor) + np.float32(offset)
         return data
 

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -59,12 +59,8 @@ class NC_ABI_L1B(NC_ABI_BASE):
             "radiance": self._rad_calibrate,
             "counts": self._raw_calibrate,
         }
-
-        try:
-            func = cal_dictionary[key["calibration"]]
-            res = func(radiances)
-        except KeyError:
-            raise ValueError("Unknown calibration '{}'".format(key["calibration"]))
+        func = cal_dictionary[key["calibration"]]
+        res = func(radiances)
 
         # convert to satpy standard units
         if res.attrs["units"] == "1" and key["calibration"] != "counts":

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -133,7 +133,7 @@ class NC_ABI_L1B(NC_ABI_BASE):
     def _vis_calibrate(self, data):
         """Calibrate visible channels to reflectance."""
         solar_irradiance = self["esun"]
-        esd = self["earth_sun_distance_anomaly_in_AU"].astype(np.float32)
+        esd = self["earth_sun_distance_anomaly_in_AU"]
 
         factor = np.pi * esd * esd / solar_irradiance
 

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -49,6 +49,7 @@ class NC_ABI_L1B(NC_ABI_BASE):
         # For raw cal, don't apply scale and offset, return raw file counts
         if key["calibration"] == "counts":
             radiances = self.nc["Rad"].copy()
+            radiances = self._adjust_coords(radiances, "Rad")
         else:
             radiances = self["Rad"]
 

--- a/satpy/readers/abi_l1b.py
+++ b/satpy/readers/abi_l1b.py
@@ -136,11 +136,11 @@ class NC_ABI_L1B(NC_ABI_BASE):
     def _vis_calibrate(self, data):
         """Calibrate visible channels to reflectance."""
         solar_irradiance = self["esun"]
-        esd = self["earth_sun_distance_anomaly_in_AU"].astype(float)
+        esd = self["earth_sun_distance_anomaly_in_AU"].astype(np.float32)
 
         factor = np.pi * esd * esd / solar_irradiance
 
-        res = data * factor
+        res = data * np.float32(factor)
         res.attrs = data.attrs
         res.attrs["units"] = "1"
         res.attrs["long_name"] = "Bidirectional Reflectance"

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -18,14 +18,17 @@
 """The abi_l1b reader tests package."""
 from __future__ import annotations
 
-import unittest
-from typing import Any
+import contextlib
+from pathlib import Path
+from typing import Any, Iterator
 from unittest import mock
 
+import dask.array as da
 import numpy as np
 import pytest
 import xarray as xr
 
+from satpy.readers.abi_l1b import NC_ABI_L1B
 from satpy.tests.utils import make_dataid
 
 RAD_SHAPE = {
@@ -36,27 +39,27 @@ RAD_SHAPE = {
 
 
 def _create_fake_rad_dataarray(
-        rad: xr.DataArray | None = None,
-        # resolution: int = 2000,
-):
-    x_image = xr.DataArray(0.)
-    y_image = xr.DataArray(0.)
-    time = xr.DataArray(0.)
+    rad: xr.DataArray | None = None,
+    # resolution: int = 2000,
+) -> xr.DataArray:
+    x_image = xr.DataArray(0.0)
+    y_image = xr.DataArray(0.0)
+    time = xr.DataArray(0.0)
     shape = (2, 5)  # RAD_SHAPE[resolution]
     if rad is None:
-        rad_data = (np.arange(shape[0] * shape[1]).reshape(shape) + 1.) * 50.
-        rad_data = (rad_data + 1.) / 0.5
+        rad_data = (np.arange(shape[0] * shape[1]).reshape(shape) + 1.0) * 50.0
+        rad_data = (rad_data + 1.0) / 0.5
         rad_data = rad_data.astype(np.int16)
         rad = xr.DataArray(
             rad_data,
             dims=("y", "x"),
             attrs={
                 "scale_factor": 0.5,
-                "add_offset": -1.,
+                "add_offset": -1.0,
                 "_FillValue": 1002,
                 "units": "W m-2 um-1 sr-1",
                 "valid_range": (0, 4095),
-            }
+            },
         )
     rad.coords["t"] = time
     rad.coords["x_image"] = x_image
@@ -68,25 +71,21 @@ def _create_fake_rad_dataset(rad=None):
     rad = _create_fake_rad_dataarray(rad=rad)
 
     x__ = xr.DataArray(
-        range(5),
-        attrs={"scale_factor": 2., "add_offset": -1.},
-        dims=("x",)
+        range(5), attrs={"scale_factor": 2.0, "add_offset": -1.0}, dims=("x",)
     )
     y__ = xr.DataArray(
-        range(2),
-        attrs={"scale_factor": -2., "add_offset": 1.},
-        dims=("y",)
+        range(2), attrs={"scale_factor": -2.0, "add_offset": 1.0}, dims=("y",)
     )
     proj = xr.DataArray(
         [],
         attrs={
-            "semi_major_axis": 1.,
-            "semi_minor_axis": 1.,
-            "perspective_point_height": 1.,
-            "longitude_of_projection_origin": -90.,
-            "latitude_of_projection_origin": 0.,
-            "sweep_angle_axis": u"x"
-        }
+            "semi_major_axis": 1.0,
+            "semi_minor_axis": 1.0,
+            "perspective_point_height": 1.0,
+            "longitude_of_projection_origin": -90.0,
+            "latitude_of_projection_origin": 0.0,
+            "sweep_angle_axis": "x",
+        },
     )
 
     fake_dataset = xr.Dataset(
@@ -95,8 +94,8 @@ def _create_fake_rad_dataset(rad=None):
             "band_id": np.array(8),
             # 'x': x__,
             # 'y': y__,
-            "x_image": xr.DataArray(0.),
-            "y_image": xr.DataArray(0.),
+            "x_image": xr.DataArray(0.0),
+            "y_image": xr.DataArray(0.0),
             "goes_imager_projection": proj,
             "yaw_flip_flag": np.array([1]),
             "planck_fk1": np.array(13432.1),
@@ -107,13 +106,12 @@ def _create_fake_rad_dataset(rad=None):
             "nominal_satellite_subpoint_lat": np.array(0.0),
             "nominal_satellite_subpoint_lon": np.array(-89.5),
             "nominal_satellite_height": np.array(35786.02),
-            "earth_sun_distance_anomaly_in_AU": np.array(0.99)
+            "earth_sun_distance_anomaly_in_AU": np.array(0.99),
         },
         coords={
             "t": rad.coords["t"],
             "x": x__,
             "y": y__,
-
         },
         attrs={
             "time_coverage_start": "2017-09-20T17:30:40.8Z",
@@ -123,93 +121,139 @@ def _create_fake_rad_dataset(rad=None):
     return fake_dataset
 
 
-class Test_NC_ABI_L1B_Base(unittest.TestCase):
-    """Common setup for NC_ABI_L1B tests."""
+def generate_l1b_filename(chan_name: str) -> str:
+    return f"OR_ABI-L1b-RadC-M4{chan_name}_G16_s20161811540362_e20161811545170_c20161811545230.nc"
 
-    @mock.patch("satpy.readers.abi_base.xr")
-    def setUp(
-            self,
-            xr_,
-            rad: xr.DataArray | None = None,
-            clip_negative_radiances: bool = False,
-            filetype_resolution: int = 0
-    ) -> None:
-        """Create a fake dataset using the given radiance data."""
-        from satpy.readers.abi_l1b import NC_ABI_L1B
 
+@pytest.fixture(scope="module")
+def l1b_c01_file(tmp_path_factory) -> list[Path]:
+    filename = generate_l1b_filename("C01")
+    data_path = tmp_path_factory.mktemp("abi_l1b").join(filename)
+    dataset = _create_fake_rad_dataset()
+    dataset.to_netcdf(data_path)
+    return [data_path]
+
+
+@pytest.fixture(scope="module")
+def l1b_all_files(
+    l1b_c01_file,
+) -> list[Path]:
+    return l1b_c01_file
+
+
+@contextlib.contextmanager
+def create_file_handler(
+    rad: xr.DataArray | None = None,
+    clip_negative_radiances: bool = False,
+    filetype_resolution: int = 0,
+) -> Iterator[NC_ABI_L1B]:
+    """Create a fake dataset using the given radiance data."""
+
+    ft_info: dict[str, Any] = {"filetype": "info"}
+    if filetype_resolution:
+        ft_info["resolution"] = filetype_resolution
+
+    with mock.patch("satpy.readers.abi_base.xr") as xr_:
         xr_.open_dataset.return_value = _create_fake_rad_dataset(rad=rad)
-        ft_info: dict[str, Any] = {"filetype": "info"}
-        if filetype_resolution:
-            ft_info["resolution"] = filetype_resolution
-        self.file_handler = NC_ABI_L1B(
+        file_handler = NC_ABI_L1B(
             "filename",
-            {"platform_shortname": "G16", "observation_type": "Rad",
-            "suffix": "custom",
-            "scene_abbr": "C", "scan_mode": "M3"},
+            {
+                "platform_shortname": "G16",
+                "observation_type": "Rad",
+                "suffix": "custom",
+                "scene_abbr": "C",
+                "scan_mode": "M3",
+            },
             ft_info,
-            clip_negative_radiances=clip_negative_radiances
+            clip_negative_radiances=clip_negative_radiances,
         )
+        yield file_handler
 
 
 class TestABIYAML:
     """Tests for the ABI L1b reader's YAML configuration."""
 
-    @pytest.mark.parametrize(("channel", "suffix"),
-                             [("C{:02d}".format(num), suffix)
-                              for num in range(1, 17)
-                              for suffix in ("", "_test_suffix")])
+    @pytest.mark.parametrize(
+        ("channel", "suffix"),
+        [
+            ("C{:02d}".format(num), suffix)
+            for num in range(1, 17)
+            for suffix in ("", "_test_suffix")
+        ],
+    )
     def test_file_patterns_match(self, channel, suffix):
         """Test that the configured file patterns work."""
         from satpy.readers import configs_for_reader, load_reader
+
         reader_configs = list(configs_for_reader("abi_l1b"))[0]
         reader = load_reader(reader_configs)
-        fn1 = ("OR_ABI-L1b-RadM1-M3{}_G16_s20182541300210_e20182541300267"
-               "_c20182541300308{}.nc").format(channel, suffix)
+        fn1 = (
+            "OR_ABI-L1b-RadM1-M3{}_G16_s20182541300210_e20182541300267"
+            "_c20182541300308{}.nc"
+        ).format(channel, suffix)
         loadables = reader.select_files_from_pathnames([fn1])
         assert len(loadables) == 1
         if not suffix and channel in ["C01", "C02", "C03", "C05"]:
-            fn2 = ("OR_ABI-L1b-RadM1-M3{}_G16_s20182541300210_e20182541300267"
-                   "_c20182541300308-000000_0.nc").format(channel)
+            fn2 = (
+                "OR_ABI-L1b-RadM1-M3{}_G16_s20182541300210_e20182541300267"
+                "_c20182541300308-000000_0.nc"
+            ).format(channel)
             loadables = reader.select_files_from_pathnames([fn2])
             assert len(loadables) == 1
 
 
-class Test_NC_ABI_L1B(Test_NC_ABI_L1B_Base):
+class Test_NC_ABI_L1B:
     """Test the NC_ABI_L1B reader."""
+
+    @property
+    def fake_rad(self):
+        """Create fake data for these tests.
+
+        Needs to be an instance method so the subclass can override it.
+
+        """
+        return None
 
     def test_basic_attributes(self):
         """Test getting basic file attributes."""
         from datetime import datetime
-        assert self.file_handler.start_time == datetime(2017, 9, 20, 17, 30, 40, 800000)
-        assert self.file_handler.end_time == datetime(2017, 9, 20, 17, 41, 17, 500000)
+
+        with create_file_handler(rad=self.fake_rad) as file_handler:
+            assert file_handler.start_time == datetime(2017, 9, 20, 17, 30, 40, 800000)
+            assert file_handler.end_time == datetime(2017, 9, 20, 17, 41, 17, 500000)
 
     def test_get_dataset(self):
         """Test the get_dataset method."""
         key = make_dataid(name="Rad", calibration="radiance")
-        res = self.file_handler.get_dataset(key, {"info": "info"})
-        exp = {"calibration": "radiance",
-               "instrument_ID": None,
-               "modifiers": (),
-               "name": "Rad",
-               "observation_type": "Rad",
-               "orbital_parameters": {"projection_altitude": 1.0,
-                                      "projection_latitude": 0.0,
-                                      "projection_longitude": -90.0,
-                                      "satellite_nominal_altitude": 35786020.,
-                                      "satellite_nominal_latitude": 0.0,
-                                      "satellite_nominal_longitude": -89.5,
-                                      "yaw_flip": True},
-               "orbital_slot": None,
-               "platform_name": "GOES-16",
-               "platform_shortname": "G16",
-               "production_site": None,
-               "scan_mode": "M3",
-               "scene_abbr": "C",
-               "scene_id": None,
-               "sensor": "abi",
-               "timeline_ID": None,
-               "suffix": "custom",
-               "units": "W m-2 um-1 sr-1"}
+        with create_file_handler(rad=self.fake_rad) as file_handler:
+            res = file_handler.get_dataset(key, {"info": "info"})
+        exp = {
+            "calibration": "radiance",
+            "instrument_ID": None,
+            "modifiers": (),
+            "name": "Rad",
+            "observation_type": "Rad",
+            "orbital_parameters": {
+                "projection_altitude": 1.0,
+                "projection_latitude": 0.0,
+                "projection_longitude": -90.0,
+                "satellite_nominal_altitude": 35786020.0,
+                "satellite_nominal_latitude": 0.0,
+                "satellite_nominal_longitude": -89.5,
+                "yaw_flip": True,
+            },
+            "orbital_slot": None,
+            "platform_name": "GOES-16",
+            "platform_shortname": "G16",
+            "production_site": None,
+            "scan_mode": "M3",
+            "scene_abbr": "C",
+            "scene_id": None,
+            "sensor": "abi",
+            "timeline_ID": None,
+            "suffix": "custom",
+            "units": "W m-2 um-1 sr-1",
+        }
 
         assert res.attrs == exp
         # we remove any time dimension information
@@ -221,40 +265,47 @@ class Test_NC_ABI_L1B(Test_NC_ABI_L1B_Base):
     @mock.patch("satpy.readers.abi_base.geometry.AreaDefinition")
     def test_get_area_def(self, adef):
         """Test the area generation."""
-        self.file_handler.get_area_def(None)
+        with create_file_handler(rad=self.fake_rad) as file_handler:
+            file_handler.get_area_def(None)
 
-        assert adef.call_count == 1
-        call_args = tuple(adef.call_args)[0]
-        assert call_args[3] == {"a": 1.0, "b": 1.0, "h": 1.0,
-                                "lon_0": -90.0, "proj": "geos", "sweep": "x", "units": "m"}
-        assert call_args[4] == self.file_handler.ncols
-        assert call_args[5] == self.file_handler.nlines
-        np.testing.assert_allclose(call_args[6], (-2, -2, 8, 2))
+            assert adef.call_count == 1
+            call_args = tuple(adef.call_args)[0]
+            assert call_args[3] == {
+                "a": 1.0,
+                "b": 1.0,
+                "h": 1.0,
+                "lon_0": -90.0,
+                "proj": "geos",
+                "sweep": "x",
+                "units": "m",
+            }
+            assert call_args[4] == file_handler.ncols
+            assert call_args[5] == file_handler.nlines
+            np.testing.assert_allclose(call_args[6], (-2, -2, 8, 2))
 
 
-class Test_NC_ABI_L1B_ir_cal(Test_NC_ABI_L1B_Base):
+class Test_NC_ABI_L1B_ir_cal:
     """Test the NC_ABI_L1B reader's default IR calibration."""
 
-    def setUp(self):
-        """Create fake data for the tests."""
-        rad_data = (np.arange(10.).reshape((2, 5)) + 1.) * 50.
-        rad_data = (rad_data + 1.) / 0.5
-        rad_data = rad_data.astype(np.int16)
-        rad = xr.DataArray(
-            rad_data,
-            dims=("y", "x"),
-            attrs={
-                "scale_factor": 0.5,
-                "add_offset": -1.,
-                "_FillValue": 1002,  # last rad_data value
-            }
-        )
-        super(Test_NC_ABI_L1B_ir_cal, self).setUp(rad=rad, filetype_resolution=2000)
+    @pytest.mark.parametrize("clip_negative_radiances", [False, True])
+    def test_ir_calibrate(self, clip_negative_radiances):
+        """Test IR calibration."""
+        with _ir_file_handler(
+            clip_negative_radiances=clip_negative_radiances
+        ) as file_handler:
+            res = file_handler.get_dataset(
+                make_dataid(name="C07", calibration="brightness_temperature"), {}
+            )
+            assert file_handler.clip_negative_radiances == clip_negative_radiances
 
-    def test_ir_calibration_attrs(self):
-        """Test IR calibrated DataArray attributes."""
-        res = self.file_handler.get_dataset(
-            make_dataid(name="C05", calibration="brightness_temperature"), {})
+        clipped_ir = 134.68753 if clip_negative_radiances else np.nan
+        expected = np.array(
+            [
+                [clipped_ir, 304.97037, 332.22778, 354.6147, 374.08688],
+                [391.58655, 407.64786, 422.60635, 436.68802, np.nan],
+            ]
+        )
+        np.testing.assert_allclose(res.data, expected, equal_nan=True, atol=1e-04)
 
         # make sure the attributes from the file are in the data array
         assert "scale_factor" not in res.attrs
@@ -262,95 +313,69 @@ class Test_NC_ABI_L1B_ir_cal(Test_NC_ABI_L1B_Base):
         assert res.attrs["standard_name"] == "toa_brightness_temperature"
         assert res.attrs["long_name"] == "Brightness Temperature"
 
-    def test_clip_negative_radiances_attribute(self):
-        """Assert that clip_negative_radiances is set to False."""
-        assert not self.file_handler.clip_negative_radiances
 
-    def test_ir_calibrate(self):
-        """Test IR calibration."""
-        res = self.file_handler.get_dataset(
-            make_dataid(name="C05", calibration="brightness_temperature"), {})
-
-        expected = np.array([[267.55572248, 305.15576503, 332.37383249, 354.73895301, 374.19710115],
-                             [391.68679226, 407.74064808, 422.69329105, 436.77021913, np.nan]])
-        assert np.allclose(res.data, expected, equal_nan=True)
-
-
-class Test_NC_ABI_L1B_clipped_ir_cal(Test_NC_ABI_L1B_Base):
-    """Test the NC_ABI_L1B reader's IR calibration (clipping negative radiance)."""
-
-    def setUp(self):
-        """Create fake data for the tests."""
-        values = np.arange(10.)
-        values[0] = -0.0001  # introduce below minimum expected radiance
-        rad_data = (values.reshape((2, 5)) + 1.) * 50.
-        rad_data = (rad_data + 1.) / 0.5
-        rad_data = rad_data.astype(np.int16)
-        rad = xr.DataArray(
-            rad_data,
-            dims=("y", "x"),
-            attrs={
-                "scale_factor": 0.5,
-                "add_offset": -1.,
-                "_FillValue": 1002,
-            }
-        )
-
-        super().setUp(rad=rad, clip_negative_radiances=True, filetype_resolution=2000)
-
-    def test_clip_negative_radiances_attribute(self):
-        """Assert that clip_negative_radiances has been set to True."""
-        assert self.file_handler.clip_negative_radiances
-
-    def test_ir_calibrate(self):
-        """Test IR calibration."""
-        res = self.file_handler.get_dataset(
-            make_dataid(name="C07", calibration="brightness_temperature"), {})
-
-        clipped_ir = 267.07775531
-        expected = np.array([[clipped_ir, 305.15576503, 332.37383249, 354.73895301, 374.19710115],
-                             [391.68679226, 407.74064808, 422.69329105, 436.77021913, np.nan]])
-        assert np.allclose(res.data, expected, equal_nan=True)
-
-    def test_get_minimum_radiance(self):
-        """Test get_minimum_radiance from Rad DataArray."""
-        from satpy.readers.abi_l1b import NC_ABI_L1B
-        data = xr.DataArray(
-               attrs={
-                   "scale_factor": 0.5,
-                   "add_offset": -1.,
-                   "_FillValue": 1002,
-               }
-        )
-        np.testing.assert_allclose(NC_ABI_L1B._get_minimum_radiance(NC_ABI_L1B, data), 0.0)
+@contextlib.contextmanager
+def _ir_file_handler(
+    data: da.Array | None = None, clip_negative_radiances: bool = False
+):
+    """Create fake data for the tests."""
+    if data is None:
+        data = _fake_ir_data()
+    rad = xr.DataArray(
+        data,
+        dims=("y", "x"),
+        attrs={
+            "scale_factor": 0.5,
+            "add_offset": -1.3,
+            "_FillValue": np.int16(
+                np.floor(((9 + 1) * 50.0 + 1.3) / 0.5)
+            ),  # last rad_data value
+        },
+    )
+    with create_file_handler(
+        rad=rad,
+        clip_negative_radiances=clip_negative_radiances,
+        filetype_resolution=2000,
+    ) as file_handler:
+        yield file_handler
 
 
-class Test_NC_ABI_L1B_vis_cal(Test_NC_ABI_L1B_Base):
+def _fake_ir_data():
+    values = np.arange(10.0)
+    rad_data = (values.reshape((2, 5)) + 1.0) * 50.0
+    rad_data[0, 0] = -0.0001  # introduce below minimum expected radiance
+    rad_data = (rad_data + 1.3) / 0.5
+    return rad_data.astype(np.int16)
+
+
+class Test_NC_ABI_L1B_vis_cal:
     """Test the NC_ABI_L1B reader."""
-
-    def setUp(self):
-        """Create fake data for the tests."""
-        rad_data = (np.arange(10.).reshape((2, 5)) + 1.)
-        rad_data = (rad_data + 1.) / 0.5
-        rad_data = rad_data.astype(np.int16)
-        rad = xr.DataArray(
-            rad_data,
-            dims=("y", "x"),
-            attrs={
-                "scale_factor": 0.5,
-                "add_offset": -1.,
-                "_FillValue": 20,
-            }
-        )
-        super(Test_NC_ABI_L1B_vis_cal, self).setUp(rad=rad, filetype_resolution=1000)
 
     def test_vis_calibrate(self):
         """Test VIS calibration."""
-        res = self.file_handler.get_dataset(
-            make_dataid(name="C05", calibration="reflectance"), {})
+        rad_data = np.arange(10.0).reshape((2, 5)) + 1.0
+        rad_data = (rad_data + 1.0) / 0.5
+        rad_data = rad_data.astype(np.int16)
+        rad = xr.DataArray(
+            rad_data,
+            dims=("y", "x"),
+            attrs={
+                "scale_factor": 0.5,
+                "add_offset": -1.0,
+                "_FillValue": 20,
+            },
+        )
+        with create_file_handler(rad=rad, filetype_resolution=1000) as file_handler:
+            res = file_handler.get_dataset(
+                make_dataid(name="C05", calibration="reflectance"), {}
+            )
 
-        expected = np.array([[0.15265617, 0.30531234, 0.45796851, 0.61062468, 0.76328085],
-                             [0.91593702, 1.06859319, 1.22124936, np.nan, 1.52656171]])
+        expected = np.array(
+            [
+                [0.15265617, 0.30531234, 0.45796851, 0.61062468, 0.76328085],
+                [0.91593702, 1.06859319, 1.22124936, np.nan, 1.52656171],
+            ]
+        )
         assert np.allclose(res.data, expected, equal_nan=True)
         assert "scale_factor" not in res.attrs
         assert "_FillValue" not in res.attrs
@@ -358,29 +383,27 @@ class Test_NC_ABI_L1B_vis_cal(Test_NC_ABI_L1B_Base):
         assert res.attrs["long_name"] == "Bidirectional Reflectance"
 
 
-class Test_NC_ABI_L1B_raw_cal(Test_NC_ABI_L1B_Base):
+class Test_NC_ABI_L1B_raw_cal:
     """Test the NC_ABI_L1B reader raw calibration."""
 
-    def setUp(self):
-        """Create fake data for the tests."""
-        rad_data = (np.arange(10.).reshape((2, 5)) + 1.)
-        rad_data = (rad_data + 1.) / 0.5
+    def test_raw_calibrate(self):
+        """Test RAW calibration."""
+        rad_data = np.arange(10.0).reshape((2, 5)) + 1.0
+        rad_data = (rad_data + 1.0) / 0.5
         rad_data = rad_data.astype(np.int16)
         rad = xr.DataArray(
             rad_data,
             dims=("y", "x"),
             attrs={
                 "scale_factor": 0.5,
-                "add_offset": -1.,
+                "add_offset": -1.0,
                 "_FillValue": 20,
-            }
+            },
         )
-        super(Test_NC_ABI_L1B_raw_cal, self).setUp(rad=rad, filetype_resolution=1000)
-
-    def test_raw_calibrate(self):
-        """Test RAW calibration."""
-        res = self.file_handler.get_dataset(
-            make_dataid(name="C05", calibration="counts"), {})
+        with create_file_handler(rad=rad) as file_handler:
+            res = file_handler.get_dataset(
+                make_dataid(name="C05", calibration="counts"), {}
+            )
 
         # We expect the raw data to be unchanged
         expected = res.data
@@ -400,24 +423,7 @@ class Test_NC_ABI_L1B_raw_cal(Test_NC_ABI_L1B_Base):
         assert res.attrs["long_name"] == "Raw Counts"
 
 
-class Test_NC_ABI_L1B_invalid_cal(Test_NC_ABI_L1B_Base):
-    """Test the NC_ABI_L1B reader with invalid calibration."""
-
-    def test_invalid_calibration(self):
-        """Test detection of invalid calibration values."""
-        # Need to use a custom DataID class because the real DataID class is
-        # smart enough to detect the invalid calibration before the ABI L1B
-        # get_dataset method gets a chance to run.
-        class FakeDataID(dict):
-            def to_dict(self):
-                return self
-
-        with self.assertRaises(ValueError, msg="Did not detect invalid cal"):
-            did = FakeDataID(name="C05", calibration="invalid", modifiers=())
-            self.file_handler.get_dataset(did, {})
-
-
-class Test_NC_ABI_File(unittest.TestCase):
+class Test_NC_ABI_File:
     """Test file opening."""
 
     @mock.patch("satpy.readers.abi_base.xr")
@@ -434,17 +440,18 @@ class Test_NC_ABI_File(unittest.TestCase):
 class Test_NC_ABI_L1B_H5netcdf(Test_NC_ABI_L1B):
     """Allow h5netcdf peculiarities."""
 
-    def setUp(self):
+    @property
+    def fake_rad(self):
         """Create fake data for the tests."""
         rad_data = np.int16(50)
         rad = xr.DataArray(
             rad_data,
             attrs={
                 "scale_factor": 0.5,
-                "add_offset": -1.,
+                "add_offset": -1.0,
                 "_FillValue": np.array([1002]),
                 "units": "W m-2 um-1 sr-1",
                 "valid_range": (0, 4095),
-            }
+            },
         )
-        super(Test_NC_ABI_L1B_H5netcdf, self).setUp(rad=rad)
+        return rad

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -404,7 +404,7 @@ class Test_NC_ABI_File(unittest.TestCase):
 
         openable_thing = mock.MagicMock()
 
-        NC_ABI_L1B(openable_thing, {"platform_shortname": "g16"}, None)
+        NC_ABI_L1B(openable_thing, {"platform_shortname": "g16"}, {})
         openable_thing.open.assert_called()
 
 

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -51,7 +51,7 @@ def _create_fake_rad_dataarray(
         rad_data = (rad_data + 1.0) / 0.5
         rad_data = rad_data.astype(np.int16)
         rad = xr.DataArray(
-            rad_data,
+            da.from_array(rad_data),
             dims=("y", "x"),
             attrs={
                 "scale_factor": 0.5,
@@ -212,7 +212,7 @@ class Test_NC_ABI_L1B:
         Needs to be an instance method so the subclass can override it.
 
         """
-        return None
+        return None  # use default from file handler creator
 
     def test_basic_attributes(self):
         """Test getting basic file attributes."""
@@ -315,14 +315,16 @@ class Test_NC_ABI_L1B_ir_cal:
 
 
 @contextlib.contextmanager
-def _ir_file_handler(
-    data: da.Array | None = None, clip_negative_radiances: bool = False
-):
+def _ir_file_handler(clip_negative_radiances: bool = False):
     """Create fake data for the tests."""
-    if data is None:
-        data = _fake_ir_data()
+    values = np.arange(10.0)
+    rad_data = (values.reshape((2, 5)) + 1.0) * 50.0
+    rad_data[0, 0] = -0.0001  # introduce below minimum expected radiance
+    rad_data = (rad_data + 1.3) / 0.5
+    data = rad_data.astype(np.int16)
+
     rad = xr.DataArray(
-        data,
+        da.from_array(data),
         dims=("y", "x"),
         attrs={
             "scale_factor": 0.5,
@@ -340,14 +342,6 @@ def _ir_file_handler(
         yield file_handler
 
 
-def _fake_ir_data():
-    values = np.arange(10.0)
-    rad_data = (values.reshape((2, 5)) + 1.0) * 50.0
-    rad_data[0, 0] = -0.0001  # introduce below minimum expected radiance
-    rad_data = (rad_data + 1.3) / 0.5
-    return rad_data.astype(np.int16)
-
-
 class Test_NC_ABI_L1B_vis_cal:
     """Test the NC_ABI_L1B reader."""
 
@@ -357,7 +351,7 @@ class Test_NC_ABI_L1B_vis_cal:
         rad_data = (rad_data + 1.0) / 0.5
         rad_data = rad_data.astype(np.int16)
         rad = xr.DataArray(
-            rad_data,
+            da.from_array(rad_data),
             dims=("y", "x"),
             attrs={
                 "scale_factor": 0.5,
@@ -392,7 +386,7 @@ class Test_NC_ABI_L1B_raw_cal:
         rad_data = (rad_data + 1.0) / 0.5
         rad_data = rad_data.astype(np.int16)
         rad = xr.DataArray(
-            rad_data,
+            da.from_array(rad_data),
             dims=("y", "x"),
             attrs={
                 "scale_factor": 0.5,
@@ -445,7 +439,7 @@ class Test_NC_ABI_L1B_H5netcdf(Test_NC_ABI_L1B):
         """Create fake data for the tests."""
         rad_data = np.int16(50)
         rad = xr.DataArray(
-            rad_data,
+            da.from_array(rad_data),
             attrs={
                 "scale_factor": 0.5,
                 "add_offset": -1.0,

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -576,6 +576,25 @@ def ignore_invalid_float_warnings():
         yield
 
 
+@contextlib.contextmanager
+def ignore_pyproj_proj_warnings():
+    """Wrap operations that we know will produce a PROJ.4 precision warning.
+
+    Only to be used internally to Pyresample when we have no other choice but
+    to use PROJ.4 strings/dicts. For example, serialization to YAML or other
+    human-readable formats or testing the methods that produce the PROJ.4
+    versions of the CRS.
+
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            "You will likely lose important projection information",
+            UserWarning,
+        )
+        yield
+
+
 def get_chunk_size_limit(dtype=float):
     """Compute the chunk size limit in bytes given *dtype* (float by default).
 


### PR DESCRIPTION
Add resolution-based chunking to the ABI L1b reader and switch default data type to 32-bit floats. This is similar to #2052 and #2584, but for the ABI L1b reader. This PR was a little more difficult than those as we are using `xr.open_dataset` here so we can't tell xarray what chunk size we want and have it be on-disk-chunk aligned. I cheat by having the on-disk chunk size hardcoded. Without this we'd end up with misaligned resolution chunks which defeats the purpose of this PR. I noticed that full disk files have a chunk size of 226 (consistently) and CONUS and M1/M2 are 250.

Edit: CSPP Geo GRB is configured to produce on-disk chunks of 226 for all sectors.

Additionally, I changed the default processing to produce 32-bit floats instead of 64-bit floats since the extra precision for non-x/y variables should be unnecessary.

Lastly, I rewrote the L1b tests. They didn't make it possible to test what I needed to test and there is a lot sense duplicate code now.

TODO:

* Actually add tests for the dtype and chunk size changes

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
