### PR TITLE
Convert Sentinel-2 MSI sensor name to lowercase in the reader YAML config file and add support for "counts" calibration

### DIFF
--- a/satpy/etc/readers/msi_safe.yaml
+++ b/satpy/etc/readers/msi_safe.yaml
@@ -38,7 +38,7 @@ datasets:
         units: W m-2 um-1 sr-1
       counts:
         standard_name: counts
-        units: "1"        
+        units: "1"
     file_type: safe_granule
 
   B02:
@@ -55,7 +55,7 @@ datasets:
         units: W m-2 um-1 sr-1
       counts:
         standard_name: counts
-        units: "1"        
+        units: "1"
     file_type: safe_granule
 
   B03:
@@ -72,7 +72,7 @@ datasets:
         units: W m-2 um-1 sr-1
       counts:
         standard_name: counts
-        units: "1"        
+        units: "1"
     file_type: safe_granule
 
   B04:
@@ -89,7 +89,7 @@ datasets:
         units: W m-2 um-1 sr-1
       counts:
         standard_name: counts
-        units: "1"        
+        units: "1"
     file_type: safe_granule
 
   B05:
@@ -106,7 +106,7 @@ datasets:
         units: W m-2 um-1 sr-1
       counts:
         standard_name: counts
-        units: "1"        
+        units: "1"
     file_type: safe_granule
 
   B06:
@@ -123,7 +123,7 @@ datasets:
         units: W m-2 um-1 sr-1
       counts:
         standard_name: counts
-        units: "1"        
+        units: "1"
     file_type: safe_granule
 
   B07:
@@ -140,7 +140,7 @@ datasets:
         units: W m-2 um-1 sr-1
       counts:
         standard_name: counts
-        units: "1"        
+        units: "1"
     file_type: safe_granule
 
   B08:
@@ -157,7 +157,7 @@ datasets:
         units: W m-2 um-1 sr-1
       counts:
         standard_name: counts
-        units: "1"        
+        units: "1"
     file_type: safe_granule
 
   B8A:
@@ -174,7 +174,7 @@ datasets:
         units: W m-2 um-1 sr-1
       counts:
         standard_name: counts
-        units: "1"        
+        units: "1"
     file_type: safe_granule
 
   B09:
@@ -191,7 +191,7 @@ datasets:
         units: W m-2 um-1 sr-1
       counts:
         standard_name: counts
-        units: "1"        
+        units: "1"
     file_type: safe_granule
 
   B10:
@@ -208,7 +208,7 @@ datasets:
         units: W m-2 um-1 sr-1
       counts:
         standard_name: counts
-        units: "1"        
+        units: "1"
     file_type: safe_granule
 
   B11:
@@ -225,7 +225,7 @@ datasets:
         units: W m-2 um-1 sr-1
       counts:
         standard_name: counts
-        units: "1"        
+        units: "1"
     file_type: safe_granule
 
   B12:
@@ -242,7 +242,7 @@ datasets:
         units: W m-2 um-1 sr-1
       counts:
         standard_name: counts
-        units: "1"        
+        units: "1"
     file_type: safe_granule
 
 

--- a/satpy/etc/readers/msi_safe.yaml
+++ b/satpy/etc/readers/msi_safe.yaml
@@ -26,7 +26,7 @@ datasets:
 
   B01:
     name: B01
-    sensor: MSI
+    sensor: msi
     wavelength: [0.415, 0.443, 0.470]
     resolution: 60
     calibration:
@@ -40,7 +40,7 @@ datasets:
 
   B02:
     name: B02
-    sensor: MSI
+    sensor: msi
     wavelength: [0.440, 0.490, 0.540]
     resolution: 10
     calibration:
@@ -54,7 +54,7 @@ datasets:
 
   B03:
     name: B03
-    sensor: MSI
+    sensor: msi
     wavelength: [0.540, 0.560, 0.580]
     resolution: 10
     calibration:
@@ -68,7 +68,7 @@ datasets:
 
   B04:
     name: B04
-    sensor: MSI
+    sensor: msi
     wavelength: [0.645, 0.665, 0.685]
     resolution: 10
     calibration:
@@ -82,7 +82,7 @@ datasets:
 
   B05:
     name: B05
-    sensor: MSI
+    sensor: msi
     wavelength: [0.695, 0.705, 0.715]
     resolution: 20
     calibration:
@@ -96,7 +96,7 @@ datasets:
 
   B06:
     name: B06
-    sensor: MSI
+    sensor: msi
     wavelength: [0.731, 0.740, 0.749]
     resolution: 20
     calibration:
@@ -110,7 +110,7 @@ datasets:
 
   B07:
     name: B07
-    sensor: MSI
+    sensor: msi
     wavelength: [0.764, 0.783, 0.802]
     resolution: 20
     calibration:
@@ -124,7 +124,7 @@ datasets:
 
   B08:
     name: B08
-    sensor: MSI
+    sensor: msi
     wavelength: [0.780, 0.842, 0.905]
     resolution: 10
     calibration:
@@ -138,7 +138,7 @@ datasets:
 
   B8A:
     name: B8A
-    sensor: MSI
+    sensor: msi
     wavelength: [0.855, 0.865, 0.875]
     resolution: 20
     calibration:
@@ -152,7 +152,7 @@ datasets:
 
   B09:
     name: B09
-    sensor: MSI
+    sensor: msi
     wavelength: [0.935, 0.945, 0.955]
     resolution: 60
     calibration:
@@ -166,7 +166,7 @@ datasets:
 
   B10:
     name: B10
-    sensor: MSI
+    sensor: msi
     wavelength: [1.365, 1.375, 1.385]
     resolution: 60
     calibration:
@@ -180,7 +180,7 @@ datasets:
 
   B11:
     name: B11
-    sensor: MSI
+    sensor: msi
     wavelength: [1.565, 1.610, 1.655]
     resolution: 20
     calibration:
@@ -194,7 +194,7 @@ datasets:
 
   B12:
     name: B12
-    sensor: MSI
+    sensor: msi
     wavelength: [2.100, 2.190, 2.280]
     resolution: 20
     calibration:

--- a/satpy/etc/readers/msi_safe.yaml
+++ b/satpy/etc/readers/msi_safe.yaml
@@ -36,6 +36,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"        
     file_type: safe_granule
 
   B02:
@@ -50,6 +53,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"        
     file_type: safe_granule
 
   B03:
@@ -64,6 +70,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"        
     file_type: safe_granule
 
   B04:
@@ -78,6 +87,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"        
     file_type: safe_granule
 
   B05:
@@ -92,6 +104,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"        
     file_type: safe_granule
 
   B06:
@@ -106,6 +121,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"        
     file_type: safe_granule
 
   B07:
@@ -120,6 +138,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"        
     file_type: safe_granule
 
   B08:
@@ -134,6 +155,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"        
     file_type: safe_granule
 
   B8A:
@@ -148,6 +172,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"        
     file_type: safe_granule
 
   B09:
@@ -162,6 +189,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"        
     file_type: safe_granule
 
   B10:
@@ -176,6 +206,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"        
     file_type: safe_granule
 
   B11:
@@ -190,6 +223,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"        
     file_type: safe_granule
 
   B12:
@@ -204,6 +240,9 @@ datasets:
       radiance:
         standard_name: toa_outgoing_radiance_per_unit_wavelength
         units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"        
     file_type: safe_granule
 
 

--- a/satpy/readers/msi_safe.py
+++ b/satpy/readers/msi_safe.py
@@ -89,6 +89,8 @@ class SAFEMSIL1C(BaseFileHandler):
             return self._mda.calibrate_to_reflectances(proj, self._channel)
         if key["calibration"] == "radiance":
             return self._mda.calibrate_to_radiances(proj, self._channel)
+        if key["calibration"] == "counts":
+            return self._mda._sanitize_data(proj)
 
     @property
     def start_time(self):

--- a/satpy/tests/reader_tests/test_msi_safe.py
+++ b/satpy/tests/reader_tests/test_msi_safe.py
@@ -920,6 +920,15 @@ class TestMTDXML:
         np.testing.assert_allclose(result, [[[np.nan, 0.01 - 10, 0.02 - 10, 0.03 - 10],
                                              [0.04 - 10, 0, 655.34 - 10, np.inf]]])
 
+    def test_xml_calibration_to_counts(self):
+        """Test the calibration to counts."""
+        fake_data = xr.DataArray([[[0, 1, 2, 3],
+                                   [4, 1000, 65534, 65535]]],
+                                 dims=["band", "x", "y"])
+        result = self.xml_fh._sanitize_data(fake_data)
+        np.testing.assert_allclose(result, [[[np.nan, 1, 2, 3],
+                                             [4, 1000, 65534, np.inf]]])
+
     def test_xml_calibration_unmasked_saturated(self):
         """Test the calibration with radiometric offset but unmasked saturated pixels."""
         from satpy.readers.msi_safe import SAFEMSIMDXML

--- a/satpy/tests/reader_tests/test_msi_safe.py
+++ b/satpy/tests/reader_tests/test_msi_safe.py
@@ -989,7 +989,7 @@ class TestSAFEMSIL1C:
                              [(True, "reflectance", [[np.nan, 0.01 - 10], [645.34, np.inf]]),
                               (False, "reflectance", [[np.nan, 0.01 - 10], [645.34, 645.35]]),
                               (True, "radiance", [[np.nan, -251.58426503], [16251.99095011, np.inf]]),
-                              (False, "counts", [[np.nan, 1], [65534, np.inf]])])
+                              (False, "counts", [[np.nan, 1], [65534, 65535]])])
     def test_calibration_and_masking(self, mask_saturated, calibration, expected):
         """Test that saturated is masked with inf when requested and that calibration is performed."""
         from satpy.readers.msi_safe import SAFEMSIL1C, SAFEMSIMDXML

--- a/satpy/tests/reader_tests/test_msi_safe.py
+++ b/satpy/tests/reader_tests/test_msi_safe.py
@@ -988,7 +988,8 @@ class TestSAFEMSIL1C:
     @pytest.mark.parametrize(("mask_saturated", "calibration", "expected"),
                              [(True, "reflectance", [[np.nan, 0.01 - 10], [645.34, np.inf]]),
                               (False, "reflectance", [[np.nan, 0.01 - 10], [645.34, 645.35]]),
-                              (True, "radiance", [[np.nan, -251.58426503], [16251.99095011, np.inf]])])
+                              (True, "radiance", [[np.nan, -251.58426503], [16251.99095011, np.inf]]),
+                              (False, "counts", [[np.nan, 1], [65534, np.inf]])])
     def test_calibration_and_masking(self, mask_saturated, calibration, expected):
         """Test that saturated is masked with inf when requested and that calibration is performed."""
         from satpy.readers.msi_safe import SAFEMSIL1C, SAFEMSIMDXML


### PR DESCRIPTION
This PR has two purposes:
1. The current sensor name in YAML is "MSI", which triggers a minor warning `Inconsistent sensor/satellite input` in pyspectral since the latter one stores sensor name in lowercase. So it's replace by lowercase.
2. Add "counts" calibration just like other sensors.
