### PR TITLE
Fix ABI L2 datasets when unitless and no calibration

### DIFF
--- a/satpy/readers/abi_l2_nc.py
+++ b/satpy/readers/abi_l2_nc.py
@@ -43,7 +43,7 @@ class NC_ABI_L2(NC_ABI_BASE):
         self._remove_problem_attrs(variable)
 
         # convert to satpy standard units
-        if variable.attrs["units"] == "1" and key["calibration"] == "reflectance":
+        if variable.attrs["units"] == "1" and key.get("calibration") == "reflectance":
             variable *= 100.0
             variable.attrs["units"] = "%"
 


### PR DESCRIPTION
Simple fix to handle the case of non-reflectance data triggering a KeyError. See #2765.

 - [x] Closes #2765 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

