### PR TITLE
Bugfix for Sentinel-2 radiance calculation

### DIFF
--- a/satpy/readers/msi_safe.py
+++ b/satpy/readers/msi_safe.py
@@ -83,7 +83,6 @@ class SAFEMSIL1C(BaseFileHandler):
         if proj is None:
             return
         proj.attrs = info.copy()
-        proj.attrs["units"] = "%"
         proj.attrs["platform_name"] = self.platform_name
         return proj
 

--- a/satpy/readers/msi_safe.py
+++ b/satpy/readers/msi_safe.py
@@ -238,8 +238,6 @@ class SAFEMSIMDXML(SAFEMSIXMLMetadata):
             return solar_irrad
         raise ValueError("No solar irradiance values were found in the metadata.")
 
-
-
     @cached_property
     def sun_earth_dist(self):
         """Get the sun-earth distance from the metadata."""

--- a/satpy/readers/msi_safe.py
+++ b/satpy/readers/msi_safe.py
@@ -15,7 +15,7 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""SAFE MSI L1C reader.
+"""SAFE MSI L1C/L2A reader.
 
 The MSI data has a special value for saturated pixels. By default, these
 pixels are set to np.inf, but for some applications it might be desirable
@@ -31,6 +31,10 @@ toggled with ``reader_kwargs`` upon Scene creation::
 L1C/L2A format description for the files read here:
 
   https://sentinels.copernicus.eu/documents/247904/685211/S2-PDGS-TAS-DI-PSD-V14.9.pdf/3d3b6c9c-4334-dcc4-3aa7-f7c0deffbaf7?t=1643013091529
+
+NOTE: At present, L1B data is not supported. If the user needs radiance data instead of counts or reflectances, these
+are retrieved by first calculating the reflectance and then working back to the radiance. L1B radiance data support
+will be added once the data is published onto the Copernicus data ecosystem.
 
 """
 

--- a/satpy/readers/msi_safe.py
+++ b/satpy/readers/msi_safe.py
@@ -59,13 +59,15 @@ PLATFORMS = {"S2A": "Sentinel-2A",
 class SAFEMSIL1C(BaseFileHandler):
     """File handler for SAFE MSI files (jp2)."""
 
-    def __init__(self, filename, filename_info, filetype_info, mda, tile_mda, mask_saturated=True):
+    def __init__(self, filename, filename_info, filetype_info, mda, tile_mda,
+                 mask_saturated=True, solar_ang_method="mean"):
         """Initialize the reader."""
         super(SAFEMSIL1C, self).__init__(filename, filename_info,
                                          filetype_info)
         del mask_saturated
         self._channel = filename_info["band_name"]
         self.process_level = filename_info["process_level"]
+        self.solar_ang_method = solar_ang_method
         self._tile_mda = tile_mda
         self._mda = mda
         self.platform_name = PLATFORMS[filename_info["fmission_id"]]
@@ -98,9 +100,17 @@ class SAFEMSIL1C(BaseFileHandler):
                 return self._mda.calibrate_to_radiances_l1b(proj, self._channel)
             else:
                 # For higher level data, radiances must be computed from the reflectance.
-                # sza = self._tile_mda.get_dataset()
+                # By default, we use the mean solar angles so that the user does not need to resample,
+                # but the user can also choose to use the solar angles from the tile metadata.
+                # This is on a coarse grid so for most bands must be resampled before use.
+                if self.solar_ang_method == "mean":
+                    zen, azi = self._tile_mda.mean_sun_angles
+                else:
+                    from satpy import DataQuery
+                    dq = DataQuery(name="solar_zenith_angle")
+                    zen = self._tile_mda.get_dataset(dq, {})
                 tmp_refl = self._mda.calibrate_to_reflectances(proj, self._channel)
-                return self._mda.calibrate_to_radiances(tmp_refl, self._channel)
+                return self._mda.calibrate_to_radiances(tmp_refl, zen, self._channel)
 
         if key["calibration"] == "counts":
             return self._mda._sanitize_data(proj)
@@ -257,14 +267,12 @@ class SAFEMSIMDXML(SAFEMSIXMLMetadata):
         data = self._sanitize_data(data)
         return (data + self.band_offset(band_name)) / physical_gain
 
-    def calibrate_to_radiances(self, data, band_name):
+    def calibrate_to_radiances(self, data, solar_zenith, band_name):
         """Calibrate *data* to radiance using the radiometric information for the metadata."""
         sed = self.sun_earth_dist
         if sed < 0.5 or sed > 1.5:
             raise ValueError(f"Sun-Earth distance is incorrect in the metadata: {sed}")
         solar_irrad_band = self.solar_irradiance(band_name)
-
-        solar_zenith = 32.029
 
         solar_zenith = np.deg2rad(solar_zenith)
 
@@ -313,7 +321,18 @@ class SAFEMSITileMDXML(SAFEMSIXMLMetadata):
             cols,
             rows,
             area_extent)
-        return area
+        return (area)
+
+    @cached_property
+    def mean_sun_angles(self):
+        """Get the mean sun angles from the metadata."""
+        angs = self.root.find(".//Mean_Sun_Angle")
+        if angs is not None:
+            zen = float(angs.find("ZENITH_ANGLE").text)
+            azi = float(angs.find("AZIMUTH_ANGLE").text)
+            return zen, azi
+        else:
+            return -999, -999
 
     @cached_property
     def projection(self):

--- a/satpy/readers/msi_safe.py
+++ b/satpy/readers/msi_safe.py
@@ -92,7 +92,9 @@ class SAFEMSIL1C(BaseFileHandler):
         if key["calibration"] == "reflectance":
             return self._mda.calibrate_to_reflectances(proj, self._channel)
         if key["calibration"] == "radiance":
-            return self._mda.calibrate_to_radiances(proj, self._channel)
+            # The calibration procedure differs for L1B and L1C/L2A data!
+            if self.process_level == "L1B":
+                return self._mda.calibrate_to_radiances(proj, self._channel)
         if key["calibration"] == "counts":
             return self._mda._sanitize_data(proj)
         if key["calibration"] in ["aerosol_thickness", "water_vapor"]:
@@ -218,7 +220,7 @@ class SAFEMSIMDXML(SAFEMSIXMLMetadata):
         """Get the saturated value from the metadata."""
         return self.special_values["SATURATED"]
 
-    def calibrate_to_radiances(self, data, band_name):
+    def calibrate_to_radiances_l1b(self, data, band_name):
         """Calibrate *data* to radiance using the radiometric information for the metadata."""
         physical_gain = self.physical_gain(band_name)
         data = self._sanitize_data(data)


### PR DESCRIPTION
This PR fixes the radiance calculation for Sentinel-2 data. Currently, the code uses the method suitable for L1b counts -> radiance computation. However, L1b data is not  (yet) available to users and the procedure is different for L1c data that's available via the Copernicus data ecosystem.

This PR switches to use the correct calculation. 

In addition, I made some changes to the reader code in preparation for the upcoming availability of L1B data for Sentinel-2. This data isn't yet supported by the reader, though, so I have added an explicit error message / reader failure mode if the user tries to process L1B data.


 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
