### PR TITLE
Update Sun-zenith reducer defaults

### DIFF
--- a/satpy/etc/composites/fci.yaml
+++ b/satpy/etc/composites/fci.yaml
@@ -33,6 +33,20 @@ composites:
       - name: vis_08
     standard_name: toa_bidirectional_reflectance
 
+  ndvi_hybrid_green_fully_sunzencorrected:
+    description: Same as ndvi_hybrid_green, but without Sun-zenith reduction
+    compositor: !!python/name:satpy.composites.spectral.NDVIHybridGreen
+    limits: [ 0.15, 0.05 ]
+    strength: 3.0
+    prerequisites:
+      - name: vis_05
+        modifiers: [ sunz_corrected, rayleigh_corrected ]
+      - name: vis_06
+        modifiers: [ sunz_corrected, rayleigh_corrected ]
+      - name: vis_08
+        modifiers: [ sunz_corrected ]
+    standard_name: toa_bidirectional_reflectance
+
   binary_cloud_mask:
     # This will set all clear pixels to '0', all pixles with cloudy features (meteorological/dust/ash clouds) to '1' and
     # missing/undefined pixels to 'nan'. This can be used for the the official EUMETSAT cloud mask product (CLM).
@@ -54,6 +68,19 @@ composites:
       - name: ndvi_hybrid_green
       - name: vis_04
         modifiers: [sunz_corrected, rayleigh_corrected, sunz_reduced]
+    standard_name: true_color
+
+  true_color_fully_sunzencorrected:
+    compositor: !!python/name:satpy.composites.SelfSharpenedRGB
+    description: >
+      Same as true_color, but without Sun-zenith reduction. For users that want to maintain as much data as possible
+      close to the terminator, at cost of some artefacts (bright limb and reddish clouds) (see issue #2643).
+    prerequisites:
+      - name: vis_06
+        modifiers: [sunz_corrected, rayleigh_corrected]
+      - name: ndvi_hybrid_green_fully_sunzencorrected
+      - name: vis_04
+        modifiers: [sunz_corrected, rayleigh_corrected]
     standard_name: true_color
 
   true_color_raw_with_corrected_green:

--- a/satpy/modifiers/geometry.py
+++ b/satpy/modifiers/geometry.py
@@ -177,7 +177,7 @@ class SunZenithReducer(SunZenithCorrectorBase):
 
     """
 
-    def __init__(self, correction_limit=55., max_sza=90, strength=1.5, **kwargs):  # noqa: D417
+    def __init__(self, correction_limit=80., max_sza=90, strength=1.3, **kwargs):  # noqa: D417
         """Collect custom configuration values.
 
         Args:

--- a/satpy/modifiers/geometry.py
+++ b/satpy/modifiers/geometry.py
@@ -181,10 +181,10 @@ class SunZenithReducer(SunZenithCorrectorBase):
         """Collect custom configuration values.
 
         Args:
-            correction_limit (float): Solar zenith angle in degrees where to start the signal reduction. Default 60.
+            correction_limit (float): Solar zenith angle in degrees where to start the signal reduction.
             max_sza (float): Maximum solar zenith angle in degrees where to apply the signal reduction. Beyond
-                             this solar zenith angle the signal will become zero. Default 90.
-            strength (float): The strength of the non-linear signal reduction. Default 1.5
+                             this solar zenith angle the signal will become zero.
+            strength (float): The strength of the non-linear signal reduction.
 
         """
         self.correction_limit = correction_limit
@@ -194,7 +194,8 @@ class SunZenithReducer(SunZenithCorrectorBase):
             raise ValueError("`max_sza` must be defined when using the SunZenithReducer.")
 
     def _apply_correction(self, proj, coszen):
-        logger.debug("Apply sun-zenith signal reduction")
+        logger.debug(f"Applying sun-zenith signal reduction with correction_limit {self.correction_limit} deg,"
+                     f" strength {self.strength}, and max_sza {self.max_sza} deg.")
         res = proj.copy()
         sunz = np.rad2deg(np.arccos(coszen.data))
         res.data = sunzen_reduction(proj.data, sunz,


### PR DESCRIPTION
This PR updates the Sun-zenith reducer default parameters to reduce the effect of the reduction and keep more data close to the terminator. See https://github.com/pytroll/satpy/issues/2643 for the discussion.

 - [x] Closes #2643 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
