### PR TITLE
Add generic calibration coefficient selector

### DIFF
--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -474,3 +474,93 @@ def remove_earthsun_distance_correction(reflectance, utc_date=None):
     with xr.set_options(keep_attrs=True):
         reflectance = reflectance / reflectance.dtype.type(sun_earth_dist * sun_earth_dist)
     return reflectance
+
+
+class CalibrationCoefficientSelector:
+    """Helper for choosing coefficients out of multiple options."""
+
+    def __init__(self, coefs, modes=None, default="nominal", fallback=None, refl_threshold=1):
+        """Initialize the coefficient selector.
+
+        Args:
+            coefs (dict): One set of calibration coefficients for each calibration
+                mode, for example ::
+
+                    {
+                        "nominal": {
+                            "ch1": nominal_coefs_ch1,
+                            "ch2": nominal_coefs_ch2
+                        },
+                        "gsics": {
+                            "ch2": gsics_coefs_ch2
+                        }
+                    }
+
+                The actual coefficients can be of any type (reader-specific).
+
+            modes (dict): Desired calibration modes per channel type ::
+
+                    {
+                        "reflective": "nominal",
+                        "emissive": "gsics"
+                    }
+
+                or per channel ::
+
+                    {
+                        "VIS006": "nominal",
+                        "IR_108": "gsics"
+                    }
+
+            default (str): Default coefficients to be used if no mode has been
+                specified. Default: "nominal".
+            fallback (str): Fallback coefficients if the desired coefficients
+                are not available for some channel.
+            refl_threshold: Central wavelengths below/above this threshold are
+                considered reflective/emissive. Default is 1um.
+        """
+        self.coefs = coefs
+        self.modes = modes or {}
+        self.default = default
+        self.fallback = fallback
+        self.refl_threshold = refl_threshold
+        if self.default not in self.coefs:
+            raise KeyError("Need at least default coefficients")
+        if self.fallback and self.fallback not in self.coefs:
+            raise KeyError("No fallback coefficients")
+
+    def get_coefs(self, dataset_id):
+        """Get calibration coefficients for the given dataset.
+
+        Args:
+            dataset_id (DataID): Desired dataset
+        """
+        mode = self._get_mode(dataset_id)
+        return self._get_coefs(dataset_id, mode)
+
+    def _get_coefs(self, dataset_id, mode):
+        ds_name = dataset_id["name"]
+        try:
+            return self.coefs[mode][ds_name]
+        except KeyError:
+            if self.fallback:
+                return self.coefs[self.fallback][ds_name]
+            raise KeyError(f"No calibration coefficients for {ds_name}")
+
+    def _get_mode(self, dataset_id):
+        try:
+            return self._get_mode_for_channel(dataset_id)
+        except KeyError:
+            return self._get_mode_for_channel_type(dataset_id)
+
+    def _get_mode_for_channel(self, dataset_id):
+        return self.modes[dataset_id["name"]]
+
+    def _get_mode_for_channel_type(self, dataset_id):
+        ch_type = self._get_channel_type(dataset_id)
+        return self.modes.get(ch_type, self.default)
+
+    def _get_channel_type(self, dataset_id):
+        if dataset_id["wavelength"].central < self.refl_threshold:
+            return "reflective"
+        return "emissive"

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -582,8 +582,6 @@ class CalibrationCoefficientPicker:
 
     .. code-block:: python
 
-        from satpy.readers.utils import CalibrationCoefficientPicker
-
         coefs = {
             "nominal": {
                 "ch1": 1.0,
@@ -605,6 +603,7 @@ class CalibrationCoefficientPicker:
 
     .. code-block:: python
 
+        >>> from satpy.readers.utils import CalibrationCoefficientPicker
         >>> picker = CalibrationCoefficientPicker(coefs, calib_wishlist)
         >>> picker.get_coefs("ch1")
         {"coefs": 1.0, "mode": "meirink"}
@@ -623,6 +622,7 @@ class CalibrationCoefficientPicker:
 
         >>> picker = CalibrationCoefficientPicker(coefs, calib_wishlist, fallback="nominal")
         >>> picker.get_coefs("ch3")
+        WARNING No gsics calibration coefficients for ch3. Falling back to nominal.
         {"coefs": 3.0, "mode": "nominal"}
 
     """

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -552,7 +552,7 @@ class _CalibrationCoefficientParser:
             return flat[channel]
 
 
-class CalibrationCoefficientSelector:
+class CalibrationCoefficientPicker:
     """Helper for choosing coefficients out of multiple options.
 
     Example: Three sets of coefficients are available (nominal, meirink, gsics).
@@ -566,7 +566,7 @@ class CalibrationCoefficientSelector:
 
     .. code-block:: python
 
-        from satpy.readers.utils import CalibrationCoefficientSelector
+        from satpy.readers.utils import CalibrationCoefficientPicker
 
         coefs = {
             "nominal": {
@@ -594,29 +594,29 @@ class CalibrationCoefficientSelector:
 
     .. code-block:: python
 
-        >>> s = CalibrationCoefficientSelector(coefs, calib_wishlist)
-        >>> s.get_coefs("ch1")
+        >>> picker = CalibrationCoefficientPicker(coefs, calib_wishlist)
+        >>> picker.get_coefs("ch1")
         "meirink_ch1"
-        >>> s.get_coefs("ch2")
+        >>> picker.get_coefs("ch2")
         "gsics_ch2"
-        >>> s.get_coefs("ch3")
+        >>> picker.get_coefs("ch3")
         KeyError: 'No gsics calibration coefficients for ch3'
-        >>> s.get_coefs("ch4")
+        >>> picker.get_coefs("ch4")
         {"mygain": 123}
-        >>> s.get_coefs("ch5")
+        >>> picker.get_coefs("ch5")
         "nominal_ch5
 
     3. Fallback to nominal for ch3:
 
     .. code-block:: python
 
-        >>> s = CalibrationCoefficientSelector(coefs, calib_wishlist, fallback="nominal")
-        >>> s.get_coefs("ch3")
+        >>> picker = CalibrationCoefficientPicker(coefs, calib_wishlist, fallback="nominal")
+        >>> picker.get_coefs("ch3")
         "nominal_ch3"
     """
 
     def __init__(self, coefs, calib_wishlist, default="nominal", fallback=None):
-        """Initialize the coefficient selector.
+        """Initialize the coefficient picker.
 
         Args:
             coefs (dict): One set of calibration coefficients for each

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -535,7 +535,9 @@ class CalibrationCoefficientSelector:
             coefs (dict): One set of calibration coefficients for each
                 calibration mode. The actual coefficients can be of any type
                 (reader-specific).
-            modes (dict): Desired calibration modes
+            modes (str or dict): Desired calibration modes. Use a dictionary
+                `{mode: channels}` to specify multiple modes. Use a string to
+                 specify one mode for all channels.
             default (str): Default coefficients to be used if no mode has been
                 specified. Default: "nominal".
             fallback (str): Fallback coefficients if the desired coefficients
@@ -549,6 +551,18 @@ class CalibrationCoefficientSelector:
             raise KeyError("Need at least default coefficients")
         if self.fallback and self.fallback not in self.coefs:
             raise KeyError("No fallback coefficients")
+        self.modes = self._make_modes(modes)
+
+    def _make_modes(self, modes):
+        if modes is None:
+            return {}
+        elif self._same_mode_for_all_channels(modes):
+            all_channels = self.coefs[self.default].keys()
+            return {modes: all_channels}
+        return modes
+
+    def _same_mode_for_all_channels(self, modes):
+        return isinstance(modes, str)
 
     def get_coefs(self, channel):
         """Get calibration coefficients for the given channel.

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -545,7 +545,7 @@ class CalibrationCoefficientSelector:
         except KeyError:
             if self.fallback:
                 return self.coefs[self.fallback][ds_name]
-            raise KeyError(f"No calibration coefficients for {ds_name}")
+            raise KeyError(f"No {mode} calibration coefficients for {ds_name}")
 
     def _get_mode(self, dataset_id):
         try:

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -487,7 +487,6 @@ class CalibrationCoefficientSelector:
     .. code-block:: python
 
         from satpy.readers.utils import CalibrationCoefficientSelector
-        from satpy.tests.utils import make_dataid
 
         coefs = {
             "nominal": {
@@ -508,20 +507,16 @@ class CalibrationCoefficientSelector:
             "gsics": ["ch2", "ch3"]
         }
 
-        ch1 = make_dataid(name="ch1")
-        ch2 = make_dataid(name="ch2")
-        ch3 = make_dataid(name="ch3")
-
     2. Query:
 
     .. code-block:: python
 
         >>> s = CalibrationCoefficientSelector(coefs, modes)
-        >>> s.get_coefs(ch1)
+        >>> s.get_coefs("ch1")
         "meirink_ch1"
-        >>> s.get_coefs(ch2)
+        >>> s.get_coefs("ch2")
         "gsics_ch2"
-        >>> s.get_coefs(ch3)
+        >>> s.get_coefs("ch3")
         KeyError: 'No gsics calibration coefficients for ch3'
 
     3. Fallback to nominal for ch3:
@@ -529,7 +524,7 @@ class CalibrationCoefficientSelector:
     .. code-block:: python
 
         >>> s = CalibrationCoefficientSelector(coefs, modes, fallback="nominal")
-        >>> s.get_coefs(ch3)
+        >>> s.get_coefs("ch3")
         "nominal_ch3"
     """
 
@@ -555,26 +550,25 @@ class CalibrationCoefficientSelector:
         if self.fallback and self.fallback not in self.coefs:
             raise KeyError("No fallback coefficients")
 
-    def get_coefs(self, dataset_id):
-        """Get calibration coefficients for the given dataset.
+    def get_coefs(self, channel):
+        """Get calibration coefficients for the given channel.
 
         Args:
-            dataset_id (DataID): Desired dataset
+            channel (str): Channel name
         """
-        mode = self._get_mode(dataset_id)
-        return self._get_coefs(dataset_id, mode)
+        mode = self._get_mode(channel)
+        return self._get_coefs(channel, mode)
 
-    def _get_coefs(self, dataset_id, mode):
-        ds_name = dataset_id["name"]
+    def _get_coefs(self, channel, mode):
         try:
-            return self.coefs[mode][ds_name]
+            return self.coefs[mode][channel]
         except KeyError:
             if self.fallback:
-                return self.coefs[self.fallback][ds_name]
-            raise KeyError(f"No {mode} calibration coefficients for {ds_name}")
+                return self.coefs[self.fallback][channel]
+            raise KeyError(f"No {mode} calibration coefficients for {channel}")
 
-    def _get_mode(self, dataset_id):
+    def _get_mode(self, channel):
         for mode, channels in self.modes.items():
-            if dataset_id["name"] in channels:
+            if channel in channels:
                 return mode
         return self.default

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -584,7 +584,7 @@ class TestCalibrationCoefficientSelector:
         """Test handling of missing coefficients."""
         calib_modes = {"reflective": "mode2"}
         s = CalibrationCoefficientSelector(coefs, calib_modes)
-        with pytest.raises(KeyError, match="No calibration *"):
+        with pytest.raises(KeyError, match="No mode2 calibration *"):
             s.get_coefs(ch1)
 
     def test_fallback_to_nominal(self, coefs, ch1):

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -35,7 +35,6 @@ from pyproj import CRS
 from satpy.readers import FSFile
 from satpy.readers import utils as hf
 from satpy.readers.utils import CalibrationCoefficientSelector
-from satpy.tests.utils import make_dataid
 
 
 class TestHelpers(unittest.TestCase):
@@ -535,17 +534,6 @@ class TestCalibrationCoefficientSelector:
             }
         }
 
-    @pytest.fixture(name="ch1")
-    def fixture_ch1(self):
-        """Make fake data ID."""
-        return make_dataid(name="ch1")
-
-    @pytest.fixture(name="dataset_ids")
-    def fixture_dataset_ids(self, ch1):
-        """Make fake data IDs."""
-        ch2 = make_dataid(name="ch2")
-        return [ch1, ch2]
-
     @pytest.mark.parametrize(
         ("calib_modes", "expected"),
         [
@@ -567,27 +555,27 @@ class TestCalibrationCoefficientSelector:
             ),
         ]
     )
-    def test_get_coefs(self, dataset_ids, coefs, calib_modes, expected):
+    def test_get_coefs(self, coefs, calib_modes, expected):
         """Test getting calibration coefficients."""
         s = CalibrationCoefficientSelector(coefs, calib_modes)
         coefs = {
-            dataset_id["name"]: s.get_coefs(dataset_id)
-            for dataset_id in dataset_ids
+            channel: s.get_coefs(channel)
+            for channel in ["ch1", "ch2"]
         }
         assert coefs == expected
 
-    def test_missing_coefs(self, coefs, ch1):
+    def test_missing_coefs(self, coefs):
         """Test handling of missing coefficients."""
         calib_modes = {"mode2": ["ch1"]}
         s = CalibrationCoefficientSelector(coefs, calib_modes)
         with pytest.raises(KeyError, match="No mode2 calibration *"):
-            s.get_coefs(ch1)
+            s.get_coefs("ch1")
 
-    def test_fallback_to_nominal(self, coefs, ch1):
+    def test_fallback_to_nominal(self, coefs):
         """Test falling back to nominal coefficients."""
         calib_modes = {"mode2": ["ch1"]}
         s = CalibrationCoefficientSelector(coefs, calib_modes, fallback="nominal")
-        assert s.get_coefs(ch1) == "nominal_ch1"
+        assert s.get_coefs("ch1") == "nominal_ch1"
 
     def test_no_default_coefs(self):
         """Test initialization without default coefficients."""

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -538,16 +538,12 @@ class TestCalibrationCoefficientSelector:
     @pytest.fixture(name="ch1")
     def fixture_ch1(self):
         """Make fake data ID."""
-        return make_dataid(name="ch1", wavelength=(0.6, 0.7, 0.8))
-
-    @pytest.fixture(name="ch2")
-    def fixture_ch2(self):
-        """Make fake data ID."""
-        return make_dataid(name="ch2", wavelength=(10, 11, 12))
+        return make_dataid(name="ch1")
 
     @pytest.fixture(name="dataset_ids")
-    def fixture_dataset_ids(self, ch1, ch2):
+    def fixture_dataset_ids(self, ch1):
         """Make fake data IDs."""
+        ch2 = make_dataid(name="ch2")
         return [ch1, ch2]
 
     @pytest.mark.parametrize(
@@ -558,16 +554,16 @@ class TestCalibrationCoefficientSelector:
                 {"ch1": "nominal_ch1", "ch2": "nominal_ch2"}
             ),
             (
-                {"reflective": "mode1"},
+                {"nominal": ["ch1", "ch2"]},
+                {"ch1": "nominal_ch1", "ch2": "nominal_ch2"}
+            ),
+            (
+                {"mode1": ["ch1"]},
                 {"ch1": "mode1_ch1", "ch2": "nominal_ch2"}
             ),
             (
-                {"reflective": "mode1", "emissive": "mode2"},
+                {"mode1": ["ch1"], "mode2": ["ch2"]},
                 {"ch1": "mode1_ch1", "ch2": "mode2_ch2"}
-            ),
-            (
-                {"ch1": "mode1"},
-                {"ch1": "mode1_ch1", "ch2": "nominal_ch2"}
             ),
         ]
     )
@@ -582,14 +578,14 @@ class TestCalibrationCoefficientSelector:
 
     def test_missing_coefs(self, coefs, ch1):
         """Test handling of missing coefficients."""
-        calib_modes = {"reflective": "mode2"}
+        calib_modes = {"mode2": ["ch1"]}
         s = CalibrationCoefficientSelector(coefs, calib_modes)
         with pytest.raises(KeyError, match="No mode2 calibration *"):
             s.get_coefs(ch1)
 
     def test_fallback_to_nominal(self, coefs, ch1):
         """Test falling back to nominal coefficients."""
-        calib_modes = {"reflective": "mode2"}
+        calib_modes = {"mode2": ["ch1"]}
         s = CalibrationCoefficientSelector(coefs, calib_modes, fallback="nominal")
         assert s.get_coefs(ch1) == "nominal_ch1"
 

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -585,10 +585,11 @@ class TestCalibrationCoefficientSelector:
     @pytest.mark.parametrize(
         "wishlist", ["mode1", {"ch2": "mode1"}, {("ch1", "ch2"): "mode1"}]
     )
-    def test_fallback_to_nominal(self, coefs, wishlist):
+    def test_fallback_to_nominal(self, coefs, wishlist, caplog):
         """Test falling back to nominal coefficients."""
         s = hf.CalibrationCoefficientSelector(coefs, wishlist, fallback="nominal")
         assert s.get_coefs("ch2") == "nominal_ch2"
+        assert "Falling back" in caplog.text
 
     def test_no_default_coefs(self):
         """Test initialization without default coefficients."""
@@ -597,7 +598,7 @@ class TestCalibrationCoefficientSelector:
 
     def test_no_fallback(self):
         """Test initialization without fallback coefficients."""
-        with pytest.raises(KeyError, match="No fallback coefficients"):
+        with pytest.raises(KeyError, match="No fallback calibration"):
             hf.CalibrationCoefficientSelector({"nominal": 123}, {}, fallback="foo")
 
     def test_invalid_wishlist_type(self):

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -522,37 +522,61 @@ class TestCalibrationCoefficientPicker:
         """Get fake coefficients."""
         return {
             "nominal": {
-                "ch1": "nominal_ch1",
-                "ch2": "nominal_ch2"
+                "ch1": 1.0,
+                "ch2": 2.0,
             },
             "mode1": {
-                "ch1": "mode1_ch1",
+                "ch1": 1.1,
             },
             "mode2": {
-                "ch2": "mode2_ch2",
+                "ch2": 2.2,
             }
         }
 
     @pytest.mark.parametrize(
         ("wishlist", "expected"),
         [
-            (None, {"ch1": "nominal_ch1", "ch2": "nominal_ch2"}),
-            ("nominal", {"ch1": "nominal_ch1", "ch2": "nominal_ch2"}),
+            (
+                None,
+                {
+                    "ch1": {"coefs": 1.0, "mode": "nominal"},
+                    "ch2": {"coefs": 2.0, "mode": "nominal"}
+                }
+            ),
+            (
+                    "nominal",
+                    {
+                        "ch1": {"coefs": 1.0, "mode": "nominal"},
+                        "ch2": {"coefs": 2.0, "mode": "nominal"}
+                    }
+            ),
             (
                 {("ch1", "ch2"): "nominal"},
-                {"ch1": "nominal_ch1", "ch2": "nominal_ch2"}
+                {
+                    "ch1": {"coefs": 1.0, "mode": "nominal"},
+                    "ch2": {"coefs": 2.0, "mode": "nominal"}
+                }
             ),
             (
                 {"ch1": "mode1"},
-                {"ch1": "mode1_ch1", "ch2": "nominal_ch2"}
+                {
+                    "ch1": {"coefs": 1.1, "mode": "mode1"},
+                    "ch2": {"coefs": 2.0, "mode": "nominal"}
+                }
             ),
             (
                 {"ch1": "mode1", "ch2": "mode2"},
-                {"ch1": "mode1_ch1", "ch2": "mode2_ch2"}
+                {
+                    "ch1": {"coefs": 1.1, "mode": "mode1"},
+                    "ch2": {"coefs": 2.2, "mode": "mode2"}
+                }
             ),
             (
                 {"ch1": "mode1", "ch2": {"gain": 1}},
-                {"ch1": "mode1_ch1", "ch2": {"gain": 1}}
+                {
+                    "ch1": {"coefs": 1.1, "mode": "mode1"},
+                    "ch2": {"coefs": {"gain": 1}, "mode": "external"}
+                }
             ),
         ]
     )
@@ -589,7 +613,8 @@ class TestCalibrationCoefficientPicker:
         """Test falling back to nominal coefficients."""
         picker = hf.CalibrationCoefficientPicker(coefs, wishlist,
                                                  fallback="nominal")
-        assert picker.get_coefs("ch2") == "nominal_ch2"
+        expected = {"coefs": 2.0, "mode": "nominal"}
+        assert picker.get_coefs("ch2") == expected
         assert "Falling back" in caplog.text
 
     def test_no_default_coefs(self):

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -542,6 +542,10 @@ class TestCalibrationCoefficientSelector:
                 {"ch1": "nominal_ch1", "ch2": "nominal_ch2"}
             ),
             (
+                "nominal",
+                {"ch1": "nominal_ch1", "ch2": "nominal_ch2"}
+            ),
+            (
                 {"nominal": ["ch1", "ch2"]},
                 {"ch1": "nominal_ch1", "ch2": "nominal_ch2"}
             ),


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
As a first step towards channel-specific calibration modes (#2599), I added a generic calibration coefficient selector that can be used by all readers.

Example: Three sets of coefficients are available (nominal, meirink, gsics). A user wants to calibrate

- channel 1 with “meirink”
- channels 2/3 with “gsics”
- channel 4 with custom coefficients
- remaining channels with default (nominal) coefficients

The user would provide a wishlist via `reader_kwargs`:

```
calib_wishlist = {
    "ch1": "meirink",
    ("ch2", "ch3"): "gsics"
    "ch4": {"mygain": 123},
}
# Also possible: Same mode for all channels via
# calib_wishlist = "gsics"
```

Readers would compile a dictionary of coefficients

```python
coefs = {
    "nominal": {
        "ch1": 1.0,
        "ch2": 2.0,
        "ch3": 3.0,
        "ch4": 4.0,
        "ch5": 5.0,
    },
    "meirink": {
        "ch1": 1.1,
    },
    "gsics": {
        "ch2": 2.2,
        # ch3 coefficients are missing
    }
}
```

and could then make queries to get the desired coefficients:

```python
>>> from satpy.readers.utils import CalibrationCoefficientPicker
>>> picker = CalibrationCoefficientPicker(coefs, calib_wishlist)
>>> picker.get_coefs("ch1")
{"coefs": 1.0, "mode": "meirink"}
>>> picker.get_coefs("ch2")
{"coefs": 2.2, "mode": "gsics"}
>>> picker.get_coefs("ch3")
KeyError: 'No gsics calibration coefficients for ch3'
>>> picker.get_coefs("ch4")
{"coefs": {"mygain": 123}, "mode": "external"}
>>> picker.get_coefs("ch5")
{"coefs": 5.0, "mode": "nominal"}
```

Fallback to nominal coefficients for channel 3:
```
>>> picker = CalibrationCoefficientPicker(coefs, calib_wishlist, fallback="nominal")
>>> picker.get_coefs("ch3")
WARNING No gsics calibration coefficients for ch3. Falling back to nominal.
{"coefs": 3.0, "mode": "nominal"}
```
Let me know what you think!

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Tests added <!-- for all bug fixes or enhancements -->
 - [X] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
