### PR TITLE
Avoid accidental NWCSAF-GEO type promotion

### DIFF
--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -205,8 +205,8 @@ class NcNWCSAF(BaseFileHandler):
         """
         variable = remove_empties(variable)
 
-        scale = variable.attrs.get("scale_factor", np.array(1))
-        offset = variable.attrs.get("add_offset", np.array(0))
+        scale = variable.attrs.get("scale_factor", np.array(1, dtype=variable.dtype))
+        offset = variable.attrs.get("add_offset", np.array(0, dtype=variable.dtype))
         if "_FillValue" in variable.attrs:
             variable.attrs["scaled_FillValue"] = variable.attrs["_FillValue"] * scale + offset
         if np.issubdtype((scale + offset).dtype, np.floating) or np.issubdtype(variable.dtype, np.floating):

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -103,7 +103,7 @@ def create_nwcsaf_geo_ct_file(directory, attrs=global_attrs_geo):
         nc_file.attrs.update(attrs)
         var_name = "ct"
 
-        var = nc_file.create_variable(var_name, ("ny", "nx"), np.uint16,
+        var = nc_file.create_variable(var_name, ("ny", "nx"), np.uint8,
                                       chunks=(256, 256))
         var[:] = RANDOM_GEN.integers(0, 255, size=(928, 1530), dtype=np.uint8)
 
@@ -352,6 +352,13 @@ class TestNcNWCSAFGeo:
     def test_end_time(self, nwcsaf_geo_ct_filehandler):
         """Test the end time property."""
         assert nwcsaf_geo_ct_filehandler.end_time == read_nwcsaf_time(END_TIME)
+
+    def test_uint8_remains_uint8(self, nwcsaf_geo_ct_filehandler):
+        """Test that loading uint8 remains uint8."""
+        ct = nwcsaf_geo_ct_filehandler.get_dataset(
+                {"name": "ct"},
+                {"name": "ct", "file_type": "nc_nwcsaf_geo"})
+        assert ct.dtype == np.dtype("uint8")
 
 
 class TestNcNWCSAFPPS:

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -326,6 +326,14 @@ class TestNcNWCSAFGeo:
         assert "add_offset" not in var.attrs
         np.testing.assert_equal(var.attrs["valid_range"], (-2000., 25000.))
 
+    def test_scale_dataset_uint8_noop(self, nwcsaf_geo_ct_filehandler):
+        """Test that uint8 is not accidentally casted when no scaling is done."""
+        attrs = {}
+        var = xr.DataArray(np.array([1, 2, 3], dtype=np.uint8), attrs=attrs)
+        var = nwcsaf_geo_ct_filehandler.scale_dataset(var, "dummy")
+        np.testing.assert_equal(var, np.array([1, 2, 3], dtype=np.uint8))
+        assert var.dtype == np.uint8
+
     def test_orbital_parameters_are_correct(self, nwcsaf_geo_ct_filehandler):
         """Test that orbital parameters are present in the dataset attributes."""
         dsid = {"name": "ct"}


### PR DESCRIPTION
Avoid accidentally promoting the type in the NWCSAF GEO reader.

**WARNING:** Needs https://github.com/pytroll/trollimage/pull/176 !

 - [x] Closes #2872  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

