### PR TITLE
Remove doc references to setup.py

### DIFF
--- a/doc/source/dev_guide/index.rst
+++ b/doc/source/dev_guide/index.rst
@@ -29,7 +29,7 @@ and all code should follow the
 practices <http://pytroll.github.io/guidelines.html>`_.
 
 Satpy is now Python 3 only and it is no longer needed to support Python 2.
-Check ``setup.py`` for the current Python versions any new code needs
+Check ``pyproject.toml`` for the current Python versions any new code needs
 to support.
 
 .. _devinstall:
@@ -63,7 +63,7 @@ clone your fork. The package can then be installed in development mode by doing:
 The first command will install all dependencies needed by the Satpy
 conda-forge package, but won't actually install Satpy. The second command
 should be run from the root of the cloned Satpy repository (where the
-``setup.py`` is) and will install the actual package.
+``pyproject.toml`` is) and will install the actual package.
 
 You can now edit the python files in your cloned repository and have them
 immediately reflected in your conda environment.

--- a/doc/source/dev_guide/plugins.rst
+++ b/doc/source/dev_guide/plugins.rst
@@ -156,19 +156,6 @@ have a ``etc/`` directory in the root of the package structure. Even so,
 for future compatibility, it is best to use the name of the package directory
 on the right-hand side of the ``=``.
 
-.. warning::
-
-    Due to some limitations in setuptools you must also define a ``setup.py``
-    file in addition to ``pyproject.toml`` if you'd like to use "editable"
-    installations (``pip install -e .``). Once
-    `this setuptools issue <https://github.com/pypa/setuptools/issues/2816>`_
-    is resolved this won't be needed. For now this minimal ``setup.py`` will
-    work:
-
-    .. code-block:: python
-
-        from setuptools import setup
-        setup()
 
 **Alternative: setup.py**
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -86,7 +86,7 @@ To install the `satpy` package and the minimum amount of python dependencies:
 
 Additional dependencies can be installed as "extras" and are grouped by
 reader, writer, or feature added. Extras available can be found in the
-`setup.py <https://github.com/pytroll/satpy/blob/main/setup.py>`_ file.
+`pyproject.toml <https://github.com/pytroll/satpy/blob/main/pyproject.toml>`_ file.
 They can be installed individually:
 
 .. code-block:: bash


### PR DESCRIPTION
This PR removes outdated references to setup.py.

 - [x] Closes #2782 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
