### PR TITLE
Fix unnecessary Dask `compute()`s in `NDVIHybridGreen` compositor

### DIFF
--- a/satpy/composites/spectral.py
+++ b/satpy/composites/spectral.py
@@ -18,8 +18,6 @@
 import logging
 import warnings
 
-import dask.array as da
-
 from satpy.composites import GenericCompositor
 from satpy.dataset import combine_metadata
 
@@ -166,8 +164,7 @@ class NDVIHybridGreen(SpectralBlender):
 
         ndvi = (ndvi_input[1] - ndvi_input[0]) / (ndvi_input[1] + ndvi_input[0])
 
-        ndvi.data = da.where(ndvi > self.ndvi_min, ndvi, self.ndvi_min)
-        ndvi.data = da.where(ndvi < self.ndvi_max, ndvi, self.ndvi_max)
+        ndvi = ndvi.clip(self.ndvi_min, self.ndvi_max)
 
         # Introduce non-linearity to ndvi for non-linear scaling to NIR blend fraction
         if self.strength != 1.0:  # self._apply_strength() has no effect if strength = 1.0 -> no non-linear behaviour

--- a/satpy/tests/compositor_tests/test_spectral.py
+++ b/satpy/tests/compositor_tests/test_spectral.py
@@ -127,7 +127,10 @@ class TestNdviHybridGreenCompositor:
                                    prerequisites=(0.51, 0.65, 0.85),
                                    standard_name="toa_bidirectional_reflectance")
 
-            res = comp((self.c01, self.c02, self.c03)).compute()
+            res = comp((self.c01, self.c02, self.c03))
+            res_np = res.data.compute()
+            assert res.dtype == res_np.dtype
+            assert res.dtype == np.float32
         np.testing.assert_array_almost_equal(res.data, np.array([[0.2646, 0.3075], [0.2120, 0.3471]]), decimal=4)
 
     def test_invalid_strength(self):

--- a/satpy/tests/compositor_tests/test_spectral.py
+++ b/satpy/tests/compositor_tests/test_spectral.py
@@ -115,8 +115,6 @@ class TestNdviHybridGreenCompositor:
         with dask.config.set(scheduler=CustomScheduler(max_computes=1)):
             comp = NDVIHybridGreen("ndvi_hybrid_green", limits=(0.15, 0.05), prerequisites=(0.51, 0.65, 0.85),
                                    standard_name="toa_bidirectional_reflectance")
-
-            # Test General functionality with linear strength (=1.0)
             res = comp((self.c01, self.c02, self.c03)).compute()
         assert res.data.dtype == np.float32
 

--- a/satpy/tests/compositor_tests/test_spectral.py
+++ b/satpy/tests/compositor_tests/test_spectral.py
@@ -120,7 +120,7 @@ class TestNdviHybridGreenCompositor:
             res = comp((self.c01, self.c02, self.c03)).compute()
         assert res.data.dtype == np.float32
 
-    def test_nonliniear_scaling(self):
+    def test_nonlinear_scaling(self):
         """Test non-linear scaling using `strength` term."""
         with dask.config.set(scheduler=CustomScheduler(max_computes=1)):
             comp = NDVIHybridGreen("ndvi_hybrid_green", limits=(0.15, 0.05), strength=2.0,


### PR DESCRIPTION
The `NDVIHybridGreenCompositor` was using `da.where()` on a `DataArray` to replace values outside limits causing unnecessary computations. This PR replaces these two calls with a `DataArray.clip()` and adds checks in the tests that there is only one computation and only when it is requested.

 - [x] Closes #2619 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests adjusted <!-- for all bug fixes or enhancements -->
