### PR TITLE
Sort reader table by name + diverse fixes

### DIFF
--- a/doc/source/_static/main.js
+++ b/doc/source/_static/main.js
@@ -1,6 +1,11 @@
 $(document).ready( function () {
     $('table.datatable').DataTable( {
     "paging": false,
-    "dom": 'lfitp'
+    "layout": {
+        'topStart': 'info',
+        'topEnd': 'search',
+        'bottomStart': null
+    },
+    "order": [[0, 'asc']]
 } );
 } );

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -194,11 +194,11 @@ html_static_path = ["_static"]
 
 html_css_files = [
     "theme_overrides.css",  # override wide tables in RTD theme
-    "https://cdn.datatables.net/1.10.23/css/jquery.dataTables.min.css",
+    "https://cdn.datatables.net/v/dt/dt-2.0.0/datatables.min.css",
 ]
 
 html_js_files = [
-    "https://cdn.datatables.net/1.10.23/js/jquery.dataTables.min.js",
+    "https://cdn.datatables.net/v/dt/dt-2.0.0/datatables.min.js",
     "main.js",
 ]
 

--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -117,7 +117,8 @@ The parameters to provide in this section are:
     file format. This can be multiline if formatted properly in YAML (see
     example below).
  status
-    The status of the reader (one of: Nominal, Beta, Alpha)
+    The status of the reader (one of: Nominal, Beta, Alpha, Defunct; see :ref:`Status Description <Status Description>`
+    for more details).
  supports_fsspec
     If the reader supports reading data via fsspec (either true or false).
  sensors

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -84,6 +84,30 @@ Documentation
 
 .. include:: reader_table.rst
 
+.. _Status Description:
+.. note::
+
+    Status description:
+
+    Defunct
+        Most likely the reader is not functional. If it is there is a good chance of
+        bugs and/or performance problems (e.g. not ported to dask/xarray yet). Future
+        development is unclear. Users are encouraged to contribute (see section
+        :doc:`dev_guide/CONTRIBUTING` and/or get help on Slack or by opening a Github issue).
+
+    Alpha
+        This denotes early development status. Reader is functional and implements some
+        or all of the nominal features. There might be bugs. Exactness of results is
+        not be guaranteed. Use at your own risk.
+
+    Beta
+        This denotes final developement status. Reader is functional and implements all
+        nominal features. Results should be dependable but there might be bugs. Users
+        are actively encouraged to test and report bugs.
+
+    Nominal
+        This denotes a finished status. Reader is functional and most likely no new
+        features will be introduced. It has been tested and there are no known bugs.
 
 Indices and tables
 ==================

--- a/satpy/etc/readers/agri_fy4a_l1.yaml
+++ b/satpy/etc/readers/agri_fy4a_l1.yaml
@@ -5,7 +5,7 @@
 reader:
   name: agri_fy4a_l1
   short_name: AGRI FY4A L1
-  long_name: FY-4A AGRI L1 data in HDF5 format
+  long_name: FY-4A AGRI Level 1 HDF5 format
   description: FY-4A AGRI instrument HDF5 reader
   status: Beta
   supports_fsspec: false

--- a/satpy/etc/readers/agri_fy4b_l1.yaml
+++ b/satpy/etc/readers/agri_fy4b_l1.yaml
@@ -7,7 +7,7 @@ reader:
   short_name: AGRI FY4B L1
   long_name: FY-4B AGRI Level 1 data HDF5 format
   description: FY-4B AGRI instrument HDF5 reader
-  status: Beta
+  status: Nominal
   supports_fsspec: false
   sensors: [agri]
   default_channels:

--- a/satpy/etc/readers/agri_fy4b_l1.yaml
+++ b/satpy/etc/readers/agri_fy4b_l1.yaml
@@ -4,7 +4,11 @@
 
 reader:
   name: agri_fy4b_l1
+  short_name: AGRI FY4B L1
+  long_name: FY-4B AGRI Level 1 data HDF5 format
   description: FY-4B AGRI instrument HDF5 reader
+  status: Beta
+  supports_fsspec: false
   sensors: [agri]
   default_channels:
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/etc/readers/agri_fy4b_l1.yaml
+++ b/satpy/etc/readers/agri_fy4b_l1.yaml
@@ -8,7 +8,7 @@ reader:
   long_name: FY-4B AGRI Level 1 data HDF5 format
   description: FY-4B AGRI instrument HDF5 reader
   status: Nominal
-  supports_fsspec: false
+  supports_fsspec: true
   sensors: [agri]
   default_channels:
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/etc/readers/ghi_l1.yaml
+++ b/satpy/etc/readers/ghi_l1.yaml
@@ -4,7 +4,11 @@
 
 reader:
   name: ghi_l1
+  short_name: GHI FY4A L1
+  long_name: FY-4A GHI Level 1 HDF5 format
   description: FY-4A GHI instrument HDF5 reader
+  status: Beta
+  supports_fsspec: false
   sensors: [ghi]
   default_channels:
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/etc/readers/ghi_l1.yaml
+++ b/satpy/etc/readers/ghi_l1.yaml
@@ -7,7 +7,7 @@ reader:
   short_name: GHI FY4A L1
   long_name: FY-4A GHI Level 1 HDF5 format
   description: FY-4A GHI instrument HDF5 reader
-  status: Beta
+  status: Nominal
   supports_fsspec: false
   sensors: [ghi]
   default_channels:

--- a/satpy/etc/readers/meris_nc_sen3.yaml
+++ b/satpy/etc/readers/meris_nc_sen3.yaml
@@ -1,6 +1,10 @@
 reader:
-  description: NC Reader for MERIS data (Sentinel 3 like format)
   name: meris_nc_sen3
+  short_name: MERIS Sentinel 3
+  long_name: Sentinel 3 MERIS NetCDF format
+  description: NC Reader for MERIS data (Sentinel 3 like format)
+  status: Beta
+  supports_fsspec: false
   sensors: [meris]
   default_channels: []
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/etc/readers/mersi_ll_l1b.yaml
+++ b/satpy/etc/readers/mersi_ll_l1b.yaml
@@ -1,6 +1,10 @@
 reader:
-  description: FY-3E Medium Resolution Spectral Imager - Low Light (MERSI-LL) L1B Reader
   name: mersi_ll_l1b
+  short_name: MERSI Low Light FY3E L1B
+  long_name: FY-3E MERSI Low Light Level 1B
+  description: FY-3E Medium Resolution Spectral Imager - Low Light (MERSI-LL) L1B Reader
+  status: Beta
+  supports_fsspec: false
   sensors: [mersi-ll]
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
 

--- a/satpy/etc/readers/mersi_ll_l1b.yaml
+++ b/satpy/etc/readers/mersi_ll_l1b.yaml
@@ -4,7 +4,7 @@ reader:
   long_name: FY-3E MERSI Low Light Level 1B
   description: FY-3E Medium Resolution Spectral Imager - Low Light (MERSI-LL) L1B Reader
   status: Nominal
-  supports_fsspec: false
+  supports_fsspec: true
   sensors: [mersi-ll]
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
 

--- a/satpy/etc/readers/mersi_ll_l1b.yaml
+++ b/satpy/etc/readers/mersi_ll_l1b.yaml
@@ -3,7 +3,7 @@ reader:
   short_name: MERSI Low Light FY3E L1B
   long_name: FY-3E MERSI Low Light Level 1B
   description: FY-3E Medium Resolution Spectral Imager - Low Light (MERSI-LL) L1B Reader
-  status: Beta
+  status: Nominal
   supports_fsspec: false
   sensors: [mersi-ll]
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/etc/readers/sgli_l1b.yaml
+++ b/satpy/etc/readers/sgli_l1b.yaml
@@ -1,7 +1,11 @@
 reader:
-  description: Reader for SGLI data
-  reference: https://gportal.jaxa.jp/gpr/assets/mng_upload/GCOM-C/SGLI_Level1_Product_Format_Description_en.pdf
   name: sgli_l1b
+  short_name: SGLI GCOM-C L1B
+  long_name: GCOM-C SGLI Level 1B HDF5 format
+  description: Reader for SGLI data
+  status: Beta
+  supports_fsspec: false
+  reference: https://gportal.jaxa.jp/gpr/assets/mng_upload/GCOM-C/SGLI_Level1_Product_Format_Description_en.pdf
   sensors: [sgli]
   default_channels: []
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader

--- a/satpy/etc/readers/viirs_compact.yaml
+++ b/satpy/etc/readers/viirs_compact.yaml
@@ -1,7 +1,7 @@
 reader:
   name: viirs_compact
   short_name: VIIRS Compact
-  long_name: SNPP VIIRS SDR data in HDF5 Compact format
+  long_name: JPSS VIIRS SDR data in HDF5 Compact format
   description: Generic Eumetsat Compact VIIRS Reader
   status: Nominal
   supports_fsspec: false

--- a/satpy/etc/readers/viirs_edr.yaml
+++ b/satpy/etc/readers/viirs_edr.yaml
@@ -1,6 +1,10 @@
 reader:
-    description: VIIRS NOAA Enterprise EDR product reader
     name: viirs_edr
+    short_name: VIIRS JPSS EDR nc
+    long_name: JPSS VIIRS EDR NetCDF format
+    description: VIIRS NOAA Enterprise EDR product reader
+    status: Beta
+    supports_fsspec: false
     reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
     sensors: [viirs]
     group_keys: ['platform_shortname']

--- a/satpy/etc/readers/viirs_l1b.yaml
+++ b/satpy/etc/readers/viirs_l1b.yaml
@@ -1,7 +1,7 @@
 reader:
   name: viirs_l1b
   short_name: VIIRS l1b
-  long_name: SNPP VIIRS Level 1b data in netCDF4 format
+  long_name: JPSS VIIRS Level 1b data in netCDF4 format
   description: Generic NASA VIIRS L1B Reader
   status: Nominal
   supports_fsspec: false

--- a/satpy/etc/readers/viirs_sdr.yaml
+++ b/satpy/etc/readers/viirs_sdr.yaml
@@ -1,7 +1,7 @@
 reader:
   name: viirs_sdr
   short_name: VIIRS SDR
-  long_name: SNPP VIIRS data in HDF5 SDR format
+  long_name: JPSS VIIRS data in HDF5 SDR format
   description: VIIRS SDR Reader
   status: Nominal
   supports_fsspec: false


### PR DESCRIPTION
Refactor automatic reader table to be sorted by name by default follwing @djhoese wish (on Slack).

Other changes:
- Also updated datatable.js to v2 due to deprecation warnings.
- Re-added info regarding reader status below reader table (probably got lost in some merge) and also added a link to it from the dev guide.
- Some readers were missing info which led to empty columns (especially the name column) leading to reader appearing at the top of the table. I added missing info to the best of my knowledge but this should probably be checked with the reader authors. Especially the status of said readers and if they support fsspec. Affected readers:
  - agri_fy4b_l1 @simonrp84 
  - ghi_l1 @simonrp84 
  - meris_nc_sen3 @johannesocean 
  - mersi_II_l1b @simonrp84 
  - sgli_l1b @mraspaud 
  - viirs_edr @djhoese 