### PR TITLE
Update tropomi_l2.yaml

### DIFF
--- a/satpy/etc/readers/tropomi_l2.yaml
+++ b/satpy/etc/readers/tropomi_l2.yaml
@@ -14,6 +14,7 @@ file_types:
         file_reader: !!python/name:satpy.readers.tropomi_l2.TROPOMIL2FileHandler
         file_patterns:
             - '{platform_shortname:3s}_{data_type:4s}_{level:3s}_{product:_<6s}_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{orbit:5d}_{collection:2d}_{processor_version:6d}_{creation_time:%Y%m%dT%H%M%S}.nc'
+            - '{platform_shortname:3s}_RPRO_{level:3s}_{product:_<6s}_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{orbit:5d}_{collection:2d}_{processor_version:6d}_{creation_time:%Y%m%dT%H%M%S}_reduced.nc'
 
 datasets:
     latitude:


### PR DESCRIPTION
The Tropomi l2 reader can read ’S5P_OFFL_L2__NO2____‘ files but cannot read 'S5P_RPRO_L2__NO2____' files. Because 'S5P_RPRO_L2__NO2____' files  have reduced in their names, which means the pattern defined here doesn't match.  Adding a new pattern to the pattern list with the reduced added to the end can work.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
