### PR TITLE
Fix various issues in unstable CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,9 @@ jobs:
         # Install pykdtree with --no-build-isolation so it builds with numpy 2.0
         # We must get LD_PRELOAD for stdlibc++ or else the manylinux wheels
         # may break the conda-forge libraries trying to use newer glibc versions
+        # NOTE: Many of the packages removed and then reinstalled below are to avoid
+        #   compatibility issues with numpy 2. When conda-forge has numpy 2 available
+        #   this shouldn't be needed.
         run: |
           python -m pip install versioneer extension-helpers setuptools-scm configobj pkgconfig
           python -m pip install \
@@ -77,7 +80,7 @@ jobs:
           numpy \
           pandas \
           scipy
-          conda remove --force-remove -y pykdtree pyresample python-geotiepoints pyhdf netcdf4 h5py cftime
+          conda remove --force-remove -y pykdtree pyresample python-geotiepoints pyhdf netcdf4 h5py cftime astropy pyerfa
           python -m pip install --upgrade --no-deps --pre --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,11 +77,12 @@ jobs:
           numpy \
           pandas \
           scipy
-          conda remove --force-remove -y pykdtree pyresample pyhdf netcdf4 h5py cftime
+          conda remove --force-remove -y pykdtree pyresample python-geotiepoints pyhdf netcdf4 h5py cftime
           python -m pip install --upgrade --no-deps --pre --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \
           git+https://github.com/pytroll/trollimage \
+          git+https://github.com/pytroll/python-geotiepoints \
           git+https://github.com/fhs/pyhdf \
           git+https://github.com/h5py/h5py \
           git+https://github.com/h5netcdf/h5netcdf \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
           numpy \
           pandas \
           scipy
-          conda remove --force-remove -y pykdtree pyresample trollimage pyhdf netcdf4 h5py cftime
+          conda remove --force-remove -y pykdtree pyresample pyhdf netcdf4 h5py cftime
           python -m pip install --upgrade --no-deps --pre --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -82,6 +82,7 @@ jobs:
           scipy
           conda remove --force-remove -y pykdtree pyresample python-geotiepoints pyhdf netcdf4 h5py cftime astropy pyerfa
           python -m pip install --upgrade --no-deps --pre --no-build-isolation \
+          pyerfa \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \
           git+https://github.com/pytroll/trollimage \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
           numpy \
           pandas \
           scipy
-          mamba remove --force-remove -y pykdtree pyresample trollimage pyhdf netcdf4 h5py
+          conda remove --force-remove -y pykdtree pyresample trollimage pyhdf netcdf4 h5py cftime
           python -m pip install --upgrade --no-deps --pre --no-build-isolation \
           git+https://github.com/storpipfugl/pykdtree \
           git+https://github.com/pytroll/pyresample \


### PR DESCRIPTION
cftime's master branch should support numpy 2 now, but from what I could tell our CI still wasn't working. My best guess is the conda-installed version is getting used before the pip one. This PR first removes the conda installed one in unstable CI before installing from source.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
