### PR TITLE
Set dtype for get_lonlats() in NIR reflectance calculation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,12 +78,12 @@ jobs:
           pandas \
           scipy
           mamba remove --force-remove -y pykdtree pyresample trollimage pyhdf netcdf4 h5py
-          python -m pip install --upgrade --no-deps --pre git+https://github.com/takluyver/h5py@cython-3
           python -m pip install --upgrade --no-deps --pre --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \
           git+https://github.com/pytroll/trollimage \
           git+https://github.com/fhs/pyhdf \
+          git+https://github.com/takluyver/h5py@cython-3 \
           git+https://github.com/Unidata/netcdf4-python \
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
           pandas \
           scipy
           mamba remove --force-remove -y pykdtree pyresample
-          python -m pip install --no-deps --upgrade --no-build-isolation \
+          python -m pip install --upgrade --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \
           git+https://github.com/dask/dask \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,8 @@ jobs:
           numpy \
           pandas \
           scipy
-          python -m pip install --no-deps --upgrade --no-build-isolation -vv git+https://github.com/storpipfugl/pykdtree
+          mamba remove --force-remove -y pykdtree
+          python -m pip install --no-deps --upgrade --no-build-isolation -vvv git+https://github.com/storpipfugl/pykdtree
           python -c "from pykdtree.kdtree import KDTree"
           python -m pip install \
           --no-deps --upgrade \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,7 @@ jobs:
           pandas \
           scipy
           mamba remove --force-remove -y pykdtree pyresample trollimage pyhdf netcdf4 h5py
-          python -m pip install --upgrade --no-deps --pre git+https://github.com/h5py/h5py
+          python -m pip install --upgrade --no-deps --pre git+https://github.com/takluyver/h5py@cython-3
           python -m pip install --upgrade --no-deps --pre --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,7 @@ jobs:
           git+https://github.com/rasterio/rasterio \
           git+https://github.com/pydata/bottleneck \
           git+https://github.com/pydata/xarray \
+          git+https://github.com/shapely/shapely \
           git+https://github.com/astropy/astropy
           LD_PRELOAD=$(python -c "import sys; print(sys.prefix)")/lib/libstdc++.so
           echo "LD_PRELOAD=${LD_PRELOAD}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,10 +77,11 @@ jobs:
           numpy \
           pandas \
           scipy
-          mamba remove --force-remove -y pykdtree pyresample
+          mamba remove --force-remove -y pykdtree pyresample trollimage
           python -m pip install --upgrade --no-deps --pre --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \
+          git+https://github.com/pytroll/trollimage \
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \
           git+https://github.com/zarr-developers/zarr \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,11 +78,9 @@ jobs:
           pandas \
           scipy
           mamba remove --force-remove -y pykdtree pyresample
-          python -m pip install --no-deps --upgrade --no-build-isolation -vvv \
+          python -m pip install --no-deps --upgrade --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
-          git+https://github.com/pytroll/pyresample
-          python -m pip install \
-          --no-deps --upgrade \
+          git+https://github.com/pytroll/pyresample \
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \
           git+https://github.com/zarr-developers/zarr \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
         # We must get LD_PRELOAD for stdlibc++ or else the manylinux wheels
         # may break the conda-forge libraries trying to use newer glibc versions
         run: |
-          python -m pip install versioneer
+          python -m pip install versioneer extension-helpers
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
         # We must get LD_PRELOAD for stdlibc++ or else the manylinux wheels
         # may break the conda-forge libraries trying to use newer glibc versions
         run: |
-          python -m pip install versioneer extension-helpers
+          python -m pip install versioneer extension-helpers setuptools-scm configobj
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \
@@ -78,7 +78,7 @@ jobs:
           pandas \
           scipy
           mamba remove --force-remove -y pykdtree pyresample
-          python -m pip install --upgrade --no-build-isolation \
+          python -m pip install --upgrade --no-deps --pre --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \
           git+https://github.com/dask/dask \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,7 @@ jobs:
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \
           git+https://github.com/pytroll/trollimage \
+          git+https://github.com/fhs/pyhdf \
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \
           git+https://github.com/zarr-developers/zarr \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,13 +77,14 @@ jobs:
           numpy \
           pandas \
           scipy
-          mamba remove --force-remove -y pykdtree pyresample trollimage pyhdf netcdf4
+          mamba remove --force-remove -y pykdtree pyresample trollimage pyhdf netcdf4 h5py
           python -m pip install --upgrade --no-deps --pre --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \
           git+https://github.com/pytroll/trollimage \
           git+https://github.com/fhs/pyhdf \
           git+https://github.com/Unidata/netcdf4-python \
+          git+https://github.com/h5py/h5py \
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \
           git+https://github.com/zarr-developers/zarr \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,8 +75,9 @@ jobs:
           matplotlib \
           numpy \
           pandas \
-          scipy; \
-          python -m pip install --no-deps --upgrade --no-build-isolation git+https://github.com/storpipfugl/pykdtree; \
+          scipy
+          python -m pip install --no-deps --upgrade --no-build-isolation -vv git+https://github.com/storpipfugl/pykdtree
+          python -c "from pykdtree.kdtree import KDTree"
           python -m pip install \
           --no-deps --upgrade \
           git+https://github.com/dask/dask \
@@ -86,7 +87,7 @@ jobs:
           git+https://github.com/rasterio/rasterio \
           git+https://github.com/pydata/bottleneck \
           git+https://github.com/pydata/xarray \
-          git+https://github.com/astropy/astropy;
+          git+https://github.com/astropy/astropy
           LD_PRELOAD=$(python -c "import sys; print(sys.prefix)")/lib/libstdc++.so
           echo "LD_PRELOAD=${LD_PRELOAD}" >> $GITHUB_ENV
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,6 +84,7 @@ jobs:
           git+https://github.com/rasterio/rasterio \
           git+https://github.com/pydata/bottleneck \
           git+https://github.com/pydata/xarray \
+          git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/astropy/astropy;
           LD_PRELOAD=$(python -c "import sys; print(sys.prefix)")/lib/libstdc++.so
           echo "LD_PRELOAD=${LD_PRELOAD}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,13 +78,13 @@ jobs:
           pandas \
           scipy
           mamba remove --force-remove -y pykdtree pyresample trollimage pyhdf netcdf4 h5py
+          python -m pip install --upgrade --no-deps --pre git+https://github.com/h5py/h5py
           python -m pip install --upgrade --no-deps --pre --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \
           git+https://github.com/pytroll/trollimage \
           git+https://github.com/fhs/pyhdf \
           git+https://github.com/Unidata/netcdf4-python \
-          git+https://github.com/h5py/h5py \
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \
           git+https://github.com/zarr-developers/zarr \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,7 +68,7 @@ jobs:
         # We must get LD_PRELOAD for stdlibc++ or else the manylinux wheels
         # may break the conda-forge libraries trying to use newer glibc versions
         run: |
-          python -m pip install versioneer extension-helpers setuptools-scm configobj
+          python -m pip install versioneer extension-helpers setuptools-scm configobj pkgconfig
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
           numpy \
           pandas \
           scipy
-          mamba remove --force-remove -y pykdtree pyresample trollimage
+          mamba remove --force-remove -y pykdtree pyresample trollimage pyhdf
           python -m pip install --upgrade --no-deps --pre --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,12 +77,13 @@ jobs:
           numpy \
           pandas \
           scipy
-          mamba remove --force-remove -y pykdtree pyresample trollimage pyhdf
+          mamba remove --force-remove -y pykdtree pyresample trollimage pyhdf netcdf4
           python -m pip install --upgrade --no-deps --pre --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \
           git+https://github.com/pytroll/trollimage \
           git+https://github.com/fhs/pyhdf \
+          git+https://github.com/Unidata/netcdf4-python \
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \
           git+https://github.com/zarr-developers/zarr \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,7 @@ jobs:
       - name: Install unstable dependencies
         if: matrix.experimental == true
         shell: bash -l {0}
+        # Install pykdtree with --no-build-isolation so it builds with numpy 2.0
         # We must get LD_PRELOAD for stdlibc++ or else the manylinux wheels
         # may break the conda-forge libraries trying to use newer glibc versions
         run: |
@@ -75,6 +76,7 @@ jobs:
           numpy \
           pandas \
           scipy; \
+          python -m pip install --no-deps --upgrade --no-build-isolation git+https://github.com/storpipfugl/pykdtree; \
           python -m pip install \
           --no-deps --upgrade \
           git+https://github.com/dask/dask \
@@ -84,7 +86,6 @@ jobs:
           git+https://github.com/rasterio/rasterio \
           git+https://github.com/pydata/bottleneck \
           git+https://github.com/pydata/xarray \
-          git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/astropy/astropy;
           LD_PRELOAD=$(python -c "import sys; print(sys.prefix)")/lib/libstdc++.so
           echo "LD_PRELOAD=${LD_PRELOAD}" >> $GITHUB_ENV

--- a/satpy/modifiers/spectral.py
+++ b/satpy/modifiers/spectral.py
@@ -79,8 +79,8 @@ class NIRReflectance(ModifierBase):
         return proj
 
     def _get_nir_inputs(self, projectables, optional_datasets):
-        nir, _tb11 = projectables
-        da_tb11 = _tb11.data
+        nir, tb11 = projectables
+        da_tb11 = tb11.data
         da_tb13_4 = self._get_tb13_4_from_optionals(optional_datasets)
         da_sun_zenith = self._get_sun_zenith_from_provided_data(nir, optional_datasets, nir.dtype)
         return (nir, da_tb11, da_tb13_4, da_sun_zenith)

--- a/satpy/modifiers/spectral.py
+++ b/satpy/modifiers/spectral.py
@@ -75,7 +75,7 @@ class NIRReflectance(ModifierBase):
         da_nir = _nir.data
         da_tb11 = _tb11.data
         da_tb13_4 = self._get_tb13_4_from_optionals(optional_datasets)
-        da_sun_zenith = self._get_sun_zenith_from_provided_data(projectables, optional_datasets)
+        da_sun_zenith = self._get_sun_zenith_from_provided_data(_nir, optional_datasets, _nir.dtype)
 
         logger.info("Getting reflective part of %s", _nir.attrs["name"])
         reflectance = self._get_reflectance_as_dask(da_nir, da_tb11, da_tb13_4, da_sun_zenith, _nir.attrs)
@@ -95,7 +95,7 @@ class NIRReflectance(ModifierBase):
         return tb13_4
 
     @staticmethod
-    def _get_sun_zenith_from_provided_data(projectables, optional_datasets):
+    def _get_sun_zenith_from_provided_data(_nir, optional_datasets, dtype):
         """Get the sunz from available data or compute it if unavailable."""
         sun_zenith = None
 
@@ -106,8 +106,7 @@ class NIRReflectance(ModifierBase):
         if sun_zenith is None:
             if sun_zenith_angle is None:
                 raise ImportError("Module pyorbital.astronomy needed to compute sun zenith angles.")
-            _nir = projectables[0]
-            lons, lats = _nir.attrs["area"].get_lonlats(chunks=_nir.data.chunks, dtype=_nir.dtype)
+            lons, lats = _nir.attrs["area"].get_lonlats(chunks=_nir.data.chunks, dtype=dtype)
             sun_zenith = sun_zenith_angle(_nir.attrs["start_time"], lons, lats)
         return sun_zenith
 

--- a/satpy/modifiers/spectral.py
+++ b/satpy/modifiers/spectral.py
@@ -107,7 +107,7 @@ class NIRReflectance(ModifierBase):
             if sun_zenith_angle is None:
                 raise ImportError("Module pyorbital.astronomy needed to compute sun zenith angles.")
             _nir = projectables[0]
-            lons, lats = _nir.attrs["area"].get_lonlats(chunks=_nir.data.chunks)
+            lons, lats = _nir.attrs["area"].get_lonlats(chunks=_nir.data.chunks, dtype=_nir.dtype)
             sun_zenith = sun_zenith_angle(_nir.attrs["start_time"], lons, lats)
         return sun_zenith
 

--- a/satpy/modifiers/spectral.py
+++ b/satpy/modifiers/spectral.py
@@ -162,16 +162,16 @@ class NIREmissivePartFromReflectance(NIRReflectance):
 
     def _get_emissivity_as_dataarray(self, projectables, optional_datasets):
         """Get the emissivity as a dataarray."""
-        _nir, _tb11 = projectables
-        da_nir = _nir.data
+        nir, _tb11 = projectables
+        da_nir = nir.data
         da_tb11 = _tb11.data
         da_tb13_4 = self._get_tb13_4_from_optionals(optional_datasets)
-        da_sun_zenith = self._get_sun_zenith_from_provided_data(projectables, optional_datasets)
+        da_sun_zenith = self._get_sun_zenith_from_provided_data(nir, optional_datasets, nir.dtype)
 
-        logger.info("Getting emissive part of %s", _nir.attrs["name"])
-        emissivity = self._get_emissivity_as_dask(da_nir, da_tb11, da_tb13_4, da_sun_zenith, _nir.attrs)
+        logger.info("Getting emissive part of %s", nir.attrs["name"])
+        emissivity = self._get_emissivity_as_dask(da_nir, da_tb11, da_tb13_4, da_sun_zenith, nir.attrs)
 
-        proj = self._create_modified_dataarray(emissivity, base_dataarray=_nir)
+        proj = self._create_modified_dataarray(emissivity, base_dataarray=nir)
         proj.attrs["units"] = "K"
         return proj
 

--- a/satpy/modifiers/spectral.py
+++ b/satpy/modifiers/spectral.py
@@ -71,16 +71,16 @@ class NIRReflectance(ModifierBase):
 
     def _get_reflectance_as_dataarray(self, projectables, optional_datasets):
         """Get the reflectance as a dataarray."""
-        _nir, _tb11 = projectables
-        da_nir = _nir.data
+        nir, _tb11 = projectables
+        da_nir = nir.data
         da_tb11 = _tb11.data
         da_tb13_4 = self._get_tb13_4_from_optionals(optional_datasets)
-        da_sun_zenith = self._get_sun_zenith_from_provided_data(_nir, optional_datasets, _nir.dtype)
+        da_sun_zenith = self._get_sun_zenith_from_provided_data(nir, optional_datasets, nir.dtype)
 
-        logger.info("Getting reflective part of %s", _nir.attrs["name"])
-        reflectance = self._get_reflectance_as_dask(da_nir, da_tb11, da_tb13_4, da_sun_zenith, _nir.attrs)
+        logger.info("Getting reflective part of %s", nir.attrs["name"])
+        reflectance = self._get_reflectance_as_dask(da_nir, da_tb11, da_tb13_4, da_sun_zenith, nir.attrs)
 
-        proj = self._create_modified_dataarray(reflectance, base_dataarray=_nir)
+        proj = self._create_modified_dataarray(reflectance, base_dataarray=nir)
         proj.attrs["units"] = "%"
         return proj
 
@@ -95,7 +95,7 @@ class NIRReflectance(ModifierBase):
         return tb13_4
 
     @staticmethod
-    def _get_sun_zenith_from_provided_data(_nir, optional_datasets, dtype):
+    def _get_sun_zenith_from_provided_data(nir, optional_datasets, dtype):
         """Get the sunz from available data or compute it if unavailable."""
         sun_zenith = None
 
@@ -106,8 +106,8 @@ class NIRReflectance(ModifierBase):
         if sun_zenith is None:
             if sun_zenith_angle is None:
                 raise ImportError("Module pyorbital.astronomy needed to compute sun zenith angles.")
-            lons, lats = _nir.attrs["area"].get_lonlats(chunks=_nir.data.chunks, dtype=dtype)
-            sun_zenith = sun_zenith_angle(_nir.attrs["start_time"], lons, lats)
+            lons, lats = nir.attrs["area"].get_lonlats(chunks=nir.data.chunks, dtype=dtype)
+            sun_zenith = sun_zenith_angle(nir.attrs["start_time"], lons, lats)
         return sun_zenith
 
     def _create_modified_dataarray(self, reflectance, base_dataarray):

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -273,7 +273,7 @@ class TestNIRReflectance(unittest.TestCase):
 
         # due to copying of DataArrays, self.get_lonlats is not the same as the one that was called
         # we must used the area from the final result DataArray
-        res.attrs["area"].get_lonlats.assert_called()
+        res.attrs["area"].get_lonlats.assert_called_with(chunks=((2,), (2,)), dtype=self.nir.dtype)
         sza.assert_called_with(self.start_time, self.lons, self.lats)
         self.refl_from_tbs.assert_called_with(self.da_sunz, self.nir.data, self.ir_.data, tb_ir_co2=None)
         assert np.allclose(res.data, self.refl * 100).compute()


### PR DESCRIPTION
This simple addition finalizes https://github.com/pytroll/pyspectral/pull/206 so that `NIRReflectance` modifier doesn't up-cast the input data to `float64`.

Includes also some refactoring between `NIRReflectance` and `NIREmissivePartFromReflectance`.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
