### PR TITLE
Fix/supress warnings in reader tests

### DIFF
--- a/satpy/readers/ahi_l2_nc.py
+++ b/satpy/readers/ahi_l2_nc.py
@@ -73,8 +73,8 @@ class HIML2NCFileHandler(BaseFileHandler):
             raise ValueError("File is not a full disk scene")
 
         self.sensor = self.nc.attrs["instrument_name"].lower()
-        self.nlines = self.nc.dims["Columns"]
-        self.ncols = self.nc.dims["Rows"]
+        self.nlines = self.nc.sizes["Columns"]
+        self.ncols = self.nc.sizes["Rows"]
         self.platform_name = self.nc.attrs["satellite_name"]
         self.platform_shortname = filename_info["platform"]
         self._meta = None

--- a/satpy/readers/ahi_l2_nc.py
+++ b/satpy/readers/ahi_l2_nc.py
@@ -100,8 +100,8 @@ class HIML2NCFileHandler(BaseFileHandler):
         # Data has 'Latitude' and 'Longitude' coords, these must be replaced.
         variable = variable.rename({"Rows": "y", "Columns": "x"})
 
-        variable = variable.drop("Latitude")
-        variable = variable.drop("Longitude")
+        variable = variable.drop_vars("Latitude")
+        variable = variable.drop_vars("Longitude")
 
         variable.attrs.update(key.to_dict())
         return variable

--- a/satpy/readers/eum_base.py
+++ b/satpy/readers/eum_base.py
@@ -33,14 +33,14 @@ def timecds2datetime(tcds):
 
     Works both with a dictionary and a numpy record_array.
     """
-    days = int(tcds["Days"])
-    milliseconds = int(tcds["Milliseconds"])
+    days = int(tcds["Days"].item())
+    milliseconds = int(tcds["Milliseconds"].item())
     try:
-        microseconds = int(tcds["Microseconds"])
+        microseconds = int(tcds["Microseconds"].item())
     except (KeyError, ValueError):
         microseconds = 0
     try:
-        microseconds += int(tcds["Nanoseconds"]) / 1000.
+        microseconds += int(tcds["Nanoseconds"].item()) / 1000.
     except (KeyError, ValueError):
         pass
 

--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -372,7 +372,7 @@ class FciL2NCSegmentFileHandler(FciL2CommonFunctions, BaseFileHandler):
         # Construct area definition from standardized area definition.
         stand_area_def = get_area_def(area_naming["area_id"])
 
-        if (stand_area_def.x_size != self.ncols) | (stand_area_def.y_size != self.nlines):
+        if (stand_area_def.width != self.ncols) | (stand_area_def.height != self.nlines):
             raise NotImplementedError("Unrecognised AreaDefinition.")
 
         mod_area_extent = self._modify_area_extent(stand_area_def.area_extent)
@@ -382,8 +382,8 @@ class FciL2NCSegmentFileHandler(FciL2CommonFunctions, BaseFileHandler):
             stand_area_def.description,
             "",
             stand_area_def.crs,
-            stand_area_def.x_size,
-            stand_area_def.y_size,
+            stand_area_def.width,
+            stand_area_def.height,
             mod_area_extent)
 
         return area_def

--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -381,7 +381,7 @@ class FciL2NCSegmentFileHandler(FciL2CommonFunctions, BaseFileHandler):
             stand_area_def.area_id,
             stand_area_def.description,
             "",
-            stand_area_def.proj_dict,
+            stand_area_def.crs,
             stand_area_def.x_size,
             stand_area_def.y_size,
             mod_area_extent)

--- a/satpy/readers/geocat.py
+++ b/satpy/readers/geocat.py
@@ -36,7 +36,6 @@ import logging
 import numpy as np
 from pyproj import Proj
 from pyresample import geometry
-from pyresample.utils import proj4_str_to_dict
 
 from satpy.readers.netcdf_utils import NetCDF4FileHandler, netCDF4
 
@@ -274,7 +273,7 @@ class GEOCATFileHandler(NetCDF4FileHandler):
             area_name,
             area_name,
             area_name,
-            proj4_str_to_dict(proj),
+            proj,
             lon.shape[1],
             lon.shape[0],
             area_extent=extents,

--- a/satpy/readers/gms/gms5_vissr_l1b.py
+++ b/satpy/readers/gms/gms5_vissr_l1b.py
@@ -307,7 +307,7 @@ class GMS5VISSRFileHandler(BaseFileHandler):
         }
 
     def _get_time_parameters(self):
-        start_time = mjd2datetime64(self._mode_block["observation_time_mjd"])
+        start_time = mjd2datetime64(self._mode_block["observation_time_mjd"]).astype("datetime64[us]")
         start_time = start_time.astype(dt.datetime).replace(second=0, microsecond=0)
         end_time = start_time + dt.timedelta(
             minutes=25

--- a/satpy/readers/goes_imager_nc.py
+++ b/satpy/readers/goes_imager_nc.py
@@ -615,8 +615,8 @@ class GOESNCBaseFileHandler(BaseFileHandler):
                                   mask_and_scale=False,
                                   chunks={"xc": CHUNK_SIZE, "yc": CHUNK_SIZE})
         self.sensor = "goes_imager"
-        self.nlines = self.nc.dims["yc"]
-        self.ncols = self.nc.dims["xc"]
+        self.nlines = self.nc.sizes["yc"]
+        self.ncols = self.nc.sizes["xc"]
         self.platform_name = self._get_platform_name(
             self.nc.attrs["Satellite Sensor"])
         self.platform_shortname = self.platform_name.replace("-", "").lower()
@@ -1124,8 +1124,8 @@ class GOESEUMGEONCFileHandler(BaseFileHandler):
                                   mask_and_scale=False,
                                   chunks={"xc": CHUNK_SIZE, "yc": CHUNK_SIZE})
         self.sensor = "goes_imager"
-        self.nlines = self.nc.dims["yc"]
-        self.ncols = self.nc.dims["xc"]
+        self.nlines = self.nc.sizes["yc"]
+        self.ncols = self.nc.sizes["xc"]
         self.platform_name = GOESNCBaseFileHandler._get_platform_name(
             self.nc.attrs["Satellite Sensor"])
         self.platform_shortname = self.platform_name.replace("-", "").lower()

--- a/satpy/readers/goes_imager_nc.py
+++ b/satpy/readers/goes_imager_nc.py
@@ -1087,7 +1087,7 @@ class GOESEUMNCFileHandler(GOESNCBaseFileHandler):
 
         # Set proper dimension names
         data = data.rename({"xc": "x", "yc": "y"})
-        data = data.drop("time")
+        data = data.drop_vars("time")
 
         # Update metadata
         self._update_metadata(data, ds_info=info)

--- a/satpy/readers/goes_imager_nc.py
+++ b/satpy/readers/goes_imager_nc.py
@@ -620,7 +620,7 @@ class GOESNCBaseFileHandler(BaseFileHandler):
         self.platform_name = self._get_platform_name(
             self.nc.attrs["Satellite Sensor"])
         self.platform_shortname = self.platform_name.replace("-", "").lower()
-        self.gvar_channel = int(self.nc["bands"].values)
+        self.gvar_channel = int(self.nc["bands"].item())
         self.sector = self._get_sector(channel=self.gvar_channel,
                                        nlines=self.nlines,
                                        ncols=self.ncols)
@@ -731,9 +731,9 @@ class GOESNCBaseFileHandler(BaseFileHandler):
     def start_time(self):
         """Start timestamp of the dataset."""
         dt = self.nc["time"].dt
-        return datetime(year=int(dt.year), month=int(dt.month), day=int(dt.day),
-                        hour=int(dt.hour), minute=int(dt.minute),
-                        second=int(dt.second), microsecond=int(dt.microsecond))
+        return datetime(year=int(dt.year.item()), month=int(dt.month.item()), day=int(dt.day.item()),
+                        hour=int(dt.hour.item()), minute=int(dt.minute.item()),
+                        second=int(dt.second.item()), microsecond=int(dt.microsecond.item()))
 
     @property
     def end_time(self):

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -198,9 +198,10 @@ SENSORS = {
 def mjd2datetime64(mjd):
     """Convert Modified Julian Day (MJD) to datetime64."""
     epoch = np.datetime64("1858-11-17 00:00")
-    day2usec = 24 * 3600 * 1E6
-    mjd_usec = (mjd * day2usec).astype(np.int64).astype("timedelta64[us]")
-    return epoch + mjd_usec
+    day2nsec = 24 * 3600 * 1E9
+    mjd_nsec = (mjd * day2nsec).astype(np.int64).astype("timedelta64[ns]")
+
+    return epoch + mjd_nsec
 
 
 class HRITJMAFileHandler(HRITFileHandler):

--- a/satpy/readers/hrpt.py
+++ b/satpy/readers/hrpt.py
@@ -78,7 +78,7 @@ def time_seconds(tc_array, year):
     word = tc_array[:, 3]
     msecs += word & 1023
     return (np.datetime64(
-        str(year) + "-01-01T00:00:00Z", "s") +
+        str(year) + "-01-01T00:00:00", "s") +
         msecs[:].astype("timedelta64[ms]") +
         (day - 1)[:].astype("timedelta64[D]"))
 
@@ -224,7 +224,7 @@ class HRPTFile(BaseFileHandler):
         """Calibrate a solar channel."""
         from pygac.calibration import calibrate_solar
         julian_days = ((np.datetime64(self.start_time)
-                        - np.datetime64(str(self.year) + "-01-01T00:00:00Z"))
+                        - np.datetime64(str(self.year) + "-01-01T00:00:00"))
                        / np.timedelta64(1, "D"))
         data = calibrate_solar(data, _get_channel_index(key), self.year, julian_days,
                                self.calibrator)

--- a/satpy/readers/mirs.py
+++ b/satpy/readers/mirs.py
@@ -18,6 +18,7 @@
 """Interface to MiRS product."""
 
 import datetime
+import importlib
 import logging
 import os
 from collections import Counter
@@ -34,13 +35,12 @@ CHUNK_SIZE = get_legacy_chunk_size()
 LOG = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
-try:
-    # try getting setuptools/distribute's version of resource retrieval first
-    from pkg_resources import resource_string as get_resource_string
-except ImportError:
-    from pkgutil import get_data as get_resource_string  # type: ignore
 
-#
+def get_resource_string(mod_part, file_part):
+    """Read resource string."""
+    ref = importlib.resources.files(mod_part).joinpath(file_part)
+    return ref.read_bytes()
+
 
 # 'Polo' variable in MiRS files use these values for H/V polarization
 POLO_V = 2

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -347,8 +347,13 @@ class NcNWCSAF(BaseFileHandler):
     @staticmethod
     def _ensure_crs_extents_in_meters(crs, area_extent):
         """Fix units in Earth shape, satellite altitude and 'units' attribute."""
+        import warnings
         if "kilo" in crs.axis_info[0].unit_name:
-            proj_dict = crs.to_dict()
+            with warnings.catch_warnings():
+                # The proj dict route is the only feasible way to modify the area, suppress the warning it causes
+                warnings.filterwarnings("ignore", category=UserWarning,
+                                        message="You will likely lose important projection information")
+                proj_dict = crs.to_dict()
             proj_dict["units"] = "m"
             if "a" in proj_dict:
                 proj_dict["a"] *= 1000.

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -36,11 +36,11 @@ from pyresample.geometry import AreaDefinition
 
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.utils import unzip_file
-from satpy.utils import get_legacy_chunk_size
+from satpy.utils import get_chunk_size_limit
 
 logger = logging.getLogger(__name__)
 
-CHUNK_SIZE = get_legacy_chunk_size()
+CHUNK_SIZE = get_chunk_size_limit()
 
 SENSOR = {"NOAA-19": "avhrr-3",
           "NOAA-18": "avhrr-3",

--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -318,15 +318,8 @@ class SatpyCFFileHandler(BaseFileHandler):
 
     def get_area_def(self, dataset_id):
         """Get area definition from CF complient netcdf."""
-        import warnings
-
         try:
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore",
-                                        message=r"You will likely lose important projection information",
-                                        category=UserWarning)
-                # FIXME: This should be silenced in Pyresample
-                area = AreaDefinition.from_cf(self.filename)
+            area = AreaDefinition.from_cf(self.filename)
             return area
         except ValueError:
             # No CF compliant projection information was found in the netcdf file or

--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -318,8 +318,15 @@ class SatpyCFFileHandler(BaseFileHandler):
 
     def get_area_def(self, dataset_id):
         """Get area definition from CF complient netcdf."""
+        import warnings
+
         try:
-            area = AreaDefinition.from_cf(self.filename)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore",
+                                        message=r"You will likely lose important projection information",
+                                        category=UserWarning)
+                # FIXME: This should be silenced in Pyresample
+                area = AreaDefinition.from_cf(self.filename)
             return area
         except ValueError:
             # No CF compliant projection information was found in the netcdf file or

--- a/satpy/readers/satpy_cf_nc.py
+++ b/satpy/readers/satpy_cf_nc.py
@@ -237,7 +237,7 @@ class SatpyCFFileHandler(BaseFileHandler):
     def fix_modifier_attr(self, ds_info):
         """Fix modifiers attribute."""
         # Empty modifiers are read as [], which causes problems later
-        if "modifiers" in ds_info and not ds_info["modifiers"]:
+        if "modifiers" in ds_info and len(ds_info["modifiers"]) == 0:
             ds_info["modifiers"] = ()
         try:
             try:

--- a/satpy/readers/seviri_l1b_nc.py
+++ b/satpy/readers/seviri_l1b_nc.py
@@ -139,8 +139,8 @@ class NCSEVIRIFileHandler(BaseFileHandler):
                                              "h": 35785831.00,
                                              "ssp_longitude": ssp_lon}
 
-        self.mda["number_of_lines"] = int(self.nc.dims["y"])
-        self.mda["number_of_columns"] = int(self.nc.dims["x"])
+        self.mda["number_of_lines"] = int(self.nc.sizes["y"])
+        self.mda["number_of_columns"] = int(self.nc.sizes["x"])
 
         # only needed for HRV channel which is not implemented yet
         # self.mda['hrv_number_of_lines'] = int(self.nc.dims['num_rows_hrv'])

--- a/satpy/readers/smos_l2_wind.py
+++ b/satpy/readers/smos_l2_wind.py
@@ -170,6 +170,6 @@ class SMOSL2WINDFileHandler(NetCDF4FileHandler):
         description = "SMOS L2 Wind Equirectangular Projection"
         area_id = "smos_eqc"
         proj_id = "equirectangular"
-        proj_dict = {"init": self["/attr/geospatial_bounds_vertical_crs"]}
-        area_def = AreaDefinition(area_id, description, proj_id, proj_dict, width, height, area_extent, )
+        proj_str = self["/attr/geospatial_bounds_vertical_crs"]
+        area_def = AreaDefinition(area_id, description, proj_id, proj_str, width, height, area_extent, )
         return area_def

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -119,6 +119,7 @@ class TestHRITJMAFileHandler(unittest.TestCase):
 
         # Check if scanline timestamps are there (dedicated test below)
         assert isinstance(reader.acq_time, np.ndarray)
+        assert reader.acq_time.dtype == np.dtype("datetime64[ns]")
 
         # Check platform
         assert reader.platform == HIMAWARI8
@@ -305,14 +306,13 @@ class TestHRITJMAFileHandler(unittest.TestCase):
     def test_mjd2datetime64(self):
         """Test conversion from modified julian day to datetime64."""
         from satpy.readers.hrit_jma import mjd2datetime64
-        assert mjd2datetime64(np.array([0])) == np.datetime64("1858-11-17", "us")
-        assert mjd2datetime64(np.array([40587.5])) == np.datetime64("1970-01-01 12:00", "us")
+        assert mjd2datetime64(np.array([0])) == np.datetime64("1858-11-17", "ns")
+        assert mjd2datetime64(np.array([40587.5])) == np.datetime64("1970-01-01 12:00", "ns")
 
     def test_get_acq_time(self):
         """Test computation of scanline acquisition times."""
         dt_line = np.arange(1, 11000+1).astype("timedelta64[s]")
-        acq_time_exp = np.datetime64("1970-01-01", "us") + dt_line
-
+        acq_time_exp = np.datetime64("1970-01-01", "ns") + dt_line
         for platform in ["Himawari-8", "MTSAT-2"]:
             # Results are not exactly identical because timestamps are stored in
             # the header with only 6 decimals precision (max diff here: 45 msec).
@@ -320,7 +320,7 @@ class TestHRITJMAFileHandler(unittest.TestCase):
             reader = self._get_reader(mda=mda)
             np.testing.assert_allclose(reader.acq_time.astype(np.int64),
                                        acq_time_exp.astype(np.int64),
-                                       atol=45000)
+                                       atol=45000000)
 
     def test_start_time_from_filename(self):
         """Test that by default the datetime in the filename is returned."""

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -105,7 +105,8 @@ class TestAHIHSDNavigation(unittest.TestCase):
     @mock.patch("satpy.readers.ahi_hsd.np.fromfile")
     def test_region(self, fromfile, np2str):
         """Test region navigation."""
-        from pyresample.utils import proj4_radius_parameters
+        from pyproj import CRS
+
         np2str.side_effect = lambda x: x
         m = mock.mock_open()
         with mock.patch("satpy.readers.ahi_hsd.open", m, create=True):
@@ -140,18 +141,9 @@ class TestAHIHSDNavigation(unittest.TestCase):
                             "spare": ""}
 
             area_def = fh.get_area_def(None)
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore",
-                                        message=r"You will likely lose important projection information",
-                                        category=UserWarning)
-                proj_dict = area_def.proj_dict
-            a, b = proj4_radius_parameters(proj_dict)
-            assert a == 6378137.0
-            assert b == 6356752.3
-            assert proj_dict["h"] == 35785863.0
-            assert proj_dict["lon_0"] == 140.7
-            assert proj_dict["proj"] == "geos"
-            assert proj_dict["units"] == "m"
+            expected_crs = CRS.from_dict(dict(a=6378137.0, b=6356752.3, h= 35785863.0,
+                                              lon_0=140.7, proj="geos", units="m"))
+            assert area_def.crs == expected_crs
             np.testing.assert_allclose(area_def.area_extent, (592000.0038256242, 4132000.0267018233,
                                                               1592000.0102878273, 5132000.033164027))
 

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -473,7 +473,7 @@ class TestAHIHSDFileHandler:
 
             # Expected and actual blocklength do not match
             fp_.tell.return_value = 100
-            with pytest.raises(UserWarning, match=r"Actual .* header size does not match expected"):
+            with pytest.warns(UserWarning, match=r"Actual .* header size does not match expected"):
                 fh._check_fpos(fp_, fpos, 0, "header 1")
 
     def test_is_valid_time(self):
@@ -491,7 +491,7 @@ class TestAHIHSDFileHandler:
                 mocker.return_value = True
                 assert fh._modify_observation_time_for_nominal(in_date) == datetime(2020, 1, 1, 3, 0, 0)
                 mocker.return_value = False
-                with pytest.raises(UserWarning,
+                with pytest.warns(UserWarning,
                                    match=r"Observation timeline is fill value, not rounding observation time"):
                     assert fh._modify_observation_time_for_nominal(in_date) == datetime(2020, 1, 1, 12, 0, 0)
 

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -151,7 +151,8 @@ class TestAHIHSDNavigation(unittest.TestCase):
     @mock.patch("satpy.readers.ahi_hsd.np.fromfile")
     def test_segment(self, fromfile, np2str):
         """Test segment navigation."""
-        from pyresample.utils import proj4_radius_parameters
+        from pyproj import CRS
+
         np2str.side_effect = lambda x: x
         m = mock.mock_open()
         with mock.patch("satpy.readers.ahi_hsd.open", m, create=True):
@@ -184,18 +185,9 @@ class TestAHIHSDNavigation(unittest.TestCase):
                             "spare": ""}
 
             area_def = fh.get_area_def(None)
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore",
-                                        message=r"You will likely lose important projection information",
-                                        category=UserWarning)
-                proj_dict = area_def.proj_dict
-            a, b = proj4_radius_parameters(proj_dict)
-            assert a == 6378137.0
-            assert b == 6356752.3
-            assert proj_dict["h"] == 35785863.0
-            assert proj_dict["lon_0"] == 140.7
-            assert proj_dict["proj"] == "geos"
-            assert proj_dict["units"] == "m"
+            expected_crs = CRS.from_dict(dict(a=6378137.0, b=6356752.3, h= 35785863.0,
+                                              lon_0=140.7, proj="geos", units="m"))
+            assert area_def.crs == expected_crs
             np.testing.assert_allclose(area_def.area_extent, (-5500000.035542117, -3300000.021325271,
                                                               5500000.035542117, -2200000.0142168473))
 

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -140,7 +140,11 @@ class TestAHIHSDNavigation(unittest.TestCase):
                             "spare": ""}
 
             area_def = fh.get_area_def(None)
-            proj_dict = area_def.proj_dict
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore",
+                                        message=r"You will likely lose important projection information",
+                                        category=UserWarning)
+                proj_dict = area_def.proj_dict
             a, b = proj4_radius_parameters(proj_dict)
             assert a == 6378137.0
             assert b == 6356752.3
@@ -188,7 +192,11 @@ class TestAHIHSDNavigation(unittest.TestCase):
                             "spare": ""}
 
             area_def = fh.get_area_def(None)
-            proj_dict = area_def.proj_dict
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore",
+                                        message=r"You will likely lose important projection information",
+                                        category=UserWarning)
+                proj_dict = area_def.proj_dict
             a, b = proj4_radius_parameters(proj_dict)
             assert a == 6378137.0
             assert b == 6356752.3

--- a/satpy/tests/reader_tests/test_ahi_l2_nc.py
+++ b/satpy/tests/reader_tests/test_ahi_l2_nc.py
@@ -90,7 +90,7 @@ def test_ahi_l2_area_def(himl2_filename, caplog):
         warnings.filterwarnings("ignore",
                                 message=r"You will likely lose important projection information",
                                 category=UserWarning)
-        assert area_def.proj4_string == ps
+        assert area_def.proj_str == ps
 
     # Check case where input data is incorrect size.
     fh = ahil2_filehandler(himl2_filename)

--- a/satpy/tests/reader_tests/test_ahi_l2_nc.py
+++ b/satpy/tests/reader_tests/test_ahi_l2_nc.py
@@ -75,6 +75,8 @@ def test_startend(himl2_filename):
 
 def test_ahi_l2_area_def(himl2_filename, caplog):
     """Test reader handles area definition correctly."""
+    import warnings
+
     ps = "+proj=geos +lon_0=140.7 +h=35785863 +x_0=0 +y_0=0 +a=6378137 +rf=298.257024882273 +units=m +no_defs +type=crs"
 
     # Check case where input data is correct size.
@@ -84,7 +86,11 @@ def test_ahi_l2_area_def(himl2_filename, caplog):
     assert area_def.width == dimensions["Columns"]
     assert area_def.height == dimensions["Rows"]
     assert np.allclose(area_def.area_extent, exp_ext)
-    assert area_def.proj4_string == ps
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore",
+                                message=r"You will likely lose important projection information",
+                                category=UserWarning)
+        assert area_def.proj4_string == ps
 
     # Check case where input data is incorrect size.
     fh = ahil2_filehandler(himl2_filename)

--- a/satpy/tests/reader_tests/test_ahi_l2_nc.py
+++ b/satpy/tests/reader_tests/test_ahi_l2_nc.py
@@ -77,7 +77,7 @@ def test_ahi_l2_area_def(himl2_filename, caplog):
     """Test reader handles area definition correctly."""
     import warnings
 
-    ps = "+proj=geos +lon_0=140.7 +h=35785863 +x_0=0 +y_0=0 +a=6378137 +rf=298.257024882273 +units=m +no_defs +type=crs"
+    ps = "+a=6378137 +h=35785863 +lon_0=140.7 +no_defs +proj=geos +rf=298.257024882273 +type=crs +units=m +x_0=0 +y_0=0"
 
     # Check case where input data is correct size.
     fh = ahil2_filehandler(himl2_filename)

--- a/satpy/tests/reader_tests/test_ahi_l2_nc.py
+++ b/satpy/tests/reader_tests/test_ahi_l2_nc.py
@@ -75,7 +75,7 @@ def test_startend(himl2_filename):
 
 def test_ahi_l2_area_def(himl2_filename, caplog):
     """Test reader handles area definition correctly."""
-    import warnings
+    from pyproj import CRS
 
     ps = "+a=6378137 +h=35785863 +lon_0=140.7 +no_defs +proj=geos +rf=298.257024882273 +type=crs +units=m +x_0=0 +y_0=0"
 
@@ -86,11 +86,9 @@ def test_ahi_l2_area_def(himl2_filename, caplog):
     assert area_def.width == dimensions["Columns"]
     assert area_def.height == dimensions["Rows"]
     assert np.allclose(area_def.area_extent, exp_ext)
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore",
-                                message=r"You will likely lose important projection information",
-                                category=UserWarning)
-        assert area_def.proj_str == ps
+
+    expected_crs = CRS(ps)
+    assert area_def.crs == expected_crs
 
     # Check case where input data is incorrect size.
     fh = ahil2_filehandler(himl2_filename)

--- a/satpy/tests/reader_tests/test_eum_base.py
+++ b/satpy/tests/reader_tests/test_eum_base.py
@@ -39,17 +39,18 @@ class TestMakeTimeCdsDictionary(unittest.TestCase):
     def test_fun(self):
         """Test function for TestMakeTimeCdsDictionary."""
         # time_cds_short
-        tcds = {"Days": 1, "Milliseconds": 2}
+        tcds = {"Days": np.array(1), "Milliseconds": np.array(2)}
         expected = datetime(1958, 1, 2, 0, 0, 0, 2000)
         assert timecds2datetime(tcds) == expected
 
         # time_cds
-        tcds = {"Days": 1, "Milliseconds": 2, "Microseconds": 3}
+        tcds = {"Days": np.array(1), "Milliseconds": np.array(2), "Microseconds": np.array(3)}
         expected = datetime(1958, 1, 2, 0, 0, 0, 2003)
         assert timecds2datetime(tcds) == expected
 
         # time_cds_expanded
-        tcds = {"Days": 1, "Milliseconds": 2, "Microseconds": 3, "Nanoseconds": 4}
+        tcds = {"Days": np.array(1), "Milliseconds": np.array(2), "Microseconds": np.array(3),
+                "Nanoseconds": np.array(4)}
         expected = datetime(1958, 1, 2, 0, 0, 0, 2003)
         assert timecds2datetime(tcds) == expected
 

--- a/satpy/tests/reader_tests/test_generic_image.py
+++ b/satpy/tests/reader_tests/test_generic_image.py
@@ -21,6 +21,7 @@ import unittest
 
 import dask.array as da
 import numpy as np
+import pytest
 import xarray as xr
 
 from satpy.tests.utils import make_dataid
@@ -128,10 +129,13 @@ class TestGenericImage(unittest.TestCase):
 
     def test_png_scene(self):
         """Test reading PNG images via satpy.Scene()."""
+        from rasterio.errors import NotGeoreferencedWarning
+
         from satpy import Scene
 
         fname = os.path.join(self.base_dir, "test_l.png")
-        scn = Scene(reader="generic_image", filenames=[fname])
+        with pytest.warns(NotGeoreferencedWarning, match=r"Dataset has no geotransform"):
+            scn = Scene(reader="generic_image", filenames=[fname])
         scn.load(["image"])
         assert scn["image"].shape == (1, self.y_size, self.x_size)
         assert scn.sensor_names == {"images"}
@@ -140,7 +144,8 @@ class TestGenericImage(unittest.TestCase):
         assert "area" not in scn["image"].attrs
 
         fname = os.path.join(self.base_dir, "20180101_0000_test_la.png")
-        scn = Scene(reader="generic_image", filenames=[fname])
+        with pytest.warns(NotGeoreferencedWarning, match=r"Dataset has no geotransform"):
+            scn = Scene(reader="generic_image", filenames=[fname])
         scn.load(["image"])
         data = da.compute(scn["image"].data)
         assert scn["image"].shape == (1, self.y_size, self.x_size)

--- a/satpy/tests/reader_tests/test_geos_area.py
+++ b/satpy/tests/reader_tests/test_geos_area.py
@@ -138,9 +138,7 @@ class TestGEOSProjectionUtil(unittest.TestCase):
 
     def test_get_area_definition(self):
         """Test the retrieval of the area definition."""
-        import warnings
-
-        from pyresample.utils import proj4_radius_parameters
+        from pyproj import CRS
 
         pdict, extent = self.make_pdict_ext(1, "N2S")
         good_res = (-3000.4032785810186, -3000.4032785810186)
@@ -148,16 +146,9 @@ class TestGEOSProjectionUtil(unittest.TestCase):
         a_def = get_area_definition(pdict, extent)
         assert a_def.area_id == pdict["a_name"]
         assert a_def.resolution == good_res
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message=r"You will likely lose important projection information",
-                                    category=UserWarning)
-            assert a_def.proj_dict["proj"] == "geos"
-            assert a_def.proj_dict["units"] == "m"
-            a, b = proj4_radius_parameters(a_def.proj_dict)
-            assert a == 6378169
-            assert b == 6356583.8
-            assert a_def.proj_dict["h"] == 35785831
+
+        expected_crs = CRS(dict(proj="geos", units="m", a=6378169, b=6356583.8, h=35785831))
+        assert a_def.crs == expected_crs
 
     def test_sampling_to_lfac_cfac(self):
         """Test conversion from angular sampling to line/column offset."""

--- a/satpy/tests/reader_tests/test_geos_area.py
+++ b/satpy/tests/reader_tests/test_geos_area.py
@@ -138,19 +138,26 @@ class TestGEOSProjectionUtil(unittest.TestCase):
 
     def test_get_area_definition(self):
         """Test the retrieval of the area definition."""
+        import warnings
+
         from pyresample.utils import proj4_radius_parameters
+
         pdict, extent = self.make_pdict_ext(1, "N2S")
         good_res = (-3000.4032785810186, -3000.4032785810186)
 
         a_def = get_area_definition(pdict, extent)
         assert a_def.area_id == pdict["a_name"]
         assert a_def.resolution == good_res
-        assert a_def.proj_dict["proj"] == "geos"
-        assert a_def.proj_dict["units"] == "m"
-        a, b = proj4_radius_parameters(a_def.proj_dict)
-        assert a == 6378169
-        assert b == 6356583.8
-        assert a_def.proj_dict["h"] == 35785831
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message=r"You will likely lose important projection information",
+                                    category=UserWarning)
+            assert a_def.proj_dict["proj"] == "geos"
+            assert a_def.proj_dict["units"] == "m"
+            a, b = proj4_radius_parameters(a_def.proj_dict)
+            assert a == 6378169
+            assert b == 6356583.8
+            assert a_def.proj_dict["h"] == 35785831
 
     def test_sampling_to_lfac_cfac(self):
         """Test conversion from angular sampling to line/column offset."""

--- a/satpy/tests/reader_tests/test_goes_imager_hrit.py
+++ b/satpy/tests/reader_tests/test_goes_imager_hrit.py
@@ -172,6 +172,8 @@ class TestHRITGOESFileHandler(unittest.TestCase):
 
     def test_get_area_def(self):
         """Test getting the area definition."""
+        import warnings
+
         self.reader.mda.update({
             "cfac": 10216334,
             "lfac": 10216334,
@@ -184,13 +186,17 @@ class TestHRITGOESFileHandler(unittest.TestCase):
                            resolution=3000)
         area = self.reader.get_area_def(dsid)
 
-        a, b = proj4_radius_parameters(area.proj_dict)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message=r"You will likely lose important projection information",
+                                    category=UserWarning)
+            a, b = proj4_radius_parameters(area.proj_dict)
+            assert area.proj_dict["h"] == ALTITUDE
+            assert area.proj_dict["lon_0"] == 100.1640625
+            assert area.proj_dict["proj"] == "geos"
+            assert area.proj_dict["units"] == "m"
         assert a == EQUATOR_RADIUS
         assert b == POLE_RADIUS
-        assert area.proj_dict["h"] == ALTITUDE
-        assert area.proj_dict["lon_0"] == 100.1640625
-        assert area.proj_dict["proj"] == "geos"
-        assert area.proj_dict["units"] == "m"
         assert area.width == 2816
         assert area.height == 464
         assert area.area_id == "goes-15_goes_imager_fd_3km"

--- a/satpy/tests/reader_tests/test_goes_imager_hrit.py
+++ b/satpy/tests/reader_tests/test_goes_imager_hrit.py
@@ -22,13 +22,10 @@ import unittest
 from unittest import mock
 
 import numpy as np
-from pyresample.utils import proj4_radius_parameters
 from xarray import DataArray
 
 from satpy.readers.goes_imager_hrit import (
     ALTITUDE,
-    EQUATOR_RADIUS,
-    POLE_RADIUS,
     HRITGOESFileHandler,
     HRITGOESPrologueFileHandler,
     make_gvar_float,
@@ -172,7 +169,7 @@ class TestHRITGOESFileHandler(unittest.TestCase):
 
     def test_get_area_def(self):
         """Test getting the area definition."""
-        import warnings
+        from pyproj import CRS
 
         self.reader.mda.update({
             "cfac": 10216334,
@@ -186,17 +183,10 @@ class TestHRITGOESFileHandler(unittest.TestCase):
                            resolution=3000)
         area = self.reader.get_area_def(dsid)
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message=r"You will likely lose important projection information",
-                                    category=UserWarning)
-            a, b = proj4_radius_parameters(area.proj_dict)
-            assert area.proj_dict["h"] == ALTITUDE
-            assert area.proj_dict["lon_0"] == 100.1640625
-            assert area.proj_dict["proj"] == "geos"
-            assert area.proj_dict["units"] == "m"
-        assert a == EQUATOR_RADIUS
-        assert b == POLE_RADIUS
+        expected_crs = CRS(dict(h=ALTITUDE, lon_0=100.1640625, proj="geos", units="m",
+                                rf=295.488065897001, a=6378169))
+        assert area.crs == expected_crs
+
         assert area.width == 2816
         assert area.height == 464
         assert area.area_id == "goes-15_goes_imager_fd_3km"

--- a/satpy/tests/reader_tests/test_goes_imager_nc_eum.py
+++ b/satpy/tests/reader_tests/test_goes_imager_nc_eum.py
@@ -139,7 +139,7 @@ class GOESNCEUMFileHandlerReflectanceTest(unittest.TestCase):
 
         xr_.open_dataset.return_value = xr.Dataset(
             {"data": xr.DataArray(data=self.reflectance, dims=("time", "yc", "xc")),
-             "time": xr.DataArray(data=np.array([0], dtype="datetime64[ms]"),
+             "time": xr.DataArray(data=np.array([0], dtype="datetime64[ns]"),
                                   dims=("time",)),
              "bands": xr.DataArray(data=np.array([1]))},
             attrs={"Satellite Sensor": "G-15"})

--- a/satpy/tests/reader_tests/test_goes_imager_nc_eum.py
+++ b/satpy/tests/reader_tests/test_goes_imager_nc_eum.py
@@ -52,7 +52,7 @@ class GOESNCEUMFileHandlerRadianceTest(unittest.TestCase):
 
         xr_.open_dataset.return_value = xr.Dataset(
             {"data": xr.DataArray(data=self.radiance, dims=("time", "yc", "xc")),
-             "time": xr.DataArray(data=np.array([0], dtype="datetime64[ms]"),
+             "time": xr.DataArray(data=np.array([0], dtype="datetime64[ns]"),
                                   dims=("time",)),
              "bands": xr.DataArray(data=np.array([1]))},
             attrs={"Satellite Sensor": "G-15"})

--- a/satpy/tests/reader_tests/test_goes_imager_nc_noaa.py
+++ b/satpy/tests/reader_tests/test_goes_imager_nc_noaa.py
@@ -58,7 +58,7 @@ class GOESNCBaseFileHandlerTest(unittest.TestCase):
              "lon": xr.DataArray(data=self.dummy2d, dims=("yc", "xc")),
              "lat": xr.DataArray(data=self.dummy2d, dims=("yc", "xc")),
              "time": xr.DataArray(data=np.array([self.time],
-                                                dtype="datetime64[ms]"),
+                                                dtype="datetime64[ns]"),
                                   dims=("time",)),
              "bands": xr.DataArray(data=np.array([self.band]))},
             attrs={"Satellite Sensor": "G-15"})
@@ -238,7 +238,7 @@ class TestMetadata:
             dims=("time", "yc", "xc")
         )
         time = xr.DataArray(
-            [np.datetime64("2018-01-01 12:00:00")],
+            [np.datetime64("2018-01-01 12:00:00").astype("datetime64[ns]")],
             dims="time"
         )
         bands = xr.DataArray([channel_id], dims="bands")
@@ -369,7 +369,7 @@ class GOESNCFileHandlerTest(unittest.TestCase):
             {"data": xr.DataArray(data=self.counts, dims=("time", "yc", "xc")),
              "lon": xr.DataArray(data=self.lon, dims=("yc", "xc")),
              "lat": xr.DataArray(data=self.lat, dims=("yc", "xc")),
-             "time": xr.DataArray(data=np.array([0], dtype="datetime64[ms]"),
+             "time": xr.DataArray(data=np.array([0], dtype="datetime64[ns]"),
                                   dims=("time",)),
              "bands": xr.DataArray(data=np.array([1]))},
             attrs={"Satellite Sensor": "G-15"})

--- a/satpy/tests/reader_tests/test_gpm_imerg.py
+++ b/satpy/tests/reader_tests/test_gpm_imerg.py
@@ -105,7 +105,7 @@ class TestHdf5IMERG(unittest.TestCase):
 
     def test_load_data(self):
         """Test loading data."""
-        import warnings
+        from pyproj import CRS
 
         from satpy.readers import load_reader
 
@@ -132,10 +132,6 @@ class TestHdf5IMERG(unittest.TestCase):
         assert res["IRprecipitation"].resolution == 0.1
         assert res["IRprecipitation"].area.width == 3600
         assert res["IRprecipitation"].area.height == 1800
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message=r"You will likely lose important projection information",
-                                    category=UserWarning)
-            assert res["IRprecipitation"].area.proj_dict == pdict
+        assert res["IRprecipitation"].area.crs == CRS(pdict)
         np.testing.assert_almost_equal(res["IRprecipitation"].area.area_extent,
                                        (-179.95, -89.95, 179.95, 89.95), 5)

--- a/satpy/tests/reader_tests/test_gpm_imerg.py
+++ b/satpy/tests/reader_tests/test_gpm_imerg.py
@@ -105,6 +105,8 @@ class TestHdf5IMERG(unittest.TestCase):
 
     def test_load_data(self):
         """Test loading data."""
+        import warnings
+
         from satpy.readers import load_reader
 
         # Filename to test, needed for start and end times
@@ -130,6 +132,10 @@ class TestHdf5IMERG(unittest.TestCase):
         assert res["IRprecipitation"].resolution == 0.1
         assert res["IRprecipitation"].area.width == 3600
         assert res["IRprecipitation"].area.height == 1800
-        assert res["IRprecipitation"].area.proj_dict == pdict
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message=r"You will likely lose important projection information",
+                                    category=UserWarning)
+            assert res["IRprecipitation"].area.proj_dict == pdict
         np.testing.assert_almost_equal(res["IRprecipitation"].area.area_extent,
                                        (-179.95, -89.95, 179.95, 89.95), 5)

--- a/satpy/tests/reader_tests/test_hrit_base.py
+++ b/satpy/tests/reader_tests/test_hrit_base.py
@@ -221,23 +221,13 @@ class TestHRITFileHandler:
 
     def test_get_area_def(self):
         """Test getting an area definition."""
-        import warnings
-
-        from pyresample.utils import proj4_radius_parameters
+        from pyproj import CRS
 
         area = self.reader.get_area_def("VIS06")
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message=r"You will likely lose important projection information",
-                                    category=UserWarning)
-            proj_dict = area.proj_dict
-        a, b = proj4_radius_parameters(proj_dict)
-        assert a == 6378169.0
-        assert b == 6356583.8
-        assert proj_dict["h"] == 35785831.0
-        assert proj_dict["lon_0"] == 44.0
-        assert proj_dict["proj"] == "geos"
-        assert proj_dict["units"] == "m"
+
+        expected_crs = CRS(dict(proj="geos", a=6378169.0, b=6356583.8, h=35785831.0, lon_0=44.0, units="m"))
+        assert area.crs == expected_crs
+
         assert area.area_extent == (-77771774058.38356, -77771774058.38356,
                                     30310525626438.438, 3720765401003.719)
 

--- a/satpy/tests/reader_tests/test_hrit_base.py
+++ b/satpy/tests/reader_tests/test_hrit_base.py
@@ -221,9 +221,16 @@ class TestHRITFileHandler:
 
     def test_get_area_def(self):
         """Test getting an area definition."""
+        import warnings
+
         from pyresample.utils import proj4_radius_parameters
+
         area = self.reader.get_area_def("VIS06")
-        proj_dict = area.proj_dict
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message=r"You will likely lose important projection information",
+                                    category=UserWarning)
+            proj_dict = area.proj_dict
         a, b = proj4_radius_parameters(proj_dict)
         assert a == 6378169.0
         assert b == 6356583.8

--- a/satpy/tests/reader_tests/test_insat3d_img_l1b_h5.py
+++ b/satpy/tests/reader_tests/test_insat3d_img_l1b_h5.py
@@ -273,12 +273,18 @@ def insat_filehandler(insat_filename):
 
 def test_filehandler_returns_area(insat_filehandler):
     """Test that filehandle returns an area."""
+    import warnings
+
     fh = insat_filehandler
 
     ds_id = make_dataid(name="MIR", resolution=4000, calibration="brightness_temperature")
     area_def = fh.get_area_def(ds_id)
-    lons, lats = area_def.get_lonlats(chunks=1000)
-    assert "+lon_0=" + str(subsatellite_longitude) in area_def.crs.to_proj4()
+    _ = area_def.get_lonlats(chunks=1000)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore",
+                                message=r"You will likely lose important projection information",
+                                category=UserWarning)
+        assert "+lon_0=" + str(subsatellite_longitude) in area_def.crs.to_proj4()
 
 
 def test_filehandler_has_start_and_end_time(insat_filehandler):

--- a/satpy/tests/reader_tests/test_insat3d_img_l1b_h5.py
+++ b/satpy/tests/reader_tests/test_insat3d_img_l1b_h5.py
@@ -273,18 +273,12 @@ def insat_filehandler(insat_filename):
 
 def test_filehandler_returns_area(insat_filehandler):
     """Test that filehandle returns an area."""
-    import warnings
-
     fh = insat_filehandler
 
     ds_id = make_dataid(name="MIR", resolution=4000, calibration="brightness_temperature")
     area_def = fh.get_area_def(ds_id)
     _ = area_def.get_lonlats(chunks=1000)
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore",
-                                message=r"You will likely lose important projection information",
-                                category=UserWarning)
-        assert "+lon_0=" + str(subsatellite_longitude) in area_def.crs.to_proj4()
+    assert subsatellite_longitude == area_def.crs.to_cf()["longitude_of_projection_origin"]
 
 
 def test_filehandler_has_start_and_end_time(insat_filehandler):

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -28,7 +28,6 @@ import pytest
 import xarray as xr
 from pyproj import CRS
 from pyresample.geometry import AreaDefinition
-from pyresample.utils import proj4_radius_parameters
 
 from satpy.readers.mviri_l1b_fiduceo_nc import (
     ALTITUDE,
@@ -497,22 +496,10 @@ class TestFiduceoMviriFileHandlers:
     def test_get_area_definition(self, file_handler, name, resolution,
                                  area_exp):
         """Test getting area definitions."""
-        import warnings
-
         dataset_id = make_dataid(name=name, resolution=resolution)
         area = file_handler.get_area_def(dataset_id)
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message=r"You will likely lose important projection information",
-                                    category=UserWarning)
-            a, b = proj4_radius_parameters(area.proj_dict)
-            a_exp, b_exp = proj4_radius_parameters(area_exp.proj_dict)
-            assert a == a_exp
-            assert b == b_exp
-            assert area.width == area_exp.width
-            assert area.height == area_exp.height
-            for key in ["h", "lon_0", "proj", "units"]:
-                assert area.proj_dict[key] == area_exp.proj_dict[key]
+
+        assert area.crs == area_exp.crs
         np.testing.assert_allclose(area.area_extent, area_exp.area_extent)
 
     def test_calib_exceptions(self, file_handler):

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -61,10 +61,10 @@ attrs_refl_exp.update(
     {"sun_earth_distance_correction_applied": True,
      "sun_earth_distance_correction_factor": 1.}
 )
-acq_time_vis_exp = [np.datetime64("1970-01-01 00:30"),
-                    np.datetime64("1970-01-01 00:30"),
-                    np.datetime64("1970-01-01 02:30"),
-                    np.datetime64("1970-01-01 02:30")]
+acq_time_vis_exp = [np.datetime64("1970-01-01 00:30").astype("datetime64[ns]"),
+                    np.datetime64("1970-01-01 00:30").astype("datetime64[ns]"),
+                    np.datetime64("1970-01-01 02:30").astype("datetime64[ns]"),
+                    np.datetime64("1970-01-01 02:30").astype("datetime64[ns]")]
 vis_counts_exp = xr.DataArray(
     np.array(
         [[0., 17., 34., 51.],
@@ -124,8 +124,8 @@ u_vis_refl_exp = xr.DataArray(
     },
     attrs=attrs_exp
 )
-acq_time_ir_wv_exp = [np.datetime64("1970-01-01 00:30"),
-                      np.datetime64("1970-01-01 02:30")]
+acq_time_ir_wv_exp = [np.datetime64("1970-01-01 00:30").astype("datetime64[ns]"),
+                      np.datetime64("1970-01-01 02:30").astype("datetime64[ns]")]
 wv_counts_exp = xr.DataArray(
     np.array(
         [[0, 85],
@@ -277,7 +277,8 @@ def fixture_fake_dataset():
             dtype=np.uint8
         )
     )
-    time = np.arange(4).astype("datetime64[h]").reshape(2, 2)
+    time = np.arange(4) * 60 * 60 * 1e9
+    time = time.astype("datetime64[ns]").reshape(2, 2)
     ds = xr.Dataset(
         data_vars={
             "count_vis": (("y", "x"), count_vis),

--- a/satpy/tests/reader_tests/test_nwcsaf_msg.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_msg.py
@@ -472,7 +472,7 @@ class TestH5NWCSAF(unittest.TestCase):
 
     def test_get_area_def(self):
         """Get the area definition."""
-        import warnings
+        from pyproj import CRS
 
         from satpy.readers.nwcsaf_msg2013_hdf5 import Hdf5NWCSAF
         from satpy.tests.utils import make_dataid
@@ -488,15 +488,8 @@ class TestH5NWCSAF(unittest.TestCase):
         for i in range(4):
             assert area_def.area_extent[i] == pytest.approx(aext_res[i], abs=1e-4)
 
-        proj_dict = AREA_DEF_DICT["proj_dict"]
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message=r"You will likely lose important projection information",
-                                    category=UserWarning)
-            assert proj_dict["proj"] == area_def.proj_dict["proj"]
-        # Not all elements passed on Appveyor, so skip testing every single element of the proj-dict:
-        # for key in proj_dict:
-        #    self.assertEqual(proj_dict[key], area_def.proj_dict[key])
+        expected_crs = CRS(AREA_DEF_DICT["proj_dict"])
+        assert expected_crs == area_def.crs
 
         assert AREA_DEF_DICT["x_size"] == area_def.width
         assert AREA_DEF_DICT["y_size"] == area_def.height

--- a/satpy/tests/reader_tests/test_nwcsaf_msg.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_msg.py
@@ -472,6 +472,8 @@ class TestH5NWCSAF(unittest.TestCase):
 
     def test_get_area_def(self):
         """Get the area definition."""
+        import warnings
+
         from satpy.readers.nwcsaf_msg2013_hdf5 import Hdf5NWCSAF
         from satpy.tests.utils import make_dataid
 
@@ -487,7 +489,11 @@ class TestH5NWCSAF(unittest.TestCase):
             assert area_def.area_extent[i] == pytest.approx(aext_res[i], abs=1e-4)
 
         proj_dict = AREA_DEF_DICT["proj_dict"]
-        assert proj_dict["proj"] == area_def.proj_dict["proj"]
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message=r"You will likely lose important projection information",
+                                    category=UserWarning)
+            assert proj_dict["proj"] == area_def.proj_dict["proj"]
         # Not all elements passed on Appveyor, so skip testing every single element of the proj-dict:
         # for key in proj_dict:
         #    self.assertEqual(proj_dict[key], area_def.proj_dict[key])

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -506,18 +506,13 @@ class TestNcNWCSAFFileKeyPrefix:
 
 
 def _check_filehandler_area_def(file_handler, dsid):
-    import warnings
+    from pyproj import CRS
 
-    correct_h = float(PROJ["gdal_projection"].split("+h=")[-1])
-    correct_a = float(PROJ["gdal_projection"].split("+a=")[-1].split()[0])
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore",
-                                message=r"You will likely lose important projection information",
-                                category=UserWarning)
-        area_definition = file_handler.get_area_def(dsid)
-        assert area_definition.proj_dict["h"] == correct_h
-        assert area_definition.proj_dict["a"] == correct_a
-        assert area_definition.proj_dict["units"] == "m"
+    area_definition = file_handler.get_area_def(dsid)
+
+    expected_crs = CRS(PROJ["gdal_projection"])
+    assert area_definition.crs == expected_crs
+
     correct_extent = (PROJ["gdal_xgeo_up_left"],
                       PROJ["gdal_ygeo_low_right"],
                       PROJ["gdal_xgeo_low_right"],

--- a/satpy/tests/reader_tests/test_oceancolorcci_l3_nc.py
+++ b/satpy/tests/reader_tests/test_oceancolorcci_l3_nc.py
@@ -166,6 +166,8 @@ class TestOCCCIReader:
 
     def test_get_area_def(self, area_exp, fake_file_dict):
         """Test area definition."""
+        import warnings
+
         reader = self._create_reader_for_resolutions([fake_file_dict["ocprod_1m"]])
         res = reader.load([ds_list_all[0]])
         area = res[ds_list_all[0]].attrs["area"]
@@ -174,7 +176,11 @@ class TestOCCCIReader:
         assert area.area_extent == area_exp.area_extent
         assert area.width == area_exp.width
         assert area.height == area_exp.height
-        assert area.proj_dict == area_exp.proj_dict
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message=r"You will likely lose important projection information",
+                                    category=UserWarning)
+            assert area.proj_dict == area_exp.proj_dict
 
     def test_bad_fname(self, fake_dataset, fake_file_dict):
         """Test case where an incorrect composite period is given."""

--- a/satpy/tests/reader_tests/test_oceancolorcci_l3_nc.py
+++ b/satpy/tests/reader_tests/test_oceancolorcci_l3_nc.py
@@ -180,6 +180,7 @@ class TestOCCCIReader:
             warnings.filterwarnings("ignore",
                                     message=r"You will likely lose important projection information",
                                     category=UserWarning)
+            # The corresponding CRS objects do not match even if the proj dicts match, so use the dicts
             assert area.proj_dict == area_exp.proj_dict
 
     def test_bad_fname(self, fake_dataset, fake_file_dict):

--- a/satpy/tests/reader_tests/test_osisaf_l3.py
+++ b/satpy/tests/reader_tests/test_osisaf_l3.py
@@ -225,7 +225,7 @@ class TestOSISAFL3ReaderICE(OSISAFL3ReaderTests):
         area_def = test.get_area_def(None)
         assert area_def.description == "osisaf_polar_stereographic"
 
-        expected_crs = CRS(dict(a=6378273.0, lat_0=-90, lat_ts=-70, lon_0=0, proj="stere"))
+        expected_crs = CRS(dict(a=6378273.0, lat_0=-90, lat_ts=-70, lon_0=0, proj="stere", rf=298.27940986765))
         assert area_def.crs == expected_crs
 
         assert area_def.width == 5
@@ -278,7 +278,7 @@ class TestOSISAFL3ReaderFluxStere(OSISAFL3ReaderTests):
         area_def = test.get_area_def(None)
         assert area_def.description == "osisaf_polar_stereographic"
 
-        expected_crs = CRS(dict(a=6378273.0, lat_0=-90, lat_ts=-70, lon_0=0, proj="stere"))
+        expected_crs = CRS(dict(a=6378273.0, lat_0=-90, lat_ts=-70, lon_0=0, proj="stere", rf=298.27940986765))
         assert area_def.crs == expected_crs
 
         assert area_def.width == 5
@@ -351,7 +351,8 @@ class TestOSISAFL3ReaderSST(OSISAFL3ReaderTests):
         area_def = test.get_area_def(None)
         assert area_def.description == "osisaf_polar_stereographic"
 
-        expected_crs = CRS(dict(a=6378273.0, lat_0=-90, lat_ts=-70, lon_0=0, proj="stere"))
+        expected_crs = CRS(dict(a=6378273.0, lat_0=-90, lat_ts=-70, lon_0=0, proj="stere", rf=298.27940986765))
+
         assert area_def.crs == expected_crs
 
         assert area_def.width == 5

--- a/satpy/tests/reader_tests/test_osisaf_l3.py
+++ b/satpy/tests/reader_tests/test_osisaf_l3.py
@@ -16,12 +16,12 @@
 """Module for testing the satpy.readers.osisaf_l3 module."""
 
 import os
-import warnings
 from datetime import datetime
 
 import numpy as np
 import pytest
 import xarray as xr
+from pyproj import CRS
 
 from satpy import DataQuery
 from satpy.readers.osisaf_l3_nc import OSISAFL3NCFileHandler
@@ -224,15 +224,9 @@ class TestOSISAFL3ReaderICE(OSISAFL3ReaderTests):
 
         area_def = test.get_area_def(None)
         assert area_def.description == "osisaf_polar_stereographic"
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message=r"You will likely lose important projection information",
-                                    category=UserWarning)
-            assert area_def.proj_dict["a"] == 6378273.0
-            assert area_def.proj_dict["lat_0"] == -90
-            assert area_def.proj_dict["lat_ts"] == -70
-            assert area_def.proj_dict["lon_0"] == 0
-            assert area_def.proj_dict["proj"] == "stere"
+
+        expected_crs = CRS(dict(a=6378273.0, lat_0=-90, lat_ts=-70, lon_0=0, proj="stere"))
+        assert area_def.crs == expected_crs
 
         assert area_def.width == 5
         assert area_def.height == 2
@@ -248,14 +242,9 @@ class TestOSISAFL3ReaderICE(OSISAFL3ReaderTests):
 
         area_def = test.get_area_def(None)
         assert area_def.description == "osisaf_lambert_azimuthal_equal_area"
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message=r"You will likely lose important projection information",
-                                    category=UserWarning)
-            assert area_def.proj_dict["R"] == 6371228
-            assert area_def.proj_dict["lat_0"] == -90
-            assert area_def.proj_dict["lon_0"] == 0
-            assert area_def.proj_dict["proj"] == "laea"
+
+        expected_crs = CRS(dict(R=6371228, lat_0=-90, lon_0=0, proj="laea"))
+        assert area_def.crs == expected_crs
 
         assert area_def.width == 5
         assert area_def.height == 2
@@ -288,15 +277,9 @@ class TestOSISAFL3ReaderFluxStere(OSISAFL3ReaderTests):
 
         area_def = test.get_area_def(None)
         assert area_def.description == "osisaf_polar_stereographic"
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message=r"You will likely lose important projection information",
-                                    category=UserWarning)
-            assert area_def.proj_dict["a"] == 6378273.0
-            assert area_def.proj_dict["lat_0"] == -90
-            assert area_def.proj_dict["lat_ts"] == -70
-            assert area_def.proj_dict["lon_0"] == 0
-            assert area_def.proj_dict["proj"] == "stere"
+
+        expected_crs = CRS(dict(a=6378273.0, lat_0=-90, lat_ts=-70, lon_0=0, proj="stere"))
+        assert area_def.crs == expected_crs
 
         assert area_def.width == 5
         assert area_def.height == 2
@@ -331,12 +314,9 @@ class TestOSISAFL3ReaderFluxGeo(OSISAFL3ReaderTests):
 
         area_def = test.get_area_def(None)
         assert area_def.description == "osisaf_geographic_area"
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message=r"You will likely lose important projection information",
-                                    category=UserWarning)
-            assert area_def.proj_dict["datum"] == "WGS84"
-            assert area_def.proj_dict["proj"] == "longlat"
+
+        expected_crs = CRS(dict(datum="WGS84", proj="longlat"))
+        assert area_def.crs == expected_crs
 
         assert area_def.width == 5
         assert area_def.height == 2
@@ -370,15 +350,9 @@ class TestOSISAFL3ReaderSST(OSISAFL3ReaderTests):
 
         area_def = test.get_area_def(None)
         assert area_def.description == "osisaf_polar_stereographic"
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore",
-                                    message=r"You will likely lose important projection information",
-                                    category=UserWarning)
-            assert area_def.proj_dict["a"] == 6378273.0
-            assert area_def.proj_dict["lat_0"] == -90
-            assert area_def.proj_dict["lat_ts"] == -70
-            assert area_def.proj_dict["lon_0"] == 0
-            assert area_def.proj_dict["proj"] == "stere"
+
+        expected_crs = CRS(dict(a=6378273.0, lat_0=-90, lat_ts=-70, lon_0=0, proj="stere"))
+        assert area_def.crs == expected_crs
 
         assert area_def.width == 5
         assert area_def.height == 2

--- a/satpy/tests/reader_tests/test_osisaf_l3.py
+++ b/satpy/tests/reader_tests/test_osisaf_l3.py
@@ -16,6 +16,7 @@
 """Module for testing the satpy.readers.osisaf_l3 module."""
 
 import os
+import warnings
 from datetime import datetime
 
 import numpy as np
@@ -223,11 +224,15 @@ class TestOSISAFL3ReaderICE(OSISAFL3ReaderTests):
 
         area_def = test.get_area_def(None)
         assert area_def.description == "osisaf_polar_stereographic"
-        assert area_def.proj_dict["a"] == 6378273.0
-        assert area_def.proj_dict["lat_0"] == -90
-        assert area_def.proj_dict["lat_ts"] == -70
-        assert area_def.proj_dict["lon_0"] == 0
-        assert area_def.proj_dict["proj"] == "stere"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message=r"You will likely lose important projection information",
+                                    category=UserWarning)
+            assert area_def.proj_dict["a"] == 6378273.0
+            assert area_def.proj_dict["lat_0"] == -90
+            assert area_def.proj_dict["lat_ts"] == -70
+            assert area_def.proj_dict["lon_0"] == 0
+            assert area_def.proj_dict["proj"] == "stere"
 
         assert area_def.width == 5
         assert area_def.height == 2
@@ -243,10 +248,14 @@ class TestOSISAFL3ReaderICE(OSISAFL3ReaderTests):
 
         area_def = test.get_area_def(None)
         assert area_def.description == "osisaf_lambert_azimuthal_equal_area"
-        assert area_def.proj_dict["R"] == 6371228
-        assert area_def.proj_dict["lat_0"] == -90
-        assert area_def.proj_dict["lon_0"] == 0
-        assert area_def.proj_dict["proj"] == "laea"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message=r"You will likely lose important projection information",
+                                    category=UserWarning)
+            assert area_def.proj_dict["R"] == 6371228
+            assert area_def.proj_dict["lat_0"] == -90
+            assert area_def.proj_dict["lon_0"] == 0
+            assert area_def.proj_dict["proj"] == "laea"
 
         assert area_def.width == 5
         assert area_def.height == 2
@@ -279,11 +288,15 @@ class TestOSISAFL3ReaderFluxStere(OSISAFL3ReaderTests):
 
         area_def = test.get_area_def(None)
         assert area_def.description == "osisaf_polar_stereographic"
-        assert area_def.proj_dict["a"] == 6378273.0
-        assert area_def.proj_dict["lat_0"] == -90
-        assert area_def.proj_dict["lat_ts"] == -70
-        assert area_def.proj_dict["lon_0"] == 0
-        assert area_def.proj_dict["proj"] == "stere"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message=r"You will likely lose important projection information",
+                                    category=UserWarning)
+            assert area_def.proj_dict["a"] == 6378273.0
+            assert area_def.proj_dict["lat_0"] == -90
+            assert area_def.proj_dict["lat_ts"] == -70
+            assert area_def.proj_dict["lon_0"] == 0
+            assert area_def.proj_dict["proj"] == "stere"
 
         assert area_def.width == 5
         assert area_def.height == 2
@@ -318,8 +331,12 @@ class TestOSISAFL3ReaderFluxGeo(OSISAFL3ReaderTests):
 
         area_def = test.get_area_def(None)
         assert area_def.description == "osisaf_geographic_area"
-        assert area_def.proj_dict["datum"] == "WGS84"
-        assert area_def.proj_dict["proj"] == "longlat"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message=r"You will likely lose important projection information",
+                                    category=UserWarning)
+            assert area_def.proj_dict["datum"] == "WGS84"
+            assert area_def.proj_dict["proj"] == "longlat"
 
         assert area_def.width == 5
         assert area_def.height == 2
@@ -353,11 +370,15 @@ class TestOSISAFL3ReaderSST(OSISAFL3ReaderTests):
 
         area_def = test.get_area_def(None)
         assert area_def.description == "osisaf_polar_stereographic"
-        assert area_def.proj_dict["a"] == 6378273.0
-        assert area_def.proj_dict["lat_0"] == -90
-        assert area_def.proj_dict["lat_ts"] == -70
-        assert area_def.proj_dict["lon_0"] == 0
-        assert area_def.proj_dict["proj"] == "stere"
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message=r"You will likely lose important projection information",
+                                    category=UserWarning)
+            assert area_def.proj_dict["a"] == 6378273.0
+            assert area_def.proj_dict["lat_0"] == -90
+            assert area_def.proj_dict["lat_ts"] == -70
+            assert area_def.proj_dict["lon_0"] == 0
+            assert area_def.proj_dict["proj"] == "stere"
 
         assert area_def.width == 5
         assert area_def.height == 2

--- a/satpy/tests/reader_tests/test_satpy_cf_nc.py
+++ b/satpy/tests/reader_tests/test_satpy_cf_nc.py
@@ -249,11 +249,14 @@ class TestCFReader:
         expected_area = cf_scene["image0"].attrs["area"]
         actual_area = scn_["image0"].attrs["area"]
         assert pytest.approx(expected_area.area_extent, 0.000001) == actual_area.area_extent
-        assert expected_area.proj_dict == actual_area.proj_dict
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message=r"You will likely lose important projection information",
+                                    category=UserWarning)
+            assert expected_area.proj_dict == actual_area.proj_dict
         assert expected_area.shape == actual_area.shape
         assert expected_area.area_id == actual_area.area_id
         assert expected_area.description == actual_area.description
-        assert expected_area.proj_dict == actual_area.proj_dict
 
     def test_write_and_read_with_swath_definition(self, cf_scene, nc_filename):
         """Save a dataset with a swath definition to file with cf_writer and read the data again."""

--- a/satpy/tests/reader_tests/test_satpy_cf_nc.py
+++ b/satpy/tests/reader_tests/test_satpy_cf_nc.py
@@ -260,12 +260,15 @@ class TestCFReader:
 
     def test_write_and_read_with_swath_definition(self, cf_scene, nc_filename):
         """Save a dataset with a swath definition to file with cf_writer and read the data again."""
-        cf_scene.save_datasets(writer="cf",
-                               filename=nc_filename,
-                               engine="h5netcdf",
-                               flatten_attrs=True,
-                               pretty=True,
-                               datasets=["swath_data"])
+        with warnings.catch_warnings():
+            # Filter out warning about missing lon/lat DataArray coordinates
+            warnings.filterwarnings("ignore", category=UserWarning, message=r"Coordinate .* referenced")
+            cf_scene.save_datasets(writer="cf",
+                                filename=nc_filename,
+                                engine="h5netcdf",
+                                flatten_attrs=True,
+                                pretty=True,
+                                datasets=["swath_data"])
         scn_ = Scene(reader="satpy_cf_nc",
                      filenames=[nc_filename])
         scn_.load(["swath_data"])

--- a/satpy/tests/reader_tests/test_seadas_l2.py
+++ b/satpy/tests/reader_tests/test_seadas_l2.py
@@ -198,7 +198,10 @@ def _add_variable_to_netcdf_file(nc, var_name, var_info):
                           fill_value=var_info.get("fill_value"))
     v[:] = var_info["data"]
     for attr_key, attr_val in var_info["attrs"].items():
+        if isinstance(attr_val, (int, float)):
+            attr_val = v.dtype.type(attr_val)
         setattr(v, attr_key, attr_val)
+
 
 
 class TestSEADAS:

--- a/satpy/tests/reader_tests/test_seviri_base.py
+++ b/satpy/tests/reader_tests/test_seviri_base.py
@@ -338,8 +338,12 @@ class TestOrbitPolynomialFinder:
     def test_get_orbit_polynomial(self, orbit_polynomials, time,
                                   orbit_polynomial_exp):
         """Test getting the satellite locator."""
+        import warnings
         finder = OrbitPolynomialFinder(orbit_polynomials)
-        orbit_polynomial = finder.get_orbit_polynomial(time=time)
+        with warnings.catch_warnings():
+            # There's no exact polynomial time match, filter the warning
+            warnings.filterwarnings("ignore", category=UserWarning, message=r"No orbit polynomial valid")
+            orbit_polynomial = finder.get_orbit_polynomial(time=time)
         assert orbit_polynomial == orbit_polynomial_exp
 
     @pytest.mark.parametrize(
@@ -356,7 +360,8 @@ class TestOrbitPolynomialFinder:
         """Test exceptions thrown while getting the satellite locator."""
         finder = OrbitPolynomialFinder(orbit_polynomials)
         with pytest.raises(NoValidOrbitParams):
-            finder.get_orbit_polynomial(time=time)
+            with pytest.warns(UserWarning, match=r"No orbit polynomial valid"):
+                finder.get_orbit_polynomial(time=time)
 
 
 class TestMeirinkSlope:

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -18,6 +18,7 @@
 """The HRIT msg reader tests package."""
 
 import unittest
+import warnings
 from datetime import datetime
 from unittest import mock
 
@@ -119,7 +120,11 @@ class TestHRITMSGFileHandlerHRV(TestHRITMSGBase):
         from pyresample.utils import proj4_radius_parameters
         area = self.reader.get_area_def(make_dataid(name="HRV", resolution=1000))
         assert area.area_extent == (-45561979844414.07, -3720765401003.719, 45602912357076.38, 77771774058.38356)
-        proj_dict = area.proj_dict
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message=r"You will likely lose important projection information",
+                                    category=UserWarning)
+            proj_dict = area.proj_dict
         a, b = proj4_radius_parameters(proj_dict)
         assert a == 6378169.0
         assert b == pytest.approx(6356583.8)
@@ -168,7 +173,11 @@ class TestHRITMSGFileHandler(TestHRITMSGBase):
         """Test getting the area def."""
         from pyresample.utils import proj4_radius_parameters
         area = self.reader.get_area_def(make_dataid(name="VIS006", resolution=3000))
-        proj_dict = area.proj_dict
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore",
+                                    message=r"You will likely lose important projection information",
+                                    category=UserWarning)
+            proj_dict = area.proj_dict
         a, b = proj4_radius_parameters(proj_dict)
         assert a == 6378169.0
         assert b == pytest.approx(6356583.8)

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit_setup.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit_setup.py
@@ -201,6 +201,7 @@ def get_acq_time_cds(start_time, nlines):
     tline["days"][1:-1] = days_since_1958 * np.ones(nlines - 2)
     offset_second = (start_time - start_time.replace(hour=0, minute=0, second=0, microsecond=0)).total_seconds()*1000
     tline["milliseconds"][1:-1] = np.arange(nlines - 2)+offset_second
+
     return tline
 
 
@@ -211,7 +212,8 @@ def get_acq_time_exp(start_time, nlines):
     tline_exp[-1] = np.datetime64("NaT")
     tline_exp[1:-1] = np.datetime64(start_time)
     tline_exp[1:-1] += np.arange(nlines - 2).astype("timedelta64[ms]")
-    return tline_exp
+
+    return tline_exp.astype("datetime64[ns]")
 
 
 def get_attrs_exp(projection_longitude=0.0):

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit_setup.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit_setup.py
@@ -49,6 +49,8 @@ def get_new_read_prologue(prologue):
 def get_fake_file_handler(observation_start_time, nlines, ncols, projection_longitude=0,
                           orbit_polynomials=ORBIT_POLYNOMIALS):
     """Create a mocked SEVIRI HRIT file handler."""
+    import warnings
+
     prologue = get_fake_prologue(projection_longitude, orbit_polynomials)
     mda = get_fake_mda(nlines=nlines, ncols=ncols, start_time=observation_start_time)
     filename_info = get_fake_filename_info(observation_start_time)
@@ -80,13 +82,16 @@ def get_fake_file_handler(observation_start_time, nlines, ncols, projection_long
         )
         epilogue = mock.MagicMock(epilogue=epilogue)
 
-        reader = HRITMSGFileHandler(
-            "filename",
-            filename_info,
-            {"filetype": "info"},
-            prologue,
-            epilogue
-        )
+        with warnings.catch_warnings():
+            # Orbit polynomial has no exact match, so filter the unnecessary warning
+            warnings.filterwarnings("ignore", category=UserWarning, message=r"No orbit polynomial valid for")
+            reader = HRITMSGFileHandler(
+                "filename",
+                filename_info,
+                {"filetype": "info"},
+                prologue,
+                epilogue
+            )
         reader.mda.update(mda)
         return reader
 

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1048,10 +1048,10 @@ class TestNativeMSGDataset:
                 "standard_name": "counts",
             }
         )
-        expected["acq_time"] = ("y", [np.datetime64("1958-01-02 00:00:01"),
-                                      np.datetime64("1958-01-02 00:00:02"),
-                                      np.datetime64("1958-01-02 00:00:03"),
-                                      np.datetime64("1958-01-02 00:00:04")])
+        expected["acq_time"] = ("y", [np.datetime64("1958-01-02 00:00:01").astype("datetime64[ns]"),
+                                      np.datetime64("1958-01-02 00:00:02").astype("datetime64[ns]"),
+                                      np.datetime64("1958-01-02 00:00:03").astype("datetime64[ns]"),
+                                      np.datetime64("1958-01-02 00:00:04").astype("datetime64[ns]")])
         return expected
 
     def test_get_dataset_with_raw_metadata(self, file_handler):

--- a/satpy/tests/reader_tests/test_seviri_l1b_nc.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_nc.py
@@ -381,7 +381,8 @@ class TestNCSEVIRIFileHandler(TestFileHandlerCalibrationBase):
         }
         file_handler.nc["orbit_polynomial_start_time_day"] = 0
         file_handler.nc["orbit_polynomial_end_time_day"] = 0
-        res = file_handler.get_dataset(dataset_id, dataset_info)
+        with pytest.warns(UserWarning, match=r"No orbit polynomial valid for"):
+            res = file_handler.get_dataset(dataset_id, dataset_info)
         assert "satellite_actual_longitude" not in res.attrs[
             "orbital_parameters"]
 

--- a/satpy/tests/reader_tests/test_seviri_l1b_nc.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_nc.py
@@ -337,8 +337,8 @@ class TestNCSEVIRIFileHandler(TestFileHandlerCalibrationBase):
             "wavelength": "wavelength",
             "standard_name": "standard_name"
         }
-        expected["acq_time"] = ("y", [np.datetime64("1958-01-02 00:00:01"),
-                                      np.datetime64("1958-01-02 00:00:02")])
+        expected["acq_time"] = ("y", [np.datetime64("1958-01-02 00:00:01").astype("datetime64[ns]"),
+                                      np.datetime64("1958-01-02 00:00:02").astype("datetime64[ns]")])
         expected = expected[::-1]  # reader flips data upside down
         if mask_bad_quality_scan_lines:
             expected = file_handler._mask_bad_quality(expected, dataset_info)

--- a/satpy/tests/reader_tests/test_slstr_l1b.py
+++ b/satpy/tests/reader_tests/test_slstr_l1b.py
@@ -18,10 +18,10 @@
 """Module for testing the satpy.readers.nc_slstr module."""
 import unittest
 import unittest.mock as mock
-import warnings
 from datetime import datetime
 
 import numpy as np
+import pytest
 import xarray as xr
 
 from satpy.dataset.dataid import DataID, ModifierTuple, WavelengthRange
@@ -151,7 +151,8 @@ class TestSLSTRReader(TestSLSTRL1B):
         test = NCSLSTR1B("somedir/S1_radiance_an.nc", filename_info, "c")
         assert test.view == "nadir"
         assert test.stripe == "a"
-        test.get_dataset(ds_id, dict(filename_info, **{"file_key": "foo"}))
+        with pytest.raises(UserWarning, match=r"No radiance adjustment supplied for channel"):
+            test.get_dataset(ds_id, dict(filename_info, **{"file_key": "foo"}))
         assert test.start_time == good_start
         assert test.end_time == good_end
         xr_.open_dataset.assert_called()
@@ -214,9 +215,8 @@ class TestSLSTRCalibration(TestSLSTRL1B):
 
         test = NCSLSTR1B("somedir/S1_radiance_co.nc", filename_info, "c")
         # Check warning is raised if we don't have calibration
-        with warnings.catch_warnings(record=True) as w:
+        with pytest.raises(UserWarning, match=r"No radiance adjustment supplied for channel"):
             test.get_dataset(ds_id, dict(filename_info, **{"file_key": "foo"}))
-            assert issubclass(w[-1].category, UserWarning)
 
         # Check user calibration is used correctly
         test = NCSLSTR1B("somedir/S1_radiance_co.nc", filename_info, "c",

--- a/satpy/tests/reader_tests/test_slstr_l1b.py
+++ b/satpy/tests/reader_tests/test_slstr_l1b.py
@@ -151,7 +151,7 @@ class TestSLSTRReader(TestSLSTRL1B):
         test = NCSLSTR1B("somedir/S1_radiance_an.nc", filename_info, "c")
         assert test.view == "nadir"
         assert test.stripe == "a"
-        with pytest.raises(UserWarning, match=r"No radiance adjustment supplied for channel"):
+        with pytest.warns(UserWarning, match=r"No radiance adjustment supplied for channel"):
             test.get_dataset(ds_id, dict(filename_info, **{"file_key": "foo"}))
         assert test.start_time == good_start
         assert test.end_time == good_end
@@ -215,7 +215,7 @@ class TestSLSTRCalibration(TestSLSTRL1B):
 
         test = NCSLSTR1B("somedir/S1_radiance_co.nc", filename_info, "c")
         # Check warning is raised if we don't have calibration
-        with pytest.raises(UserWarning, match=r"No radiance adjustment supplied for channel"):
+        with pytest.warns(UserWarning, match=r"No radiance adjustment supplied for channel"):
             test.get_dataset(ds_id, dict(filename_info, **{"file_key": "foo"}))
 
         # Check user calibration is used correctly


### PR DESCRIPTION
This PR fixes and/or suppresses a bunch of warnings emitted by the Satpy reader tests.

 - [x] Tests adjusted
