### PR TITLE
Update docs for Developer's Guide, add dev-key for dependency install…

### DIFF
--- a/doc/source/dev_guide/index.rst
+++ b/doc/source/dev_guide/index.rst
@@ -72,7 +72,7 @@ All the required dependencies for a full development environment, i.e. running t
 tests and building the documentation, can be installed with::
 
     conda install eccodes
-    pip install -e ".[all]"
+    pip install -e ".[dev]"
 
 Running tests
 =============
@@ -125,7 +125,7 @@ Satpy's documentation is built using Sphinx. All documentation lives in the
 ``doc/`` directory of the project repository. For building the documentation,
 additional packages are needed. These can be installed with ::
 
-    pip install -e ".[all]"
+    pip install -e ".[doc]"
 
 After editing the source files there the documentation can be generated locally::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ tests = ["behave", "h5py", "netCDF4", "pyhdf", "imageio",
          "rioxarray", "pytest", "pytest-lazy-fixtures", "defusedxml",
          "s3fs", "eccodes", "h5netcdf", "xarray-datatree",
          "skyfield", "ephem", "pint-xarray", "astropy", "dask-image", "python-geotiepoints", "numba"]
+dev = ["satpy[doc,tests]"]
 
 [project.scripts]
 satpy_retrieve_all_aux_data = "satpy.aux_download:retrieve_all_cmd"


### PR DESCRIPTION
This PR fixes documentation under "Developer's Guide" by introducing new dependency group `dev`in `pyproject.toml`-file and updating the docs accordingly.

Old documentation instructed the user to run `pip install -e ".[all]"`, which only results to a warning as dependency key `all` does not exist in `pyproject.toml`-file.

 - [x] Closes #2823  
 - [x] Fully documented
