### PR TITLE
Add missing `h` docstring information to _geos_area.py

### DIFF
--- a/satpy/readers/_geos_area.py
+++ b/satpy/readers/_geos_area.py
@@ -72,6 +72,7 @@ def get_area_extent(pdict):
             coff: Column offset factor
             loff: Line offset factor
             scandir: 'N2S' for standard (N->S), 'S2N' for inverse (S->N)
+            h: Altitude of satellite (m)
 
     Returns:
         aex: An area extent for the scene

--- a/satpy/readers/_geos_area.py
+++ b/satpy/readers/_geos_area.py
@@ -72,7 +72,7 @@ def get_area_extent(pdict):
             coff: Column offset factor
             loff: Line offset factor
             scandir: 'N2S' for standard (N->S), 'S2N' for inverse (S->N)
-            h: Altitude of satellite (m)
+            h: Altitude of satellite above the Earth's surface (m)
 
     Returns:
         aex: An area extent for the scene


### PR DESCRIPTION
fix the document of get_area_extent function,add the description of  parameter h .

