### PR TITLE
Fix VIIRS EDR using the wrong geolocation arrays

### DIFF
--- a/satpy/tests/reader_tests/test_viirs_edr.py
+++ b/satpy/tests/reader_tests/test_viirs_edr.py
@@ -213,6 +213,14 @@ def cloud_height_file(tmp_path_factory: TempPathFactory) -> Path:
     data_vars = _create_continuous_variables(
         ("CldTopTemp", "CldTopHght", "CldTopPres")
     )
+    lon_pc = data_vars["Longitude"].copy(deep=True)
+    lat_pc = data_vars["Latitude"].copy(deep=True)
+    lon_pc.attrs["long_name"] = "BAD"
+    lat_pc.attrs["long_name"] = "BAD"
+    del lon_pc.encoding["_FillValue"]
+    del lat_pc.encoding["_FillValue"]
+    data_vars["Longitude_Pc"] = lon_pc
+    data_vars["Latitude_Pc"] = lat_pc
     return _create_fake_file(tmp_path_factory, fn, data_vars)
 
 
@@ -556,6 +564,9 @@ def _shared_metadata_checks(data_arr: xr.DataArray) -> None:
     assert lons.max() <= 180.0
     assert lats.min() >= -90.0
     assert lats.max() <= 90.0
+    # Some files (ex. CloudHeight) have other lon/lats that shouldn't be used
+    assert lons.attrs.get("long_name") != "BAD"
+    assert lats.attrs.get("long_name") != "BAD"
 
     if "valid_range" in data_arr.attrs:
         valid_range = data_arr.attrs["valid_range"]


### PR DESCRIPTION
The VIIRS EDR CloudHeight files includes not only normal lon/lat arrays but a parallax corrected lon/lat. These parallax lon/lats don't include proper metadata (ex. `_FillValue`) so loading them causes fill values to remain like `-999.9` instead of NaN. My previous code in this reader was rather naive and basically said if a variable name contained "longitude" or "latitude" then we should use it as the geolocation for our data arrays. This code was picking up the parallax corrected lon/lats instead of the "standard" ones. This PR is an attempt at making the reader smarter at choosing the right lon/lat arrays.

CC @kathys

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
