### PR TITLE
Fix default AWIPS tiled _FillValue of -1 for newer versions of xarray

### DIFF
--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -626,10 +626,7 @@ def _get_factor_offset_fill(input_data_arr, vmin, vmax, encoding):
         fills = [2 ** file_bit_depth - 1]
     elif unsigned_in_signed:
         # max unsigned value is -1 as a signed int
-        # xarray will take the unpacked/in-memory type (unsigned) and convert
-        # it to the packed/on-disk type (signed) for us
-        unsigned_type = np.dtype("u" + dtype.name)
-        fills = [dtype.type(-1).astype(unsigned_type)]
+        fills = [dtype.type(-1)]
     else:
         # max value
         fills = [2 ** (file_bit_depth - 1) - 1]
@@ -1066,12 +1063,10 @@ class AWIPSNetCDFTemplate(NetCDFTemplate):
             new_ds.coords["x"].encoding["dtype"] = "int16"
             new_ds.coords["x"].encoding["scale_factor"] = np.float64(xy_factors.mx)
             new_ds.coords["x"].encoding["add_offset"] = np.float64(xy_factors.bx)
-            new_ds.coords["x"].encoding["_FillValue"] = -1
         if "y" in new_ds.coords:
             new_ds.coords["y"].encoding["dtype"] = "int16"
             new_ds.coords["y"].encoding["scale_factor"] = np.float64(xy_factors.my)
             new_ds.coords["y"].encoding["add_offset"] = np.float64(xy_factors.by)
-            new_ds.coords["y"].encoding["_FillValue"] = -1
         return new_ds
 
     def apply_tile_info(self, new_ds, tile_info):

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -626,7 +626,10 @@ def _get_factor_offset_fill(input_data_arr, vmin, vmax, encoding):
         fills = [2 ** file_bit_depth - 1]
     elif unsigned_in_signed:
         # max unsigned value is -1 as a signed int
-        fills = [-1]
+        # xarray will take the unpacked/in-memory type (unsigned) and convert
+        # it to the packed/on-disk type (signed) for us
+        unsigned_type = np.dtype("u" + dtype.name)
+        fills = [dtype.type(-1).astype(unsigned_type)]
     else:
         # max value
         fills = [2 ** (file_bit_depth - 1) - 1]
@@ -1598,7 +1601,7 @@ class AWIPSTiledWriter(Writer):
         area_data_arrs = self._group_by_area(datasets)
         datasets_to_save = []
         output_filenames = []
-        creation_time = dt.datetime.utcnow()
+        creation_time = dt.datetime.now(dt.UTC)
         area_tile_data_gen = self._iter_area_tile_info_and_datasets(
             area_data_arrs, template, lettered_grid, sector_id, num_subtiles,
             tile_size, tile_count, use_sector_reference)

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -1105,7 +1105,7 @@ class AWIPSNetCDFTemplate(NetCDFTemplate):
         if creator is None:
             creator = "Satpy Version {} - AWIPS Tiled Writer".format(__version__)
         if creation_time is None:
-            creation_time = dt.datetime.utcnow()
+            creation_time = dt.datetime.now(dt.timezone.utc)
 
         self._add_sector_id_global(new_ds, sector_id)
         new_ds.attrs["Conventions"] = "CF-1.7"
@@ -1601,7 +1601,7 @@ class AWIPSTiledWriter(Writer):
         area_data_arrs = self._group_by_area(datasets)
         datasets_to_save = []
         output_filenames = []
-        creation_time = dt.datetime.now(dt.UTC)
+        creation_time = dt.datetime.now(dt.timezone.utc)
         area_tile_data_gen = self._iter_area_tile_info_and_datasets(
             area_data_arrs, template, lettered_grid, sector_id, num_subtiles,
             tile_size, tile_count, use_sector_reference)


### PR DESCRIPTION
Fixes compatibility with (currently unstable) xarray for the AWIPS tiled (`awips_tiled`) writer when using the default `_Unsigned` fill value of `-1`. Starting with

https://github.com/pydata/xarray/pull/9136

Xarray automatically converts the _FillValue to the proper dtype in a way that does not allow (or rather numpy does not allow) certain values to be automatically cast between types. In the case of this -1 it was trying to cast it directly to the unsigned type (give or take some bit depth differences) and failing. The -1 was just a convenience in the writer code anyway. I've added the necessary code to specify the fill value as the unsigned numpy type so that xarray can convert it when the file is saved.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
