### PR TITLE
Add no-op image_ready enhancement

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -721,7 +721,7 @@ class DayNightCompositor(GenericCompositor):
         self.day_night = day_night
         self.include_alpha = include_alpha
         self._has_sza = False
-        super(DayNightCompositor, self).__init__(name, **kwargs)
+        super().__init__(name, **kwargs)
 
     def __call__(
             self,

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -653,3 +653,8 @@ def _jma_true_color_reproduction(img_data, platform=None):
 
     output = da.dot(img_data.T, ccm.T)
     return output.T
+
+
+def no_op(img):
+    """Do not do anything to the image."""
+    return img.data

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -1285,3 +1285,9 @@ enhancements:
   imager_with_lightning:
     standard_name: imager_with_lightning
     operations: []
+
+  image_ready:
+    standard_name: image_ready
+    operations:
+      - name: no_op
+        method: !!python/name:satpy.enhancements.no_op

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -711,3 +711,15 @@ class TestTCREnhancement:
         img = XRImage(self.rgb)
         with pytest.raises(KeyError, match="No conversion matrix found for platform Fakesat"):
             jma_true_color_reproduction(img)
+
+
+def test_no_op_enhancement():
+    """Test the no-op enhancement."""
+    from satpy.enhancements import no_op
+
+    data = da.arange(-100, 1000, 110).reshape(2, 5)
+    rgb_data = np.stack([data, data, data])
+    rgb = xr.DataArray(rgb_data, dims=("bands", "y", "x"),
+                       coords={"bands": ["R", "G", "B"]},
+                       attrs={"platform_name": "Himawari-8"})
+    assert no_op(rgb) is rgb.data

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -456,10 +456,10 @@ class TestColormapLoading:
         """Test that colors can be a list/tuple."""
         from satpy.enhancements import create_colormap
         colors = [
-            [0, 0, 1],
-            [1, 0, 1],
-            [0, 1, 1],
-            [1, 1, 1],
+            [0., 0., 1.],
+            [1., 0., 1.],
+            [0., 1., 1.],
+            [1., 1., 1.],
         ]
         values = [2, 4, 6, 8]
         cmap = create_colormap({"colors": colors, "color_scale": 1})


### PR DESCRIPTION
This PR adds a no-op enhancement for data that is image-ready, ie where nothing needs to be done. The enhancement key (standard_name) is called `image_ready`.

I didn't add any test, as the function is not doing anything. But shout if you think I should do otherwise.