### PR TITLE
Update thresholds for FCI geo_color low-level cloud layer

### DIFF
--- a/satpy/etc/composites/fci.yaml
+++ b/satpy/etc/composites/fci.yaml
@@ -218,8 +218,8 @@ composites:
    compositor: !!python/name:satpy.composites.LowCloudCompositor
    values_water: 0
    values_land: 100
-   range_water: [1.35, 5.0]
-   range_land: [4.35, 6.75]
+   range_water: [0.0, 4.0]
+   range_land: [1.5, 4.0]
    prerequisites:
      - compositor: !!python/name:satpy.composites.DifferenceCompositor
        prerequisites:


### PR DESCRIPTION
This PR updates the thresholds used for the low-level cloud detection used in the FCI `geo_color` recipe. This update is needed to properly capture low level clouds, especially over land, following the evolution and improvement in FCI IR calibration during MTG-I commissioning since this recipe was initially added.

The thresholds over water surfaces are now in line with those used for ABI and AHI, whereas the lower threshold over land surface types is slightly higher. This is done in order to mitigate the false alarms over desert areas which are inevitable with the current `geo_color` implementation given the difference in surface emissivity between the ir_38 and ir_105 channels. For FCI, this is a bigger challenge given the presence of the Sahara desert.

The current set of thresholds are proposed by myself and @ameraner as they seem to provide a rather good tradeoff. But mitigating the false alarms over Sahara, naturally comes with the expense of slightly lower sensitivity of actual low clouds over other land surface types. So I'm happy to revise if others prefer to use the same threshold as for ABI and AHI. 

Below a set of images comparing different thresholds of a couple of scenes. Note in the full disk images, that all arid surface types or surface types with significantly difference surface emissivity (also over southern Africa and South America) have a blue glow when using the same thresholds as ABI and AHI.

![image](https://github.com/user-attachments/assets/2690edbb-ed1a-4769-ba0a-7801170159a9)

The full resolution images can be seen here:
- [main](https://sftp.eumetsat.int/public/file/pz2q8hpc_kqoruligtptoa/FCI_GeoColor_202407220200_1.35-5.0_4.35-6.75.png)
- [same thresholds as ABI and AHI](https://sftp.eumetsat.int/public/file/3le7cx5rukeqgkxgz-zx9w/FCI_GeoColor_202407220200_0-4.0_0-4.0.png)
- [this PR](https://sftp.eumetsat.int/public/file/jvsr5upna0ixbkvjlf5rqq/FCI_GeoColor_202407220200_0-4.0_1.5-4.0.png)
- [night_microphysics](https://sftp.eumetsat.int/public/file/eokm488cpemybaoearf4vg/FCI_night_microphysics_20240722T020003.png)

And an animation (different date) with the proposed thresholds (this PR) can be seen [here](https://sftp.eumetsat.int/public/file/ioce272xkkaf8kqhiravuw/FCI_hres_geocolor_20240726_FR-6.mp4).




