### PR TITLE
Fix instrument name reading from attributes for VIIRS L2 data

### DIFF
--- a/satpy/readers/viirs_l2.py
+++ b/satpy/readers/viirs_l2.py
@@ -70,7 +70,13 @@ class VIIRSL2FileHandler(NetCDF4FileHandler):
     @property
     def sensor_name(self):
         """Get sensor name."""
-        return self["/attr/instrument"].lower()
+        try:
+            # Until v3r0 (or v3r1)
+            instrument = self["/attr/instrument_name"].lower()
+        except KeyError:
+            # Changed in ASCI v3r1 or v3r2
+            instrument = self["/attr/instrument"].lower()
+        return instrument
 
     def _get_dataset_file_units(self, ds_info, var_path):
         file_units = ds_info.get("units")

--- a/satpy/tests/reader_tests/test_viirs_l2.py
+++ b/satpy/tests/reader_tests/test_viirs_l2.py
@@ -66,6 +66,33 @@ class FakeNetCDF4FileHandlerVIIRSL2(FakeNetCDF4FileHandler):
             file_content["Aerosol_Optical_Thickness_550_Land_Ocean_Best_Estimate"] = DEFAULT_FILE_DATA
 
 
+class FakeNetCDF4FileHandlerVIIRSL2_V3R0(FakeNetCDF4FileHandlerVIIRSL2):
+    """Swap-in NetCDF4 File Handler for ASCI version <= v3r0."""
+
+    def get_test_content(self, filename, filename_info, filetype_info):
+        """Mimic reader input file content."""
+        dt = filename_info.get("start_time", datetime(2023, 12, 30, 22, 30, 0))
+        file_type = filename[:6]
+        num_lines = DEFAULT_FILE_SHAPE[0]
+        num_pixels = DEFAULT_FILE_SHAPE[1]
+        num_scans = 5
+        file_content = {
+            "/dimension/number_of_scans": num_scans,
+            "/dimension/number_of_lines": num_lines,
+            "/dimension/number_of_pixels": num_pixels,
+            "/attr/time_coverage_start": dt.strftime("%Y-%m-%dT%H:%M:%S.000Z"),
+            "/attr/time_coverage_end": (dt + timedelta(minutes=6)).strftime(
+                "%Y-%m-%dT%H:%M:%S.000Z"
+            ),
+            "/attr/orbit_number": 26384,
+            "/attr/instrument_name": "VIIRS",
+            "/attr/satellite_name": "Suomi-NPP",
+        }
+        self._fill_contents_with_default_data(file_content, file_type)
+        convert_file_content_to_data_array(file_content)
+        return file_content
+
+
 class TestVIIRSL2FileHandler:
     """Test VIIRS_L2 Reader."""
     yaml_file = "viirs_l2.yaml"
@@ -133,3 +160,47 @@ class TestVIIRSL2FileHandler:
             d_np = d.compute()
             assert d.dtype == d_np.dtype
             assert d.dtype == np.float32
+
+
+class TestVIIRSL2V3R0FileHandler:
+    """Test VIIRS_L2 Reader for ASCI version <= v3r0."""
+    yaml_file = "viirs_l2.yaml"
+
+    def setup_method(self):
+        """Wrap NetCDF4 file handler with our own fake handler."""
+        from satpy._config import config_search_paths
+        from satpy.readers.viirs_l2 import VIIRSL2FileHandler
+
+        self.reader_configs = config_search_paths(
+            os.path.join("readers", self.yaml_file)
+        )
+        self.p = mock.patch.object(
+            VIIRSL2FileHandler, "__bases__", (FakeNetCDF4FileHandlerVIIRSL2_V3R0,)
+        )
+        self.fake_handler = self.p.start()
+        self.p.is_local = True
+
+    def teardown_method(self):
+        """Stop wrapping the NetCDF4 file handler."""
+        self.p.stop()
+
+    @pytest.mark.parametrize(
+        ("filename", "datasets"),
+        [
+            pytest.param("CLDPROP_L2_VIIRS_SNPP.A2023364.2230.011.2023365115856.nc",
+                         ["Cloud_Top_Height"], id="CLDPROP"),
+            pytest.param("CLDMSK_L2_VIIRS_SNPP.A2023364.2230.001.2023365105952.nc",
+                         ["Clear_Sky_Confidence"], id="CLDMSK"),
+            pytest.param("AERDB_L2_VIIRS_SNPP.A2023364.2230.011.2023365113427.nc",
+                         ["Aerosol_Optical_Thickness_550_Land_Ocean_Best_Estimate",
+                          "Angstrom_Exponent_Land_Ocean_Best_Estimate"], id="AERDB"),
+        ],
+    )
+    def test_load_l2_files(self, filename, datasets):
+        """Test L2 File Loading."""
+        r = load_reader(self.reader_configs)
+        loadables = r.select_files_from_pathnames([filename])
+        r.create_filehandlers(loadables)
+        loaded_datasets = r.load(datasets)
+        for d in loaded_datasets.values():
+            assert d.attrs["sensor"] == "viirs"


### PR DESCRIPTION
The some of the attributes in the CSPP/ASCI files have been renamed between v3r0 and v3r2. The only on I've seen that affects Satpy is the instrument name. The [original reader version](https://github.com/pytroll/satpy/blob/v0.43.0.post0/satpy/readers/viirs_l2.py#L58) was based on older data and works at least until v3r0 files, but the current one seems to handle only the newer files. With this PR both can be read.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
