### PR TITLE
Fix RealisticColors compositor upcasting data to float64

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -992,17 +992,17 @@ class RealisticColors(GenericCompositor):
         hrv = projectables[2]
 
         try:
-            ch3 = 3 * hrv - vis06 - vis08
+            ch3 = 3.0 * hrv - vis06 - vis08
             ch3.attrs = hrv.attrs
         except ValueError:
             raise IncompatibleAreas
 
         ndvi = (vis08 - vis06) / (vis08 + vis06)
-        ndvi = np.where(ndvi < 0, 0, ndvi)
+        ndvi = ndvi.where(ndvi >= 0.0, 0.0)
 
-        ch1 = ndvi * vis06 + (1 - ndvi) * vis08
+        ch1 = ndvi * vis06 + (1.0 - ndvi) * vis08
         ch1.attrs = vis06.attrs
-        ch2 = ndvi * vis08 + (1 - ndvi) * vis06
+        ch2 = ndvi * vis08 + (1.0 - ndvi) * vis06
         ch2.attrs = vis08.attrs
 
         res = super(RealisticColors, self).__call__((ch1, ch2, ch3),

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -1867,3 +1867,37 @@ def _create_fake_composite_config(yaml_filename: str):
         },
             comp_file,
         )
+
+
+class TestRealisticColors:
+    """Test the SEVIRI Realistic Colors compositor."""
+
+    def test_realistic_colors(self):
+        """Test the compositor."""
+        from satpy.composites import RealisticColors
+
+        vis06 = xr.DataArray(da.arange(0, 15, dtype=np.float32).reshape(3, 5), dims=("y", "x"),
+                             attrs={"foo": "foo"})
+        vis08 = xr.DataArray(da.arange(15, 0, -1, dtype=np.float32).reshape(3, 5), dims=("y", "x"),
+                             attrs={"bar": "bar"})
+        hrv = xr.DataArray(6 * da.ones((3, 5), dtype=np.float32), dims=("y", "x"),
+                           attrs={"baz": "baz"})
+
+        expected_red = np.array([[0.0, 2.733333, 4.9333334, 6.6, 7.733333],
+                                 [8.333333, 8.400001, 7.9333334, 7.0, 6.0],
+                                 [5.0, 4.0, 3.0, 2.0, 1.0]], dtype=np.float32)
+        expected_green = np.array([
+            [15.0, 12.266666, 10.066668, 8.400001, 7.2666664],
+            [6.6666665, 6.6000004, 7.0666666, 8.0, 9.0],
+            [10.0, 11.0, 12.0, 13.0, 14.0]], dtype=np.float32)
+
+        with dask.config.set(scheduler=CustomScheduler(max_computes=1)):
+            comp = RealisticColors("Ni!")
+            res = comp((vis06, vis08, hrv))
+
+        arr = res.values
+
+        assert res.dtype == np.float32
+        np.testing.assert_allclose(arr[0, :, :], expected_red)
+        np.testing.assert_allclose(arr[1, :, :], expected_green)
+        np.testing.assert_allclose(arr[2, :, :], 3.0)


### PR DESCRIPTION
The `RealisticColors` compositor was upcasting the data to `float64` (via `np.where()` usage). This PR fixes the issue, and adds the first test for the compositor.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
