### PR TITLE
Fix ABI readers using wrong dtype for resolution-based chunks

### DIFF
--- a/satpy/readers/abi_base.py
+++ b/satpy/readers/abi_base.py
@@ -94,10 +94,10 @@ class NC_ABI_BASE(BaseFileHandler):
         # this is true for all CSPP Geo GRB output (226 for all sectors) and full disk from other sources
         # 250 has been seen for AWS/CLASS CONUS, Mesoscale 1, and Mesoscale 2 files
         # we align this with 4 on-disk chunks at 500m, so it will be 2 on-disk chunks for 1km, and 1 for 2km
-        high_res_elems_disk_aligned = np.round(max(num_high_res_elems_per_dim / (4 * 226), 1)) * (4 * 226)
+        high_res_elems_disk_aligned = round(max(num_high_res_elems_per_dim / (4 * 226), 1)) * (4 * 226)
         low_res_factor = int(self.filetype_info.get("resolution", 2000) // 500)
         res_elems_per_dim = int(high_res_elems_disk_aligned / low_res_factor)
-        return (res_elems_per_dim ** 2) * 4
+        return (res_elems_per_dim ** 2) * 2  # 16-bit integers on disk
 
     @staticmethod
     def _rename_dims(nc):

--- a/satpy/tests/reader_tests/test_abi_l1b.py
+++ b/satpy/tests/reader_tests/test_abi_l1b.py
@@ -136,18 +136,14 @@ def generate_l1b_filename(chan_name: str) -> str:
 
 @pytest.fixture()
 def c01_refl(tmp_path) -> xr.DataArray:
-    # 4 bytes for 32-bit floats
-    # 4 on-disk chunks for 500 meter data
-    # 226 on-disk chunk size
-    # Square (**2) for 2D size
-    with dask.config.set({"array.chunk-size": ((226 * 4) ** 2) * 4}):
+    with _apply_dask_chunk_size():
         reader = _create_reader_for_data(tmp_path, "C01", None, 1000)
         return reader.load(["C01"])["C01"]
 
 
 @pytest.fixture()
 def c01_rad(tmp_path) -> xr.DataArray:
-    with dask.config.set({"array.chunk-size": ((226 * 4) ** 2) * 4}):
+    with _apply_dask_chunk_size():
         reader = _create_reader_for_data(tmp_path, "C01", None, 1000)
         return reader.load([DataQuery(name="C01", calibration="radiance")])["C01"]
 
@@ -169,14 +165,14 @@ def c01_rad_h5netcdf(tmp_path) -> xr.DataArray:
             "valid_range": (0, 4095),
         },
     )
-    with dask.config.set({"array.chunk-size": ((226 * 4) ** 2) * 4}):
+    with _apply_dask_chunk_size():
         reader = _create_reader_for_data(tmp_path, "C01", rad, 1000)
         return reader.load([DataQuery(name="C01", calibration="radiance")])["C01"]
 
 
 @pytest.fixture()
 def c01_counts(tmp_path) -> xr.DataArray:
-    with dask.config.set({"array.chunk-size": ((226 * 4) ** 2) * 4}):
+    with _apply_dask_chunk_size():
         reader = _create_reader_for_data(tmp_path, "C01", None, 1000)
         return reader.load([DataQuery(name="C01", calibration="counts")])["C01"]
 
@@ -187,7 +183,7 @@ def c07_bt_creator(tmp_path) -> Callable:
         clip_negative_radiances: bool = False,
     ):
         rad = _fake_c07_data()
-        with dask.config.set({"array.chunk-size": ((226 * 4) ** 2) * 4}):
+        with _apply_dask_chunk_size():
             reader = _create_reader_for_data(
                 tmp_path,
                 "C07",
@@ -241,14 +237,22 @@ def _create_reader_for_data(
     return load_readers([str(data_path)], "abi_l1b", reader_kwargs=reader_kwargs)["abi_l1b"]
 
 
+def _apply_dask_chunk_size():
+    # 226 on-disk chunk size
+    # 8 on-disk chunks for 500 meter data
+    # Square (**2) for 2D size
+    # 4 bytes for 32-bit floats
+    return dask.config.set({"array.chunk-size": ((226 * 8) ** 2) * 4})
+
+
 def _get_and_check_array(data_arr: xr.DataArray, exp_dtype: npt.DTypeLike) -> npt.NDArray:
     data_np = data_arr.data.compute()
     assert isinstance(data_arr, xr.DataArray)
     assert isinstance(data_arr.data, da.Array)
     assert isinstance(data_np, np.ndarray)
     res = 1000 if RAD_SHAPE[1000][0] == data_np.shape[0] else 2000
-    assert data_arr.chunks[0][0] == 226 * (4 / (res / 500))
-    assert data_arr.chunks[1][0] == 226 * (4 / (res / 500))
+    assert data_arr.chunks[0][0] == 226 * (8 / (res / 500))
+    assert data_arr.chunks[1][0] == 226 * (8 / (res / 500))
 
     assert data_np.dtype == data_arr.dtype
     assert data_np.dtype == exp_dtype


### PR DESCRIPTION
In-file data is 16-bit so our size has to be based on that. This is a continuation of #2621 where a user on slack (Matthew Scutter) discovered that his performance got worse after that PR. This was because he was using large chunk sizes already and it was making this bug (fixed in this PR) more apparent. As a summary of what's going on and how we compute chunks:

1. Take current dask setting for number of bytes per chunk.
2. Get number of elements in one "square" chunk in one dimension (N elements in an N * N chunk of B bytes for each element).
3. Align this number of elements to be 4 * 226, representing the hardcoded on-disk chunk size of 226 elements and 4 for the highest multiplier of resolution (4 == 500m => 2 for 1km => 1 for 2km).
4. Scale this aligned number of elements to the specific resolution for a specific file type. So divide by 2 for 1km data, or divide by 4 for 2km data, or divide by 1 (no-op) for 500m data (C02).
5. Convert this number of elements back to an amount of memory by squaring it (2D square chunk) and then multiplying by the number of bytes for a single pixel. For our final data this is 4 for a 32-bit float.
6. Temporarily set the dask array.chunk-size setting to this number of bytes.

This 4 in the second to last step is the problem because the files are actually 16-bit integers in the file. So if we do all our calculations for 32-bit floats, give it to dask when xarray open_dataset is called, but dask sees 16-bit integers we'll have chunks that are about 2x the size we want them to be once we end up scaling these 16-bit integers to 32-bit floats with the scale factor and add offset in the file.

This PR fixes this by changing this second to last step to multiply by 2 (2 bytes == 16-bit integers). This should also prevent the issue that Matthew Scutter was seeing where the number of chunks would end up not being aligned depending on the rounding and dividing dask ends up doing. Here's what you see with dask's default of 128MB:

1. 226 on-disk aligned 500 meter band number of bytes: 117679104
2. `sqrt(117679104 / 2)` for 16-bit integers gets you 7670.6944 elements per dimension (not an equal number of elements). So you end up with 33.94113 on-disk chunks to include. So dask needs to choose 33 or 34 on-disk chunks (it actually chooses 33).
3. For the 1km band that would be 29419776 bytes => 3835.347181155834 elements per dimension => 16.9706 on-disk chunks (dask chooses 16).
4. For the 2km band it chooses 8 on-disk chunks.

The above points out that since dask is not computing nice round number of elements we get inconsistent and not resolution-aligned chunk sizes (33 on-disk chunks for 500m, 16 for 1km, 8 for 2km).

If after this fix we still don't have consistent chunking someone please tell me as soon as possible.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
