### PR TITLE
Update xarray version in CF writer tests for compression kwarg

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -570,5 +570,5 @@ def _should_use_compression_keyword():
     versions = _get_backend_versions()
     return (
         versions["libnetcdf"] >= Version("4.9.0") and
-        versions["xarray"] >= Version("2023.12")
+        versions["xarray"] >= Version("2024.1")
     )


### PR DESCRIPTION
Yet another XArray release without the compression kwarg fix, so lets bump the version up a notch.
