### PR TITLE
Add first version of LI composites and enhancements for point and accumulated products

### DIFF
--- a/satpy/etc/areas.yaml
+++ b/satpy/etc/areas.yaml
@@ -443,6 +443,26 @@ mtg_fci_fdss_2km:
     upper_right_xy: [5567999.994203017,  5567999.994203017]
     units: m
 
+mtg_fci_fdss_4km:
+  description:
+    MTG FCI Full Disk Scanning Service area definition
+    with 4 km SSP resolution
+  projection:
+    proj: geos
+    lon_0: 0
+    h: 35786400
+    x_0: 0
+    y_0: 0
+    ellps: WGS84
+    no_defs: null
+  shape:
+    height: 2784
+    width: 2784
+  area_extent:
+    lower_left_xy: [-5567999.994203018, -5567999.994203018]
+    upper_right_xy: [5567999.994203017,  5567999.994203017]
+    units: m
+
 # Full disk - segmented products
 mtg_fci_fdss_6km:
   description:

--- a/satpy/etc/composites/fci.yaml
+++ b/satpy/etc/composites/fci.yaml
@@ -190,6 +190,43 @@ composites:
       - name: vis_04
     standard_name: true_color_reproduction_color_stretch
 
+### True Color with LI lightning
+
+  true_color_with_night_ir105_acc_flash:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - acc_flash_alpha
+      - true_color_with_night_ir105
+
+  true_color_with_night_ir105_acc_flash_area:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - acc_flash_area_alpha
+      - true_color_with_night_ir105
+
+  true_color_with_night_ir105_acc_flash_radiance:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - acc_flash_radiance_alpha
+      - true_color_with_night_ir105
+
+  true_color_with_night_ir105_flash_radiance:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - flash_radiance_alpha
+      - true_color_with_night_ir105
+
+  true_color_with_night_ir105_group_radiance:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - group_radiance_alpha
+      - true_color_with_night_ir105
+
 ### GeoColor
   geo_color:
    compositor: !!python/name:satpy.composites.DayNightCompositor

--- a/satpy/etc/composites/li.yaml
+++ b/satpy/etc/composites/li.yaml
@@ -2,8 +2,75 @@
 sensor_name: visir/li
 
 composites:
+
+  acc_flash:
+    description: Composite to colorise the AF product using the flash accumulation
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    standard_name: acc_flash
+    prerequisites:
+    - flash_accumulation
+  acc_flash_alpha:
+    description: Composite to colorise the AF product using the flash accumulation with transparency
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    standard_name: acc_flash_alpha
+    prerequisites:
+    - flash_accumulation
+
+  acc_flash_area:
+    description: Composite to colorise the AFA product using the flash area
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    standard_name: acc_flash_area
+    prerequisites:
+    - accumulated_flash_area
+  acc_flash_area_alpha:
+    description: Composite to colorise the AFA product using the flash area with transparency
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    standard_name: acc_flash_area_alpha
+    prerequisites:
+    - accumulated_flash_area
+
+  acc_flash_radiance:
+    description: Composite to colorise the AFR product using the flash radiance
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    standard_name: lightning_radiance
+    prerequisites:
+    - flash_radiance
+  acc_flash_radiance_alpha:
+    description: Composite to colorise the AFR product using the flash radiance with transparency
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    standard_name: lightning_radiance_alpha
+    prerequisites:
+    - flash_radiance
+
+  flash_radiance:
+    description: Composite to colorise the LFL product using the flash radiance
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    standard_name: lightning_radiance
+    prerequisites:
+    - radiance
+  flash_radiance_alpha:
+    description: Composite to colorise the LFL product using the flash radiance with transparency
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    standard_name: lightning_radiance_alpha
+    prerequisites:
+    - radiance
+
+  group_radiance:
+    description: Composite to colorise the LGR product using the flash radiance
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    standard_name: lightning_radiance
+    prerequisites:
+    - radiance
+  group_radiance_alpha:
+    description: Composite to colorise the LGR product using the flash radiance with transparency
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    standard_name: lightning_radiance_alpha
+    prerequisites:
+    - radiance
+
+  # DEPRECATED, USE acc_flash_area instead
   flash_area:
     compositor: !!python/name:satpy.composites.SingleBandCompositor
-    standard_name: flash_area
+    standard_name: acc_flash_area
     prerequisites:
     - accumulated_flash_area

--- a/satpy/etc/composites/li.yaml
+++ b/satpy/etc/composites/li.yaml
@@ -2,7 +2,6 @@
 sensor_name: visir/li
 
 composites:
-
   acc_flash:
     description: Composite to colorise the AF product using the flash accumulation
     compositor: !!python/name:satpy.composites.SingleBandCompositor
@@ -68,7 +67,7 @@ composites:
     prerequisites:
     - radiance
 
-  # DEPRECATED, USE acc_flash_area instead
+  # DEPRECATED, USE acc_flash_area INSTEAD
   flash_area:
     compositor: !!python/name:satpy.composites.SingleBandCompositor
     standard_name: acc_flash_area

--- a/satpy/etc/composites/li.yaml
+++ b/satpy/etc/composites/li.yaml
@@ -1,6 +1,6 @@
 ---
 sensor_name: visir/li
-
+# these are tentative recipes that will need to be further tuned as we gain experience with LI data
 composites:
   acc_flash:
     description: Composite to colorise the AF product using the flash accumulation

--- a/satpy/etc/composites/seviri.yaml
+++ b/satpy/etc/composites/seviri.yaml
@@ -598,3 +598,74 @@ composites:
       - method: equal
         value: High_semitransparent_above_snow_ice
         transparency: 60
+
+### Composites with LI lightning
+  natural_color_with_night_ir_acc_flash:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - acc_flash_alpha
+      - natural_color_with_night_ir
+
+  natural_color_with_night_ir_acc_flash_area:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - acc_flash_area_alpha
+      - natural_color_with_night_ir
+
+  natural_color_with_night_ir_acc_flash_radiance:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - acc_flash_radiance_alpha
+      - natural_color_with_night_ir
+
+  natural_color_with_night_ir_flash_radiance:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - flash_radiance_alpha
+      - natural_color_with_night_ir
+
+  natural_color_with_night_ir_group_radiance:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - group_radiance_alpha
+      - natural_color_with_night_ir
+
+  hrv_acc_flash:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - acc_flash_alpha
+      - HRV
+
+  hrv_acc_flash_area:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - acc_flash_area_alpha
+      - HRV
+
+  hrv_acc_flash_radiance:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - acc_flash_radiance_alpha
+      - HRV
+
+  hrv_flash_radiance:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - flash_radiance_alpha
+      - HRV
+
+  hrv_group_radiance:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    standard_name: imager_with_lightning
+    prerequisites:
+      - group_radiance_alpha
+      - HRV

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -1269,3 +1269,7 @@ enhancements:
          stretch: crude
          min_stretch: [0,0,0]
          max_stretch: [1,1,1]
+
+  imager_with_lightning:
+    standard_name: imager_with_lightning
+    operations: []

--- a/satpy/etc/enhancements/li.yaml
+++ b/satpy/etc/enhancements/li.yaml
@@ -1,4 +1,6 @@
 enhancements:
+# note that the colormap parameters are tuned for 5 minutes of files accumulation
+# these are tentative recipes that will need to be further tuned as we gain experience with LI data
 
   acc_flash:
     standard_name: acc_flash

--- a/satpy/etc/enhancements/li.yaml
+++ b/satpy/etc/enhancements/li.yaml
@@ -1,10 +1,58 @@
 enhancements:
 
-  flash_area:
-    standard_name: flash_area
+  acc_flash:
+    standard_name: acc_flash
+    operations:
+    - name: colorize
+      method: !!python/name:satpy.enhancements.colorize
+      kwargs:
+        palettes:
+        - {colors: ylorrd, min_value: 0, max_value: 5}
+
+  acc_flash_alpha:
+    standard_name: acc_flash_alpha
+    operations:
+    - name: colorize
+      method: !!python/name:satpy.enhancements.colorize
+      kwargs:
+        palettes:
+        - {colors: ylorrd, min_value: 0, max_value: 5,
+           min_alpha: 120, max_alpha: 180}
+
+  acc_flash_area:
+    standard_name: acc_flash_area
     operations:
     - name: colorize
       method: !!python/name:satpy.enhancements.colorize
       kwargs:
         palettes:
         - {colors: ylorrd, min_value: 0, max_value: 20}
+
+  acc_flash_area_alpha:
+    standard_name: acc_flash_area_alpha
+    operations:
+    - name: colorize
+      method: !!python/name:satpy.enhancements.colorize
+      kwargs:
+        palettes:
+        - {colors: ylorrd, min_value: 0, max_value: 20,
+           min_alpha: 120, max_alpha: 180}
+
+  lightning_radiance:
+    standard_name: lightning_radiance
+    operations:
+    - name: colorize
+      method: !!python/name:satpy.enhancements.colorize
+      kwargs:
+        palettes:
+        - {colors: ylorrd, min_value: 0, max_value: 1000}
+
+  lightning_radiance_alpha:
+    standard_name: lightning_radiance_alpha
+    operations:
+    - name: colorize
+      method: !!python/name:satpy.enhancements.colorize
+      kwargs:
+        palettes:
+        - {colors: ylorrd, min_value: 0, max_value: 1000,
+           min_alpha: 120, max_alpha: 180}


### PR DESCRIPTION
This PR adds a series of composites and related enhancements for LI. These include standalone LI colorised composites, and a second version with linear transparency (`*_alpha`, which depend on https://github.com/pytroll/satpy/pull/2817), to be used in combination with other backgrounds. Some combinations with FCI and SEVIRI backgrounds are also added.

The naming of the composites was tricky; I have tried to keep the names as simple, short, clear, generic and future-proof as possible, while at the same time having to avoid the actual names of the variables inside the LI files.

Feedback welcome!

*Please note that these are just a first tentative version of the composites and enhancements, which will need to be further tuned/modified in the future, while we gather experiences and opinions. If you need the recipes to be stable already, please consider copying them to your local configs*.

Recipes based on this, using the LI-L1b-background in the background (instead of FCI or SEVIRI), have been used for the LI pre-operational release press release (https://www.eumetsat.int/lightning-imagers-data-debut-time-storm-season, https://user.eumetsat.int/news-events/news/mtg-lightning-imager-li-level-2-data-available).

Example images for the FCI combination are given below. The script to generate these images in an animation is also given below. The images are the result of 5 minutes accumulations, and the colormap range is adapted for this accumulation period. Accumulated (gridded) products are summed up to 5 minutes using a custom Multiscene blend method. Point files are summed up using the `bucket_sum` resampler (which needs https://github.com/pytroll/pyresample/pull/602 to work), remapping the point lightnings to a 4km grid in order to make the "markers" of an acceptable size. The summed-up LI dataset needs to be added manually to the background Scene, which is not so elegant and requires the knowledge of the name of LI dataset that is being used... solutions for this are welcome! When the script is more mature, it could be added to the documentation as well. 

true_color_with_night_ir105_acc_flash:
![FCI-LI_n_central_eu_true_color_with_night_ir105_acc_flash_20240526-155500_20240526-160000](https://github.com/pytroll/satpy/assets/49722768/4306eac7-af11-407f-8a8d-549c283c758e)
true_color_with_night_ir105_acc_flash_area:
![FCI-LI_n_central_eu_true_color_with_night_ir105_acc_flash_area_20240526-155500_20240526-160000](https://github.com/pytroll/satpy/assets/49722768/466066a7-094b-422e-80e2-0381b63fd096)
true_color_with_night_ir105_acc_flash_radiance:
![FCI-LI_n_central_eu_true_color_with_night_ir105_acc_flash_radiance_20240526-155500_20240526-160000](https://github.com/pytroll/satpy/assets/49722768/ef5505c0-4cf1-4da8-80ab-8805fc48add7)
true_color_with_night_ir105_flash_radiance:
![FCI-LI_n_central_eu_true_color_with_night_ir105_flash_radiance_20240526-155501_20240526-160001](https://github.com/pytroll/satpy/assets/49722768/d7dc4835-38a8-49be-a9f2-8f650ad0f172)
true_color_with_night_ir105_group_radiance:
![FCI-LI_n_central_eu_true_color_with_night_ir105_group_radiance_20240526-155501_20240526-160001](https://github.com/pytroll/satpy/assets/49722768/c3878bcc-dad8-45d3-9758-388552470aa3)

```python
import fnmatch
import gc
import hdf5plugin
import numpy as np
import xarray as xr

from satpy import Scene, MultiScene
from satpy.dataset import combine_metadata
from satpy.readers import find_files_and_readers
from satpy.utils import debug_on
import datetime

debug_on()

li_ds_dict = {
    'true_color_with_night_ir105_acc_flash': {'li_ds': 'acc_flash_alpha',
                                              'li_prod': 'AF'},
    'true_color_with_night_ir105_acc_flash_area': {'li_ds': 'acc_flash_area_alpha',
                                                   'li_prod': 'AFA'},
    'true_color_with_night_ir105_acc_flash_radiance': {'li_ds': 'acc_flash_radiance_alpha',
                                                       'li_prod': 'AFR'},
    'true_color_with_night_ir105_flash_radiance': {'li_ds': 'flash_radiance_alpha',
                                                   'li_prod': 'LFL'},
    'true_color_with_night_ir105_group_radiance': {'li_ds': 'group_radiance_alpha',
                                                   'li_prod': 'LGR'}
}
fci_prod = 'true_color_with_night_ir105'


def nan_sum(datasets):
    attrs = combine_metadata(*[data_arr.attrs for data_arr in datasets])
    # concatenate datasets in list order to apply sum function later
    concat_ds = xr.concat(datasets, dim="sum_dim")
    # apply sum, using skipna True to keep all valid pixels, min_count=1 to return to NaN if no active pixel found
    # keep_attrs=True since we need e.g. the area attribute later on
    sum_ds = concat_ds.sum(dim="sum_dim", skipna=True, keep_attrs=True, min_count=1)
    sum_ds.attrs = attrs
    return sum_ds


def plot_li_acc_with_background(li_filenames, fci_scene, output_folder, dataset_names, llboxes):
    li_dataset = li_ds_dict[dataset_names[0]].get('li_ds')
    li_type = 'accumulated' if 'acc' in li_dataset else 'point'

    # sum up the LI datasets
    if li_type == 'accumulated':
        # could this be a custom FileYAMLReader instead? Then one could use a simple multi-reader Scene
        liscn = MultiScene.from_files(li_filenames, reader='li_l2_nc')
        liscn.load([li_dataset])
        li_scn_b = liscn.blend(nan_sum)
    else:
        liscn = Scene(li_filenames, reader='li_l2_nc')
        liscn.load([li_dataset])
        li_scn_b = liscn.resample('mtg_fci_fdss_4km', resampler='bucket_sum', empty_bucket_value=np.nan)

    # insert the summed-up LI dataset into the FCI Scene, to allow the generation of the combined composite
    fci_scene[li_dataset] = li_scn_b[li_dataset]

    fci_scene.load(dataset_names, upper_right_corner='NE', unload=False, generate=False)
    ms_r = fci_scene.resample('mtg_fci_fdss_1km', resampler='native')

    # crop the Scene and save the image
    for ll_box_name, ll_box_val in llboxes.items():
        if ll_box_val is None:
            ms_lcl = ms_r
        else:
            ms_lcl = ms_r.crop(ll_bbox=ll_box_val)

        ms_lcl.save_datasets(datasets=dataset_names,
                             filename=output_folder +
                                      f'/FCI-LI_{ll_box_name}_{{name}}_'
                                      f'{fci_scene[li_dataset].attrs["start_time"].strftime("%Y%m%d-%H%M%S")}_'
                                      f'{fci_scene[li_dataset].attrs["end_time"].strftime("%Y%m%d-%H%M%S")}.png',
                             )

    # delete Scenes and garbage-collect to avoid segfaults when generating animations
    del liscn
    del li_scn_b
    gc.collect()

    return


def round_down_to_nearest_10_minutes(dt):
    # get the rounded down minutes
    new_minute = (dt.minute // 10) * 10
    # Create a new datetime object with the rounded minutes and reset seconds and microseconds to zero
    rounded_dt = dt.replace(minute=new_minute, second=0, microsecond=0)
    return rounded_dt


def get_last_complete_fci_start_end(dt):
    end_dt = round_down_to_nearest_10_minutes(dt)
    start_dt = end_dt - datetime.timedelta(minutes=10)
    return start_dt, end_dt


def generate_animation_frames(anim_start, anim_end, accumulation_window, interval, dataset_names, fci_folder, li_folder,
                              llboxes, output_folder):

    current_time = anim_start
    fci_fn = []
    fci_scene = None

    while current_time <= anim_end:
        print("\n" * 10)
        print("*" * 10)
        print("*" * 10)
        print(current_time)

        # get the LI filenames
        # add two seconds to avoid picking up LE/LEF products that start at 1 sec after
        li_start = current_time - accumulation_window + datetime.timedelta(seconds=2)
        li_end = current_time - datetime.timedelta(seconds=0.1)
        li_filenames = find_files_and_readers(base_dir=li_folder,
                                              start_time=li_start,
                                              end_time=li_end,
                                              reader='li_l2_nc',
                                              )

        # get the FCI filenames
        fci_start, fci_end = get_last_complete_fci_start_end(current_time)
        fci_filenames = find_files_and_readers(base_dir=fci_folder,
                                               start_time=fci_start,
                                               end_time=fci_end,
                                               reader='fci_l1c_nc')
        # filter only FDHSI
        fci_filenames = fnmatch.filter(fci_filenames['fci_l1c_nc'], "*FDHSI*")
        if len(fci_filenames) == 0:
            print("**\n\n missing FCI files \n\n**")
            continue

        # reuse FCI Scene if filenames are still the same
        if sorted(fci_filenames) != fci_fn:
            fci_scene = Scene(filenames=fci_filenames, reader='fci_l1c_nc')
            fci_scene.load([fci_prod], upper_right_corner='NE', unload=False, generate=False)
            fci_fn = sorted(fci_filenames)

        for dataset_name in dataset_names:
            dataset_name = [dataset_name]
            # get files only for this filename
            li_filenames_for_prod = sorted(fnmatch.filter(li_filenames['li_l2_nc'],
                                                          f"*LI-2-{li_ds_dict[dataset_name[0]].get('li_prod')}-*---*"))
            if len(li_filenames_for_prod) == 0:
                print(f"**\n\n missing LI files for {li_ds_dict[dataset_name[0]].get('li_prod')}\n\n**")
                continue
            plot_li_acc_with_background(li_filenames_for_prod, fci_scene, output_folder, dataset_name, llboxes)

        current_time += interval


def main():
    dataset_names = [
        'true_color_with_night_ir105_acc_flash',
        'true_color_with_night_ir105_acc_flash_area',
        'true_color_with_night_ir105_acc_flash_radiance',
        'true_color_with_night_ir105_flash_radiance',
        'true_color_with_night_ir105_group_radiance',
    ]

    output_folder = '/tcenas/proj/optcalimg/andream/fci_li_vis/test/'

    fci_folder = '/tcenas/scratch/andream/fci_reactivation_l1c_data/'
    li_folder = '/tcenas/scratch/andream/lil2/'

    anim_start = datetime.datetime(2024, 5, 26, 16, 00)
    anim_end = datetime.datetime(2024, 5, 26, 17, 0)
    interval = datetime.timedelta(minutes=1)
    accumulation_window = datetime.timedelta(minutes=5)

    llboxes = {
        # 'alps': [4.9, 43.2, 15.7, 49.9],
        # 'ITCZ_Africa': [-18, -11, 52, 21],
        # 'global': None,
        # 'Europe': [-10, 31, 30, 80],
        'n_central_eu': [4, 49, 19, 62],
    }

    generate_animation_frames(anim_start, anim_end, accumulation_window, interval, dataset_names, fci_folder, li_folder,
                              llboxes, output_folder)


if __name__ == "__main__":
    main()

```



