### PR TITLE
Enhance support for FY-3F/MERSI-3

### DIFF
--- a/satpy/etc/readers/mersi3_l1b.yaml
+++ b/satpy/etc/readers/mersi3_l1b.yaml
@@ -438,7 +438,7 @@ datasets:
         standard_name: counts
   '19':
     name: '19'
-    wavelength: [1.23, 1.24, 1.25]  # or 1.03um?
+    wavelength: [1.02, 1.03, 1.04]
     resolution: 1000
     file_type: mersi3_l1b_1000
     file_key: Data/EV_1KM_RefSB
@@ -599,7 +599,7 @@ datasets:
         file_key: Geolocation/Longitude
       250:
         file_type: mersi3_l1b_250_geo
-        file_key: Longitude
+        file_key: GEO/Longitude
   latitude:
     name: latitude
     units: degrees_north
@@ -610,7 +610,7 @@ datasets:
         file_key: Geolocation/Latitude
       250:
         file_type: mersi3_l1b_250_geo
-        file_key: Latitude
+        file_key: GEO/Latitude
   solar_zenith_angle:
     name: solar_zenith_angle
     units: degree

--- a/satpy/readers/mersi_l1b.py
+++ b/satpy/readers/mersi_l1b.py
@@ -21,7 +21,7 @@
 The files for this reader are HDF5 and come in four varieties; band data
 and geolocation data, both at 250m and 1000m resolution.
 
-This reader was tested on FY-3A/B/C MERSI-1, FY-3D MERSI-2, FY-3E MERSI-LL and FY-3G MERSI-RM data,
+This reader was tested on FY-3A/B/C MERSI-1, FY-3D MERSI-2, FY-3E MERSI-LL, FY-3F MERSI-3 and FY-3G MERSI-RM data,
 but should work on future platforms as well assuming no file format changes.
 
 """
@@ -238,10 +238,10 @@ class MERSIL1B(HDF5FileHandler):
         After applying slope and intercept, we just get it. And Same way for IR bands, no matter which sensor it is.
 
         """
-        mersi_2_vis = [str(i) for i in range(1, 20)]
+        mersi_2_3_vis = [str(i) for i in range(1, 20)]
         mersi_rm_vis = [str(i) for i in range(1, 6)]
 
-        if self.sensor_name == "mersi-2" and datset_id["name"] in mersi_2_vis:
+        if (self.sensor_name == "mersi-2" or self.sensor_name == "mersi-3") and datset_id["name"] in mersi_2_3_vis:
             E0 = self["/attr/Solar_Irradiance"]
             rad = self._get_ref_dataset(data, ds_info) / 100 * E0[mersi_2_vis.index(datset_id["name"])] / np.pi
         elif self.sensor_name == "mersi-rm" and datset_id["name"] in mersi_rm_vis:
@@ -285,7 +285,7 @@ class MERSIL1B(HDF5FileHandler):
         elif self.sensor_name == "mersi-2":
             corr_coeff_a = float(self["/attr/TBB_Trans_Coefficient_A"][calibration_index])
             corr_coeff_b = float(self["/attr/TBB_Trans_Coefficient_B"][calibration_index])
-        elif self.sensor_name == "mersi-ll":
+        elif self.sensor_name == "mersi-ll" or self.sensor_name == "mersi-3":
             # MERSI-LL stores these coefficients differently
             try:
                 coeffs = self["/attr/TBB_Trans_Coefficient"]

--- a/satpy/tests/reader_tests/test_mersi_l1b.py
+++ b/satpy/tests/reader_tests/test_mersi_l1b.py
@@ -339,6 +339,10 @@ class FakeHDF5FileHandler2(FakeHDF5FileHandler):
             global_attrs["/attr/Satellite Name"] = "FY-3E"
             global_attrs["/attr/Sensor Identification Code"] = "MERSI LL"
             ftype = "LL"
+        elif "mersi3_l1b" in self.filetype_info["file_type"]:
+            global_attrs["/attr/Satellite Name"] = "FY-3F"
+            global_attrs["/attr/Sensor Identification Code"] = "MERSI"
+            ftype = "VIS"
         elif "mersi_rm" in self.filetype_info["file_type"]:
             global_attrs["/attr/Satellite Name"] = "FY-3G"
             global_attrs["/attr/Sensor Identification Code"] = "MERSI RM"
@@ -555,14 +559,14 @@ class MERSI12llL1BTester(MERSIL1BTester):
         reader = _test_find_files_and_readers(self.reader_configs, filenames)
 
         ds_ids = []
-        test_bands = self.bands_1000 + self.bands_250 if self.yaml_file in ["mersi2_l1b.yaml", "mersi_ll_l1b.yaml"] \
+        test_bands = self.bands_1000 + self.bands_250 if self.yaml_file in ["mersi2_l1b.yaml", "mersi3_l1b.yaml", "mersi_ll_l1b.yaml"] \
             else self.ir_250_bands + self.ir_1000_bands
 
         for band_name in test_bands:
             ds_ids.append(make_dataid(name=band_name, calibration="radiance"))
         res = reader.load(ds_ids)
         assert len(res) == len(test_bands)
-        if self.yaml_file in ["mersi2_l1b.yaml", "mersi_ll_l1b.yaml"]:
+        if self.yaml_file in ["mersi2_l1b.yaml", "mersi3_l1b.yaml", "mersi_ll_l1b.yaml"]:
             _assert_bands_mda_as_exp(res, self.bands_250, ("radiance", "mW/ (m2 cm-1 sr)", (2 * 40, 2048 * 2)))
             _assert_bands_mda_as_exp(res, self.bands_1000, ("radiance", "mW/ (m2 cm-1 sr)", (2 * 10, 2048)))
         else:
@@ -631,7 +635,7 @@ class TestFY3DMERSI2L1B(MERSI12llL1BTester):
 
 
 class TestFY3EMERSIllL1B(MERSI12llL1BTester):
-    """Test the FY3D MERSI2 L1B reader."""
+    """Test the FY3E MERSI2 L1B reader."""
 
     yaml_file = "mersi_ll_l1b.yaml"
     filenames_1000m = ["FY3E_MERSI_GRAN_L1_20230410_1910_1000M_V0.HDF", "FY3E_MERSI_GRAN_L1_20230410_1910_GEO1K_V0.HDF"]
@@ -645,8 +649,23 @@ class TestFY3EMERSIllL1B(MERSI12llL1BTester):
     bands_250 = vis_250_bands + ir_250_bands
 
 
+class TestFY3FMERSIllL1B(MERSI12llL1BTester):
+    """Test the FY3F MERSI2 L1B reader."""
+
+    yaml_file = "mersi3_l1b.yaml"
+    filenames_1000m = ["FY3F_MERSI_GRAN_L1_20230410_1910_1000M_V0.HDF", "FY3F_MERSI_GRAN_L1_20230410_1910_GEO1K_V0.HDF"]
+    filenames_250m = ["FY3F_MERSI_GRAN_L1_20230410_1910_0250M_V0.HDF", "FY3F_MERSI_GRAN_L1_20230410_1910_GEOQK_V0.HDF"]
+    filenames_all = filenames_1000m + filenames_250m
+    vis_250_bands = ["1", "2", "3", "4"]
+    ir_250_bands = ["24", "25"]
+    vis_1000_bands = ["5", "8", "9", "11", "15", "17", "19"]
+    ir_1000_bands = ["20", "21", "23"]
+    bands_1000 = vis_1000_bands + ir_1000_bands
+    bands_250 = vis_250_bands + ir_250_bands
+
+
 class TestMERSIRML1B(MERSIL1BTester):
-    """Test the FY3E MERSI-RM L1B reader."""
+    """Test the FY3G MERSI-RM L1B reader."""
 
     yaml_file = "mersi_rm_l1b.yaml"
     filenames_500m = ["FY3G_MERSI_GRAN_L1_20230410_1910_0500M_V1.HDF",


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
This PR enhanced support for FY-3F/MERSI-3 data. Includes fixed geolocation dataset name in 250m data, support get coefficients, etc.
Actually, I'm not sure whether the test config is correct. theoretically, this test is basically the same as the FY-3D.
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
