### PR TITLE
Pin pytest to fix CI

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -43,7 +43,7 @@ dependencies:
   - python-eccodes
   # 2.19.1 seems to cause library linking issues
   - eccodes>=2.20
-  - pytest
+  - pytest<8.0.0
   - pytest-cov
   - pytest-lazy-fixture
   - fsspec


### PR DESCRIPTION
This PR limits pytest to <8.0 to fix the CI
