### PR TITLE
Add missing coverage configuration section to pyproject.toml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,6 +102,7 @@ jobs:
         shell: bash -l {0}
         run: |
           git config --global --add safe.directory /github/workspace
+          git config --local --add safe.directory /github/workspace
           python -m pip install --no-deps -e .
 
       - name: Run unit tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,6 +121,7 @@ jobs:
         with:
           flag-name: run-${{ matrix.test_number }}
           parallel: true
+          debug: true
         if: runner.os == 'Linux'
 
       - name: Run behaviour tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,8 +101,6 @@ jobs:
       - name: Install satpy
         shell: bash -l {0}
         run: |
-          git config --global --add safe.directory /github/workspace
-          git config --local --add safe.directory /github/workspace
           python -m pip install --no-deps -e .
 
       - name: Run unit tests
@@ -119,12 +117,10 @@ jobs:
           env_vars: OS,PYTHON_VERSION,UNSTABLE
 
       - name: Coveralls Parallel
-#        uses: AndreMiras/coveralls-python-action@develop
-        uses: djhoese/coveralls-python-action@git-safe-dir
+        uses: AndreMiras/coveralls-python-action@develop
         with:
           flag-name: run-${{ matrix.test_number }}
           parallel: true
-          debug: true
         if: runner.os == 'Linux'
 
       - name: Run behaviour tests
@@ -146,7 +142,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-#        uses: AndreMiras/coveralls-python-action@develop
-        uses: djhoese/coveralls-python-action@git-safe-dir
+        uses: AndreMiras/coveralls-python-action@develop
         with:
           parallel-finished: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,7 +117,7 @@ jobs:
           env_vars: OS,PYTHON_VERSION,UNSTABLE
 
       - name: Coveralls Parallel
-        uses: AndreMiras/coveralls-python-action@develop
+        uses: djhoese/coveralls-python-action@git-safe-dir
         with:
           flag-name: run-${{ matrix.test_number }}
           parallel: true
@@ -142,6 +142,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-        uses: AndreMiras/coveralls-python-action@develop
+        uses: djhoese/coveralls-python-action@git-safe-dir
         with:
           parallel-finished: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,8 +34,6 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
-        run: |
-          git config --global --add safe.directory /github/workspace
 
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3
@@ -103,6 +101,7 @@ jobs:
       - name: Install satpy
         shell: bash -l {0}
         run: |
+          git config --global --add safe.directory /github/workspace
           python -m pip install --no-deps -e .
 
       - name: Run unit tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,7 +117,7 @@ jobs:
           env_vars: OS,PYTHON_VERSION,UNSTABLE
 
       - name: Coveralls Parallel
-        uses: AndreaMiras/coveralls-python-action@develop
+        uses: AndreMiras/coveralls-python-action@develop
         with:
           flag-name: run-${{ matrix.test_number }}
           parallel: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,7 +119,8 @@ jobs:
           env_vars: OS,PYTHON_VERSION,UNSTABLE
 
       - name: Coveralls Parallel
-        uses: AndreMiras/coveralls-python-action@develop
+#        uses: AndreMiras/coveralls-python-action@develop
+        uses: djhoese/coveralls-python-action@git-safe-dir
         with:
           flag-name: run-${{ matrix.test_number }}
           parallel: true
@@ -145,6 +146,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-        uses: AndreMiras/coveralls-python-action@develop
+#        uses: AndreMiras/coveralls-python-action@develop
+        uses: djhoese/coveralls-python-action@git-safe-dir
         with:
           parallel-finished: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -117,7 +117,7 @@ jobs:
           env_vars: OS,PYTHON_VERSION,UNSTABLE
 
       - name: Coveralls Parallel
-        uses: djhoese/coveralls-python-action@git-safe-dir
+        uses: AndreaMiras/coveralls-python-action@develop
         with:
           flag-name: run-${{ matrix.test_number }}
           parallel: true
@@ -143,6 +143,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Coveralls Finished
-        uses: djhoese/coveralls-python-action@git-safe-dir
+        uses: AndreMiras/coveralls-python-action@develop
         with:
           parallel-finished: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v4
+        run: |
+          git config --global --add safe.directory /github/workspace
 
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,6 +123,7 @@ jobs:
         with:
           flag-name: run-${{ matrix.test_number }}
           parallel: true
+          debug: true
         if: runner.os == 'Linux'
 
       - name: Run behaviour tests

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,7 +121,6 @@ jobs:
         with:
           flag-name: run-${{ matrix.test_number }}
           parallel: true
-          debug: true
         if: runner.os == 'Linux'
 
       - name: Run behaviour tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,3 +145,7 @@ convention = "google"
 [tool.ruff.lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
+
+[tool.coverage.run]
+relative_files = true
+omit = ["satpy/version.py"]


### PR DESCRIPTION
CI was failing to upload coveralls for two reasons:

1. When we moved to pyproject.toml one of the config sections regarding coverage was forgotten.
2. A new security feature in git was causing the coveralls action to fail. I've fixed this upstream.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
