### PR TITLE
Fix uniqueness of hdf5-based dask arrays

### DIFF
--- a/satpy/readers/hdf5_utils.py
+++ b/satpy/readers/hdf5_utils.py
@@ -129,7 +129,7 @@ def from_h5_array(h5dset):
     chunk_size = dc.get("array.chunk-size")
 
     chunks = normalize_chunks(chunk_size, dtype=h5dset.dtype, previous_chunks=h5dset.chunks, shape=h5dset.shape)
-    name = tokenize(os.fspath(h5dset.file.filename), h5dset.name, chunks)
+    name = h5dset.name + "-" + tokenize(os.fspath(h5dset.file.filename), h5dset.name, chunks)
 
     dset_data = da.from_array(h5dset, chunks=chunks, name=name)
     return dset_data

--- a/satpy/tests/reader_tests/test_hdf5_utils.py
+++ b/satpy/tests/reader_tests/test_hdf5_utils.py
@@ -150,3 +150,12 @@ class TestHDF5FileHandler(unittest.TestCase):
         assert "fake_ds" not in file_handler
 
         assert isinstance(file_handler["ds2_f/attr/test_ref"], np.ndarray)
+
+    def test_array_name_uniqueness(self):
+        """Test the dask array generated from an hdf5 dataset stay constant and unique."""
+        from satpy.readers.hdf5_utils import HDF5FileHandler
+        file_handler = HDF5FileHandler("test.h5", {}, {})
+
+        dsname = "test_group/ds1_f"
+
+        assert file_handler[dsname].data.name == file_handler[dsname].data.name

--- a/satpy/tests/reader_tests/test_hdf5_utils.py
+++ b/satpy/tests/reader_tests/test_hdf5_utils.py
@@ -159,3 +159,4 @@ class TestHDF5FileHandler(unittest.TestCase):
         dsname = "test_group/ds1_f"
 
         assert file_handler[dsname].data.name == file_handler[dsname].data.name
+        assert file_handler[dsname].data.name.startswith("/" + dsname)


### PR DESCRIPTION
This PR makes sure that the same hdf5 dataset read from the same file yields the same dask array (name).

 - [x] Closes #2724  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->

