### PR TITLE
Fix LI L2 accumulated products `'with_area_definition': False` 1-d coordinates computation

### DIFF
--- a/satpy/readers/li_base_nc.py
+++ b/satpy/readers/li_base_nc.py
@@ -371,6 +371,9 @@ class LINCFileHandler(NetCDF4FsspecFileHandler):
         azimuth = azimuth.values * point_height
         elevation = elevation.values * point_height
 
+        # In the MTG world, azimuth is defined as positive towards west, while proj expects it positive towards east
+        azimuth *= -1
+
         lon, lat = projection(azimuth, elevation, inverse=True)
 
         return np.stack([lon.astype(azimuth.dtype), lat.astype(elevation.dtype)])

--- a/satpy/readers/li_l2_nc.py
+++ b/satpy/readers/li_l2_nc.py
@@ -73,7 +73,7 @@ class LIL2NCFileHandler(LINCFileHandler):
         if var_with_swath_coord and self.with_area_def:
             return get_area_def("mtg_fci_fdss_2km")
 
-        raise NotImplementedError("Area definition is not supported for accumulated products.")
+        raise NotImplementedError("Area definition is not supported for non-accumulated products.")
 
     def is_var_with_swath_coord(self, dsid):
         """Check if the variable corresponding to this dataset is listed as variable with swath coordinates."""

--- a/satpy/tests/reader_tests/_li_test_utils.py
+++ b/satpy/tests/reader_tests/_li_test_utils.py
@@ -521,9 +521,13 @@ def accumulation_dimensions(nacc, nobs):
 
 def fci_grid_definition(axis, nobs):
     """FCI grid definition on X or Y axis."""
+    scale_factor = 5.58871526031607e-5
+    add_offset = -0.15561777642350116
     if axis == "X":
         long_name = "azimuth angle encoded as column"
         standard_name = "projection_x_coordinate"
+        scale_factor *= -1
+        add_offset *= -1
     else:
         long_name = "zenith angle encoded as row"
         standard_name = "projection_y_coordinate"
@@ -531,10 +535,10 @@ def fci_grid_definition(axis, nobs):
     return {
         "format": "i2",
         "shape": ("pixels",),
-        "add_offset": -0.155619516,
+        "add_offset": add_offset,
         "axis": axis,
         "long_name": long_name,
-        "scale_factor": 5.58878e-5,
+        "scale_factor": scale_factor,
         "standard_name": standard_name,
         "units": "radian",
         "valid_range": np.asarray([1, 5568]),
@@ -548,12 +552,12 @@ def mtg_geos_projection():
         "format": "i4",
         "shape": ("accumulations",),
         "grid_mapping_name": "geostationary",
-        "inverse_flattening": 298.2572221,
+        "inverse_flattening": 298.257223563,
         "latitude_of_projection_origin": 0,
         "longitude_of_projection_origin": 0,
-        "perspective_point_height": 42164000,
-        "semi_major_axis": 6378169,
-        "semi_minor_axis": 6356583.8,
+        "perspective_point_height": 3.57864e7,
+        "semi_major_axis": 6378137.0,
+        "semi_minor_axis": 6356752.31424518,
         "sweep_angle_axis": "y",
         "long_name": "MTG geostationary projection",
         "default_data": lambda: -2147483647

--- a/satpy/tests/reader_tests/test_li_l2_nc.py
+++ b/satpy/tests/reader_tests/test_li_l2_nc.py
@@ -651,7 +651,7 @@ class TestLIL2():
         cols = x.astype(int) - 1
         rows = (LI_GRID_SHAPE[0] - y.astype(int))
 
-        # compute lonlat from 1-d coords generation
+        # compute lonlat from 1-d coords generation (called when with_area_definition==False)
         handler.generate_coords_from_scan_angles()
         lon = handler.internal_variables["longitude"].values
         lat = handler.internal_variables["latitude"].values

--- a/satpy/tests/reader_tests/test_li_l2_nc.py
+++ b/satpy/tests/reader_tests/test_li_l2_nc.py
@@ -639,29 +639,29 @@ class TestLIL2():
             np.testing.assert_equal(lon, lon_ref)
             np.testing.assert_equal(lat, lat_ref)
 
-
     def test_coords_and_grid_consistency(self, filetype_infos):
         """Compare computed latlon coords for 1-d version with latlon from areadef as for the gridded version."""
         handler = LIL2NCFileHandler("filename", {}, extract_filetype_info(filetype_infos, "li_l2_af_nc"),
-                                with_area_definition=True)
+                                    with_area_definition=True)
 
-        # Get azimuth/elevation arrays from handler
+        # Get cols/rows arrays from handler
         x = handler.get_measured_variable(handler.swath_coordinates["azimuth"])
         y = handler.get_measured_variable(handler.swath_coordinates["elevation"])
+        cols = x.astype(int) - 1
+        rows = (LI_GRID_SHAPE[0] - y.astype(int))
 
+        # compute lonlat from 1-d coords generation
         handler.generate_coords_from_scan_angles()
         lon = handler.internal_variables["longitude"].values
         lat = handler.internal_variables["latitude"].values
 
+        # compute lonlat from 2-d areadef
         dsid = make_dataid(name="flash_accumulation")
         area_def = handler.get_area_def(dsid)
-        rows = (LI_GRID_SHAPE[0] - y.astype(int))
-        cols = x.astype(int) - 1
         lon_areadef, lat_areadef = area_def.get_lonlat_from_array_coordinates(cols, rows)
 
         np.testing.assert_allclose(lon, lon_areadef, rtol=1e-3)
         np.testing.assert_allclose(lat, lat_areadef, rtol=1e-3)
-
 
     def test_get_area_def_acc_products(self, filetype_infos):
         """Test retrieval of area def for accumulated products."""

--- a/satpy/tests/reader_tests/test_li_l2_nc.py
+++ b/satpy/tests/reader_tests/test_li_l2_nc.py
@@ -600,10 +600,11 @@ class TestLIL2():
             handler = LIL2NCFileHandler("filename", {}, extract_filetype_info(filetype_infos, prod))
 
             # Get azimuth/elevation arrays from handler
-            x = handler.get_measured_variable(handler.swath_coordinates["azimuth"])
-            azimuth = handler.apply_use_rescaling(x)
-            y = handler.get_measured_variable(handler.swath_coordinates["elevation"])
-            elevation = handler.apply_use_rescaling(y)
+            azimuth = handler.get_measured_variable(handler.swath_coordinates["azimuth"])
+            azimuth = handler.apply_use_rescaling(azimuth)
+
+            elevation = handler.get_measured_variable(handler.swath_coordinates["elevation"])
+            elevation = handler.apply_use_rescaling(elevation)
 
             # Initialize proj_dict
             proj_var = handler.swath_coordinates["projection"]

--- a/satpy/tests/reader_tests/test_li_l2_nc.py
+++ b/satpy/tests/reader_tests/test_li_l2_nc.py
@@ -627,6 +627,7 @@ class TestLIL2():
             projection = Proj(proj_dict)
             azimuth_vals = azimuth.values * point_height
             elevation_vals = elevation.values * point_height
+            azimuth_vals *= -1
             lon_ref, lat_ref = projection(azimuth_vals, elevation_vals, inverse=True)
             # Convert to float32:
             lon_ref = lon_ref.astype(np.float32)


### PR DESCRIPTION
This PR fixes a bug in the `li_l2_nc` reader when requesting accumulated products as 1-d arrays (by using `reader_kwargs={'with_area_definition': False}`).  *Note that it is anyway recommended to request accumulated products as 2-d arrays using `reader_kwargs={'with_area_definition': True}` (as discussed in https://github.com/pytroll/satpy/pull/2789).*

The bug was due to a missing `*= -1` on the azimuth geos angle coordinate (used inside the 1-d coordinates calculation), needed to account for a convention difference between MTG data and Proj. Without this fix, the coordinates (particularly the longitude) are computed with fully wrong values.

This PR fixes this issue and adds a test to check the consistency between the 1-d computed coordinates and the according coordinates extracted from the 2-d arrays with `AreaDefinition`. Before this fix this test would have failed.
It also updates the test filecontents for more realistic tests.

 - [x] Tests added <!-- for all bug fixes or enhancements -->

Checking the reader on a real-life case, comparing the resampled 1-d arrays and the 2-d arrays:

Before this PR, the lightning data is at fully wrong locations (left: resampled 1-d arrays, right: 2-d):
![image](https://github.com/pytroll/satpy/assets/49722768/70724a60-04e1-4e69-84e8-a551a0318d49)

After this PR, the results are comparable (left: resampled 1-d arrays, right: 2-d)::
![image](https://github.com/pytroll/satpy/assets/49722768/f4c31782-e9af-42df-a4cd-d3039ce13327)

According code:
```python
from satpy import Scene
from glob import glob
import matplotlib.pyplot as plt
import os
import numpy as np
from satpy.utils import debug_on;

debug_on()
from satpy.writers import get_enhanced_image
import matplotlib

matplotlib.use("TkAgg")

ll_bbox = [33, 13, 60, 27]

# # initialise SEVIRI Scene
sevscn = Scene(
    filenames=['/tcenas/fbf/MSG/in/MSG3/OPE3/SEVI-MSG15/MSG3-SEVI-MSG15-0100-NA-20240501121242.333000000Z-NA.nat'],
    reader='seviri_l1b_native')
sevscn.load(['natural_color'])
sevscn_r = sevscn.resample('mtg_fci_fdss_2km', resampler='nearest')
sevscn_r = sevscn_r.crop(ll_bbox=ll_bbox)
seviri_img = np.moveaxis(get_enhanced_image(sevscn_r['natural_color']).data.values, 0, -1)

# initialise LI L2 acc product scene as 1-d array output
path_to_testdata = '/tcenas/scratch/andream/lil2a/'
scn = Scene(filenames=glob(os.path.join(path_to_testdata, '*AF*---*T_0073_0001.nc')), reader='li_l2_nc',
            reader_kwargs={'with_area_definition': False})
scn.load(['flash_accumulation'])
# resample 1-d array onto grid
scn_r = scn.resample('mtg_fci_fdss_2km', resampler='bucket_avg')
scn_r_c = scn_r.crop(ll_bbox=ll_bbox)

# plot resampled 1-d arrays on top of SEVIRI
crs = scn_r_c["flash_accumulation"].attrs['area'].to_cartopy_crs()
fig, axs = plt.subplots(1, 2, subplot_kw={'projection': crs})
ax = axs[0]
ax.coastlines(resolution='10m')

ax.imshow(seviri_img, transform=crs, extent=crs.bounds, origin='upper',
          interpolation='none')
ax.imshow(scn_r_c["flash_accumulation"], transform=crs, extent=crs.bounds, origin='upper',
          interpolation='none')


# initialise LI L2 acc product scene as 2-d array output (recommended, does not require resampling)
scn_adef = Scene(filenames=glob(os.path.join(path_to_testdata, '*AF*---*T_0073_0001.nc')), reader='li_l2_nc',
            reader_kwargs={'with_area_definition': True})
scn_adef.load(['flash_accumulation'], upper_right_corner='NE')
scn_adef_c = scn_adef.crop(ll_bbox=ll_bbox)

# plot 2d-array on top of SEVIRI
crs = scn_adef_c["flash_accumulation"].attrs['area'].to_cartopy_crs()
ax = axs[1]
ax.coastlines(resolution='10m')

ax.imshow(seviri_img, transform=crs, extent=crs.bounds, origin='upper',
          interpolation='none')
ax.imshow(scn_adef_c["flash_accumulation"], transform=crs, extent=crs.bounds, origin='upper',
          interpolation='none')

plt.show(block=False)
```
