### PR TITLE
Enhance visibility of missing dependencies

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -561,18 +561,12 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None):
         reader_kwargs = {}
 
     for idx, reader_configs in enumerate(configs_for_reader(reader)):
-        if isinstance(filenames, dict):
-            readers_files = set(filenames[reader[idx]])
-        else:
-            readers_files = remaining_filenames
-
+        readers_files = _get_readers_files(filenames, reader, idx, remaining_filenames)
         reader_instance = _get_reader_instance(reader, reader_configs, idx, reader_kwargs)
-        if reader_instance is None:
+        if reader_instance is None or not readers_files:
+            # Reader initiliasation failed or no files were given
             continue
 
-        if not readers_files:
-            # we weren't given any files for this reader
-            continue
         loadables = reader_instance.select_files_from_pathnames(readers_files)
         if loadables:
             reader_instance.create_storage_items(
@@ -580,12 +574,19 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None):
                     fh_kwargs=reader_kwargs_without_filter[None if reader is None else reader[idx]])
             reader_instances[reader_instance.name] = reader_instance
             remaining_filenames -= set(loadables)
+
         if not remaining_filenames:
             break
 
     _check_remaining_files(remaining_filenames)
     _check_reader_instances(reader_instances)
     return reader_instances
+
+
+def _get_readers_files(filenames, reader, idx, remaining_filenames):
+    if isinstance(filenames, dict):
+        return set(filenames[reader[idx]])
+    return remaining_filenames
 
 
 def _get_reader_instance(reader, reader_configs, idx, reader_kwargs):

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -557,13 +557,16 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None):
     reader, filenames, remaining_filenames = _get_reader_and_filenames(reader, filenames)
     (reader_kwargs, reader_kwargs_without_filter) = _get_reader_kwargs(reader, reader_kwargs)
 
+    if reader_kwargs is None:
+        reader_kwargs = {}
+
     for idx, reader_configs in enumerate(configs_for_reader(reader)):
         if isinstance(filenames, dict):
             readers_files = set(filenames[reader[idx]])
         else:
             readers_files = remaining_filenames
 
-        reader_instance = _get_reader_instance(reader, reader_configs, idx, **reader_kwargs)
+        reader_instance = _get_reader_instance(reader, reader_configs, idx, reader_kwargs)
         if reader_instance is None:
             continue
 
@@ -585,7 +588,7 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None):
     return reader_instances
 
 
-def _get_reader_instance(reader, reader_configs, idx, **reader_kwargs):
+def _get_reader_instance(reader, reader_configs, idx, reader_kwargs):
     reader_instance = None
     try:
         reader_instance = load_reader(

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -597,7 +597,7 @@ def _get_reader_instance(reader, reader_configs, idx, reader_kwargs):
     except (KeyError, IOError) as err:
         LOG.info("Cannot use %s", str(reader_configs))
         LOG.debug(str(err))
-    except yaml.YAMLError as err:
+    except yaml.constructor.ConstructorError as err:
         _log_yaml_error(reader_configs, err)
 
     return reader_instance

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -563,16 +563,9 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None):
         else:
             readers_files = remaining_filenames
 
-        try:
-            reader_instance = load_reader(
-                    reader_configs,
-                    **reader_kwargs[None if reader is None else reader[idx]])
-        except (KeyError, IOError) as err:
-            LOG.info("Cannot use %s", str(reader_configs))
-            LOG.debug(str(err))
+        reader_instance = _get_reader_instance(reader, reader_configs, idx, **reader_kwargs)
+        if reader_instance is None:
             continue
-        except yaml.YAMLError as err:
-            _log_yaml_error(reader_configs, err)
 
         if not readers_files:
             # we weren't given any files for this reader
@@ -590,6 +583,21 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None):
     _check_remaining_files(remaining_filenames)
     _check_reader_instances(reader_instances)
     return reader_instances
+
+
+def _get_reader_instance(reader, reader_configs, idx, **reader_kwargs):
+    reader_instance = None
+    try:
+        reader_instance = load_reader(
+            reader_configs,
+            **reader_kwargs[None if reader is None else reader[idx]])
+    except (KeyError, IOError) as err:
+        LOG.info("Cannot use %s", str(reader_configs))
+        LOG.debug(str(err))
+    except yaml.YAMLError as err:
+        _log_yaml_error(reader_configs, err)
+
+    return reader_instance
 
 
 def _log_yaml_error(reader_configs, err):

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -567,10 +567,12 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None):
             reader_instance = load_reader(
                     reader_configs,
                     **reader_kwargs[None if reader is None else reader[idx]])
-        except (KeyError, IOError, yaml.YAMLError) as err:
+        except (KeyError, IOError) as err:
             LOG.info("Cannot use %s", str(reader_configs))
             LOG.debug(str(err))
             continue
+        except yaml.YAMLError as err:
+            _log_yaml_error(reader_configs, err)
 
         if not readers_files:
             # we weren't given any files for this reader
@@ -588,6 +590,11 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None):
     _check_remaining_files(remaining_filenames)
     _check_reader_instances(reader_instances)
     return reader_instances
+
+
+def _log_yaml_error(reader_configs, err):
+    LOG.error("Problem with %s", str(reader_configs))
+    LOG.error(str(err))
 
 
 def _early_exit(filenames, reader):

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -455,7 +455,7 @@ class TestReaderLoader(unittest.TestCase):
 
         filenames = ["AVHR_xxx_1B_M01_20241015100703Z_20241015114603Z_N_O_20241015105547Z.nat"]
         error_message = "YAML test error message"
-        load_reader.side_effect = yaml.YAMLError(error_message)
+        load_reader.side_effect = yaml.constructor.ConstructorError(error_message)
 
         with self._caplog.at_level(logging.ERROR):
             with pytest.raises(ValueError, match="No supported files found"):

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -458,7 +458,7 @@ class TestReaderLoader(unittest.TestCase):
         load_reader.side_effect = yaml.YAMLError(error_message)
 
         with self._caplog.at_level(logging.ERROR):
-            with pytest.raises(match=ValueError):
+            with pytest.raises(ValueError, match="No supported files found"):
                 _ = load_readers(filenames=filenames, reader="avhrr_l1b_eps")
             assert error_message in self._caplog.text
 

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -458,7 +458,7 @@ class TestReaderLoader(unittest.TestCase):
         load_reader.side_effect = yaml.YAMLError(error_message)
 
         with self._caplog.at_level(logging.ERROR):
-            with pytest.raises(UnboundLocalError):
+            with pytest.raises(match=ValueError):
                 _ = load_readers(filenames=filenames, reader="avhrr_l1b_eps")
             assert error_message in self._caplog.text
 


### PR DESCRIPTION
Curently PyYAML hides import errors in instantiated classes, and these are only logged at `DEBUG` level. This PR changes the log level to `ERROR` for these cases.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
