### PR TITLE
Add a reader for MODIS Level 3 files in CMG format.

### DIFF
--- a/satpy/etc/readers/modis_l3.yaml
+++ b/satpy/etc/readers/modis_l3.yaml
@@ -9,7 +9,7 @@ reader:
   sensors: [modis]
 
 file_types:
-  mcd43_cmg_hdf:
+  modis_l3_cmg_hdf:
     file_patterns:
     - 'MCD43C{prod_type}.A{start_time:%Y%j}.{collection:03d}.{production_time:%Y%j%H%M%S}.hdf'
     - 'M{platform_indicator:1s}D09CMG.A{start_time:%Y%j}.{collection:03d}.{production_time:%Y%j%H%M%S}.hdf'

--- a/satpy/etc/readers/modis_l3.yaml
+++ b/satpy/etc/readers/modis_l3.yaml
@@ -1,0 +1,16 @@
+reader:
+  name: modis_l3
+  short_name: MODIS l3
+  long_name: MODIS Level 3 (mcd43) data in HDF-EOS format
+  description: MODIS HDF-EOS L3 Reader
+  status: Beta
+  supports_fsspec: false
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
+  sensors: [modis]
+
+file_types:
+  mcd43_cmg_hdf:
+    file_patterns:
+    - 'MCD43C{prod_type}.A{start_time:%Y%j}.{collection:03d}.{production_time:%Y%j%H%M%S}.hdf'
+    - 'M{platform_indicator:1s}D09CMG.A{start_time:%Y%j}.{collection:03d}.{production_time:%Y%j%H%M%S}.hdf'
+    file_reader: !!python/name:satpy.readers.modis_l3.ModisL3GriddedHDFFileHandler

--- a/satpy/readers/hdfeos_base.py
+++ b/satpy/readers/hdfeos_base.py
@@ -148,10 +148,7 @@ class HDFEOSBaseFileReader(BaseFileHandler):
 
     @classmethod
     def _split_line(cls, line, lines):
-        try:
-            key, val = line.split("=")
-        except ValueError:
-            key, val = line.split("=", maxsplit=1)
+        key, val = line.split("=", maxsplit=1)
         key = key.strip()
         val = val.strip()
         try:

--- a/satpy/readers/hdfeos_base.py
+++ b/satpy/readers/hdfeos_base.py
@@ -148,7 +148,10 @@ class HDFEOSBaseFileReader(BaseFileHandler):
 
     @classmethod
     def _split_line(cls, line, lines):
-        key, val = line.split("=")
+        try:
+            key, val = line.split("=")
+        except ValueError:
+            key, val = line.split("=", maxsplit=1)
         key = key.strip()
         val = val.strip()
         try:

--- a/satpy/readers/modis_l3.py
+++ b/satpy/readers/modis_l3.py
@@ -62,7 +62,6 @@ class ModisL3GriddedHDFFileHandler(HDFEOSGeoReader):
 
     def _sort_grid(self):
         """Get the grid properties."""
-
         # First, get the grid resolution
         self._get_res()
 

--- a/satpy/readers/modis_l3.py
+++ b/satpy/readers/modis_l3.py
@@ -93,12 +93,11 @@ class ModisL3GriddedHDFFileHandler(HDFEOSGeoReader):
 
     def available_datasets(self, configured_datasets=None):
         """Automatically determine datasets provided by this file."""
-        logger.debug("Available_datasets begin...")
-
-        ds_dict = self.sd.datasets()
 
         yield from super().available_datasets(configured_datasets)
         common = {"file_type": "mcd43_cmg_hdf", "resolution": self.resolution}
+        ds_dict = self.sd.datasets()
+
         for key in ds_dict.keys():
             if "/" in key:  # not a dataset
                 continue

--- a/satpy/readers/modis_l3.py
+++ b/satpy/readers/modis_l3.py
@@ -61,9 +61,6 @@ class ModisL3GriddedHDFFileHandler(HDFEOSGeoReader):
             self.resolution = 360. / self.ncols
         else:
             self.resolution = float(gridname[pos:pos2])
-
-
-
     def _sort_grid(self):
         """Get the grid properties."""
 

--- a/satpy/readers/modis_l3.py
+++ b/satpy/readers/modis_l3.py
@@ -116,6 +116,7 @@ class ModisL3GriddedHDFFileHandler(HDFEOSGeoReader):
             if self.file_type_matches(ds_info["file_type"]) is None:
                 # this is not the file type for this dataset
                 yield None, ds_info
+                continue
             yield file_key in ds_dict.keys(), ds_info
 
         yield from self._dynamic_variables_from_file(handled_var_names)

--- a/satpy/readers/modis_l3.py
+++ b/satpy/readers/modis_l3.py
@@ -68,7 +68,7 @@ class ModisL3GriddedHDFFileHandler(HDFEOSGeoReader):
 
         # For some reason, a few of the CMG products multiply their
         # decimal degree extents by one million. This fixes it.
-        if lowerright[0] > 1e6:
+        if lowerright[0] > 1e6 or upperleft[0] > 1e6:
             upperleft = tuple(val / 1e6 for val in upperleft)
             lowerright = tuple(val / 1e6 for val in lowerright)
 

--- a/satpy/readers/modis_l3.py
+++ b/satpy/readers/modis_l3.py
@@ -127,6 +127,5 @@ class ModisL3GriddedHDFFileHandler(HDFEOSGeoReader):
                                        self.ncols,
                                        self.nrows,
                                        self.area_extent)
-        self.area = area
 
-        return self.area
+        return area

--- a/satpy/readers/modis_l3.py
+++ b/satpy/readers/modis_l3.py
@@ -37,10 +37,8 @@ import logging
 from pyresample import geometry
 
 from satpy.readers.hdfeos_base import HDFEOSGeoReader
-from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
-CHUNK_SIZE = get_legacy_chunk_size()
 
 
 class ModisL3GriddedHDFFileHandler(HDFEOSGeoReader):
@@ -61,6 +59,7 @@ class ModisL3GriddedHDFFileHandler(HDFEOSGeoReader):
             self.resolution = 360. / self.ncols
         else:
             self.resolution = float(gridname[pos:pos2])
+
     def _sort_grid(self):
         """Get the grid properties."""
 
@@ -77,7 +76,7 @@ class ModisL3GriddedHDFFileHandler(HDFEOSGeoReader):
             upperleft = tuple(val / 1e6 for val in upperleft)
             lowerright = tuple(val / 1e6 for val in lowerright)
 
-        self.area_extent = (upperleft[0], lowerright[1], lowerright[0], upperleft[1])
+        return (upperleft[0], lowerright[1], lowerright[0], upperleft[1])
 
 
     def __init__(self, filename, filename_info, filetype_info, **kwargs):
@@ -89,7 +88,7 @@ class ModisL3GriddedHDFFileHandler(HDFEOSGeoReader):
         self.ncols = self.metadata["GridStructure"]["GRID_1"]["XDim"]
 
         # Get the grid name and other projection info
-        self._sort_grid()
+        self.area_extent = self._sort_grid()
 
 
     def available_datasets(self, configured_datasets=None):

--- a/satpy/readers/modis_l3.py
+++ b/satpy/readers/modis_l3.py
@@ -98,8 +98,6 @@ class ModisL3GriddedHDFFileHandler(HDFEOSGeoReader):
         # Initialise set of variable names to carry through code
         handled_var_names = set()
 
-        yield from super().available_datasets(configured_datasets)
-
         ds_dict = self.sd.datasets()
 
         for is_avail, ds_info in (configured_datasets or []):

--- a/satpy/readers/modis_l3.py
+++ b/satpy/readers/modis_l3.py
@@ -21,12 +21,13 @@ Introduction
 ------------
 
 The ``modis_l3`` reader reads Modis L3 products in hdf-eos format.
-Since there are a multitude of different level 3 datasets not all of theses are implemented (yet).
 
+There are multiple level 3 products, including some on sinusoidal grids and some on the climate modeling grid (CMG).
+This reader supports the CMG products at present, and the sinusoidal products will be added if there is demand.
 
-Currently the reader supports:
-    - mcd43c1: BRDF/Albedo Model Parameters dataset
-    - mcd43c3: BRDF/Albedo Albedo dataset
+The reader has been tested with:
+    - MCD43c*: BRDF/Albedo data, such as parameters, albedo and nbar
+    - MOD09CMG: Surface Reflectance on climate monitoring grid.
 
 To get a list of the available datasets for a given file refer to the "Load data" section in :doc:`../reading`.
 

--- a/satpy/readers/modis_l3.py
+++ b/satpy/readers/modis_l3.py
@@ -20,7 +20,7 @@
 Introduction
 ------------
 
-The ``modis_l3`` reader reads Modis L3 products in hdf-eos format.
+The ``modis_l3`` reader reads MODIS L3 products in HDF-EOS format.
 
 There are multiple level 3 products, including some on sinusoidal grids and some on the climate modeling grid (CMG).
 This reader supports the CMG products at present, and the sinusoidal products will be added if there is demand.

--- a/satpy/readers/modis_l3.py
+++ b/satpy/readers/modis_l3.py
@@ -61,10 +61,21 @@ class ModisL3GriddedHDFFileHandler(HDFEOSGeoReader):
         # Get the grid resolution
         pos = gridname.rfind("_") + 1
         pos2 = gridname.rfind("Deg")
-        self.resolution = float(gridname[pos:pos2])
+
+        # Some products don't have resolution listed.
+        if pos < 0 or pos2 < 0:
+            self.resolution = 360. / self.ncols
+        else:
+            self.resolution = float(gridname[pos:pos2])
 
         upperleft = self.metadata["GridStructure"]["GRID_1"]["UpperLeftPointMtrs"]
         lowerright = self.metadata["GridStructure"]["GRID_1"]["LowerRightMtrs"]
+
+        # For some reason, a few of the CMG products multiply their
+        # decimal degree extents by one million. This fixes it.
+        if lowerright[0] > 1e6:
+            upperleft = tuple(val / 1e6 for val in upperleft)
+            lowerright = tuple(val / 1e6 for val in lowerright)
 
         self.area_extent = (upperleft[0], lowerright[1], lowerright[0], upperleft[1])
 

--- a/satpy/readers/modis_l3.py
+++ b/satpy/readers/modis_l3.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Modis level 3 hdf-eos format reader.
+
+Introduction
+------------
+
+The ``modis_l3`` reader reads Modis L3 products in hdf-eos format.
+Since there are a multitude of different level 3 datasets not all of theses are implemented (yet).
+
+
+Currently the reader supports:
+    - mcd43c1: BRDF/Albedo Model Parameters dataset
+    - mcd43c3: BRDF/Albedo Albedo dataset
+
+To get a list of the available datasets for a given file refer to the "Load data" section in :doc:`../reading`.
+
+"""
+import logging
+
+from pyresample import geometry
+
+from satpy.readers.hdfeos_base import HDFEOSGeoReader
+from satpy.utils import get_legacy_chunk_size
+
+logger = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
+
+
+class ModisL3GriddedHDFFileHandler(HDFEOSGeoReader):
+    """File handler for MODIS HDF-EOS Level 3 CMG gridded files."""
+
+    def __init__(self, filename, filename_info, filetype_info, **kwargs):
+        """Init the file handler."""
+        super().__init__(filename, filename_info, filetype_info, **kwargs)
+
+        # Initialise number of rows and columns
+        self.nrows = self.metadata["GridStructure"]["GRID_1"]["YDim"]
+        self.ncols = self.metadata["GridStructure"]["GRID_1"]["XDim"]
+
+        # Get the grid name and other projection info
+        gridname = self.metadata["GridStructure"]["GRID_1"]["GridName"]
+        if "CMG" not in gridname:
+            raise ValueError("Only CMG grids are supported")
+
+        # Get the grid resolution
+        pos = gridname.rfind("_") + 1
+        pos2 = gridname.rfind("Deg")
+        self.resolution = float(gridname[pos:pos2])
+
+        upperleft = self.metadata["GridStructure"]["GRID_1"]["UpperLeftPointMtrs"]
+        lowerright = self.metadata["GridStructure"]["GRID_1"]["LowerRightMtrs"]
+
+        self.area_extent = (upperleft[0], lowerright[1], lowerright[0], upperleft[1])
+
+
+    def available_datasets(self, configured_datasets=None):
+        """Automatically determine datasets provided by this file."""
+        logger.debug("Available_datasets begin...")
+
+        ds_dict = self.sd.datasets()
+
+        yield from super().available_datasets(configured_datasets)
+        common = {"file_type": "mcd43_cmg_hdf", "resolution": self.resolution}
+        for key in ds_dict.keys():
+            if "/" in key:  # not a dataset
+                continue
+            yield True, {"name": key} | common
+
+    def get_dataset(self, dataset_id, dataset_info):
+        """Get DataArray for specified dataset."""
+        dataset_name = dataset_id["name"]
+        dataset = self.load_dataset(dataset_name, dataset_info.pop("category", False))
+        self._add_satpy_metadata(dataset_id, dataset)
+
+        return dataset
+
+
+    def get_area_def(self, dsid):
+        """Get the area definition.
+
+        This is fixed, but not defined in the file. So we must
+        generate it ourselves with some assumptions.
+        """
+        proj_param = "EPSG:4326"
+
+        area = geometry.AreaDefinition("gridded_modis",
+                                       "A gridded L3 MODIS area",
+                                       "longlat",
+                                       proj_param,
+                                       self.ncols,
+                                       self.nrows,
+                                       self.area_extent)
+        self.area = area
+
+        return self.area

--- a/satpy/readers/viirs_edr.py
+++ b/satpy/readers/viirs_edr.py
@@ -215,6 +215,7 @@ class VIIRSJRRFileHandler(BaseFileHandler):
             if self.file_type_matches(ds_info["file_type"]) is None:
                 # this is not the file type for this dataset
                 yield None, ds_info
+                continue
             yield file_key in self.nc, ds_info
 
         yield from self._dynamic_variables_from_file(handled_var_names)

--- a/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
+++ b/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
@@ -249,7 +249,7 @@ def create_hdfeos_test_file(filename: str,
     if metadata_dict is not None and metadata_dict != {}:
         # Check if we're dealing with an L3 file
         if "l3_type" not in metadata_dict.keys():
-            if "file_shortname" not in metadata_dict["file_shortname"].keys():
+            if "file_shortname" not in metadata_dict.keys():
                 raise ValueError("'file_shortname' is required when including metadata.")
             # For L1 and L2 files we need to know the resolution
             if "geo_resolution" not in metadata_dict.keys():

--- a/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
+++ b/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
@@ -365,7 +365,9 @@ def _create_struct_metadata_cmg(res) -> str:
 
 
 def _create_header_metadata() -> str:
-    archive_metadata_header = "GROUP = ARCHIVEDMETADATA\nEND_GROUP = ARCHIVEDMETADATA\nEND"
+    archive_metadata_header = ("GROUP = ARCHIVEDMETADATA\n"
+                               'TEST_URL = "http://modis.gsfc.nasa.gov/?some_val=100"\n'
+                               "END_GROUP = ARCHIVEDMETADATA\nEND")
     return archive_metadata_header
 
 

--- a/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
+++ b/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
@@ -19,6 +19,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import Optional
 
 import numpy as np
 import pytest
@@ -227,9 +228,9 @@ def generate_imapp_filename(suffix):
 
 def create_hdfeos_test_file(filename: str,
                             variable_infos: dict,
-                            struct_meta: str = "",
-                            core_meta: str = "",
-                            archive_meta: str = "",
+                            struct_meta: Optional[str] = None,
+                            core_meta: Optional[str] = None,
+                            archive_meta: Optional[str] = None,
                             ) -> None:
     """Create a fake MODIS L1b HDF4 file with headers.
 
@@ -244,11 +245,11 @@ def create_hdfeos_test_file(filename: str,
     """
     h = SD(filename, SDC.WRITE | SDC.CREATE)
 
-    if struct_meta != "":
+    if struct_meta:
         setattr(h, "StructMetadata.0", struct_meta)
-    if core_meta != "":
+    if core_meta:
         setattr(h, "CoreMetadata.0", core_meta)
-    if archive_meta != "":
+    if archive_meta:
         setattr(h, "ArchiveMetadata.0", archive_meta)
 
     for var_name, var_info in variable_infos.items():

--- a/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
+++ b/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
@@ -596,23 +596,33 @@ def generate_nasa_l3_filename(prefix: str) -> str:
     return f"{prefix}.A{now:%Y%j}.061.{now:%Y%j%H%M%S}.hdf"
 
 
+def modis_l3_file(tmpdir_factory, f_prefix, var_name, geo_res, f_short):
+    """Create a MODIS L3 file of the desired type."""
+    filename = generate_nasa_l3_filename(f_prefix)
+    full_path = str(tmpdir_factory.mktemp("modis_l3").join(filename))
+    variable_infos = _get_l3_refl_variable_info(var_name)
+    create_hdfeos_test_file(full_path, variable_infos, geo_resolution=geo_res, file_shortname=f_short)
+    return [full_path]
+
+
 @pytest.fixture(scope="session")
 def modis_l3_nasa_mod09_file(tmpdir_factory) -> list[str]:
     """Create a single MOD09 L3 HDF4 file with headers."""
-    filename = generate_nasa_l3_filename("MOD09CMG")
-    full_path = str(tmpdir_factory.mktemp("modis_l3").join(filename))
-    variable_infos = _get_l3_refl_variable_info("Coarse_Resolution_Surface_Reflectance_Band_2")
-    create_hdfeos_test_file(full_path, variable_infos, geo_resolution=-999, file_shortname="MOD09")
-    return [full_path]
+    return modis_l3_file(tmpdir_factory,
+                         "MOD09CMG",
+                         "Coarse_Resolution_Surface_Reflectance_Band_2",
+                         -999,
+                         "MOD09")
+
 
 @pytest.fixture(scope="session")
 def modis_l3_nasa_mod43_file(tmpdir_factory) -> list[str]:
-    """Create a single MOD09 L3 HDF4 file with headers."""
-    filename = generate_nasa_l3_filename("MCD43C1")
-    full_path = str(tmpdir_factory.mktemp("modis_l3").join(filename))
-    variable_infos = _get_l3_refl_variable_info("BRDF_Albedo_Parameter1_Band2")
-    create_hdfeos_test_file(full_path, variable_infos, geo_resolution=-9999, file_shortname="MCD43C1")
-    return [full_path]
+    """Create a single MVCD43 L3 HDF4 file with headers."""
+    return modis_l3_file(tmpdir_factory,
+                         "MCD43C1",
+                         "BRDF_Albedo_Parameter1_Band2",
+                         -9999,
+                         "MCD43C1")
 
 
 @pytest.fixture(scope="session")

--- a/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
+++ b/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
@@ -228,7 +228,7 @@ def generate_imapp_filename(suffix):
 
 def create_hdfeos_test_file(filename: str,
                             variable_infos: dict,
-                            metadata_dict: Optional[dict] = {}):
+                            metadata_dict: Optional[dict] = None):
     """Create a fake MODIS L1b HDF4 file with headers.
 
     Args:

--- a/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
+++ b/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
@@ -229,6 +229,16 @@ def generate_imapp_filename(suffix):
     return f"t1.{now:%y%j.%H%M}.{suffix}.hdf"
 
 
+def _add_geo_metadata(h, geo_res):
+    """Add the geoinfo metadata to the fake file."""
+    if geo_res == -999 or geo_res == -9999:
+        setattr(h, 'StructMetadata.0', _create_struct_metadata_cmg(geo_res))  # noqa
+    else:
+        setattr(h, 'StructMetadata.0', _create_struct_metadata(geo_res))  # noqa
+
+    return h
+
+
 def create_hdfeos_test_file(filename: str,
                             variable_infos: dict,
                             geo_resolution: Optional[int] = None,
@@ -254,10 +264,7 @@ def create_hdfeos_test_file(filename: str,
     if include_metadata:
         if geo_resolution is None or file_shortname is None:
             raise ValueError("'geo_resolution' and 'file_shortname' are required when including metadata.")
-        elif geo_resolution == -999 or geo_resolution == -9999:
-            setattr(h, 'StructMetadata.0', _create_struct_metadata_cmg(geo_resolution))  # noqa
-        else:
-            setattr(h, 'StructMetadata.0', _create_struct_metadata(geo_resolution))  # noqa
+        h = _add_geo_metadata(h, geo_resolution)
         setattr(h, 'CoreMetadata.0', _create_core_metadata(file_shortname))  # noqa
         setattr(h, 'ArchiveMetadata.0', _create_header_metadata())  # noqa
 
@@ -344,16 +351,16 @@ def _create_struct_metadata_cmg(res) -> str:
         upright = "LowerRightMtrs=(180.000000,-90.000000)\n"
 
     struct_metadata_header = ("GROUP=SwathStructure\n"
-                             "END_GROUP=SwathStructure\n"
-                             "GROUP=GridStructure\n"
-                                "GROUP=GRID_1\n"
-                                    f"{gridline}\n"
-                                    "XDim=7200\n"
-                                    "YDim=3600\n"
-                                    f"{upleft}\n"
-                                    f"{upright}\n"
-                                "END_GROUP=GRID_1\n"
-                             "END_GROUP=GridStructure\nEND")
+                              "END_GROUP=SwathStructure\n"
+                              "GROUP=GridStructure\n"
+                              "GROUP=GRID_1\n"
+                              f"{gridline}\n"
+                              "XDim=7200\n"
+                              "YDim=3600\n"
+                              f"{upleft}\n"
+                              f"{upright}\n"
+                              "END_GROUP=GRID_1\n"
+                              "END_GROUP=GridStructure\nEND")
     return struct_metadata_header
 
 

--- a/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
+++ b/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
@@ -254,11 +254,11 @@ def create_hdfeos_test_file(filename: str,
     if include_metadata:
         if geo_resolution is None or file_shortname is None:
             raise ValueError("'geo_resolution' and 'file_shortname' are required when including metadata.")
-        setattr(h, 'CoreMetadata.0', _create_core_metadata(file_shortname))  # noqa
-        if geo_resolution == -999 or geo_resolution == -9999:
+        elif geo_resolution == -999 or geo_resolution == -9999:
             setattr(h, 'StructMetadata.0', _create_struct_metadata_cmg(geo_resolution))  # noqa
         else:
             setattr(h, 'StructMetadata.0', _create_struct_metadata(geo_resolution))  # noqa
+        setattr(h, 'CoreMetadata.0', _create_core_metadata(file_shortname))  # noqa
         setattr(h, 'ArchiveMetadata.0', _create_header_metadata())  # noqa
 
     for var_name, var_info in variable_infos.items():

--- a/satpy/tests/reader_tests/modis_tests/conftest.py
+++ b/satpy/tests/reader_tests/modis_tests/conftest.py
@@ -32,4 +32,6 @@ from ._modis_fixtures import (  # noqa: F401, I001
     modis_l2_nasa_mod06_file,
     modis_l2_nasa_mod35_file,
     modis_l2_nasa_mod35_mod03_files,
+    modis_l3_nasa_mod09_file,
+    modis_l3_nasa_mod43_file,
 )

--- a/satpy/tests/reader_tests/modis_tests/test_modis_l3.py
+++ b/satpy/tests/reader_tests/modis_tests/test_modis_l3.py
@@ -63,6 +63,29 @@ class TestModisL3:
         assert len(available_datasets) > 0
         assert loadable in available_datasets
 
+        from satpy.readers.modis_l3 import ModisL3GriddedHDFFileHandler
+        fh = ModisL3GriddedHDFFileHandler(filename[0], {}, {"file_type": "modis_l3_cmg_hdf"})
+        configured_datasets = [[None, {"name": "none_ds", "file_type": "modis_l3_cmg_hdf"}],
+                               [True, {"name": "true_ds", "file_type": "modis_l3_cmg_hdf"}],
+                               [False, {"name": "false_ds", "file_type": "modis_l3_cmg_hdf"}],
+                               [None, {"name": "other_ds", "file_type": "modis_l2_random"}]]
+        for status, mda in fh.available_datasets(configured_datasets):
+            if mda["name"] == "none_ds":
+                assert mda["file_type"] == "modis_l3_cmg_hdf"
+                assert status is False
+            elif mda["name"] == "true_ds":
+                assert mda["file_type"] == "modis_l3_cmg_hdf"
+                assert status
+            elif mda["name"] == "false_ds":
+                assert mda["file_type"] == "modis_l3_cmg_hdf"
+                assert status is False
+            elif mda["name"] == "other_ds":
+                assert mda["file_type"] == "modis_l2_random"
+                assert status is None
+            elif mda["name"] == loadable:
+                assert mda["file_type"] == "modis_l3_cmg_hdf"
+                assert status
+
     def test_load_l3_dataset(self, modis_l3_nasa_mod09_file):
         """Load and check an L2 variable."""
         scene = Scene(reader="modis_l3", filenames=modis_l3_nasa_mod09_file)

--- a/satpy/tests/reader_tests/modis_tests/test_modis_l3.py
+++ b/satpy/tests/reader_tests/modis_tests/test_modis_l3.py
@@ -27,8 +27,6 @@ from pytest_lazyfixture import lazy_fixture
 
 from satpy import Scene, available_readers
 
-from ._modis_fixtures import _shape_for_resolution
-
 
 def _expected_area():
     proj_param = "EPSG:4326"
@@ -101,6 +99,6 @@ class TestModisL3:
         assert data_arr_comp.dtype == data_arr.dtype
         assert data_arr_comp.dtype == np.float32
 
-        assert data_arr_comp.shape == _shape_for_resolution(-999)
+        assert data_arr_comp.shape == (3600, 7200)
         assert data_arr_comp.attrs.get("resolution") == 0.05
         assert data_arr_comp.attrs.get("area") == _expected_area()

--- a/satpy/tests/reader_tests/modis_tests/test_modis_l3.py
+++ b/satpy/tests/reader_tests/modis_tests/test_modis_l3.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Unit tests for MODIS L3 HDF reader."""
+
+from __future__ import annotations
+
+import dask.array as da
+import pytest
+from pyresample import geometry
+from pytest_lazyfixture import lazy_fixture
+
+from satpy import Scene, available_readers
+
+from ._modis_fixtures import _shape_for_resolution
+
+
+def _expected_area():
+    proj_param = "EPSG:4326"
+
+    return geometry.AreaDefinition("gridded_modis",
+                                   "A gridded L3 MODIS area",
+                                   "longlat",
+                                   proj_param,
+                                   7200,
+                                   3600,
+                                   (-180, -90, 180, 90))
+
+
+class TestModisL3:
+    """Test MODIS L3 reader."""
+
+    def test_available_reader(self):
+        """Test that MODIS L3 reader is available."""
+        assert "modis_l3" in available_readers()
+
+    @pytest.mark.parametrize(
+        ("loadable", "filename"),
+        [
+            ("Coarse_Resolution_Surface_Reflectance_Band_2", lazy_fixture("modis_l3_nasa_mod09_file")),
+            ("BRDF_Albedo_Parameter1_Band2",lazy_fixture("modis_l3_nasa_mod43_file")),
+        ]
+    )
+    def test_scene_available_datasets(self, loadable, filename):
+        """Test that datasets are available."""
+        scene = Scene(reader="modis_l3", filenames=filename)
+        available_datasets = scene.all_dataset_names()
+        assert len(available_datasets) > 0
+        assert loadable in available_datasets
+
+    def test_load_l3_dataset(self, modis_l3_nasa_mod09_file):
+        """Load and check an L2 variable."""
+        scene = Scene(reader="modis_l3", filenames=modis_l3_nasa_mod09_file)
+
+        ds_name = "Coarse_Resolution_Surface_Reflectance_Band_2"
+        scene.load([ds_name])
+
+        data_arr = scene[ds_name]
+        assert isinstance(data_arr.data, da.Array)
+        data_arr = data_arr.compute()
+
+        assert data_arr.shape == _shape_for_resolution(-999)
+        assert data_arr.attrs.get("resolution") == 0.05
+        assert data_arr.attrs.get("area") == _expected_area()

--- a/satpy/tests/reader_tests/modis_tests/test_modis_l3.py
+++ b/satpy/tests/reader_tests/modis_tests/test_modis_l3.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import dask.array as da
+import numpy as np
 import pytest
 from pyresample import geometry
 from pytest_lazyfixture import lazy_fixture
@@ -71,8 +72,12 @@ class TestModisL3:
 
         data_arr = scene[ds_name]
         assert isinstance(data_arr.data, da.Array)
-        data_arr = data_arr.compute()
+        data_arr_comp = data_arr.compute()
 
-        assert data_arr.shape == _shape_for_resolution(-999)
-        assert data_arr.attrs.get("resolution") == 0.05
-        assert data_arr.attrs.get("area") == _expected_area()
+        # Check types
+        assert data_arr_comp.dtype == data_arr.dtype
+        assert data_arr_comp.dtype == np.float32
+
+        assert data_arr_comp.shape == _shape_for_resolution(-999)
+        assert data_arr_comp.attrs.get("resolution") == 0.05
+        assert data_arr_comp.attrs.get("area") == _expected_area()

--- a/satpy/tests/reader_tests/modis_tests/test_modis_l3.py
+++ b/satpy/tests/reader_tests/modis_tests/test_modis_l3.py
@@ -53,7 +53,7 @@ class TestModisL3:
         ("loadable", "filename"),
         [
             ("Coarse_Resolution_Surface_Reflectance_Band_2", lazy_fixture("modis_l3_nasa_mod09_file")),
-            ("BRDF_Albedo_Parameter1_Band2",lazy_fixture("modis_l3_nasa_mod43_file")),
+            ("BRDF_Albedo_Parameter1_Band2", lazy_fixture("modis_l3_nasa_mod43_file")),
         ]
     )
     def test_scene_available_datasets(self, loadable, filename):

--- a/satpy/tests/reader_tests/test_viirs_edr.py
+++ b/satpy/tests/reader_tests/test_viirs_edr.py
@@ -285,6 +285,33 @@ def _create_fake_dataset(vars_dict: dict[str, xr.DataArray]) -> xr.Dataset:
     return ds
 
 
+def test_available_datasets(aod_file):
+    """Test that available datasets doesn't claim non-filetype datasets.
+
+    For example, if a YAML-configured dataset's file type is not loaded
+    then the available status is `None` and should remain `None`. This
+    means no file type knows what to do with this dataset. If it is
+    `False` then that means that a file type knows of the dataset, but
+    that the variable is not available in the file. In the below test
+    this isn't the case so the YAML-configured dataset should be
+    provided once and have a `None` availability.
+
+    """
+    from satpy.readers.viirs_edr import VIIRSJRRFileHandler
+    file_handler = VIIRSJRRFileHandler(
+        aod_file,
+        {"platform_shortname": "npp"},
+        {"file_type": "jrr_aod"},
+    )
+    fake_yaml_datasets = [
+        (None, {"file_key": "fake", "file_type": "fake_file", "name": "fake"}),
+    ]
+    available_datasets = list(file_handler.available_datasets(configured_datasets=fake_yaml_datasets))
+    fake_availables = [avail_tuple for avail_tuple in available_datasets if avail_tuple[1]["name"] == "fake"]
+    assert len(fake_availables) == 1
+    assert fake_availables[0][0] is None
+
+
 class TestVIIRSJRRReader:
     """Test the VIIRS JRR L2 reader."""
 


### PR DESCRIPTION
This PR adds a reader for MODIS Level 3 (daily / monthly / etc) products on the climate monitoring grid.

I'd like feedback on the change I made to `hdfeos_base.py`. The CMG data has metadata containing URLs with `=` signs, which confuses the `_split_line` method. My change means that only the first `=` is used to split strings, with the subsequent ones assumed as part of the metadata.
Personally, I don't think the `try...except` is needed as there should only ever be one important `=` in each string. But I wrote it this way in case there's some problem I've not thought of. Opinions welcome.


 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented 