### PR TITLE
Add NWC SAF GEO v2021 ASIIF-TF and ASII-GW dataset names

### DIFF
--- a/satpy/etc/readers/nwcsaf-geo.yaml
+++ b/satpy/etc/readers/nwcsaf-geo.yaml
@@ -689,11 +689,13 @@ datasets:
     file_type: nc_nwcsaf_rdt
 
 # ----ASII products in multiple files ------------
+  # until v2018
   asii_turb_trop_prob:
     name: asii_turb_trop_prob
     resolution: 3000
     file_type: [nc_nwcsaf_asii_tf, nc_nwcsaf_asii]
 
+  # until v2018
   asii_turb_prob_pal:
     name: asii_turb_prob_pal
     resolution: 3000
@@ -701,6 +703,24 @@ datasets:
 
 # ----ASII-TF product ------------
 
+  # v2021 onwards
+  asiitf_prob:
+    name: asiitf_prob
+    resolution: 3000
+    file_type: nc_nwcsaf_asii_tf
+
+  # v2021 onwards
+  asiitf_prob_pal:
+    name: asiitf_prob_pal
+    file_type: nc_nwcsaf_asii_tf
+
+  # v2021 onwards
+  asiitf_status_flag:
+    name: asiitf_status_flag
+    resolution: 3000
+    file_type: nc_nwcsaf_asii_tf
+
+  # until v2018
   asii_turb_prob_status_flag:
     name: asii_turb_trop_prob_status_flag
     resolution: 3000
@@ -718,11 +738,30 @@ datasets:
 
 # ----ASII-GW product ------------
 
+  # v2021 onwards
+  asiigw_wv_prob:
+    name: asiigw_wv_prob
+    resolution: 3000
+    file_type: nc_nwcsaf_asii_gw
+
+  # v2021 onwards
+  asiigw_status_flag:
+    name: asiigw_status_flag
+    resolution: 3000
+    file_type: nc_nwcsaf_asii_gw
+
+  # v2021 onwards
+  asiigw_wv_prob_pal:
+    name: asiigw_wv_prob_pal
+    file_type: nc_nwcsaf_asii_gw
+
+  # until v2018
   asii_turb_wave_prob:
     name: asii_turb_wave_prob
     resolution: 3000
     file_type: nc_nwcsaf_asii_gw
 
+  # until v2018
   asii_turb_wave_prob_status_flag:
     name: asii_turb_wave_prob_status_flag
     resolution: 3000

--- a/satpy/etc/readers/nwcsaf-geo.yaml
+++ b/satpy/etc/readers/nwcsaf-geo.yaml
@@ -77,6 +77,11 @@ datasets:
     resolution: 3000
     file_type: nc_nwcsaf_cma
 
+  cma_quality:
+    name: cma_quality
+    resolution: 3000
+    file_type: nc_nwcsaf_cma
+
   cma_pal:
     name: cma_pal
     resolution: 3000
@@ -126,6 +131,11 @@ datasets:
 
   ct:
     name: ct
+    resolution: 3000
+    file_type: nc_nwcsaf_ct
+
+  ct_status_flag:
+    name: ct_status_flag
     resolution: 3000
     file_type: nc_nwcsaf_ct
 

--- a/satpy/etc/readers/nwcsaf-geo.yaml
+++ b/satpy/etc/readers/nwcsaf-geo.yaml
@@ -380,7 +380,7 @@ datasets:
     file_type: nc_nwcsaf_crr-ph
 
   crrph_pal:
-    name: crrph_intensity_pal
+    name: crrph_pal
     resolution: 3000
     file_type: nc_nwcsaf_crr-ph
 
@@ -400,7 +400,7 @@ datasets:
     file_type: nc_nwcsaf_crr-ph
 
   crrph_status_flag:
-    name: crrph_status
+    name: crrph_status_flag
     resolution: 3000
     file_type: nc_nwcsaf_crr-ph
 

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -570,5 +570,5 @@ def _should_use_compression_keyword():
     versions = _get_backend_versions()
     return (
         versions["libnetcdf"] >= Version("4.9.0") and
-        versions["xarray"] >= Version("2023.12")
+        versions["xarray"] >= Version("2024.1")
     )


### PR DESCRIPTION
In NWC SAF GEO v2021 some of the dataset names inside the files have changed. This PR adds those. The old names in v2018 files are kept as-is, so the users need to migrate to the new ones.

Also some missing dataset names were added to silence few warnings.

 - [x] Closes #2672 
