### PR TITLE
Revert CI env change so geotiepoints comes from conda-forge

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -48,7 +48,7 @@ dependencies:
   - fsspec
   - botocore>=1.33
   - s3fs
-#  - python-geotiepoints
+  - python-geotiepoints
   - pooch
   - pip
   - skyfield
@@ -63,4 +63,3 @@ dependencies:
     - trollimage>=1.23
     - pyspectral
     - pyorbital
-    - python-geotiepoints


### PR DESCRIPTION
Forgot that I made this change in #2835 because I needed to wait for the new python-geotiepoints to be available on conda-forge.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
