### PR TITLE
Workaround AWIPS bug not handling integers properly in "awips_tiled" writer

### DIFF
--- a/satpy/tests/writer_tests/test_awips_tiled.py
+++ b/satpy/tests/writer_tests/test_awips_tiled.py
@@ -198,7 +198,7 @@ class TestAWIPSTiledWriter:
             check_required_properties(unmasked_ds, output_ds)
             scale_factor = output_ds["data"].encoding["scale_factor"]
             np.testing.assert_allclose(input_data_arr.values, output_ds["data"].data,
-                                       atol=scale_factor / 2)
+                                       atol=scale_factor * 0.75)
 
     def test_units_length_warning(self, tmp_path):
         """Test long 'units' warnings are raised."""

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -630,7 +630,13 @@ def _get_factor_offset_fill(input_data_arr, vmin, vmax, encoding):
         # max value
         fills = [2 ** (file_bit_depth - 1) - 1]
 
-    mx = (vmax - vmin) / (2 ** bit_depth - 1 - num_fills)
+    # NOTE: AWIPS is buggy and does not properly handle both
+    #   halves an integers data space. The below code limits
+    #   unsigned integers to the positive half and this seems
+    #   to work better with current AWIPS.
+    mx = (vmax - vmin) / (2 ** (bit_depth - 1) - 1 - num_fills)
+    # NOTE: This is what the line should look like if AWIPS wasn't buggy:
+    # mx = (vmax - vmin) / (2 ** bit_depth - 1 - num_fills)
     bx = vmin
     if not is_unsigned and not unsigned_in_signed:
         bx += 2 ** (bit_depth - 1) * mx


### PR DESCRIPTION
Discovered by @spruceboy and the rest of the GINA team in Alaska. It seems AWIPS is fine displaying data that is unsigned 16-bit integers stored in a 16-bit *signed* integer with the `_Unsigned: true` attribute. However, AWIPS does like this data when using special "derivedParameters" functionality where it treats the data as signed data before passing it to additional processing. In an attempt workaround this issue @spruceboy tried saving the data as signed integers (no `_Unsigned` attribute) and that fixed the addition processing, but broke the visualization. The simplest fix for now (seeing as AWIPS development will take 6-12 months minimum once the fix is implemented) is in this PR which is to only use the positive side of the signed variable.

Note: I had to update one of the tests because the precision of the saved NetCDF data compared to the original input data was reduced, *BUT* this PR is not fixing a Satpy bug. This PR is working around an AWIPS bug.

CC @kathys

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
