### PR TITLE
Fix DayNightCompositor compatibility with numpy 2

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -48,7 +48,7 @@ dependencies:
   - fsspec
   - botocore>=1.33
   - s3fs
-  - python-geotiepoints
+#  - python-geotiepoints
   - pooch
   - pip
   - skyfield
@@ -63,3 +63,4 @@ dependencies:
     - trollimage>=1.23
     - pyspectral
     - pyorbital
+    - python-geotiepoints

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -764,8 +764,8 @@ class DayNightCompositor(GenericCompositor):
             self,
             projectables: Sequence[xr.DataArray],
     ) -> xr.DataArray:
-        lim_low = np.cos(np.deg2rad(self.lim_low))
-        lim_high = np.cos(np.deg2rad(self.lim_high))
+        lim_low = float(np.cos(np.deg2rad(self.lim_low)))
+        lim_high = float(np.cos(np.deg2rad(self.lim_high)))
         try:
             coszen = np.cos(np.deg2rad(projectables[2 if self.day_night == "day_night" else 1]))
             self._has_sza = True
@@ -775,8 +775,8 @@ class DayNightCompositor(GenericCompositor):
             # Get chunking that matches the data
             coszen = get_cos_sza(projectables[0])
         # Calculate blending weights
-        coszen -= np.min((lim_high, lim_low))
-        coszen /= np.abs(lim_low - lim_high)
+        coszen -= min(lim_high, lim_low)
+        coszen /= abs(lim_low - lim_high)
         return coszen.clip(0, 1)
 
     def _get_data_for_single_side_product(

--- a/satpy/tests/modifier_tests/test_angles.py
+++ b/satpy/tests/modifier_tests/test_angles.py
@@ -371,15 +371,17 @@ class TestAngleGeneration:
         assert isinstance(raa, xr.DataArray)
         np.testing.assert_allclose(expected_raa, raa)
 
-    def test_solazi_correction(self):
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_solazi_correction(self, dtype):
         """Test that solar azimuth angles are corrected into the right range."""
         from satpy.modifiers.angles import _get_sun_azimuth_ndarray
 
-        lats = np.array([-80, 40, 0, 40, 80])
-        lons = np.array([-80, 40, 0, 40, 80])
+        lats = np.array([-80, 40, 0, 40, 80], dtype=dtype)
+        lons = np.array([-80, 40, 0, 40, 80], dtype=dtype)
 
         date = dt.datetime(2022, 1, 5, 12, 50, 0)
 
         azi = _get_sun_azimuth_ndarray(lats, lons, date)
 
         assert np.all(azi > 0)
+        assert azi.dtype == dtype

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -18,7 +18,6 @@
 """Module for testing the satpy.readers.netcdf_utils module."""
 
 import os
-import pathlib
 import unittest
 
 import numpy as np
@@ -234,8 +233,9 @@ class TestNetCDF4FileHandler(unittest.TestCase):
         """Test that error is raised when file not found."""
         from satpy.readers.netcdf_utils import NetCDF4FileHandler
 
-        with pytest.raises(IOError, match=".*No such file or directory.*"):
-            NetCDF4FileHandler(str(pathlib.Path("/") / "thisfiledoesnotexist.nc"), {}, {})
+        # NOTE: Some versions of NetCDF C report unknown file format on Windows
+        with pytest.raises(IOError, match=".*(No such file or directory|Unknown file format).*"):
+            NetCDF4FileHandler("/thisfiledoesnotexist.nc", {}, {})
 
     def test_get_and_cache_npxr_is_xr(self):
         """Test that get_and_cache_npxr() returns xr.DataArray."""

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -18,6 +18,7 @@
 """Module for testing the satpy.readers.netcdf_utils module."""
 
 import os
+import pathlib
 import unittest
 
 import numpy as np
@@ -234,7 +235,7 @@ class TestNetCDF4FileHandler(unittest.TestCase):
         from satpy.readers.netcdf_utils import NetCDF4FileHandler
 
         with pytest.raises(IOError, match=".*No such file or directory.*"):
-            NetCDF4FileHandler("/thisfiledoesnotexist.nc", {}, {})
+            NetCDF4FileHandler(str(pathlib.Path("/") / "thisfiledoesnotexist.nc"), {}, {})
 
     def test_get_and_cache_npxr_is_xr(self):
         """Test that get_and_cache_npxr() returns xr.DataArray."""

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -606,11 +606,12 @@ class TestDayNightCompositor(unittest.TestCase):
         """Test compositor with day portion without alpha_band when SZA data is not provided."""
         from satpy.composites import DayNightCompositor
 
-        with dask.config.set(scheduler=CustomScheduler(max_computes=1)):
-            comp = DayNightCompositor(name="dn_test", day_night="day_only", include_alpha=False)
-            res = comp((self.data_a,))
-            res = res.compute()
+        # with dask.config.set(scheduler=CustomScheduler(max_computes=1)):
+        comp = DayNightCompositor(name="dn_test", day_night="day_only", include_alpha=False)
+        res_dask = comp((self.data_a,))
+        res = res_dask.compute()
         expected = np.array([[0., 0.33164983], [0.66835017, 1.]], dtype=np.float32)
+        assert res_dask.dtype == res.dtype
         assert res.dtype == np.float32
         np.testing.assert_allclose(res.values[0], expected)
         assert "A" not in res.bands


### PR DESCRIPTION
Requires https://github.com/pytroll/pyorbital/pull/155 to be fully fixed as far as the DayNightCompositor goes. I mentioned it on slack, but basically `np.some_func(float)` with numpy 2 will always produce a `numpy.float64`. Any future calculations with that result will then upcast/promote to `numpy.float64` even if there are 32-bit float arrays.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
