### PR TITLE
Fix start/end time properties of `hrit_jma` reader

### DIFF
--- a/satpy/readers/avhrr_l1b_gaclac.py
+++ b/satpy/readers/avhrr_l1b_gaclac.py
@@ -43,7 +43,7 @@ from pygac.lac_klm import LACKLMReader
 from pygac.lac_pod import LACPODReader
 
 from satpy.readers.file_handlers import BaseFileHandler
-from satpy.utils import get_legacy_chunk_size
+from satpy.utils import datetime64_to_pydatetime, get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
 
@@ -185,8 +185,8 @@ class GACLACFile(BaseFileHandler):
 
         # Update start/end time using the actual scanline timestamps
         times = self.reader.get_times()
-        self._start_time = times[0].astype(dt.datetime)
-        self._end_time = times[-1].astype(dt.datetime)
+        self._start_time = datetime64_to_pydatetime(times[0])
+        self._end_time = datetime64_to_pydatetime(times[-1])
 
         # Select user-defined scanlines and/or strip invalid coordinates
         if (self.start_line is not None or self.end_line is not None
@@ -224,8 +224,8 @@ class GACLACFile(BaseFileHandler):
         """
         sliced = self._slice(data)
         times = self._slice(times)
-        self._start_time = times[0].astype(dt.datetime)
-        self._end_time = times[-1].astype(dt.datetime)
+        self._start_time = datetime64_to_pydatetime(times[0])
+        self._end_time = datetime64_to_pydatetime(times[-1])
         return sliced, times
 
     def _slice(self, data):

--- a/satpy/readers/gms/gms5_vissr_l1b.py
+++ b/satpy/readers/gms/gms5_vissr_l1b.py
@@ -164,7 +164,7 @@ import satpy.readers.gms.gms5_vissr_navigation as nav
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.hrit_jma import mjd2datetime64
 from satpy.readers.utils import generic_open
-from satpy.utils import get_legacy_chunk_size
+from satpy.utils import datetime64_to_pydatetime, get_legacy_chunk_size
 
 CHUNK_SIZE = get_legacy_chunk_size()
 
@@ -307,8 +307,7 @@ class GMS5VISSRFileHandler(BaseFileHandler):
         }
 
     def _get_time_parameters(self):
-        start_time = mjd2datetime64(self._mode_block["observation_time_mjd"]).astype("datetime64[us]")
-        start_time = start_time.astype(dt.datetime).replace(second=0, microsecond=0)
+        start_time = self._get_start_time()
         end_time = start_time + dt.timedelta(
             minutes=25
         )  # Source: GMS User Guide, section 3.3.1
@@ -316,6 +315,11 @@ class GMS5VISSRFileHandler(BaseFileHandler):
             "nominal_start_time": start_time,
             "nominal_end_time": end_time,
         }
+
+    def _get_start_time(self):
+        start_time = mjd2datetime64(self._mode_block["observation_time_mjd"])
+        start_time = datetime64_to_pydatetime(start_time)
+        return start_time.replace(second=0, microsecond=0)
 
     def get_dataset(self, dataset_id, ds_info):
         """Get dataset from file."""

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -114,6 +114,7 @@ import logging
 import numpy as np
 import xarray as xr
 
+import satpy.utils
 from satpy.readers._geos_area import get_area_definition, get_area_extent
 from satpy.readers.hrit_base import (
     HRITFileHandler,
@@ -474,10 +475,10 @@ class HRITJMAFileHandler(HRITFileHandler):
     def start_time(self):
         """Get start time of the scan."""
         if self._use_acquisition_time_as_start_time:
-            return self.acq_time[0].astype(dt.datetime)
+            return satpy.utils.datetime64_to_pydatetime(self.acq_time[0])
         return self._start_time
 
     @property
     def end_time(self):
         """Get end time of the scan."""
-        return self.acq_time[-1].astype(dt.datetime)
+        return satpy.utils.datetime64_to_pydatetime(self.acq_time[-1])

--- a/satpy/readers/viirs_vgac_l1c_nc.py
+++ b/satpy/readers/viirs_vgac_l1c_nc.py
@@ -22,7 +22,7 @@ import numpy as np
 import xarray as xr
 
 from satpy.readers.file_handlers import BaseFileHandler
-from satpy.utils import datetime64_to_pydatetime, get_legacy_chunk_size
+from satpy.utils import get_legacy_chunk_size
 
 CHUNK_SIZE = get_legacy_chunk_size()
 logger = logging.getLogger(__name__)
@@ -72,10 +72,6 @@ class VGACFileHandler(BaseFileHandler):
             data.attrs["end_time"] = dt.datetime.strptime(data.attrs["EndTime"], "%Y-%m-%dT%H:%M:%S")
             self._end_time = data.attrs["end_time"]
             self._start_time = data.attrs["start_time"]
-
-    def dt64_to_datetime(self, dt64):
-        """Conversion of numpy.datetime64 to datetime objects."""
-        return datetime64_to_pydatetime(dt64)
 
     def extract_time_data(self, data, nc):
         """Decode time data."""

--- a/satpy/readers/viirs_vgac_l1c_nc.py
+++ b/satpy/readers/viirs_vgac_l1c_nc.py
@@ -22,7 +22,7 @@ import numpy as np
 import xarray as xr
 
 from satpy.readers.file_handlers import BaseFileHandler
-from satpy.utils import get_legacy_chunk_size
+from satpy.utils import datetime64_to_pydatetime, get_legacy_chunk_size
 
 CHUNK_SIZE = get_legacy_chunk_size()
 logger = logging.getLogger(__name__)
@@ -75,9 +75,7 @@ class VGACFileHandler(BaseFileHandler):
 
     def dt64_to_datetime(self, dt64):
         """Conversion of numpy.datetime64 to datetime objects."""
-        if isinstance(dt64, np.datetime64):
-            return dt64.astype(dt.datetime)
-        return dt64
+        return datetime64_to_pydatetime(dt64)
 
     def extract_time_data(self, data, nc):
         """Decode time data."""

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -337,11 +337,11 @@ class TestHRITJMAFileHandler(unittest.TestCase):
         """Test that by the datetime from the metadata returned when `use_acquisition_time_as_start_time=True`."""
         import datetime as dt
         start_time = dt.datetime(2022, 1, 20, 12, 10)
-        expected = dt.datetime(1970, 1, 1, 0, 0, 1, 36799)
         for platform in ["Himawari-8", "MTSAT-2"]:
             mda = self._get_mda(platform=platform)
             reader = self._get_reader(
                 mda=mda,
                 filename_info={"start_time": start_time},
                 reader_kwargs={"use_acquisition_time_as_start_time": True})
-            assert reader.start_time == expected
+            assert reader.start_time == dt.datetime(1970, 1, 1, 0, 0, 1, 36799)
+            assert reader.end_time == dt.datetime(1970, 1, 1, 3, 3, 20, 16000)

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -337,10 +337,11 @@ class TestHRITJMAFileHandler(unittest.TestCase):
         """Test that by the datetime from the metadata returned when `use_acquisition_time_as_start_time=True`."""
         import datetime as dt
         start_time = dt.datetime(2022, 1, 20, 12, 10)
+        expected = dt.datetime(1970, 1, 1, 0, 0, 1, 36799)
         for platform in ["Himawari-8", "MTSAT-2"]:
             mda = self._get_mda(platform=platform)
             reader = self._get_reader(
                 mda=mda,
                 filename_info={"start_time": start_time},
                 reader_kwargs={"use_acquisition_time_as_start_time": True})
-            assert reader.start_time == reader.acq_time[0].astype(dt.datetime)
+            assert reader.start_time == expected

--- a/satpy/tests/reader_tests/test_viirs_vgac_l1c_nc.py
+++ b/satpy/tests/reader_tests/test_viirs_vgac_l1c_nc.py
@@ -113,17 +113,6 @@ class TestVGACREader:
         assert scn_.end_time == dt.datetime(year=2023, month=3, day=28,
                                             hour=10, minute=11, second=12)
 
-    def test_dt64_to_datetime(self):
-        """Test datetime conversion branch."""
-        from satpy.readers.viirs_vgac_l1c_nc import VGACFileHandler
-        fh = VGACFileHandler(filename="",
-                             filename_info={"start_time": "2023-03-28T09:08:07"},
-                             filetype_info="")
-        in_dt = dt.datetime(year=2023, month=3, day=28,
-                            hour=9, minute=8, second=7)
-        out_dt = fh.dt64_to_datetime(in_dt)
-        assert out_dt == in_dt
-
     def test_decode_time_variable(self):
         """Test decode time variable branch."""
         from satpy.readers.viirs_vgac_l1c_nc import VGACFileHandler

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -32,6 +32,7 @@ import xarray as xr
 from satpy.tests.utils import xfail_skyfield_unstable_numpy2
 from satpy.utils import (
     angle2xyz,
+    datetime64_to_pydatetime,
     get_legacy_chunk_size,
     get_satpos,
     import_error_helper,
@@ -613,3 +614,21 @@ def test_find_in_ancillary():
             match=("Could not find dataset named thumb in "
                    "ancillary variables for dataset 'hand'")):
         find_in_ancillary(hand, "thumb")
+
+
+@pytest.mark.parametrize(
+    ("dt64", "expected"),
+    [
+        (
+                np.datetime64("2000-01-02T03:04:05.000000006"),
+                datetime.datetime(2000, 1, 2, 3, 4, 5, 0)
+        ),
+        (
+                np.datetime64("2000-01-02T03:04:05.000006"),
+                datetime.datetime(2000, 1, 2, 3, 4, 5, 6)
+        )
+    ]
+)
+def test_datetime64_to_pydatetime(dt64, expected):
+    """Test conversion from datetime64 to Python datetime."""
+    assert datetime64_to_pydatetime(dt64) == expected

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -31,7 +31,6 @@ from urllib.parse import urlparse
 
 import dask.utils
 import numpy as np
-import pandas as pd
 import xarray as xr
 import yaml
 from yaml import BaseLoader, UnsafeLoader
@@ -855,4 +854,4 @@ def datetime64_to_pydatetime(dt64):
     Returns (dt.datetime):
         Converted timestamp
     """
-    return pd.Timestamp(dt64).to_pydatetime(warn=False)
+    return dt64.astype("datetime64[us]").astype(datetime.datetime)

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -31,6 +31,7 @@ from urllib.parse import urlparse
 
 import dask.utils
 import numpy as np
+import pandas as pd
 import xarray as xr
 import yaml
 from yaml import BaseLoader, UnsafeLoader
@@ -841,3 +842,17 @@ def find_in_ancillary(data, dataset):
             f"variables for dataset {data.attrs.get('name')!r}, "
             f"found {cnt:d}")
     return matches[0]
+
+
+def datetime64_to_pydatetime(dt64):
+    """Convert numpy.datetime64 timestamp to Python datetime.
+
+    Discards nanosecond precision, because Python datetime only has microsecond
+    precision.
+
+    Args:
+        dt64 (np.datetime64): Timestamp to be converted
+    Returns (dt.datetime):
+        Converted timestamp
+    """
+    return pd.Timestamp(dt64).to_pydatetime(warn=False)


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Fix `start/end_time` properties of `hrit_jma` reader to return `datetime` objects (currently integers).

Reason: `datetime64.astype(dt.datetime)` doesn't always return a `datetime` object. (see https://github.com/numpy/numpy/issues/20351).

```python
>>> np.datetime64("2000-01-01T00:00:00.000001").astype(dt.datetime)  # microsecond precision
datetime.datetime(2000, 1, 1, 0, 0, 0, 1)
>>> np.datetime64("2000-01-01T00:00:00.000000001").astype(dt.datetime)  # nanosecond precision
946684800000000001
```

I've updated usages of `datetime64.astype(dt.datetime)` in other readers, too. Although it doesn't seem to be a problem there, because they use micro/millisecond precision.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Tests added <!-- for all bug fixes or enhancements -->

