### PR TITLE
Add a testing utility for faking reading

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -94,3 +94,4 @@ The following people have made contributions to this project:
 - [Will Sharpe (wjsharpe)](https://github.com/wjsharpe)
 - [Sara Hörnquist (shornqui)](https://github.com/shornqui)
 - [Antonio Valentino](https://github.com/avalentino)
+- [Pouria Khalaj](https://github.com/pkhalaj)

--- a/doc/source/dev_guide/index.rst
+++ b/doc/source/dev_guide/index.rst
@@ -19,6 +19,7 @@ at the pages listed below.
     satpy_internals
     aux_data
     writing_tests
+    testing
 
 Coding guidelines
 =================

--- a/doc/source/dev_guide/testing.rst
+++ b/doc/source/dev_guide/testing.rst
@@ -3,4 +3,4 @@ Testing Satpy-based applications
 
 The ``satpy.testing`` modules provides tools for writing tests of applications that use Satpy.
 
-- For faking reading, you can use `:func:satpy.testing.fake_satpy_reading`.
+- For faking reading, you can use ``:func:satpy.testing.fake_satpy_reading``.

--- a/doc/source/dev_guide/testing.rst
+++ b/doc/source/dev_guide/testing.rst
@@ -3,4 +3,4 @@ Testing Satpy-based applications
 
 The ``satpy.testing`` modules provides tools for writing tests of applications that use Satpy.
 
-- For faking reading, you can use ``:func:satpy.testing.fake_satpy_reading``.
+- For faking reading, you can use :func:`~satpy.testing.fake_satpy_reading`

--- a/doc/source/dev_guide/testing.rst
+++ b/doc/source/dev_guide/testing.rst
@@ -1,0 +1,6 @@
+Testing Satpy-based applications
+================================
+
+The ``satpy.testing`` modules provides tools for writing tests of applications that use Satpy.
+
+- For faking reading, you can use `:func:satpy.testing.fake_satpy_reading`.

--- a/doc/source/dev_guide/testing.rst
+++ b/doc/source/dev_guide/testing.rst
@@ -3,4 +3,4 @@ Testing Satpy-based applications
 
 The ``satpy.testing`` modules provides tools for writing tests of applications that use Satpy.
 
-- To allow Scene creation and loading fake datasets without reading any data file: :func:`~satpy.testing.fake_satpy_reading`
+- To allow Scene creation and loading fake datasets without reading any data files: :func:`~satpy.testing.fake_satpy_reading`

--- a/doc/source/dev_guide/testing.rst
+++ b/doc/source/dev_guide/testing.rst
@@ -3,4 +3,4 @@ Testing Satpy-based applications
 
 The ``satpy.testing`` modules provides tools for writing tests of applications that use Satpy.
 
-- For faking reading, you can use :func:`~satpy.testing.fake_satpy_reading`
+- To allow Scene creation and loading fake datasets without reading any data file: :func:`~satpy.testing.fake_satpy_reading`

--- a/satpy/testing.py
+++ b/satpy/testing.py
@@ -12,7 +12,7 @@ import satpy.scene
 def fake_satpy_reading(scene_dict):
     """Fake the satpy reading and populate the returned scene with the contents of *scene_dict*.
 
-    This allows users to test their programs that use satpy with actually needing to read files, eg::
+    This allows users to test their programs that use satpy without actually needing to read files, eg::
 
         scene_dict = {channel: somedata}
 

--- a/satpy/testing.py
+++ b/satpy/testing.py
@@ -1,0 +1,37 @@
+"""Testing helpers for satpy."""
+
+from contextlib import contextmanager
+from unittest import mock
+
+import pytest
+
+import satpy.scene
+
+
+@contextmanager
+def fake_satpy_reading(scene_dict):
+    """Fake the satpy reading and populate the returned scene with the contents of *scene_dict*.
+
+    This allows users to test their programs that use satpy with actually needing to read files, eg::
+
+        scene_dict = {channel: somedata}
+
+        with fake_satpy_reading(scene_dict):
+            scene = Scene(input_files, reader="dummy_reader")
+            scene.load([channel])
+
+    """
+    with pytest.MonkeyPatch().context() as monkeypatch:
+        reader_instance = mock.Mock()
+        reader_instance.sensor_names = ["dummy_sensor"]
+        fake_load_readers = mock.Mock()
+        fake_load_readers.return_value = {"dummy_reader": reader_instance}
+        monkeypatch.setattr(satpy.scene, "load_readers", fake_load_readers)
+
+        def fake_load(self, channels):
+            for channel in channels:
+                self[channel] = scene_dict[channel]
+
+
+        monkeypatch.setattr(satpy.scene.Scene, "load", fake_load)
+        yield

--- a/satpy/tests/test_testing.py
+++ b/satpy/tests/test_testing.py
@@ -1,0 +1,26 @@
+"""Tests for the testing helper module."""
+
+import numpy as np
+import xarray as xr
+
+from satpy import Scene
+from satpy.resample import get_area_def
+from satpy.testing import fake_satpy_reading
+
+
+def test_fake_reading(tmp_path):
+    """Test that the fake reading context manager populates a scene."""
+    input_files = [tmp_path / "my_input_file"]
+    area = get_area_def("euro4")
+    random = np.random.default_rng()
+    somedata = xr.DataArray(random.uniform(size=area.shape), dims=["y", "x"])
+    somedata.attrs["area"] = area
+
+    channel = "VIS006"
+
+    scene_dict = {channel: somedata}
+
+    with fake_satpy_reading(scene_dict):
+        scene = Scene(input_files, reader="dummy_reader")
+        scene.load([channel])
+    assert scene[channel] is somedata


### PR DESCRIPTION
This PR adds a testing utility to satpy for faking reading.

Useful for testing programs that use satpy for reading with actually needing to read anything.
Can be used like this:

```python

        scene_dict = {channel: somedata}
        with fake_satpy_reading(scene_dict):
            scene = Scene(input_files, reader="dummy_reader")
            scene.load([channel])
```

and the scene will be loaded with the contents of `scene_dict`.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
