### PR TITLE
Ici reader tiepoints bugfix

### DIFF
--- a/satpy/readers/ici_l1b_nc.py
+++ b/satpy/readers/ici_l1b_nc.py
@@ -197,7 +197,10 @@ class IciL1bNCFileHandler(NetCDF4FileHandler):
         n_subs = longitude.n_subs
         lons = da.zeros((n_scan.size, n_samples, horns.size))
         lats = da.zeros((n_scan.size, n_samples, horns.size))
-        n_subs = np.linspace(0, n_samples - 1, n_subs.size).astype(int)
+        n_subs = np.append(
+            np.arange(0, n_samples, np.ceil(n_samples / n_subs.size)),
+            n_samples - 1
+        ).astype(int)
         for horn in horns.values:
             satint = GeoInterpolator(
                 (longitude.values[:, :, horn], latitude.values[:, :, horn]),

--- a/satpy/tests/reader_tests/test_ici_l1b_nc.py
+++ b/satpy/tests/reader_tests/test_ici_l1b_nc.py
@@ -445,8 +445,14 @@ class TestIciL1bNCFileHandler:
         """Test interpolate geographic coordinates."""
         shape = (N_SCAN, N_SUBS, N_HORNS)
         dims = ("n_scan", "n_subs", "n_horns")
+        sub_pos = np.append(
+            np.arange(0, N_SAMPLES, np.ceil(N_SAMPLES / N_SUBS)),
+            N_SAMPLES - 1
+        )
         longitude = xr.DataArray(
-            2. * np.ones(shape),
+            np.tile( # longitudes between 0 and 10
+                10 * sub_pos / sub_pos[-1], (N_SCAN, N_HORNS, 1)
+            ).swapaxes(1, 2),
             dims=dims,
             coords={
                 "n_horns": np.arange(N_HORNS),
@@ -462,7 +468,9 @@ class TestIciL1bNCFileHandler:
         expect_shape = (N_SCAN, N_SAMPLES, N_HORNS)
         assert lon.shape == expect_shape
         assert lat.shape == expect_shape
-        np.testing.assert_allclose(lon, 2.0)
+        np.testing.assert_allclose(lon[:, 0, :], 0.)
+        np.testing.assert_allclose(lon[:, -1, :], 10.)
+        np.testing.assert_allclose(np.diff(lon[0, :, 0]), 10 / (N_SAMPLES - 1))
         np.testing.assert_allclose(lat, 1.0)
 
     def test_interpolate_viewing_angle(self, reader):


### PR DESCRIPTION
This small PR fixes how pixel positions are reconstructed from tiepoints for the ICI reader. The tiepoints are not evenly distributed around the scan end as was assumed earlier.  
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Add your name to `AUTHORS.md` if not there already
