### PR TITLE
Fix missing radiance units in eps l1b

### DIFF
--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -81,10 +81,10 @@ def read_records(filename):
             grh = np.fromfile(fdes, grh_dtype, 1)
             if grh.size == 0:
                 break
-            rec_class = record_class[int(grh["record_class"])]
+            rec_class = record_class[int(grh["record_class"].squeeze())]
             sub_class = grh["RECORD_SUBCLASS"][0]
 
-            expected_size = int(grh["RECORD_SIZE"])
+            expected_size = int(grh["RECORD_SIZE"].squeeze())
             bare_size = expected_size - grh_dtype.itemsize
             try:
                 the_type = form.dtype((rec_class, sub_class))
@@ -144,7 +144,8 @@ class EPSAVHRRFile(BaseFileHandler):
     sensors = {"AVHR": "avhrr-3"}
 
     units = {"reflectance": "%",
-             "brightness_temperature": "K"}
+             "brightness_temperature": "K",
+             "radiance":  "W m^-2 sr^-1"}
 
     def __init__(self, filename, filename_info, filetype_info):
         """Initialize FileHandler."""

--- a/satpy/tests/reader_tests/test_eps_l1b.py
+++ b/satpy/tests/reader_tests/test_eps_l1b.py
@@ -134,6 +134,17 @@ class TestEPSL1B(BaseTestCaseEPSL1B):
         assert res.attrs["calibration"] == "brightness_temperature"
         assert res.attrs["units"] == "K"
 
+    def test_get_dataset_radiance(self):
+        """Test loading a data array with radiance calibration."""
+        did = make_dataid(name="1", calibration="radiance")
+        res = self.fh.get_dataset(did, {})
+        assert isinstance(res, xr.DataArray)
+        assert res.attrs["platform_name"] == "Metop-C"
+        assert res.attrs["sensor"] == "avhrr-3"
+        assert res.attrs["name"] == "1"
+        assert res.attrs["calibration"] == "radiance"
+        assert res.attrs["units"] == "W m^-2 sr^-1"
+
     def test_navigation(self):
         """Test the navigation."""
         did = make_dataid(name="longitude")


### PR DESCRIPTION
This PR fixes a bug preventing reading radiance from avhrr eps l1b data.

 - [x] Closes #2654  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

