### PR TITLE
Fix deprecated "compositor" usage in modifier definitions

### DIFF
--- a/satpy/etc/composites/sgli.yaml
+++ b/satpy/etc/composites/sgli.yaml
@@ -4,7 +4,7 @@ sensor_name: visir/sgli
 modifiers:
 
   rayleigh_corrected:
-    compositor: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
     atmosphere: us-standard
     aerosol_type: rayleigh_only
     prerequisites:
@@ -17,7 +17,7 @@ modifiers:
     - solar_zenith_angle
 
   rayleigh_corrected_marine_clean:
-    compositor: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
     atmosphere: us-standard
     aerosol_type: marine_clean_aerosol
     prerequisites:
@@ -30,7 +30,7 @@ modifiers:
     - solar_zenith_angle
 
   rayleigh_corrected_marine_tropical:
-    compositor: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
     atmosphere: tropical
     aerosol_type: marine_tropical_aerosol
     prerequisites:
@@ -43,7 +43,7 @@ modifiers:
     - solar_zenith_angle
 
   rayleigh_corrected_desert:
-    compositor: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
     atmosphere: tropical
     aerosol_type: desert_aerosol
     prerequisites:
@@ -56,7 +56,7 @@ modifiers:
     - solar_zenith_angle
 
   rayleigh_corrected_land:
-    compositor: !!python/name:satpy.modifiers.PSPRayleighReflectance
+    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
     atmosphere: us-standard
     aerosol_type: continental_average_aerosol
     prerequisites:


### PR DESCRIPTION
Noticed some deprecation warnings in my Polar2Grid tests.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
