### PR TITLE
fixed DNB_SENZ file_key

### DIFF
--- a/satpy/etc/readers/viirs_l1b.yaml
+++ b/satpy/etc/readers/viirs_l1b.yaml
@@ -481,7 +481,7 @@ datasets:
     resolution: 743
     coordinates: [dnb_lon, dnb_lat]
     file_type: vgeod
-    file_key: geolocation_data/solar_zenith
+    file_key: geolocation_data/sensor_zenith
   DNB_LZA:
     name: dnb_lunar_zenith_angle
     standard_name: lunar_zenith_angle


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Changed DNB_SENZ file_key in viirs_l1b reader yaml from 'geolocation_data/solar_zenith' to 'geolocation_data/sensor_zenith'. 

 - [ ] Closes #2790
