### PR TITLE
Update pyhdf-based arrs to be manually tokenized

### DIFF
--- a/satpy/readers/hdf4_utils.py
+++ b/satpy/readers/hdf4_utils.py
@@ -18,10 +18,12 @@
 """Helpers for reading hdf4-based files."""
 
 import logging
+import os
 
 import dask.array as da
 import numpy as np
 import xarray as xr
+from dask.base import tokenize
 from pyhdf.SD import SD, SDC, SDS
 
 from satpy.readers.file_handlers import BaseFileHandler
@@ -45,12 +47,24 @@ HTYPE_TO_DTYPE = {
 }
 
 
-def from_sds(var, *args, **kwargs):
+def from_sds(var, src_path, *args, **kwargs):
     """Create a dask array from a SD dataset."""
-    var.__dict__["dtype"] = np.dtype(HTYPE_TO_DTYPE[var.info()[3]])
-    shape = var.info()[2]
+    var_info = var.info()
+    var.__dict__["dtype"] = np.dtype(HTYPE_TO_DTYPE[var_info[3]])
+    shape = var_info[2]
     var.__dict__["shape"] = shape if isinstance(shape, (tuple, list)) else tuple(shape)
-    return da.from_array(var, *args, **kwargs)
+
+    name = kwargs.pop("name", None)
+    if name is None:
+        var_name = var_info[0]
+        tokenize_args = (os.fspath(src_path), var_name)
+        if args:
+            tokenize_args += (args,)
+        if kwargs:
+            tokenize_args += (kwargs,)
+        # put variable name in the front for easier dask debugging
+        name = var_name + "-" + tokenize(*tokenize_args)
+    return da.from_array(var, *args, name=name, **kwargs)
 
 
 class HDF4FileHandler(BaseFileHandler):
@@ -92,7 +106,7 @@ class HDF4FileHandler(BaseFileHandler):
 
     def _open_xarray_dataset(self, val, chunks=CHUNK_SIZE):
         """Read the band in blocks."""
-        dask_arr = from_sds(val, chunks=chunks)
+        dask_arr = from_sds(val, self.filename, chunks=chunks)
         attrs = val.attributes()
         return xr.DataArray(dask_arr, dims=("y", "x"),
                             attrs=attrs)

--- a/satpy/readers/hdf4_utils.py
+++ b/satpy/readers/hdf4_utils.py
@@ -47,7 +47,7 @@ HTYPE_TO_DTYPE = {
 }
 
 
-def from_sds(var, src_path, *args, **kwargs):
+def from_sds(var, src_path, **kwargs):
     """Create a dask array from a SD dataset."""
     var_info = var.info()
     var.__dict__["dtype"] = np.dtype(HTYPE_TO_DTYPE[var_info[3]])
@@ -58,8 +58,6 @@ def from_sds(var, src_path, *args, **kwargs):
     if name is None:
         var_name = var_info[0]
         tokenize_args = (os.fspath(src_path), var_name)
-        if args:
-            tokenize_args += (args,)
         if kwargs:
             tokenize_args += (kwargs,)
         # put variable name in the front for easier dask debugging

--- a/satpy/readers/hdf4_utils.py
+++ b/satpy/readers/hdf4_utils.py
@@ -62,7 +62,7 @@ def from_sds(var, src_path, **kwargs):
             tokenize_args += (kwargs,)
         # put variable name in the front for easier dask debugging
         name = var_name + "-" + tokenize(*tokenize_args)
-    return da.from_array(var, *args, name=name, **kwargs)
+    return da.from_array(var, name=name, **kwargs)
 
 
 class HDF4FileHandler(BaseFileHandler):

--- a/satpy/readers/hdfeos_base.py
+++ b/satpy/readers/hdfeos_base.py
@@ -216,7 +216,7 @@ class HDFEOSBaseFileReader(BaseFileHandler):
 
         dataset = self._read_dataset_in_file(dataset_name)
         chunks = self._chunks_for_variable(dataset)
-        dask_arr = from_sds(dataset, chunks=chunks)
+        dask_arr = from_sds(dataset, self.filename, chunks=chunks)
         dims = ("y", "x") if dask_arr.ndim == 2 else None
         data = xr.DataArray(dask_arr, dims=dims,
                             attrs=dataset.attributes())

--- a/satpy/readers/modis_l1b.py
+++ b/satpy/readers/modis_l1b.py
@@ -117,7 +117,7 @@ class HDFEOSBandReader(HDFEOSBaseFileReader):
         var_attrs = subdata.attributes()
         uncertainty = self.sd.select(var_name + "_Uncert_Indexes")
         chunks = self._chunks_for_variable(subdata)
-        array = xr.DataArray(from_sds(subdata, chunks=chunks)[band_index, :, :],
+        array = xr.DataArray(from_sds(subdata, self.filename, chunks=chunks)[band_index, :, :],
                              dims=["y", "x"]).astype(np.float32)
         valid_range = var_attrs["valid_range"]
         valid_min = np.float32(valid_range[0])
@@ -214,7 +214,7 @@ class HDFEOSBandReader(HDFEOSBaseFileReader):
         if not self._mask_saturated:
             return array
         uncertainty_chunks = self._chunks_for_variable(uncertainty)
-        band_uncertainty = from_sds(uncertainty, chunks=uncertainty_chunks)[band_index, :, :]
+        band_uncertainty = from_sds(uncertainty, self.filename, chunks=uncertainty_chunks)[band_index, :, :]
         array = array.where(band_uncertainty < 15)
         return array
 

--- a/satpy/readers/modis_l2.py
+++ b/satpy/readers/modis_l2.py
@@ -111,7 +111,7 @@ class ModisL2HDFFileHandler(HDFEOSGeoReader):
     def _select_hdf_dataset(self, hdf_dataset_name, byte_dimension):
         """Load a dataset from HDF-EOS level 2 file."""
         dataset = self.sd.select(hdf_dataset_name)
-        dask_arr = from_sds(dataset, chunks=CHUNK_SIZE)
+        dask_arr = from_sds(dataset, self.filename, chunks=CHUNK_SIZE)
         attrs = dataset.attributes()
         dims = ["y", "x"]
         if byte_dimension == 0:


### PR DESCRIPTION
This avoids a bug in dask or cloudpickle that alters the state of the pyhdf SDS object in some way making it unusable. The PR in dask that started triggering this was in https://github.com/dask/dask/pull/11320. My guess is that the repeated pickling/serialization is losing some hidden state in the pyhdf SDS object and then pyhdf or HDF-C no longer knows how to work with it.

We could register SDS with normalize_token in dask or we could just do what I do in this PR and come up with the token/name ourselves. Note this is the name for the dask array/task. This is similar to work done in the past by @mraspaud for the HDF5 utility package to make sure things are consistent across file variable loads.

One alternative to the PR as it is right now would be to copy `from_sds` as a method on the HDF utility class so it knows how to use `self.filename` automatically for the tokenizing. Also I'm realizing maybe the src_path shouldn't be required as it is only used if the `name` kwarg isn't provided. Thoughts @mraspaud @gerritholl ?

 - [x] Closes #2884 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
