### PR TITLE
Keep original dtype in DayNightCompositor

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -869,7 +869,7 @@ def _get_single_channel(data: xr.DataArray) -> xr.DataArray:
 
 
 def _get_weight_mask_for_single_side_product(data_a, data_b):
-    if isinstance(data_a, int):
+    if data_b.shape:
         return ~da.isnan(data_b)
     return ~da.isnan(data_a)
 

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -713,9 +713,7 @@ class DayNightCompositor(GenericCompositor):
         datasets = self.match_data_arrays(datasets)
         # At least one composite is requested.
         foreground_data = datasets[0]
-
         weights = self._get_coszen_blending_weights(datasets)
-
         # Apply enhancements to the foreground data
         foreground_data = enhance2dataset(foreground_data)
 
@@ -759,7 +757,6 @@ class DayNightCompositor(GenericCompositor):
         # Calculate blending weights
         coszen -= np.min((lim_high, lim_low))
         coszen /= np.abs(lim_low - lim_high)
-
         return coszen.clip(0, 1)
 
     def _get_data_for_single_side_product(
@@ -786,8 +783,8 @@ class DayNightCompositor(GenericCompositor):
 
     def _get_day_night_data_for_single_side_product(self, foreground_data):
         if "day" in self.day_night:
-            return foreground_data, 0
-        return 0, foreground_data
+            return foreground_data, foreground_data.dtype.type(0)
+        return foreground_data.dtype.type(0), foreground_data
 
     def _get_data_for_combined_product(self, day_data, night_data):
         # Apply enhancements also to night-side data
@@ -848,15 +845,16 @@ class DayNightCompositor(GenericCompositor):
 def _get_band_names(day_data, night_data):
     try:
         bands = day_data["bands"]
-    except TypeError:
+    except (IndexError, TypeError):
         bands = night_data["bands"]
     return bands
 
 
 def _get_single_band_data(data, band):
-    if isinstance(data, int):
+    try:
+        return data.sel(bands=band)
+    except AttributeError:
         return data
-    return data.sel(bands=band)
 
 
 def _get_single_channel(data: xr.DataArray) -> xr.DataArray:
@@ -894,7 +892,8 @@ def add_alpha_bands(data):
         alpha = new_data[0].copy()
         alpha.data = da.ones((data.sizes["y"],
                               data.sizes["x"]),
-                             chunks=new_data[0].chunks)
+                             chunks=new_data[0].chunks,
+                             dtype=data.dtype)
         # Rename band to indicate it's alpha
         alpha["bands"] = "A"
         new_data.append(alpha)

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -403,8 +403,9 @@ def get_cos_sza(data_arr: xr.DataArray) -> xr.DataArray:
     """
     chunks = _geo_chunks_from_data_arr(data_arr)
     lons, lats = _get_valid_lonlats(data_arr.attrs["area"], chunks)
-    lons = lons.astype(data_arr.dtype)
-    lats = lats.astype(data_arr.dtype)
+    if lons.dtype != data_arr.dtype and np.issubdtype(data_arr.dtype, np.floating):
+        lons = lons.astype(data_arr.dtype)
+        lats = lats.astype(data_arr.dtype)
     cos_sza = _get_cos_sza(data_arr.attrs["start_time"], lons, lats)
     return _geo_dask_to_data_array(cos_sza)
 

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -395,6 +395,8 @@ def get_cos_sza(data_arr: xr.DataArray) -> xr.DataArray:
     """
     chunks = _geo_chunks_from_data_arr(data_arr)
     lons, lats = _get_valid_lonlats(data_arr.attrs["area"], chunks)
+    lons = lons.astype(data_arr.dtype)
+    lats = lats.astype(data_arr.dtype)
     cos_sza = _get_cos_sza(data_arr.attrs["start_time"], lons, lats)
     return _geo_dask_to_data_array(cos_sza)
 

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -490,7 +490,6 @@ class TestDayNightCompositor(unittest.TestCase):
             res = comp((self.data_b,))
             res = res.compute()
         expected_l_channel = np.array([[np.nan, 0.], [0.5, 1.]], dtype=np.float32)
-        # FIXME: with the current changes the np.nan becomes 0.0 instead, why?!
         expected_alpha = np.array([[np.nan, 0.], [0., 0.]], dtype=np.float32)
         assert res.dtype == np.float32
         np.testing.assert_allclose(res.values[0], expected_l_channel)

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -437,7 +437,7 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="day_night")
             res = comp((self.data_a, self.data_b, self.sza))
             res = res.compute()
-        expected = np.array([[0., 0.22122352], [0.5, 1.]], dtype=np.float32)
+        expected = np.array([[0., 0.22122374], [0.5, 1.]], dtype=np.float32)
         assert res.dtype == np.float32
         np.testing.assert_allclose(res.values[0], expected, rtol=1e-6)
 
@@ -462,7 +462,7 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="night_only", include_alpha=True)
             res = comp((self.data_b, self.sza))
             res = res.compute()
-        expected_red_channel = np.array([[np.nan, 0.], [0.49999994, 1.]], dtype=np.float32)
+        expected_red_channel = np.array([[np.nan, 0.], [0.5, 1.]], dtype=np.float32)
         expected_alpha = np.array([[0., 0.3329599], [1., 1.]], dtype=np.float32)
         assert res.dtype == np.float32
         np.testing.assert_allclose(res.values[0], expected_red_channel)
@@ -476,7 +476,7 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="night_only", include_alpha=False)
             res = comp((self.data_a, self.sza))
             res = res.compute()
-        expected = np.array([[0., 0.11042608], [0.6683501, 1.]], dtype=np.float32)
+        expected = np.array([[0., 0.11042609], [0.6683502, 1.]], dtype=np.float32)
         assert res.dtype == np.float32
         np.testing.assert_allclose(res.values[0], expected)
         assert "A" not in res.bands
@@ -558,7 +558,7 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="day_only", include_alpha=True)
             res = comp((self.data_b,))
             res = res.compute()
-        expected_l_channel = np.array([[np.nan, 0.], [0.49999994, 1.]], dtype=np.float32)
+        expected_l_channel = np.array([[np.nan, 0.], [0.5, 1.]], dtype=np.float32)
         expected_alpha = np.array([[np.nan, 1.], [1., 1.]], dtype=np.float32)
         assert res.dtype == np.float32
         np.testing.assert_allclose(res.values[0], expected_l_channel)

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -396,7 +396,7 @@ class TestDayNightCompositor(unittest.TestCase):
         start_time = datetime(2018, 1, 1, 18, 0, 0)
 
         # RGB
-        a = np.zeros((3, 2, 2), dtype=np.float64)
+        a = np.zeros((3, 2, 2), dtype=np.float32)
         a[:, 0, 0] = 0.1
         a[:, 0, 1] = 0.2
         a[:, 1, 0] = 0.3
@@ -404,7 +404,7 @@ class TestDayNightCompositor(unittest.TestCase):
         a = da.from_array(a, a.shape)
         self.data_a = xr.DataArray(a, attrs={"test": "a", "start_time": start_time},
                                    coords={"bands": bands}, dims=("bands", "y", "x"))
-        b = np.zeros((3, 2, 2), dtype=np.float64)
+        b = np.zeros((3, 2, 2), dtype=np.float32)
         b[:, 0, 0] = np.nan
         b[:, 0, 1] = 0.25
         b[:, 1, 0] = 0.50
@@ -413,7 +413,7 @@ class TestDayNightCompositor(unittest.TestCase):
         self.data_b = xr.DataArray(b, attrs={"test": "b", "start_time": start_time},
                                    coords={"bands": bands}, dims=("bands", "y", "x"))
 
-        sza = np.array([[80., 86.], [94., 100.]])
+        sza = np.array([[80., 86.], [94., 100.]], dtype=np.float32)
         sza = da.from_array(sza, sza.shape)
         self.sza = xr.DataArray(sza, dims=("y", "x"))
 
@@ -437,8 +437,9 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="day_night")
             res = comp((self.data_a, self.data_b, self.sza))
             res = res.compute()
-        expected = np.array([[0., 0.22122352], [0.5, 1.]])
-        np.testing.assert_allclose(res.values[0], expected)
+        expected = np.array([[0., 0.22122352], [0.5, 1.]], dtype=np.float32)
+        assert res.dtype == np.float32
+        np.testing.assert_allclose(res.values[0], expected, rtol=1e-6)
 
     def test_daynight_area(self):
         """Test compositor both day and night portions when SZA data is not provided."""
@@ -448,7 +449,8 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="day_night")
             res = comp((self.data_a, self.data_b))
             res = res.compute()
-        expected_channel = np.array([[0., 0.33164983], [0.66835017, 1.]])
+        expected_channel = np.array([[0., 0.33164983], [0.66835017, 1.]], dtype=np.float32)
+        assert res.dtype == np.float32
         for i in range(3):
             np.testing.assert_allclose(res.values[i], expected_channel)
 
@@ -460,8 +462,9 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="night_only", include_alpha=True)
             res = comp((self.data_b, self.sza))
             res = res.compute()
-        expected_red_channel = np.array([[np.nan, 0.], [0.5, 1.]])
-        expected_alpha = np.array([[0., 0.33296056], [1., 1.]])
+        expected_red_channel = np.array([[np.nan, 0.], [0.49999994, 1.]], dtype=np.float32)
+        expected_alpha = np.array([[0., 0.3329599], [1., 1.]], dtype=np.float32)
+        assert res.dtype == np.float32
         np.testing.assert_allclose(res.values[0], expected_red_channel)
         np.testing.assert_allclose(res.values[-1], expected_alpha)
 
@@ -473,7 +476,8 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="night_only", include_alpha=False)
             res = comp((self.data_a, self.sza))
             res = res.compute()
-        expected = np.array([[0., 0.11042631], [0.66835017, 1.]])
+        expected = np.array([[0., 0.11042608], [0.6683501, 1.]], dtype=np.float32)
+        assert res.dtype == np.float32
         np.testing.assert_allclose(res.values[0], expected)
         assert "A" not in res.bands
 
@@ -485,8 +489,10 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="night_only", include_alpha=True)
             res = comp((self.data_b,))
             res = res.compute()
-        expected_l_channel = np.array([[np.nan, 0.], [0.5, 1.]])
-        expected_alpha = np.array([[np.nan, 0.], [0., 0.]])
+        expected_l_channel = np.array([[np.nan, 0.], [0.49999994, 1.]], dtype=np.float32)
+        # FIXME: with the current changes the np.nan becomes 0.0 instead, why?!
+        expected_alpha = np.array([[np.nan, 0.], [0., 0.]], dtype=np.float32)
+        assert res.dtype == np.float32
         np.testing.assert_allclose(res.values[0], expected_l_channel)
         np.testing.assert_allclose(res.values[-1], expected_alpha)
 
@@ -498,7 +504,8 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="night_only", include_alpha=False)
             res = comp((self.data_b,))
             res = res.compute()
-        expected = np.array([[np.nan, 0.], [0., 0.]])
+        expected = np.array([[np.nan, 0.], [0., 0.]], dtype=np.float32)
+        assert res.dtype == np.float32
         np.testing.assert_allclose(res.values[0], expected)
         assert "A" not in res.bands
 
@@ -510,8 +517,9 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="day_only", include_alpha=True)
             res = comp((self.data_a, self.sza))
             res = res.compute()
-        expected_red_channel = np.array([[0., 0.33164983], [0.66835017, 1.]])
-        expected_alpha = np.array([[1., 0.66703944], [0., 0.]])
+        expected_red_channel = np.array([[0., 0.33164983], [0.66835017, 1.]], dtype=np.float32)
+        expected_alpha = np.array([[1., 0.6670401], [0., 0.]], dtype=np.float32)
+        assert res.dtype == np.float32
         np.testing.assert_allclose(res.values[0], expected_red_channel)
         np.testing.assert_allclose(res.values[-1], expected_alpha)
 
@@ -523,7 +531,8 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="day_only", include_alpha=False)
             res = comp((self.data_a, self.sza))
             res = res.compute()
-        expected_channel_data = np.array([[0., 0.22122352], [0., 0.]])
+        expected_channel_data = np.array([[0., 0.22122373], [0., 0.]], dtype=np.float32)
+        assert res.dtype == np.float32
         for i in range(3):
             np.testing.assert_allclose(res.values[i], expected_channel_data)
         assert "A" not in res.bands
@@ -536,8 +545,9 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="day_only", include_alpha=True)
             res = comp((self.data_a,))
             res = res.compute()
-        expected_l_channel = np.array([[0., 0.33164983], [0.66835017, 1.]])
-        expected_alpha = np.array([[1., 1.], [1., 1.]])
+        expected_l_channel = np.array([[0., 0.33164983], [0.66835017, 1.]], dtype=np.float32)
+        expected_alpha = np.array([[1., 1.], [1., 1.]], dtype=np.float32)
+        assert res.dtype == np.float32
         np.testing.assert_allclose(res.values[0], expected_l_channel)
         np.testing.assert_allclose(res.values[-1], expected_alpha)
 
@@ -549,8 +559,9 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="day_only", include_alpha=True)
             res = comp((self.data_b,))
             res = res.compute()
-        expected_l_channel = np.array([[np.nan, 0.], [0.5, 1.]])
-        expected_alpha = np.array([[np.nan, 1.], [1., 1.]])
+        expected_l_channel = np.array([[np.nan, 0.], [0.49999994, 1.]], dtype=np.float32)
+        expected_alpha = np.array([[np.nan, 1.], [1., 1.]], dtype=np.float32)
+        assert res.dtype == np.float32
         np.testing.assert_allclose(res.values[0], expected_l_channel)
         np.testing.assert_allclose(res.values[-1], expected_alpha)
 
@@ -562,7 +573,8 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="day_only", include_alpha=False)
             res = comp((self.data_a,))
             res = res.compute()
-        expected = np.array([[0., 0.33164983], [0.66835017, 1.]])
+        expected = np.array([[0., 0.33164983], [0.66835017, 1.]], dtype=np.float32)
+        assert res.dtype == np.float32
         np.testing.assert_allclose(res.values[0], expected)
         assert "A" not in res.bands
 

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -489,7 +489,7 @@ class TestDayNightCompositor(unittest.TestCase):
             comp = DayNightCompositor(name="dn_test", day_night="night_only", include_alpha=True)
             res = comp((self.data_b,))
             res = res.compute()
-        expected_l_channel = np.array([[np.nan, 0.], [0.49999994, 1.]], dtype=np.float32)
+        expected_l_channel = np.array([[np.nan, 0.], [0.5, 1.]], dtype=np.float32)
         # FIXME: with the current changes the np.nan becomes 0.0 instead, why?!
         expected_alpha = np.array([[np.nan, 0.], [0., 0.]], dtype=np.float32)
         assert res.dtype == np.float32

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -119,13 +119,15 @@ class TestSunZenithCorrector:
             sunz_ds1 = sunz_ds1.astype(np.float32)
         comp = SunZenithCorrector(name="sza_test", modifiers=tuple())
         res = comp((sunz_ds1,), test_attr="test")
-        np.testing.assert_allclose(res.values, np.array([[22.401667, 22.31777], [22.437503, 22.353533]]))
+        np.testing.assert_allclose(res.values, np.array([[22.401667, 22.31777], [22.437503, 22.353533]]),
+                                   rtol=1e-6)
         assert "y" in res.coords
         assert "x" in res.coords
         ds1 = sunz_ds1.copy().drop_vars(("y", "x"))
         res = comp((ds1,), test_attr="test")
         res_np = res.compute()
-        np.testing.assert_allclose(res_np.values, np.array([[22.401667, 22.31777], [22.437503, 22.353533]]))
+        np.testing.assert_allclose(res_np.values, np.array([[22.401667, 22.31777], [22.437503, 22.353533]]),
+                                   rtol=1e-6)
         assert res.dtype == res_np.dtype
         assert "y" not in res.coords
         assert "x" not in res.coords

--- a/satpy/tests/writer_tests/test_ninjogeotiff.py
+++ b/satpy/tests/writer_tests/test_ninjogeotiff.py
@@ -630,7 +630,7 @@ def test_write_and_read_file_units(
     np.testing.assert_allclose(float(tgs["ninjo_Gradient"]),
                                0.467717, rtol=1e-5)
     np.testing.assert_allclose(float(tgs["ninjo_AxisIntercept"]),
-                               -79.86771)
+                               -79.86771, rtol=1e-5)
     fn2 = os.fspath(tmp_path / "test2.tif")
     with caplog.at_level(logging.WARNING):
         ngtw.save_dataset(


### PR DESCRIPTION
This PR is a start to keep the `dtype` of the input data until saving. To have the tests pass, another PR is needed for Trollimage so that the enhancements don't upscale the data.

The tests require https://github.com/pytroll/trollimage/pull/150 to be merged (done) and a new Trollimage release including it. This is a side-effect of the Satpy feature applying a linear stretch by default, and in the current release this up-casts `float32` to `float64`.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
