### PR TITLE
Add an optional kwarg to CloudCompositor for RGBA output

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1033,8 +1033,10 @@ class RealisticColors(GenericCompositor):
 class CloudCompositor(GenericCompositor):
     """Detect clouds based on thresholding and use it as a mask for compositing."""
 
+    _supported_modes = ["LA", "RGBA"]
+
     def __init__(self, name, transition_min=258.15, transition_max=298.15,  # noqa: D417
-                 transition_gamma=3.0, invert_alpha=False, **kwargs):
+                 transition_gamma=3.0, invert_alpha=False, mode="LA", **kwargs):
         """Collect custom configuration values.
 
         Args:
@@ -1045,12 +1047,17 @@ class CloudCompositor(GenericCompositor):
             transition_gamma (float): Gamma correction to apply at the end
             invert_alpha (bool): Invert the alpha channel to make low data values transparent
                                  and high data values opaque.
+            mode (str, optional): Image mode to return.
+                                  This shall be "LA" (default) or "RGBA".
 
         """
         self.transition_min = transition_min
         self.transition_max = transition_max
         self.transition_gamma = transition_gamma
         self.invert_alpha = invert_alpha
+        if mode not in self._supported_modes:
+            raise ValueError(f"Invalid mode {mode!s}.  Supported modes: " + ", ".join(self._supported_modes))
+        self.mode = mode
         super(CloudCompositor, self).__init__(name, **kwargs)
 
     def __call__(self, projectables, **kwargs):
@@ -1077,7 +1084,10 @@ class CloudCompositor(GenericCompositor):
 
         # gamma adjustment
         alpha **= gamma
-        res = super(CloudCompositor, self).__call__((data, alpha), **kwargs)
+        if self.mode == "LA":
+            res = super(CloudCompositor, self).__call__((data, alpha), **kwargs)
+        else:
+            res = super(CloudCompositor, self).__call__((data, data,data, alpha), **kwargs)
         return res
 
 

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -978,7 +978,7 @@ class TestCloudCompositor:
         """Test that errors are raised for invalid settings."""
         from satpy.composites import CloudCompositor
         with pytest.raises(ValueError, match="Invalid mode RGB.  Supported modes: LA, RGBA"):
-            res = CloudCompositor("test", mode="RGB")
+            _ = CloudCompositor("test", mode="RGB")
 
 
 class TestPrecipCloudsCompositor(unittest.TestCase):

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -952,6 +952,35 @@ class TestCloudCompositorCommonMask:
         np.testing.assert_raises(ValueError, self.colormap_composite, [data])
 
 
+class TestCloudCompositor:
+    """Test CloudCompositor."""
+
+    def setup_method(self):
+        """Create test data."""
+        self.data = xr.DataArray(da.from_array(np.array([[260, 290, 300], [250, 280, 300]])), dims=("y", "x"))
+
+    @pytest.mark.parametrize(
+        ("invert_alpha", "mode", "expected_alpha"),
+        [
+            (False, "LA", np.array([[0.8675683, 0.0084585, 0.0], [1.0, 0.0934222, 0.0]])),
+            (True, "RGBA", np.array([[0.0000989, 0.5048337, 1.0], [0.0, 0.162995, 1.0]]))
+        ]
+    )
+    def test_cloud_compositor(self, invert_alpha, mode, expected_alpha):
+        """Test general default functionality of compositor."""
+        from satpy.composites import CloudCompositor
+        comp = CloudCompositor(name="test", invert_alpha=invert_alpha, mode=mode)
+        res = comp([self.data])
+        assert res.attrs["mode"] == mode
+        np.testing.assert_almost_equal(res.values[len(mode) - 1], expected_alpha)
+
+    def test_cloud_compositor_validity_checks(self):
+        """Test that errors are raised for invalid settings."""
+        from satpy.composites import CloudCompositor
+        with pytest.raises(ValueError, match="Invalid mode RGB.  Supported modes: LA, RGBA"):
+            res = CloudCompositor("test", mode="RGB")
+
+
 class TestPrecipCloudsCompositor(unittest.TestCase):
     """Test the PrecipClouds compositor."""
 


### PR DESCRIPTION
Usually `CloudCompositor` produces an LA mode image. But sometimes you may want RGBA result. So this PR will add "mode" kwarg just like `MaskingCompositor`.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
