### PR TITLE
fix typo in docstring in fci_l1c_nc.py

### DIFF
--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -222,7 +222,7 @@ class FCIL1cNCFileHandler(NetCDF4FsspecFileHandler):
     def rc_period_min(self):
         """Get nominal repeat cycle duration.
 
-        As RSS is not yet implemeted and error will be raised if RSS are to be read
+        As RSS is not yet implemented an error will be raised if RSS are tried to be read.
         """
         if self.filename_info["coverage"] not in ["FD","AF"]:
             raise NotImplementedError(f"coverage for {self.filename_info['coverage']} not supported by this reader")


### PR DESCRIPTION
Fix typo in a docstring in the FCI L1C NC reader.