### PR TITLE
Add missing defusedxml

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -26,6 +26,7 @@ The following people have made contributions to this project:
 - [Adam Dybbroe (adybbroe)](https://github.com/adybbroe)
 - [Ulrik Egede (egede)](https://github.com/egede)
 - [Joleen Feltz (joleenf)](https://github.com/joleenf)
+- [Florian Fichtner (fwfichtner)](https://github.com/fwfichtner)
 - [Stephan Finkensieper (sfinkens)](https://github.com/sfinkens) - Deutscher Wetterdienst
 - [Gionata Ghiggi (ghiggi)](https://github.com/ghiggi)
 - [Andrea Grillini (AppLEaDaY)](https://github.com/AppLEaDaY)

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ extras_require = {
     "amsr2_l1b": ["h5py >= 2.7.0"],
     "hrpt": ["pyorbital >= 1.3.1", "pygac", "python-geotiepoints >= 1.1.7"],
     "hrit_msg": ["pytroll-schedule"],
-    "msi_safe": ["rioxarray", "bottleneck", "python-geotiepoints"],
+    "msi_safe": ["rioxarray", "bottleneck", "python-geotiepoints", "defusedxml"],
     "nc_nwcsaf_msg": ["netCDF4 >= 1.1.8"],
     "sar_c": ["python-geotiepoints >= 1.1.7", "rasterio", "rioxarray", "defusedxml"],
     "abi_l1b": ["h5netcdf"],

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ test_requires = ["behave", "h5py", "netCDF4", "pyhdf", "imageio",
 
 extras_require = {
     # Readers:
+    "avhrr_l1b_eps": ["defusedxml"],
     "avhrr_l1b_gaclac": ["pygac >= 1.3.0"],
     "modis_l1b": ["pyhdf", "python-geotiepoints >= 1.1.7"],
     "geocat": ["pyhdf"],


### PR DESCRIPTION
- adds `defusedxml` to `msi_reader` extra
- adds new extra `avhrr_l1b_eps` because it was also missing `defusedxml`

Feel free to cherry-pick if you don't like the new reader.

 - [x] Closes #2759
 - [ ] Tests added
