### PR TITLE
Drop python 3.9

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,9 +24,6 @@ jobs:
           - python-version: "3.12"
             os: "ubuntu-latest"
             experimental: true
-          - python-version: "3.13"
-            os: "ubuntu-latest"
-            experimental: true
 
     env:
       PYTHON_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,10 +18,13 @@ jobs:
       fail-fast: true
       matrix:
         os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.9", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         experimental: [false]
         include:
           - python-version: "3.12"
+            os: "ubuntu-latest"
+            experimental: true
+          - python-version: "3.13"
             os: "ubuntu-latest"
             experimental: true
 

--- a/.github/workflows/deploy-sdist.yaml
+++ b/.github/workflows/deploy-sdist.yaml
@@ -19,7 +19,7 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install -q build
-          python -m build -s
+          python -m build
 
       - name: Publish package to PyPI
         if: github.event.action == 'published'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
           - types-setuptools
           - types-PyYAML
           - types-requests
-        args: ["--python-version", "3.9", "--ignore-missing-imports"]
+        args: ["--python-version", "3.10", "--ignore-missing-imports"]
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -2,7 +2,7 @@ name: readthedocs
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python=3.11
   - pip
   - platformdirs
   - dask

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "zarr",
 ]
 readme = "README.rst"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = { text = "GPLv3" }
 classifiers = [
     "Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
This PR drops support for python 3.9, as deemed reasonable in #2741. This superseeds #2741 which was difficult to merge with main.
~Also, we added an experimental build for python 3.13.~

 - [x] Closes #2741 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->

