### PR TITLE
doc: move reader table to reading section

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -66,6 +66,7 @@ The following people have made contributions to this project:
 - [Lars Ørum Rasmussen (loerum)](https://github.com/loerum)
 - [Martin Raspaud (mraspaud)](https://github.com/mraspaud)
 - [William Roberts (wroberts4)](https://github.com/wroberts4)
+- [Benjamin Rösner (BENR0)](https://github.com/BENR0)
 - [Pascale Roquet (roquetp)](https://github.com/roquetp)
 - [Kristian Rune Larsen](https://github.com/)
 - [RutgerK (RutgerK)](https://github.com/RutgerK)

--- a/doc/source/_static/main.js
+++ b/doc/source/_static/main.js
@@ -1,10 +1,12 @@
 $(document).ready( function () {
     $('table.datatable').DataTable( {
-    "paging": false,
+    "paging": true,
+    "pageLength": 15,
     "layout": {
         'topStart': 'info',
         'topEnd': 'search',
-        'bottomStart': null
+        'bottomStart': null,
+        'bottomEnd': 'paging'
     },
     "order": [[0, 'asc']]
 } );

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -81,6 +81,11 @@ Documentation
     Security Policy <https://github.com/pytroll/satpy/blob/main/SECURITY.md>
 
 
+.. note::
+
+    Please note that the reader table that used to be placed here has moved to the "reading"
+    section here:  :ref:`reader_table`.
+
 Indices and tables
 ==================
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -7,11 +7,11 @@ remote-sensing earth-observing satellite instruments. Satpy
 provides users with readers that convert geophysical parameters from various
 file formats to the common Xarray :class:`~xarray.DataArray` and
 :class:`~xarray.Dataset` classes for easier interoperability with other
-scientific python libraries. Satpy also provides interfaces for creating
-RGB (Red/Green/Blue) images and other composite types by combining data
-from multiple instrument bands or products. Various atmospheric corrections
-and visual enhancements are provided for improving the usefulness and quality
-of output images. Output data can be written to
+scientific python libraries. For a full list of available readers see :ref:`reader_table`.
+Satpy also provides interfaces for creating RGB (Red/Green/Blue) images and other
+composite types by combining data from multiple instrument bands or products.
+Various atmospheric corrections and visual enhancements are provided for
+improving the usefulness and quality of output images. Output data can be written to
 multiple output file formats such as PNG, GeoTIFF, and CF standard NetCDF
 files. Satpy also allows users to resample data to geographic projected grids
 (areas). Satpy is maintained by the open source
@@ -80,34 +80,6 @@ Documentation
     Release Notes <https://github.com/pytroll/satpy/blob/main/CHANGELOG.md>
     Security Policy <https://github.com/pytroll/satpy/blob/main/SECURITY.md>
 
-.. _reader_table:
-
-.. include:: reader_table.rst
-
-.. _Status Description:
-.. note::
-
-    Status description:
-
-    Defunct
-        Most likely the reader is not functional. If it is there is a good chance of
-        bugs and/or performance problems (e.g. not ported to dask/xarray yet). Future
-        development is unclear. Users are encouraged to contribute (see section
-        :doc:`dev_guide/CONTRIBUTING` and/or get help on Slack or by opening a Github issue).
-
-    Alpha
-        This denotes early development status. Reader is functional and implements some
-        or all of the nominal features. There might be bugs. Exactness of results is
-        not be guaranteed. Use at your own risk.
-
-    Beta
-        This denotes final developement status. Reader is functional and implements all
-        nominal features. Results should be dependable but there might be bugs. Users
-        are actively encouraged to test and report bugs.
-
-    Nominal
-        This denotes a finished status. Reader is functional and most likely no new
-        features will be introduced. It has been tested and there are no known bugs.
 
 Indices and tables
 ==================

--- a/doc/source/reading.rst
+++ b/doc/source/reading.rst
@@ -23,6 +23,37 @@ To return additional reader information use `available_readers(as_dict=True)`::
     >>> from satpy import available_readers
     >>> available_readers()
 
+.. _reader_table:
+Reader Table
+------------
+
+.. include:: reader_table.rst
+
+.. _Status Description:
+.. note::
+
+    Status description:
+
+    Defunct
+        Most likely the reader is not functional. If it is there is a good chance of
+        bugs and/or performance problems (e.g. not ported to dask/xarray yet). Future
+        development is unclear. Users are encouraged to contribute (see section
+        :doc:`dev_guide/CONTRIBUTING` and/or get help on Slack or by opening a Github issue).
+
+    Alpha
+        This denotes early development status. Reader is functional and implements some
+        or all of the nominal features. There might be bugs. Exactness of results is
+        not be guaranteed. Use at your own risk.
+
+    Beta
+        This denotes final developement status. Reader is functional and implements all
+        nominal features. Results should be dependable but there might be bugs. Users
+        are actively encouraged to test and report bugs.
+
+    Nominal
+        This denotes a finished status. Reader is functional and most likely no new
+        features will be introduced. It has been tested and there are no known bugs.
+
 Filter loaded files
 ===================
 

--- a/doc/source/reading.rst
+++ b/doc/source/reading.rst
@@ -56,6 +56,91 @@ Reader Table
         This denotes a finished status. Reader is functional and most likely no new
         features will be introduced. It has been tested and there are no known bugs.
 
+Documentation for specific readers
+----------------------------------
+
+SEVIRI L1.5 data readers
+------------------------
+
+.. automodule:: satpy.readers.seviri_base
+    :noindex:
+
+SEVIRI HRIT format reader
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: satpy.readers.seviri_l1b_hrit
+    :noindex:
+
+SEVIRI Native format reader
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: satpy.readers.seviri_l1b_native
+    :noindex:
+
+SEVIRI netCDF format reader
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: satpy.readers.seviri_l1b_nc
+    :noindex:
+
+
+Other xRIT-based readers
+------------------------
+
+.. automodule:: satpy.readers.hrit_base
+    :noindex:
+
+
+JMA HRIT format reader
+^^^^^^^^^^^^^^^^^^^^^^
+
+
+.. automodule:: satpy.readers.hrit_jma
+    :noindex:
+
+GOES HRIT format reader
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: satpy.readers.goes_imager_hrit
+    :noindex:
+
+Electro-L HRIT format reader
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: satpy.readers.electrol_hrit
+    :noindex:
+
+hdf-eos based readers
+---------------------
+
+.. automodule:: satpy.readers.modis_l1b
+    :noindex:
+
+.. automodule:: satpy.readers.modis_l2
+    :noindex:
+
+satpy cf nc readers
+---------------------
+
+.. automodule:: satpy.readers.satpy_cf_nc
+    :noindex:
+
+hdf5 based readers
+------------------
+
+.. automodule:: satpy.readers.agri_l1
+    :noindex:
+
+.. automodule:: satpy.readers.ghi_l1
+    :noindex:
+
+Arctica-M N1 HDF5 format reader
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: satpy.readers.msu_gsa_l1b
+    :noindex:
+
+
 Filter loaded files
 ===================
 
@@ -323,87 +408,3 @@ Adding a Reader to Satpy
 ========================
 
 This is described in the developer guide, see :doc:`dev_guide/custom_reader`.
-
-Implemented readers
-===================
-
-SEVIRI L1.5 data readers
-------------------------
-
-.. automodule:: satpy.readers.seviri_base
-    :noindex:
-
-SEVIRI HRIT format reader
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: satpy.readers.seviri_l1b_hrit
-    :noindex:
-
-SEVIRI Native format reader
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: satpy.readers.seviri_l1b_native
-    :noindex:
-
-SEVIRI netCDF format reader
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: satpy.readers.seviri_l1b_nc
-    :noindex:
-
-
-Other xRIT-based readers
-------------------------
-
-.. automodule:: satpy.readers.hrit_base
-    :noindex:
-
-
-JMA HRIT format reader
-^^^^^^^^^^^^^^^^^^^^^^
-
-
-.. automodule:: satpy.readers.hrit_jma
-    :noindex:
-
-GOES HRIT format reader
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: satpy.readers.goes_imager_hrit
-    :noindex:
-
-Electro-L HRIT format reader
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: satpy.readers.electrol_hrit
-    :noindex:
-
-hdf-eos based readers
----------------------
-
-.. automodule:: satpy.readers.modis_l1b
-    :noindex:
-
-.. automodule:: satpy.readers.modis_l2
-    :noindex:
-
-satpy cf nc readers
----------------------
-
-.. automodule:: satpy.readers.satpy_cf_nc
-    :noindex:
-
-hdf5 based readers
-------------------
-
-.. automodule:: satpy.readers.agri_l1
-    :noindex:
-
-.. automodule:: satpy.readers.ghi_l1
-    :noindex:
-
-Arctica-M N1 HDF5 format reader
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: satpy.readers.msu_gsa_l1b
-    :noindex:

--- a/doc/source/reading.rst
+++ b/doc/source/reading.rst
@@ -60,32 +60,32 @@ Documentation for specific readers
 ----------------------------------
 
 SEVIRI L1.5 data readers
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.seviri_base
     :noindex:
 
 SEVIRI HRIT format reader
-^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""
 
 .. automodule:: satpy.readers.seviri_l1b_hrit
     :noindex:
 
 SEVIRI Native format reader
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""""
 
 .. automodule:: satpy.readers.seviri_l1b_native
     :noindex:
 
 SEVIRI netCDF format reader
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""""
 
 .. automodule:: satpy.readers.seviri_l1b_nc
     :noindex:
 
 
 Other xRIT-based readers
-------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.hrit_base
     :noindex:
@@ -111,7 +111,7 @@ Electro-L HRIT format reader
     :noindex:
 
 hdf-eos based readers
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.modis_l1b
     :noindex:
@@ -120,13 +120,13 @@ hdf-eos based readers
     :noindex:
 
 satpy cf nc readers
----------------------
+^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.satpy_cf_nc
     :noindex:
 
 hdf5 based readers
-------------------
+^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.agri_l1
     :noindex:

--- a/doc/source/reading.rst
+++ b/doc/source/reading.rst
@@ -23,7 +23,9 @@ To return additional reader information use `available_readers(as_dict=True)`::
     >>> from satpy import available_readers
     >>> available_readers()
 
+
 .. _reader_table:
+
 Reader Table
 ------------
 


### PR DESCRIPTION
This removes the reader table from the index page and moves it to the reading section where users might expect to find it. Furthermore a link was added to the index page which also leads to the reader table.

 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
