### PR TITLE
Make NetCDF file cache handling compatible with dask distributed

### DIFF
--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -26,7 +26,7 @@ import xarray as xr
 
 from satpy.readers.core.file_handlers import BaseFileHandler
 from satpy.readers.core.remote import open_file_or_filename
-from satpy.readers.core.utils import get_distributed_friendly_dask_array, np2str
+from satpy.readers.core.utils import get_serialisable_dask_array, np2str
 from satpy.utils import get_legacy_chunk_size
 
 LOG = logging.getLogger(__name__)
@@ -352,13 +352,13 @@ class NetCDF4FileHandler(BaseFileHandler):
             else:
                 v = ds[key]
         if group is None:
-            dv = get_distributed_friendly_dask_array(
+            dv = get_serialisable_dask_array(
                     self.manager, key,
                     chunks=v.shape, dtype=v.dtype,
                     auto_maskandscale=self._auto_maskandscale)
         else:
-            dv = get_distributed_friendly_dask_array(
-                    self.manager, key, group=group,
+            dv = get_serialisable_dask_array(
+                    self.manager, "/".join([group, key]),
                     chunks=v.shape, dtype=v.dtype,
                     auto_maskandscale=self._auto_maskandscale)
         attrs = self._get_object_attrs(v)

--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -18,6 +18,7 @@
 """Helpers for reading netcdf-based files."""
 
 import logging
+import warnings
 
 import netCDF4
 import numpy as np
@@ -126,6 +127,16 @@ class NetCDF4FileHandler(BaseFileHandler):
 
     def _get_file_handle(self):
         return netCDF4.Dataset(self.filename, "r")
+
+    @property
+    def file_handle(self):
+        """Backward-compatible way for file handle caching."""
+        warnings.warn(
+                "attribute .file_handle is deprecated, use .manager instead",
+                DeprecationWarning)
+        if self.manager is None:
+            return None
+        return self.manager.acquire()
 
     @staticmethod
     def _set_file_handle_auto_maskandscale(file_handle, auto_maskandscale):

--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -105,7 +105,7 @@ class NetCDF4FileHandler(BaseFileHandler):
         self._auto_maskandscale = auto_maskandscale
         if cache_handle:
             self.manager = xr.backends.CachingFileManager(
-                    functools.partial(_NCDatasetWrapper,
+                    functools.partial(_nc_dataset_wrapper,
                                       auto_maskandscale=auto_maskandscale),
                     self.filename, mode="r")
             file_handle = self.manager.acquire()
@@ -481,23 +481,14 @@ class NetCDF4FsspecFileHandler(NetCDF4FileHandler):
             return obj.attrs[key]
         return super()._get_attr(obj, key)
 
-class _NCDatasetWrapper(netCDF4.Dataset):
+def _nc_dataset_wrapper(*args, auto_maskandscale, **kwargs):
     """Wrap netcdf4.Dataset setting auto_maskandscale globally.
 
-    Helper class that wraps netcdf4.Dataset while setting extra parameters.
-    By encapsulating this in a helper class, we can
+    Helper function that wraps netcdf4.Dataset while setting extra parameters.
+    By encapsulating this in a helper function, we can
     pass it to CachingFileManager directly.  Currently sets
     auto_maskandscale globally (for all variables).
     """
-
-    def __init__(self, *args, auto_maskandscale=False, **kwargs):
-        """Initialise object."""
-        super().__init__(*args, **kwargs)
-        self._set_extra_settings(auto_maskandscale=auto_maskandscale)
-
-    def _set_extra_settings(self, auto_maskandscale):
-        """Set our own custom settings.
-
-        Currently only applies set_auto_maskandscale.
-        """
-        self.set_auto_maskandscale(auto_maskandscale)
+    nc = netCDF4.Dataset(*args, **kwargs)
+    nc.set_auto_maskandscale(auto_maskandscale)
+    return nc

--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -211,10 +211,7 @@ class NetCDF4FileHandler(BaseFileHandler):
     def __del__(self):
         """Delete the file handler."""
         if self.manager is not None:
-            try:
-                self.manager.close()
-            except RuntimeError:  # presumably closed already
-                pass
+            self.manager.close()
 
     def _collect_global_attrs(self, obj):
         """Collect all the global attributes for the provided file object."""

--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -118,7 +118,7 @@ class NetCDF4FileHandler(BaseFileHandler):
                 raise
 
             self._set_file_handle_auto_maskandscale(file_handle, auto_maskandscale)
-            self._set_xarray_kwargs(xarray_kwargs, auto_maskandscale)
+        self._set_xarray_kwargs(xarray_kwargs, auto_maskandscale)
 
         listed_variables = filetype_info.get("required_netcdf_variables")
         if listed_variables:

--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -103,15 +103,22 @@ class NetCDF4FileHandler(BaseFileHandler):
         self.cached_file_content = {}
         self._use_h5netcdf = False
         self._auto_maskandscale = auto_maskandscale
-        try:
-            file_handle = self._get_file_handle()
-        except IOError:
-            LOG.exception(
-                "Failed reading file %s. Possibly corrupted file", self.filename)
-            raise
+        if cache_handle:
+            self.manager = xr.backends.CachingFileManager(
+                    functools.partial(_NCDatasetWrapper,
+                                      auto_maskandscale=auto_maskandscale),
+                    self.filename, mode="r")
+            file_handle = self.manager.acquire()
+        else:
+            try:
+                file_handle = self._get_file_handle()
+            except IOError:
+                LOG.exception(
+                    "Failed reading file %s. Possibly corrupted file", self.filename)
+                raise
 
-        self._set_file_handle_auto_maskandscale(file_handle, auto_maskandscale)
-        self._set_xarray_kwargs(xarray_kwargs, auto_maskandscale)
+            self._set_file_handle_auto_maskandscale(file_handle, auto_maskandscale)
+            self._set_xarray_kwargs(xarray_kwargs, auto_maskandscale)
 
         listed_variables = filetype_info.get("required_netcdf_variables")
         if listed_variables:
@@ -121,12 +128,7 @@ class NetCDF4FileHandler(BaseFileHandler):
             self.collect_dimensions("", file_handle)
         self.collect_cache_vars(cache_var_size)
 
-        if cache_handle:
-            self.manager = xr.backends.CachingFileManager(
-                    functools.partial(_NCDatasetWrapper,
-                                      auto_maskandscale=auto_maskandscale),
-                    self.filename, mode="r")
-        else:
+        if not cache_handle:
             file_handle.close()
 
     def _get_file_handle(self):

--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -101,6 +101,7 @@ class NetCDF4FileHandler(BaseFileHandler):
         self.file_content = {}
         self.cached_file_content = {}
         self._use_h5netcdf = False
+        self._auto_maskandscale = auto_maskandscale
         try:
             file_handle = self._get_file_handle()
         except IOError:
@@ -347,6 +348,7 @@ class NetCDF4FileHandler(BaseFileHandler):
     def _get_var_from_manager(self, group, key):
         # Not getting coordinates as this is more work, therefore more
         # overhead, and those are not used downstream.
+
         with self.manager.acquire_context() as ds:
             if group is not None:
                 v = ds[group][key]
@@ -355,11 +357,13 @@ class NetCDF4FileHandler(BaseFileHandler):
         if group is None:
             dv = get_distributed_friendly_dask_array(
                     self.manager, key,
-                    chunks=v.shape, dtype=v.dtype)
+                    chunks=v.shape, dtype=v.dtype,
+                    auto_maskandscale=self._auto_maskandscale)
         else:
             dv = get_distributed_friendly_dask_array(
                     self.manager, key, group=group,
-                    chunks=v.shape, dtype=v.dtype)
+                    chunks=v.shape, dtype=v.dtype,
+                    auto_maskandscale=self._auto_maskandscale)
         attrs = self._get_object_attrs(v)
         x = xr.DataArray(
                 dv,

--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -27,7 +27,7 @@ import xarray as xr
 
 from satpy.readers.core.file_handlers import BaseFileHandler
 from satpy.readers.core.remote import open_file_or_filename
-from satpy.readers.core.utils import get_serialisable_dask_array, np2str
+from satpy.readers.core.utils import get_serializable_dask_array, np2str
 from satpy.utils import get_legacy_chunk_size
 
 LOG = logging.getLogger(__name__)
@@ -355,15 +355,13 @@ class NetCDF4FileHandler(BaseFileHandler):
             else:
                 v = ds[key]
         if group is None:
-            dv = get_serialisable_dask_array(
+            dv = get_serializable_dask_array(
                     self.manager, key,
-                    chunks=v.shape, dtype=v.dtype,
-                    auto_maskandscale=self._auto_maskandscale)
+                    chunks=v.shape, dtype=v.dtype)
         else:
-            dv = get_serialisable_dask_array(
+            dv = get_serializable_dask_array(
                     self.manager, "/".join([group, key]),
-                    chunks=v.shape, dtype=v.dtype,
-                    auto_maskandscale=self._auto_maskandscale)
+                    chunks=v.shape, dtype=v.dtype)
         attrs = self._get_object_attrs(v)
         x = xr.DataArray(
                 dv,

--- a/satpy/readers/core/utils.py
+++ b/satpy/readers/core/utils.py
@@ -703,7 +703,7 @@ def _make_coefs(coefs, mode):
 
 
 def get_distributed_friendly_dask_array(manager, varname, chunks, dtype,
-                                        group="/"):
+                                        group="/", auto_maskandscale=None):
     """Construct a dask array from a variable for dask distributed.
 
     When we construct a dask array using da.array and use that to create an
@@ -733,9 +733,16 @@ def get_distributed_friendly_dask_array(manager, varname, chunks, dtype,
             What dtype to use.
         group (str):
             What group to read the variable from.
+        auto_maskandscale (bool, optional):
+            Apply automatic masking and scaling.  This will only
+            work if CachingFileManager.acquire returns a handler with a
+            method set_auto_maskandscale, such as is the case for
+            NetCDF4.Dataset.
     """
     def get_chunk():
         with manager.acquire_context() as nc:
+            if auto_maskandscale is not None:
+                nc.set_auto_maskandscale(auto_maskandscale)
             return nc["/".join([group, varname])][:]
 
     return da.map_blocks(

--- a/satpy/readers/core/utils.py
+++ b/satpy/readers/core/utils.py
@@ -702,7 +702,7 @@ def _make_coefs(coefs, mode):
     return {"coefs": coefs, "mode": mode}
 
 
-def get_distributed_friendly_dask_array(manager, varname, chunks=None):
+def get_distributed_friendly_dask_array(manager, varname, chunks, dtype):
     """Construct a dask array from a variable for dask distributed.
 
     When we construct a dask array using da.array and use that to create an
@@ -726,8 +726,10 @@ def get_distributed_friendly_dask_array(manager, varname, chunks=None):
             dataset to be read.
         varname (str):
             Name of the variable.
-        chunks (tuple or None, optional):
+        chunks (tuple):
             Chunks to use when creating the dask array.
+        dtype (dtype):
+            What dtype to use.
     """
     def get_chunk():
         with manager.acquire_context() as nc:
@@ -736,4 +738,5 @@ def get_distributed_friendly_dask_array(manager, varname, chunks=None):
     return da.map_blocks(
             get_chunk,
             chunks=chunks,
+            dtype=dtype,
             meta=np.array([]))

--- a/satpy/readers/core/utils.py
+++ b/satpy/readers/core/utils.py
@@ -722,7 +722,7 @@ def get_serializable_dask_array(manager, varname, chunks, dtype):
 
     Args:
         manager (xarray.backends.CachingFileManager):
-            Instance of xarray.backends.CachingFileManager encapsulating the
+            Instance of :class:`~xarray.backends.CachingFileManager` encapsulating the
             dataset to be read.
         varname (str):
             Name of the variable (possibly including a group path).
@@ -741,4 +741,4 @@ def get_serializable_dask_array(manager, varname, chunks, dtype):
             get_chunk,
             chunks=chunks,
             dtype=dtype,
-            meta=np.array([]))
+            meta=np.array([], dtype=dtype))

--- a/satpy/readers/core/utils.py
+++ b/satpy/readers/core/utils.py
@@ -702,9 +702,9 @@ def _make_coefs(coefs, mode):
     return {"coefs": coefs, "mode": mode}
 
 
-def get_distributed_friendly_dask_array(manager, varname, chunks, dtype,
-                                        group="/", auto_maskandscale=None):
-    """Construct a dask array from a variable for dask distributed.
+def get_serialisable_dask_array(manager, varname, chunks, dtype,
+                                auto_maskandscale=None):
+    """Construct a serialisable dask array from a variable.
 
     When we construct a dask array using da.array and use that to create an
     xarray dataarray, the result is not serialisable and dask graphs using
@@ -726,13 +726,11 @@ def get_distributed_friendly_dask_array(manager, varname, chunks, dtype,
             Instance of xarray.backends.CachingFileManager encapsulating the
             dataset to be read.
         varname (str):
-            Name of the variable.
+            Name of the variable (possibly including a group path).
         chunks (tuple):
             Chunks to use when creating the dask array.
         dtype (dtype):
             What dtype to use.
-        group (str):
-            What group to read the variable from.
         auto_maskandscale (bool, optional):
             Apply automatic masking and scaling.  This will only
             work if CachingFileManager.acquire returns a handler with a
@@ -744,7 +742,7 @@ def get_distributed_friendly_dask_array(manager, varname, chunks, dtype,
         with manager.acquire_context() as nc:
             if auto_maskandscale is not None:
                 nc.set_auto_maskandscale(auto_maskandscale)
-            var = nc["/".join([group, varname])]
+            var = nc[varname] #"/".join([group, varname])]
             return var[tuple(slice(*x) for x in arrloc)]
 
     return da.map_blocks(

--- a/satpy/readers/core/utils.py
+++ b/satpy/readers/core/utils.py
@@ -705,11 +705,11 @@ def _make_coefs(coefs, mode):
 def get_serializable_dask_array(manager, varname, chunks, dtype):
     """Construct a serializable dask array from a variable.
 
-    When we construct a dask array using da.array and use that to create an
-    xarray dataarray, the result is not serializable and dask graphs using
-    this dataarray cannot be computed when the dask distributed scheduler
-    is in use.  To circumvent this problem, xarray provides the
-    CachingFileManager.  See GH#2815 for more information.
+    When we construct a dask array using da.array from a file, and use
+    that to create an xarray dataarray, the result is not serializable
+    and dask graphs using this dataarray cannot be computed when the dask
+    distributed scheduler is in use.  To circumvent this problem, xarray
+    provides the CachingFileManager.  See GH#2815 for more information.
 
     Should have at least one dimension.
 
@@ -717,8 +717,8 @@ def get_serializable_dask_array(manager, varname, chunks, dtype):
 
         >>> import netCDF4
         >>> from xarray.backends import CachingFileManager
-        >>> cfm = CachingFileManager(netCDF4.Dataset, fn, mode="r")
-        >>> arr = get_serializable_dask_array(cfm, "my_var")
+        >>> cfm = CachingFileManager(netCDF4.Dataset, filename, mode="r")
+        >>> arr = get_serializable_dask_array(cfm, "my_var", 1024, "f4")
 
     Args:
         manager (xarray.backends.CachingFileManager):

--- a/satpy/readers/core/utils.py
+++ b/satpy/readers/core/utils.py
@@ -702,7 +702,8 @@ def _make_coefs(coefs, mode):
     return {"coefs": coefs, "mode": mode}
 
 
-def get_distributed_friendly_dask_array(manager, varname, chunks, dtype):
+def get_distributed_friendly_dask_array(manager, varname, chunks, dtype,
+                                        group="/"):
     """Construct a dask array from a variable for dask distributed.
 
     When we construct a dask array using da.array and use that to create an
@@ -730,10 +731,12 @@ def get_distributed_friendly_dask_array(manager, varname, chunks, dtype):
             Chunks to use when creating the dask array.
         dtype (dtype):
             What dtype to use.
+        group (str):
+            What group to read the variable from.
     """
     def get_chunk():
         with manager.acquire_context() as nc:
-            return nc[varname][:]
+            return nc["/".join([group, varname])][:]
 
     return da.map_blocks(
             get_chunk,

--- a/satpy/readers/core/utils.py
+++ b/satpy/readers/core/utils.py
@@ -702,7 +702,7 @@ def _make_coefs(coefs, mode):
     return {"coefs": coefs, "mode": mode}
 
 
-def get_distributed_friendly_dask_array(manager, varname):
+def get_distributed_friendly_dask_array(manager, varname, chunks=None):
     """Construct a dask array from a variable for dask distributed.
 
     When we construct a dask array using da.array and use that to create an
@@ -711,21 +711,29 @@ def get_distributed_friendly_dask_array(manager, varname):
     is in use.  To circumvent this problem, xarray provides the
     CachingFileManager.  See GH#2815 for more information.
 
+    Should have at least one dimension.
+
+    Example::
+
+        >>> import NetCDF4
+        >>> from xarray.backends import CachingFileManager
+        >>> cfm = CachingFileManager(NetCDF4.Dataset, fn, mode="r")
+        >>> arr = get_distributed_friendly_dask_array(cfm, "my_var")
+
     Args:
         manager (xarray.backends.CachingFileManager):
             Instance of xarray.backends.CachingFileManager encapsulating the
             dataset to be read.
         varname (str):
             Name of the variable.
+        chunks (tuple or None, optional):
+            Chunks to use when creating the dask array.
     """
-    def get_chunk(block_info):
+    def get_chunk():
         with manager.acquire_context() as nc:
-            loc = block_info[None]["array-location"][0]
-            rv = nc[varname][loc[0]:loc[1]]
-        return rv
+            return nc[varname][:]
 
     return da.map_blocks(
             get_chunk,
-            chunks=(10,),
-            meta=np.array([]),
-            dtype="i4")
+            chunks=chunks,
+            meta=np.array([]))

--- a/satpy/readers/core/utils.py
+++ b/satpy/readers/core/utils.py
@@ -702,11 +702,11 @@ def _make_coefs(coefs, mode):
     return {"coefs": coefs, "mode": mode}
 
 
-def get_serialisable_dask_array(manager, varname, chunks, dtype):
-    """Construct a serialisable dask array from a variable.
+def get_serializable_dask_array(manager, varname, chunks, dtype):
+    """Construct a serializable dask array from a variable.
 
     When we construct a dask array using da.array and use that to create an
-    xarray dataarray, the result is not serialisable and dask graphs using
+    xarray dataarray, the result is not serializable and dask graphs using
     this dataarray cannot be computed when the dask distributed scheduler
     is in use.  To circumvent this problem, xarray provides the
     CachingFileManager.  See GH#2815 for more information.
@@ -718,7 +718,7 @@ def get_serialisable_dask_array(manager, varname, chunks, dtype):
         >>> import netCDF4
         >>> from xarray.backends import CachingFileManager
         >>> cfm = CachingFileManager(netCDF4.Dataset, fn, mode="r")
-        >>> arr = get_serialisable_dask_array(cfm, "my_var")
+        >>> arr = get_serializable_dask_array(cfm, "my_var")
 
     Args:
         manager (xarray.backends.CachingFileManager):

--- a/satpy/readers/core/utils.py
+++ b/satpy/readers/core/utils.py
@@ -716,9 +716,9 @@ def get_distributed_friendly_dask_array(manager, varname, chunks, dtype,
 
     Example::
 
-        >>> import NetCDF4
+        >>> import netCDF4
         >>> from xarray.backends import CachingFileManager
-        >>> cfm = CachingFileManager(NetCDF4.Dataset, fn, mode="r")
+        >>> cfm = CachingFileManager(netCDF4.Dataset, fn, mode="r")
         >>> arr = get_distributed_friendly_dask_array(cfm, "my_var")
 
     Args:

--- a/satpy/readers/core/utils.py
+++ b/satpy/readers/core/utils.py
@@ -739,11 +739,13 @@ def get_distributed_friendly_dask_array(manager, varname, chunks, dtype,
             method set_auto_maskandscale, such as is the case for
             NetCDF4.Dataset.
     """
-    def get_chunk():
+    def get_chunk(block_info=None):
+        arrloc = block_info[None]["array-location"]
         with manager.acquire_context() as nc:
             if auto_maskandscale is not None:
                 nc.set_auto_maskandscale(auto_maskandscale)
-            return nc["/".join([group, varname])][:]
+            var = nc["/".join([group, varname])]
+            return var[tuple(slice(*x) for x in arrloc)]
 
     return da.map_blocks(
             get_chunk,

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # Copyright (c) 2014-2025 Satpy developers
 #
 # This file is part of satpy.

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -226,8 +226,6 @@ class TestNetCDF4FileHandler(unittest.TestCase):
         np.testing.assert_array_equal(
                 h["ds2_f"],
                 np.arange(10. * 100).reshape((10, 100)))
-        h.__del__()
-        assert not h.file_handle.isopen()
 
     def test_filenotfound(self):
         """Test that error is raised when file not found."""

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -417,8 +417,6 @@ def test_caching_distributed(dummy_nc):
 
     fh = NetCDF4FileHandler(dummy_nc, {}, {}, cache_handle=True)
 
-    Client()
-
     def doubler(x):
         return x * 2
 
@@ -428,5 +426,7 @@ def test_caching_distributed(dummy_nc):
     # reliably, even though the problem also manifests itself (in different
     # ways) without map_blocks.
 
-    dask_doubler = fh["kaitum"].map_blocks(doubler)
-    dask_doubler.compute()
+
+    with Client():
+        dask_doubler = fh["kaitum"].map_blocks(doubler)
+        dask_doubler.compute()

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -18,7 +18,6 @@
 """Module for testing the satpy.readers.core.netcdf module."""
 
 import os
-import unittest
 
 import numpy as np
 import pytest
@@ -71,13 +70,15 @@ class FakeNetCDF4FileHandler(NetCDF4FileHandler):
         raise NotImplementedError("Fake File Handler subclass must implement 'get_test_content'")
 
 
-class TestNetCDF4FileHandler(unittest.TestCase):
+class TestNetCDF4FileHandler:
     """Test NetCDF4 File Handler Utility class."""
 
-    def setUp(self):
+    @pytest.fixture()
+    def dummy_nc_file(self, tmp_path):
         """Create a test NetCDF4 file."""
         from netCDF4 import Dataset
-        with Dataset("test.nc", "w") as nc:
+        fn = tmp_path / "test.nc"
+        with Dataset(fn, "w") as nc:
             # Create dimensions
             nc.createDimension("rows", 10)
             nc.createDimension("cols", 100)
@@ -116,17 +117,14 @@ class TestNetCDF4FileHandler(unittest.TestCase):
                 d.test_attr_str = "test_string"
                 d.test_attr_int = 0
                 d.test_attr_float = 1.2
+        return fn
 
-    def tearDown(self):
-        """Remove the previously created test file."""
-        os.remove("test.nc")
-
-    def test_all_basic(self):
+    def test_all_basic(self, dummy_nc_file):
         """Test everything about the NetCDF4 class."""
         import xarray as xr
 
         from satpy.readers.core.netcdf import NetCDF4FileHandler
-        file_handler = NetCDF4FileHandler("test.nc", {}, {})
+        file_handler = NetCDF4FileHandler(dummy_nc_file, {}, {})
 
         assert file_handler["/dimension/rows"] == 10
         assert file_handler["/dimension/cols"] == 100
@@ -165,7 +163,7 @@ class TestNetCDF4FileHandler(unittest.TestCase):
         assert file_handler.file_handle is None
         assert file_handler["ds2_sc"] == 42
 
-    def test_listed_variables(self):
+    def test_listed_variables(self, dummy_nc_file):
         """Test that only listed variables/attributes area collected."""
         from satpy.readers.core.netcdf import NetCDF4FileHandler
 
@@ -175,12 +173,12 @@ class TestNetCDF4FileHandler(unittest.TestCase):
                 "attr/test_attr_str",
             ]
         }
-        file_handler = NetCDF4FileHandler("test.nc", {}, filetype_info)
+        file_handler = NetCDF4FileHandler(dummy_nc_file, {}, filetype_info)
         assert len(file_handler.file_content) == 2
         assert "test_group/attr/test_attr_str" in file_handler.file_content
         assert "attr/test_attr_str" in file_handler.file_content
 
-    def test_listed_variables_with_composing(self):
+    def test_listed_variables_with_composing(self, dummy_nc_file):
         """Test that composing for listed variables is performed."""
         from satpy.readers.core.netcdf import NetCDF4FileHandler
 
@@ -199,7 +197,7 @@ class TestNetCDF4FileHandler(unittest.TestCase):
                 ],
             }
         }
-        file_handler = NetCDF4FileHandler("test.nc", {}, filetype_info)
+        file_handler = NetCDF4FileHandler(dummy_nc_file, {}, filetype_info)
         assert len(file_handler.file_content) == 3
         assert "test_group/ds1_f/attr/test_attr_str" in file_handler.file_content
         assert "test_group/ds1_i/attr/test_attr_str" in file_handler.file_content
@@ -208,10 +206,10 @@ class TestNetCDF4FileHandler(unittest.TestCase):
         assert not any("another_parameter" in var for var in file_handler.file_content)
         assert "test_group/attr/test_attr_str" in file_handler.file_content
 
-    def test_caching(self):
+    def test_caching(self, dummy_nc_file):
         """Test that caching works as intended."""
         from satpy.readers.core.netcdf import NetCDF4FileHandler
-        h = NetCDF4FileHandler("test.nc", {}, {}, cache_var_size=1000,
+        h = NetCDF4FileHandler(dummy_nc_file, {}, {}, cache_var_size=1000,
                                cache_handle=True)
         assert h.file_handle is not None
         assert h.file_handle.isopen()
@@ -235,21 +233,21 @@ class TestNetCDF4FileHandler(unittest.TestCase):
         with pytest.raises(IOError, match=".*(No such file or directory|Unknown file format).*"):
             NetCDF4FileHandler("/thisfiledoesnotexist.nc", {}, {})
 
-    def test_get_and_cache_npxr_is_xr(self):
+    def test_get_and_cache_npxr_is_xr(self, dummy_nc_file):
         """Test that get_and_cache_npxr() returns xr.DataArray."""
         import xarray as xr
 
         from satpy.readers.core.netcdf import NetCDF4FileHandler
-        file_handler = NetCDF4FileHandler("test.nc", {}, {}, cache_handle=True)
+        file_handler = NetCDF4FileHandler(dummy_nc_file, {}, {}, cache_handle=True)
 
         data = file_handler.get_and_cache_npxr("test_group/ds1_f")
         assert isinstance(data, xr.DataArray)
 
-    def test_get_and_cache_npxr_data_is_cached(self):
+    def test_get_and_cache_npxr_data_is_cached(self, dummy_nc_file):
         """Test that the data are cached when get_and_cache_npxr() is called."""
         from satpy.readers.core.netcdf import NetCDF4FileHandler
 
-        file_handler = NetCDF4FileHandler("test.nc", {}, {}, cache_handle=True)
+        file_handler = NetCDF4FileHandler(dummy_nc_file, {}, {}, cache_handle=True)
         data = file_handler.get_and_cache_npxr("test_group/ds1_f")
 
         # Delete the dataset from the file content dict, it should be available from the cache
@@ -263,7 +261,6 @@ class TestNetCDF4FsspecFileHandler:
 
     def test_default_to_netcdf4_lib(self):
         """Test that the NetCDF4 backend is used by default."""
-        import os
         import tempfile
 
         import h5py

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -73,7 +73,7 @@ class FakeNetCDF4FileHandler(NetCDF4FileHandler):
 class TestNetCDF4FileHandler:
     """Test NetCDF4 File Handler Utility class."""
 
-    @pytest.fixture()
+    @pytest.fixture
     def dummy_nc_file(self, tmp_path):
         """Create a test NetCDF4 file."""
         from netCDF4 import Dataset
@@ -390,7 +390,7 @@ def test_get_data_as_xarray_scalar_h5netcdf(tmp_path):
     assert res.attrs == NC_ATTRS
 
 
-@pytest.fixture()
+@pytest.fixture
 def dummy_nc(tmp_path):
     """Fixture to create a dummy NetCDF file and return its path."""
     import xarray as xr

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -393,3 +393,40 @@ def test_get_data_as_xarray_scalar_h5netcdf(tmp_path):
     res = get_data_as_xarray(fid["test_data"])
     np.testing.assert_equal(res.data, np.array(data))
     assert res.attrs == NC_ATTRS
+
+
+@pytest.fixture()
+def dummy_nc(tmp_path):
+    """Fixture to create a dummy NetCDF file and return its path."""
+    import xarray as xr
+
+    fn = tmp_path / "sjaunja.nc"
+    ds = xr.Dataset(data_vars={"kaitum": (["x"], np.arange(10))})
+    ds.to_netcdf(fn)
+    return fn
+
+
+def test_caching_distributed(dummy_nc):
+    """Test that the distributed scheduler works with file handle caching.
+
+    This is a test for GitHub issue 2815.
+    """
+    from dask.distributed import Client
+
+    from satpy.readers.netcdf_utils import NetCDF4FileHandler
+
+    fh = NetCDF4FileHandler(dummy_nc, {}, {}, cache_handle=True)
+
+    Client()
+
+    def doubler(x):
+        return x * 2
+
+    # As documented in GH issue 2815, using dask distributed with the file
+    # handle cacher might fail in non-trivial ways, such as giving incorrect
+    # results.  Testing map_blocks is one way to reproduce the problem
+    # reliably, even though the problem also manifests itself (in different
+    # ways) without map_blocks.
+
+    dask_doubler = fh["kaitum"].map_blocks(doubler)
+    dask_doubler.compute()

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -697,7 +697,7 @@ class TestDistributed:
     @pytest.mark.parametrize("dtype", ["i4", "f4", "f8"])
     @pytest.mark.parametrize("grp", ["/", "/in/a/group"])
     def test_get_serialisable_dask_array(self, tmp_path, dask_dist_client, shape, dtype, grp):
-        """Test getting a dask distributed friendly dask array."""
+        """Test getting a dask distributed friendly serialisable dask array."""
         import netCDF4
         from xarray.backends import CachingFileManager
 

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -29,13 +29,13 @@ import numpy.testing
 import pyresample.geometry
 import pytest
 import xarray as xr
-from dask.distributed.utils_test import cleanup  # noqa
-from dask.distributed.utils_test import client as dask_dist_client  # noqa
 from dask.distributed.utils_test import (  # noqa
+    cleanup,  # noqa
     cluster_fixture,
     loop,
     loop_in_thread,
 )
+from dask.distributed.utils_test import client as dask_dist_client  # noqa
 from fsspec.implementations.memory import MemoryFile, MemoryFileSystem
 from pyproj import CRS
 

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -696,7 +696,7 @@ class TestDistributed:
     @pytest.mark.parametrize("shape", [(2,), (2, 3), (2, 3, 4)])
     @pytest.mark.parametrize("dtype", ["i4", "f4", "f8"])
     @pytest.mark.parametrize("grp", ["/", "/in/a/group"])
-    def test_get_distributed_friendly_dask_array(self, tmp_path, dask_dist_client, shape, dtype, grp):
+    def test_get_serialisable_dask_array(self, tmp_path, dask_dist_client, shape, dtype, grp):
         """Test getting a dask distributed friendly dask array."""
         import netCDF4
         from xarray.backends import CachingFileManager
@@ -710,9 +710,8 @@ class TestDistributed:
         ds.to_netcdf(fn, group=grp)
 
         cfm = CachingFileManager(netCDF4.Dataset, fn, mode="r")
-        arr = hf.get_distributed_friendly_dask_array(cfm, "kaitum",
-                                                     chunks=shape, dtype=dtype,
-                                                     group=grp)
+        arr = hf.get_serialisable_dask_array(cfm, "/".join([grp, "kaitum"]),
+                                             chunks=shape, dtype=dtype)
 
         # As documented in GH issue 2815, using dask distributed with the file
         # handle cacher might fail in non-trivial ways, such as giving incorrect

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -517,6 +517,64 @@ def test_generic_open_binary(tmp_path, data, filename, mode):
     assert read_binary_data == dummy_data
 
 
+class TestDistributed:
+    """Distributed-related tests.
+
+    Distributed-related tests are grouped so that they can share a class-scoped
+    fixture setting up the distributed client, as this setup is relatively
+    slow.
+    """
+
+    @pytest.fixture(scope="class")
+    def dask_dist_client(self):
+        """Set up and close a dask distributed client."""
+        from dask.distributed import Client
+        cl = Client()
+        yield cl
+        cl.close()
+
+
+    @pytest.mark.parametrize("shape", [(2,), (2, 3), (2, 3, 4)])
+    @pytest.mark.parametrize("dtype", ["i4", "f4", "f8"])
+    @pytest.mark.parametrize("grp", ["/", "/in/a/group"])
+    def test_get_serializable_dask_array(self, tmp_path, dask_dist_client, shape, dtype, grp):
+        """Test getting a dask distributed friendly serialisable dask array."""
+        import netCDF4
+        from xarray.backends import CachingFileManager
+
+        fn = tmp_path / "sjaunja.nc"
+        ds = xr.Dataset(
+                data_vars={
+                    "kaitum": (["x", "y", "z"][:len(shape)],
+                               np.arange(np.prod(shape),
+                                         dtype=dtype).reshape(shape))})
+        ds.to_netcdf(fn, group=grp)
+
+        cfm = CachingFileManager(netCDF4.Dataset, fn, mode="r")
+        arr = hf.get_serializable_dask_array(cfm, "/".join([grp, "kaitum"]),
+                                             chunks=shape, dtype=dtype)
+
+        # As documented in GH issue 2815, using dask distributed with the file
+        # handle cacher might fail in non-trivial ways, such as giving incorrect
+        # results.  Testing map_blocks is one way to reproduce the problem
+        # reliably, even though the problem also manifests itself (in different
+        # ways) without map_blocks.
+
+        def doubler(x):
+            # with a workaround for https://github.com/numpy/numpy/issues/27029
+            return x * x.dtype.type(2)
+
+        dask_doubler = arr.map_blocks(doubler, dtype=arr.dtype)
+        res = dask_doubler.compute()
+        # test before and after computation, as to confirm we have the correct
+        # shape and dtype and that computing doesn't change them
+        assert shape == dask_doubler.shape
+        assert shape == res.shape
+        assert dtype == dask_doubler.dtype
+        assert dtype == res.dtype
+        np.testing.assert_array_equal(res, np.arange(np.prod(shape)).reshape(shape)*2)
+
+
 class TestCalibrationCoefficientPicker:
     """Unit tests for calibration coefficient selection."""
 
@@ -663,72 +721,3 @@ def test_init_import_warns(name):
 
     with pytest.warns(UserWarning, match=".*has been moved.*"):
         _ = getattr(utils, name)
-
-
-@pytest.fixture()
-def dummy_nc(tmp_path):
-    """Fixture to create a dummy NetCDF file and return its path."""
-    import xarray as xr
-
-    fn = tmp_path / "sjaunja.nc"
-    ds = xr.Dataset(data_vars={"kaitum": (["x"], np.arange(10, dtype="i4"))})
-    ds.to_netcdf(fn)
-    return fn
-
-
-class TestDistributed:
-    """Distributed-related tests.
-
-    Distributed-related tests are grouped so that they can share a class-scoped
-    fixture setting up the distributed client, as this setup is relatively
-    slow.
-    """
-
-    @pytest.fixture(scope="class")
-    def dask_dist_client(self):
-        """Set up and close a dask distributed client."""
-        from dask.distributed import Client
-        cl = Client()
-        yield cl
-        cl.close()
-
-
-    @pytest.mark.parametrize("shape", [(2,), (2, 3), (2, 3, 4)])
-    @pytest.mark.parametrize("dtype", ["i4", "f4", "f8"])
-    @pytest.mark.parametrize("grp", ["/", "/in/a/group"])
-    def test_get_serialisable_dask_array(self, tmp_path, dask_dist_client, shape, dtype, grp):
-        """Test getting a dask distributed friendly serialisable dask array."""
-        import netCDF4
-        from xarray.backends import CachingFileManager
-
-        fn = tmp_path / "sjaunja.nc"
-        ds = xr.Dataset(
-                data_vars={
-                    "kaitum": (["x", "y", "z"][:len(shape)],
-                               np.arange(np.prod(shape),
-                                         dtype=dtype).reshape(shape))})
-        ds.to_netcdf(fn, group=grp)
-
-        cfm = CachingFileManager(netCDF4.Dataset, fn, mode="r")
-        arr = hf.get_serialisable_dask_array(cfm, "/".join([grp, "kaitum"]),
-                                             chunks=shape, dtype=dtype)
-
-        # As documented in GH issue 2815, using dask distributed with the file
-        # handle cacher might fail in non-trivial ways, such as giving incorrect
-        # results.  Testing map_blocks is one way to reproduce the problem
-        # reliably, even though the problem also manifests itself (in different
-        # ways) without map_blocks.
-
-        def doubler(x):
-            # with a workaround for https://github.com/numpy/numpy/issues/27029
-            return x * x.dtype.type(2)
-
-        dask_doubler = arr.map_blocks(doubler, dtype=arr.dtype)
-        res = dask_doubler.compute()
-        # test before and after computation, as to confirm we have the correct
-        # shape and dtype and that computing doesn't change them
-        assert shape == dask_doubler.shape
-        assert shape == res.shape
-        assert dtype == dask_doubler.dtype
-        assert dtype == res.dtype
-        np.testing.assert_array_equal(res, np.arange(np.prod(shape)).reshape(shape)*2)

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -721,9 +721,10 @@ class TestDistributed:
         # ways) without map_blocks.
 
         def doubler(x):
-            return x * 2
+            # with a workaround for https://github.com/numpy/numpy/issues/27029
+            return x * x.dtype.type(2)
 
-        dask_doubler = arr.map_blocks(doubler)
+        dask_doubler = arr.map_blocks(doubler, dtype=arr.dtype)
         res = dask_doubler.compute()
         # test before and after computation, as to confirm we have the correct
         # shape and dtype and that computing doesn't change them

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -524,55 +524,45 @@ def test_generic_open_binary(tmp_path, data, filename, mode):
     assert read_binary_data == dummy_data
 
 
+@pytest.mark.parametrize("shape", [(2,), (2, 3), (2, 3, 4)])
+@pytest.mark.parametrize("dtype", ["i4", "f4", "f8"])
+@pytest.mark.parametrize("grp", ["/", "/in/a/group"])
+def test_get_serializable_dask_array(tmp_path, client, shape, dtype, grp):  # noqa
+    """Test getting a dask distributed friendly serialisable dask array."""
+    import netCDF4
+    from xarray.backends import CachingFileManager
 
-class TestDistributed:
-    """Distributed-related tests.
+    fn = tmp_path / "sjaunja.nc"
+    ds = xr.Dataset(
+            data_vars={
+                "kaitum": (["x", "y", "z"][:len(shape)],
+                           np.arange(np.prod(shape),
+                                     dtype=dtype).reshape(shape))})
+    ds.to_netcdf(fn, group=grp)
 
-    Distributed-related tests are grouped so that they can share a class-scoped
-    fixture setting up the distributed client, as this setup is relatively
-    slow.
-    """
+    cfm = CachingFileManager(netCDF4.Dataset, fn, mode="r")
+    arr = hf.get_serializable_dask_array(cfm, "/".join([grp, "kaitum"]),
+                                         chunks=shape, dtype=dtype)
 
+    # As documented in GH issue 2815, using dask distributed with the file
+    # handle cacher might fail in non-trivial ways, such as giving incorrect
+    # results.  Testing map_blocks is one way to reproduce the problem
+    # reliably, even though the problem also manifests itself (in different
+    # ways) without map_blocks.
 
-    @pytest.mark.parametrize("shape", [(2,), (2, 3), (2, 3, 4)])
-    @pytest.mark.parametrize("dtype", ["i4", "f4", "f8"])
-    @pytest.mark.parametrize("grp", ["/", "/in/a/group"])
-    def test_get_serializable_dask_array(self, tmp_path, client, shape, dtype, grp):  # noqa
-        """Test getting a dask distributed friendly serialisable dask array."""
-        import netCDF4
-        from xarray.backends import CachingFileManager
+    def doubler(x):
+        # with a workaround for https://github.com/numpy/numpy/issues/27029
+        return x * x.dtype.type(2)
 
-        fn = tmp_path / "sjaunja.nc"
-        ds = xr.Dataset(
-                data_vars={
-                    "kaitum": (["x", "y", "z"][:len(shape)],
-                               np.arange(np.prod(shape),
-                                         dtype=dtype).reshape(shape))})
-        ds.to_netcdf(fn, group=grp)
-
-        cfm = CachingFileManager(netCDF4.Dataset, fn, mode="r")
-        arr = hf.get_serializable_dask_array(cfm, "/".join([grp, "kaitum"]),
-                                             chunks=shape, dtype=dtype)
-
-        # As documented in GH issue 2815, using dask distributed with the file
-        # handle cacher might fail in non-trivial ways, such as giving incorrect
-        # results.  Testing map_blocks is one way to reproduce the problem
-        # reliably, even though the problem also manifests itself (in different
-        # ways) without map_blocks.
-
-        def doubler(x):
-            # with a workaround for https://github.com/numpy/numpy/issues/27029
-            return x * x.dtype.type(2)
-
-        dask_doubler = arr.map_blocks(doubler, dtype=arr.dtype)
-        res = dask_doubler.compute()
-        # test before and after computation, as to confirm we have the correct
-        # shape and dtype and that computing doesn't change them
-        assert shape == dask_doubler.shape
-        assert shape == res.shape
-        assert dtype == dask_doubler.dtype
-        assert dtype == res.dtype
-        np.testing.assert_array_equal(res, np.arange(np.prod(shape)).reshape(shape)*2)
+    dask_doubler = arr.map_blocks(doubler, dtype=arr.dtype)
+    res = dask_doubler.compute()
+    # test before and after computation, as to confirm we have the correct
+    # shape and dtype and that computing doesn't change them
+    assert shape == dask_doubler.shape
+    assert shape == res.shape
+    assert dtype == dask_doubler.dtype
+    assert dtype == res.dtype
+    np.testing.assert_array_equal(res, np.arange(np.prod(shape)).reshape(shape)*2)
 
 
 class TestCalibrationCoefficientPicker:

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -29,6 +29,13 @@ import numpy.testing
 import pyresample.geometry
 import pytest
 import xarray as xr
+from dask.distributed.utils_test import cleanup  # noqa
+from dask.distributed.utils_test import client as dask_dist_client  # noqa
+from dask.distributed.utils_test import (  # noqa
+    cluster_fixture,
+    loop,
+    loop_in_thread,
+)
 from fsspec.implementations.memory import MemoryFile, MemoryFileSystem
 from pyproj import CRS
 
@@ -517,6 +524,7 @@ def test_generic_open_binary(tmp_path, data, filename, mode):
     assert read_binary_data == dummy_data
 
 
+
 class TestDistributed:
     """Distributed-related tests.
 
@@ -525,19 +533,11 @@ class TestDistributed:
     slow.
     """
 
-    @pytest.fixture(scope="class")
-    def dask_dist_client(self):
-        """Set up and close a dask distributed client."""
-        from dask.distributed import Client
-        cl = Client()
-        yield cl
-        cl.close()
-
 
     @pytest.mark.parametrize("shape", [(2,), (2, 3), (2, 3, 4)])
     @pytest.mark.parametrize("dtype", ["i4", "f4", "f8"])
     @pytest.mark.parametrize("grp", ["/", "/in/a/group"])
-    def test_get_serializable_dask_array(self, tmp_path, dask_dist_client, shape, dtype, grp):
+    def test_get_serializable_dask_array(self, tmp_path, dask_dist_client, shape, dtype, grp):  # noqa
         """Test getting a dask distributed friendly serialisable dask array."""
         import netCDF4
         from xarray.backends import CachingFileManager

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -676,43 +676,59 @@ def dummy_nc(tmp_path):
     return fn
 
 
-@pytest.mark.parametrize("shape", [(2,), (2, 3), (2, 3, 4)])
-@pytest.mark.parametrize("dtype", ["i4", "f4", "f8"])
-def test_get_distributed_friendly_dask_array(tmp_path, shape, dtype):
-    """Test getting a dask distributed friendly dask array."""
-    import netCDF4
-    from dask.distributed import Client
-    from xarray.backends import CachingFileManager
+class TestDistributed:
+    """Distributed-related tests.
 
-    fn = tmp_path / "sjaunja.nc"
-    ds = xr.Dataset(
-            data_vars={
-                "kaitum": (["x", "y", "z"][:len(shape)],
-                           np.arange(np.prod(shape),
-                                     dtype=dtype).reshape(shape))})
-    ds.to_netcdf(fn)
+    Distributed-related tests are grouped so that they can share a class-scoped
+    fixture setting up the distributed client, as this setup is relatively
+    slow.
+    """
 
-    cfm = CachingFileManager(netCDF4.Dataset, fn, mode="r")
-    arr = hf.get_distributed_friendly_dask_array(cfm, "kaitum",
-                                                 chunks=shape, dtype=dtype)
+    @pytest.fixture(scope="class")
+    def dask_dist_client(self):
+        """Set up and close a dask distributed client."""
+        from dask.distributed import Client
+        cl = Client()
+        yield cl
+        cl.close()
 
-    # As documented in GH issue 2815, using dask distributed with the file
-    # handle cacher might fail in non-trivial ways, such as giving incorrect
-    # results.  Testing map_blocks is one way to reproduce the problem
-    # reliably, even though the problem also manifests itself (in different
-    # ways) without map_blocks.
 
-    def doubler(x):
-        return x * 2
+    @pytest.mark.parametrize("shape", [(2,), (2, 3), (2, 3, 4)])
+    @pytest.mark.parametrize("dtype", ["i4", "f4", "f8"])
+    @pytest.mark.parametrize("grp", ["/", "/in/a/group"])
+    def test_get_distributed_friendly_dask_array(self, tmp_path, dask_dist_client, shape, dtype, grp):
+        """Test getting a dask distributed friendly dask array."""
+        import netCDF4
+        from xarray.backends import CachingFileManager
 
-    # FIXME: setting up the client is slow, taking more than one second —
-    # consider putting it in a class-scoped fixture and putting this test
-    # in a class (so it is still shared between parameterised runs)
-    with Client():
+        fn = tmp_path / "sjaunja.nc"
+        ds = xr.Dataset(
+                data_vars={
+                    "kaitum": (["x", "y", "z"][:len(shape)],
+                               np.arange(np.prod(shape),
+                                         dtype=dtype).reshape(shape))})
+        ds.to_netcdf(fn, group=grp)
+
+        cfm = CachingFileManager(netCDF4.Dataset, fn, mode="r")
+        arr = hf.get_distributed_friendly_dask_array(cfm, "kaitum",
+                                                     chunks=shape, dtype=dtype,
+                                                     group=grp)
+
+        # As documented in GH issue 2815, using dask distributed with the file
+        # handle cacher might fail in non-trivial ways, such as giving incorrect
+        # results.  Testing map_blocks is one way to reproduce the problem
+        # reliably, even though the problem also manifests itself (in different
+        # ways) without map_blocks.
+
+        def doubler(x):
+            return x * 2
+
         dask_doubler = arr.map_blocks(doubler)
         res = dask_doubler.compute()
-    assert shape == dask_doubler.shape  # we will need dtype before compute
-    assert shape == res.shape
-    assert dtype == dask_doubler.dtype
-    assert dtype == res.dtype
-    np.testing.assert_array_equal(res, np.arange(np.prod(shape)).reshape(shape)*2)
+        # test before and after computation, as to confirm we have the correct
+        # shape and dtype and that computing doesn't change them
+        assert shape == dask_doubler.shape
+        assert shape == res.shape
+        assert dtype == dask_doubler.dtype
+        assert dtype == res.dtype
+        np.testing.assert_array_equal(res, np.arange(np.prod(shape)).reshape(shape)*2)

--- a/satpy/tests/reader_tests/test_utils.py
+++ b/satpy/tests/reader_tests/test_utils.py
@@ -30,12 +30,12 @@ import pyresample.geometry
 import pytest
 import xarray as xr
 from dask.distributed.utils_test import (  # noqa
-    cleanup,  # noqa
+    cleanup,
+    client,
     cluster_fixture,
     loop,
     loop_in_thread,
 )
-from dask.distributed.utils_test import client as dask_dist_client  # noqa
 from fsspec.implementations.memory import MemoryFile, MemoryFileSystem
 from pyproj import CRS
 
@@ -537,7 +537,7 @@ class TestDistributed:
     @pytest.mark.parametrize("shape", [(2,), (2, 3), (2, 3, 4)])
     @pytest.mark.parametrize("dtype", ["i4", "f4", "f8"])
     @pytest.mark.parametrize("grp", ["/", "/in/a/group"])
-    def test_get_serializable_dask_array(self, tmp_path, dask_dist_client, shape, dtype, grp):  # noqa
+    def test_get_serializable_dask_array(self, tmp_path, client, shape, dtype, grp):  # noqa
         """Test getting a dask distributed friendly serialisable dask array."""
         import netCDF4
         from xarray.backends import CachingFileManager


### PR DESCRIPTION
This PR makes file cache handling in the NetCDF4FileHandler compatible with dask distributed.  It adds a utility function in `satpy.readers.utils` called `get_distributed_friendly_dask_array`, which can be used to produce a dask.array from a netCDF4 variable that can be used in an xarray, but dask graphs remain picklable and thus computable when including this one.  This utility function is now used in NetCDF4FileHandler, which replaces homegrown file handle caching by caching using xarray.backends.CachingFileManager, which is needed to implement the aforementioned utility function.

 - [x] Closes #2815 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
