### PR TITLE
Fix composites failing on non-aligned geolocation coordinates

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -157,7 +157,7 @@ class CompositeBase:
                 elif o.get(k) is not None:
                     d[k] = o[k]
 
-    def match_data_arrays(self, data_arrays):
+    def match_data_arrays(self, data_arrays: Sequence[xr.DataArray]) -> list[xr.DataArray]:
         """Match data arrays so that they can be used together in a composite.
 
         For the purpose of this method, "can be used together" means:
@@ -189,46 +189,7 @@ class CompositeBase:
         new_arrays = list(unify_chunks(*new_arrays))
         return new_arrays
 
-    def drop_coordinates(self, data_arrays):
-        """Drop negligible non-dimensional coordinates.
-
-        Drops negligible coordinates if they do not correspond to any
-        dimension.  Negligible coordinates are defined in the
-        :attr:`NEGLIGIBLE_COORDS` module attribute.
-
-        Args:
-            data_arrays (List[arrays]): Arrays to be checked
-        """
-        new_arrays = []
-        for ds in data_arrays:
-            drop = [coord for coord in ds.coords
-                    if coord not in ds.dims and
-                    any([neglible in coord for neglible in NEGLIGIBLE_COORDS])]
-            if drop:
-                new_arrays.append(ds.drop_vars(drop))
-            else:
-                new_arrays.append(ds)
-
-        return new_arrays
-
-    def align_geo_coordinates(self, data_arrays: Sequence[xr.DataArray]) -> list[xr.DataArray]:
-        """Align DataArrays along geolocation coordinates.
-
-        See :func:`~xarray.align` for more information. This function uses
-        the "override" join method to essentially ignore differences between
-        coordinates. The :meth:`check_geolocation` should be called before
-        this to ensure that geolocation coordinates and "area" are compatible.
-        The :meth:`drop_coordinates` method should be called before this to
-        ensure that coordinates that are considered "negligible" when computing
-        composites do not affect alignment.
-
-        """
-        non_geo_coords = tuple(
-            coord_name for data_arr in data_arrays
-            for coord_name in data_arr.coords if coord_name not in ("x", "y"))
-        return xr.align(*data_arrays, join="override", exclude=non_geo_coords)
-
-    def check_geolocation(self, data_arrays):
+    def check_geolocation(self, data_arrays: Sequence[xr.DataArray]) -> None:
         """Check that the geolocations of the *data_arrays* are compatible.
 
         For the purpose of this method, "compatible" means:
@@ -238,7 +199,7 @@ class CompositeBase:
         - If all have an area, the areas should be all the same.
 
         Args:
-            data_arrays (List[arrays]): Arrays to be checked
+            data_arrays: Arrays to be checked
 
         Raises:
             :class:`IncompatibleAreas`:
@@ -268,6 +229,47 @@ class CompositeBase:
             LOG.debug("Not all areas are the same in "
                       "'{}'".format(self.attrs["name"]))
             raise IncompatibleAreas("Areas are different")
+
+    @staticmethod
+    def drop_coordinates(data_arrays: Sequence[xr.DataArray]) -> list[xr.DataArray]:
+        """Drop negligible non-dimensional coordinates.
+
+        Drops negligible coordinates if they do not correspond to any
+        dimension.  Negligible coordinates are defined in the
+        :attr:`NEGLIGIBLE_COORDS` module attribute.
+
+        Args:
+            data_arrays (List[arrays]): Arrays to be checked
+        """
+        new_arrays = []
+        for ds in data_arrays:
+            drop = [coord for coord in ds.coords
+                    if coord not in ds.dims and
+                    any([neglible in coord for neglible in NEGLIGIBLE_COORDS])]
+            if drop:
+                new_arrays.append(ds.drop_vars(drop))
+            else:
+                new_arrays.append(ds)
+
+        return new_arrays
+
+    @staticmethod
+    def align_geo_coordinates(data_arrays: Sequence[xr.DataArray]) -> list[xr.DataArray]:
+        """Align DataArrays along geolocation coordinates.
+
+        See :func:`~xarray.align` for more information. This function uses
+        the "override" join method to essentially ignore differences between
+        coordinates. The :meth:`check_geolocation` should be called before
+        this to ensure that geolocation coordinates and "area" are compatible.
+        The :meth:`drop_coordinates` method should be called before this to
+        ensure that coordinates that are considered "negligible" when computing
+        composites do not affect alignment.
+
+        """
+        non_geo_coords = tuple(
+            coord_name for data_arr in data_arrays
+            for coord_name in data_arr.coords if coord_name not in ("x", "y"))
+        return list(xr.align(*data_arrays, join="override", exclude=non_geo_coords))
 
 
 class DifferenceCompositor(CompositeBase):


### PR DESCRIPTION
See #2668 for detailed discussion. Basically #2610 switched from the internal satpy base resampler to the pyresample base resampler class. This overall isn't a problem except for the pyresample base resample has a shortcut where it won't process an input if it detects that the target geometry is the same as the source geometry. In those cases it returns the original DataArray with no additional modification. This logically/theoretically shouldn't be a problem, but it reveals a larger issue.

When y and x coordinates are generated from different sources they may have very small differences due to floating point precision issues. So example an x and y that are a subset/slice of a larger pair of x/y arrays may be different than an x/y generated from a sliced/subset AreaDefinition of the same original area definition (again, look at my comments in the referenced issue).

This PR updates one part of Satpy to make these operations work as overall the resampler change revealed an existing issue that was previously being hidden. The composite base class now performs a call to `xarray.align` to make sure that input arrays are compatible, but for `y` and `x` coordinates it will re-assign them to match the first input. The docstring in the new method explains any concerns about this.

 - [x] Closes #2668 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

