### PR TITLE
Fix 'viirs_edr' renaming two sets of dimensions to the same names

### DIFF
--- a/satpy/tests/reader_tests/test_viirs_edr.py
+++ b/satpy/tests/reader_tests/test_viirs_edr.py
@@ -152,6 +152,7 @@ def _create_surf_refl_variables() -> dict[str, xr.DataArray]:
         "750m Surface Reflectance Band M1": xr.DataArray(m_data, dims=m_dims, attrs=sr_attrs),
     }
     for data_arr in data_arrs.values():
+        data_arr.encoding["chunksizes"] = data_arr.shape
         if "scale_factor" not in data_arr.attrs:
             continue
         data_arr.encoding["dtype"] = np.int16


### PR DESCRIPTION
So this wasn't actually a problem until xarray 2023.9.0 where something changed to be more strict about dimensions and coordinates. This also wasn't failing in tests because my tests assume the ideal case of the file metadata. The real files however seem to have incorrect coordinates for some variables:

```
        short \750m\ Surface\ Reflectance\ Band\ M10(Along_Track_750m, Along_Scan_750m) ;
                \750m\ Surface\ Reflectance\ Band\ M10:scale_factor = 0.0001f ;
                \750m\ Surface\ Reflectance\ Band\ M10:add_offset = 0.f ;
                \750m\ Surface\ Reflectance\ Band\ M10:coordinates = "Latitude_at_375m_resolution, Longitude_at_375m_resolution" ;
```

Obviously the 750m data should not be pointing to the 375m lon/lat variables as coordinates. This was made worse by my renaming in `__init__` from both sets of dimensions (375m and 750m) to the same name "y" and "x". This PR switches that renaming to happen per DataArray. Note I am not testing this particular case with bad coordinate names because I believe the algorithm developers have been told and the file coordinates should get fixed...hopefully.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
