### PR TITLE
Anticipate filehandler sorting in `GEOSegmentYAMLReader` to have sorted handlers also with `pad_data=False`

### DIFF
--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -1178,11 +1178,13 @@ class GEOSegmentYAMLReader(GEOFlippableFileYAMLReader):
                 if "segment" not in fh.filename_info:
                     fh.filename_info["segment"] = fh.filename_info.get("count_in_repeat_cycle", 1)
 
-        # sort by segment number
-        for file_type in created_fhs.keys():
-            created_fhs[file_type] = sorted(created_fhs[file_type], key=lambda x: x.filename_info.get("segment", 1))
-
+        self._sort_segment_filehandler_by_segment_number()
         return created_fhs
+
+    def _sort_segment_filehandler_by_segment_number(self):
+        for file_type in self.file_handlers.keys():
+            self.file_handlers[file_type] = sorted(self.file_handlers[file_type],
+                                                   key=lambda x: x.filename_info.get("segment", 0))
 
     def _load_dataset(self, dsid, ds_info, file_handlers, dim="y", pad_data=True):
         """Load only a piece of the dataset."""

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -1182,9 +1182,10 @@ class GEOSegmentYAMLReader(GEOFlippableFileYAMLReader):
         return created_fhs
 
     def _sort_segment_filehandler_by_segment_number(self):
-        for file_type in self.file_handlers.keys():
-            self.file_handlers[file_type] = sorted(self.file_handlers[file_type],
-                                                   key=lambda x: x.filename_info.get("segment", 0))
+        if hasattr(self, "file_handlers"):
+            for file_type in self.file_handlers.keys():
+                self.file_handlers[file_type] = sorted(self.file_handlers[file_type],
+                                                       key=lambda x: x.filename_info.get("segment", 0))
 
     def _load_dataset(self, dsid, ds_info, file_handlers, dim="y", pad_data=True):
         """Load only a piece of the dataset."""

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -1051,11 +1051,11 @@ class TestGEOSegmentYAMLReader(unittest.TestCase):
         fake_fh_3.filename_info["segment"] = 3
 
         # put the filehandlers in an unsorted order
-        cfh.return_value = {"ft1": [fake_fh_1, fake_fh_3, fake_fh_2]}
+        reader.file_handlers = {"ft1": [fake_fh_1, fake_fh_3, fake_fh_2]}
 
         # check that the created filehandlers are sorted by segment number
-        created_fhs = reader.create_filehandlers(["fake.nc"])
-        assert [fh.filename_info["segment"] for fh in created_fhs["ft1"]] == [1, 2, 3]
+        reader.create_filehandlers(["fake.nc"])
+        assert [fh.filename_info["segment"] for fh in reader.file_handlers["ft1"]] == [1, 2, 3]
 
     @patch.object(yr.FileYAMLReader, "__init__", lambda x: None)
     @patch("satpy.readers.yaml_reader.FileYAMLReader._load_dataset")


### PR DESCRIPTION
This PR fixes the issue reported in https://github.com/pytroll/satpy/issues/2588 by making the segment sorting happen early during `create_filehandlers`, so that it acts for both `pad_data=True` and `False`. 

The root cause was that the filehandler sorting _by segment_ was done only in the default `pad_data=True` branch inside the padding mechanism of `GEOSegmentYAMLReader`. When calling e.g. `scn.load(['ir_105'], pad_data=False, upper_right_corner='NE')`, in the previous implementation the filehandlers were being sorted (in the base `FileYAMLReader.create_filehandlers`) only by `start_time` (which is always the same after https://github.com/pytroll/satpy/pull/2420), and then alphabetically by filenames. This is problematic for FCI where sorting alphabetically means sorting by `processing_time`, and there are cases where the `processing_time` order does not correspond to the chunk order (due to parallel processing), causing the issue. 

Note that even without https://github.com/pytroll/satpy/pull/2420, some FCI segments have the same filename `start_time`, hence the bug would have happened anyway.

 - [x] Closes #2588 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
