### PR TITLE
Match all projectables in `NDVIHybridGreen.__call__` to avoid coordinate mismatch errors

### DIFF
--- a/satpy/composites/spectral.py
+++ b/satpy/composites/spectral.py
@@ -159,9 +159,9 @@ class NDVIHybridGreen(SpectralBlender):
         LOG.info(f"Applying NDVI-weighted hybrid-green correction with limits [{self.limits[0]}, "
                  f"{self.limits[1]}] and strength {self.strength}.")
 
-        ndvi_input = self.match_data_arrays([projectables[1], projectables[2]])
+        ndvi_input = self.match_data_arrays(projectables)
 
-        ndvi = (ndvi_input[1] - ndvi_input[0]) / (ndvi_input[1] + ndvi_input[0])
+        ndvi = (ndvi_input[2] - ndvi_input[1]) / (ndvi_input[2] + ndvi_input[1])
 
         ndvi = ndvi.clip(self.ndvi_min, self.ndvi_max)
 

--- a/satpy/composites/spectral.py
+++ b/satpy/composites/spectral.py
@@ -159,9 +159,9 @@ class NDVIHybridGreen(SpectralBlender):
         LOG.info(f"Applying NDVI-weighted hybrid-green correction with limits [{self.limits[0]}, "
                  f"{self.limits[1]}] and strength {self.strength}.")
 
-        ndvi_input = self.match_data_arrays(projectables)
+        projectables = self.match_data_arrays(projectables)
 
-        ndvi = (ndvi_input[2] - ndvi_input[1]) / (ndvi_input[2] + ndvi_input[1])
+        ndvi = (projectables[2] - projectables[1]) / (projectables[2] + projectables[1])
 
         ndvi = ndvi.clip(self.ndvi_min, self.ndvi_max)
 

--- a/satpy/tests/compositor_tests/test_spectral.py
+++ b/satpy/tests/compositor_tests/test_spectral.py
@@ -79,10 +79,10 @@ class TestNdviHybridGreenCompositor:
             dims=("y", "x"), coords=[coord_val, coord_val], attrs={"name": "C02"})
         self.c02 = xr.DataArray(
             da.from_array(np.array([[0.25, 0.30], [0.25, 0.35]], dtype=np.float32), chunks=25),
-            dims=("y", "x"), coords=[coord_val, coord_val],  attrs={"name": "C03"})
+            dims=("y", "x"), coords=[coord_val, coord_val], attrs={"name": "C03"})
         self.c03 = xr.DataArray(
             da.from_array(np.array([[0.35, 0.35], [0.28, 0.65]], dtype=np.float32), chunks=25),
-            dims=("y", "x"), coords=[coord_val, coord_val],  attrs={"name": "C04"})
+            dims=("y", "x"), coords=[coord_val, coord_val], attrs={"name": "C04"})
 
     def test_ndvi_hybrid_green(self):
         """Test General functionality with linear scaling from ndvi to blend fraction."""


### PR DESCRIPTION
This PR, in combination with https://github.com/pytroll/satpy/pull/2690, fixes https://github.com/pytroll/satpy/issues/2668. 

In the previous implementation, inside the `NDVIHybridGreen` compositor, only the projectables related to the NDVI were being matched. The resulting NDVI fraction was then being combined with the remaining projectable in the super `__call__`, which resulted in failures due to mismatching coordinates. 

This PR fixes this bug by matching all arrays.

 - [x] Closes #2668 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
