### PR TITLE
Ensure lazyness of the olci nc reader

### DIFF
--- a/satpy/readers/olci_nc.py
+++ b/satpy/readers/olci_nc.py
@@ -272,8 +272,16 @@ class NCOLCILowResData(NCOLCIBase):
                  engine=None, **kwargs):
         """Init the file handler."""
         super().__init__(filename, filename_info, filetype_info, engine)
-        self.l_step = self.nc.attrs["al_subsampling_factor"]
-        self.c_step = self.nc.attrs["ac_subsampling_factor"]
+
+    @property
+    def l_step(self):
+        """Get the line step."""
+        return self.nc.attrs["al_subsampling_factor"]
+
+    @property
+    def c_step(self):
+        """Get the column step."""
+        return self.nc.attrs["ac_subsampling_factor"]
 
     def _do_interpolate(self, data):
 


### PR DESCRIPTION
This PR fixes the olci nc reader so that the netcdf4 files for geolocaltion are not opened until necessary.

I really see this as a refactoring, so I didn't add any test, but I could if the reviewer thinks it's needed.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
