### PR TITLE
Fix cutoffs for night_ir_alpha and bump up trollimage version

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -59,6 +59,6 @@ dependencies:
   - bokeh
   - pip:
     - trollsift
-    - trollimage>=1.20
+    - trollimage>=1.23
     - pyspectral
     - pyorbital

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -421,6 +421,7 @@ composites:
       - name: HRV
         modifiers: [sunz_corrected]
       - IR_108
+
   hrv_fog:
     compositor: !!python/name:satpy.composites.GenericCompositor
     standard_name: hrv_fog

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -1104,7 +1104,7 @@ enhancements:
     operations:
     - name: stretch
       method: !!python/name:satpy.enhancements.stretch
-      kwargs: {stretch: linear, cutoffs: [0.02, 0.02]}
+      kwargs: {stretch: linear, cutoffs: [[0.02, 0.02], [0.02, 0.02], [0.02, 0.02], [0.02, 0.02]]}
     - name: inverse
       method: !!python/name:satpy.enhancements.invert
       args:

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from glob import glob
 from setuptools import find_packages, setup
 
 requires = ["numpy >=1.21", "pillow", "pyresample >=1.24.0", "trollsift",
-            "trollimage >=1.20", "pykdtree", "pyyaml >=5.1", "xarray >=0.14.1",
+            "trollimage >=1.23", "pykdtree", "pyyaml >=5.1", "xarray >=0.14.1",
             "dask[array] >=0.17.1", "pyproj>=2.2", "zarr", "donfig", "appdirs",
             "packaging", "pooch", "pyorbital"]
 


### PR DESCRIPTION
This PR fixes the satpy configuration for the night ir enhancement for the problem that was reported in https://github.com/pytroll/trollimage/issues/162

