### PR TITLE
Activate LI L2 accumulated products gridding by default

### DIFF
--- a/satpy/readers/li_l2_nc.py
+++ b/satpy/readers/li_l2_nc.py
@@ -46,7 +46,7 @@ CHUNK_SIZE = get_legacy_chunk_size()
 class LIL2NCFileHandler(LINCFileHandler):
     """Implementation class for the unified LI L2 satpy reader."""
 
-    def __init__(self, filename, filename_info, filetype_info, with_area_definition=False):
+    def __init__(self, filename, filename_info, filetype_info, with_area_definition=True):
         """Initialize LIL2NCFileHandler."""
         super(LIL2NCFileHandler, self).__init__(filename, filename_info, filetype_info)
 

--- a/satpy/readers/li_l2_nc.py
+++ b/satpy/readers/li_l2_nc.py
@@ -13,34 +13,50 @@
 # You should have received a copy of the GNU General Public License
 # along with satpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""MTG Lightning Imager (LI) L2 unified reader.
+"""MTG Lightning Imager (LI) Level-2 (L2) unified reader.
 
 This reader supports reading all the products from the LI L2
 processing level:
 
+Point products:
   * L2-LE Lightning Events
   * L2-LEF Lightning Events Filtered
   * L2-LFL Lightning Flashes
   * L2-LGR Lightning Groups
+Accumulated products:
   * L2-AF Accumulated Flashes
   * L2-AFA Accumulated Flash Area
   * L2-AFR Accumulated Flash Radiance
 
-Point-based products (LE, LEF, LFL, LGR) are provided as 1-D arrays, with a ``pyresample.geometry.SwathDefinition`` area
+Per default, the unified LI L2 reader returns the data either as an 1-D array
+or as a 2-D array depending on the product type.
+
+Point-based products (LE, LEF, LFL, LGR) are "classic" lightning products
+consisting of values with attached latitude and longitude coordinates.
+Hence, these products are provided by the reader as 1-D arrays,
+with a ``pyresample.geometry.SwathDefinition`` area
 attribute containing the points lat-lon coordinates.
 
-Accumulated products (AF, AFA, AFR) are provided as 2-D arrays in the FCI 2km grid as per intended usage,
-with a ``pyresample.geometry.AreaDefinition`` area attribute containing the grid geolocation information.
+Accumulated products (AF, AFA, AFR) are the result of temporal accumulation
+of events (e.g. over 30 seconds), and are gridded in the FCI 2km geostationary
+projection grid, in order to facilitate the synergistic usage together with FCI.
+Compared to the point products, the gridded products also give information
+about the spatial extent of the lightning activity.
+Hence, these products are provided by the reader as 2-D arrays in the FCI 2km
+grid as per intended usage, with a ``pyresample.geometry.AreaDefinition`` area
+attribute containing the grid geolocation information.
 In this way, the products can directly be overlaid to FCI data.
-If needed, the products can still be accessed as 1-d array by setting the reader kwarg ``with_area_definition=False``,
-eg::
+If needed, the accumulated products can also be accessed as 1-d array by
+setting the reader kwarg ``with_area_definition=False``,
+e.g.::
 
   scn = Scene(filenames=filenames, reader="li_l2_nc", reader_kwargs={'with_area_definition': False})
 
-The lat-lon coordinates of the points/grid pixels can be accessed using e.g.
+For both 1-d and 2-d products, the lat-lon coordinates of the points/grid pixels
+can be accessed using e.g.
 ``scn['dataset_name'].attrs['area'].get_lonlats()``.
 
-See the LI L2 Product User Guide `PUG`_ for more information on the products.
+See the LI L2 Product User Guide `PUG`_ for more information.
 
 .. _PUG: https://www-dr.eumetsat.int/media/49348
 

--- a/satpy/readers/li_l2_nc.py
+++ b/satpy/readers/li_l2_nc.py
@@ -13,18 +13,36 @@
 # You should have received a copy of the GNU General Public License
 # along with satpy.  If not, see <http://www.gnu.org/licenses/>.
 
-"""MTG Lighting Imager (LI) L2 unified reader.
+"""MTG Lightning Imager (LI) L2 unified reader.
 
 This reader supports reading all the products from the LI L2
 processing level:
 
-  * L2-LE
-  * L2-LGR
-  * L2-AFA
-  * L2-LEF
-  * L2-LFL
-  * L2-AF
-  * L2-AFR
+  * L2-LE Lightning Events
+  * L2-LEF Lightning Events Filtered
+  * L2-LFL Lightning Flashes
+  * L2-LGR Lightning Groups
+  * L2-AF Accumulated Flashes
+  * L2-AFA Accumulated Flash Area
+  * L2-AFR Accumulated Flash Radiance
+
+Point-based products (LE, LEF, LFL, LGR) are provided as 1-D arrays, with a ``pyresample.geometry.SwathDefinition`` area
+attribute containing the points lat-lon coordinates.
+
+Accumulated products (AF, AFA, AFR) are provided as 2-D arrays in the FCI 2km grid as per intended usage,
+with a ``pyresample.geometry.AreaDefinition`` area attribute containing the grid geolocation information.
+In this way, the products can directly be overlaid to FCI data.
+If needed, the products can still be accessed as 1-d array by setting the reader kwarg ``with_area_definition=False``,
+eg::
+
+  scn = Scene(filenames=filenames, reader="li_l2_nc", reader_kwargs={'with_area_definition': False})
+
+The lat-lon coordinates of the points/grid pixels can be accessed using e.g.
+``scn['dataset_name'].attrs['area'].get_lonlats()``.
+
+See the LI L2 Product User Guide `PUG`_ for more information on the products.
+
+.. _PUG: https://www-dr.eumetsat.int/media/49348
 
 """
 

--- a/satpy/tests/reader_tests/test_li_l2_nc.py
+++ b/satpy/tests/reader_tests/test_li_l2_nc.py
@@ -174,7 +174,8 @@ class TestLIL2():
                 "end_time": "1000"
             }
 
-            handler = LIL2NCFileHandler("filename", filename_info, extract_filetype_info(filetype_infos, ftype))
+            handler = LIL2NCFileHandler("filename", filename_info, extract_filetype_info(filetype_infos, ftype),
+                                        with_area_definition=False)
             ds_desc = handler.ds_desc
 
             # retrieve the schema that what used to generate the content for that product:
@@ -480,7 +481,8 @@ class TestLIL2():
 
     def test_coordinates_projection(self, filetype_infos):
         """Should automatically generate lat/lon coords from projection data."""
-        handler = LIL2NCFileHandler("filename", {}, extract_filetype_info(filetype_infos, "li_l2_af_nc"))
+        handler = LIL2NCFileHandler("filename", {}, extract_filetype_info(filetype_infos, "li_l2_af_nc"),
+                                    with_area_definition=False)
 
         dsid = make_dataid(name="flash_accumulation")
         dset = handler.get_dataset(dsid)
@@ -492,7 +494,8 @@ class TestLIL2():
         with pytest.raises(NotImplementedError):
             handler.get_area_def(dsid)
 
-        handler = LIL2NCFileHandler("filename", {}, extract_filetype_info(filetype_infos, "li_l2_afr_nc"))
+        handler = LIL2NCFileHandler("filename", {}, extract_filetype_info(filetype_infos, "li_l2_afr_nc"),
+                                    with_area_definition=False)
 
         dsid = make_dataid(name="flash_radiance")
         dset = handler.get_dataset(dsid)
@@ -501,7 +504,8 @@ class TestLIL2():
         assert dset.attrs["coordinates"][0] == "longitude"
         assert dset.attrs["coordinates"][1] == "latitude"
 
-        handler = LIL2NCFileHandler("filename", {}, extract_filetype_info(filetype_infos, "li_l2_afa_nc"))
+        handler = LIL2NCFileHandler("filename", {}, extract_filetype_info(filetype_infos, "li_l2_afa_nc"),
+                                    with_area_definition=False)
 
         dsid = make_dataid(name="accumulated_flash_area")
         dset = handler.get_dataset(dsid)


### PR DESCRIPTION
This PR changes the default behaviour of the LI L2 reader, such that the accumulated products are delivered automatically as 2-d arrays.

**Background and current state**:
The LI L2 products consist of two types of products: 
- point products (LE, LEF, LFL, LGR): "classic" lightning products consisting of values with a lat-lon 
- accumulated (and gridded) products (AF, AFR, AFA): these products are the result of temporal accumulation (e.g. 30 seconds), and have been regridded to the FCI 2km grid by the ground processor, in order to facilitate the synergistic usage together with FCI.

Now, both products are actually stored in the NetCDF files as 1-d arrays. In the case of the accumulated products, each entry in the 1-d array corresponds to a specific pixel in the FCI grid (i.e. the corresponding column and row number are given in the file). 

The mapping of these points onto the FCI grid, to obtain a 2-d array with an `AreaDefinition`, is already implemented in the reader, but needs to be activated by passing the reader kwarg `with_area_definition=True`.  **The default value of this is currently set to `False`.** This is because, during the first implementation of the reader, it was decided to follow the rationale of "the reader shall return data as it's stored in the file and not modify it".

**Why do we want to change this (set `with_area_definition=True` as default)?**
The reasons are multiple:
- the accumulated products are designed and computed to be used in the grid. It is more intuitive for a user if the reader returns an accumulated product already in the 2-d grid, ready to be used, rather than a 1-d array that needs remapping in a specific way.
- activating the automatic regridding by default avoids the risk of users resampling the 1-d points to a 2-d grid with methods that can introduce artifacts (e.g. nearest or bilinear that introduce "pixel bleeding" effects)
- the usage of `reader_kwargs` through the `Scene` object is a rather advanced operation, and requires the user to fully find and understand the reader documentation, which is not always trivial. It also introduces an extra step that is otherwise not required in the standard Satpy API usage.
- It simplifies the usage and combination with FCI, e.g. by allowing the generation of multi-sensor composites out-of-the box with the same handling of the FCI data.
- Advanced users that would like to keep the data as 1-d arrays for further customised processing, can of course still do so via the `Scene` `reader_kwargs` interface.

For these reasons, we think that this is a good exception to the "reader doesn't modify data" guideline, since it applies an operation to the data that is anyway expected to be performed for the product to be usable, improving the user-friendliness.

Note that LI L2 accumulated products have not been widely distributed so far, and the most attention for these will start with the LI pre-operational dissemination (hopefully in a couple of months time), so we think it's a good time to introduce this now.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
