### PR TITLE
Fix LI L2 reader for accumulated products from archive

### DIFF
--- a/satpy/readers/li_l2_nc.py
+++ b/satpy/readers/li_l2_nc.py
@@ -130,26 +130,24 @@ class LIL2NCFileHandler(LINCFileHandler):
         cols = self.get_measured_variable("x")
         attrs = data_array.attrs
 
+        rows, cols = da.compute(rows, cols)
+
         # origin is in the south-west corner, so we flip the rows (applying
         # offset of 1 implicitly)
         # And we manually offset the columns by 1 too:
         rows = (LI_GRID_SHAPE[0] - rows.astype(int))
         cols = cols.astype(int) - 1
 
-        # Create an empty 1-D array for the results
-        li_grid_flat_size = LI_GRID_SHAPE[0] * LI_GRID_SHAPE[1]
-        flattened_result = da.zeros((LI_GRID_SHAPE[0] * LI_GRID_SHAPE[1]), dtype=data_array.dtype,
-                                    chunks=(li_grid_flat_size,))
+        # initialise results array with zeros
+        data_2d = da.zeros((LI_GRID_SHAPE[0], LI_GRID_SHAPE[1]), dtype=data_array.dtype,
+                           chunks=(LI_GRID_SHAPE[0], LI_GRID_SHAPE[1]))
 
-        # Insert the data. If a pixel has more than one entry, the values are added up (np.add.at functionality)
-        indices = xr.DataArray(da.asarray(rows * LI_GRID_SHAPE[0] + cols))
-        flattened_result = da.map_blocks(_np_add_at_wrapper, flattened_result, indices, data_array,
-                                         dtype=data_array.dtype,
-                                         chunks=(li_grid_flat_size,))
-        flattened_result = da.where(flattened_result > 0, flattened_result, np.nan)
+        # insert the data. If a pixel has more than one entry, the values are added up (np.add.at functionality)
+        data_2d = da.map_blocks(_np_add_at_wrapper, data_2d, (rows, cols), data_array,
+                                dtype=data_array.dtype,
+                                chunks=(LI_GRID_SHAPE[0], LI_GRID_SHAPE[1]))
+        data_2d = da.where(data_2d > 0, data_2d, np.nan)
 
-        # ... reshape to final 2D grid
-        data_2d = da.reshape(flattened_result, LI_GRID_SHAPE)
         xarr = xr.DataArray(da.asarray(data_2d, CHUNK_SIZE), dims=("y", "x"))
         xarr.attrs = attrs
 
@@ -157,8 +155,8 @@ class LIL2NCFileHandler(LINCFileHandler):
 
 
 def _np_add_at_wrapper(target_array, indices, data):
-    # copy needed for correct computation in-place inside the da.map_blocks
+    # copy needed for correct computation in-place
     ta = target_array.copy()
     # add.at is not implemented in xarray, so we explicitly need the np.array
-    np.add.at(ta, indices.values, data.values)
+    np.add.at(ta, indices, data.values)
     return ta

--- a/satpy/tests/reader_tests/test_li_l2_nc.py
+++ b/satpy/tests/reader_tests/test_li_l2_nc.py
@@ -792,10 +792,12 @@ class TestLIL2():
         # prepare reference array
         data = handler_without_area_def.get_dataset(dsid).values
         ref_arr = np.empty(LI_GRID_SHAPE, dtype=arr.dtype)
-        ref_arr[:] = np.nan
+        ref_arr[:] = 0
         rows = (LI_GRID_SHAPE[0] - yarr)
         cols = xarr - 1
-        ref_arr[rows, cols] = data
+        for n_entry in range(len(data)):
+            ref_arr[rows[n_entry], cols[n_entry]] += data[n_entry]
+        ref_arr = np.where(ref_arr > 0, ref_arr, np.nan)
 
         # Check all nan values are at the same locations:
         assert np.all(np.isnan(arr) == np.isnan(ref_arr))


### PR DESCRIPTION
This PR solves the bug identified in #2859 .

It implements two parallel solutions:
- [x] the nominal main product (e.g. `accumulated_flash_area`) is cumulated, so that it contains the entire observations for the 10-min period of the ARC products
- [ ] new sub-datasets are added in order to be able to differentiate  between the single 30s repeat cycles inside the 10-min ARC products. The start and end times are included in the dataset names.

The first solution allows the interchangeable usage of normal and ARC files, including the generation of composites. The usage of the new sub-datasets requires more expert handling (e.g. the usage of `scn.available_dataset_names()` to retrieve the list of sub-datasets).

 - [x] Closes #2859 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
