### PR TITLE
Fix assert_called_once usage in resample tests

### DIFF
--- a/satpy/tests/scene_tests/test_resampling.py
+++ b/satpy/tests/scene_tests/test_resampling.py
@@ -319,14 +319,14 @@ class TestSceneResampling:
             assert not slice_data.called
             assert not get_area_slices.called
             scene.resample(target_area)
-            assert slice_data.called_once
-            assert get_area_slices.called_once
+            slice_data.assert_called_once
+            get_area_slices.assert_called_once
             scene.resample(target_area, reduce_data=True)
             # 2 times for each dataset
             # once for default (reduce_data=True)
             # once for kwarg forced to `True`
             assert slice_data.call_count == 2 * 3
-            assert get_area_slices.called_once
+            get_area_slices.assert_called_once
 
     def test_resample_ancillary(self):
         """Test that the Scene reducing data does not affect final output."""

--- a/satpy/tests/scene_tests/test_resampling.py
+++ b/satpy/tests/scene_tests/test_resampling.py
@@ -316,17 +316,18 @@ class TestSceneResampling:
             ds_walker.return_value = test_order
             slice_data.side_effect = orig_slice_data
             scene.resample(target_area, reduce_data=False)
-            assert not slice_data.called
-            assert not get_area_slices.called
+            slice_data.assert_not_called()
+            get_area_slices.assert_not_called()
             scene.resample(target_area)
-            slice_data.assert_called_once()
-            get_area_slices.assert_called_once()
+            assert slice_data.call_count == 3
+            assert get_area_slices.call_count == 2
             scene.resample(target_area, reduce_data=True)
             # 2 times for each dataset
             # once for default (reduce_data=True)
             # once for kwarg forced to `True`
             assert slice_data.call_count == 2 * 3
-            get_area_slices.assert_called_once()
+            # reductions are cached, no additional reductions in second call
+            assert get_area_slices.call_count == 2
 
     def test_resample_ancillary(self):
         """Test that the Scene reducing data does not affect final output."""

--- a/satpy/tests/scene_tests/test_resampling.py
+++ b/satpy/tests/scene_tests/test_resampling.py
@@ -320,14 +320,16 @@ class TestSceneResampling:
             get_area_slices.assert_not_called()
             scene.resample(target_area)
             assert slice_data.call_count == 3
-            assert get_area_slices.call_count == 2
+            assert get_area_slices.call_count == 1
+            assert get_area_slices_big.call_count == 1
             scene.resample(target_area, reduce_data=True)
             # 2 times for each dataset
             # once for default (reduce_data=True)
             # once for kwarg forced to `True`
             assert slice_data.call_count == 2 * 3
-            # reductions are cached, no additional reductions in second call
+            # get area slices is called again, once per area
             assert get_area_slices.call_count == 2
+            assert get_area_slices_big.call_count == 2
 
     def test_resample_ancillary(self):
         """Test that the Scene reducing data does not affect final output."""

--- a/satpy/tests/scene_tests/test_resampling.py
+++ b/satpy/tests/scene_tests/test_resampling.py
@@ -319,14 +319,14 @@ class TestSceneResampling:
             assert not slice_data.called
             assert not get_area_slices.called
             scene.resample(target_area)
-            slice_data.assert_called_once
-            get_area_slices.assert_called_once
+            slice_data.assert_called_once()
+            get_area_slices.assert_called_once()
             scene.resample(target_area, reduce_data=True)
             # 2 times for each dataset
             # once for default (reduce_data=True)
             # once for kwarg forced to `True`
             assert slice_data.call_count == 2 * 3
-            get_area_slices.assert_called_once
+            get_area_slices.assert_called_once()
 
     def test_resample_ancillary(self):
         """Test that the Scene reducing data does not affect final output."""

--- a/satpy/tests/writer_tests/test_ninjogeotiff.py
+++ b/satpy/tests/writer_tests/test_ninjogeotiff.py
@@ -630,7 +630,7 @@ def test_write_and_read_file_units(
     np.testing.assert_allclose(float(tgs["ninjo_Gradient"]),
                                0.467717, rtol=1e-5)
     np.testing.assert_allclose(float(tgs["ninjo_AxisIntercept"]),
-                               -79.86771)
+                               -79.86771, rtol=1e-5)
     fn2 = os.fspath(tmp_path / "test2.tif")
     with caplog.at_level(logging.WARNING):
         ngtw.save_dataset(


### PR DESCRIPTION
 - [ ] Closes #2646
