### PR TITLE
Add OCI L2 BGC reader

### DIFF
--- a/doc/source/reading.rst
+++ b/doc/source/reading.rst
@@ -305,6 +305,13 @@ time etc. The following attributes are standardized across all readers:
   should happen and when they actually do. See :ref:`time_metadata` below for
   details.
 * ``raw_metadata``: Raw, unprocessed metadata from the reader.
+* ``rows_per_scan``: Optional integer indicating how many rows of data
+  represent a single scan of the instrument. This is primarily used by
+  some resampling algorithms (ex. EWA) to produce better results and only
+  makes sense for swath-based (usually polar-orbiting) instruments. For
+  example, MODIS 1km data has 10 rows of data per scan. If an instrument
+  does not have multiple rows per scan this should usually be set to 0 rather
+  than 1 to indicate that the entire swath should be treated as a whole.
 
 Note that the above attributes are not necessarily available for each dataset.
 

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -1192,6 +1192,18 @@ enhancements:
           factor: 21.0
           min_stretch: 0.0
           max_stretch: 20.0
+  chlor_a_bgc:
+    name: chlor_a
+    reader: oci_l2_bgc
+    operations:
+      - name: stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs:
+          stretch: log
+          base: "10"
+          factor: 21.0
+          min_stretch: 0.0
+          max_stretch: 20.0
 
   cimss_cloud_type:
     standard_name: cimss_cloud_type

--- a/satpy/etc/readers/oci_l2_bgc.yaml
+++ b/satpy/etc/readers/oci_l2_bgc.yaml
@@ -1,0 +1,37 @@
+reader:
+  name: oci_l2_bgc
+  short_name: PACE OCI L2 BGC
+  long_name: PACE OCI L2 Biogeochemical in NetCDF format
+  description: PACE OCI L2 Biogeochemical Reader
+  status: Beta
+  supports_fsspec: false
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
+  sensors: [oci]
+
+file_types:
+  bgc_nc:
+    file_patterns:
+    # Example: PACE_OCI.20240907T191809.L2.OC_BGC.V2_0.NRT.nc4
+      - '{platform:s}_{sensor:s}.{start_time:%Y%m%dT%H%M%S}.L2.OC_BGC.V{sw_version:s}.{processing_type:s}nc4'
+    file_reader: !!python/name:satpy.readers.seadas_l2.SEADASL2NetCDFFileHandler
+    geo_resolution: 1000
+
+datasets:
+  longitude:
+    name: longitude
+    file_type: [bgc_nc]
+    file_key: ["navigation_data/longitude", "longitude"]
+    resolution: 1000
+
+  latitude:
+    name: latitude
+    file_type: [bgc_nc]
+    file_key: ["navigation_data/latitude", "latitude"]
+    resolution: 1000
+
+  chlor_a:
+    name: chlor_a
+    file_type: [bgc_nc]
+    file_key: ["geophysical_data/chlor_a", "chlor_a"]
+    resolution: 1000
+    coordinates: [longitude, latitude]

--- a/satpy/readers/seadas_l2.py
+++ b/satpy/readers/seadas_l2.py
@@ -54,6 +54,8 @@ class _SEADASL2Base:
             return 10
         if "viirs" in self.sensor_names:
             return 16
+        if "oci" in self.sensor_names:
+            return 0
         raise ValueError(f"Don't know how to read data for sensors: {self.sensor_names}")
 
     def _platform_name(self):
@@ -82,7 +84,10 @@ class _SEADASL2Base:
         sensor_name = self[self.sensor_attr_name].lower()
         if sensor_name.startswith("modis"):
             return {"modis"}
-        return {"viirs"}
+        if sensor_name.startswith("viirs"):
+            return {"viirs"}
+        # Example: OCI
+        return {sensor_name}
 
     def get_dataset(self, data_id, dataset_info):
         """Get DataArray for the specified DataID."""

--- a/satpy/tests/reader_tests/test_oci_l2_bgc.py
+++ b/satpy/tests/reader_tests/test_oci_l2_bgc.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2024 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Tests for the 'oci_l2_bgc' reader."""
+
+import numpy as np
+import pytest
+from pyresample.geometry import SwathDefinition
+
+from satpy import Scene, available_readers
+
+from .test_seadas_l2 import _create_seadas_chlor_a_netcdf_file
+
+# NOTE:
+# The following fixtures are not defined in this file, but are used and injected by Pytest:
+# - tmp_path_factory
+
+
+@pytest.fixture(scope="module")
+def oci_l2_bgc_netcdf(tmp_path_factory):
+    """Create MODIS SEADAS NetCDF file."""
+    filename = "PACE_OCI.20211118T175853.L2.OC_BGC.V2_0.NRT.nc4"
+    full_path = str(tmp_path_factory.mktemp("oci_l2_bgc") / filename)
+    return _create_seadas_chlor_a_netcdf_file(full_path, "PACE", "OCI")
+
+
+class TestSEADAS:
+    """Test the OCI L2 file reader."""
+
+    def test_available_reader(self):
+        """Test that OCI L2 reader is available."""
+        assert "oci_l2_bgc" in available_readers()
+
+    def test_scene_available_datasets(self, oci_l2_bgc_netcdf):
+        """Test that datasets are available."""
+        scene = Scene(reader="oci_l2_bgc", filenames=oci_l2_bgc_netcdf)
+        available_datasets = scene.all_dataset_names()
+        assert len(available_datasets) > 0
+        assert "chlor_a" in available_datasets
+
+    @pytest.mark.parametrize("apply_quality_flags", [False, True])
+    def test_load_chlor_a(self, oci_l2_bgc_netcdf, apply_quality_flags):
+        """Test that we can load 'chlor_a'."""
+        reader_kwargs = {"apply_quality_flags": apply_quality_flags}
+        scene = Scene(reader="oci_l2_bgc", filenames=oci_l2_bgc_netcdf, reader_kwargs=reader_kwargs)
+        scene.load(["chlor_a"])
+        data_arr = scene["chlor_a"]
+        assert data_arr.dims == ("y", "x")
+        assert data_arr.attrs["platform_name"] == "PACE"
+        assert data_arr.attrs["sensor"] == {"oci"}
+        assert data_arr.attrs["units"] == "mg m^-3"
+        assert data_arr.dtype.type == np.float32
+        assert isinstance(data_arr.attrs["area"], SwathDefinition)
+        assert data_arr.attrs["rows_per_scan"] == 0
+        data = data_arr.data.compute()
+        if apply_quality_flags:
+            assert np.isnan(data[2, 2])
+            assert np.count_nonzero(np.isnan(data)) == 1
+        else:
+            assert np.count_nonzero(np.isnan(data)) == 0

--- a/satpy/tests/reader_tests/test_seadas_l2.py
+++ b/satpy/tests/reader_tests/test_seadas_l2.py
@@ -190,6 +190,7 @@ def _create_seadas_chlor_a_netcdf_file(full_path, mission, sensor):
     geophys_group = nc.createGroup("geophysical_data")
     _add_variable_to_netcdf_file(geophys_group, "chlor_a", chlor_a_info)
     _add_variable_to_netcdf_file(geophys_group, "l2_flags", l2_flags_info)
+    nc.close()
     return [full_path]
 
 


### PR DESCRIPTION
We have a user who wants to be able to read OCI L2 Chlorophyll data from "biogeochemical" files (BGC). These are generally standardized to match the existing SEADAS L2 files that we (Polar2Grid) already supported so this new reader uses that reader for all its python functionality.

TODO: If there is a "rows per scan" similar to VIIRS or MODIS then I need to update the python code to use that.

Related https://github.com/ssec/polar2grid/issues/708

CC @kathys

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->