### PR TITLE
Reduce the number of warnings in writer tests

### DIFF
--- a/satpy/cf/coords.py
+++ b/satpy/cf/coords.py
@@ -291,8 +291,8 @@ def add_time_bounds_dimension(ds: xr.Dataset, time: str = "time") -> xr.Dataset:
                      if start_time is not None)
     end_time = min(end_time for end_time in end_times
                    if end_time is not None)
-    ds["time_bnds"] = xr.DataArray([[np.datetime64(start_time),
-                                     np.datetime64(end_time)]],
+    ds["time_bnds"] = xr.DataArray([[np.datetime64(start_time, "ns"),
+                                     np.datetime64(end_time, "ns")]],
                                    dims=["time", "bnds_1d"])
     ds[time].attrs["bounds"] = "time_bnds"
     ds[time].attrs["standard_name"] = "time"

--- a/satpy/tests/test_writers.py
+++ b/satpy/tests/test_writers.py
@@ -548,13 +548,20 @@ class TestComputeWriterResults(unittest.TestCase):
         import tempfile
         from datetime import datetime
 
+        from pyresample.geometry import AreaDefinition
+
         from satpy.scene import Scene
 
+        adef = AreaDefinition(
+            "test", "test", "test", "EPSG:4326",
+            100, 200, (-180., -90., 180., 90.),
+        )
         ds1 = xr.DataArray(
             da.zeros((100, 200), chunks=50),
             dims=("y", "x"),
             attrs={"name": "test",
-                   "start_time": datetime(2018, 1, 1, 0, 0, 0)}
+                   "start_time": datetime(2018, 1, 1, 0, 0, 0),
+                   "area": adef}
         )
         self.scn = Scene()
         self.scn["test"] = ds1
@@ -650,8 +657,14 @@ class TestBaseWriter:
         import tempfile
         from datetime import datetime
 
+        from pyresample.geometry import AreaDefinition
+
         from satpy.scene import Scene
 
+        adef = AreaDefinition(
+            "test", "test", "test", "EPSG:4326",
+            100, 200, (-180., -90., 180., 90.),
+        )
         ds1 = xr.DataArray(
             da.zeros((100, 200), chunks=50),
             dims=("y", "x"),
@@ -659,6 +672,7 @@ class TestBaseWriter:
                 "name": "test",
                 "start_time": datetime(2018, 1, 1, 0, 0, 0),
                 "sensor": "fake_sensor",
+                "area": adef,
             }
         )
         ds2 = ds1.copy()

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -152,7 +152,8 @@ class TestCFWriter:
         scn = Scene()
         scn["1"] = xr.DataArray([1, 2, 3])
         with TempFile() as filename:
-            scn.save_datasets(filename=filename, writer="cf", include_orig_name=True, numeric_name_prefix="")
+            with pytest.warns(UserWarning, match=r"Invalid NetCDF dataset name"):
+                scn.save_datasets(filename=filename, writer="cf", include_orig_name=True, numeric_name_prefix="")
             with xr.open_dataset(filename) as f:
                 np.testing.assert_array_equal(f["1"][:], [1, 2, 3])
                 assert "original_name" not in f["1"].attrs

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -247,7 +247,7 @@ class TestCFWriter:
                                          attrs=dict(start_time=start_time,
                                                     end_time=end_time))
         with TempFile() as filename:
-            scn.save_datasets(filename=filename, writer="cf")
+            scn.save_datasets(filename=filename, writer="cf", encoding={"time": {"units": "seconds since 2018-01-01"}})
             with xr.open_dataset(filename, decode_cf=True) as f:
                 np.testing.assert_array_equal(f["time"], scn["test-array"]["time"])
                 bounds_exp = np.array([[start_time, end_time]], dtype="datetime64[m]")
@@ -264,7 +264,8 @@ class TestCFWriter:
                                          coords={"time": ("y", times)},
                                          attrs=dict(start_time=times[0], end_time=times[-1]))
         with TempFile() as filename:
-            scn.save_datasets(filename=filename, writer="cf", pretty=True)
+            scn.save_datasets(filename=filename, writer="cf", pretty=True,
+                              encoding={"time": {"units": "seconds since 2018-01-01"}})
             with xr.open_dataset(filename, decode_cf=True) as f:
                 np.testing.assert_array_equal(f["time"], scn["test-array"]["time"])
 
@@ -280,7 +281,11 @@ class TestCFWriter:
                                          attrs=dict(start_time=start_time,
                                                     end_time=end_time))
         with TempFile() as filename:
-            scn.save_datasets(filename=filename, writer="cf")
+            with warnings.catch_warnings():
+                # The purpose is to use the default time encoding, silence the warning
+                warnings.filterwarnings("ignore", category=UserWarning,
+                                        message=r"Times can't be serialized faithfully to int64 with requested units")
+                scn.save_datasets(filename=filename, writer="cf")
             # Check decoded time coordinates & bounds
             with xr.open_dataset(filename, decode_cf=True) as f:
                 bounds_exp = np.array([[start_time, end_time]], dtype="datetime64[m]")
@@ -319,7 +324,8 @@ class TestCFWriter:
                                           attrs=dict(start_time=start_timeB,
                                                      end_time=end_timeB))
         with TempFile() as filename:
-            scn.save_datasets(filename=filename, writer="cf")
+            scn.save_datasets(filename=filename, writer="cf",
+                              encoding={"time": {"units": "seconds since 2018-01-01"}})
             with xr.open_dataset(filename, decode_cf=True) as f:
                 bounds_exp = np.array([[start_timeA, end_timeB]], dtype="datetime64[m]")
                 np.testing.assert_array_equal(f["time_bnds"], bounds_exp)
@@ -340,7 +346,8 @@ class TestCFWriter:
                                           dims=["x", "y", "time"],
                                           coords={"time": [np.datetime64("2018-05-30T10:05:00", "ns")]})
         with TempFile() as filename:
-            scn.save_datasets(filename=filename, writer="cf")
+            scn.save_datasets(filename=filename, writer="cf",
+                              encoding={"time": {"units": "seconds since 2018-01-01"}})
             with xr.open_dataset(filename, decode_cf=True) as f:
                 bounds_exp = np.array([[start_timeA, end_timeA]], dtype="datetime64[m]")
                 np.testing.assert_array_equal(f["time_bnds"], bounds_exp)
@@ -357,7 +364,8 @@ class TestCFWriter:
                                          attrs=dict(start_time=start_time,
                                                     end_time=end_time))
         with TempFile() as filename:
-            scn.save_datasets(filename=filename, writer="cf", unlimited_dims=["time"])
+            scn.save_datasets(filename=filename, writer="cf", unlimited_dims=["time"],
+                              encoding={"time": {"units": "seconds since 2018-01-01"}})
             with xr.open_dataset(filename) as f:
                 assert set(f.encoding["unlimited_dims"]) == {"time"}
 

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -240,7 +240,7 @@ class TestCFWriter:
         test_array = np.array([[1, 2], [3, 4]])
         scn["test-array"] = xr.DataArray(test_array,
                                          dims=["x", "y"],
-                                         coords={"time": np.datetime64("2018-05-30T10:05:00")},
+                                         coords={"time": np.datetime64("2018-05-30T10:05:00", "ns")},
                                          attrs=dict(start_time=start_time,
                                                     end_time=end_time))
         with TempFile() as filename:
@@ -255,7 +255,7 @@ class TestCFWriter:
         scn = Scene()
         test_array = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
         times = np.array(["2018-05-30T10:05:00", "2018-05-30T10:05:01",
-                          "2018-05-30T10:05:02", "2018-05-30T10:05:03"], dtype=np.datetime64)
+                          "2018-05-30T10:05:02", "2018-05-30T10:05:03"], dtype="datetime64[ns]")
         scn["test-array"] = xr.DataArray(test_array,
                                          dims=["y", "x"],
                                          coords={"time": ("y", times)},
@@ -273,7 +273,7 @@ class TestCFWriter:
         test_array = np.array([[1, 2], [3, 4]]).reshape(2, 2, 1)
         scn["test-array"] = xr.DataArray(test_array,
                                          dims=["x", "y", "time"],
-                                         coords={"time": [np.datetime64("2018-05-30T10:05:00")]},
+                                         coords={"time": [np.datetime64("2018-05-30T10:05:00", "ns")]},
                                          attrs=dict(start_time=start_time,
                                                     end_time=end_time))
         with TempFile() as filename:
@@ -307,12 +307,12 @@ class TestCFWriter:
         test_arrayB = np.array([[1, 2], [3, 5]]).reshape(2, 2, 1)
         scn["test-arrayA"] = xr.DataArray(test_arrayA,
                                           dims=["x", "y", "time"],
-                                          coords={"time": [np.datetime64("2018-05-30T10:05:00")]},
+                                          coords={"time": [np.datetime64("2018-05-30T10:05:00", "ns")]},
                                           attrs=dict(start_time=start_timeA,
                                                      end_time=end_timeA))
         scn["test-arrayB"] = xr.DataArray(test_arrayB,
                                           dims=["x", "y", "time"],
-                                          coords={"time": [np.datetime64("2018-05-30T10:05:00")]},
+                                          coords={"time": [np.datetime64("2018-05-30T10:05:00", "ns")]},
                                           attrs=dict(start_time=start_timeB,
                                                      end_time=end_timeB))
         with TempFile() as filename:
@@ -330,12 +330,12 @@ class TestCFWriter:
         test_arrayB = np.array([[1, 2], [3, 5]]).reshape(2, 2, 1)
         scn["test-arrayA"] = xr.DataArray(test_arrayA,
                                           dims=["x", "y", "time"],
-                                          coords={"time": [np.datetime64("2018-05-30T10:05:00")]},
+                                          coords={"time": [np.datetime64("2018-05-30T10:05:00", "ns")]},
                                           attrs=dict(start_time=start_timeA,
                                                      end_time=end_timeA))
         scn["test-arrayB"] = xr.DataArray(test_arrayB,
                                           dims=["x", "y", "time"],
-                                          coords={"time": [np.datetime64("2018-05-30T10:05:00")]})
+                                          coords={"time": [np.datetime64("2018-05-30T10:05:00", "ns")]})
         with TempFile() as filename:
             scn.save_datasets(filename=filename, writer="cf")
             with xr.open_dataset(filename, decode_cf=True) as f:
@@ -350,7 +350,7 @@ class TestCFWriter:
         test_array = np.array([[1, 2], [3, 4]])
         scn["test-array"] = xr.DataArray(test_array,
                                          dims=["x", "y"],
-                                         coords={"time": np.datetime64("2018-05-30T10:05:00")},
+                                         coords={"time": np.datetime64("2018-05-30T10:05:00", "ns")},
                                          attrs=dict(start_time=start_time,
                                                     end_time=end_time))
         with TempFile() as filename:

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -208,8 +208,10 @@ class TestCFWriter:
                                   attrs={"name": "HRV", "start_time": tstart, "end_time": tend})
 
         with TempFile() as filename:
-            scn.save_datasets(filename=filename, writer="cf", groups={"visir": ["IR_108", "VIS006"], "hrv": ["HRV"]},
-                              pretty=True)
+            with pytest.warns(UserWarning, match=r"Cannot pretty-format"):
+                scn.save_datasets(filename=filename, writer="cf",
+                                  groups={"visir": ["IR_108", "VIS006"], "hrv": ["HRV"]},
+                                  pretty=True)
 
             nc_root = xr.open_dataset(filename)
             assert "history" in nc_root.attrs

--- a/satpy/tests/writer_tests/test_geotiff.py
+++ b/satpy/tests/writer_tests/test_geotiff.py
@@ -32,12 +32,19 @@ import xarray as xr
 
 def _get_test_datasets_2d():
     """Create a single 2D test dataset."""
+    from pyresample.geometry import AreaDefinition
+
+    adef = AreaDefinition(
+        "test", "test", "test", "EPSG:4326",
+        100, 200, (-180., -90., 180., 90.),
+    )
     ds1 = xr.DataArray(
         da.zeros((100, 200), chunks=50),
         dims=("y", "x"),
         attrs={"name": "test",
                "start_time": datetime.utcnow(),
-               "units": "K"}
+               "units": "K",
+               "area": adef}
     )
     return [ds1]
 
@@ -54,12 +61,19 @@ def _get_test_datasets_2d_nonlinear_enhancement():
 
 def _get_test_datasets_3d():
     """Create a single 3D test dataset."""
+    from pyresample.geometry import AreaDefinition
+
+    adef = AreaDefinition(
+        "test", "test", "test", "EPSG:4326",
+        100, 200, (-180., -90., 180., 90.),
+    )
     ds1 = xr.DataArray(
         da.zeros((3, 100, 200), chunks=50),
         dims=("bands", "y", "x"),
         coords={"bands": ["R", "G", "B"]},
         attrs={"name": "test",
-               "start_time": datetime.utcnow()}
+               "start_time": datetime.utcnow(),
+               "area": adef}
     )
     return [ds1]
 

--- a/satpy/tests/writer_tests/test_mitiff.py
+++ b/satpy/tests/writer_tests/test_mitiff.py
@@ -52,14 +52,13 @@ class TestMITIFFWriter(unittest.TestCase):
 
         import dask.array as da
         import xarray as xr
+        from pyproj import CRS
         from pyresample.geometry import AreaDefinition
-        from pyresample.utils import proj4_str_to_dict
         area_def = AreaDefinition(
             "test",
             "test",
             "test",
-            proj4_str_to_dict("+proj=stere +datum=WGS84 +ellps=WGS84 "
-                              "+lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
+            CRS("+proj=stere +datum=WGS84 +ellps=WGS84 +lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
             100,
             200,
             (-1000., -1500., 1000., 1500.),
@@ -119,14 +118,13 @@ class TestMITIFFWriter(unittest.TestCase):
 
         import dask.array as da
         import xarray as xr
+        from pyproj import CRS
         from pyresample.geometry import AreaDefinition
-        from pyresample.utils import proj4_str_to_dict
         area_def = AreaDefinition(
             "test",
             "test",
             "test",
-            proj4_str_to_dict("+proj=stere +datum=WGS84 +ellps=WGS84 "
-                              "+lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
+            CRS("+proj=stere +datum=WGS84 +ellps=WGS84 +lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
             100,
             200,
             (-1000., -1500., 1000., 1500.),
@@ -186,14 +184,14 @@ class TestMITIFFWriter(unittest.TestCase):
 
         import dask.array as da
         import xarray as xr
+        from pyproj import CRS
         from pyresample.geometry import AreaDefinition
-        from pyresample.utils import proj4_str_to_dict
+
         area_def = AreaDefinition(
             "test",
             "test",
             "test",
-            proj4_str_to_dict("+proj=stere +datum=WGS84 +ellps=WGS84 "
-                              "+lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
+            CRS("+proj=stere +datum=WGS84 +ellps=WGS84 +lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
             100,
             200,
             (-1000., -1500., 1000., 1500.),
@@ -217,14 +215,14 @@ class TestMITIFFWriter(unittest.TestCase):
 
         import dask.array as da
         import xarray as xr
+        from pyproj import CRS
         from pyresample.geometry import AreaDefinition
-        from pyresample.utils import proj4_str_to_dict
+
         area_def = AreaDefinition(
             "test",
             "test",
             "test",
-            proj4_str_to_dict("+proj=geos +datum=WGS84 +ellps=WGS84 "
-                              "+lon_0=0. h=36000. +units=km"),
+            CRS("+proj=geos +datum=WGS84 +ellps=WGS84 +lon_0=0. h=36000. +units=km"),
             100,
             200,
             (-1000., -1500., 1000., 1500.),
@@ -248,14 +246,14 @@ class TestMITIFFWriter(unittest.TestCase):
 
         import dask.array as da
         import xarray as xr
+        from pyproj import CRS
         from pyresample.geometry import AreaDefinition
-        from pyresample.utils import proj4_str_to_dict
+
         area_def = AreaDefinition(
             "test",
             "test",
             "test",
-            proj4_str_to_dict("+proj=geos +datum=WGS84 +ellps=WGS84 "
-                              "+lon_0=0. h=36000. +units=km"),
+            CRS("+proj=geos +datum=WGS84 +ellps=WGS84 +lon_0=0. h=36000. +units=km"),
             100,
             200,
             (-1000., -1500., 1000., 1500.),
@@ -278,14 +276,14 @@ class TestMITIFFWriter(unittest.TestCase):
         from datetime import datetime
 
         import xarray as xr
+        from pyproj import CRS
         from pyresample.geometry import AreaDefinition
-        from pyresample.utils import proj4_str_to_dict
+
         area_def = AreaDefinition(
             "test",
             "test",
             "test",
-            proj4_str_to_dict("+proj=stere +datum=WGS84 +ellps=WGS84 "
-                              "+lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
+            CRS("+proj=stere +datum=WGS84 +ellps=WGS84 +lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
             100,
             200,
             (-1000., -1500., 1000., 1500.),
@@ -313,8 +311,8 @@ class TestMITIFFWriter(unittest.TestCase):
 
         import dask.array as da
         import xarray as xr
+        from pyproj import CRS
         from pyresample.geometry import AreaDefinition
-        from pyresample.utils import proj4_str_to_dict
 
         from satpy.scene import Scene
         from satpy.tests.utils import make_dsq
@@ -322,8 +320,7 @@ class TestMITIFFWriter(unittest.TestCase):
             "test",
             "test",
             "test",
-            proj4_str_to_dict("+proj=stere +datum=WGS84 +ellps=WGS84 "
-                              "+lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
+            CRS("+proj=stere +datum=WGS84 +ellps=WGS84 +lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
             100,
             200,
             (-1000., -1500., 1000., 1500.),
@@ -418,8 +415,8 @@ class TestMITIFFWriter(unittest.TestCase):
 
         import dask.array as da
         import xarray as xr
+        from pyproj import CRS
         from pyresample.geometry import AreaDefinition
-        from pyresample.utils import proj4_str_to_dict
 
         from satpy.scene import Scene
         from satpy.tests.utils import make_dsq
@@ -427,8 +424,7 @@ class TestMITIFFWriter(unittest.TestCase):
             "test",
             "test",
             "test",
-            proj4_str_to_dict("+proj=stere +datum=WGS84 +ellps=WGS84 "
-                              "+lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
+            CRS("+proj=stere +datum=WGS84 +ellps=WGS84 +lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
             100,
             200,
             (-1000., -1500., 1000., 1500.),
@@ -473,16 +469,15 @@ class TestMITIFFWriter(unittest.TestCase):
 
         import dask.array as da
         import xarray as xr
+        from pyproj import CRS
         from pyresample.geometry import AreaDefinition
-        from pyresample.utils import proj4_str_to_dict
 
         from satpy.tests.utils import make_dsq
         area_def = AreaDefinition(
             "test",
             "test",
             "test",
-            proj4_str_to_dict("+proj=stere +datum=WGS84 +ellps=WGS84 "
-                              "+lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
+            CRS("+proj=stere +datum=WGS84 +ellps=WGS84 +lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
             100,
             200,
             (-1000., -1500., 1000., 1500.),
@@ -508,16 +503,15 @@ class TestMITIFFWriter(unittest.TestCase):
 
         import dask.array as da
         import xarray as xr
+        from pyproj import CRS
         from pyresample.geometry import AreaDefinition
-        from pyresample.utils import proj4_str_to_dict
 
         from satpy.tests.utils import make_dsq
         area_def = AreaDefinition(
             "test",
             "test",
             "test",
-            proj4_str_to_dict("+proj=stere +datum=WGS84 +ellps=WGS84 "
-                              "+lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
+            CRS("+proj=stere +datum=WGS84 +ellps=WGS84 +lon_0=0. +lat_0=90 +lat_ts=60 +units=km"),
             100,
             200,
             (-1000., -1500., 1000., 1500.),

--- a/satpy/tests/writer_tests/test_mitiff.py
+++ b/satpy/tests/writer_tests/test_mitiff.py
@@ -844,23 +844,23 @@ class TestMITIFFWriter(unittest.TestCase):
         from pyresample.geometry import AreaDefinition
 
         from satpy.writers.mitiff import MITIFFWriter
-        checks = [{"epsg": "+init=EPSG:32631",
+        checks = [{"epsg": "EPSG:32631",
                    "proj4": (" Proj string: +proj=etmerc +lat_0=0 +lon_0=3 +k=0.9996 "
                              "+ellps=WGS84 +datum=WGS84 +units=km +x_0=501020.000000 "
                              "+y_0=1515.000000\n")},
-                  {"epsg": "+init=EPSG:32632",
+                  {"epsg": "EPSG:32632",
                    "proj4": (" Proj string: +proj=etmerc +lat_0=0 +lon_0=9 +k=0.9996 "
                              "+ellps=WGS84 +datum=WGS84 +units=km +x_0=501020.000000 "
                              "+y_0=1515.000000\n")},
-                  {"epsg": "+init=EPSG:32633",
+                  {"epsg": "EPSG:32633",
                    "proj4": (" Proj string: +proj=etmerc +lat_0=0 +lon_0=15 +k=0.9996 "
                              "+ellps=WGS84 +datum=WGS84 +units=km +x_0=501020.000000 "
                              "+y_0=1515.000000\n")},
-                  {"epsg": "+init=EPSG:32634",
+                  {"epsg": "EPSG:32634",
                    "proj4": (" Proj string: +proj=etmerc +lat_0=0 +lon_0=21 +k=0.9996 "
                              "+ellps=WGS84 +datum=WGS84 +units=km +x_0=501020.000000 "
                              "+y_0=1515.000000\n")},
-                  {"epsg": "+init=EPSG:32635",
+                  {"epsg": "EPSG:32635",
                    "proj4": (" Proj string: +proj=etmerc +lat_0=0 +lon_0=27 +k=0.9996 "
                              "+ellps=WGS84 +datum=WGS84 +units=km +x_0=501020.000000 "
                              "+y_0=1515.000000\n")}]

--- a/satpy/writers/mitiff.py
+++ b/satpy/writers/mitiff.py
@@ -221,6 +221,8 @@ class MITIFFWriter(ImageWriter):
         return _image_description
 
     def _add_proj4_string(self, datasets, first_dataset):
+        import warnings
+
         proj4_string = " Proj string: "
 
         if isinstance(datasets, list):
@@ -232,7 +234,11 @@ class MITIFFWriter(ImageWriter):
         if hasattr(area, "crs") and area.crs.to_epsg() is not None:
             proj4_string += "+init=EPSG:{}".format(area.crs.to_epsg())
         else:
-            proj4_string += area.proj_str
+            # Filter out the PROJ warning of losing projection information
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=UserWarning,
+                                        message=r"You will likely lose important projection information")
+                proj4_string += area.proj_str
 
         x_0 = 0
         y_0 = 0


### PR DESCRIPTION
Update the code where possible, suppress where necessary, to reduce the number of warnings in Satpy writer tests. The remaining are CF version dependant and various Numpy RuntimeWarnings.

 - [x] Tests adjusted
