### PR TITLE
Update unstable version of h5py in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,7 +83,7 @@ jobs:
           git+https://github.com/pytroll/pyresample \
           git+https://github.com/pytroll/trollimage \
           git+https://github.com/fhs/pyhdf \
-          git+https://github.com/takluyver/h5py@cython-3 \
+          git+https://github.com/djhoese/h5py@cython-3-davidh \
           git+https://github.com/Unidata/netcdf4-python \
           git+https://github.com/dask/dask \
           git+https://github.com/dask/distributed \


### PR DESCRIPTION
A while ago I updated the unstable CI to deal with numpy 2.0 changes. The final issue ended up being h5py not being Cython 3 compatible. I have a PR with h5py now that fixes this so this update is trying it out while waiting for that PR to be merged.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
