### PR TITLE
Adapt the SEVIRI native format reader in Satpy to support remote reading

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -95,5 +95,4 @@ The following people have made contributions to this project:
 - [Will Sharpe (wjsharpe)](https://github.com/wjsharpe)
 - [Sara Hörnquist (shornqui)](https://github.com/shornqui)
 - [Antonio Valentino](https://github.com/avalentino)
-- [Pouria Khalaj](https://github.com/pkhalaj)
 - [Clément (ludwigvonkoopa)](https://github.com/ludwigVonKoopa)

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -43,6 +43,7 @@ The following people have made contributions to this project:
 - [Jactry Zeng](https://github.com/jactry)
 - [Johannes Johansson (JohannesSMHI)](https://github.com/JohannesSMHI)
 - [Sauli Joro (sjoro)](https://github.com/sjoro)
+- [Pouria Khalaj](https://github.com/pkhalaj)
 - [Janne Kotro (jkotro)](https://github.com/jkotro)
 - [Ralph Kuehn (ralphk11)](https://github.com/ralphk11)
 - [Panu Lahtinen (pnuu)](https://github.com/pnuu)

--- a/satpy/etc/readers/seviri_l1b_native.yaml
+++ b/satpy/etc/readers/seviri_l1b_native.yaml
@@ -5,7 +5,7 @@ reader:
   description: >
     Reader for EUMETSAT MSG SEVIRI Level 1b native format files.
   status: Nominal
-  supports_fsspec: false
+  supports_fsspec: true
   sensors: [seviri]
   default_channels: [HRV, IR_016, IR_039, IR_087, IR_097, IR_108, IR_120, IR_134, VIS006, VIS008, WV_062, WV_073]
   reader: !!python/name:satpy.readers.yaml_reader.GEOFlippableFileYAMLReader

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -204,7 +204,7 @@ class NativeMSGFileHandler(BaseFileHandler):
             "auto",
             shape=(self.mda["number_of_lines"],),
             dtype=dtype)
-        self.dask_array = da.map_blocks(
+        self._dask_array = da.map_blocks(
             _get_array,
             dtype=dtype,
             chunks=chunks,
@@ -594,10 +594,10 @@ class NativeMSGFileHandler(BaseFileHandler):
         # Check if there is only 1 channel in the list as a change
         # is needed in the array assignment ie channel id is not present
         if len(self.mda["channel_list"]) == 1:
-            raw = self.dask_array["visir"]["line_data"]
+            raw = self._dask_array["visir"]["line_data"]
         else:
             i = self.mda["channel_list"].index(dataset_id["name"])
-            raw = self.dask_array["visir"]["line_data"][:, i, :]
+            raw = self._dask_array["visir"]["line_data"][:, i, :]
         data = dec10216(raw.flatten())
         data = data.reshape(shape)
         return data
@@ -608,7 +608,7 @@ class NativeMSGFileHandler(BaseFileHandler):
 
         data_list = []
         for i in range(3):
-            raw = self.dask_array["hrv"]["line_data"][:, i, :]
+            raw = self._dask_array["hrv"]["line_data"][:, i, :]
             data = dec10216(raw.flatten())
             data = data.reshape(shape_layer)
             data_list.append(data)
@@ -667,7 +667,7 @@ class NativeMSGFileHandler(BaseFileHandler):
 
     def _get_acq_time_hrv(self):
         """Get raw acquisition time for HRV channel."""
-        tline = self.dask_array["hrv"]["acq_time"]
+        tline = self._dask_array["hrv"]["acq_time"]
         tline0 = tline[:, 0]
         tline1 = tline[:, 1]
         tline2 = tline[:, 2]
@@ -679,9 +679,9 @@ class NativeMSGFileHandler(BaseFileHandler):
         # Check if there is only 1 channel in the list as a change
         # is needed in the array assignment, i.e. channel id is not present
         if len(self.mda["channel_list"]) == 1:
-            return self.dask_array["visir"]["acq_time"].compute()
+            return self._dask_array["visir"]["acq_time"].compute()
         i = self.mda["channel_list"].index(dataset_id["name"])
-        return self.dask_array["visir"]["acq_time"][:, i].compute()
+        return self._dask_array["visir"]["acq_time"][:, i].compute()
 
     def _update_attrs(self, dataset, dataset_info):
         """Update dataset attributes."""

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -198,7 +198,7 @@ class NativeMSGFileHandler(BaseFileHandler):
         self.image_boundaries = ImageBoundaries(self.header, self.trailer, self.mda)
 
     def _make_dask_array_with_map_blocks(self):
-        """Makes the dask array using the ``da.map_blocks()`` functionality."""
+        """Make the dask array using the ``da.map_blocks()`` functionality."""
         dtype = self._get_data_dtype()
         chunks = da.core.normalize_chunks(
             "auto",
@@ -292,7 +292,7 @@ class NativeMSGFileHandler(BaseFileHandler):
         return np.dtype(drec)
 
     def _number_of_visir_channels(self):
-        """Returns the number of visir channels, i.e. all channels excluding ``HRV``."""
+        """Return the number of visir channels, i.e. all channels excluding ``HRV``."""
         return len([s for s in self.mda["channel_list"] if not s == "HRV"])
 
     def _read_header(self):

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -208,7 +208,7 @@ class NativeMSGFileHandler(BaseFileHandler):
             _get_array,
             dtype=dtype,
             chunks=chunks,
-            meta=np.zeros(1, dtype=dtype),
+            meta=np.empty(1, dtype=dtype),
             # The following will be passed as keyword arguments to the `_get_array()` function.
             filename=self.filename,
             hdr_size=self.header_type.itemsize

--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -208,7 +208,7 @@ class NativeMSGFileHandler(BaseFileHandler):
             _get_array,
             dtype=dtype,
             chunks=chunks,
-            meta=np.empty(1, dtype=dtype),
+            meta=np.array([], dtype=dtype),
             # The following will be passed as keyword arguments to the `_get_array()` function.
             filename=self.filename,
             hdr_size=self.header_type.itemsize

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -361,6 +361,27 @@ def generic_open(filename, *args, **kwargs):
     fp.close()
 
 
+def fromfile(filename, dtype, count=1, offset=0):
+    """Reads the numpy array from a (remote or local) file using a buffer.
+
+    Note:
+        This function relies on the :func:`generic_open` context manager to read a file remotely.
+
+    Args:
+        filename: Either the name of the file to read or a :class:`satpy.readers.FSFile` object.
+        dtype: The data type of the numpy array
+        count (Optional, default ``1``): Number of items to read
+        offset (Optional, default ``0``): Starting point for reading the buffer from
+
+    Returns:
+        The content of the filename as a numpy array with the given data type.
+    """
+    with generic_open(filename, mode="rb") as istream:
+        istream.seek(offset)
+        content = np.frombuffer(istream.read(dtype.itemsize * count), dtype=dtype, count=count)
+    return content
+
+
 def bbox(img):
     """Find the bounding box around nonzero elements in the given array.
 

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -362,7 +362,7 @@ def generic_open(filename, *args, **kwargs):
 
 
 def fromfile(filename, dtype, count=1, offset=0):
-    """Reads the numpy array from a (remote or local) file using a buffer.
+    """Read the numpy array from a (remote or local) file using a buffer.
 
     Note:
         This function relies on the :func:`generic_open` context manager to read a file remotely.

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -98,8 +98,8 @@ def get_geostationary_angle_extent(geos_area):
     h = float(h) / 1000 + req
 
     # compute some constants
-    aeq = 1 - req**2 / (h ** 2)
-    ap_ = 1 - rp**2 / (h ** 2)
+    aeq = 1 - req ** 2 / (h ** 2)
+    ap_ = 1 - rp ** 2 / (h ** 2)
 
     # generate points around the north hemisphere in satellite projection
     # make it a bit smaller so that we stay inside the valid area
@@ -142,15 +142,15 @@ def _lonlat_from_geos_angle(x, y, geos_area):
     b__ = (a / float(b)) ** 2
 
     sd = np.sqrt((h__ * np.cos(x) * np.cos(y)) ** 2 -
-                 (np.cos(y)**2 + b__ * np.sin(y)**2) *
-                 (h__**2 - (float(a) / 1000)**2))
+                 (np.cos(y) ** 2 + b__ * np.sin(y) ** 2) *
+                 (h__ ** 2 - (float(a) / 1000) ** 2))
     # sd = 0
 
-    sn = (h__ * np.cos(x) * np.cos(y) - sd) / (np.cos(y)**2 + b__ * np.sin(y)**2)
+    sn = (h__ * np.cos(x) * np.cos(y) - sd) / (np.cos(y) ** 2 + b__ * np.sin(y) ** 2)
     s1 = h__ - sn * np.cos(x) * np.cos(y)
     s2 = sn * np.sin(x) * np.cos(y)
     s3 = -sn * np.sin(y)
-    sxy = np.sqrt(s1**2 + s2**2)
+    sxy = np.sqrt(s1 ** 2 + s2 ** 2)
 
     lons = np.rad2deg(np.arctan2(s2, s1)) + lon_0
     lats = np.rad2deg(-np.arctan2(b__ * s3, sxy))
@@ -256,7 +256,7 @@ def _unzip_with_pbzip(filename, tmpfilepath, fdn):
     if n_thr:
         runner = [pbzip,
                   "-dc",
-                  "-p"+str(n_thr),
+                  "-p" + str(n_thr),
                   filename]
     else:
         runner = [pbzip,
@@ -416,7 +416,7 @@ def get_earth_radius(lon, lat, a, b):
     latlong = pyproj.CRS.from_dict({"proj": "latlong", "a": a, "b": b, "units": "m"})
     transformer = pyproj.Transformer.from_crs(latlong, geocent)
     x, y, z = transformer.transform(lon, lat, 0.0)
-    return np.sqrt(x**2 + y**2 + z**2)
+    return np.sqrt(x ** 2 + y ** 2 + z ** 2)
 
 
 def reduce_mda(mda, max_size=100):

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1338,7 +1338,7 @@ def amend_seviri_native_null_header(hdr_null_numpy):
 
         For example, ``_amend_15_DATA_HEADER__SatelliteStatus__SatelliteDefinition__SatelliteId()`` corresponds to an
         auxiliary function which manipulates the following entry:
-            ``hdr_null_numpy_as_dict["15_DATA_HEADER"]["SatelliteStatus"]["SatelliteDefinition"]["SatelliteId"]``
+        ``hdr_null_numpy_as_dict["15_DATA_HEADER"]["SatelliteStatus"]["SatelliteDefinition"]["SatelliteId"]``
     """
 
     def _amend_15_MAIN_PRODUCT_HEADER():

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -632,7 +632,7 @@ def prepare_area_definitions(test_dict):
     trailer = create_test_trailer(is_rapid_scan)
     expected_area_def = test_dict["expected_area_def"]
 
-    with mock.patch("satpy.readers.seviri_l1b_native.np.fromfile") as fromfile, \
+    with mock.patch("satpy.readers.seviri_l1b_native.fromfile") as fromfile, \
             mock.patch("satpy.readers.seviri_l1b_native.recarray2dict") as recarray2dict, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_array") as _get_array, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer"), \
@@ -716,7 +716,7 @@ def prepare_is_roi(test_dict):
     trailer = create_test_trailer(is_rapid_scan)
     expected = test_dict["is_roi"]
 
-    with mock.patch("satpy.readers.seviri_l1b_native.np.fromfile") as fromfile, \
+    with mock.patch("satpy.readers.seviri_l1b_native.fromfile") as fromfile, \
             mock.patch("satpy.readers.seviri_l1b_native.recarray2dict") as recarray2dict, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_array") as _get_array, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer"), \
@@ -1166,11 +1166,11 @@ def test_header_type(file_content, exp_header_size):
     )
     if file_content == b"foobar":
         header.pop("15_SECONDARY_PRODUCT_HEADER")
-    with mock.patch("satpy.readers.seviri_l1b_native.np.fromfile") as fromfile, \
+    with mock.patch("satpy.readers.seviri_l1b_native.fromfile") as fromfile, \
             mock.patch("satpy.readers.seviri_l1b_native.recarray2dict") as recarray2dict, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_array") as _get_array, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer"), \
-            mock.patch("builtins.open", mock.mock_open(read_data=file_content)):
+            mock.patch("satpy.readers.seviri_l1b_native.generic_open", mock.mock_open(read_data=file_content)):
         fromfile.return_value = header
         recarray2dict.side_effect = (lambda x: x)
         _get_array.return_value = np.arange(3)
@@ -1196,11 +1196,11 @@ def test_header_warning():
         good_qual="NOK"
     )
 
-    with mock.patch("satpy.readers.seviri_l1b_native.np.fromfile") as fromfile, \
+    with mock.patch("satpy.readers.seviri_l1b_native.fromfile") as fromfile, \
             mock.patch("satpy.readers.seviri_l1b_native.recarray2dict") as recarray2dict, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_array") as _get_array, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer"), \
-            mock.patch("builtins.open", mock.mock_open(read_data=ASCII_STARTSWITH)):
+            mock.patch("satpy.readers.seviri_l1b_native.generic_open", mock.mock_open(read_data=ASCII_STARTSWITH)):
         recarray2dict.side_effect = (lambda x: x)
         _get_array.return_value = np.arange(3)
 
@@ -1233,7 +1233,7 @@ def test_header_warning():
 )
 def test_has_archive_header(starts_with, expected):
     """Test if the file includes an ASCII archive header."""
-    with mock.patch("builtins.open", mock.mock_open(read_data=starts_with)):
+    with mock.patch("satpy.readers.seviri_l1b_native.generic_open", mock.mock_open(read_data=starts_with)):
         actual = has_archive_header("filename")
     assert actual == expected
 
@@ -1248,7 +1248,7 @@ def test_read_header():
     dtypes = np.dtype([(k, t) for k, t in zip(keys, types)])
     hdr_data = np.array([values], dtype=dtypes)
 
-    with mock.patch("satpy.readers.seviri_l1b_native.np.fromfile") as fromfile:
+    with mock.patch("satpy.readers.seviri_l1b_native.fromfile") as fromfile:
         fromfile.return_value = hdr_data
         actual = recarray2dict(hdr_data)
     assert actual == expected

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1345,15 +1345,15 @@ def amend_seviri_native_null_header(hdr_null_numpy):
         hdr_null_numpy[0][0][0] = (b"FormatName                  : ", b"NATIVE\n")
 
     def _amend_15_SECONDARY_PRODUCT_HEADER():
-        hdr_null_numpy[0][1][9] = (b"SelectedBandIDs", b"XXXXXXXXXXXX")
-        hdr_null_numpy[0][1][10] = (b"SouthLineSelectedRectangle", b"1")
-        hdr_null_numpy[0][1][11] = (b"NorthLineSelectedRectangle", b"3712")
-        hdr_null_numpy[0][1][12] = (b"EastColumnSelectedRectangle", b"1")
-        hdr_null_numpy[0][1][13] = (b"WestColumnSelectedRectangle", b"3712")
-        hdr_null_numpy[0][1][14] = (b"NumberLinesVISIR", b"3712")
-        hdr_null_numpy[0][1][15] = (b"NumberColumnsVISIR", b"3712")
-        hdr_null_numpy[0][1][16] = (b"NumberLinesHRV", b"11136")
-        hdr_null_numpy[0][1][17] = (b"NumberColumnsHRV", b"11136")
+        hdr_null_numpy[0][1][9] = (b"SelectedBandIDs", b"XXXXXXXXXXX-")
+        hdr_null_numpy[0][1][10] = (b"SouthLineSelectedRectangle", b"3360")
+        hdr_null_numpy[0][1][11] = (b"NorthLineSelectedRectangle", b"3373")
+        hdr_null_numpy[0][1][12] = (b"EastColumnSelectedRectangle", b"1714")
+        hdr_null_numpy[0][1][13] = (b"WestColumnSelectedRectangle", b"1729")
+        hdr_null_numpy[0][1][14] = (b"NumberLinesVISIR", b"14")
+        hdr_null_numpy[0][1][15] = (b"NumberColumnsVISIR", b"16")
+        hdr_null_numpy[0][1][16] = (b"NumberLinesHRV", b"42")
+        hdr_null_numpy[0][1][17] = (b"NumberColumnsHRV", b"48")
 
     def _amend_GP_PK_SH1__PacketTime():
         hdr_null_numpy[0][3][5] = (23158, 27921912)
@@ -1386,7 +1386,7 @@ def append_data_and_trailer_content_to_seviri_native_header(filename, hdr_null_n
     The data and trailer are also null and appending them to the header results in a complete seviri nat file.
     """
     # size of different parts of the seviri native file in bytes
-    size = dict(header_with_archive=450400, data=270344960, trailer=380363)
+    size = {"header_with_archive": 450400, "data": 13090, "trailer": 380363}
     zero_bytes = bytearray(size["data"] + size["trailer"])
     bytes_data = bytes(zero_bytes)
 

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1298,9 +1298,11 @@ def test_read_physical_seviri_nat_file(full_path):
     assert len(scene.available_dataset_ids()) == 36
     assert set(scene.available_dataset_names()) == set(CHANNEL_INDEX_LIST)
 
-    scene.load(["VIS006"])
-    assert scene["VIS006"].shape == (3712, 3712)
-    assert isinstance(scene["VIS006"], xr.core.dataarray.DataArray)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        scene.load(["VIS006"])
+        assert scene["VIS006"].shape == (3712, 3712)
+        assert isinstance(scene["VIS006"], xr.core.dataarray.DataArray)
 
 
 def scene_from_physical_seviri_nat_file(filename):

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1004,12 +1004,12 @@ class TestNativeMSGDataset:
     def test_time(self, file_handler):
         """Test start/end nominal/observation time handling."""
         assert dt.datetime(2006, 1, 1, 12, 15, 9, 304888) == file_handler.observation_start_time
-        assert dt.datetime(2006, 1, 1, 12, 15,) == file_handler.start_time
+        assert dt.datetime(2006, 1, 1, 12, 15, ) == file_handler.start_time
         assert file_handler.start_time == file_handler.nominal_start_time
 
         assert dt.datetime(2006, 1, 1, 12, 27, 9, 304888) == file_handler.observation_end_time
         assert file_handler.end_time == file_handler.nominal_end_time
-        assert dt.datetime(2006, 1, 1, 12, 30,) == file_handler.end_time
+        assert dt.datetime(2006, 1, 1, 12, 30, ) == file_handler.end_time
 
     def test_repeat_cycle_duration(self, file_handler):
         """Test repeat cycle handling for FD or ReduscedScan."""

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -928,7 +928,7 @@ class TestNativeMSGDataset:
             fh.header = header
             fh.trailer = trailer
             fh.mda = mda
-            fh.dask_array = da.from_array(data)
+            fh._dask_array = da.from_array(data)
             fh.platform_id = 324
             fh.fill_disk = False
             fh.calib_mode = "NOMINAL"

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1273,13 +1273,13 @@ def test_read_header():
 
 @pytest.fixture(scope="session")
 def session_tmp_path(tmp_path_factory):
-    """Generates a single temp path to use for the entire session."""
+    """Generate a single temp path to use for the entire session."""
     return tmp_path_factory.mktemp("data")
 
 
 @pytest.fixture(scope="session")
 def tmp_seviri_nat_filename(session_tmp_path):
-    """Creates a fully-qualified filename for a seviri native format file."""
+    """Create a fully-qualified filename for a seviri native format file."""
     full_file_path = session_tmp_path / "MSG4-SEVI-MSG15-0100-NA-20210528075743.722000000Z-N.nat"
     create_physical_seviri_native_file(full_file_path)
     return full_file_path
@@ -1287,7 +1287,7 @@ def tmp_seviri_nat_filename(session_tmp_path):
 
 @pytest.fixture(scope="session")
 def compress_seviri_native_file(tmp_seviri_nat_filename, session_tmp_path):
-    """Compresses the given seviri native file into a zip file."""
+    """Compress the given seviri native file into a zip file."""
     zip_full_path = session_tmp_path / "test_seviri_native.zip"
     with zipfile.ZipFile(zip_full_path, mode="w") as archive:
         archive.write(tmp_seviri_nat_filename, os.path.basename(tmp_seviri_nat_filename))
@@ -1299,7 +1299,7 @@ def compress_seviri_native_file(tmp_seviri_nat_filename, session_tmp_path):
     lf("compress_seviri_native_file")
 ])
 def test_read_physical_seviri_nat_file(full_path):
-    """Tests that the physical seviri native file can be read successfully, in case of both a plain and a zip file.
+    """Test that the physical seviri native file can be read successfully, in case of both a plain and a zip file.
 
     Note:
         The purpose of this function is not to fully test the properties of the scene. It only provides a test for
@@ -1319,26 +1319,26 @@ def test_read_physical_seviri_nat_file(full_path):
 
 
 def scene_from_physical_seviri_nat_file(filename):
-    """Generates a Scene object from the given seviri native file."""
+    """Generate a Scene object from the given seviri native file."""
     return Scene([filename], reader="seviri_l1b_native", reader_kwargs={"fill_disk": True})
 
 
 def create_physical_seviri_native_file(seviri_nat_full_file_path):
-    """Creates a physical seviri native file on disk."""
+    """Create a physical seviri native file on disk."""
     header_type, header_null = generate_seviri_native_null_header()
     amend_seviri_native_null_header(header_null)
     append_data_and_trailer_content_to_seviri_native_header(seviri_nat_full_file_path, header_null)
 
 
 def generate_seviri_native_null_header():
-    """Generates the header of the seviri native format which is filled with zeros, hence the term null!"""
+    """Generate the header of the seviri native format which is filled with zeros, hence the term null!"""
     header_type = Msg15NativeHeaderRecord().get(True)
     null_header = np.zeros(header_type.shape, dtype=header_type).reshape(1, )
     return header_type, null_header
 
 
 def amend_seviri_native_null_header(hdr_null_numpy):
-    """Amends the given null header so that the ``seviri_l1b_native`` reader can properly parse it.
+    """Amend the given null header so that the ``seviri_l1b_native`` reader can properly parse it.
 
     This is achieved by setting values for the bare minimum number of header fields so that the reader can make sense of
     the given header. This function relies on a number of auxiliary functions all of which are enclosed in the body of
@@ -1394,7 +1394,7 @@ def amend_seviri_native_null_header(hdr_null_numpy):
 
 
 def append_data_and_trailer_content_to_seviri_native_header(filename, hdr_null_numpy):
-    """Generates the data and trailer part (null content) of the file and appends them to the null header.
+    """Generate the data and trailer part (null content) of the file and appends them to the null header.
 
     The data and trailer are also null and appending them to the header results in a complete seviri nat file.
     """

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -634,7 +634,7 @@ def prepare_area_definitions(test_dict):
 
     with mock.patch("satpy.readers.seviri_l1b_native.np.fromfile") as fromfile, \
             mock.patch("satpy.readers.seviri_l1b_native.recarray2dict") as recarray2dict, \
-            mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_memmap") as _get_memmap, \
+            mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_array") as _get_array, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer"), \
             mock.patch(
                 "satpy.readers.seviri_l1b_native.has_archive_header"
@@ -642,7 +642,7 @@ def prepare_area_definitions(test_dict):
         has_archive_header.return_value = True
         fromfile.return_value = header
         recarray2dict.side_effect = (lambda x: x)
-        _get_memmap.return_value = np.arange(3)
+        _get_array.return_value = np.arange(3)
         fh = NativeMSGFileHandler(filename=None, filename_info={}, filetype_info=None)
         fh.fill_disk = fill_disk
         fh.header = header
@@ -718,7 +718,7 @@ def prepare_is_roi(test_dict):
 
     with mock.patch("satpy.readers.seviri_l1b_native.np.fromfile") as fromfile, \
             mock.patch("satpy.readers.seviri_l1b_native.recarray2dict") as recarray2dict, \
-            mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_memmap") as _get_memmap, \
+            mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_array") as _get_array, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer"), \
             mock.patch(
                 "satpy.readers.seviri_l1b_native.has_archive_header"
@@ -726,7 +726,7 @@ def prepare_is_roi(test_dict):
         has_archive_header.return_value = True
         fromfile.return_value = header
         recarray2dict.side_effect = (lambda x: x)
-        _get_memmap.return_value = np.arange(3)
+        _get_array.return_value = np.arange(3)
         fh = NativeMSGFileHandler(filename=None, filename_info={}, filetype_info=None)
         fh.header = header
         fh.trailer = trailer
@@ -1168,12 +1168,12 @@ def test_header_type(file_content, exp_header_size):
         header.pop("15_SECONDARY_PRODUCT_HEADER")
     with mock.patch("satpy.readers.seviri_l1b_native.np.fromfile") as fromfile, \
             mock.patch("satpy.readers.seviri_l1b_native.recarray2dict") as recarray2dict, \
-            mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_memmap") as _get_memmap, \
+            mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_array") as _get_array, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer"), \
             mock.patch("builtins.open", mock.mock_open(read_data=file_content)):
         fromfile.return_value = header
         recarray2dict.side_effect = (lambda x: x)
-        _get_memmap.return_value = np.arange(3)
+        _get_array.return_value = np.arange(3)
         fh = NativeMSGFileHandler(filename=None, filename_info={}, filetype_info=None)
         assert fh.header_type.itemsize == exp_header_size
         assert "15_SECONDARY_PRODUCT_HEADER" in fh.header
@@ -1198,11 +1198,11 @@ def test_header_warning():
 
     with mock.patch("satpy.readers.seviri_l1b_native.np.fromfile") as fromfile, \
             mock.patch("satpy.readers.seviri_l1b_native.recarray2dict") as recarray2dict, \
-            mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_memmap") as _get_memmap, \
+            mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_array") as _get_array, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer"), \
             mock.patch("builtins.open", mock.mock_open(read_data=ASCII_STARTSWITH)):
         recarray2dict.side_effect = (lambda x: x)
-        _get_memmap.return_value = np.arange(3)
+        _get_array.return_value = np.arange(3)
 
         exp_warning = "The quality flag for this file indicates not OK. Use this data with caution!"
 

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1278,7 +1278,7 @@ def compress_seviri_native_file(tmp_seviri_nat_filename, session_tmp_path):
     zip_full_path = session_tmp_path / "test_seviri_native.zip"
     with zipfile.ZipFile(zip_full_path, mode="w") as archive:
         archive.write(tmp_seviri_nat_filename, os.path.basename(tmp_seviri_nat_filename))
-    return f"zip://*.nat::{zip_full_path}"
+    return f"zip://*.nat::file://{zip_full_path.as_posix()}"
 
 
 @pytest.mark.slow()

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1281,8 +1281,6 @@ def compress_seviri_native_file(tmp_seviri_nat_filename, session_tmp_path):
     return f"zip://*.nat::file://{zip_full_path.as_posix()}"
 
 
-@pytest.mark.slow()
-@pytest.mark.order("last")
 @pytest.mark.parametrize(("full_path"), [
     lf("tmp_seviri_nat_filename"),
     lf("compress_seviri_native_file")

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -638,7 +638,9 @@ def prepare_area_definitions(test_dict):
 
     with mock.patch("satpy.readers.seviri_l1b_native.fromfile") as fromfile, \
             mock.patch("satpy.readers.seviri_l1b_native.recarray2dict") as recarray2dict, \
-            mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_array") as _get_array, \
+            mock.patch("satpy.readers.seviri_l1b_native._get_array") as _get_array, \
+            mock.patch(
+                "satpy.readers.seviri_l1b_native.NativeMSGFileHandler._number_of_visir_channels") as _n_visir_ch, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer"), \
             mock.patch(
                 "satpy.readers.seviri_l1b_native.has_archive_header"
@@ -647,6 +649,7 @@ def prepare_area_definitions(test_dict):
         fromfile.return_value = header
         recarray2dict.side_effect = (lambda x: x)
         _get_array.return_value = np.arange(3)
+        _n_visir_ch.return_value = 11
         fh = NativeMSGFileHandler(filename=None, filename_info={}, filetype_info=None)
         fh.fill_disk = fill_disk
         fh.header = header
@@ -722,7 +725,9 @@ def prepare_is_roi(test_dict):
 
     with mock.patch("satpy.readers.seviri_l1b_native.fromfile") as fromfile, \
             mock.patch("satpy.readers.seviri_l1b_native.recarray2dict") as recarray2dict, \
-            mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_array") as _get_array, \
+            mock.patch("satpy.readers.seviri_l1b_native._get_array") as _get_array, \
+            mock.patch(
+                "satpy.readers.seviri_l1b_native.NativeMSGFileHandler._number_of_visir_channels") as _n_visir_ch, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer"), \
             mock.patch(
                 "satpy.readers.seviri_l1b_native.has_archive_header"
@@ -731,6 +736,7 @@ def prepare_is_roi(test_dict):
         fromfile.return_value = header
         recarray2dict.side_effect = (lambda x: x)
         _get_array.return_value = np.arange(3)
+        _n_visir_ch.return_value = 11
         fh = NativeMSGFileHandler(filename=None, filename_info={}, filetype_info=None)
         fh.header = header
         fh.trailer = trailer
@@ -1172,12 +1178,15 @@ def test_header_type(file_content, exp_header_size):
         header.pop("15_SECONDARY_PRODUCT_HEADER")
     with mock.patch("satpy.readers.seviri_l1b_native.fromfile") as fromfile, \
             mock.patch("satpy.readers.seviri_l1b_native.recarray2dict") as recarray2dict, \
-            mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_array") as _get_array, \
+            mock.patch("satpy.readers.seviri_l1b_native._get_array") as _get_array, \
+            mock.patch(
+                "satpy.readers.seviri_l1b_native.NativeMSGFileHandler._number_of_visir_channels") as _n_visir_ch, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer"), \
             mock.patch("satpy.readers.seviri_l1b_native.generic_open", mock.mock_open(read_data=file_content)):
         fromfile.return_value = header
         recarray2dict.side_effect = (lambda x: x)
         _get_array.return_value = np.arange(3)
+        _n_visir_ch.return_value = 11
         fh = NativeMSGFileHandler(filename=None, filename_info={}, filetype_info=None)
         assert fh.header_type.itemsize == exp_header_size
         assert "15_SECONDARY_PRODUCT_HEADER" in fh.header
@@ -1202,7 +1211,9 @@ def test_header_warning():
 
     with mock.patch("satpy.readers.seviri_l1b_native.fromfile") as fromfile, \
             mock.patch("satpy.readers.seviri_l1b_native.recarray2dict") as recarray2dict, \
-            mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._get_array") as _get_array, \
+            mock.patch("satpy.readers.seviri_l1b_native._get_array") as _get_array, \
+            mock.patch(
+                "satpy.readers.seviri_l1b_native.NativeMSGFileHandler._number_of_visir_channels") as _n_visir_ch, \
             mock.patch("satpy.readers.seviri_l1b_native.NativeMSGFileHandler._read_trailer"), \
             mock.patch("satpy.readers.seviri_l1b_native.generic_open", mock.mock_open(read_data=ASCII_STARTSWITH)):
         recarray2dict.side_effect = (lambda x: x)
@@ -1211,6 +1222,8 @@ def test_header_warning():
         exp_warning = "The quality flag for this file indicates not OK. Use this data with caution!"
 
         fromfile.return_value = header_good
+        _n_visir_ch.return_value = 11
+
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             NativeMSGFileHandler(filename=None, filename_info={}, filetype_info=None)


### PR DESCRIPTION
This PR adds a feature to Satpy to allow for reading SEVIRI native format files remotely. It relies on the [fsspec](https://filesystem-spec.readthedocs.io/en/latest/index.html) package.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
