### PR TITLE
Fix the viirs EDR tests for newer xarray

### DIFF
--- a/satpy/tests/reader_tests/test_viirs_edr.py
+++ b/satpy/tests/reader_tests/test_viirs_edr.py
@@ -132,7 +132,8 @@ def _create_surf_refl_variables() -> dict[str, xr.DataArray]:
                  "valid_min": -180.0, "valid_max": 180.0}
     lat_attrs = {"standard_name": "latitude", "units": "degrees_north", "_FillValue": -999.9,
                  "valid_min": -90.0, "valid_max": 90.0}
-    sr_attrs = {"units": "unitless", "_FillValue": -9999, "scale_factor": 0.0001, "add_offset": 0.0}
+    sr_attrs = {"units": "unitless", "_FillValue": -9999,
+                "scale_factor": np.float32(0.0001), "add_offset": np.float32(0.0)}
 
     i_data = np.random.random_sample((I_ROWS, I_COLS)).astype(np.float32)
     m_data = np.random.random_sample((M_ROWS, M_COLS)).astype(np.float32)
@@ -257,7 +258,8 @@ def _create_continuous_variables(var_names: Iterable[str]) -> dict[str, xr.DataA
 
     lon_attrs = {"standard_name": "longitude", "units": "degrees_east", "_FillValue": -999.9}
     lat_attrs = {"standard_name": "latitude", "units": "degrees_north", "_FillValue": -999.9}
-    cont_attrs = {"units": "Kelvin", "_FillValue": -9999, "scale_factor": 0.0001, "add_offset": 0.0}
+    cont_attrs = {"units": "Kelvin", "_FillValue": -9999,
+                  "scale_factor": np.float32(0.0001), "add_offset": np.float32(0.0)}
 
     m_data = np.random.random_sample((M_ROWS, M_COLS)).astype(np.float32)
     data_arrs = {


### PR DESCRIPTION
This PR fixes the Viirs EDR tests for new xarray.

Dtype checks were failing because of the test file generation was being given float64 scale and offset parameters to the encoding.

