### PR TITLE
Fci/l2/amv/reader

### DIFF
--- a/satpy/etc/readers/fci_l2_nc.yaml
+++ b/satpy/etc/readers/fci_l2_nc.yaml
@@ -2837,13 +2837,13 @@ datasets:
     file_key: channel_id
     standard_name: channel_id
 
-  latitude:
+  amv_latitude:
     name: latitude
     file_type: nc_fci_amv
     file_key: latitude
     standard_name: latitude
 
-  longitude:
+  amv_longitude:
     name: longitude
     file_type: nc_fci_amv
     file_key: longitude

--- a/satpy/etc/readers/fci_l2_nc.yaml
+++ b/satpy/etc/readers/fci_l2_nc.yaml
@@ -65,12 +65,12 @@ file_types:
       - '{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+FCI-2-ASR-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc'
 
   nc_fci_amvi:
-    file_reader: !!python/name:readers.fci_amv_l2_nc.FciAmvL2NCFileHandler
+    file_reader: !!python/name:satpy.readers.fci_l2_nc.FciL2NCAMVFileHandler
     file_patterns:
       - '{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+FCI-2-AMVI-{channel}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc'
 
   nc_fci_amv:
-    file_reader: !!python/name:readers.fci_amv_l2_nc.FciAmvL2NCFileHandler
+    file_reader: !!python/name:satpy.readers.fci_l2_nc.FciL2NCAMVFileHandler
     file_patterns:
       - '{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+FCI-2-AMV-{channel}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc'
 

--- a/satpy/etc/readers/fci_l2_nc.yaml
+++ b/satpy/etc/readers/fci_l2_nc.yaml
@@ -64,6 +64,16 @@ file_types:
     file_patterns:
       - '{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+FCI-2-ASR-{subtype}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc'
 
+  nc_fci_amvi:
+    file_reader: !!python/name:readers.fci_amv_l2_nc.FciAmvL2NCFileHandler
+    file_patterns:
+      - '{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+FCI-2-AMVI-{channel}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc'
+
+  nc_fci_amv:
+    file_reader: !!python/name:readers.fci_amv_l2_nc.FciAmvL2NCFileHandler
+    file_patterns:
+      - '{pflag}_{location_indicator},{data_designator},MTI{spacecraft_id:1d}+FCI-2-AMV-{channel}-{coverage}-{subsetting}-{component1}-{component2}-{component3}-{purpose}-{format}_{oflag}_{originator}_{processing_time:%Y%m%d%H%M%S}_{facility_or_tool}_{environment}_{start_time:%Y%m%d%H%M%S}_{end_time:%Y%m%d%H%M%S}_{processing_mode}_{special_compression}_{disposition_mode}_{repeat_cycle_in_day:>04d}_{count_in_repeat_cycle:>04d}.nc'
+
 datasets:
 
 # CLM
@@ -2732,5 +2742,262 @@ datasets:
   product_timeliness_asr:
     name: product_timeliness_asr
     file_type: nc_fci_asr
+    file_key: product_timeliness
+    long_name: product_timeliness_index
+
+# AMV Intermediate Product
+  intm_latitude:
+    name: intm_latitude
+    file_type: nc_fci_amvi
+    file_key: intm_latitude
+    standard_name: latitude
+
+  intm_longitude:
+    name: intm_longitude
+    file_type: nc_fci_amvi
+    file_key: intm_longitude
+    standard_name: longitude
+
+  intm_speed:
+    name: intm_speed
+    file_type: nc_fci_amvi
+    file_key: intm_speed
+    standard_name: wind_speed
+    coordinates:
+      - intm_longitude
+      - intm_latitude
+
+  intm_u_component:
+    name: intm_u_component
+    file_type: nc_fci_amvi
+    file_key: intm_u_component
+    standard_name: wind_speed_horizontal_component
+    coordinates:
+      - intm_longitude
+      - intm_latitude
+
+  intm_v_component:
+    name: intm_v_component
+    file_type: nc_fci_amvi
+    file_key: intm_v_component
+    standard_name: wind_speed_vertical_component
+    coordinates:
+      - intm_longitude
+      - intm_latitude
+
+  intm_direction:
+    name: intm_direction
+    file_type: nc_fci_amvi
+    file_key: intm_direction
+    standard_name: wind_to_direction
+    coordinates:
+      - intm_longitude
+      - intm_latitude
+
+  intm_pressure:
+    name: intm_pressure
+    file_type: nc_fci_amvi
+    file_key: intm_pressure
+    standard_name: wind_pressure
+    coordinates:
+      - intm_longitude
+      - intm_latitude
+
+  intm_temperature:
+    name: intm_temperature
+    file_type: nc_fci_amvi
+    file_key: intm_temperature
+    standard_name: wind_temperature
+    coordinates:
+      - intm_longitude
+      - intm_latitude
+
+  intm_target_type:
+    name: intm_target_type
+    file_type: nc_fci_amvi
+    file_key: target_type
+    standard_name: wind_target_type
+    coordinates:
+      - intm_longitude
+      - intm_latitude
+
+  intm_wind_method:
+    name: intm_wind_method
+    file_type: nc_fci_amvi
+    file_key: wind_method
+    standard_name: wind_wind_method
+    coordinates:
+      - intm_longitude
+      - intm_latitude
+
+# AMV Final Product
+  channel_id:
+    name: channel_id
+    file_type: nc_fci_amv
+    file_key: channel_id
+    standard_name: channel_id
+
+  latitude:
+    name: latitude
+    file_type: nc_fci_amv
+    file_key: latitude
+    standard_name: latitude
+
+  longitude:
+    name: longitude
+    file_type: nc_fci_amv
+    file_key: longitude
+    standard_name: longitude
+
+  speed:
+    name: speed
+    file_type: nc_fci_amv
+    file_key: speed
+    standard_name: wind_speed
+    coordinates:
+      - longitude
+      - latitude
+
+  speed_u_component:
+    name: speed_u_component
+    file_type: nc_fci_amv
+    file_key: speed_u_component
+    standard_name: wind_speed_horizontal_component
+    coordinates:
+      - longitude
+      - latitude
+
+  speed_v_component:
+    name: speed_v_component
+    file_type: nc_fci_amv
+    file_key: speed_v_component
+    standard_name: wind_speed_vertical_component
+    coordinates:
+      - longitude
+      - latitude
+
+  direction:
+    name: direction
+    file_type: nc_fci_amv
+    file_key: direction
+    standard_name: wind_to_direction
+    coordinates:
+      - longitude
+      - latitude
+
+  pressure:
+    name: pressure
+    file_type: nc_fci_amv
+    file_key: pressure
+    standard_name: wind_pressure
+    coordinates:
+      - longitude
+      - latitude
+
+  temperature:
+    name: temperature
+    file_type: nc_fci_amv
+    file_key: temperature
+    standard_name: wind_temperature
+    coordinates:
+      - longitude
+      - latitude
+
+  target_type:
+    name: target_type
+    file_type: nc_fci_amv
+    file_key: target_type
+    standard_name: wind_target_type
+    coordinates:
+      - longitude
+      - latitude
+
+  wind_method:
+    name: wind_method
+    file_type: nc_fci_amv
+    file_key: wind_method
+    standard_name: wind_wind_method
+    coordinates:
+      - longitude
+      - latitude
+
+  fcst_u:
+    name: fcst_u
+    file_type: nc_fci_amv
+    file_key: forecast_u_component
+    standard_name: wind_forecast_u_component
+    coordinates:
+      - longitude
+      - latitude
+
+  fcst_v:
+    name: fcst_v
+    file_type: nc_fci_amv
+    file_key: forecast_v_component
+    standard_name: wind_forecast_v_component
+    coordinates:
+      - longitude
+      - latitude
+
+  best_fit_pres:
+    name: best_fit_pres
+    file_type: nc_fci_amv
+    file_key: best_fit_pressure
+    standard_name: wind_best_fit_pressure
+    coordinates:
+      - longitude
+      - latitude
+
+  best_fit_u:
+    name: best_fit_u
+    file_type: nc_fci_amv
+    file_key: best_fit_u_component
+    standard_name: wind_best_fit_u_component
+    coordinates:
+      - longitude
+      - latitude
+
+  best_fit_v:
+    name: best_fit_v
+    file_type: nc_fci_amv
+    file_key: best_fit_v_component
+    standard_name: wind_best_fit_v_component
+    coordinates:
+      - longitude
+      - latitude
+
+  qi:
+    name: qi
+    file_type: nc_fci_amv
+    file_key: overall_reliability
+    standard_name: wind_overall_reliability
+    coordinates:
+      - longitude
+      - latitude
+
+  qi_excl_fcst:
+    name: qi_excl_fcst
+    file_type: nc_fci_amv
+    file_key: overall_reliability_exc_forecast
+    standard_name: wind_overall_reliability_exc_forecast
+    coordinates:
+      - longitude
+      - latitude
+
+  product_quality:
+    name: product_quality
+    file_type: nc_fci_amv
+    file_key: product_quality
+    long_name: product_quality_index
+
+  product_completeness:
+    name: product_completeness
+    file_type: nc_fci_amv
+    file_key: product_completeness
+    long_name: product_completeness_index
+
+  product_timeliness:
+    name: product_timeliness
+    file_type: nc_fci_amv
     file_key: product_timeliness
     long_name: product_timeliness_index

--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -475,10 +475,3 @@ class FciL2NCAMVFileHandler(FciL2CommonFunctions, BaseFileHandler):
         variable.attrs.update(self._get_global_attributes())
 
         return variable
-
-    def __del__(self):
-        """Close the NetCDF file that may still be open."""
-        try:
-            self.nc.close()
-        except AttributeError:
-            pass

--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -22,6 +22,7 @@ import numpy as np
 import xarray as xr
 from pyresample import geometry
 
+from satpy._compat import cached_property
 from satpy.readers._geos_area import get_geos_area_naming, make_ext
 from satpy.readers.eum_base import get_service_mode
 from satpy.readers.file_handlers import BaseFileHandler
@@ -152,6 +153,7 @@ class FciL2NCFileHandler(FciL2CommonFunctions, BaseFileHandler):
         self.ncols = self.nc["x"].size
         self._projection = self.nc["mtg_geos_projection"]
         self.multi_dims = {"maximum_number_of_layers": "layer", "number_of_vis_channels": "vis_channel_id"}
+
 
     def get_area_def(self, key):
         """Return the area definition."""
@@ -408,14 +410,15 @@ class FciL2NCAMVFileHandler(FciL2CommonFunctions, BaseFileHandler):
         """Open the NetCDF file with xarray and prepare for dataset reading."""
         super().__init__(filename, filename_info, filetype_info)
 
-        # Use xarray's default netcdf4 engine to open the file
-        self.nc = xr.open_dataset(
+    @cached_property
+    def nc(self):
+        """Read the file."""
+        return xr.open_dataset(
             self.filename,
             decode_cf=True,
             mask_and_scale=True,
             chunks={
                 "number_of_images": CHUNK_SIZE,
-                # 'number_of_height_estimates': CHUNK_SIZE,
                 "number_of_winds": CHUNK_SIZE
             }
         )

--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -452,9 +452,9 @@ class FciL2NCAMVFileHandler(FciL2CommonFunctions, BaseFileHandler):
         """
         attributes = {
             "filename": self.filename,
-            "spacecraft_name": self._spacecraft_name,
-            "sensor": self._sensor_name,
-            "platform_name": self._spacecraft_name,
+            "spacecraft_name": self.spacecraft_name,
+            "sensor": self.sensor_name,
+            "platform_name": self.spacecraft_name,
             "channel":self.filename_info["channel"]
         }
         return attributes

--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -419,25 +419,6 @@ class FciL2NCAMVFileHandler(FciL2CommonFunctions, BaseFileHandler):
                 "number_of_winds": CHUNK_SIZE
             }
         )
-    @property
-    def spacecraft_name(self):
-        """Get spacecraft name."""
-        try:
-            return self.nc.attrs["platform"]
-        except KeyError:
-            # TODO if the platform attribute is not valid, return a default value
-            logger.warning("Spacecraft name cannot be obtained from file content, use default value instead")
-            return "MTI1"
-
-    @property
-    def sensor_name(self):
-        """Get instrument name."""
-        try:
-            return self.nc.attrs["data_source"]
-        except KeyError:
-            # TODO if the data_source attribute is not valid, return a default value
-            logger.warning("Sensor cannot be obtained from file content, use default value instead")
-            return "FCI"
 
     def _get_global_attributes(self):
         """Create a dictionary of global attributes to be added to all datasets.

--- a/satpy/tests/reader_tests/test_fci_l2_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l2_nc.py
@@ -585,3 +585,12 @@ class TestFciL2NCAMVFileHandler(unittest.TestCase):
         assert dataset.attrs["test_attr"] == "attr"
         assert dataset.attrs["units"] == "test_units"
         assert dataset.attrs["fill_value"] == -999
+
+    def test_dataset_with_invalid_filekey(self):
+         """Test the correct execution of the get_dataset function with an invalid file_key."""
+         invalid_dataset = self.fh.get_dataset(make_dataid(name="test_invalid", resolution=2000),
+                                               {"name": "test_invalid",
+                                                "file_key": "test_invalid",
+                                                "fill_value": -999,
+                                                "file_type": "test_file_type"})
+         assert invalid_dataset is None

--- a/satpy/tests/reader_tests/test_fci_l2_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l2_nc.py
@@ -534,9 +534,9 @@ class TestFciL2NCAMVFileHandler(unittest.TestCase):
             qi = nc.createVariable("product_quality", np.int8)
             qi[:] = 99.
 
-            test_dataset = nc.createVariable("test_one_layer", np.float32,
+            test_dataset = nc.createVariable("test_dataset", np.float32,
                                                   dimensions="number_of_winds")
-            test_dataset[:] = np.ones((50000))
+            test_dataset[:] = np.ones(50000)
             test_dataset.test_attr = "attr"
             test_dataset.units = "test_units"
 
@@ -581,8 +581,7 @@ class TestFciL2NCAMVFileHandler(unittest.TestCase):
                                        "file_key": "test_dataset",
                                        "fill_value": -999,
                                        "file_type": "test_file_type"})
-
-        np.testing.assert_allclose(dataset.values, np.ones((50000)))
+        np.testing.assert_allclose(dataset.values, np.ones(50000))
         assert dataset.attrs["test_attr"] == "attr"
         assert dataset.attrs["units"] == "test_units"
         assert dataset.attrs["fill_value"] == -999

--- a/satpy/tests/reader_tests/test_fci_l2_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l2_nc.py
@@ -509,7 +509,7 @@ class TestFciL2NCReadingByteData(unittest.TestCase):
         assert dataset.values == 0
 
 class TestFciL2NCAMVFileHandler:
-    """Test the FciL2NCFileHandler reader."""
+    """Test the FciL2NCAMVFileHandler reader."""
 
     def setup_method(self):
         """Set up the test by creating a test file and opening it with the reader."""
@@ -548,7 +548,8 @@ class TestFciL2NCAMVFileHandler:
 
         self.fh = FciL2NCAMVFileHandler(filename=self.test_file,
                                         filename_info={"channel":"test_channel"},
-                                        filetype_info={})
+                                        filetype_info={}
+                                        )
 
     def tearDown(self):
         """Remove the previously created test file."""

--- a/satpy/tests/reader_tests/test_fci_l2_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l2_nc.py
@@ -508,10 +508,10 @@ class TestFciL2NCReadingByteData(unittest.TestCase):
 
         assert dataset.values == 0
 
-class TestFciL2NCAMVFileHandler(unittest.TestCase):
+class TestFciL2NCAMVFileHandler:
     """Test the FciL2NCFileHandler reader."""
 
-    def setUp(self):
+    def setup_method(self):
         """Set up the test by creating a test file and opening it with the reader."""
         # Easiest way to test the reader is to create a test netCDF file on the fly
         # Create unique filenames to prevent race conditions when tests are run in parallel


### PR DESCRIPTION
This PR add a reader for the FCI L2 AMV. 
Since the AMV products are NetCDF files that only use 1 dimension (`number_of_winds`) to define all the variables. 
It need a dedicated File Handler to avoid adding exception handler for non-array stuff like x and y. 
This File handler inherit `FciL2CommonFunctions` and only modify a couple of methods including the get_dataset. 
It is rather simple and does not process the data. 
There is no Area definition since the product does not contain any. 
Only the lat,lon needs to be used to project and display the AMV on a map. 

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented(see EUM PUG?)  <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
