### PR TITLE
Update `check_satpy` to use new `show_version` to display package versions

### DIFF
--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -278,13 +278,17 @@ class TestCheckSatpy:
         """Test 'check_satpy' with specific features provided."""
         from satpy.utils import check_satpy
         with mock.patch("satpy.utils.print") as print_mock:
-            check_satpy(readers=["viirs_sdr"], extras=("cartopy", "__fake"))
-            checked_fake = False
-            for call in print_mock.mock_calls:
-                if len(call[1]) > 0 and "__fake" in call[1][0]:
-                    assert "ok" not in call[1][1]
-                    checked_fake = True
-            assert checked_fake, "Did not find __fake module mentioned in checks"
+            check_satpy(readers=["viirs_sdr"], packages=("cartopy", "__fake"))
+            checked_fake = any("__fake: not installed" in c[1] for c in print_mock.mock_calls if len(c[1]))
+            assert checked_fake, "Did not find __fake package mentioned in checks"
+
+class TestShowVersions:
+    """Test the 'show_versions' function."""
+
+    def test_basic_show_versions(self):
+        """Test 'check_satpy' basic functionality."""
+        from satpy.utils import show_versions
+        show_versions()
 
 
 def test_debug_on(caplog):

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -291,36 +291,25 @@ class TestShowVersions:
         from satpy.utils import show_versions
         show_versions()
 
-    def test_show_specific_version(self):
+    def test_show_specific_version(self, capsys):
         """Test 'show_version' works with installed package."""
         from satpy.utils import show_versions
-        with mock.patch("satpy.utils.print") as print_mock:
-            show_versions(packages=["pytest"])
+        show_versions(packages=["pytest"])
+        out, _ = capsys.readouterr()
 
-            # no regex or `.__version__` based checks to prevent edge case failures
-            pytest_mentioned = any(
-                "pytest:" in c[1][0] for c in print_mock.mock_calls if len(c[1])
-            )
-            pytest_installed = all(
-                "pytest: not installed" not in c[1][0]
-                for c in print_mock.mock_calls
-                if len(c[1])
-            )
-            check_pytest = pytest_mentioned and pytest_installed
-            assert check_pytest, "pytest with package version not in print output"
+        pytest_mentioned = "pytest:" in out
+        pytest_installed = "pytest: not installed" not in out
+        check_pytest = pytest_mentioned and pytest_installed
+        assert check_pytest, "pytest with package version not in print output"
 
-    def test_show_missing_specific_version(self):
+    def test_show_missing_specific_version(self, capsys):
         """Test 'show_version' works with missing package."""
         from satpy.utils import show_versions
+        show_versions(packages=["__fake"])
+        out, _ = capsys.readouterr()
 
-        with mock.patch("satpy.utils.print") as print_mock:
-            show_versions(packages=["__fake"])
-            checked_fake = any(
-                "__fake: not installed" in c[1]
-                for c in print_mock.mock_calls
-                if len(c[1])
-            )
-            assert checked_fake, "Did not find '__fake: not installed' in print output"
+        check_fake = "__fake: not installed" in out
+        assert check_fake, "Did not find '__fake: not installed' in print output"
 
 
 def test_debug_on(caplog):
@@ -330,12 +319,7 @@ def test_debug_on(caplog):
     def depwarn():
         logger = logging.getLogger("satpy.silly")
         logger.debug("But now it's just got SILLY.")
-        warnings.warn(
-            "Stop that! It's SILLY.",
-            DeprecationWarning,
-            stacklevel=2
-        )
-
+        warnings.warn("Stop that! It's SILLY.", DeprecationWarning, stacklevel=2)
     warnings.filterwarnings("ignore", category=DeprecationWarning)
     debug_on(False)
     filts_before = warnings.filters.copy()

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -291,6 +291,37 @@ class TestShowVersions:
         from satpy.utils import show_versions
         show_versions()
 
+    def test_show_specific_version(self):
+        """Test 'show_version' works with installed package."""
+        from satpy.utils import show_versions
+        with mock.patch("satpy.utils.print") as print_mock:
+            show_versions(packages=["pytest"])
+
+            # no regex or `.__version__` based checks to prevent edge case failures
+            pytest_mentioned = any(
+                "pytest:" in c[1][0] for c in print_mock.mock_calls if len(c[1])
+            )
+            pytest_installed = all(
+                "pytest: not installed" not in c[1][0]
+                for c in print_mock.mock_calls
+                if len(c[1])
+            )
+            check_pytest = pytest_mentioned and pytest_installed
+            assert check_pytest, "pytest with package version not in print output"
+
+    def test_show_missing_specific_version(self):
+        """Test 'show_version' works with missing package."""
+        from satpy.utils import show_versions
+
+        with mock.patch("satpy.utils.print") as print_mock:
+            show_versions(packages=["__fake"])
+            checked_fake = any(
+                "__fake: not installed" in c[1]
+                for c in print_mock.mock_calls
+                if len(c[1])
+            )
+            assert checked_fake, "Did not find '__fake: not installed' in print output"
+
 
 def test_debug_on(caplog):
     """Test that debug_on is working as expected."""

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -282,6 +282,7 @@ class TestCheckSatpy:
             checked_fake = any("__fake: not installed" in c[1] for c in print_mock.mock_calls if len(c[1]))
             assert checked_fake, "Did not find __fake package mentioned in checks"
 
+
 class TestShowVersions:
     """Test the 'show_versions' function."""
 

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -498,8 +498,8 @@ def check_satpy(readers=None, writers=None, extras=None):
         writers (list or None): Limit writers checked to those specified
         extras (list or None): Limit extras checked to those specified
 
-    Returns: bool
-        True if all specified features were successfully loaded.
+    Returns:
+        None
 
     """
     from satpy.readers import configs_for_reader

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -492,6 +492,7 @@ def _check_package_version(package_name: str) -> Optional[str]:
     except importlib.metadata.PackageNotFoundError:
         return None
 
+
 def show_versions(packages=None):
     """Shows version for system, python and common packages (if installed).
 


### PR DESCRIPTION
MR to add `show_versions` to `satpy.utils` to allow for use in `satpy.utils.check_satpy`. 
Use case is to help in figuring out run-time environment factors while debugging issues.

