### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         experimental: [false]
         include:
           - python-version: "3.12"

--- a/.github/workflows/deploy-sdist.yaml
+++ b/.github/workflows/deploy-sdist.yaml
@@ -19,7 +19,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install -q build
-          python -m build -s
+          python -m build
 
       - name: Publish package to PyPI
         if: github.event.action == 'published'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
           - types-pkg-resources
           - types-PyYAML
           - types-requests
-        args: ["--python-version", "3.9", "--ignore-missing-imports"]
+        args: ["--python-version", "3.10", "--ignore-missing-imports"]
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -2,7 +2,7 @@ name: readthedocs
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python=3.11
   - pip
   - appdirs
   - dask

--- a/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
+++ b/satpy/tests/reader_tests/test_viirs_edr_active_fires.py
@@ -38,19 +38,19 @@ from satpy.tests.utils import convert_file_content_to_data_array
 DEFAULT_FILE_SHAPE = (1, 100)
 
 DEFAULT_LATLON_FILE_DTYPE = np.float32
-DEFAULT_LATLON_FILE_DATA = np.arange(start=43, stop=45, step=0.02,
+DEFAULT_LATLON_FILE_DATA = np.arange(43, stop=45, step=0.02,
                                      dtype=DEFAULT_LATLON_FILE_DTYPE).reshape(DEFAULT_FILE_SHAPE)
 
 DEFAULT_DETECTION_FILE_DTYPE = np.uint8
-DEFAULT_DETECTION_FILE_DATA = np.arange(start=60, stop=100, step=0.4,
+DEFAULT_DETECTION_FILE_DATA = np.arange(60, stop=100, step=0.4,
                                         dtype=DEFAULT_DETECTION_FILE_DTYPE).reshape(DEFAULT_FILE_SHAPE)
 
 DEFAULT_M13_FILE_DTYPE = np.float32
-DEFAULT_M13_FILE_DATA = np.arange(start=300, stop=340, step=0.4,
+DEFAULT_M13_FILE_DATA = np.arange(300, stop=340, step=0.4,
                                   dtype=DEFAULT_M13_FILE_DTYPE).reshape(DEFAULT_FILE_SHAPE)
 
 DEFAULT_POWER_FILE_DTYPE = np.float32
-DEFAULT_POWER_FILE_DATA = np.arange(start=1, stop=25, step=0.24,
+DEFAULT_POWER_FILE_DATA = np.arange(1, stop=25, step=0.24,
                                     dtype=DEFAULT_POWER_FILE_DTYPE).reshape(DEFAULT_FILE_SHAPE)
 
 

--- a/setup.py
+++ b/setup.py
@@ -165,7 +165,7 @@ setup(name=NAME,
                               ]},
       zip_safe=False,
       install_requires=requires,
-      python_requires=">=3.9",
+      python_requires=">=3.10",
       extras_require=extras_require,
       entry_points=entry_points,
       )


### PR DESCRIPTION
Following the guidance of:

https://scientific-python.org/specs/spec-0000/

This PR drops Python 3.9 support and adjusts CI, pre-commit, and readthedocs to use newer versions of Python. This means the currently supported versions of Python will be 3.10, 3.11, and 3.12.

CC @pytroll/satpy-core I've asked for reviews from some of you, but I think as long as there are no complaints this should be a simple agreement and merge.
