### PR TITLE
Update the vii_l1b-reader, for new testdata format of VII

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -90,3 +90,4 @@ The following people have made contributions to this project:
 - [Yufei Zhu (yufeizhu600)](https://github.com/yufeizhu600)
 - [Youva Aoun (YouvaEUMex)](https://github.com/YouvaEUMex)
 - [Will Sharpe (wjsharpe)](https://github.com/wjsharpe)
+- [Sara Hörnquist (shornqui)](https://github.com/shornqui)

--- a/satpy/readers/vii_l1b_nc.py
+++ b/satpy/readers/vii_l1b_nc.py
@@ -47,7 +47,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
         self._bt_conversion_a = self["data/calibration_data/bt_conversion_a"].values
         self._bt_conversion_b = self["data/calibration_data/bt_conversion_b"].values
         self._channel_cw_thermal = self["data/calibration_data/channel_cw_thermal"].values
-        self._integrated_solar_irradiance = self["data/calibration_data/Band_averaged_solar_irradiance"].values
+        self._integrated_solar_irradiance = self["data/calibration_data/band_averaged_solar_irradiance"].values
         # Computes the angle factor for reflectance calibration as inverse of cosine of solar zenith angle
         # (the values in the product file are on tie points and in degrees,
         # therefore interpolation and conversion to radians are required)

--- a/satpy/tests/reader_tests/test_vii_l1b_nc.py
+++ b/satpy/tests/reader_tests/test_vii_l1b_nc.py
@@ -68,7 +68,7 @@ class TestViiL1bNCFileHandler(unittest.TestCase):
             bt_b[:] = np.arange(9)
             cw = g1_1.createVariable("channel_cw_thermal", np.float32, dimensions=("num_chan_thermal",))
             cw[:] = np.arange(9)
-            isi = g1_1.createVariable("Band_averaged_solar_irradiance", np.float32, dimensions=("num_chan_solar",))
+            isi = g1_1.createVariable("band_averaged_solar_irradiance", np.float32, dimensions=("num_chan_solar",))
             isi[:] = np.arange(11)
 
             # Create measurement_data group


### PR DESCRIPTION
EUMETSAT has updated the EPS-SG testdata for VII (METimage), to version 2.1. There is one variable in the netCDF-file that has changed names. Because of that the VII-level1b-reader needs to be update.
(I have also checked with EUMETSAT, this change is meant to stay -the old variable name was a bug.)

There were no need to add new tests, but there was an updated test, due to this change.


<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
