### PR TITLE
Fix nominal time attributes in SEVIRI HRIT

### DIFF
--- a/satpy/readers/seviri_l1b_hrit.py
+++ b/satpy/readers/seviri_l1b_hrit.py
@@ -765,8 +765,8 @@ class HRITMSGFileHandler(HRITFileHandler):
         res.attrs["standard_name"] = info["standard_name"]
         res.attrs["platform_name"] = self.platform_name
         res.attrs["sensor"] = "seviri"
-        res.attrs["nominal_start_time"] = self.nominal_start_time,
-        res.attrs["nominal_end_time"] = self.nominal_end_time,
+        res.attrs["nominal_start_time"] = self.nominal_start_time
+        res.attrs["nominal_end_time"] = self.nominal_end_time
         res.attrs["time_parameters"] = {
             "nominal_start_time": self.nominal_start_time,
             "nominal_end_time": self.nominal_end_time,

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit_setup.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit_setup.py
@@ -238,8 +238,8 @@ def get_attrs_exp(projection_longitude=0.0):
                                "satellite_actual_latitude": -0.5711243456528018,
                                "satellite_actual_altitude": 35783296.150123544},
         "georef_offset_corrected": True,
-        "nominal_start_time": (datetime(2006, 1, 1, 12, 15),),
-        "nominal_end_time": (datetime(2006, 1, 1, 12, 30),),
+        "nominal_start_time": datetime(2006, 1, 1, 12, 15),
+        "nominal_end_time": datetime(2006, 1, 1, 12, 30),
         "time_parameters": {
             "nominal_start_time": datetime(2006, 1, 1, 12, 15),
             "nominal_end_time": datetime(2006, 1, 1, 12, 30),


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Fix `nominal_start/end_time` attributes in SEVIRI HRIT, which were tuples due to a trailing comma.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Tests added <!-- for all bug fixes or enhancements -->
