### PR TITLE
Add support for EO-SIP AVHRR LAC data

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -47,6 +47,7 @@ dependencies:
   - pytest-cov
   - pytest-lazy-fixture
   - fsspec
+  - botocore>=1.33
   - s3fs
   - python-geotiepoints
   - pooch

--- a/satpy/etc/readers/avhrr_l1b_gaclac.yaml
+++ b/satpy/etc/readers/avhrr_l1b_gaclac.yaml
@@ -185,3 +185,4 @@ file_types:
         file_patterns:
         - '{creation_site:3s}.{transfer_mode:4s}.{platform_id:2s}.D{start_time:%y%j.S%H%M}.E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}'
         - '{subscription_prefix:10d}.{creation_site:3s}.{transfer_mode:4s}.{platform_id:2s}.D{start_time:%y%j.S%H%M}.E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}'
+        - '{platform_id:3s}_RPRO_AVH_L1B_1P_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{orbit_number:06d}/image.l1b'

--- a/satpy/readers/avhrr_l1b_gaclac.py
+++ b/satpy/readers/avhrr_l1b_gaclac.py
@@ -100,20 +100,16 @@ class GACLACFile(BaseFileHandler):
         self.platform_id = filename_info["platform_id"]
 
         if len(self.platform_id) == 3:
-            self.reader_kwargs["eosip_header"] = True
+            self.reader_kwargs["header_datetime"] = datetime(2000, 1, 1)
 
-        if self.platform_id in ["NK", "NL", "NM", "NN", "NP",
-                                "N15", "N16", "N17", "N18", "N19",
-                                "M1", "M2", "M3",
-                                "MOB", "MOA", "MOC"]:
+        if self._is_avhrr3():
             if filename_info.get("transfer_mode") == "GHRR":
                 self.reader_class = GACKLMReader
             else:
                 self.reader_class = LACKLMReader
             self.chn_dict = AVHRR3_CHANNEL_NAMES
             self.sensor = "avhrr-3"
-        elif self.platform_id in ["NC", "NE", "NF", "NG", "NH", "ND", "NJ",
-                                  "N07", "N08", "N09", "N10", "N11", "N12", "N14"]:
+        elif self._is_avhrr2():
             if filename_info.get("transfer_mode") == "GHRR":
                 self.reader_class = GACPODReader
             else:
@@ -128,6 +124,16 @@ class GACLACFile(BaseFileHandler):
             self.chn_dict = AVHRR_CHANNEL_NAMES
             self.sensor = "avhrr"
         self.filename_info = filename_info
+
+    def _is_avhrr2(self):
+        return self.platform_id in ["NC", "NE", "NF", "NG", "NH", "ND", "NJ",
+                                    "N07", "N08", "N09", "N10", "N11", "N12", "N14"]
+
+    def _is_avhrr3(self):
+        return self.platform_id in ["NK", "NL", "NM", "NN", "NP",
+                                    "N15", "N16", "N17", "N18", "N19",
+                                    "M1", "M2", "M3",
+                                    "MOB", "MOA", "MOC"]
 
     def read_raw_data(self):
         """Create a pygac reader and read raw data from the file."""

--- a/satpy/readers/avhrr_l1b_gaclac.py
+++ b/satpy/readers/avhrr_l1b_gaclac.py
@@ -98,9 +98,14 @@ class GACLACFile(BaseFileHandler):
         if self._end_time < self._start_time:
             self._end_time += timedelta(days=1)
         self.platform_id = filename_info["platform_id"]
+
+        if len(self.platform_id) == 3:
+            self.reader_kwargs["eosip_header"] = True
+
         if self.platform_id in ["NK", "NL", "NM", "NN", "NP",
+                                "N15", "N16", "N17", "N18", "N19",
                                 "M1", "M2", "M3",
-                                "N15", "N16", "N17", "N18", "N19"]:
+                                "MOB", "MOA", "MOC"]:
             if filename_info.get("transfer_mode") == "GHRR":
                 self.reader_class = GACKLMReader
             else:

--- a/satpy/readers/avhrr_l1b_gaclac.py
+++ b/satpy/readers/avhrr_l1b_gaclac.py
@@ -30,7 +30,7 @@ formats as well as calibration and navigation methods.
 """
 
 import logging
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 
 import dask.array as da
 import numpy as np
@@ -100,7 +100,7 @@ class GACLACFile(BaseFileHandler):
         self.platform_id = filename_info["platform_id"]
 
         if len(self.platform_id) == 3:
-            self.reader_kwargs["header_datetime"] = datetime(2000, 1, 1)
+            self.reader_kwargs["header_date"] = date(2000, 1, 1)
 
         if self._is_avhrr3():
             if filename_info.get("transfer_mode") == "GHRR":

--- a/satpy/readers/avhrr_l1b_gaclac.py
+++ b/satpy/readers/avhrr_l1b_gaclac.py
@@ -98,15 +98,17 @@ class GACLACFile(BaseFileHandler):
         if self._end_time < self._start_time:
             self._end_time += timedelta(days=1)
         self.platform_id = filename_info["platform_id"]
-        if self.platform_id in ["NK", "NL", "NM", "NN", "NP", "M1", "M2",
-                                "M3"]:
+        if self.platform_id in ["NK", "NL", "NM", "NN", "NP",
+                                "M1", "M2", "M3",
+                                "N15", "N16", "N17", "N18", "N19"]:
             if filename_info.get("transfer_mode") == "GHRR":
                 self.reader_class = GACKLMReader
             else:
                 self.reader_class = LACKLMReader
             self.chn_dict = AVHRR3_CHANNEL_NAMES
             self.sensor = "avhrr-3"
-        elif self.platform_id in ["NC", "ND", "NF", "NH", "NJ"]:
+        elif self.platform_id in ["NC", "NE", "NF", "NG", "NH", "ND", "NJ",
+                                  "N07", "N08", "N09", "N10", "N11", "N12", "N14"]:
             if filename_info.get("transfer_mode") == "GHRR":
                 self.reader_class = GACPODReader
             else:

--- a/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
+++ b/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
@@ -190,7 +190,7 @@ class TestGACLACFile(GACLACFilePatcher):
                 fh = self._get_eosip_fh(filename, **kwargs)
                 assert fh.start_time < fh.end_time
                 assert fh.reader_class is reader_cls
-                assert fh.reader_kwargs["header_datetime"] > datetime.date(1994, 11, 15)
+                assert fh.reader_kwargs["header_date"] > datetime.date(1994, 11, 15)
 
     def test_read_raw_data(self):
         """Test raw data reading."""

--- a/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
+++ b/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
@@ -17,7 +17,7 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Pygac interface."""
 
-from datetime import datetime
+from datetime import date, datetime
 from unittest import TestCase, mock
 
 import dask.array as da
@@ -190,7 +190,7 @@ class TestGACLACFile(GACLACFilePatcher):
                 fh = self._get_eosip_fh(filename, **kwargs)
                 assert fh.start_time < fh.end_time
                 assert fh.reader_class is reader_cls
-                assert fh.reader_kwargs["header_date"] > datetime.date(1994, 11, 15)
+                assert fh.reader_kwargs["header_date"] > date(1994, 11, 15)
 
     def test_read_raw_data(self):
         """Test raw data reading."""

--- a/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
+++ b/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
@@ -26,6 +26,7 @@ import pytest
 import xarray as xr
 
 GAC_PATTERN = '{creation_site:3s}.{transfer_mode:4s}.{platform_id:2s}.D{start_time:%y%j.S%H%M}.E{end_time:%H%M}.B{orbit_number:05d}{end_orbit_last_digits:02d}.{station:2s}'  # noqa
+EOSIP_PATTERN = '{platform_id:3s}_RPRO_AVH_L1B_1P_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{orbit_number:06d}/image.l1b'  # noqa
 
 GAC_POD_FILENAMES = ["NSS.GHRR.NA.D79184.S1150.E1337.B0008384.WI",
                      "NSS.GHRR.NA.D79184.S2350.E0137.B0008384.WI",
@@ -67,6 +68,8 @@ LAC_KLM_FILENAMES = ["BRN.HRPT.M1.D14152.S0958.E1012.B0883232.UB",
                      "BRN.HRPT.NP.D16185.S1427.E1440.B3814646.UB",
                      "NSS.FRAC.M2.D12153.S1729.E1910.B2915354.SV",
                      "NSS.LHRR.NP.D16306.S1803.E1814.B3985555.WI"]
+
+LAC_EOSIP_FILENAMES = ["N06_RPRO_AVH_L1B_1P_20061206T010808_20061206T012223_007961/image.l1b"]
 
 
 @mock.patch("satpy.readers.avhrr_l1b_gaclac.GACLACFile.__init__", return_value=None)
@@ -138,6 +141,12 @@ class TestGACLACFile(GACLACFilePatcher):
         filename_info = parse(GAC_PATTERN, filename)
         return self.GACLACFile(filename, filename_info, {}, **kwargs)
 
+    def _get_eosip_fh(self, filename, **kwargs):
+        """Create a file handler."""
+        from trollsift import parse
+        filename_info = parse(EOSIP_PATTERN, filename)
+        return self.GACLACFile(filename, filename_info, {}, **kwargs)
+
     def test_init(self):
         """Test GACLACFile initialization."""
         from pygac.gac_klm import GACKLMReader
@@ -160,6 +169,28 @@ class TestGACLACFile(GACLACFilePatcher):
                 fh = self._get_fh(filename, **kwargs)
                 assert fh.start_time < fh.end_time
                 assert fh.reader_class is reader_cls
+
+
+    def test_init_eosip(self):
+        """Test GACLACFile initialization."""
+        from pygac.lac_pod import LACPODReader
+
+        kwargs = {"start_line": 1,
+                  "end_line": 2,
+                  "strip_invalid_coords": True,
+                  "interpolate_coords": True,
+                  "adjust_clock_drift": True,
+                  "tle_dir": "tle_dir",
+                  "tle_name": "tle_name",
+                  "tle_thresh": 123,
+                  "calibration": "calibration"}
+        for filenames, reader_cls in zip([LAC_EOSIP_FILENAMES],
+                                         [LACPODReader]):
+            for filename in filenames:
+                fh = self._get_eosip_fh(filename, **kwargs)
+                assert fh.start_time < fh.end_time
+                assert fh.reader_class is reader_cls
+                assert fh.reader_kwargs["eosip_header"] is True
 
     def test_read_raw_data(self):
         """Test raw data reading."""

--- a/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
+++ b/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
@@ -190,7 +190,7 @@ class TestGACLACFile(GACLACFilePatcher):
                 fh = self._get_eosip_fh(filename, **kwargs)
                 assert fh.start_time < fh.end_time
                 assert fh.reader_class is reader_cls
-                assert fh.reader_kwargs["eosip_header"] is True
+                assert fh.reader_kwargs["header_datetime"] > datetime.date(1994, 11, 15)
 
     def test_read_raw_data(self):
         """Test raw data reading."""


### PR DESCRIPTION
This PR fixes a couple of things in the avhrr gaclac reader to accept EO-SIP (ESA) format LAC data

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
