### PR TITLE
Move FSFile to separate module and add some reader type annotations

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
           - types-pkg-resources
           - types-PyYAML
           - types-requests
+          - typing_extensions  # Remove when Python 3.9 is dropped
         args: ["--python-version", "3.9", "--ignore-missing-imports"]
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -20,25 +20,38 @@ from __future__ import annotations
 
 import logging
 import os
-import pickle  # nosec B403
 import warnings
 from datetime import datetime, timedelta
-from functools import total_ordering
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterable, Sequence
 
+try:
+    from typing import TypeAlias  # type: ignore
+except ImportError:
+    # python <=3.9
+    from typing_extensions import TypeAlias
+
+import fsspec.core
 import yaml
 from yaml import UnsafeLoader
 
 from satpy._config import config_search_paths, get_entry_points_config_dirs, glob_config
 
+from ._fsfile import FSFile
 from .yaml_reader import AbstractYAMLReader
 from .yaml_reader import load_yaml_configs as load_yaml_reader_configs
 
 LOG = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    # type aliases (TypeAlias added to stdlib in Python 3.10)
+    SatpyPathLike: TypeAlias = FSFile | fsspec.core.OpenFile | Path | str
+    ReaderName: TypeAlias = str
+    ReaderKwargs: TypeAlias = dict[str, Any]
 
 # Old Name -> New Name
 PENDING_OLD_READER_NAMES = {"fci_l1c_fdhsi": "fci_l1c_nc", "viirs_l2_cloud_mask_nc": "viirs_edr"}
-OLD_READER_NAMES: dict[str, str] = {}
+OLD_READER_NAMES: dict[ReaderName, ReaderName] = {}
 
 
 def group_files(files_to_sort, reader=None, time_threshold=10,
@@ -528,14 +541,18 @@ def _get_loadables_for_reader_config(base_dir, reader, sensor, reader_configs,
     return (reader_instance, loadables, sensor_supported)
 
 
-def load_readers(filenames=None, reader=None, reader_kwargs=None):
+def load_readers(
+        filenames: Iterable[SatpyPathLike] | dict[ReaderName, Iterable[SatpyPathLike]] | None = None,
+        reader: ReaderName | Sequence[ReaderName] | None = None,
+        reader_kwargs: ReaderKwargs | dict[ReaderName | None, ReaderKwargs] | None = None,
+) -> dict[ReaderName, Any]:
     """Create specified readers and assign files to them.
 
     Args:
-        filenames (iterable or dict): A sequence of files that will be used to load data from. A ``dict`` object
-                                      should map reader names to a list of filenames for that reader.
-        reader (str or list): The name of the reader to use for loading the data or a list of names.
-        reader_kwargs (dict): Keyword arguments to pass to specific reader instances.
+        filenames: A sequence of files that will be used to load data from. A ``dict`` object
+            should map reader names to a list of filenames for that reader.
+        reader: The name of the reader to use for loading the data or a list of names.
+        reader_kwargs: Keyword arguments to pass to specific reader instances.
             This can either be a single dictionary that will be passed to all
             reader instances, or a mapping of reader names to dictionaries.  If
             the keys of ``reader_kwargs`` match exactly the list of strings in
@@ -627,13 +644,17 @@ def _check_reader_instances(reader_instances):
                          "provided files match the filter parameters.")
 
 
-def _get_reader_kwargs(reader, reader_kwargs):
+def _get_reader_kwargs(
+        reader: ReaderName | None,
+        reader_kwargs: ReaderKwargs | dict[ReaderName | None, ReaderKwargs] | None,
+) -> tuple[dict[ReaderName | None, ReaderKwargs], dict[ReaderName | None, ReaderKwargs]]:
     """Help load_readers to form reader_kwargs.
 
     Helper for load_readers to get reader_kwargs and
     reader_kwargs_without_filter in the desirable form.
     """
-    reader_kwargs = reader_kwargs or {}
+    if reader_kwargs is None:
+        reader_kwargs = {}
 
     # ensure one reader_kwargs per reader, None if not provided
     if reader is None:
@@ -647,134 +668,6 @@ def _get_reader_kwargs(reader, reader_kwargs):
         reader_kwargs_without_filter[k].pop("filter_parameters", None)
 
     return (reader_kwargs, reader_kwargs_without_filter)
-
-
-@total_ordering
-class FSFile(os.PathLike):
-    """Implementation of a PathLike file object, that can be opened.
-
-    Giving the filenames to :class:`Scene` with valid transfer protocols will automatically
-    use this class so manual usage of this class is needed mainly for fine-grained control.
-
-    This class is made to be used in conjuction with fsspec or s3fs. For example::
-
-        from satpy import Scene
-
-        import fsspec
-        filename = 'noaa-goes16/ABI-L1b-RadC/2019/001/17/*_G16_s20190011702186*'
-
-        the_files = fsspec.open_files("simplecache::s3://" + filename, s3={'anon': True})
-
-        from satpy.readers import FSFile
-        fs_files = [FSFile(open_file) for open_file in the_files]
-
-        scn = Scene(filenames=fs_files, reader='abi_l1b')
-        scn.load(['true_color_raw'])
-
-    """
-
-    def __init__(self, file, fs=None):
-        """Initialise the FSFile instance.
-
-        Args:
-            file (str, Pathlike, or OpenFile):
-                String, object implementing the `os.PathLike` protocol, or
-                an `fsspec.OpenFile` instance.  If passed an instance of
-                `fsspec.OpenFile`, the following argument ``fs`` has no
-                effect.
-            fs (fsspec filesystem, optional)
-                Object implementing the fsspec filesystem protocol.
-        """
-        self._fs_open_kwargs = _get_fs_open_kwargs(file)
-        try:
-            self._file = file.path
-            self._fs = file.fs
-        except AttributeError:
-            self._file = file
-            self._fs = fs
-
-    def __str__(self):
-        """Return the string version of the filename."""
-        return os.fspath(self._file)
-
-    def __fspath__(self):
-        """Comply with PathLike."""
-        return os.fspath(self._file)
-
-    def __repr__(self):
-        """Representation of the object."""
-        return '<FSFile "' + str(self._file) + '">'
-
-    def open(self, *args, **kwargs):
-        """Open the file.
-
-        This is read-only.
-        """
-        fs_open_kwargs = self._update_with_fs_open_kwargs(kwargs)
-        try:
-            return self._fs.open(self._file, *args, **fs_open_kwargs)
-        except AttributeError:
-            return open(self._file, *args, **kwargs)
-
-    def _update_with_fs_open_kwargs(self, user_kwargs):
-        """Complement keyword arguments for opening a file via file system."""
-        kwargs = user_kwargs.copy()
-        kwargs.update(self._fs_open_kwargs)
-        return kwargs
-
-    def __lt__(self, other):
-        """Implement ordering.
-
-        Ordering is defined by the string representation of the filename,
-        without considering the file system.
-        """
-        return os.fspath(self) < os.fspath(other)
-
-    def __eq__(self, other):
-        """Implement equality comparisons.
-
-        Two FSFile instances are considered equal if they have the same
-        filename and the same file system.
-        """
-        return (isinstance(other, FSFile) and
-                self._file == other._file and
-                self._fs == other._fs)
-
-    def __hash__(self):
-        """Implement hashing.
-
-        Make FSFile objects hashable, so that they can be used in sets.  Some
-        parts of satpy and perhaps others use sets of filenames (strings or
-        pathlib.Path), or maybe use them as dictionary keys.  This requires
-        them to be hashable.  To ensure FSFile can work as a drop-in
-        replacement for strings of Path objects to represent the location of
-        blob of data, FSFile should be hashable too.
-
-        Returns the hash, computed from the hash of the filename and the hash
-        of the filesystem.
-        """
-        try:
-            fshash = hash(self._fs)
-        except TypeError:  # fsspec < 0.8.8 for CachingFileSystem
-            fshash = hash(pickle.dumps(self._fs))  # nosec B403
-        return hash(self._file) ^ fshash
-
-
-def _get_fs_open_kwargs(file):
-    """Get keyword arguments for opening a file via file system.
-
-    For example compression.
-    """
-    return {
-        "compression": _get_compression(file)
-    }
-
-
-def _get_compression(file):
-    try:
-        return file.compression
-    except AttributeError:
-        return None
 
 
 def open_file_or_filename(unknown_file_thing):

--- a/satpy/readers/_fsfile.py
+++ b/satpy/readers/_fsfile.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+import pickle  # nosec B403
+from functools import total_ordering
+
+
+@total_ordering
+class FSFile(os.PathLike):
+    """Implementation of a PathLike file object, that can be opened.
+
+    Giving the filenames to :class:`Scene` with valid transfer protocols will automatically
+    use this class so manual usage of this class is needed mainly for fine-grained control.
+
+    This class is made to be used in conjuction with fsspec or s3fs. For example::
+
+        from satpy import Scene
+
+        import fsspec
+        filename = 'noaa-goes16/ABI-L1b-RadC/2019/001/17/*_G16_s20190011702186*'
+
+        the_files = fsspec.open_files("simplecache::s3://" + filename, s3={'anon': True})
+
+        from satpy.readers import FSFile
+        fs_files = [FSFile(open_file) for open_file in the_files]
+
+        scn = Scene(filenames=fs_files, reader='abi_l1b')
+        scn.load(['true_color_raw'])
+
+    """
+
+    def __init__(self, file, fs=None):
+        """Initialise the FSFile instance.
+
+        Args:
+            file (str, Pathlike, or OpenFile):
+                String, object implementing the `os.PathLike` protocol, or
+                an `fsspec.OpenFile` instance.  If passed an instance of
+                `fsspec.OpenFile`, the following argument ``fs`` has no
+                effect.
+            fs (fsspec filesystem, optional)
+                Object implementing the fsspec filesystem protocol.
+        """
+        self._fs_open_kwargs = _get_fs_open_kwargs(file)
+        try:
+            self._file = file.path
+            self._fs = file.fs
+        except AttributeError:
+            self._file = file
+            self._fs = fs
+
+    def __str__(self):
+        """Return the string version of the filename."""
+        return os.fspath(self._file)
+
+    def __fspath__(self):
+        """Comply with PathLike."""
+        return os.fspath(self._file)
+
+    def __repr__(self):
+        """Representation of the object."""
+        return '<FSFile "' + str(self._file) + '">'
+
+    def open(self, *args, **kwargs):
+        """Open the file.
+
+        This is read-only.
+        """
+        fs_open_kwargs = self._update_with_fs_open_kwargs(kwargs)
+        try:
+            return self._fs.open(self._file, *args, **fs_open_kwargs)
+        except AttributeError:
+            return open(self._file, *args, **kwargs)
+
+    def _update_with_fs_open_kwargs(self, user_kwargs):
+        """Complement keyword arguments for opening a file via file system."""
+        kwargs = user_kwargs.copy()
+        kwargs.update(self._fs_open_kwargs)
+        return kwargs
+
+    def __lt__(self, other):
+        """Implement ordering.
+
+        Ordering is defined by the string representation of the filename,
+        without considering the file system.
+        """
+        return os.fspath(self) < os.fspath(other)
+
+    def __eq__(self, other):
+        """Implement equality comparisons.
+
+        Two FSFile instances are considered equal if they have the same
+        filename and the same file system.
+        """
+        return (isinstance(other, FSFile) and
+                self._file == other._file and
+                self._fs == other._fs)
+
+    def __hash__(self):
+        """Implement hashing.
+
+        Make FSFile objects hashable, so that they can be used in sets.  Some
+        parts of satpy and perhaps others use sets of filenames (strings or
+        pathlib.Path), or maybe use them as dictionary keys.  This requires
+        them to be hashable.  To ensure FSFile can work as a drop-in
+        replacement for strings of Path objects to represent the location of
+        blob of data, FSFile should be hashable too.
+
+        Returns the hash, computed from the hash of the filename and the hash
+        of the filesystem.
+        """
+        try:
+            fshash = hash(self._fs)
+        except TypeError:  # fsspec < 0.8.8 for CachingFileSystem
+            fshash = hash(pickle.dumps(self._fs))  # nosec B403
+        return hash(self._file) ^ fshash
+
+
+def _get_fs_open_kwargs(file):
+    """Get keyword arguments for opening a file via file system.
+
+    For example compression.
+    """
+    return {
+        "compression": _get_compression(file)
+    }
+
+
+def _get_compression(file):
+    try:
+        return file.compression
+    except AttributeError:
+        return None


### PR DESCRIPTION
This is me playing with type annotations for some of the ugliness that is reader creation. This got...interesting. If you thought you hated type annotations before, just look at these changes.

Oh yeah, I moved `FSFile` to a sub-module.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
