### PR TITLE
Add defusedxml to extra requirements for xml readers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ test_requires = ["behave", "h5py", "netCDF4", "pyhdf", "imageio",
 
 extras_require = {
     # Readers:
+    "avhrr_l1b_eps": ["defusedxml"],
     "avhrr_l1b_gaclac": ["pygac >= 1.3.0"],
     "modis_l1b": ["pyhdf", "python-geotiepoints >= 1.1.7"],
     "geocat": ["pyhdf"],
@@ -47,7 +48,7 @@ extras_require = {
     "amsr2_l1b": ["h5py >= 2.7.0"],
     "hrpt": ["pyorbital >= 1.3.1", "pygac", "python-geotiepoints >= 1.1.7"],
     "hrit_msg": ["pytroll-schedule"],
-    "msi_safe": ["rioxarray", "bottleneck", "python-geotiepoints"],
+    "msi_safe": ["rioxarray", "bottleneck", "python-geotiepoints", "defusedxml"],
     "nc_nwcsaf_msg": ["netCDF4 >= 1.1.8"],
     "sar_c": ["python-geotiepoints >= 1.1.7", "rasterio", "rioxarray", "defusedxml"],
     "abi_l1b": ["h5netcdf"],


### PR DESCRIPTION
This PR adds defusedxml as an extra requirement for some of the xml-based readers in Satpy.

This issue was reported by @lobsiger in the pytroll mailing list https://groups.google.com/g/pytroll/c/cXhNKmMleGg 
and the solution was suggest by @djhoese in this message https://groups.google.com/g/pytroll/c/cXhNKmMleGg/m/yCXcjpFHAQAJ

