### PR TITLE
Remove deprecated usage of pyspectral's download_luts aerosol_type

### DIFF
--- a/benchmarks/abi_l1b_benchmarks.py
+++ b/benchmarks/abi_l1b_benchmarks.py
@@ -43,7 +43,7 @@ class ABIL1B(GeoBenchmarks):
             if len(get_filenames(self.subdir)) != 16:
                 raise RuntimeError("Existing data files do not match the expected number of files.")
         download_rsr()
-        download_luts(aerosol_type="rayleigh_only")
+        download_luts(aerosol_types=["rayleigh_only"])
 
     def setup(self):
         """Set up the benchmarks."""

--- a/benchmarks/ahi_hsd_benchmarks.py
+++ b/benchmarks/ahi_hsd_benchmarks.py
@@ -43,7 +43,7 @@ class HimawariHSD(GeoBenchmarks):
         except ImportError:
             assert len(get_filenames(self.subdir)) == 4  # nosec
         download_rsr()
-        download_luts(aerosol_type="rayleigh_only")
+        download_luts(aerosol_types=["rayleigh_only"])
 
     def setup(self):
         """Set up the benchmarks."""

--- a/benchmarks/seviri_hrit_benchmarks.py
+++ b/benchmarks/seviri_hrit_benchmarks.py
@@ -43,7 +43,7 @@ class SEVIRIHRIT(GeoBenchmarks):
         except ImportError:
             assert len(get_filenames(self.subdir)) == 114  # nosec
         download_rsr()
-        download_luts(aerosol_type="rayleigh_only")
+        download_luts(aerosol_types=["rayleigh_only"])
 
     def setup(self):
         """Set up the benchmarks."""

--- a/benchmarks/viirs_sdr_benchmarks.py
+++ b/benchmarks/viirs_sdr_benchmarks.py
@@ -42,7 +42,7 @@ class VIIRSSDRBenchmarkBase:
         except ImportError:
             assert len(self.get_filenames()) == 6 * 3  # nosec
         download_rsr()
-        download_luts(aerosol_type="rayleigh_only")
+        download_luts(aerosol_types=["rayleigh_only"])
 
     def setup(self, name):
         """Set up the benchmarks."""


### PR DESCRIPTION
Noticed while removing a usage in pyspectral. See https://github.com/pytroll/pyspectral/pull/235

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
