### PR TITLE
Fix nwcsaf_geo start time to be nominal time

### DIFF
--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -372,7 +372,10 @@ class NcNWCSAF(BaseFileHandler):
     @property
     def start_time(self):
         """Return the start time of the object."""
-        return read_nwcsaf_time(self.nc.attrs["time_coverage_start"])
+        try:
+            return read_nwcsaf_time(self.nc.attrs["nominal_product_time"])
+        except KeyError:
+            return read_nwcsaf_time(self.nc.attrs["time_coverage_start"])
 
     @property
     def end_time(self):

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -44,6 +44,7 @@ dimensions = {"nx": 1530,
               "pal_rgb": 3}
 
 NOMINAL_LONGITUDE = 0.0
+NOMINAL_TIME = "2023-01-18T10:30:00Z"
 START_TIME = "2023-01-18T10:39:17Z"
 END_TIME = "2023-01-18T10:42:22Z"
 START_TIME_PPS = "20230118T103917000Z"
@@ -56,6 +57,9 @@ global_attrs = {"source": "NWC/GEO version v2021.1",
                 "time_coverage_end": END_TIME}
 
 global_attrs.update(PROJ)
+
+global_attrs_geo = global_attrs.copy()
+global_attrs_geo["nominal_product_time"] = NOMINAL_TIME
 
 CTTH_PALETTE_MEANINGS = ("0 500 1000 1500")
 
@@ -90,7 +94,7 @@ def nwcsaf_geo_ct_filename(tmp_path_factory):
     return create_nwcsaf_geo_ct_file(tmp_path_factory.mktemp("data"))
 
 
-def create_nwcsaf_geo_ct_file(directory, attrs=global_attrs):
+def create_nwcsaf_geo_ct_file(directory, attrs=global_attrs_geo):
     """Create a CT file."""
     filename = directory / "S_NWC_CT_MSG4_MSG-N-VISIR_20230118T103000Z_PLAX.nc"
     with h5netcdf.File(filename, mode="w") as nc_file:
@@ -227,7 +231,7 @@ def nwcsaf_pps_cpp_filehandler(nwcsaf_pps_cpp_filename):
 @pytest.fixture(scope="session")
 def nwcsaf_old_geo_ct_filename(tmp_path_factory):
     """Create a CT file and return the filename."""
-    attrs = global_attrs.copy()
+    attrs = global_attrs_geo.copy()
     attrs.update(PROJ_KM)
     attrs["time_coverage_start"] = np.array(["2023-01-18T10:39:17Z"], dtype="S20")
     return create_nwcsaf_geo_ct_file(tmp_path_factory.mktemp("data-old"), attrs=attrs)
@@ -343,7 +347,7 @@ class TestNcNWCSAFGeo:
 
     def test_start_time(self, nwcsaf_geo_ct_filehandler):
         """Test the start time property."""
-        assert nwcsaf_geo_ct_filehandler.start_time == read_nwcsaf_time(START_TIME)
+        assert nwcsaf_geo_ct_filehandler.start_time == read_nwcsaf_time(NOMINAL_TIME)
 
     def test_end_time(self, nwcsaf_geo_ct_filehandler):
         """Test the end time property."""


### PR DESCRIPTION
NWCSAF GEO file contain a different time for start of time coverage and nominal time. This PR makes the reader choose the nominal time when available.

 - [x] Tests added <!-- for all bug fixes or enhancements -->

