### PR TITLE
Fix AWIPS tiled writer handling of odd units in VIIRS EDR products

### DIFF
--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -246,6 +246,7 @@ UNIT_CONV = {
     "percent": "%",
     "Kelvin": "kelvin",
     "K": "kelvin",
+    "Meter": "meters",
 }
 
 TileInfo = namedtuple("TileInfo", ["tile_count", "image_shape", "tile_shape",


### PR DESCRIPTION
@kathys and @cfdierking noticed that some VIIRS EDR products have the units "Meter" which is not CF compliant nor AWIPS compliant. This PR adds a work around to the AWIPS tiled writer to rewrite "Meter" as "meters. I'm making this a "draft PR" for now as I might add more unit conversions if Kathy or Carl find others. This is a small enough fix that is more about AWIPS and input file metadata than the writer operating properly so I won't be adding a test.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->

