### PR TITLE
Add fsspec support to `li_l2_nc` reader

### DIFF
--- a/satpy/etc/readers/generic_image.yaml
+++ b/satpy/etc/readers/generic_image.yaml
@@ -4,7 +4,7 @@ reader:
     long_name: Generic Images e.g. GeoTIFF
     description: generic image reader
     status: Nominal
-    supports_fsspec: false
+    supports_fsspec: true
     reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
     sensors: [images]
     default_channels: [image]

--- a/satpy/readers/li_base_nc.py
+++ b/satpy/readers/li_base_nc.py
@@ -191,12 +191,12 @@ import numpy as np
 import xarray as xr
 from pyproj import Proj
 
-from satpy.readers.netcdf_utils import NetCDF4FileHandler
+from satpy.readers.netcdf_utils import NetCDF4FsspecFileHandler
 
 logger = logging.getLogger(__name__)
 
 
-class LINCFileHandler(NetCDF4FileHandler):
+class LINCFileHandler(NetCDF4FsspecFileHandler):
     """Base class used as parent for the concrete LI reader classes."""
 
     def __init__(self, filename, filename_info, filetype_info, cache_handle=True):

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -383,7 +383,7 @@ def get_data_as_xarray(variable):
     try:
         arr = xr.DataArray(
             variable[:], dims=variable.dimensions, attrs=attrs, name=variable.name)
-    except (ValueError, IndexError):
+    except ValueError:
         # Handle scalars for h5netcdf backend
         arr = xr.DataArray(
             variable.__array__(), dims=variable.dimensions, attrs=attrs, name=variable.name)

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -379,14 +379,15 @@ def get_data_as_xarray(variable):
     try:
         attrs = variable.attrs
     except AttributeError:
+        # netCDF4 backend requires usage of __dict__ to get the attributes
         attrs = variable.__dict__
     try:
-        arr = xr.DataArray(
-            variable[:], dims=variable.dimensions, attrs=attrs, name=variable.name)
-    except ValueError:
+        data = variable[:]
+    except (ValueError, IndexError):
         # Handle scalars for h5netcdf backend
-        arr = xr.DataArray(
-            variable.__array__(), dims=variable.dimensions, attrs=attrs, name=variable.name)
+        data = variable.__array__()
+
+    arr = xr.DataArray(data, dims=variable.dimensions, attrs=attrs, name=variable.name)
 
     return arr
 

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -259,12 +259,16 @@ class NetCDF4FileHandler(BaseFileHandler):
         for var_name in cache_vars:
             v = self.file_content[var_name]
             try:
+                attrs = v.attrs
+            except AttributeError:
+                attrs = v.__dict__
+            try:
                 arr = xr.DataArray(
-                    v[:], dims=v.dimensions, attrs=v.__dict__, name=v.name)
-            except ValueError:
+                    v[:], dims=v.dimensions, attrs=attrs, name=v.name)
+            except (ValueError, IndexError):
                 # Handle scalars for h5netcdf backend
                 arr = xr.DataArray(
-                    v.__array__(), dims=v.dimensions, attrs=v.__dict__, name=v.name)
+                    v.__array__(), dims=v.dimensions, attrs=attrs, name=v.name)
             self.cached_file_content[var_name] = arr
 
     def _collect_cache_var_names(self, cache_var_size):

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -300,10 +300,8 @@ NC_ATTRS = {
     "scale_factor": 0.01,
     "add_offset": 0}
 
-def test_get_data_as_xarray_netcdf4():
+def test_get_data_as_xarray_netcdf4(tmp_path):
     """Test getting xr.DataArray from netcdf4 variable."""
-    import tempfile
-
     import netCDF4 as nc
     import numpy as np
 
@@ -311,26 +309,22 @@ def test_get_data_as_xarray_netcdf4():
 
     data = np.array([1, 2, 3])
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        # Create an empty HDF5
-        fname = os.path.join(tmpdir, "test.nc")
-        dset = nc.Dataset(fname, "w")
-        dset.createDimension("y", None)
-        var = dset.createVariable("test_data", "uint8", ("y",))
-        var[:] = data
-        var.setncatts(NC_ATTRS)
-        # Turn off automatic scale factor and offset handling
-        dset.set_auto_maskandscale(False)
-        res = get_data_as_xarray(var)
-        np.testing.assert_equal(res.data, data)
-        assert res.attrs == NC_ATTRS
-        dset.close()
+    fname = tmp_path / "test.nc"
+    dset = nc.Dataset(fname, "w")
+    dset.createDimension("y", None)
+    var = dset.createVariable("test_data", "uint8", ("y",))
+    var[:] = data
+    var.setncatts(NC_ATTRS)
+    # Turn off automatic scale factor and offset handling
+    dset.set_auto_maskandscale(False)
+    res = get_data_as_xarray(var)
+    np.testing.assert_equal(res.data, data)
+    assert res.attrs == NC_ATTRS
+    dset.close()
 
 
-def test_get_data_as_xarray_h5netcdf():
+def test_get_data_as_xarray_h5netcdf(tmp_path):
     """Test getting xr.DataArray from h5netcdf variable."""
-    import tempfile
-
     import h5netcdf
     import numpy as np
 
@@ -338,15 +332,13 @@ def test_get_data_as_xarray_h5netcdf():
 
     data = np.array([1, 2, 3])
 
-    with tempfile.TemporaryDirectory() as tmpdir:
-        # Create an empty HDF5
-        fname = os.path.join(tmpdir, "test.nc")
-        with h5netcdf.File(fname, "w") as fid:
-            fid.dimensions = {"y": data.size}
-            var = fid.create_variable("test_data", ("y",), "uint8")
-            var[:] = data
-            for key in NC_ATTRS:
-                var.attrs[key] = NC_ATTRS[key]
-            res = get_data_as_xarray(var)
-            np.testing.assert_equal(res.data, data)
-            assert res.attrs == NC_ATTRS
+    fname = tmp_path / "test.nc"
+    with h5netcdf.File(fname, "w") as fid:
+        fid.dimensions = {"y": data.size}
+        var = fid.create_variable("test_data", ("y",), "uint8")
+        var[:] = data
+        for key in NC_ATTRS:
+            var.attrs[key] = NC_ATTRS[key]
+        res = get_data_as_xarray(var)
+        np.testing.assert_equal(res.data, data)
+        assert res.attrs == NC_ATTRS


### PR DESCRIPTION
This PR adds remote reading support to `li_l2_nc` reader via fsspec.

The change in `NetCDF4FileHandler.collect_cache_vars()` for getting the attributes is that for `h5netcdf` backend the `v.__dict__` returns (for `longitude` dataset as an example):
```python
{'_parent_ref': <weakref at 0x7fb98d573420; to 'File' at 0x7fb98d1d54f0>, '_root_ref': <weakref at 0x7fb98d573420; to 'File' at 0x7fb98d1d54f0>, '_h5path': '/longitude', '_dimensions': ('flashes',), '_initialized': True}
```

instead of `v.attrs`

```python
<class 'h5netcdf.attrs.Attributes'>
_FillValue: -32767
long_name: 'Longitude of flash'
units: 'degrees_east'
standard_name: 'longitude'
scale_factor: 0.0027
add_offset: 0.0
```

This could be wrapped in `dict(v.attrs)` but apparently this already work as dictionary so there's no need.

The change is needed for the coordinates to be handled properly by setting `standard_name`, scale and offset.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
