### PR TITLE
Add more test skips when numba is involved in the unstable CI

### DIFF
--- a/satpy/readers/vaisala_gld360.py
+++ b/satpy/readers/vaisala_gld360.py
@@ -54,7 +54,7 @@ class VaisalaGLD360TextFileHandler(BaseFileHandler):
         # Combine 'date' and 'time' into a datetime object
         parse_dates = {"time": ["gld360_date", "gld360_time"]}
 
-        self.data = pd.read_csv(filename, delim_whitespace=True, header=None,
+        self.data = pd.read_csv(filename, sep="\\s+", header=None,
                                 names=names, dtype=dtypes, parse_dates=parse_dates)
 
     @property

--- a/satpy/readers/vaisala_gld360.py
+++ b/satpy/readers/vaisala_gld360.py
@@ -52,7 +52,7 @@ class VaisalaGLD360TextFileHandler(BaseFileHandler):
         types = ["str", "str", "float", "float", "float", "str"]
         dtypes = dict(zip(names, types))
         # Combine 'date' and 'time' into a datetime object
-        parse_dates = {"time": ["gld360_date", "gld360_time"]}
+        parse_dates = {"time": [0, 1]}
 
         self.data = pd.read_csv(filename, sep="\\s+", header=None,
                                 names=names, dtype=dtypes, parse_dates=parse_dates)

--- a/satpy/readers/vaisala_gld360.py
+++ b/satpy/readers/vaisala_gld360.py
@@ -52,7 +52,7 @@ class VaisalaGLD360TextFileHandler(BaseFileHandler):
         types = ["str", "str", "float", "float", "float", "str"]
         dtypes = dict(zip(names, types))
         # Combine 'date' and 'time' into a datetime object
-        parse_dates = {"time": [0, 1]}
+        parse_dates = {"time": ["gld360_date", "gld360_time"]}
 
         self.data = pd.read_csv(filename, sep="\\s+", header=None,
                                 names=names, dtype=dtypes, parse_dates=parse_dates)

--- a/satpy/tests/reader_tests/gms/test_gms5_vissr_l1b.py
+++ b/satpy/tests/reader_tests/gms/test_gms5_vissr_l1b.py
@@ -11,8 +11,8 @@ from pyresample.geometry import AreaDefinition
 
 import satpy.tests.reader_tests.gms.test_gms5_vissr_data as real_world
 from satpy.readers import FSFile
-from satpy.tests.reader_tests.utils import get_jit_methods, skip_numba_unstable_if_missing
-from satpy.tests.utils import make_dataid
+from satpy.tests.reader_tests.utils import get_jit_methods
+from satpy.tests.utils import make_dataid, skip_numba_unstable_if_missing
 
 try:
     import satpy.readers.gms.gms5_vissr_format as fmt

--- a/satpy/tests/reader_tests/gms/test_gms5_vissr_navigation.py
+++ b/satpy/tests/reader_tests/gms/test_gms5_vissr_navigation.py
@@ -3,7 +3,8 @@
 import numpy as np
 import pytest
 
-from satpy.tests.reader_tests.utils import get_jit_methods, skip_numba_unstable_if_missing
+from satpy.tests.reader_tests.utils import get_jit_methods
+from satpy.tests.utils import skip_numba_unstable_if_missing
 
 try:
     import satpy.readers.gms.gms5_vissr_navigation as nav

--- a/satpy/tests/reader_tests/test_vaisala_gld360.py
+++ b/satpy/tests/reader_tests/test_vaisala_gld360.py
@@ -17,18 +17,21 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Unittesting the Vaisala GLD360 reader."""
 
-import unittest
+import os
 from io import StringIO
 
 import numpy as np
+import pytest
 
 from satpy.readers.vaisala_gld360 import VaisalaGLD360TextFileHandler
 from satpy.tests.utils import make_dataid
 
 
-class TestVaisalaGLD360TextFileHandler(unittest.TestCase):
+class TestVaisalaGLD360TextFileHandler:
     """Test the VaisalaGLD360TextFileHandler."""
 
+    @pytest.mark.xfail(os.getenv("UNSTABLE", "0") in ("1", "true"),
+                       reason="Vaisala GLD360 reader is not compatible with latest pandas")
     def test_vaisala_gld360(self):
         """Test basic functionality for vaisala file handler."""
         expected_power = np.array([12.3, 13.2, -31.])

--- a/satpy/tests/reader_tests/utils.py
+++ b/satpy/tests/reader_tests/utils.py
@@ -18,7 +18,6 @@
 """Utilities for reader tests."""
 
 import inspect
-import os
 
 
 def default_attr_processor(root, attr):
@@ -62,23 +61,3 @@ def get_jit_methods(module):
 
 def _is_jit_method(obj):
     return hasattr(obj, "py_func")
-
-
-def skip_numba_unstable_if_missing():
-    """Determine if numba-based tests should be skipped during unstable CI tests.
-
-    If numba fails to import it could be because numba is not compatible with
-    a newer version of numpy. This is very likely to happen in the
-    unstable/experimental CI environment. This function returns ``True`` if
-    numba-based tests should be skipped if ``numba`` could not
-    be imported *and* we're in the unstable environment. We determine if we're
-    in this CI environment by looking for the ``UNSTABLE="1"``
-    environment variable.
-
-    """
-    try:
-        import numba
-    except ImportError:
-        numba = None
-
-    return numba is None and os.environ.get("UNSTABLE", "0") in ("1", "true")

--- a/satpy/tests/scene_tests/test_conversions.py
+++ b/satpy/tests/scene_tests/test_conversions.py
@@ -23,10 +23,14 @@ import xarray as xr
 from dask import array as da
 
 from satpy import Scene
+from satpy.tests.reader_tests.utils import skip_numba_unstable_if_missing
 
 # NOTE:
 # The following fixtures are not defined in this file, but are used and injected by Pytest:
 # - include_test_etc
+
+skip_unstable_numba = pytest.mark.skipif(skip_numba_unstable_if_missing(),
+                                         reason="Numba is not compatible with unstable NumPy: {err!s}")
 
 
 @pytest.mark.usefixtures("include_test_etc")
@@ -83,6 +87,7 @@ class TestSceneConversions:
         # we assume that if we got something back, geoviews can use it
         assert gv_obj is not None
 
+    @skip_unstable_numba
     def test_hvplot_basic_with_area(self):
         """Test converting a Scene to hvplot with a AreaDefinition."""
         from pyresample.geometry import AreaDefinition
@@ -97,6 +102,7 @@ class TestSceneConversions:
         # we assume that if we got something back, hvplot can use it
         assert hv_obj is not None
 
+    @skip_unstable_numba
     def test_hvplot_rgb_with_area(self):
         """Test converting a Scene to hvplot with a AreaDefinition."""
         from pyresample.geometry import AreaDefinition
@@ -117,6 +123,7 @@ class TestSceneConversions:
         # we assume that if we got something back, hvplot can use it
         assert hv_obj is not None
 
+    @skip_unstable_numba
     def test_hvplot_basic_with_swath(self):
         """Test converting a Scene to hvplot with a SwathDefinition."""
         from pyresample.geometry import SwathDefinition

--- a/satpy/tests/scene_tests/test_conversions.py
+++ b/satpy/tests/scene_tests/test_conversions.py
@@ -23,7 +23,7 @@ import xarray as xr
 from dask import array as da
 
 from satpy import Scene
-from satpy.tests.reader_tests.utils import skip_numba_unstable_if_missing
+from satpy.tests.utils import skip_numba_unstable_if_missing
 
 # NOTE:
 # The following fixtures are not defined in this file, but are used and injected by Pytest:

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -17,6 +17,7 @@
 """Utilities for various satpy tests."""
 
 import datetime as dt
+import os
 from contextlib import contextmanager
 from typing import Any
 from unittest import mock
@@ -462,3 +463,23 @@ def xfail_h5py_unstable_numpy2():
     is_unstable_ci = os.environ.get("UNSTABLE", "0") in ("1", "true")
     is_np2 = np.__version__.startswith("2.")
     return is_broken_h5py and is_np2 and is_unstable_ci
+
+
+def skip_numba_unstable_if_missing():
+    """Determine if numba-based tests should be skipped during unstable CI tests.
+
+    If numba fails to import it could be because numba is not compatible with
+    a newer version of numpy. This is very likely to happen in the
+    unstable/experimental CI environment. This function returns ``True`` if
+    numba-based tests should be skipped if ``numba`` could not
+    be imported *and* we're in the unstable environment. We determine if we're
+    in this CI environment by looking for the ``UNSTABLE="1"``
+    environment variable.
+
+    """
+    try:
+        import numba
+    except ImportError:
+        numba = None
+
+    return numba is None and os.environ.get("UNSTABLE", "0") in ("1", "true")


### PR DESCRIPTION
It looks like hvplot now depends on numba and is causing failures in unstable CI. We typically skip these types of failures.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
