### PR TITLE
Make CF encoding of dataset attributes public

### DIFF
--- a/satpy/cf/attrs.py
+++ b/satpy/cf/attrs.py
@@ -128,8 +128,8 @@ def _encode_to_cf(obj):
         return _encode_python_objects(obj)
 
 
-def _encode_nc_attrs(attrs):
-    """Encode dataset attributes in a netcdf compatible datatype.
+def encode_attrs_to_cf(attrs):
+    """Encode dataset attributes as a netcdf compatible datatype.
 
     Args:
         attrs (dict):
@@ -161,7 +161,7 @@ def preprocess_attrs(
     if flatten_attrs:
         data_arr.attrs = flatten_dict(data_arr.attrs)
 
-    data_arr.attrs = _encode_nc_attrs(data_arr.attrs)
+    data_arr.attrs = encode_attrs_to_cf(data_arr.attrs)
 
     return data_arr
 
@@ -224,7 +224,7 @@ def preprocess_header_attrs(header_attrs, flatten_attrs=False):
     if header_attrs is not None:
         if flatten_attrs:
             header_attrs = flatten_dict(header_attrs)
-        header_attrs = _encode_nc_attrs(header_attrs)  # OrderedDict
+        header_attrs = encode_attrs_to_cf(header_attrs)  # OrderedDict
     else:
         header_attrs = {}
     header_attrs = _add_history(header_attrs)

--- a/satpy/tests/cf_tests/test_attrs.py
+++ b/satpy/tests/cf_tests/test_attrs.py
@@ -24,14 +24,14 @@ class TestCFAttributeEncoding:
 
     def test__encode_nc_attrs(self):
         """Test attributes encoding."""
-        from satpy.cf.attrs import _encode_nc_attrs
+        from satpy.cf.attrs import encode_attrs_to_cf
         from satpy.tests.cf_tests._test_data import get_test_attrs
         from satpy.tests.utils import assert_dict_array_equality
 
         attrs, expected, _ = get_test_attrs()
 
         # Test encoding
-        encoded = _encode_nc_attrs(attrs)
+        encoded = encode_attrs_to_cf(attrs)
         assert_dict_array_equality(expected, encoded)
 
         # Test decoding of json-encoded attributes

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -566,9 +566,9 @@ def _should_use_compression_keyword():
     # xarray currently ignores the "compression" keyword, see
     # https://github.com/pydata/xarray/issues/7388. There's already an open
     # PR, so we assume that this will be fixed in the next minor release
-    # (current release is 2023.12). If not, tests will fail and remind us.
+    # (current release is 2023.02). If not, tests will fail and remind us.
     versions = _get_backend_versions()
     return (
         versions["libnetcdf"] >= Version("4.9.0") and
-        versions["xarray"] >= Version("2024.02")
+        versions["xarray"] >= Version("2023.12")
     )

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -566,9 +566,9 @@ def _should_use_compression_keyword():
     # xarray currently ignores the "compression" keyword, see
     # https://github.com/pydata/xarray/issues/7388. There's already an open
     # PR, so we assume that this will be fixed in the next minor release
-    # (current release is 2023.02). If not, tests will fail and remind us.
+    # (current release is 2023.12). If not, tests will fail and remind us.
     versions = _get_backend_versions()
     return (
         versions["libnetcdf"] >= Version("4.9.0") and
-        versions["xarray"] >= Version("2023.12")
+        versions["xarray"] >= Version("2024.02")
     )


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
In some of my projects I have been using `satpy.writer.encode_attrs_nc`, which has been made private in Satpy 0.45. This is an attempt to get it back :slightly_smiling_face: 

~~Also, xarray still doesn't support the `compression` kwarg, so I bumped the anticipated version number by two months.~~ Solved by Panu

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
