### PR TITLE
Get rid of warnings in compositor tests

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -204,7 +204,7 @@ class CompositeBase:
                     if coord not in ds.dims and
                     any([neglible in coord for neglible in NEGLIGIBLE_COORDS])]
             if drop:
-                new_arrays.append(ds.drop(drop))
+                new_arrays.append(ds.drop_vars(drop))
             else:
                 new_arrays.append(ds)
 

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1180,7 +1180,8 @@ class RatioSharpenedRGB(GenericCompositor):
 
 
 def _get_sharpening_ratio(high_res, low_res):
-    ratio = high_res / low_res
+    with np.errstate(divide="ignore"):
+        ratio = high_res / low_res
     # make ratio a no-op (multiply by 1) where the ratio is NaN, infinity,
     # or it is negative.
     ratio[~np.isfinite(ratio) | (ratio < 0)] = 1.0

--- a/satpy/composites/ahi.py
+++ b/satpy/composites/ahi.py
@@ -14,7 +14,3 @@
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Composite classes for AHI."""
-
-# The green corrector used to be defined here, but was moved to spectral.py
-# in Satpy 0.38 because it also applies to FCI.
-from .spectral import GreenCorrector  # noqa: F401

--- a/satpy/composites/spectral.py
+++ b/satpy/composites/spectral.py
@@ -16,7 +16,6 @@
 """Composite classes for spectral adjustments."""
 
 import logging
-import warnings
 
 from satpy.composites import GenericCompositor
 from satpy.dataset import combine_metadata
@@ -199,23 +198,3 @@ class NDVIHybridGreen(SpectralBlender):
             + self.limits[0]
 
         return fraction
-
-
-class GreenCorrector(SpectralBlender):
-    """Previous class used to blend channels for green band corrections.
-
-    This method has been refactored to make it more generic. The replacement class is 'SpectralBlender' which computes
-    a weighted average based on N number of channels and N number of corresponding weights/fractions. A new class
-    called 'HybridGreen' has been created, which performs a correction of green bands centered at 0.51 microns
-    following Miller et al. (2016, :doi:`10.1175/BAMS-D-15-00154.2`) in order to improve true color imagery.
-    """
-
-    def __init__(self, *args, fractions=(0.85, 0.15), **kwargs):
-        """Set default keyword argument values."""
-        warnings.warn(
-            "'GreenCorrector' is deprecated, use 'SpectralBlender' instead, or 'HybridGreen' for hybrid green"
-            " correction following Miller et al. (2016).",
-            UserWarning,
-            stacklevel=2
-        )
-        super().__init__(fractions=fractions, *args, **kwargs)

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -15,46 +15,6 @@ modifiers:
     - solar_zenith_angle
 
 composites:
-  green:
-    deprecation_warning: "'green' is a deprecated composite. Use the equivalent 'hybrid_green' instead."
-    compositor: !!python/name:satpy.composites.spectral.HybridGreen
-    # FUTURE: Set a wavelength...see what happens. Dependency finding
-    #         probably wouldn't work.
-    prerequisites:
-      # should we be using the most corrected or least corrected inputs?
-      # what happens if something requests more modifiers on top of this?
-      - wavelength: 0.51
-        modifiers: [sunz_corrected, rayleigh_corrected]
-      - wavelength: 0.85
-        modifiers:  [sunz_corrected]
-    standard_name: toa_bidirectional_reflectance
-
-  green_true_color_reproduction:
-    # JMA True Color Reproduction green band
-    # http://www.jma.go.jp/jma/jma-eng/satellite/introduction/TCR.html
-    deprecation_warning: "'green_true_color_reproduction' is a deprecated composite. Use the equivalent 'reproduced_green' instead."
-    compositor: !!python/name:satpy.composites.spectral.SpectralBlender
-    fractions: [0.6321, 0.2928, 0.0751]
-    prerequisites:
-      - name: B02
-        modifiers: [sunz_corrected, rayleigh_corrected]
-      - name: B03
-        modifiers: [sunz_corrected, rayleigh_corrected]
-      - name: B04
-        modifiers: [sunz_corrected]
-    standard_name: none
-
-  green_nocorr:
-    deprecation_warning: "'green_nocorr' is a deprecated composite. Use the equivalent 'hybrid_green_nocorr' instead."
-    compositor: !!python/name:satpy.composites.spectral.HybridGreen
-    # FUTURE: Set a wavelength...see what happens. Dependency finding
-    #         probably wouldn't work.
-    prerequisites:
-      # should we be using the most corrected or least corrected inputs?
-      # what happens if something requests more modifiers on top of this?
-      - wavelength: 0.51
-      - wavelength: 0.85
-    standard_name: toa_reflectance
 
   hybrid_green:
     compositor: !!python/name:satpy.composites.spectral.HybridGreen

--- a/satpy/tests/compositor_tests/test_spectral.py
+++ b/satpy/tests/compositor_tests/test_spectral.py
@@ -21,7 +21,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from satpy.composites.spectral import GreenCorrector, HybridGreen, NDVIHybridGreen, SpectralBlender
+from satpy.composites.spectral import HybridGreen, NDVIHybridGreen, SpectralBlender
 from satpy.tests.utils import CustomScheduler
 
 
@@ -63,18 +63,6 @@ class TestSpectralComposites:
         assert isinstance(res, xr.DataArray)
         assert isinstance(res.data, da.Array)
         assert res.attrs["name"] == "hybrid_green"
-        assert res.attrs["standard_name"] == "toa_bidirectional_reflectance"
-        data = res.compute()
-        np.testing.assert_allclose(data, 0.23)
-
-    def test_green_corrector(self):
-        """Test the deprecated class for green corrections."""
-        comp = GreenCorrector("blended_channel", fractions=(0.85, 0.15), prerequisites=(0.51, 0.85),
-                              standard_name="toa_bidirectional_reflectance")
-        res = comp((self.c01, self.c03))
-        assert isinstance(res, xr.DataArray)
-        assert isinstance(res.data, da.Array)
-        assert res.attrs["name"] == "blended_channel"
         assert res.attrs["standard_name"] == "toa_bidirectional_reflectance"
         data = res.compute()
         np.testing.assert_allclose(data, 0.23)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from glob import glob
 from setuptools import find_packages, setup
 
 requires = ["numpy >=1.21", "pillow", "pyresample >=1.24.0", "trollsift",
-            "trollimage >=1.20", "pykdtree", "pyyaml >=5.1", "xarray >=0.10.1, !=0.13.0",
+            "trollimage >=1.20", "pykdtree", "pyyaml >=5.1", "xarray >=0.14.1",
             "dask[array] >=0.17.1", "pyproj>=2.2", "zarr", "donfig", "appdirs",
             "packaging", "pooch", "pyorbital"]
 


### PR DESCRIPTION
This PR cleans the compositor tests so that they emit zero warnings when ran with `pytest -Werror satpy/tests/test_composites.py satpy/tests/compositor_tests/`.

The backwards incompatile change is the removal of `GreenCorrector` class, which is not used internally, and was deprecated in November 2022 in v0.39.0. Someone might be using it in their own configs.

The lower version limit of XArray is raised to v0.14.1 where `xr.DataArray.drop_vars()` was added and `.drop()` was deprecated.

Three deprecated AHI composites were removed, which were related to the deprecation of `GreenCorrector`.

 - [x] Tests adjusted