### PR TITLE
Fix eps_l1b reader Delayed usage causing docs failures 

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -278,7 +278,7 @@ latex_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "dask": ("https://docs.dask.org/en/latest", None),
-    "geoviews": ("http://geoviews.org", None),
+    "geoviews": ("https://geoviews.org", None),
     "jobqueue": ("https://jobqueue.dask.org/en/latest", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "pydecorate": ("https://pydecorate.readthedocs.io/en/stable", None),
@@ -287,7 +287,7 @@ intersphinx_mapping = {
     "pyresample": ("https://pyresample.readthedocs.io/en/stable", None),
     "pytest": ("https://docs.pytest.org/en/stable/", None),
     "python": ("https://docs.python.org/3", None),
-    "scipy": ("http://scipy.github.io/devdocs", None),
+    "scipy": ("https://scipy.github.io/devdocs", None),
     "trollimage": ("https://trollimage.readthedocs.io/en/stable", None),
     "trollsift": ("https://trollsift.readthedocs.io/en/stable", None),
     "xarray": ("https://xarray.pydata.org/en/stable", None),

--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -212,7 +212,7 @@ class EPSAVHRRFile(BaseFileHandler):
     def _interpolate(self, lons_like, lats_like):
         nav_sample_rate = self["NAV_SAMPLE_RATE"]
         if nav_sample_rate == 20 and self.pixels == 2048:
-            lons_like_1km, lats_like_1km = self._interpolate_20km_to_1km(lons_like, lats_like)
+            lons_like_1km, lats_like_1km = _interpolate_20km_to_1km(lons_like, lats_like)
             lons_like_1km = da.from_delayed(lons_like_1km, dtype=lons_like.dtype,
                                             shape=(self.scanlines, self.pixels))
             lats_like_1km = da.from_delayed(lats_like_1km, dtype=lats_like.dtype,

--- a/satpy/readers/eps_l1b.py
+++ b/satpy/readers/eps_l1b.py
@@ -224,12 +224,6 @@ class EPSAVHRRFile(BaseFileHandler):
                                   " and earth views = " +
                                   str(self.pixels))
 
-    @delayed(nout=2, pure=True)
-    def _interpolate_20km_to_1km(self, lons, lats):
-        # Note: delayed will cast input dask-arrays to numpy arrays (needed by metop20kmto1km).
-        from geotiepoints import metop20kmto1km
-        return metop20kmto1km(lons, lats)
-
     def _get_full_angles(self, solar_zenith, sat_zenith, solar_azimuth, sat_azimuth):
 
         nav_sample_rate = self["NAV_SAMPLE_RATE"]
@@ -403,3 +397,10 @@ class EPSAVHRRFile(BaseFileHandler):
         """Get end time."""
         # return datetime.strptime(self["SENSING_END"], "%Y%m%d%H%M%SZ")
         return self._end_time
+
+
+@delayed(nout=2, pure=True)
+def _interpolate_20km_to_1km(lons, lats):
+    # Note: delayed will cast input dask-arrays to numpy arrays (needed by metop20kmto1km).
+    from geotiepoints import metop20kmto1km
+    return metop20kmto1km(lons, lats)


### PR DESCRIPTION
This was discussed on slack and first seen failing in #2699. Readthedocs builds were failing with a new version of dask. Sphinx apidocs were trying to analyze if a method was a staticmethod and failing with:

```
  File "/home/docs/checkouts/readthedocs.org/user_builds/satpy/conda/2699/lib/python3.10/site-packages/sphinx/ext/autodoc/__init__.py", line 2159, in import_object
    inspect.isstaticmethod(obj, cls=self.parent, name=self.object_name)):
  File "/home/docs/checkouts/readthedocs.org/user_builds/satpy/conda/2699/lib/python3.10/site-packages/sphinx/util/inspect.py", line 214, in isstaticmethod
    if meth:
  File "/home/docs/checkouts/readthedocs.org/user_builds/satpy/conda/2699/lib/python3.10/site-packages/dask/delayed.py", line 645, in __bool__
    raise TypeError("Truth of Delayed objects is not supported")
TypeError: Truth of Delayed objects is not supported
```

I was able to reproduce it locally with the newest dask and discovered that it was the `eps_l1b.py` reader. This reader declared a regular class method as a Delayed object. This is generally considered bad practice as it makes the Delayed object non-serializable in distributed environments/workflows. Technically making it a staticmethod should have fixed it but when I tried it locally I couldn't make it work. I instead decided to make it a global function as there was no real reason to tie it to the class. This seems to fix it.

I then checked trollimage which does use delayed staticmethods and it doesn't fail, but that's because the staticmethod isn't made delayed until it is called. For example `res = dask.delayed(self._some_static_method)(a, b, c)`. This type of calling seems fine.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
