### PR TITLE
Add reader for Landsat L1 data

### DIFF
--- a/satpy/etc/composites/oli_tirs.yaml
+++ b/satpy/etc/composites/oli_tirs.yaml
@@ -1,0 +1,422 @@
+sensor_name: visir/oli_tirs
+
+modifiers:
+  rayleigh_corrected:
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: rayleigh_only
+    prerequisites:
+      - name: 'b04'
+        modifiers: [sunz_corrected]
+    optional_prerequisites:
+      - name: satellite_azimuth_angle
+      - name: satellite_zenith_angle
+      - name: solar_azimuth_angle
+      - name: solar_zenith_angle
+
+  rayleigh_corrected_antarctic:
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: antarctic_aerosol
+    prerequisites:
+      - name: 'b04'
+        modifiers: [sunz_corrected]
+    optional_prerequisites:
+      - name: satellite_azimuth_angle
+      - name: satellite_zenith_angle
+      - name: solar_azimuth_angle
+      - name: solar_zenith_angle
+
+  rayleigh_corrected_continental_average:
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: continental_average_aerosol
+    prerequisites:
+      - name: 'b04'
+        modifiers: [sunz_corrected]
+    optional_prerequisites:
+      - name: satellite_azimuth_angle
+      - name: satellite_zenith_angle
+      - name: solar_azimuth_angle
+      - name: solar_zenith_angle
+
+  rayleigh_corrected_continental_clean:
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: continental_clean_aerosol
+    prerequisites:
+      - name: 'b04'
+        modifiers: [sunz_corrected]
+    optional_prerequisites:
+      - name: satellite_azimuth_angle
+      - name: satellite_zenith_angle
+      - name: solar_azimuth_angle
+      - name: solar_zenith_angle
+
+  rayleigh_corrected_continental_polluted:
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: continental_polluted_aerosol
+    prerequisites:
+      - name: 'b04'
+        modifiers: [sunz_corrected]
+    optional_prerequisites:
+      - name: satellite_azimuth_angle
+      - name: satellite_zenith_angle
+      - name: solar_azimuth_angle
+      - name: solar_zenith_angle
+
+  rayleigh_corrected_desert:
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: desert_aerosol
+    prerequisites:
+      - name: 'b04'
+        modifiers: [sunz_corrected]
+    optional_prerequisites:
+      - name: satellite_azimuth_angle
+      - name: satellite_zenith_angle
+      - name: solar_azimuth_angle
+      - name: solar_zenith_angle
+
+  rayleigh_corrected_marine_clean:
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: marine_clean_aerosol
+    prerequisites:
+      - name: 'b04'
+        modifiers: [sunz_corrected]
+    optional_prerequisites:
+      - name: satellite_azimuth_angle
+      - name: satellite_zenith_angle
+      - name: solar_azimuth_angle
+      - name: solar_zenith_angle
+
+  rayleigh_corrected_marine_polluted:
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: marine_polluted_aerosol
+    prerequisites:
+      - name: 'b04'
+        modifiers: [sunz_corrected]
+    optional_prerequisites:
+      - name: satellite_azimuth_angle
+      - name: satellite_zenith_angle
+      - name: solar_azimuth_angle
+      - name: solar_zenith_angle
+
+  rayleigh_corrected_marine_tropical:
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: marine_tropical_aerosol
+    prerequisites:
+      - name: 'b04'
+        modifiers: [sunz_corrected]
+    optional_prerequisites:
+      - name: satellite_azimuth_angle
+      - name: satellite_zenith_angle
+      - name: solar_azimuth_angle
+      - name: solar_zenith_angle
+
+  rayleigh_corrected_rural:
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: rural_aerosol
+    prerequisites:
+      - name: 'b04'
+        modifiers: [sunz_corrected]
+    optional_prerequisites:
+      - name: satellite_azimuth_angle
+      - name: satellite_zenith_angle
+      - name: solar_azimuth_angle
+      - name: solar_zenith_angle
+
+  rayleigh_corrected_urban:
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    atmosphere: us-standard
+    aerosol_type: urban_aerosol
+    prerequisites:
+      - name: 'b04'
+        modifiers: [sunz_corrected]
+    optional_prerequisites:
+      - name: satellite_azimuth_angle
+      - name: satellite_zenith_angle
+      - name: solar_azimuth_angle
+      - name: solar_zenith_angle
+
+
+composites:
+  true_color:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - name: 'b04'
+      modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+    - name: 'b03'
+      modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+    - name: 'b02'
+      modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+    standard_name: true_color
+
+  true_color_antarctic:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'b04'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_antarctic]
+      - name: 'b03'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_antarctic]
+      - name: 'b02'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_antarctic]
+    standard_name: true_color
+
+  true_color_continental_average:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'b04'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_average]
+      - name: 'b03'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_average]
+      - name: 'b02'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_average]
+    standard_name: true_color
+
+  true_color_continental_clean:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'b04'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_clean]
+      - name: 'b03'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_clean]
+      - name: 'b02'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_clean]
+    standard_name: true_color
+
+  true_color_continental_polluted:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'b04'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_polluted]
+      - name: 'b03'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_polluted]
+      - name: 'b02'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_polluted]
+    standard_name: true_color
+
+  true_color_desert:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'b04'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_desert]
+      - name: 'b03'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_desert]
+      - name: 'b02'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_desert]
+    standard_name: true_color
+
+  true_color_marine_clean:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'b04'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_clean]
+      - name: 'b03'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_clean]
+      - name: 'b02'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_clean]
+    standard_name: true_color
+
+  true_color_marine_polluted:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'b04'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_polluted]
+      - name: 'b03'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_polluted]
+      - name: 'b02'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_polluted]
+    standard_name: true_color
+
+  true_color_marine_tropical:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'b04'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_tropical]
+      - name: 'b03'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_tropical]
+      - name: 'b02'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_tropical]
+    standard_name: true_color
+
+  true_color_rural:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'b04'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_rural]
+      - name: 'b03'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_rural]
+      - name: 'b02'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_rural]
+    standard_name: true_color
+
+  true_color_urban:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'b04'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_urban]
+      - name: 'b03'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_urban]
+      - name: 'b02'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_urban]
+    standard_name: true_color
+
+  true_color_uncorr:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'b04'
+        modifiers: [effective_solar_pathlength_corrected]
+      - name: 'b03'
+        modifiers: [effective_solar_pathlength_corrected]
+      - name: 'b02'
+        modifiers: [effective_solar_pathlength_corrected]
+    standard_name: true_color
+
+  true_color_raw:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'b04'
+        # modifiers: [effective_solar_pathlength_corrected]
+      - name: 'b03'
+        # modifiers: [effective_solar_pathlength_corrected]
+      - name: 'b02'
+        # modifiers: [effective_solar_pathlength_corrected]
+    standard_name: true_color
+
+  natural_color:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+    - name: 'b06'
+      modifiers: [effective_solar_pathlength_corrected]
+    - name: 'b05'
+      modifiers: [effective_solar_pathlength_corrected]
+    - name: 'b04'
+      modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+    standard_name: natural_color
+
+  urban_color:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'b07'
+        modifiers: [effective_solar_pathlength_corrected]
+      - name: 'b06'
+        modifiers: [effective_solar_pathlength_corrected]
+      - name: 'b04'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+    standard_name: natural_color
+
+  false_color:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'b05'
+        modifiers: [effective_solar_pathlength_corrected]
+      - name: 'b04'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+      - name: 'b03'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+    standard_name: natural_color
+
+  ndvi:
+    # Normalized Difference Vegetation Index
+    # For more information please review https://custom-scripts.sentinel-hub.com/sentinel-2/ndvi/
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    prerequisites:
+    - compositor: !!python/name:satpy.composites.RatioCompositor
+      prerequisites:
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: 'b05'
+            modifiers: [effective_solar_pathlength_corrected]
+          - name: 'b04'
+            modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+      - compositor: !!python/name:satpy.composites.SumCompositor
+        prerequisites:
+          - name: 'b05'
+            modifiers: [effective_solar_pathlength_corrected]
+          - name: 'b04'
+            modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+    standard_name: ndvi_msi
+
+  ndmi:
+    # Normalized Difference Moisture Index
+    # For more information please review https://custom-scripts.sentinel-hub.com/sentinel-2/ndmi/
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    prerequisites:
+    - compositor: !!python/name:satpy.composites.RatioCompositor
+      prerequisites:
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: 'b05'
+            modifiers: [effective_solar_pathlength_corrected]
+          - name: 'b06'
+            modifiers: [effective_solar_pathlength_corrected]
+      - compositor: !!python/name:satpy.composites.SumCompositor
+        prerequisites:
+          - name: 'b05'
+            modifiers: [effective_solar_pathlength_corrected]
+          - name: 'b06'
+            modifiers: [effective_solar_pathlength_corrected]
+    standard_name: ndmi_msi
+
+  ndwi:
+    # Normalized Difference Water Index
+    # For more information please review https://custom-scripts.sentinel-hub.com/sentinel-2/ndwi/
+    compositor: !!python/name:satpy.composites.SingleBandCompositor
+    prerequisites:
+    - compositor: !!python/name:satpy.composites.RatioCompositor
+      prerequisites:
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: 'b03'
+            modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+          - name: 'b05'
+            modifiers: [effective_solar_pathlength_corrected]
+      - compositor: !!python/name:satpy.composites.SumCompositor
+        prerequisites:
+          - name: 'b03'
+            modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+          - name: 'b05'
+            modifiers: [effective_solar_pathlength_corrected]
+    standard_name: ndwi_msi
+
+  ndsi:
+    # Normalized Difference Snow Index
+    # For more information please review https://custom-scripts.sentinel-hub.com/sentinel-2/ndsi/
+    compositor: !!python/name:satpy.composites.MaskingCompositor
+    prerequisites:
+    - name: 'b06'
+      modifiers: [effective_solar_pathlength_corrected]
+    - compositor: !!python/name:satpy.composites.RatioCompositor
+      prerequisites:
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: 'b03'
+            modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+          - name: 'b06'
+            modifiers: [effective_solar_pathlength_corrected]
+      - compositor: !!python/name:satpy.composites.SumCompositor
+        prerequisites:
+          - name: 'b03'
+            modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+          - name: 'b06'
+            modifiers: [effective_solar_pathlength_corrected]
+    conditions:
+    - method: less_equal
+      value: 0.42
+      transparency: 100
+    - method: isnan
+      transparency: 100
+    standard_name: ndsi_msi
+
+  ndsi_with_true_color:
+    compositor: !!python/name:satpy.composites.BackgroundCompositor
+    prerequisites:
+      - name: ndsi
+      - name: true_color
+    standard_name: no_enhancement

--- a/satpy/etc/readers/oli_tirs_l1_tif.yaml
+++ b/satpy/etc/readers/oli_tirs_l1_tif.yaml
@@ -1,0 +1,305 @@
+reader:
+  name: oli_tirs_l1_tif
+  short_name: OLI/TIRS L1 GeoTIFF
+  long_name: Landsat-8/9 OLI/TIRS L1 data in GeoTIFF format.
+  description: GeoTIFF reader for Landsat-8/9 OLI/TIRS L1 data.
+  status: Beta
+  supports_fsspec: false
+  sensors: [oli, tirs]
+  default_channels: []
+  reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
+
+file_types:
+  b01_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B1.TIF']
+        requires: [l1_metadata]
+  b02_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B2.TIF']
+        requires: [l1_metadata]
+  b03_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B3.TIF']
+        requires: [l1_metadata]
+  b04_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B4.TIF']
+        requires: [l1_metadata]
+  b05_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B5.TIF']
+        requires: [l1_metadata]
+  b06_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B6.TIF']
+        requires: [l1_metadata]
+  b07_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B7.TIF']
+        requires: [l1_metadata]
+  b08_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B8.TIF']
+        requires: [l1_metadata]
+  b09_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B9.TIF']
+        requires: [l1_metadata]
+  b10_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B10.TIF']
+        requires: [l1_metadata]
+  b11_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B11.TIF']
+        requires: [l1_metadata]
+  sza_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_SZA.TIF']
+        requires: [l1_metadata]
+  saa_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_SAA.TIF']
+        requires: [l1_metadata]
+  vza_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_VZA.TIF']
+        requires: [l1_metadata]
+  vaa_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_VAA.TIF']
+        requires: [l1_metadata]
+  qa_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_QA.TIF']
+        requires: [l1_metadata]
+  qa_radsat_granule:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_QA_RADSAT.TIF']
+        requires: [l1_metadata]
+  l1_metadata:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_MD_Reader
+        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_MTL.xml']
+
+datasets:
+  # Channels on the OLI instrument
+  B01:
+    name: B01
+    sensor: oli
+    wavelength: [0.433, 0.443, 0.453]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: b01_granule
+  B02:
+    name: B02
+    sensor: oli
+    wavelength: [0.450, 0.482, 0.515]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: b02_granule
+  B03:
+    name: B03
+    sensor: oli
+    wavelength: [0.525, 0.565, 0.600]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: b03_granule
+  B04:
+    name: B04
+    sensor: oli
+    wavelength: [0.630, 0.660, 0.680]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: b04_granule
+  B05:
+    name: B05
+    sensor: oli
+    wavelength: [0.845, 0.867, 0.885]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: b05_granule
+  B06:
+    name: B06
+    sensor: oli
+    wavelength: [1.560, 1.650, 1.660]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: b06_granule
+  B07:
+    name: B07
+    sensor: oli
+    wavelength: [2.100, 2.215, 2.300]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: b07_granule
+  B08:
+    name: B08
+    sensor: oli
+    wavelength: [0.500, 0.579, 0.680]
+    resolution: 15
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: b03_granule
+  B09:
+    name: B09
+    sensor: oli
+    wavelength: [1.360, 1.373, 1.390]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: b09_granule
+  # Channels on the TIRS instrument
+  B10:
+    name: B10
+    sensor: tirs
+    wavelength: [10.6, 10.888, 11.19]
+    resolution: 30
+    calibration:
+      brightness_temperature:
+        standard_name: brightness_temperature
+        units: "K"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: b10_granule
+  B11:
+    name: B11
+    sensor: tirs
+    wavelength: [11.5, 11.981, 12.51]
+    resolution: 30
+    calibration:
+      brightness_temperature:
+        standard_name: brightness_temperature
+        units: "K"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: b11_granule
+
+  # QA Variables
+  qa:
+    name: qa
+    sensor: oli
+    resolution: 30
+    file_type: qa_granule
+  qa_radsat:
+    name: qa_radsat
+    sensor: oli
+    resolution: 30
+    file_type: qa_radsat_granule
+
+  # Angles datasets
+  sza:
+    name: sza
+    sensor: oli
+    standard_name: solar_zenith_angle
+    resolution: 30
+    units: "degrees"
+    file_type: sza_granule
+  saa:
+    name: saa
+    sensor: oli
+    standard_name: solar_azimuth_angle
+    resolution: 30
+    units: "degrees"
+    file_type: saa_granule
+  vza:
+    name: vza
+    sensor: oli
+    standard_name: viewing_zenith_angle
+    resolution: 30
+    units: "degrees"
+    file_type: vza_granule
+  vaa:
+    name: vaa
+    sensor: oli
+    standard_name: viewing_azimuth_angle
+    resolution: 30
+    units: "degrees"
+    file_type: vaa_granule

--- a/satpy/etc/readers/oli_tirs_l1_tif.yaml
+++ b/satpy/etc/readers/oli_tirs_l1_tif.yaml
@@ -5,7 +5,7 @@ reader:
   description: GeoTIFF reader for Landsat-8/9 OLI/TIRS L1 data.
   status: Beta
   supports_fsspec: false
-  sensors: [oli, tirs]
+  sensors: oli_tirs
   default_channels: []
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
 
@@ -102,7 +102,7 @@ file_types:
 datasets:
   b01:
     name: b01
-    sensor: oli
+    sensor: oli_tirs
     wavelength: [0.433, 0.443, 0.453]
     resolution: 30
     calibration:
@@ -119,7 +119,7 @@ datasets:
 
   b02:
     name: b02
-    sensor: oli
+    sensor: oli_tirs
     wavelength: [0.450, 0.482, 0.515]
     resolution: 30
     calibration:
@@ -136,7 +136,7 @@ datasets:
 
   b03:
     name: b03
-    sensor: oli
+    sensor: oli_tirs
     wavelength: [0.525, 0.565, 0.600]
     resolution: 30
     calibration:
@@ -153,7 +153,7 @@ datasets:
 
   b04:
     name: b04
-    sensor: oli
+    sensor: oli_tirs
     wavelength: [0.630, 0.660, 0.680]
     resolution: 30
     calibration:
@@ -170,7 +170,7 @@ datasets:
 
   b05:
     name: b05
-    sensor: oli
+    sensor: oli_tirs
     wavelength: [0.845, 0.867, 0.885]
     resolution: 30
     calibration:
@@ -187,7 +187,7 @@ datasets:
 
   b06:
     name: b06
-    sensor: oli
+    sensor: oli_tirs
     wavelength: [1.560, 1.650, 1.660]
     resolution: 30
     calibration:
@@ -204,7 +204,7 @@ datasets:
 
   b07:
     name: b07
-    sensor: oli
+    sensor: oli_tirs
     wavelength: [2.100, 2.215, 2.300]
     resolution: 30
     calibration:
@@ -221,7 +221,7 @@ datasets:
 
   b08:
     name: b08
-    sensor: oli
+    sensor: oli_tirs
     wavelength: [0.500, 0.579, 0.680]
     resolution: 15
     calibration:
@@ -238,7 +238,7 @@ datasets:
 
   b09:
     name: b09
-    sensor: oli
+    sensor: oli_tirs
     wavelength: [1.360, 1.373, 1.390]
     resolution: 30
     calibration:
@@ -256,7 +256,7 @@ datasets:
   # Channels on the TIRS instrument
   b10:
     name: b10
-    sensor: tirs
+    sensor: oli_tirs
     wavelength: [10.6, 10.888, 11.19]
     resolution: 30
     calibration:
@@ -273,7 +273,7 @@ datasets:
 
   b11:
     name: b11
-    sensor: tirs
+    sensor: oli_tirs
     wavelength: [11.5, 11.981, 12.51]
     resolution: 30
     calibration:
@@ -291,44 +291,44 @@ datasets:
   # QA Variables
   qa:
     name: qa
-    sensor: oli
+    sensor: oli_tirs
     resolution: 30
     file_type: granule_qa
 
   qa_radsat:
     name: qa_radsat
-    sensor: oli
+    sensor: oli_tirs
     resolution: 30
     file_type: granule_qa_radsat
 
   # Angles datasets
-  sza:
-    name: sza
-    sensor: oli
+  solar_zenith_angle:
+    name: solar_zenith_angle
+    sensor: oli_tirs
     standard_name: solar_zenith_angle
     resolution: 30
     units: "degrees"
     file_type: granule_sza
 
-  saa:
-    name: saa
-    sensor: oli
+  solar_azimuth_angle:
+    name: solar_azimuth_angle
+    sensor: oli_tirs
     standard_name: solar_azimuth_angle
     resolution: 30
     units: "degrees"
     file_type: granule_saa
 
-  vza:
-    name: vza
-    sensor: oli
+  satellite_zenith_angle:
+    name: satellite_zenith_angle
+    sensor: oli_tirs
     standard_name: viewing_zenith_angle
     resolution: 30
     units: "degrees"
     file_type: granule_vza
 
-  vaa:
-    name: vaa
-    sensor: oli
+  satellite_azimuth_angle:
+    name: satellite_azimuth_angle
+    sensor: oli_tirs
     standard_name: viewing_azimuth_angle
     resolution: 30
     units: "degrees"

--- a/satpy/etc/readers/oli_tirs_l1_tif.yaml
+++ b/satpy/etc/readers/oli_tirs_l1_tif.yaml
@@ -10,82 +10,98 @@ reader:
   reader: !!python/name:satpy.readers.yaml_reader.FileYAMLReader
 
 file_types:
-  b01_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B1.TIF']
+    # Bands on the OLI subsystem
+    granule_b01:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B1.TIF']
         requires: [l1_metadata]
-  b02_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B2.TIF']
+
+    granule_b02:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B2.TIF']
         requires: [l1_metadata]
-  b03_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B3.TIF']
+
+    granule_b03:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B3.TIF']
         requires: [l1_metadata]
-  b04_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B4.TIF']
+
+    granule_b04:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B4.TIF']
         requires: [l1_metadata]
-  b05_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B5.TIF']
+
+    granule_b05:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B5.TIF']
         requires: [l1_metadata]
-  b06_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B6.TIF']
+
+    granule_b06:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B6.TIF']
         requires: [l1_metadata]
-  b07_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B7.TIF']
+
+    granule_b07:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B7.TIF']
         requires: [l1_metadata]
-  b08_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B8.TIF']
+
+    granule_b08:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B8.TIF']
         requires: [l1_metadata]
-  b09_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B9.TIF']
+
+    granule_b09:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B9.TIF']
         requires: [l1_metadata]
-  b10_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B10.TIF']
+
+    # Bands on the TIRS subsystem
+    granule_b10:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B10.TIF']
         requires: [l1_metadata]
-  b11_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B11.TIF']
+
+    granule_b11:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B11.TIF']
         requires: [l1_metadata]
-  sza_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_SZA.TIF']
+
+    # Geometry datasets
+    granule_sza:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_SZA.TIF']
         requires: [l1_metadata]
-  saa_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_SAA.TIF']
+    granule_saa:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_SAA.TIF']
         requires: [l1_metadata]
-  vza_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_VZA.TIF']
+    granule_vza:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_VZA.TIF']
         requires: [l1_metadata]
-  vaa_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_VAA.TIF']
+    granule_vaa:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_VAA.TIF']
         requires: [l1_metadata]
-  qa_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_QA.TIF']
+
+    # QA Variables
+    granule_qa:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_QA.TIF']
         requires: [l1_metadata]
-  qa_radsat_granule:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_CH_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_QA_RADSAT.TIF']
+    granule_qa_radsat:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_QA_RADSAT.TIF']
         requires: [l1_metadata]
-  l1_metadata:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tiff.OLITIRS_MD_Reader
-        file_patterns: ['{platform_type:1s}{data_type:{1s}{spacecraft_id:2s}_{process_level_correction:4s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_MTL.xml']
+
+    l1_metadata:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSMDReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_MTL.xml']
 
 datasets:
-  # Channels on the OLI instrument
-  B01:
-    name: B01
+  b01:
+    name: b01
     sensor: oli
     wavelength: [0.433, 0.443, 0.453]
     resolution: 30
@@ -99,9 +115,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: b01_granule
-  B02:
-    name: B02
+    file_type: granule_b01
+
+  b02:
+    name: b02
     sensor: oli
     wavelength: [0.450, 0.482, 0.515]
     resolution: 30
@@ -115,9 +132,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: b02_granule
-  B03:
-    name: B03
+    file_type: granule_b02
+
+  b03:
+    name: b03
     sensor: oli
     wavelength: [0.525, 0.565, 0.600]
     resolution: 30
@@ -131,9 +149,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: b03_granule
-  B04:
-    name: B04
+    file_type: granule_b03
+
+  b04:
+    name: b04
     sensor: oli
     wavelength: [0.630, 0.660, 0.680]
     resolution: 30
@@ -147,9 +166,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: b04_granule
-  B05:
-    name: B05
+    file_type: granule_b04
+
+  b05:
+    name: b05
     sensor: oli
     wavelength: [0.845, 0.867, 0.885]
     resolution: 30
@@ -163,9 +183,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: b05_granule
-  B06:
-    name: B06
+    file_type: granule_b05
+
+  b06:
+    name: b06
     sensor: oli
     wavelength: [1.560, 1.650, 1.660]
     resolution: 30
@@ -179,9 +200,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: b06_granule
-  B07:
-    name: B07
+    file_type: granule_b06
+
+  b07:
+    name: b07
     sensor: oli
     wavelength: [2.100, 2.215, 2.300]
     resolution: 30
@@ -195,9 +217,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: b07_granule
-  B08:
-    name: B08
+    file_type: granule_b07
+
+  b08:
+    name: b08
     sensor: oli
     wavelength: [0.500, 0.579, 0.680]
     resolution: 15
@@ -211,9 +234,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: b03_granule
-  B09:
-    name: B09
+    file_type: granule_b08
+
+  b09:
+    name: b09
     sensor: oli
     wavelength: [1.360, 1.373, 1.390]
     resolution: 30
@@ -227,10 +251,11 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: b09_granule
+    file_type: granule_b09
+
   # Channels on the TIRS instrument
-  B10:
-    name: B10
+  b10:
+    name: b10
     sensor: tirs
     wavelength: [10.6, 10.888, 11.19]
     resolution: 30
@@ -244,9 +269,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: b10_granule
-  B11:
-    name: B11
+    file_type: granule_b10
+
+  b11:
+    name: b11
     sensor: tirs
     wavelength: [11.5, 11.981, 12.51]
     resolution: 30
@@ -260,19 +286,20 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: b11_granule
+    file_type: granule_b11
 
   # QA Variables
   qa:
     name: qa
     sensor: oli
     resolution: 30
-    file_type: qa_granule
+    file_type: granule_qa
+
   qa_radsat:
     name: qa_radsat
     sensor: oli
     resolution: 30
-    file_type: qa_radsat_granule
+    file_type: granule_qa_radsat
 
   # Angles datasets
   sza:
@@ -281,25 +308,28 @@ datasets:
     standard_name: solar_zenith_angle
     resolution: 30
     units: "degrees"
-    file_type: sza_granule
+    file_type: granule_sza
+
   saa:
     name: saa
     sensor: oli
     standard_name: solar_azimuth_angle
     resolution: 30
     units: "degrees"
-    file_type: saa_granule
+    file_type: granule_saa
+
   vza:
     name: vza
     sensor: oli
     standard_name: viewing_zenith_angle
     resolution: 30
     units: "degrees"
-    file_type: vza_granule
+    file_type: granule_vza
+
   vaa:
     name: vaa
     sensor: oli
     standard_name: viewing_azimuth_angle
     resolution: 30
     units: "degrees"
-    file_type: vaa_granule
+    file_type: granule_vaa

--- a/satpy/readers/oli_tirs_l1_tif.py
+++ b/satpy/readers/oli_tirs_l1_tif.py
@@ -237,7 +237,7 @@ class OLITIRSMDReader(BaseFileHandler):
     def band_saturation(self):
         """Return per-band saturation flag."""
         bdict = {}
-        for i in range(1, 9):
+        for i in range(1, 10):
             bdict[f"b{i:02d}"] = self._get_satflag(i)
 
         return bdict
@@ -266,7 +266,7 @@ class OLITIRSMDReader(BaseFileHandler):
     def band_calibration(self):
         """Return per-band saturation flag."""
         bdict = {}
-        for i in range(1, 9):
+        for i in range(1, 10):
             bdict[f"b{i:02d}"] = self._get_band_viscal(i)
         for i in range(10, 12):
             bdict[f"b{i:02d}"] = self._get_band_tircal(i)

--- a/satpy/readers/oli_tirs_l1_tif.py
+++ b/satpy/readers/oli_tirs_l1_tif.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Landsat OLI/TIRS Level 1 reader.
+
+Details of the data format can be found here:
+  https://d9-wret.s3.us-west-2.amazonaws.com/assets/palladium/production/s3fs-public/atoms/files/LSDS-1822_Landsat8-9-OLI-TIRS-C2-L1-DFCB-v6.pdf
+  https://www.usgs.gov/landsat-missions/using-usgs-landsat-level-1-data-product
+
+"""
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+PLATFORMS = {"08": "Landsat-8",
+             "09": "Landsat-9"}

--- a/satpy/readers/oli_tirs_l1_tif.py
+++ b/satpy/readers/oli_tirs_l1_tif.py
@@ -62,23 +62,13 @@ class OLITIRSCHReader(BaseFileHandler):
 
     @property
     def start_time(self):
-        """Return start time.
-
-        This is actually the scene center time, as we don't have the start time.
-        It is constructed from the observation date (from the filename) and the center time (from the metadata).
-        """
-        return datetime(self._obs_date.year, self._obs_date.month, self._obs_date.day,
-                        self._mda.center_time.hour, self._mda.center_time.minute, self._mda.center_time.second)
+        """Return start time."""
+        return self._mda.start_time
 
     @property
     def end_time(self):
-        """Return end time.
-
-        This is actually the scene center time, as we don't have the end time.
-        It is constructed from the observation date (from the filename) and the center time (from the metadata).
-        """
-        return datetime(self._obs_date.year, self._obs_date.month, self._obs_date.day,
-                        self._mda.center_time.hour, self._mda.center_time.minute, self._mda.center_time.second)
+        """Return end time."""
+        return self._mda.end_time
 
     def __init__(self, filename, filename_info, filetype_info, mda, **kwargs):
         """Initialize the reader."""
@@ -210,6 +200,26 @@ class OLITIRSMDReader(BaseFileHandler):
     def center_time(self):
         """Return center time."""
         return datetime.strptime(self.root.find(".//IMAGE_ATTRIBUTES/SCENE_CENTER_TIME").text[:-2], "%H:%M:%S.%f")
+
+    @property
+    def start_time(self):
+        """Return start time.
+
+        This is actually the scene center time, as we don't have the start time.
+        It is constructed from the observation date (from the filename) and the center time (from the metadata).
+        """
+        return datetime(self._obs_date.year, self._obs_date.month, self._obs_date.day,
+                        self.center_time.hour, self.center_time.minute, self.center_time.second)
+
+    @property
+    def end_time(self):
+        """Return end time.
+
+        This is actually the scene center time, as we don't have the end time.
+        It is constructed from the observation date (from the filename) and the center time (from the metadata).
+        """
+        return datetime(self._obs_date.year, self._obs_date.month, self._obs_date.day,
+                        self.center_time.hour, self.center_time.minute, self.center_time.second)
 
     @property
     def cloud_cover(self):

--- a/satpy/readers/oli_tirs_l1_tif.py
+++ b/satpy/readers/oli_tirs_l1_tif.py
@@ -24,9 +24,246 @@ Details of the data format can be found here:
 """
 
 import logging
+from datetime import datetime
 
+import defusedxml.ElementTree as ET
+import numpy as np
+import rasterio
+import xarray as xr
+from pyresample import utils
+
+from satpy.readers.file_handlers import BaseFileHandler
+from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
+CHUNK_SIZE = get_legacy_chunk_size()
 
 PLATFORMS = {"08": "Landsat-8",
              "09": "Landsat-9"}
+
+OLI_BANDLIST = ["b01", "b02", "b03", "b04", "b05", "b06", "b07", "b08", "b09"]
+TIRS_BANDLIST = ["b10", "b11"]
+ANGLIST = ["sza", "saa", "vza", "vaa"]
+
+BANDLIST = OLI_BANDLIST + TIRS_BANDLIST
+
+
+class OLITIRSCHReader(BaseFileHandler):
+    """File handler for Landsat L1 files (tif)."""
+
+    @staticmethod
+    def get_btype(file_type):
+        """Return the band type from the file type."""
+        pos = file_type.rfind("_")
+        if pos == -1:
+            raise ValueError(f"Invalid file type: {file_type}")
+        else:
+            return file_type[pos+1:]
+
+    @property
+    def start_time(self):
+        """Return start time.
+
+        This is actually the scene center time, as we don't have the start time.
+        It is constructed from the observation date (from the filename) and the center time (from the metadata).
+        """
+        return datetime(self._obs_date.year, self._obs_date.month, self._obs_date.day,
+                        self._mda.center_time.hour, self._mda.center_time.minute, self._mda.center_time.second)
+
+    @property
+    def end_time(self):
+        """Return end time.
+
+        This is actually the scene center time, as we don't have the end time.
+        It is constructed from the observation date (from the filename) and the center time (from the metadata).
+        """
+        return datetime(self._obs_date.year, self._obs_date.month, self._obs_date.day,
+                        self._mda.center_time.hour, self._mda.center_time.minute, self._mda.center_time.second)
+
+    def __init__(self, filename, filename_info, filetype_info, mda, **kwargs):
+        """Initialize the reader."""
+        super(OLITIRSCHReader, self).__init__(filename, filename_info, filetype_info)
+
+        # Check we have landsat data
+        if filename_info["platform_type"] != "L":
+            raise ValueError("This reader only supports Landsat data")
+
+        # Get the channel name
+        self.channel = self.get_btype(filetype_info["file_type"])
+
+        # Data can be VIS, TIR or Combined. This flag denotes what the granule contains (O, T or C respectively).
+        self.chan_selector = filename_info["data_type"]
+
+        self._obs_date = filename_info["observation_date"]
+        self._mda = mda
+
+        # Retrieve some per-band useful metadata
+        self.bsat = self._mda.band_saturation
+        self.calinfo = self._mda.band_calibration
+        self.platform_name = PLATFORMS[filename_info["spacecraft_id"]]
+
+    def get_dataset(self, key, info):
+        """Load a dataset."""
+        if self.channel != key["name"]:
+            return
+
+        logger.debug("Reading %s.", key["name"])
+
+        dataset = rasterio.open(self.filename)
+
+        # Create area definition
+        if hasattr(dataset, "crs") and dataset.crs is not None:
+            self.area = utils.get_area_def_from_raster(dataset)
+
+            # Create area definition
+            if hasattr(dataset, "crs") and dataset.crs is not None:
+                self.area = utils.get_area_def_from_raster(dataset)
+
+            data = xr.open_dataset(self.filename, engine="rasterio",
+                                   chunks={"band": 1,
+                                           "y": CHUNK_SIZE,
+                                           "x": CHUNK_SIZE},
+                                   mask_and_scale=False)["band_data"].squeeze()
+
+            # The fill value for Landsat is '0', for calibration simplicity convert it to np.nan
+            data = xr.where(data == 0, np.float32(np.nan), data)
+
+            attrs = data.attrs.copy()
+
+            # Add useful metadata to the attributes.
+            attrs["perc_cloud_cover"] = self._mda.cloud_cover
+
+            # Only OLI bands have a saturation flag
+            if key["name"] in OLI_BANDLIST:
+                attrs["saturated"] = self.bsat[key["name"]]
+
+            # Rename to Satpy convention
+            data = data.rename({"band": "bands"})
+
+            data.attrs = attrs
+
+            # Calibrate if we're using a band rather than a QA or geometry dataset
+            if key["name"] in BANDLIST:
+                data = self.calibrate(data, key["calibration"])
+            if key["name"] in ANGLIST:
+                data = data * 0.01
+                data.attrs["units"] = "degrees"
+
+            return data
+
+    def calibrate(self, data, calibration):
+        """Calibrate the data from counts into the desired units."""
+        if calibration == "counts":
+            data.attrs["standard_name"] = "counts"
+            data.attrs["units"] = "1"
+            return data.astype(np.float32)
+
+        if calibration in ["radiance", "brightness_temperature"]:
+            data.attrs["standard_name"] = "toa_outgoing_radiance_per_unit_wavelength"
+            data.attrs["units"] = "W m-2 um-1 sr-1"
+            data = data * self.calinfo[self.channel][0] + self.calinfo[self.channel][1]
+            if calibration == "radiance":
+                return data.astype(np.float32)
+
+        if calibration == "reflectance":
+            if int(self.channel[1:]) < 10:
+                data.attrs["standard_name"] = "toa_bidirectional_reflectance"
+                data.attrs["units"] = "%"
+                data = data * self.calinfo[self.channel][2] + self.calinfo[self.channel][3]
+                return data.astype(np.float32)
+            raise ValueError(f"Reflectance not available for thermal bands: {self.channel}")
+
+        if calibration == "brightness_temperature":
+            if self.channel[1:] in ["10", "11"]:
+                data.attrs["standard_name"] = "counts"
+                data.attrs["units"] = "K"
+                data = (self.calinfo[self.channel][3] / np.log((self.calinfo[self.channel][2] / data) + 1))
+                return data.astype(np.float32)
+            raise ValueError(f"Brightness temperature not available for visible bands: {self.channel}")
+
+        return data.astype(np.float32)
+
+    def get_area_def(self, dsid):
+        """Get area definition of the image."""
+        if self.area is None:
+            raise NotImplementedError("No CRS information available from image")
+        return self.area
+
+class OLITIRSMDReader(BaseFileHandler):
+    """File handler for Landsat L1 files (tif)."""
+    def __init__(self, filename, filename_info, filetype_info):
+        """Init the reader."""
+        super().__init__(filename, filename_info, filetype_info)
+        # Check we have landsat data
+        if filename_info["platform_type"] != "L":
+            raise ValueError("This reader only supports Landsat data")
+
+        self._obs_date = filename_info["observation_date"]
+        self.root = ET.parse(self.filename)
+        self.process_level = filename_info["process_level_correction"]
+        self.platform_name = PLATFORMS[filename_info["spacecraft_id"]]
+        import bottleneck  # noqa
+        import geotiepoints  # noqa
+
+
+    @property
+    def center_time(self):
+        """Return center time."""
+        return datetime.strptime(self.root.find(".//IMAGE_ATTRIBUTES/SCENE_CENTER_TIME").text, "%H:%M:%S.%f0Z")
+
+    @property
+    def cloud_cover(self):
+        """Return estimated granule cloud cover percentage."""
+        return float(self.root.find(".//IMAGE_ATTRIBUTES/CLOUD_COVER").text)
+
+    def _get_satflag(self, band):
+        """Return saturation flag for a band."""
+        flag = self.root.find(f".//IMAGE_ATTRIBUTES/SATURATION_BAND_{band}").text
+        if flag == "Y":
+            return True
+        return False
+
+    @property
+    def band_saturation(self):
+        """Return per-band saturation flag."""
+        bdict = {}
+        for i in range(1, 9):
+            bdict[f"b{i:02d}"] = self._get_satflag(i)
+
+        return bdict
+
+    def _get_band_radcal(self, band):
+        """Get the radiance scale and offset values."""
+        rad_gain = float(self.root.find(f".//LEVEL1_RADIOMETRIC_RESCALING/RADIANCE_MULT_BAND_{band}").text)
+        rad_add = float(self.root.find(f".//LEVEL1_RADIOMETRIC_RESCALING/RADIANCE_ADD_BAND_{band}").text)
+        return rad_gain, rad_add
+
+    def _get_band_viscal(self, band):
+        """Return visible channel calibration info."""
+        rad_gain, rad_add = self._get_band_radcal(band)
+        ref_gain = float(self.root.find(f".//LEVEL1_RADIOMETRIC_RESCALING/REFLECTANCE_MULT_BAND_{band}").text)
+        ref_add = float(self.root.find(f".//LEVEL1_RADIOMETRIC_RESCALING/REFLECTANCE_ADD_BAND_{band}").text)
+        return (rad_gain, rad_add, ref_gain, ref_add)
+
+    def _get_band_tircal(self, band):
+        """Return thermal channel calibration info."""
+        rad_gain, rad_add = self._get_band_radcal(band)
+        bt_k1 = float(self.root.find(f".//LEVEL1_THERMAL_CONSTANTS/K1_CONSTANT_BAND_{band}").text)
+        bt_k2 = float(self.root.find(f".//LEVEL1_THERMAL_CONSTANTS/K2_CONSTANT_BAND_{band}").text)
+        return (rad_gain, rad_add, bt_k1, bt_k2)
+
+    @property
+    def band_calibration(self):
+        """Return per-band saturation flag."""
+        bdict = {}
+        for i in range(1, 9):
+            bdict[f"b{i:02d}"] = self._get_band_viscal(i)
+        for i in range(10, 12):
+            bdict[f"b{i:02d}"] = self._get_band_tircal(i)
+
+
+        return bdict
+
+    def earth_sun_distance(self):
+        """Return Earth-Sun distance."""
+        return float(self.root.find(".//IMAGE_ATTRIBUTES/EARTH_SUN_DISTANCE").text)

--- a/satpy/readers/oli_tirs_l1_tif.py
+++ b/satpy/readers/oli_tirs_l1_tif.py
@@ -95,7 +95,7 @@ class OLITIRSCHReader(BaseFileHandler):
     def get_dataset(self, key, info):
         """Load a dataset."""
         if self.channel != key["name"]:
-            return
+            raise ValueError(f"Requested channel {key['name']} does not match the reader channel {self.channel}")
 
         logger.debug("Reading %s.", key["name"])
 

--- a/satpy/readers/oli_tirs_l1_tif.py
+++ b/satpy/readers/oli_tirs_l1_tif.py
@@ -34,10 +34,8 @@ import numpy as np
 import xarray as xr
 
 from satpy.readers.file_handlers import BaseFileHandler
-from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
-CHUNK_SIZE = get_legacy_chunk_size()
 
 PLATFORMS = {"08": "Landsat-8",
              "09": "Landsat-9"}
@@ -111,11 +109,11 @@ class OLITIRSCHReader(BaseFileHandler):
 
         logger.debug("Reading %s.", key["name"])
 
-        data = xr.open_dataset(self.filename, engine="rasterio",
-                               chunks={"band": 1,
-                                       "y": CHUNK_SIZE,
-                                       "x": CHUNK_SIZE},
-                               mask_and_scale=False)["band_data"].squeeze()
+        data = xr.open_dataarray(self.filename, engine="rasterio",
+                                 chunks={"band": 1,
+                                         "y": "auto",
+                                         "x": "auto"},
+                                 mask_and_scale=False).squeeze()
 
 
         # The fill value for Landsat is '0', for calibration simplicity convert it to np.nan

--- a/satpy/readers/oli_tirs_l1_tif.py
+++ b/satpy/readers/oli_tirs_l1_tif.py
@@ -209,7 +209,7 @@ class OLITIRSMDReader(BaseFileHandler):
     @property
     def center_time(self):
         """Return center time."""
-        return datetime.strptime(self.root.find(".//IMAGE_ATTRIBUTES/SCENE_CENTER_TIME").text, "%H:%M:%S.%f0Z")
+        return datetime.strptime(self.root.find(".//IMAGE_ATTRIBUTES/SCENE_CENTER_TIME").text[:-2], "%H:%M:%S.%f")
 
     @property
     def cloud_cover(self):

--- a/satpy/readers/oli_tirs_l1_tif.py
+++ b/satpy/readers/oli_tirs_l1_tif.py
@@ -21,6 +21,9 @@ Details of the data format can be found here:
   https://d9-wret.s3.us-west-2.amazonaws.com/assets/palladium/production/s3fs-public/atoms/files/LSDS-1822_Landsat8-9-OLI-TIRS-C2-L1-DFCB-v6.pdf
   https://www.usgs.gov/landsat-missions/using-usgs-landsat-level-1-data-product
 
+NOTE: The scene geometry data (SZA, VZA, SAA, VAA) is retrieved from the L1 TIFF files, which are derived from Band 04.
+The geometry differs between bands, so if you need precise geometry you should calculate this from the metadata instead.
+
 """
 
 import logging

--- a/satpy/tests/reader_tests/test_oli_tirs_l1_tif.py
+++ b/satpy/tests/reader_tests/test_oli_tirs_l1_tif.py
@@ -1,0 +1,576 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Unittests for generic image reader."""
+
+import os
+import unittest
+
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+
+metadata_text = b"""<?xml version="1.0" encoding="UTF-8"?>
+<LANDSAT_METADATA_FILE>
+  <PRODUCT_CONTENTS>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P975CC9B</DIGITAL_OBJECT_IDENTIFIER>
+    <LANDSAT_PRODUCT_ID>LC08_L1GT_026200_20240502_20240513_02_T2</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L1GT</PROCESSING_LEVEL>
+    <COLLECTION_NUMBER>02</COLLECTION_NUMBER>
+    <COLLECTION_CATEGORY>T2</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <FILE_NAME_BAND_1>LC08_L1GT_026200_20240502_20240513_02_T2_B1.TIF</FILE_NAME_BAND_1>
+    <FILE_NAME_BAND_2>LC08_L1GT_026200_20240502_20240513_02_T2_B2.TIF</FILE_NAME_BAND_2>
+    <FILE_NAME_BAND_3>LC08_L1GT_026200_20240502_20240513_02_T2_B3.TIF</FILE_NAME_BAND_3>
+    <FILE_NAME_BAND_4>LC08_L1GT_026200_20240502_20240513_02_T2_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_BAND_5>LC08_L1GT_026200_20240502_20240513_02_T2_B5.TIF</FILE_NAME_BAND_5>
+    <FILE_NAME_BAND_6>LC08_L1GT_026200_20240502_20240513_02_T2_B6.TIF</FILE_NAME_BAND_6>
+    <FILE_NAME_BAND_7>LC08_L1GT_026200_20240502_20240513_02_T2_B7.TIF</FILE_NAME_BAND_7>
+    <FILE_NAME_BAND_8>LC08_L1GT_026200_20240502_20240513_02_T2_B8.TIF</FILE_NAME_BAND_8>
+    <FILE_NAME_BAND_9>LC08_L1GT_026200_20240502_20240513_02_T2_B9.TIF</FILE_NAME_BAND_9>
+    <FILE_NAME_BAND_10>LC08_L1GT_026200_20240502_20240513_02_T2_B10.TIF</FILE_NAME_BAND_10>
+    <FILE_NAME_BAND_11>LC08_L1GT_026200_20240502_20240513_02_T2_B11.TIF</FILE_NAME_BAND_11>
+    <FILE_NAME_QUALITY_L1_PIXEL>LC08_L1GT_026200_20240502_20240513_02_T2_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LC08_L1GT_026200_20240502_20240513_02_T2_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_ANGLE_COEFFICIENT>LC08_L1GT_026200_20240502_20240513_02_T2_ANG.txt</FILE_NAME_ANGLE_COEFFICIENT>
+    <FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>LC08_L1GT_026200_20240502_20240513_02_T2_VAA.TIF</FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>LC08_L1GT_026200_20240502_20240513_02_T2_VZA.TIF</FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>LC08_L1GT_026200_20240502_20240513_02_T2_SAA.TIF</FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>LC08_L1GT_026200_20240502_20240513_02_T2_SZA.TIF</FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>
+    <FILE_NAME_METADATA_ODL>LC08_L1GT_026200_20240502_20240513_02_T2_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LC08_L1GT_026200_20240502_20240513_02_T2_MTL.xml</FILE_NAME_METADATA_XML>
+    <DATA_TYPE_BAND_1>UINT16</DATA_TYPE_BAND_1>
+    <DATA_TYPE_BAND_2>UINT16</DATA_TYPE_BAND_2>
+    <DATA_TYPE_BAND_3>UINT16</DATA_TYPE_BAND_3>
+    <DATA_TYPE_BAND_4>UINT16</DATA_TYPE_BAND_4>
+    <DATA_TYPE_BAND_5>UINT16</DATA_TYPE_BAND_5>
+    <DATA_TYPE_BAND_6>UINT16</DATA_TYPE_BAND_6>
+    <DATA_TYPE_BAND_7>UINT16</DATA_TYPE_BAND_7>
+    <DATA_TYPE_BAND_8>UINT16</DATA_TYPE_BAND_8>
+    <DATA_TYPE_BAND_9>UINT16</DATA_TYPE_BAND_9>
+    <DATA_TYPE_BAND_10>UINT16</DATA_TYPE_BAND_10>
+    <DATA_TYPE_BAND_11>UINT16</DATA_TYPE_BAND_11>
+    <DATA_TYPE_QUALITY_L1_PIXEL>UINT16</DATA_TYPE_QUALITY_L1_PIXEL>
+    <DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>UINT16</DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <DATA_TYPE_ANGLE_SENSOR_AZIMUTH_BAND_4>INT16</DATA_TYPE_ANGLE_SENSOR_AZIMUTH_BAND_4>
+    <DATA_TYPE_ANGLE_SENSOR_ZENITH_BAND_4>INT16</DATA_TYPE_ANGLE_SENSOR_ZENITH_BAND_4>
+    <DATA_TYPE_ANGLE_SOLAR_AZIMUTH_BAND_4>INT16</DATA_TYPE_ANGLE_SOLAR_AZIMUTH_BAND_4>
+    <DATA_TYPE_ANGLE_SOLAR_ZENITH_BAND_4>INT16</DATA_TYPE_ANGLE_SOLAR_ZENITH_BAND_4>
+  </PRODUCT_CONTENTS>
+  <IMAGE_ATTRIBUTES>
+    <SPACECRAFT_ID>LANDSAT_8</SPACECRAFT_ID>
+    <SENSOR_ID>OLI_TIRS</SENSOR_ID>
+    <WRS_TYPE>2</WRS_TYPE>
+    <WRS_PATH>26</WRS_PATH>
+    <WRS_ROW>200</WRS_ROW>
+    <NADIR_OFFNADIR>NADIR</NADIR_OFFNADIR>
+    <TARGET_WRS_PATH>26</TARGET_WRS_PATH>
+    <TARGET_WRS_ROW>200</TARGET_WRS_ROW>
+    <DATE_ACQUIRED>2024-05-02</DATE_ACQUIRED>
+    <SCENE_CENTER_TIME>18:00:24.6148649Z</SCENE_CENTER_TIME>
+    <STATION_ID>LGN</STATION_ID>
+    <CLOUD_COVER>0.85</CLOUD_COVER>
+    <CLOUD_COVER_LAND>-1</CLOUD_COVER_LAND>
+    <IMAGE_QUALITY_OLI>9</IMAGE_QUALITY_OLI>
+    <IMAGE_QUALITY_TIRS>9</IMAGE_QUALITY_TIRS>
+    <SATURATION_BAND_1>N</SATURATION_BAND_1>
+    <SATURATION_BAND_2>N</SATURATION_BAND_2>
+    <SATURATION_BAND_3>N</SATURATION_BAND_3>
+    <SATURATION_BAND_4>Y</SATURATION_BAND_4>
+    <SATURATION_BAND_5>N</SATURATION_BAND_5>
+    <SATURATION_BAND_6>N</SATURATION_BAND_6>
+    <SATURATION_BAND_7>N</SATURATION_BAND_7>
+    <SATURATION_BAND_8>N</SATURATION_BAND_8>
+    <SATURATION_BAND_9>N</SATURATION_BAND_9>
+    <ROLL_ANGLE>-0.000</ROLL_ANGLE>
+    <SUN_AZIMUTH>-39.71362413</SUN_AZIMUTH>
+    <SUN_ELEVATION>-41.46228969</SUN_ELEVATION>
+    <EARTH_SUN_DISTANCE>1.0079981</EARTH_SUN_DISTANCE>
+    <TRUNCATION_OLI>UPPER</TRUNCATION_OLI>
+    <TIRS_SSM_MODEL>FINAL</TIRS_SSM_MODEL>
+    <TIRS_SSM_POSITION_STATUS>ESTIMATED</TIRS_SSM_POSITION_STATUS>
+  </IMAGE_ATTRIBUTES>
+  <PROJECTION_ATTRIBUTES>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>40</UTM_ZONE>
+    <GRID_CELL_SIZE_PANCHROMATIC>15.00</GRID_CELL_SIZE_PANCHROMATIC>
+    <GRID_CELL_SIZE_REFLECTIVE>30.00</GRID_CELL_SIZE_REFLECTIVE>
+    <GRID_CELL_SIZE_THERMAL>30.00</GRID_CELL_SIZE_THERMAL>
+    <PANCHROMATIC_LINES>200</PANCHROMATIC_LINES>
+    <PANCHROMATIC_SAMPLES>200</PANCHROMATIC_SAMPLES>
+    <REFLECTIVE_LINES>100</REFLECTIVE_LINES>
+    <REFLECTIVE_SAMPLES>100</REFLECTIVE_SAMPLES>
+    <THERMAL_LINES>100</THERMAL_LINES>
+    <THERMAL_SAMPLES>100</THERMAL_SAMPLES>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <CORNER_UL_LAT_PRODUCT>24.18941</CORNER_UL_LAT_PRODUCT>
+    <CORNER_UL_LON_PRODUCT>58.17657</CORNER_UL_LON_PRODUCT>
+    <CORNER_UR_LAT_PRODUCT>24.15493</CORNER_UR_LAT_PRODUCT>
+    <CORNER_UR_LON_PRODUCT>60.44878</CORNER_UR_LON_PRODUCT>
+    <CORNER_LL_LAT_PRODUCT>22.06522</CORNER_LL_LAT_PRODUCT>
+    <CORNER_LL_LON_PRODUCT>58.15819</CORNER_LL_LON_PRODUCT>
+    <CORNER_LR_LAT_PRODUCT>22.03410</CORNER_LR_LAT_PRODUCT>
+    <CORNER_LR_LON_PRODUCT>60.39501</CORNER_LR_LON_PRODUCT>
+    <CORNER_UL_PROJECTION_X_PRODUCT>619500.000</CORNER_UL_PROJECTION_X_PRODUCT>
+    <CORNER_UL_PROJECTION_Y_PRODUCT>2675700.000</CORNER_UL_PROJECTION_Y_PRODUCT>
+    <CORNER_UR_PROJECTION_X_PRODUCT>850500.000</CORNER_UR_PROJECTION_X_PRODUCT>
+    <CORNER_UR_PROJECTION_Y_PRODUCT>2675700.000</CORNER_UR_PROJECTION_Y_PRODUCT>
+    <CORNER_LL_PROJECTION_X_PRODUCT>619500.000</CORNER_LL_PROJECTION_X_PRODUCT>
+    <CORNER_LL_PROJECTION_Y_PRODUCT>2440500.000</CORNER_LL_PROJECTION_Y_PRODUCT>
+    <CORNER_LR_PROJECTION_X_PRODUCT>850500.000</CORNER_LR_PROJECTION_X_PRODUCT>
+    <CORNER_LR_PROJECTION_Y_PRODUCT>2440500.000</CORNER_LR_PROJECTION_Y_PRODUCT>
+  </PROJECTION_ATTRIBUTES>
+  <LEVEL1_PROCESSING_RECORD>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P975CC9B</DIGITAL_OBJECT_IDENTIFIER>
+    <REQUEST_ID>1885324_00001</REQUEST_ID>
+    <LANDSAT_SCENE_ID>LC80262002024123LGN00</LANDSAT_SCENE_ID>
+    <LANDSAT_PRODUCT_ID>LC08_L1GT_026200_20240502_20240513_02_T2</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L1GT</PROCESSING_LEVEL>
+    <COLLECTION_CATEGORY>T2</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <DATE_PRODUCT_GENERATED>2024-05-13T15:32:54Z</DATE_PRODUCT_GENERATED>
+    <PROCESSING_SOFTWARE_VERSION>LPGS_16.4.0</PROCESSING_SOFTWARE_VERSION>
+    <FILE_NAME_BAND_1>LC08_L1GT_026200_20240502_20240513_02_T2_B1.TIF</FILE_NAME_BAND_1>
+    <FILE_NAME_BAND_2>LC08_L1GT_026200_20240502_20240513_02_T2_B2.TIF</FILE_NAME_BAND_2>
+    <FILE_NAME_BAND_3>LC08_L1GT_026200_20240502_20240513_02_T2_B3.TIF</FILE_NAME_BAND_3>
+    <FILE_NAME_BAND_4>LC08_L1GT_026200_20240502_20240513_02_T2_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_BAND_5>LC08_L1GT_026200_20240502_20240513_02_T2_B5.TIF</FILE_NAME_BAND_5>
+    <FILE_NAME_BAND_6>LC08_L1GT_026200_20240502_20240513_02_T2_B6.TIF</FILE_NAME_BAND_6>
+    <FILE_NAME_BAND_7>LC08_L1GT_026200_20240502_20240513_02_T2_B7.TIF</FILE_NAME_BAND_7>
+    <FILE_NAME_BAND_8>LC08_L1GT_026200_20240502_20240513_02_T2_B8.TIF</FILE_NAME_BAND_8>
+    <FILE_NAME_BAND_9>LC08_L1GT_026200_20240502_20240513_02_T2_B9.TIF</FILE_NAME_BAND_9>
+    <FILE_NAME_BAND_10>LC08_L1GT_026200_20240502_20240513_02_T2_B10.TIF</FILE_NAME_BAND_10>
+    <FILE_NAME_BAND_11>LC08_L1GT_026200_20240502_20240513_02_T2_B11.TIF</FILE_NAME_BAND_11>
+    <FILE_NAME_QUALITY_L1_PIXEL>LC08_L1GT_026200_20240502_20240513_02_T2_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LC08_L1GT_026200_20240502_20240513_02_T2_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_ANGLE_COEFFICIENT>LC08_L1GT_026200_20240502_20240513_02_T2_ANG.txt</FILE_NAME_ANGLE_COEFFICIENT>
+    <FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>LC08_L1GT_026200_20240502_20240513_02_T2_VAA.TIF</FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>LC08_L1GT_026200_20240502_20240513_02_T2_VZA.TIF</FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>LC08_L1GT_026200_20240502_20240513_02_T2_SAA.TIF</FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>LC08_L1GT_026200_20240502_20240513_02_T2_SZA.TIF</FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>
+    <FILE_NAME_METADATA_ODL>LC08_L1GT_026200_20240502_20240513_02_T2_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LC08_L1GT_026200_20240502_20240513_02_T2_MTL.xml</FILE_NAME_METADATA_XML>
+    <FILE_NAME_CPF>LC08CPF_20240429_20240630_02.03</FILE_NAME_CPF>
+    <FILE_NAME_BPF_OLI>LO8BPF20240502162846_20240502181430.01</FILE_NAME_BPF_OLI>
+    <FILE_NAME_BPF_TIRS>LT8BPF20240502144307_20240510102926.01</FILE_NAME_BPF_TIRS>
+    <FILE_NAME_RLUT>LC08RLUT_20150303_20431231_02_01.h5</FILE_NAME_RLUT>
+    <DATA_SOURCE_TIRS_STRAY_LIGHT_CORRECTION>TIRS</DATA_SOURCE_TIRS_STRAY_LIGHT_CORRECTION>
+    <DATA_SOURCE_ELEVATION>GLS2000</DATA_SOURCE_ELEVATION>
+  </LEVEL1_PROCESSING_RECORD>
+  <LEVEL1_MIN_MAX_RADIANCE>
+    <RADIANCE_MAXIMUM_BAND_1>748.04883</RADIANCE_MAXIMUM_BAND_1>
+    <RADIANCE_MINIMUM_BAND_1>-61.77412</RADIANCE_MINIMUM_BAND_1>
+    <RADIANCE_MAXIMUM_BAND_2>766.01111</RADIANCE_MAXIMUM_BAND_2>
+    <RADIANCE_MINIMUM_BAND_2>-63.25745</RADIANCE_MINIMUM_BAND_2>
+    <RADIANCE_MAXIMUM_BAND_3>705.87274</RADIANCE_MAXIMUM_BAND_3>
+    <RADIANCE_MINIMUM_BAND_3>-58.29120</RADIANCE_MINIMUM_BAND_3>
+    <RADIANCE_MAXIMUM_BAND_4>595.23163</RADIANCE_MAXIMUM_BAND_4>
+    <RADIANCE_MINIMUM_BAND_4>-49.15442</RADIANCE_MINIMUM_BAND_4>
+    <RADIANCE_MAXIMUM_BAND_5>364.25208</RADIANCE_MAXIMUM_BAND_5>
+    <RADIANCE_MINIMUM_BAND_5>-30.08006</RADIANCE_MINIMUM_BAND_5>
+    <RADIANCE_MAXIMUM_BAND_6>90.58618</RADIANCE_MAXIMUM_BAND_6>
+    <RADIANCE_MINIMUM_BAND_6>-7.48064</RADIANCE_MINIMUM_BAND_6>
+    <RADIANCE_MAXIMUM_BAND_7>30.53239</RADIANCE_MAXIMUM_BAND_7>
+    <RADIANCE_MINIMUM_BAND_7>-2.52137</RADIANCE_MINIMUM_BAND_7>
+    <RADIANCE_MAXIMUM_BAND_8>673.63843</RADIANCE_MAXIMUM_BAND_8>
+    <RADIANCE_MINIMUM_BAND_8>-55.62928</RADIANCE_MINIMUM_BAND_8>
+    <RADIANCE_MAXIMUM_BAND_9>142.35797</RADIANCE_MAXIMUM_BAND_9>
+    <RADIANCE_MINIMUM_BAND_9>-11.75597</RADIANCE_MINIMUM_BAND_9>
+    <RADIANCE_MAXIMUM_BAND_10>22.00180</RADIANCE_MAXIMUM_BAND_10>
+    <RADIANCE_MINIMUM_BAND_10>0.10033</RADIANCE_MINIMUM_BAND_10>
+    <RADIANCE_MAXIMUM_BAND_11>22.00180</RADIANCE_MAXIMUM_BAND_11>
+    <RADIANCE_MINIMUM_BAND_11>0.10033</RADIANCE_MINIMUM_BAND_11>
+  </LEVEL1_MIN_MAX_RADIANCE>
+  <LEVEL1_MIN_MAX_REFLECTANCE>
+    <REFLECTANCE_MAXIMUM_BAND_1>1.210700</REFLECTANCE_MAXIMUM_BAND_1>
+    <REFLECTANCE_MINIMUM_BAND_1>-0.099980</REFLECTANCE_MINIMUM_BAND_1>
+    <REFLECTANCE_MAXIMUM_BAND_2>1.210700</REFLECTANCE_MAXIMUM_BAND_2>
+    <REFLECTANCE_MINIMUM_BAND_2>-0.099980</REFLECTANCE_MINIMUM_BAND_2>
+    <REFLECTANCE_MAXIMUM_BAND_3>1.210700</REFLECTANCE_MAXIMUM_BAND_3>
+    <REFLECTANCE_MINIMUM_BAND_3>-0.099980</REFLECTANCE_MINIMUM_BAND_3>
+    <REFLECTANCE_MAXIMUM_BAND_4>1.210700</REFLECTANCE_MAXIMUM_BAND_4>
+    <REFLECTANCE_MINIMUM_BAND_4>-0.099980</REFLECTANCE_MINIMUM_BAND_4>
+    <REFLECTANCE_MAXIMUM_BAND_5>1.210700</REFLECTANCE_MAXIMUM_BAND_5>
+    <REFLECTANCE_MINIMUM_BAND_5>-0.099980</REFLECTANCE_MINIMUM_BAND_5>
+    <REFLECTANCE_MAXIMUM_BAND_6>1.210700</REFLECTANCE_MAXIMUM_BAND_6>
+    <REFLECTANCE_MINIMUM_BAND_6>-0.099980</REFLECTANCE_MINIMUM_BAND_6>
+    <REFLECTANCE_MAXIMUM_BAND_7>1.210700</REFLECTANCE_MAXIMUM_BAND_7>
+    <REFLECTANCE_MINIMUM_BAND_7>-0.099980</REFLECTANCE_MINIMUM_BAND_7>
+    <REFLECTANCE_MAXIMUM_BAND_8>1.210700</REFLECTANCE_MAXIMUM_BAND_8>
+    <REFLECTANCE_MINIMUM_BAND_8>-0.099980</REFLECTANCE_MINIMUM_BAND_8>
+    <REFLECTANCE_MAXIMUM_BAND_9>1.210700</REFLECTANCE_MAXIMUM_BAND_9>
+    <REFLECTANCE_MINIMUM_BAND_9>-0.099980</REFLECTANCE_MINIMUM_BAND_9>
+  </LEVEL1_MIN_MAX_REFLECTANCE>
+  <LEVEL1_MIN_MAX_PIXEL_VALUE>
+    <QUANTIZE_CAL_MAX_BAND_1>65535</QUANTIZE_CAL_MAX_BAND_1>
+    <QUANTIZE_CAL_MIN_BAND_1>1</QUANTIZE_CAL_MIN_BAND_1>
+    <QUANTIZE_CAL_MAX_BAND_2>65535</QUANTIZE_CAL_MAX_BAND_2>
+    <QUANTIZE_CAL_MIN_BAND_2>1</QUANTIZE_CAL_MIN_BAND_2>
+    <QUANTIZE_CAL_MAX_BAND_3>65535</QUANTIZE_CAL_MAX_BAND_3>
+    <QUANTIZE_CAL_MIN_BAND_3>1</QUANTIZE_CAL_MIN_BAND_3>
+    <QUANTIZE_CAL_MAX_BAND_4>65535</QUANTIZE_CAL_MAX_BAND_4>
+    <QUANTIZE_CAL_MIN_BAND_4>1</QUANTIZE_CAL_MIN_BAND_4>
+    <QUANTIZE_CAL_MAX_BAND_5>65535</QUANTIZE_CAL_MAX_BAND_5>
+    <QUANTIZE_CAL_MIN_BAND_5>1</QUANTIZE_CAL_MIN_BAND_5>
+    <QUANTIZE_CAL_MAX_BAND_6>65535</QUANTIZE_CAL_MAX_BAND_6>
+    <QUANTIZE_CAL_MIN_BAND_6>1</QUANTIZE_CAL_MIN_BAND_6>
+    <QUANTIZE_CAL_MAX_BAND_7>65535</QUANTIZE_CAL_MAX_BAND_7>
+    <QUANTIZE_CAL_MIN_BAND_7>1</QUANTIZE_CAL_MIN_BAND_7>
+    <QUANTIZE_CAL_MAX_BAND_8>65535</QUANTIZE_CAL_MAX_BAND_8>
+    <QUANTIZE_CAL_MIN_BAND_8>1</QUANTIZE_CAL_MIN_BAND_8>
+    <QUANTIZE_CAL_MAX_BAND_9>65535</QUANTIZE_CAL_MAX_BAND_9>
+    <QUANTIZE_CAL_MIN_BAND_9>1</QUANTIZE_CAL_MIN_BAND_9>
+    <QUANTIZE_CAL_MAX_BAND_10>65535</QUANTIZE_CAL_MAX_BAND_10>
+    <QUANTIZE_CAL_MIN_BAND_10>1</QUANTIZE_CAL_MIN_BAND_10>
+    <QUANTIZE_CAL_MAX_BAND_11>65535</QUANTIZE_CAL_MAX_BAND_11>
+    <QUANTIZE_CAL_MIN_BAND_11>1</QUANTIZE_CAL_MIN_BAND_11>
+  </LEVEL1_MIN_MAX_PIXEL_VALUE>
+  <LEVEL1_RADIOMETRIC_RESCALING>
+    <RADIANCE_MULT_BAND_1>1.2357E-02</RADIANCE_MULT_BAND_1>
+    <RADIANCE_MULT_BAND_2>1.2654E-02</RADIANCE_MULT_BAND_2>
+    <RADIANCE_MULT_BAND_3>1.1661E-02</RADIANCE_MULT_BAND_3>
+    <RADIANCE_MULT_BAND_4>9.8329E-03</RADIANCE_MULT_BAND_4>
+    <RADIANCE_MULT_BAND_5>6.0172E-03</RADIANCE_MULT_BAND_5>
+    <RADIANCE_MULT_BAND_6>1.4964E-03</RADIANCE_MULT_BAND_6>
+    <RADIANCE_MULT_BAND_7>5.0438E-04</RADIANCE_MULT_BAND_7>
+    <RADIANCE_MULT_BAND_8>1.1128E-02</RADIANCE_MULT_BAND_8>
+    <RADIANCE_MULT_BAND_9>2.3517E-03</RADIANCE_MULT_BAND_9>
+    <RADIANCE_MULT_BAND_10>3.3420E-04</RADIANCE_MULT_BAND_10>
+    <RADIANCE_MULT_BAND_11>3.3420E-04</RADIANCE_MULT_BAND_11>
+    <RADIANCE_ADD_BAND_1>-61.78647</RADIANCE_ADD_BAND_1>
+    <RADIANCE_ADD_BAND_2>-63.27010</RADIANCE_ADD_BAND_2>
+    <RADIANCE_ADD_BAND_3>-58.30286</RADIANCE_ADD_BAND_3>
+    <RADIANCE_ADD_BAND_4>-49.16426</RADIANCE_ADD_BAND_4>
+    <RADIANCE_ADD_BAND_5>-30.08607</RADIANCE_ADD_BAND_5>
+    <RADIANCE_ADD_BAND_6>-7.48213</RADIANCE_ADD_BAND_6>
+    <RADIANCE_ADD_BAND_7>-2.52188</RADIANCE_ADD_BAND_7>
+    <RADIANCE_ADD_BAND_8>-55.64041</RADIANCE_ADD_BAND_8>
+    <RADIANCE_ADD_BAND_9>-11.75832</RADIANCE_ADD_BAND_9>
+    <RADIANCE_ADD_BAND_10>0.10000</RADIANCE_ADD_BAND_10>
+    <RADIANCE_ADD_BAND_11>0.10000</RADIANCE_ADD_BAND_11>
+    <REFLECTANCE_MULT_BAND_1>2.0000E-05</REFLECTANCE_MULT_BAND_1>
+    <REFLECTANCE_MULT_BAND_2>2.0000E-05</REFLECTANCE_MULT_BAND_2>
+    <REFLECTANCE_MULT_BAND_3>2.0000E-05</REFLECTANCE_MULT_BAND_3>
+    <REFLECTANCE_MULT_BAND_4>2.0000E-05</REFLECTANCE_MULT_BAND_4>
+    <REFLECTANCE_MULT_BAND_5>2.0000E-05</REFLECTANCE_MULT_BAND_5>
+    <REFLECTANCE_MULT_BAND_6>2.0000E-05</REFLECTANCE_MULT_BAND_6>
+    <REFLECTANCE_MULT_BAND_7>2.0000E-05</REFLECTANCE_MULT_BAND_7>
+    <REFLECTANCE_MULT_BAND_8>2.0000E-05</REFLECTANCE_MULT_BAND_8>
+    <REFLECTANCE_MULT_BAND_9>2.0000E-05</REFLECTANCE_MULT_BAND_9>
+    <REFLECTANCE_ADD_BAND_1>-0.100000</REFLECTANCE_ADD_BAND_1>
+    <REFLECTANCE_ADD_BAND_2>-0.100000</REFLECTANCE_ADD_BAND_2>
+    <REFLECTANCE_ADD_BAND_3>-0.100000</REFLECTANCE_ADD_BAND_3>
+    <REFLECTANCE_ADD_BAND_4>-0.100000</REFLECTANCE_ADD_BAND_4>
+    <REFLECTANCE_ADD_BAND_5>-0.100000</REFLECTANCE_ADD_BAND_5>
+    <REFLECTANCE_ADD_BAND_6>-0.100000</REFLECTANCE_ADD_BAND_6>
+    <REFLECTANCE_ADD_BAND_7>-0.100000</REFLECTANCE_ADD_BAND_7>
+    <REFLECTANCE_ADD_BAND_8>-0.100000</REFLECTANCE_ADD_BAND_8>
+    <REFLECTANCE_ADD_BAND_9>-0.100000</REFLECTANCE_ADD_BAND_9>
+  </LEVEL1_RADIOMETRIC_RESCALING>
+  <LEVEL1_THERMAL_CONSTANTS>
+    <K1_CONSTANT_BAND_10>774.8853</K1_CONSTANT_BAND_10>
+    <K2_CONSTANT_BAND_10>1321.0789</K2_CONSTANT_BAND_10>
+    <K1_CONSTANT_BAND_11>480.8883</K1_CONSTANT_BAND_11>
+    <K2_CONSTANT_BAND_11>1201.1442</K2_CONSTANT_BAND_11>
+  </LEVEL1_THERMAL_CONSTANTS>
+  <LEVEL1_PROJECTION_PARAMETERS>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>40</UTM_ZONE>
+    <GRID_CELL_SIZE_PANCHROMATIC>15.00</GRID_CELL_SIZE_PANCHROMATIC>
+    <GRID_CELL_SIZE_REFLECTIVE>30.00</GRID_CELL_SIZE_REFLECTIVE>
+    <GRID_CELL_SIZE_THERMAL>30.00</GRID_CELL_SIZE_THERMAL>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <RESAMPLING_OPTION>CUBIC_CONVOLUTION</RESAMPLING_OPTION>
+  </LEVEL1_PROJECTION_PARAMETERS>
+</LANDSAT_METADATA_FILE>
+"""
+
+class TestOLITIRSL1(unittest.TestCase):
+    """Test generic image reader."""
+
+    def setUp(self):
+        """Create temporary images and metadata to test on."""
+        import tempfile
+        from datetime import datetime
+
+        from pyresample.geometry import AreaDefinition
+
+        from satpy.scene import Scene
+
+        self.date = datetime(2024, 5, 12)
+
+        self.filename_info = dict(observation_date=datetime(2024, 5, 3),
+                                  platform_type="L",
+                                  process_level_correction="L1TP",
+                                  spacecraft_id="08",
+                                  data_type="C")
+        self.ftype_info = {"file_type": "granule_b04"}
+
+        # Create area definition
+        pcs_id = "WGS 84 / UTM zone 40N"
+        proj4_dict = {"proj": "utm", "zone": 40, "datum": "WGS84", "units": "m", "no_defs": None, "type": "crs"}
+        self.x_size = 100
+        self.y_size = 100
+        area_extent = (619485., 2440485., 850515., 2675715.)
+        self.area_def = AreaDefinition("geotiff_area", pcs_id, pcs_id,
+                                       proj4_dict, self.x_size, self.y_size,
+                                       area_extent)
+
+        # Create datasets for L, LA, RGB and RGBA mode images
+        self.test_data__1 = da.random.randint(12000, 16000,
+                                              size=(self.y_size, self.x_size),
+                                              chunks=(50, 50)).astype(np.uint16)
+        self.test_data__2 = da.random.randint(8000, 14000,
+                                              size=(self.y_size, self.x_size),
+                                              chunks=(50, 50)).astype(np.uint16)
+        self.test_data__3= da.random.randint(0, 10000,
+                                             size=(self.y_size, self.x_size),
+                                             chunks=(50, 50)).astype(np.uint16)
+
+        ds_b4 = xr.DataArray(self.test_data__1,
+                             dims=("y", "x"),
+                             attrs={"name": "b04",
+                                    "start_time": self.date})
+
+        ds_b11 = xr.DataArray(self.test_data__2,
+                              dims=("y", "x"),
+                              attrs={"name": "b04",
+                                     "start_time": self.date})
+
+        ds_sza = xr.DataArray(self.test_data__3,
+                              dims=("y", "x"),
+                              attrs={"name": "sza",
+                                     "start_time": self.date})
+
+        # Temp dir for the saved images
+        self.base_dir = tempfile.mkdtemp()
+
+        # Filenames to be used during testing
+        self.fnames = [f"{self.base_dir}/LC08_L1GT_026200_20240502_20240513_02_T2_B4.TIF",
+                       f"{self.base_dir}/LC08_L1GT_026200_20240502_20240513_02_T2_B11.TIF",
+                       f"{self.base_dir}/LC08_L1GT_026200_20240502_20240513_02_T2_MTL.xml",
+                       f"{self.base_dir}/LC08_L1GT_026200_20240502_20240513_02_T2_SZA.TIF"]
+
+        self.bad_fname_plat = self.fnames[0].replace("LC08", "BC08")
+        self.bad_fname_plat2 = self.fnames[2].replace("LC08", "BC08")
+
+        self.bad_fname_chan = self.fnames[0].replace("B4", "B5")
+
+        # Put the datasets to Scene for easy saving
+        scn = Scene()
+        scn["b4"] = ds_b4
+        scn["b4"].attrs["area"] = self.area_def
+        scn["b11"] = ds_b11
+        scn["b11"].attrs["area"] = self.area_def
+        scn["sza"] = ds_sza
+        scn["sza"].attrs["area"] = self.area_def
+
+        # Save the images.  Two images in PNG and two in GeoTIFF
+        scn.save_dataset("b4", writer="geotiff", enhance=False, fill_value=0,
+                         filename=os.path.join(self.base_dir, self.fnames[0]))
+        scn.save_dataset("b11", writer="geotiff", enhance=False, fill_value=0,
+                         filename=os.path.join(self.base_dir, self.fnames[1]))
+        scn.save_dataset("sza", writer="geotiff", enhance=False, fill_value=0,
+                         filename=os.path.join(self.base_dir, self.fnames[3]))
+
+        scn.save_dataset("b4", writer="geotiff", enhance=False, fill_value=0,
+                         filename=self.bad_fname_plat)
+        scn.save_dataset("b4", writer="geotiff", enhance=False, fill_value=0,
+                         filename=self.bad_fname_chan)
+
+        # Write the metadata to a file
+        with open(os.path.join(self.base_dir, self.fnames[2]), "wb") as f:
+            f.write(metadata_text)
+        with open(self.bad_fname_plat2, "wb") as f:
+            f.write(metadata_text)
+
+        self.scn = scn
+
+    def tearDown(self):
+        """Remove the temporary directory created for a test."""
+        try:
+            import shutil
+            shutil.rmtree(self.base_dir, ignore_errors=True)
+        except OSError:
+            pass
+
+    def test_basicload(self):
+        """Test loading a Landsat Scene."""
+        from satpy import Scene
+        scn = Scene(reader="oli_tirs_l1_tif", filenames=[self.fnames[0],
+                                                         self.fnames[1],
+                                                         self.fnames[2]])
+        scn.load(["b04", "b11"])
+
+        # Check dataset is loaded correctly
+        assert scn["b04"].shape == (100, 100)
+        assert scn["b04"].attrs["area"] == self.area_def
+        assert scn["b04"].attrs["saturated"]
+        assert scn["b11"].shape == (100, 100)
+        assert scn["b11"].attrs["area"] == self.area_def
+        with pytest.raises(KeyError, match="saturated"):
+            assert not scn["b11"].attrs["saturated"]
+
+    def test_ch_startend(self):
+        """Test correct retrieval of start/end times."""
+        from datetime import datetime
+
+        from satpy import Scene
+        scn = Scene(reader="oli_tirs_l1_tif", filenames=[self.fnames[0], self.fnames[3], self.fnames[2]])
+        bnds = scn.available_dataset_names()
+        assert bnds == ["b04", "sza"]
+
+        scn.load(["b04"])
+        assert scn.start_time == datetime(2024, 5, 2, 18, 0, 24)
+        assert scn.end_time == datetime(2024, 5, 2, 18, 0, 24)
+
+    def test_loading(self):
+        """Test loading a Landsat Scene with good and bad channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import OLITIRSCHReader, OLITIRSMDReader
+        good_mda = OLITIRSMDReader(self.fnames[2], self.filename_info, {})
+        rdr = OLITIRSCHReader(self.fnames[0], self.filename_info, self.ftype_info, good_mda)
+
+        # Check case with good file data and load request
+        rdr.get_dataset({"name": "b04", "calibration": "counts"}, {})
+
+        # Check case with request to load channel not matching filename
+        with pytest.raises(ValueError, match="Requested channel b05 does not match the reader channel b04"):
+            rdr.get_dataset({"name": "b05", "calibration": "counts"}, {})
+
+        bad_finfo = self.filename_info.copy()
+        bad_finfo["data_type"] = "T"
+
+        # Check loading invalid channel for data type
+        rdr = OLITIRSCHReader(self.fnames[1], bad_finfo, self.ftype_info, good_mda)
+        with pytest.raises(ValueError, match= "Requested channel b04 is not available in this granule"):
+            rdr.get_dataset({"name": "b04", "calibration": "counts"}, {})
+
+        bad_finfo["data_type"] = "O"
+        ftype_b11 = self.ftype_info.copy()
+        ftype_b11["file_type"] = "granule_b11"
+        rdr = OLITIRSCHReader(self.fnames[1], bad_finfo, ftype_b11, good_mda)
+        with pytest.raises(ValueError, match="Requested channel b11 is not available in this granule"):
+            rdr.get_dataset({"name": "b11", "calibration": "counts"}, {})
+
+    def test_badfiles(self):
+        """Test loading a Landsat Scene with bad data."""
+        from satpy.readers.oli_tirs_l1_tif import OLITIRSCHReader, OLITIRSMDReader
+        bad_fname_info = self.filename_info.copy()
+        bad_fname_info["platform_type"] = "B"
+
+        # Test that metadata reader initialises with correct filename
+        good_mda = OLITIRSMDReader(self.fnames[2], self.filename_info, {})
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            OLITIRSMDReader(self.fnames[2], bad_fname_info, {})
+
+            # Test that metadata reader initialises with correct filename
+        OLITIRSCHReader(self.fnames[0], self.filename_info, self.ftype_info, good_mda)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            OLITIRSCHReader(self.fnames[0], bad_fname_info, self.ftype_info, good_mda)
+        bad_ftype_info = self.ftype_info.copy()
+        bad_ftype_info["file_type"] = "granule-b05"
+        with pytest.raises(ValueError, match="Invalid file type: granule-b05"):
+            OLITIRSCHReader(self.fnames[0], self.filename_info, bad_ftype_info, good_mda)
+
+    def test_calibration_modes(self):
+        """Test calibration modes for the reader."""
+        from satpy import Scene
+
+        # Check counts calibration
+        scn = Scene(reader="oli_tirs_l1_tif", filenames=self.fnames)
+        scn.load(["b04", "b11"], calibration="counts")
+        np.testing.assert_allclose(scn["b04"].values, self.test_data__1)
+        np.testing.assert_allclose(scn["b11"].values, self.test_data__2)
+        assert scn["b04"].attrs["units"] == "1"
+        assert scn["b11"].attrs["units"] == "1"
+        assert scn["b04"].attrs["standard_name"] == "counts"
+        assert scn["b11"].attrs["standard_name"] == "counts"
+
+        # Check radiance calibration
+        exp_b04 = (self.test_data__1 * 0.0098329 - 49.16426).astype(np.float32)
+        exp_b11 = (self.test_data__2 * 0.0003342 + 0.100000).astype(np.float32)
+
+        scn = Scene(reader="oli_tirs_l1_tif", filenames=self.fnames)
+        scn.load(["b04", "b11"], calibration="radiance")
+        assert scn["b04"].attrs["units"] == "W m-2 um-1 sr-1"
+        assert scn["b11"].attrs["units"] == "W m-2 um-1 sr-1"
+        assert scn["b04"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
+        assert scn["b11"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
+        np.testing.assert_allclose(scn["b04"].values, exp_b04, rtol=1e-4)
+        np.testing.assert_allclose(scn["b11"].values, exp_b11, rtol=1e-4)
+
+        # Check top level calibration
+        exp_b04 = (self.test_data__1 * 2e-05 - 0.1).astype(np.float32)
+        exp_b11 = (self.test_data__2 * 0.0003342 + 0.100000)
+        exp_b11 = (1201.1442 / np.log((480.8883 / exp_b11) + 1)).astype(np.float32)
+        scn = Scene(reader="oli_tirs_l1_tif", filenames=self.fnames)
+        scn.load(["b04", "b11"])
+
+        assert scn["b04"].attrs["units"] == "%"
+        assert scn["b11"].attrs["units"] == "K"
+        assert scn["b04"].attrs["standard_name"] == "toa_bidirectional_reflectance"
+        assert scn["b11"].attrs["standard_name"] == "toa_brightness_temperature"
+        np.testing.assert_allclose(np.array(scn["b04"].values), np.array(exp_b04), rtol=1e-4)
+        np.testing.assert_allclose(scn["b11"].values, exp_b11, rtol=1e-6)
+
+        # Check angles are calculated correctly
+        scn = Scene(reader="oli_tirs_l1_tif", filenames=self.fnames)
+        scn.load(["sza"])
+        assert scn["sza"].attrs["units"] == "degrees"
+        assert scn["sza"].attrs["standard_name"] == "solar_zenith_angle"
+        np.testing.assert_allclose(scn["sza"].values * 100, np.array(self.test_data__3), atol=0.01, rtol=1e-3)
+
+    def test_metadata(self):
+        """Check that metadata values loaded correctly."""
+        from satpy.readers.oli_tirs_l1_tif import OLITIRSMDReader
+        mda = OLITIRSMDReader(self.fnames[2], self.filename_info, {})
+
+        cal_test_dict = {"b01": (0.012357, -61.78647, 2e-05, -0.1),
+                         "b05": (0.0060172, -30.08607, 2e-05, -0.1),
+                         "b10": (0.0003342, 0.1, 774.8853, 1321.0789)}
+
+        assert mda.platform_name == "Landsat-8"
+        assert mda.earth_sun_distance() == 1.0079981
+        assert mda.band_calibration["b01"] == cal_test_dict["b01"]
+        assert mda.band_calibration["b05"] == cal_test_dict["b05"]
+        assert mda.band_calibration["b10"] == cal_test_dict["b10"]
+        assert not mda.band_saturation["b01"]
+        assert mda.band_saturation["b04"]
+        assert not mda.band_saturation["b05"]
+        with pytest.raises(KeyError):
+            mda.band_saturation["b10"]
+
+    def test_area_def(self):
+        """Check we can get the area defs properly."""
+        from satpy.readers.oli_tirs_l1_tif import OLITIRSMDReader
+        mda = OLITIRSMDReader(self.fnames[2], self.filename_info, {})
+
+        standard_area = mda.build_area_def("b01")
+        pan_area = mda.build_area_def("b08")
+
+        assert standard_area.area_extent == (619485.0, 2440485.0, 850515.0, 2675715.0)
+        assert pan_area.area_extent == (619492.5, 2440492.5, 850507.5, 2675707.5)

--- a/satpy/tests/reader_tests/test_oli_tirs_l1_tif.py
+++ b/satpy/tests/reader_tests/test_oli_tirs_l1_tif.py
@@ -343,7 +343,7 @@ class TestOLITIRSL1(unittest.TestCase):
         self.test_data__2 = da.random.randint(8000, 14000,
                                               size=(self.y_size, self.x_size),
                                               chunks=(50, 50)).astype(np.uint16)
-        self.test_data__3= da.random.randint(0, 10000,
+        self.test_data__3= da.random.randint(1, 10000,
                                              size=(self.y_size, self.x_size),
                                              chunks=(50, 50)).astype(np.uint16)
 


### PR DESCRIPTION
This PR adds a reader for Landsat collection 2 level 1 data. It has been tested on Landsat 8 and 9 data and doesn't yet support older satellites in the landsat series.

Right now this is a draft as I haven't added tests, but the reader itself should be fully-functional.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
