### PR TITLE
Fix nominal end time in AHI HSD

### DIFF
--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -758,9 +758,9 @@ class NominalTimeCalculator:
         self.timeline = timeline
         self.area = area
 
-    def get_nominal_start_time(self, observation_time):
+    def get_nominal_start_time(self, observation_start_time):
         """Get nominal start time of the scan."""
-        return self._modify_observation_time_for_nominal(observation_time)
+        return self._modify_observation_time_for_nominal(observation_start_time)
 
     def get_nominal_end_time(self, nominal_start_time):
         """Get nominal end time of the scan."""

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -429,59 +429,18 @@ class AHIHSDFileHandler(BaseFileHandler):
     @property
     def nominal_start_time(self):
         """Time this band was nominally to be recorded."""
-        return self._modify_observation_time_for_nominal(self.observation_start_time)
+        timeline = "{:04d}".format(self.basic_info["observation_timeline"][0])
+        calc = NominalTimeCalculator(timeline,
+                                     self.observation_area)
+        return calc.get_nominal_start_time(self.observation_start_time)
 
     @property
     def nominal_end_time(self):
         """Get the nominal end time."""
-        freq = self._observation_frequency
-        return self.nominal_start_time + timedelta(minutes=freq // 60, seconds=freq % 60)
-
-    @staticmethod
-    def _is_valid_timeline(timeline):
-        """Check that the `observation_timeline` value is not a fill value."""
-        if int(timeline[:2]) > 23:
-            return False
-        return True
-
-    @property
-    def _observation_frequency(self):
-        frequencies = {"FLDK": 600, "JP": 150, "R3": 150, "R4": 30, "R5": 30}
-        area = self.observation_area
-        if area != "FLDK":
-            # e.g. JP01, JP02 etc
-            area = area[:2]
-        return frequencies[area]
-
-    def _modify_observation_time_for_nominal(self, observation_time):
-        """Round observation time to a nominal time based on known observation frequency.
-
-        AHI observations are split into different sectors including Full Disk
-        (FLDK), Japan (JP) sectors, and smaller regional (R) sectors. Each
-        sector is observed at different frequencies (ex. every 10 minutes,
-        every 2.5 minutes, and every 30 seconds). This method will take the
-        actual observation time and round it to the nearest interval for this
-        sector. So if the observation time is 13:32:48 for the "JP02" sector
-        which is the second Japan observation where every Japan observation is
-        2.5 minutes apart, then the result should be 13:32:30.
-        """
         timeline = "{:04d}".format(self.basic_info["observation_timeline"][0])
-        if not self._is_valid_timeline(timeline):
-            warnings.warn(
-                "Observation timeline is fill value, not rounding observation time.",
-                stacklevel=3
-            )
-            return observation_time
-        dt = self._get_offset_relative_to_timeline()
-        return observation_time.replace(
-            hour=int(timeline[:2]), minute=int(timeline[2:4]) + dt//60,
-            second=dt % 60, microsecond=0)
-
-    def _get_offset_relative_to_timeline(self):
-        if self.observation_area == "FLDK":
-            return 0
-        sector_repeat = int(self.observation_area[2:]) - 1
-        return self._observation_frequency * sector_repeat
+        calc = NominalTimeCalculator(timeline,
+                                     self.observation_area)
+        return calc.get_nominal_end_time(self.nominal_start_time)
 
     def get_dataset(self, key, info):
         """Get the dataset."""
@@ -784,3 +743,72 @@ class AHIHSDFileHandler(BaseFileHandler):
         c2_ = self._header["calibration"]["c2_rad2tb_conversion"][0]
 
         return (c0_ + c1_ * Te_ + c2_ * Te_ ** 2).clip(0)
+
+
+class NominalTimeCalculator:
+    """Get time when a scan was nominally to be recorded."""
+
+    def __init__(self, timeline, area):
+        """Initialize the nominal timestamp calculator.
+
+        Args:
+            timeline (str): Observation timeline (four characters HHMM)
+            area (str): Observation area (four characters, e.g. FLDK)
+        """
+        self.timeline = timeline
+        self.area = area
+
+    def get_nominal_start_time(self, observation_time):
+        """Get nominal start time of the scan."""
+        return self._modify_observation_time_for_nominal(observation_time)
+
+    def get_nominal_end_time(self, nominal_start_time):
+        """Get nominal end time of the scan."""
+        freq = self._observation_frequency
+        return nominal_start_time + timedelta(minutes=freq // 60,
+                                              seconds=freq % 60)
+
+    def _modify_observation_time_for_nominal(self, observation_time):
+        """Round observation time to a nominal time based on known observation frequency.
+
+        AHI observations are split into different sectors including Full Disk
+        (FLDK), Japan (JP) sectors, and smaller regional (R) sectors. Each
+        sector is observed at different frequencies (ex. every 10 minutes,
+        every 2.5 minutes, and every 30 seconds). This method will take the
+        actual observation time and round it to the nearest interval for this
+        sector. So if the observation time is 13:32:48 for the "JP02" sector
+        which is the second Japan observation where every Japan observation is
+        2.5 minutes apart, then the result should be 13:32:30.
+        """
+        if not self._is_valid_timeline(self.timeline):
+            warnings.warn(
+                "Observation timeline is fill value, not rounding observation time.",
+                stacklevel=3
+            )
+            return observation_time
+        dt = self._get_offset_relative_to_timeline()
+        return observation_time.replace(
+            hour=int(self.timeline[:2]), minute=int(self.timeline[2:4]) + dt//60,
+            second=dt % 60, microsecond=0)
+
+    @staticmethod
+    def _is_valid_timeline(timeline):
+        """Check that the `observation_timeline` value is not a fill value."""
+        if int(timeline[:2]) > 23:
+            return False
+        return True
+
+    def _get_offset_relative_to_timeline(self):
+        if self.area == "FLDK":
+            return 0
+        sector_repeat = int(self.area[2:]) - 1
+        return self._observation_frequency * sector_repeat
+
+    @property
+    def _observation_frequency(self):
+        frequencies = {"FLDK": 600, "JP": 150, "R3": 150, "R4": 30, "R5": 30}
+        area = self.area
+        if area != "FLDK":
+            # e.g. JP01, JP02 etc
+            area = area[:2]
+        return frequencies[area]

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -414,7 +414,7 @@ class AHIHSDFileHandler(BaseFileHandler):
     @property
     def end_time(self):
         """Get the nominal end time."""
-        return self.nominal_start_time
+        return self.nominal_end_time
 
     @property
     def observation_start_time(self):
@@ -429,12 +429,12 @@ class AHIHSDFileHandler(BaseFileHandler):
     @property
     def nominal_start_time(self):
         """Time this band was nominally to be recorded."""
-        return self._modify_observation_time_for_nominal(self.observation_start_time)
+        return self._modify_observation_time_for_nominal(self.observation_start_time, "start")
 
     @property
     def nominal_end_time(self):
         """Get the nominal end time."""
-        return self._modify_observation_time_for_nominal(self.observation_end_time)
+        return self._modify_observation_time_for_nominal(self.observation_end_time, "end")
 
     @staticmethod
     def _is_valid_timeline(timeline):
@@ -471,7 +471,7 @@ class AHIHSDFileHandler(BaseFileHandler):
         else:
             observation_frequency_seconds = observation_frequencies[self.observation_area[:2]]
             dt_start = observation_frequency_seconds * (int(self.observation_area[2:]) - 1)
-            dt_end = observation_frequencies[self.observation_area[:2]]
+            dt_end = observation_frequency_seconds
 
         dt = dt_start
         if start_or_end_time == "end":

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -427,19 +427,19 @@ class AHIHSDFileHandler(BaseFileHandler):
         return datetime(1858, 11, 17) + timedelta(days=float(self.basic_info["observation_end_time"].item()))
 
     @property
+    def _timeline(self):
+        return "{:04d}".format(self.basic_info["observation_timeline"][0])
+
+    @property
     def nominal_start_time(self):
         """Time this band was nominally to be recorded."""
-        timeline = "{:04d}".format(self.basic_info["observation_timeline"][0])
-        calc = NominalTimeCalculator(timeline,
-                                     self.observation_area)
+        calc = NominalTimeCalculator(self._timeline, self.observation_area)
         return calc.get_nominal_start_time(self.observation_start_time)
 
     @property
     def nominal_end_time(self):
         """Get the nominal end time."""
-        timeline = "{:04d}".format(self.basic_info["observation_timeline"][0])
-        calc = NominalTimeCalculator(timeline,
-                                     self.observation_area)
+        calc = NominalTimeCalculator(self._timeline, self.observation_area)
         return calc.get_nominal_end_time(self.nominal_start_time)
 
     def get_dataset(self, key, info):

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -443,7 +443,7 @@ class AHIHSDFileHandler(BaseFileHandler):
             return False
         return True
 
-    def _modify_observation_time_for_nominal(self, observation_time):
+    def _modify_observation_time_for_nominal(self, observation_time, start_or_end_time="start"):
         """Round observation time to a nominal time based on known observation frequency.
 
         AHI observations are split into different sectors including Full Disk
@@ -464,11 +464,18 @@ class AHIHSDFileHandler(BaseFileHandler):
             )
             return observation_time
 
+        observation_frequencies = {"FLDK": 600, "JP": 150, "R3": 150, "R4": 30, "R5": 30}
         if self.observation_area == "FLDK":
-            dt = 0
+            dt_start = 0
+            dt_end = observation_frequencies["FLDK"]
         else:
-            observation_frequency_seconds = {"JP": 150, "R3": 150, "R4": 30, "R5": 30}[self.observation_area[:2]]
-            dt = observation_frequency_seconds * (int(self.observation_area[2:]) - 1)
+            observation_frequency_seconds = observation_frequencies[self.observation_area[:2]]
+            dt_start = observation_frequency_seconds * (int(self.observation_area[2:]) - 1)
+            dt_end = observation_frequencies[self.observation_area[:2]]
+
+        dt = dt_start
+        if start_or_end_time == "end":
+            dt += dt_end
 
         return observation_time.replace(
             hour=int(timeline[:2]), minute=int(timeline[2:4]) + dt//60,

--- a/satpy/readers/ahi_hsd.py
+++ b/satpy/readers/ahi_hsd.py
@@ -433,13 +433,13 @@ class AHIHSDFileHandler(BaseFileHandler):
     @property
     def nominal_start_time(self):
         """Time this band was nominally to be recorded."""
-        calc = NominalTimeCalculator(self._timeline, self.observation_area)
+        calc = _NominalTimeCalculator(self._timeline, self.observation_area)
         return calc.get_nominal_start_time(self.observation_start_time)
 
     @property
     def nominal_end_time(self):
         """Get the nominal end time."""
-        calc = NominalTimeCalculator(self._timeline, self.observation_area)
+        calc = _NominalTimeCalculator(self._timeline, self.observation_area)
         return calc.get_nominal_end_time(self.nominal_start_time)
 
     def get_dataset(self, key, info):
@@ -745,7 +745,7 @@ class AHIHSDFileHandler(BaseFileHandler):
         return (c0_ + c1_ * Te_ + c2_ * Te_ ** 2).clip(0)
 
 
-class NominalTimeCalculator:
+class _NominalTimeCalculator:
     """Get time when a scan was nominally to be recorded."""
 
     def __init__(self, timeline, area):

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -765,8 +765,8 @@ class HRITMSGFileHandler(HRITFileHandler):
         res.attrs["standard_name"] = info["standard_name"]
         res.attrs["platform_name"] = self.platform_name
         res.attrs["sensor"] = "seviri"
-        res.attrs["nominal_start_time"] = self.nominal_start_time
-        res.attrs["nominal_end_time"] = self.nominal_end_time
+        res.attrs["nominal_start_time"] = self.nominal_start_time,
+        res.attrs["nominal_end_time"] = self.nominal_end_time,
         res.attrs["time_parameters"] = {
             "nominal_start_time": self.nominal_start_time,
             "nominal_end_time": self.nominal_end_time,

--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -765,8 +765,8 @@ class HRITMSGFileHandler(HRITFileHandler):
         res.attrs["standard_name"] = info["standard_name"]
         res.attrs["platform_name"] = self.platform_name
         res.attrs["sensor"] = "seviri"
-        res.attrs["nominal_start_time"] = self.nominal_start_time,
-        res.attrs["nominal_end_time"] = self.nominal_end_time,
+        res.attrs["nominal_start_time"] = self.nominal_start_time
+        res.attrs["nominal_end_time"] = self.nominal_end_time
         res.attrs["time_parameters"] = {
             "nominal_start_time": self.nominal_start_time,
             "nominal_end_time": self.nominal_end_time,

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -702,3 +702,40 @@ class TestNominalTimeCalculator:
         nom_end_time = calc.get_nominal_end_time(nom_start_time)
         assert nom_start_time == expected["tstart"]
         assert nom_end_time == expected["tend"]
+
+    @pytest.mark.parametrize(
+        ("timeline", "obs_start_time", "expected"),
+        [
+            (
+                "1200",
+                datetime(2023, 1, 1, 12, 0, 1),
+                {"tstart": datetime(2023, 1, 1, 12, 0, 0),
+                 "tend": datetime(2023, 1, 1, 12, 10, 0)}
+            ),
+            (
+                "1200",
+                datetime(2023, 1, 1, 11, 59, 59),
+                {"tstart": datetime(2023, 1, 1, 12, 0, 0),
+                 "tend": datetime(2023, 1, 1, 12, 10, 0)}
+            ),
+            (
+                "0000",
+                datetime(2023, 1, 1, 0, 0, 1),
+                {"tstart": datetime(2023, 1, 1, 0, 0, 0),
+                 "tend": datetime(2023, 1, 1, 0, 10, 0)}
+            ),
+            (
+                "0000",
+                datetime(2022, 12, 31, 23, 59, 59),
+                {"tstart": datetime(2023, 1, 1, 0, 0, 0),
+                 "tend": datetime(2023, 1, 1, 0, 10, 0)}
+            ),
+        ]
+    )
+    def test_timelines(self, timeline, obs_start_time, expected):
+        """Test nominal timestamps for multiple timelines."""
+        calc = NominalTimeCalculator(timeline, "FLDK")
+        nom_start_time = calc.get_nominal_start_time(obs_start_time)
+        nom_end_time = calc.get_nominal_end_time(nom_start_time)
+        assert nom_start_time == expected["tstart"]
+        assert nom_end_time == expected["tend"]

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -341,7 +341,7 @@ class TestAHIHSDFileHandler:
 
             time_params_exp = {
                 "nominal_start_time": datetime(2018, 10, 22, 3, 0, 0, 0),
-                "nominal_end_time": datetime(2018, 10, 22, 3, 0, 0, 0),
+                "nominal_end_time": datetime(2018, 10, 22, 3, 10, 0, 0),
                 "observation_start_time": datetime(2018, 10, 22, 3, 0, 20, 596896),
                 "observation_end_time": datetime(2018, 10, 22, 3, 10, 20, 596896),
             }
@@ -417,30 +417,63 @@ class TestAHIHSDFileHandler:
         """Test start/end/scheduled time properties."""
         with _fake_hsd_handler() as fh:
             assert fh.start_time == datetime(2018, 10, 22, 3, 0)
-            assert fh.end_time == datetime(2018, 10, 22, 3, 0)
+            assert fh.end_time == datetime(2018, 10, 22, 3, 10)
             assert fh.observation_start_time == datetime(2018, 10, 22, 3, 0, 20, 596896)
             assert fh.observation_end_time == datetime(2018, 10, 22, 3, 10, 20, 596896)
             assert fh.nominal_start_time == datetime(2018, 10, 22, 3, 0, 0, 0)
-            assert fh.nominal_end_time == datetime(2018, 10, 22, 3, 0, 0, 0)
+            assert fh.nominal_end_time == datetime(2018, 10, 22, 3, 10, 0, 0)
 
-    def test_scanning_frequencies(self):
+    @pytest.mark.parametrize(
+        ("observation_area", "start_time", "end_time"),
+        [
+            (
+                "JP01",
+                datetime(2018, 10, 22, 3, 0, 0),
+                datetime(2018, 10, 22, 3, 2, 30)
+            ),
+            (
+                "JP04",
+                datetime(2018, 10, 22, 3, 7, 30, 0),
+                datetime(2018, 10, 22, 3, 10, 0, 0)
+            ),
+            (
+                "R301",
+                datetime(2018, 10, 22, 3, 0, 0),
+                datetime(2018, 10, 22, 3, 2, 30)
+            ),
+            (
+                "R304",
+                datetime(2018, 10, 22, 3, 7, 30, 0),
+                datetime(2018, 10, 22, 3, 10, 0, 0)
+            ),
+            (
+                "R401",
+                datetime(2018, 10, 22, 3, 0, 0),
+                datetime(2018, 10, 22, 3, 0, 30)
+            ),
+            (
+                "R420",
+                datetime(2018, 10, 22, 3, 9, 30, 0),
+                datetime(2018, 10, 22, 3, 10, 0, 0)
+            ),
+            (
+                "R501",
+                datetime(2018, 10, 22, 3, 0, 0),
+                datetime(2018, 10, 22, 3, 0, 30)
+            ),
+            (
+                "R520",
+                datetime(2018, 10, 22, 3, 9, 30, 0),
+                datetime(2018, 10, 22, 3, 10, 0, 0)
+            ),
+        ]
+    )
+    def test_scanning_frequencies(self, observation_area, start_time, end_time):
         """Test scanning frequencies."""
         with _fake_hsd_handler() as fh:
-            fh.observation_area = "JP04"
-            assert fh.nominal_start_time == datetime(2018, 10, 22, 3, 7, 30, 0)
-            assert fh.nominal_end_time == datetime(2018, 10, 22, 3, 7, 30, 0)
-            fh.observation_area = "R304"
-            assert fh.nominal_start_time == datetime(2018, 10, 22, 3, 7, 30, 0)
-            assert fh.nominal_end_time == datetime(2018, 10, 22, 3, 7, 30, 0)
-            fh.observation_area = "R420"
-            assert fh.nominal_start_time == datetime(2018, 10, 22, 3, 9, 30, 0)
-            assert fh.nominal_end_time == datetime(2018, 10, 22, 3, 9, 30, 0)
-            fh.observation_area = "R520"
-            assert fh.nominal_start_time == datetime(2018, 10, 22, 3, 9, 30, 0)
-            assert fh.nominal_end_time == datetime(2018, 10, 22, 3, 9, 30, 0)
-            fh.observation_area = "FLDK"
-            assert fh.nominal_start_time == datetime(2018, 10, 22, 3, 0, 0, 0)
-            assert fh.nominal_end_time == datetime(2018, 10, 22, 3, 0, 0, 0)
+            fh.observation_area = observation_area
+            assert fh.nominal_start_time == start_time
+            assert fh.nominal_end_time == end_time
 
     def test_blocklen_error(self, *mocks):
         """Test erraneous blocklength."""

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -707,16 +707,16 @@ class TestNominalTimeCalculator:
         ("timeline", "obs_start_time", "expected"),
         [
             (
-                "1200",
-                datetime(2023, 1, 1, 12, 0, 1),
-                {"tstart": datetime(2023, 1, 1, 12, 0, 0),
-                 "tend": datetime(2023, 1, 1, 12, 10, 0)}
+                "2350",
+                datetime(2022, 12, 31, 23, 50, 1),
+                {"tstart": datetime(2022, 12, 31, 23, 50, 0),
+                 "tend": datetime(2023, 1, 1, 0, 0, 0)}
             ),
             (
-                "1200",
-                datetime(2023, 1, 1, 11, 59, 59),
-                {"tstart": datetime(2023, 1, 1, 12, 0, 0),
-                 "tend": datetime(2023, 1, 1, 12, 10, 0)}
+                "2350",
+                datetime(2022, 12, 31, 23, 49, 59),
+                {"tstart": datetime(2022, 12, 31, 23, 50, 0),
+                 "tend": datetime(2023, 1, 1, 0, 0, 0)}
             ),
             (
                 "0000",

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -29,7 +29,7 @@ import dask.array as da
 import numpy as np
 import pytest
 
-from satpy.readers.ahi_hsd import AHIHSDFileHandler, NominalTimeCalculator
+from satpy.readers.ahi_hsd import AHIHSDFileHandler, _NominalTimeCalculator
 from satpy.readers.utils import get_geostationary_mask
 from satpy.tests.utils import make_dataid
 
@@ -645,7 +645,7 @@ class TestNominalTimeCalculator:
     )
     def test_invalid_timeline(self, timeline, expected):
         """Test handling of invalid timeline."""
-        calc = NominalTimeCalculator(timeline, "FLDK")
+        calc = _NominalTimeCalculator(timeline, "FLDK")
         res = calc.get_nominal_start_time(datetime(2020, 1, 1, 12, 0, 0))
         assert res == expected
 
@@ -697,7 +697,7 @@ class TestNominalTimeCalculator:
     def test_areas(self, area, expected):
         """Test nominal timestamps for multiple areas."""
         obs_start_time = datetime(2018, 10, 22, 3, 0, 20, 596896)
-        calc = NominalTimeCalculator("0300", area)
+        calc = _NominalTimeCalculator("0300", area)
         nom_start_time = calc.get_nominal_start_time(obs_start_time)
         nom_end_time = calc.get_nominal_end_time(nom_start_time)
         assert nom_start_time == expected["tstart"]
@@ -734,7 +734,7 @@ class TestNominalTimeCalculator:
     )
     def test_timelines(self, timeline, obs_start_time, expected):
         """Test nominal timestamps for multiple timelines."""
-        calc = NominalTimeCalculator(timeline, "FLDK")
+        calc = _NominalTimeCalculator(timeline, "FLDK")
         nom_start_time = calc.get_nominal_start_time(obs_start_time)
         nom_end_time = calc.get_nominal_end_time(nom_start_time)
         assert nom_start_time == expected["tstart"]

--- a/satpy/tests/reader_tests/test_ahi_hsd.py
+++ b/satpy/tests/reader_tests/test_ahi_hsd.py
@@ -40,7 +40,7 @@ FAKE_BASIC_INFO: InfoDict = {
     "satellite": "Himawari-8",
     "observation_area": "FLDK",
     "observation_start_time": 58413.12523839,
-    "observation_end_time": 58413.12562439,
+    "observation_end_time": 58413.132182834444,
     "observation_timeline": "0300",
 }
 FAKE_DATA_INFO: InfoDict = {
@@ -343,7 +343,7 @@ class TestAHIHSDFileHandler:
                 "nominal_start_time": datetime(2018, 10, 22, 3, 0, 0, 0),
                 "nominal_end_time": datetime(2018, 10, 22, 3, 0, 0, 0),
                 "observation_start_time": datetime(2018, 10, 22, 3, 0, 20, 596896),
-                "observation_end_time": datetime(2018, 10, 22, 3, 0, 53, 947296),
+                "observation_end_time": datetime(2018, 10, 22, 3, 10, 20, 596896),
             }
             actual_time_params = im.attrs["time_parameters"]
             for key, value in time_params_exp.items():
@@ -419,7 +419,7 @@ class TestAHIHSDFileHandler:
             assert fh.start_time == datetime(2018, 10, 22, 3, 0)
             assert fh.end_time == datetime(2018, 10, 22, 3, 0)
             assert fh.observation_start_time == datetime(2018, 10, 22, 3, 0, 20, 596896)
-            assert fh.observation_end_time == datetime(2018, 10, 22, 3, 0, 53, 947296)
+            assert fh.observation_end_time == datetime(2018, 10, 22, 3, 10, 20, 596896)
             assert fh.nominal_start_time == datetime(2018, 10, 22, 3, 0, 0, 0)
             assert fh.nominal_end_time == datetime(2018, 10, 22, 3, 0, 0, 0)
 


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->

I noticed that for AHI HSD, the attributes `start_time/end_time` and `nominal_start_time/nominal_end_time` are identical.

```python
import satpy
import glob

filenames = glob.glob("*.DAT")
scene = satpy.Scene(filenames, reader="ahi_hsd")
scene.load(["B13"])

print(scene["B13"].attrs["start_time"])
print(scene["B13"].attrs["end_time"])
print(scene["B13"].attrs["time_parameters"]["nominal_start_time"])
print(scene["B13"].attrs["time_parameters"]["nominal_end_time"])
```

Output:

```
2020-01-01 12:00:00
2020-01-01 12:00:00
2020-01-01 12:00:00
2020-01-01 12:00:00
```

This has two reasons:

1. The `end_time` property returns `nominal_start_time`. See https://github.com/pytroll/satpy/blob/main/satpy/readers/ahi_hsd.py#L417
2. The `observation_end_time` (e.g. 03:10:12.34567 for a full disk scan) is rounded to the "observation timeline" (03:00:00 or "0300" in the header). See https://github.com/pytroll/satpy/blob/main/satpy/readers/ahi_hsd.py#L473. Here, the offset `dt` only accounts for the start of the scan, not the total scan duration.

To fix this, I modified the `nominal_end_time` property to add the scan duration to the nominal start time.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
