### PR TITLE
Update VIIRS L1b reader to use additional netcdf attributes

### DIFF
--- a/satpy/readers/viirs_l1b.py
+++ b/satpy/readers/viirs_l1b.py
@@ -35,6 +35,21 @@ class VIIRSL1BFileHandler(NetCDF4FileHandler):
         return dt.datetime.strptime(datestr, "%Y-%m-%dT%H:%M:%S.000Z")
 
     @property
+    def day_night_flag(self):
+        """Get the day/night flag."""
+        return self["/attr/DayNightFlag"]
+
+    @property
+    def start_direction(self):
+        """Get the swath start direction flag."""
+        return self["/attr/startDirection"]
+
+    @property
+    def end_direction(self):
+        """Get the swath end direction flag."""
+        return self["/attr/endDirection"]
+
+    @property
     def start_orbit_number(self):
         """Get start orbit number."""
         try:
@@ -188,6 +203,9 @@ class VIIRSL1BFileHandler(NetCDF4FileHandler):
             "file_units": file_units,
             "platform_name": self.platform_name,
             "sensor": self.sensor_name,
+            "day_night": self.day_night_flag,
+            "start_direction": self.start_direction,
+            "end_direction": self.end_direction,
             "start_orbit": self.start_orbit_number,
             "end_orbit": self.end_orbit_number,
         })

--- a/satpy/tests/reader_tests/test_viirs_l1b.py
+++ b/satpy/tests/reader_tests/test_viirs_l1b.py
@@ -65,6 +65,9 @@ class FakeNetCDF4FileHandlerDay(FakeNetCDF4FileHandler):
             "/attr/orbit_number": 26384,
             "/attr/instrument": "VIIRS",
             "/attr/platform": "Suomi-NPP",
+            "/attr/DayNightFlag": "Day",
+            "/attr/startDirection": "Descending",
+            "/attr/endDirection": "Ascending",
         }
         self._fill_contents_with_default_data(file_content, file_type)
         self._set_dataset_specific_metadata(file_content)
@@ -271,6 +274,9 @@ class TestVIIRSL1BReaderDay:
             assert v.attrs["area"].lons.attrs["rows_per_scan"] == 2
             assert v.attrs["area"].lats.attrs["rows_per_scan"] == 2
             assert v.attrs["sensor"] == "viirs"
+            assert v.attrs["day_night"] == "Day"
+            assert v.attrs["start_direction"] == "Descending"
+            assert v.attrs["end_direction"] == "Ascending"
 
     def test_load_i_band_angles(self):
         """Test loading all M bands as radiances."""


### PR DESCRIPTION
The VIIRS L1b reader (NASA format VIIRS data) misses some netCDF attributes that may be useful to users.
This PR adds those attributes: The day/night flag (`Day`, `Night` or `Both`) and the starting plus ending orbital direction (`Ascending` or `Descending`). I also added a test to make sure the attrs are being read.

 - [ ] Tests added <!-- for all bug fixes or enhancements -->