### PR TITLE
Fix data type when getting a line offset for a segmented hrit_jma

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -38,6 +38,7 @@ The following people have made contributions to this project:
 - [Gerrit Holl (gerritholl)](https://github.com/gerritholl) - Deutscher Wetterdienst
 - [David Hoese (djhoese)](https://github.com/djhoese)
 - [Marc Honnorat (honnorat)](https://github.com/honnorat)
+- [Mario Hros (k3a)](https://github.com/k3a)
 - [Lloyd Hughes (system123)](https://github.com/system123)
 - [Sara Hörnquist (shornqui)](https://github.com/shornqui)
 - [Mikhail Itkin (mitkin)](https://github.com/mitkin)

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -345,8 +345,8 @@ class HRITJMAFileHandler(HRITFileHandler):
         if self.is_segmented:
             # loff in the file specifies the offset of the full disk image
             # centre (1375/2750 for VIS/IR)
-            segment_number = self.mda["segment_sequence_number"] - 1
-            loff -= (self.mda["total_no_image_segm"] - segment_number - 1) * nlines
+            segment_number = int(self.mda["segment_sequence_number"]) - 1
+            loff -= (int(self.mda["total_no_image_segm"]) - segment_number - 1) * nlines
         elif self.area_id in (NORTH_HEMIS, SOUTH_HEMIS):
             # loff in the file specifies the start line of the half disk image
             # in the full disk image

--- a/satpy/tests/reader_tests/test_ahi_hrit.py
+++ b/satpy/tests/reader_tests/test_ahi_hrit.py
@@ -75,8 +75,8 @@ class TestHRITJMAFileHandler(unittest.TestCase):
         proj_h8 = b"GEOS(140.70)                    "
         proj_mtsat2 = b"GEOS(145.00)                    "
         proj_name = proj_h8 if platform == "Himawari-8" else proj_mtsat2
-        return {"image_segm_seq_no": segno,
-                "total_no_image_segm": numseg,
+        return {"image_segm_seq_no": np.uint8(segno),
+                "total_no_image_segm": np.uint8(numseg),
                 "projection_name": proj_name,
                 "projection_parameters": {
                     "a": 6378169.00,
@@ -85,10 +85,10 @@ class TestHRITJMAFileHandler(unittest.TestCase):
                 },
                 "cfac": 10233128,
                 "lfac": 10233128,
-                "coff": coff,
-                "loff": loff,
-                "number_of_columns": ncols,
-                "number_of_lines": nlines,
+                "coff": np.int32(coff),
+                "loff": np.int32(loff),
+                "number_of_columns": np.uint16(ncols),
+                "number_of_lines": np.uint16(nlines),
                 "image_data_function": idf,
                 "image_observation_time": self._get_acq_time(nlines)}
 


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

Fixes the following uint8 overflow when loading Himawari hrit data distributed by EumetCast:

```
Traceback (most recent call last):
  File "/Work/meteo/satpy-tests/./test5.py", line 18, in <module>
    scn = Scene(filenames=filenames, reader='ahi_hrit')
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Work/meteo/venv/lib/python3.12/site-packages/satpy/scene.py", line 155, in __init__
    self._readers = self._create_reader_instances(filenames=filenames,
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Work/meteo/venv/lib/python3.12/site-packages/satpy/scene.py", line 176, in _create_reader_instances
    return load_readers(filenames=filenames,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Work/meteo/venv/lib/python3.12/site-packages/satpy/readers/__init__.py", line 580, in load_readers
    reader_instance.create_storage_items(
  File "/Work/meteo/venv/lib/python3.12/site-packages/satpy/readers/yaml_reader.py", line 617, in create_storage_items
    return self.create_filehandlers(files, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Work/meteo/venv/lib/python3.12/site-packages/satpy/readers/yaml_reader.py", line 1180, in create_filehandlers
    created_fhs = super(GEOSegmentYAMLReader, self).create_filehandlers(
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Work/meteo/venv/lib/python3.12/site-packages/satpy/readers/yaml_reader.py", line 629, in create_filehandlers
    filehandlers = self._new_filehandlers_for_filetype(filetype_info,
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Work/meteo/venv/lib/python3.12/site-packages/satpy/readers/yaml_reader.py", line 612, in _new_filehandlers_for_filetype
    return list(filtered_iter)
           ^^^^^^^^^^^^^^^^^^^
  File "/Work/meteo/venv/lib/python3.12/site-packages/satpy/readers/yaml_reader.py", line 594, in filter_fh_by_metadata
    for filehandler in filehandlers:
  File "/Work/meteo/venv/lib/python3.12/site-packages/satpy/readers/yaml_reader.py", line 590, in _new_filehandler_instances
    yield filetype_cls(filename, filename_info, filetype_info, *req_fh, **fh_kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Work/meteo/venv/lib/python3.12/site-packages/satpy/readers/hrit_jma.py", line 278, in __init__
    self.area = self._get_area_def()
                ^^^^^^^^^^^^^^^^^^^^
  File "/Work/meteo/venv/lib/python3.12/site-packages/satpy/readers/hrit_jma.py", line 365, in _get_area_def
    "loff": self._get_line_offset(),
            ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Work/meteo/venv/lib/python3.12/site-packages/satpy/readers/hrit_jma.py", line 349, in _get_line_offset
    loff -= (self.mda["total_no_image_segm"] - segment_number - 1) * nlines
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
OverflowError: Python integer 550 out of bounds for uint8
```