### PR TITLE
Import DataTree from xarray

### DIFF
--- a/satpy/readers/insat3d_img_l1b_h5.py
+++ b/satpy/readers/insat3d_img_l1b_h5.py
@@ -7,11 +7,7 @@ from functools import cached_property
 import dask.array as da
 import numpy as np
 import xarray as xr
-
-from satpy.utils import import_error_helper
-
-with import_error_helper("xarray-datatree"):
-    from datatree import DataTree
+from xarray.core.datatree import DataTree
 
 from satpy.readers.file_handlers import BaseFileHandler
 


### PR DESCRIPTION
This PR fixes the error with the unstable build hopefully.
Note that very shortly, this will need to be changed again as DataTree will become public API in xarray.
Progress in https://github.com/pydata/xarray/issues/8572


 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
