### PR TITLE
Bugfix vgac reader

### DIFF
--- a/satpy/readers/viirs_vgac_l1c_nc.py
+++ b/satpy/readers/viirs_vgac_l1c_nc.py
@@ -83,7 +83,7 @@ class VGACFileHandler(BaseFileHandler):
         """Decode time data."""
         reference_time = np.datetime64(datetime.strptime(nc["proj_time0"].attrs["units"],
                                                          "days since %d/%m/%YT%H:%M:%S"))
-        delta_part_of_day, delta_full_days = np.modf(nc["proj_time0"].values[0])
+        delta_part_of_day, delta_full_days = np.modf(nc["proj_time0"].values)
         delta_full_days = np.timedelta64(delta_full_days.astype(np.int64), "D").astype("timedelta64[us]")
         delta_part_of_day = delta_part_of_day * np.timedelta64(1, "D").astype("timedelta64[us]")
         delta_hours = data.values * np.timedelta64(1, "h").astype("timedelta64[us]")

--- a/satpy/tests/reader_tests/test_viirs_vgac_l1c_nc.py
+++ b/satpy/tests/reader_tests/test_viirs_vgac_l1c_nc.py
@@ -72,7 +72,7 @@ def nc_filename(tmp_path):
         delta_full_days = delta_days.astype("timedelta64[D]")
         hidden_reference_time = reference_time + delta_full_days
         delta_part_of_days = start_time - hidden_reference_time
-        proj_time0 = nc.createVariable("proj_time0", np.float64, ("one",))
+        proj_time0 = nc.createVariable("proj_time0", np.float64)
         proj_time0[:] = (delta_full_days.astype(np.int64) +
                          0.000001 * delta_part_of_days.astype("timedelta64[us]").astype(np.int64) / (60 * 60 * 24))
         proj_time0.units = "days since 01/01/2010T00:00:00"


### PR DESCRIPTION
Fix a bug I intruded when writing unit test for the time var in the vgac reader. The time_proj0 is a scalar in the files, and now also in the unittest case.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
