### PR TITLE
Decode time parameters in CF Reader

### DIFF
--- a/satpy/cf/decoding.py
+++ b/satpy/cf/decoding.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""CF decoding."""
+import copy
+import json
+from datetime import datetime
+
+
+def decode_attrs(attrs):
+    """Decode CF-encoded attributes to Python object.
+
+    Converts timestamps to datetime and strings starting with "{" to
+    dictionary.
+
+    Args:
+        attrs (dict): Attributes to be decoded
+
+    Returns (dict): Decoded attributes
+    """
+    attrs = copy.deepcopy(attrs)
+    _decode_dict_type_attrs(attrs)
+    _decode_timestamps(attrs)
+    return attrs
+
+
+def _decode_dict_type_attrs(attrs):
+    for key, val in attrs.items():
+        attrs[key] = _str2dict(val)
+
+
+def _str2dict(val):
+    """Convert string to dictionary."""
+    if isinstance(val, str) and val.startswith("{"):
+        val = json.loads(val, object_hook=_datetime_parser_json)
+    return val
+
+
+def _decode_timestamps(attrs):
+    for key, value in attrs.items():
+        timestamp = _str2datetime(value)
+        if timestamp:
+            attrs[key] = timestamp
+
+
+def _datetime_parser_json(json_dict):
+    """Traverse JSON dictionary and parse timestamps."""
+    for key, value in json_dict.items():
+        timestamp = _str2datetime(value)
+        if timestamp:
+            json_dict[key] = timestamp
+    return json_dict
+
+
+def _str2datetime(string):
+    """Convert string to datetime object."""
+    try:
+        return datetime.fromisoformat(string)
+    except (TypeError, ValueError):
+        return None

--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -316,7 +316,10 @@ class SatpyCFFileHandler(BaseFileHandler):
 
     def _decode_dict_type_attrs(self, data):
         for key in ["orbital_parameters", "time_parameters"]:
-            data.attrs[key] = _str2dict(data.attrs[key])
+            try:
+                data.attrs[key] = _str2dict(data.attrs[key])
+            except KeyError:
+                continue
 
     def get_area_def(self, dataset_id):
         """Get area definition from CF complient netcdf."""

--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -315,11 +315,8 @@ class SatpyCFFileHandler(BaseFileHandler):
         return data
 
     def _decode_dict_type_attrs(self, data):
-        for key in ["orbital_parameters", "time_parameters"]:
-            try:
-                data.attrs[key] = _str2dict(data.attrs[key])
-            except KeyError:
-                continue
+        for key, val in data.attrs.items():
+            data.attrs[key] = _str2dict(val)
 
     def get_area_def(self, dataset_id):
         """Get area definition from CF complient netcdf."""
@@ -346,6 +343,6 @@ def _datetime_parser(json_dict):
 
 def _str2dict(val):
     """Convert string to dictionary."""
-    if isinstance(val, str):
+    if isinstance(val, str) and val.startswith("{"):
         val = json.loads(val, object_hook=_datetime_parser)
     return val

--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -179,6 +179,7 @@ Output:
 import itertools
 import json
 import logging
+from datetime import datetime
 
 import xarray as xr
 from pyresample import AreaDefinition
@@ -347,10 +348,9 @@ class DatasetAttributeDecoder:
 
 
 def _datetime_parser(json_dict):
-    import dateutil.parser
     for key, value in json_dict.items():
         try:
-            json_dict[key] = dateutil.parser.parse(value)
+            json_dict[key] = datetime.fromisoformat(value)
         except (TypeError, ValueError):
             pass
     return json_dict

--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -313,7 +313,12 @@ class SatpyCFFileHandler(BaseFileHandler):
         data.attrs.update(nc.attrs)  # For now add global attributes to all datasets
         if "orbital_parameters" in data.attrs:
             data.attrs["orbital_parameters"] = _str2dict(data.attrs["orbital_parameters"])
-
+        if "time_parameters" in data.attrs:
+            time_params = _str2dict(data.attrs["time_parameters"])
+            from dateutil.parser import isoparse
+            for key, val in time_params.items():
+                time_params[key] = isoparse(val)
+            data.attrs["time_parameters"] = time_params
         return data
 
     def get_area_def(self, dataset_id):

--- a/satpy/tests/cf_tests/test_decoding.py
+++ b/satpy/tests/cf_tests/test_decoding.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2023 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for CF decoding."""
+from datetime import datetime
+
+import pytest
+
+import satpy.cf.decoding
+
+
+class TestDecodeAttrs:
+    """Test decoding of CF-encoded attributes."""
+
+    @pytest.fixture()
+    def attrs(self):
+        """Get CF-encoded attributes."""
+        return {
+            "my_integer": 0,
+            "my_float": 0.0,
+            "my_list": [1, 2, 3],
+            "my_timestamp1": "2000-01-01",
+            "my_timestamp2": "2000-01-01 12:15:33",
+            "my_timestamp3": "2000-01-01 12:15:33.123456",
+            "my_dict": '{"a": {"b": [1, 2, 3]}, "c": {"d": "2000-01-01 12:15:33.123456"}}'
+        }
+
+    @pytest.fixture()
+    def expected(self):
+        """Get expected decoded results."""
+        return {
+            "my_integer": 0,
+            "my_float": 0.0,
+            "my_list": [1, 2, 3],
+            "my_timestamp1": datetime(2000, 1, 1),
+            "my_timestamp2": datetime(2000, 1, 1, 12, 15, 33),
+            "my_timestamp3": datetime(2000, 1, 1, 12, 15, 33, 123456),
+            "my_dict": {"a": {"b": [1, 2, 3]},
+                        "c": {"d": datetime(2000, 1, 1, 12, 15, 33, 123456)}}
+        }
+
+    def test_decoding(self, attrs, expected):
+        """Test decoding of CF-encoded attributes."""
+        res = satpy.cf.decoding.decode_attrs(attrs)
+        assert res == expected
+
+    def test_decoding_doesnt_modify_original(self, attrs):
+        """Test that decoding doesn't modify the original attributes."""
+        satpy.cf.decoding.decode_attrs(attrs)
+        assert isinstance(attrs["my_dict"], str)

--- a/satpy/tests/reader_tests/test_satpy_cf_nc.py
+++ b/satpy/tests/reader_tests/test_satpy_cf_nc.py
@@ -111,7 +111,8 @@ def common_attrs(area):
         "end_time": datetime(2019, 4, 1, 12, 15),
         "platform_name": "tirosn",
         "orbit_number": 99999,
-        "area": area
+        "area": area,
+        "my_timestamp": datetime(2000, 1, 1)
     }
 
 
@@ -445,6 +446,14 @@ class TestCFReader:
             orig_attrs = cf_scene["image0"].attrs[attr_name]
             new_attrs = scn_["image0"].attrs[attr_name]
             assert new_attrs == orig_attrs
+
+    def test_decoding_of_timestamps(self, cf_scene, nc_filename):
+        """Test decoding of timestamps."""
+        cf_scene.save_datasets(writer="cf", filename=nc_filename)
+        scn = Scene(reader="satpy_cf_nc", filenames=[nc_filename])
+        scn.load(["image0"])
+        expected = cf_scene["image0"].attrs["my_timestamp"]
+        assert scn["image0"].attrs["my_timestamp"] == expected
 
     def test_write_and_read_from_two_files(self, nc_filename, nc_filename_i):
         """Save two datasets with different resolution and read the solar_zenith_angle again."""

--- a/satpy/tests/reader_tests/test_satpy_cf_nc.py
+++ b/satpy/tests/reader_tests/test_satpy_cf_nc.py
@@ -107,7 +107,7 @@ def area():
 def common_attrs(area):
     """Get common dataset attributes."""
     return {
-        "start_time": datetime(2019, 4, 1, 12, 0),
+        "start_time": datetime(2019, 4, 1, 12, 0, 0, 123456),
         "end_time": datetime(2019, 4, 1, 12, 15),
         "platform_name": "tirosn",
         "orbit_number": 99999,

--- a/satpy/tests/reader_tests/test_satpy_cf_nc.py
+++ b/satpy/tests/reader_tests/test_satpy_cf_nc.py
@@ -147,6 +147,10 @@ def cf_scene():
                                   "nadir_longitude": 1,
                                   "nadir_latitude": 1,
                                   "only_in_1": False
+                              },
+                              "time_parameters": {
+                                  "nominal_start_time": tstart,
+                                  "nominal_end_time": tend
                               }
                           })
 
@@ -388,18 +392,17 @@ class TestCFReader:
         np.testing.assert_array_equal(scn_["1"].data, cf_scene["1"].data)
         np.testing.assert_array_equal(scn_["1"].coords["lon"], cf_scene["lon"].data)  # lon loded as coord
 
-    def test_orbital_parameters(self, cf_scene, nc_filename):
-        """Test that the orbital parameters in attributes are handled correctly."""
+    def test_decoding_of_dict_type_attributes(self, cf_scene, nc_filename):
+        """Test decoding of dict type attributes."""
         cf_scene.save_datasets(writer="cf",
                                filename=nc_filename)
         scn_ = Scene(reader="satpy_cf_nc",
                      filenames=[nc_filename])
         scn_.load(["image0"])
-        orig_attrs = cf_scene["image0"].attrs["orbital_parameters"]
-        new_attrs = scn_["image0"].attrs["orbital_parameters"]
-        assert isinstance(new_attrs, dict)
-        for key in orig_attrs:
-            assert orig_attrs[key] == new_attrs[key]
+        for attr_name in ["orbital_parameters", "time_parameters"]:
+            orig_attrs = cf_scene["image0"].attrs[attr_name]
+            new_attrs = scn_["image0"].attrs[attr_name]
+            assert new_attrs == orig_attrs
 
     def test_write_and_read_from_two_files(self, nc_filename, nc_filename_i):
         """Save two datasets with different resolution and read the solar_zenith_angle again."""


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Fixes #2680 and #2609 by updating attribute decoding in the CF reader:

1. Convert string timestamps to `datetime`.
2. Convert string attributes starting with `{` to dictionary (see see https://github.com/pytroll/satpy/issues/2609#issuecomment-1778937364)

~~I've pulled in `dateutil` as dependency to make it work, but I'm open to discuss this (see thread on slack).~~ 
Edit: Found a way to parse timestamps with varying precision (e.g. `2020-01-01 00:00` or `2020-01-01 00:00:00.123456`) using `datetime.fromisoformat`

I also refactored the tests a bit to reduce complexity of the test setup.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Tests added <!-- for all bug fixes or enhancements -->

