### PR TITLE
Add file pattern for CRRPh of NWC SAF GEO v2021

### DIFF
--- a/satpy/etc/readers/nwcsaf-geo.yaml
+++ b/satpy/etc/readers/nwcsaf-geo.yaml
@@ -41,7 +41,8 @@ file_types:
 
     nc_nwcsaf_crr-ph:
         file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
-        file_patterns: ['S_NWC_CRR-Ph_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc']
+        file_patterns: ['S_NWC_CRR-Ph_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc',
+                        'S_NWC_CRRPh_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc']
 
     nc_nwcsaf_ishai:
         file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF

--- a/satpy/tests/reader_tests/test_virr_l1b.py
+++ b/satpy/tests/reader_tests/test_virr_l1b.py
@@ -158,7 +158,7 @@ class TestVIRRL1BReader(unittest.TestCase):
                                                        "solar_azimuth_angle", "sensor_azimuth_angle"]
                 assert ["virr_geoxx", "virr_l1b"] == attributes["file_type"]
                 assert ("longitude", "latitude") == attributes["coordinates"]
-            assert band_values[dataset["name"]] == round(float(np.array(ds[ds.shape[0] // 2][ds.shape[1] // 2])), 6)
+            np.testing.assert_allclose(band_values[dataset["name"]], ds[ds.shape[0] // 2][ds.shape[1] // 2], rtol=1e-6)
             assert "valid_range" not in ds.attrs
 
     def test_fy3b_file(self):


### PR DESCRIPTION
The 2021 version NWC SAF GEO software producess CRRPh ("convective rain rate from physical somethingorother") using file names like `S_NWC_CRRPh_MSG3_MSG-N-VISIR_20231128T051500Z.nc`. The previous version (v2018) has the files named with a dash: `S_NWC_CRR-Ph_MSG3_MSG-N-VISIR_20231128T051500Z.nc`. This PR adds the new pattern.

There's a similar change to `PC-Ph` -> `PCPh` but we don't have that product currently in the config, and I'm not sure its yet supported.

In addition one unrelated failing test assertion is adjusted for floating point handling.
