### PR TITLE
Update Landsat reader for compatibility with Pyspectral.

### DIFF
--- a/satpy/etc/composites/oli_tirs.yaml
+++ b/satpy/etc/composites/oli_tirs.yaml
@@ -6,7 +6,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: rayleigh_only
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [sunz_corrected]
     optional_prerequisites:
       - name: satellite_azimuth_angle
@@ -19,7 +19,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: antarctic_aerosol
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [sunz_corrected]
     optional_prerequisites:
       - name: satellite_azimuth_angle
@@ -32,7 +32,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: continental_average_aerosol
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [sunz_corrected]
     optional_prerequisites:
       - name: satellite_azimuth_angle
@@ -45,7 +45,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: continental_clean_aerosol
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [sunz_corrected]
     optional_prerequisites:
       - name: satellite_azimuth_angle
@@ -58,7 +58,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: continental_polluted_aerosol
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [sunz_corrected]
     optional_prerequisites:
       - name: satellite_azimuth_angle
@@ -71,7 +71,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: desert_aerosol
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [sunz_corrected]
     optional_prerequisites:
       - name: satellite_azimuth_angle
@@ -84,7 +84,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: marine_clean_aerosol
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [sunz_corrected]
     optional_prerequisites:
       - name: satellite_azimuth_angle
@@ -97,7 +97,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: marine_polluted_aerosol
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [sunz_corrected]
     optional_prerequisites:
       - name: satellite_azimuth_angle
@@ -110,7 +110,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: marine_tropical_aerosol
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [sunz_corrected]
     optional_prerequisites:
       - name: satellite_azimuth_angle
@@ -123,7 +123,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: rural_aerosol
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [sunz_corrected]
     optional_prerequisites:
       - name: satellite_azimuth_angle
@@ -136,7 +136,7 @@ modifiers:
     atmosphere: us-standard
     aerosol_type: urban_aerosol
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [sunz_corrected]
     optional_prerequisites:
       - name: satellite_azimuth_angle
@@ -149,176 +149,176 @@ composites:
   true_color:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-    - name: 'b04'
+    - name: 'B4'
       modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
-    - name: 'b03'
+    - name: 'B3'
       modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
-    - name: 'b02'
+    - name: 'B2'
       modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
     standard_name: true_color
 
   true_color_antarctic:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_antarctic]
-      - name: 'b03'
+      - name: 'B3'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_antarctic]
-      - name: 'b02'
+      - name: 'B2'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_antarctic]
     standard_name: true_color
 
   true_color_continental_average:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_average]
-      - name: 'b03'
+      - name: 'B3'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_average]
-      - name: 'b02'
+      - name: 'B2'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_average]
     standard_name: true_color
 
   true_color_continental_clean:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_clean]
-      - name: 'b03'
+      - name: 'B3'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_clean]
-      - name: 'b02'
+      - name: 'B2'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_clean]
     standard_name: true_color
 
   true_color_continental_polluted:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_polluted]
-      - name: 'b03'
+      - name: 'B3'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_polluted]
-      - name: 'b02'
+      - name: 'B2'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_continental_polluted]
     standard_name: true_color
 
   true_color_desert:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_desert]
-      - name: 'b03'
+      - name: 'B3'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_desert]
-      - name: 'b02'
+      - name: 'B2'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_desert]
     standard_name: true_color
 
   true_color_marine_clean:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_clean]
-      - name: 'b03'
+      - name: 'B3'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_clean]
-      - name: 'b02'
+      - name: 'B2'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_clean]
     standard_name: true_color
 
   true_color_marine_polluted:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_polluted]
-      - name: 'b03'
+      - name: 'B3'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_polluted]
-      - name: 'b02'
+      - name: 'B2'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_polluted]
     standard_name: true_color
 
   true_color_marine_tropical:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_tropical]
-      - name: 'b03'
+      - name: 'B3'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_tropical]
-      - name: 'b02'
+      - name: 'B2'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_marine_tropical]
     standard_name: true_color
 
   true_color_rural:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_rural]
-      - name: 'b03'
+      - name: 'B3'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_rural]
-      - name: 'b02'
+      - name: 'B2'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_rural]
     standard_name: true_color
 
   true_color_urban:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_urban]
-      - name: 'b03'
+      - name: 'B3'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_urban]
-      - name: 'b02'
+      - name: 'B2'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected_urban]
     standard_name: true_color
 
   true_color_uncorr:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [effective_solar_pathlength_corrected]
-      - name: 'b03'
+      - name: 'B3'
         modifiers: [effective_solar_pathlength_corrected]
-      - name: 'b02'
+      - name: 'B2'
         modifiers: [effective_solar_pathlength_corrected]
     standard_name: true_color
 
   true_color_raw:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - name: 'b04'
+      - name: 'B4'
         # modifiers: [effective_solar_pathlength_corrected]
-      - name: 'b03'
+      - name: 'B3'
         # modifiers: [effective_solar_pathlength_corrected]
-      - name: 'b02'
+      - name: 'B2'
         # modifiers: [effective_solar_pathlength_corrected]
     standard_name: true_color
 
   natural_color:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-    - name: 'b06'
+    - name: 'B6'
       modifiers: [effective_solar_pathlength_corrected]
-    - name: 'b05'
+    - name: 'B5'
       modifiers: [effective_solar_pathlength_corrected]
-    - name: 'b04'
+    - name: 'B4'
       modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
     standard_name: natural_color
 
   urban_color:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - name: 'b07'
+      - name: 'B7'
         modifiers: [effective_solar_pathlength_corrected]
-      - name: 'b06'
+      - name: 'B6'
         modifiers: [effective_solar_pathlength_corrected]
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
     standard_name: natural_color
 
   false_color:
     compositor: !!python/name:satpy.composites.GenericCompositor
     prerequisites:
-      - name: 'b05'
+      - name: 'B5'
         modifiers: [effective_solar_pathlength_corrected]
-      - name: 'b04'
+      - name: 'B4'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
-      - name: 'b03'
+      - name: 'B3'
         modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
     standard_name: natural_color
 
@@ -331,15 +331,15 @@ composites:
       prerequisites:
       - compositor: !!python/name:satpy.composites.DifferenceCompositor
         prerequisites:
-          - name: 'b05'
+          - name: 'B5'
             modifiers: [effective_solar_pathlength_corrected]
-          - name: 'b04'
+          - name: 'B4'
             modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
       - compositor: !!python/name:satpy.composites.SumCompositor
         prerequisites:
-          - name: 'b05'
+          - name: 'B5'
             modifiers: [effective_solar_pathlength_corrected]
-          - name: 'b04'
+          - name: 'B4'
             modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
     standard_name: ndvi_msi
 
@@ -352,15 +352,15 @@ composites:
       prerequisites:
       - compositor: !!python/name:satpy.composites.DifferenceCompositor
         prerequisites:
-          - name: 'b05'
+          - name: 'B5'
             modifiers: [effective_solar_pathlength_corrected]
-          - name: 'b06'
+          - name: 'B6'
             modifiers: [effective_solar_pathlength_corrected]
       - compositor: !!python/name:satpy.composites.SumCompositor
         prerequisites:
-          - name: 'b05'
+          - name: 'B5'
             modifiers: [effective_solar_pathlength_corrected]
-          - name: 'b06'
+          - name: 'B6'
             modifiers: [effective_solar_pathlength_corrected]
     standard_name: ndmi_msi
 
@@ -373,15 +373,15 @@ composites:
       prerequisites:
       - compositor: !!python/name:satpy.composites.DifferenceCompositor
         prerequisites:
-          - name: 'b03'
+          - name: 'B3'
             modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
-          - name: 'b05'
+          - name: 'B5'
             modifiers: [effective_solar_pathlength_corrected]
       - compositor: !!python/name:satpy.composites.SumCompositor
         prerequisites:
-          - name: 'b03'
+          - name: 'B3'
             modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
-          - name: 'b05'
+          - name: 'B5'
             modifiers: [effective_solar_pathlength_corrected]
     standard_name: ndwi_msi
 
@@ -390,21 +390,21 @@ composites:
     # For more information please review https://custom-scripts.sentinel-hub.com/sentinel-2/ndsi/
     compositor: !!python/name:satpy.composites.MaskingCompositor
     prerequisites:
-    - name: 'b06'
+    - name: 'B6'
       modifiers: [effective_solar_pathlength_corrected]
     - compositor: !!python/name:satpy.composites.RatioCompositor
       prerequisites:
       - compositor: !!python/name:satpy.composites.DifferenceCompositor
         prerequisites:
-          - name: 'b03'
+          - name: 'B3'
             modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
-          - name: 'b06'
+          - name: 'B6'
             modifiers: [effective_solar_pathlength_corrected]
       - compositor: !!python/name:satpy.composites.SumCompositor
         prerequisites:
-          - name: 'b03'
+          - name: 'B3'
             modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
-          - name: 'b06'
+          - name: 'B6'
             modifiers: [effective_solar_pathlength_corrected]
     conditions:
     - method: less_equal

--- a/satpy/etc/readers/oli_tirs_l1_tif.yaml
+++ b/satpy/etc/readers/oli_tirs_l1_tif.yaml
@@ -11,58 +11,58 @@ reader:
 
 file_types:
     # Bands on the OLI subsystem
-    granule_b01:
+    granule_B1:
         file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B1.TIF']
         requires: [l1_metadata]
 
-    granule_b02:
+    granule_B2:
         file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B2.TIF']
         requires: [l1_metadata]
 
-    granule_b03:
+    granule_B3:
         file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B3.TIF']
         requires: [l1_metadata]
 
-    granule_b04:
+    granule_B4:
         file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B4.TIF']
         requires: [l1_metadata]
 
-    granule_b05:
+    granule_B5:
         file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B5.TIF']
         requires: [l1_metadata]
 
-    granule_b06:
+    granule_B6:
         file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B6.TIF']
         requires: [l1_metadata]
 
-    granule_b07:
+    granule_B7:
         file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B7.TIF']
         requires: [l1_metadata]
 
-    granule_b08:
+    granule_B8:
         file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B8.TIF']
         requires: [l1_metadata]
 
-    granule_b09:
+    granule_B9:
         file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B9.TIF']
         requires: [l1_metadata]
 
     # Bands on the TIRS subsystem
-    granule_b10:
+    granule_B10:
         file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B10.TIF']
         requires: [l1_metadata]
 
-    granule_b11:
+    granule_B11:
         file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_B11.TIF']
         requires: [l1_metadata]
@@ -100,8 +100,8 @@ file_types:
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_MTL.xml']
 
 datasets:
-  b01:
-    name: b01
+  B1:
+    name: B1
     sensor: oli_tirs
     wavelength: [0.433, 0.443, 0.453]
     resolution: 30
@@ -115,10 +115,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: granule_b01
+    file_type: granule_B1
 
-  b02:
-    name: b02
+  B2:
+    name: B2
     sensor: oli_tirs
     wavelength: [0.450, 0.482, 0.515]
     resolution: 30
@@ -132,10 +132,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: granule_b02
+    file_type: granule_B2
 
-  b03:
-    name: b03
+  B3:
+    name: B3
     sensor: oli_tirs
     wavelength: [0.525, 0.565, 0.600]
     resolution: 30
@@ -149,10 +149,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: granule_b03
+    file_type: granule_B3
 
-  b04:
-    name: b04
+  B4:
+    name: B4
     sensor: oli_tirs
     wavelength: [0.630, 0.660, 0.680]
     resolution: 30
@@ -166,10 +166,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: granule_b04
+    file_type: granule_B4
 
-  b05:
-    name: b05
+  B5:
+    name: B5
     sensor: oli_tirs
     wavelength: [0.845, 0.867, 0.885]
     resolution: 30
@@ -183,10 +183,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: granule_b05
+    file_type: granule_B5
 
-  b06:
-    name: b06
+  B6:
+    name: B6
     sensor: oli_tirs
     wavelength: [1.560, 1.650, 1.660]
     resolution: 30
@@ -200,10 +200,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: granule_b06
+    file_type: granule_B6
 
-  b07:
-    name: b07
+  B7:
+    name: B7
     sensor: oli_tirs
     wavelength: [2.100, 2.215, 2.300]
     resolution: 30
@@ -217,10 +217,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: granule_b07
+    file_type: granule_B7
 
-  b08:
-    name: b08
+  B8:
+    name: B8
     sensor: oli_tirs
     wavelength: [0.500, 0.579, 0.680]
     resolution: 15
@@ -234,10 +234,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: granule_b08
+    file_type: granule_B8
 
-  b09:
-    name: b09
+  B9:
+    name: B9
     sensor: oli_tirs
     wavelength: [1.360, 1.373, 1.390]
     resolution: 30
@@ -251,11 +251,11 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: granule_b09
+    file_type: granule_B9
 
   # Channels on the TIRS instrument
-  b10:
-    name: b10
+  B10:
+    name: B10
     sensor: oli_tirs
     wavelength: [10.6, 10.888, 11.19]
     resolution: 30
@@ -269,10 +269,10 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: granule_b10
+    file_type: granule_B10
 
-  b11:
-    name: b11
+  B11:
+    name: B11
     sensor: oli_tirs
     wavelength: [11.5, 11.981, 12.51]
     resolution: 30
@@ -286,7 +286,7 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: granule_b11
+    file_type: granule_B11
 
   # QA Variables
   qa:

--- a/satpy/readers/oli_tirs_l1_tif.py
+++ b/satpy/readers/oli_tirs_l1_tif.py
@@ -40,9 +40,9 @@ logger = logging.getLogger(__name__)
 PLATFORMS = {"08": "Landsat-8",
              "09": "Landsat-9"}
 
-OLI_BANDLIST = ["b01", "b02", "b03", "b04", "b05", "b06", "b07", "b08", "b09"]
-TIRS_BANDLIST = ["b10", "b11"]
-PAN_BANDLIST = ["b08"]
+OLI_BANDLIST = ["B1", "B2", "B3", "B4", "B5", "B6", "B7", "B8", "B9"]
+TIRS_BANDLIST = ["B10", "B11"]
+PAN_BANDLIST = ["B8"]
 ANGLIST = ["satellite_azimuth_angle",
            "satellite_zenith_angle",
            "solar_azimuth_angle",
@@ -235,7 +235,7 @@ class OLITIRSMDReader(BaseFileHandler):
         """Return per-band saturation flag."""
         bdict = {}
         for i in range(1, 10):
-            bdict[f"b{i:02d}"] = self._get_satflag(i)
+            bdict[f"B{i:01d}"] = self._get_satflag(i)
 
         return bdict
 
@@ -264,9 +264,9 @@ class OLITIRSMDReader(BaseFileHandler):
         """Return per-band saturation flag."""
         bdict = {}
         for i in range(1, 10):
-            bdict[f"b{i:02d}"] = self._get_band_viscal(i)
+            bdict[f"B{i:01d}"] = self._get_band_viscal(i)
         for i in range(10, 12):
-            bdict[f"b{i:02d}"] = self._get_band_tircal(i)
+            bdict[f"B{i:02d}"] = self._get_band_tircal(i)
 
         return bdict
 

--- a/satpy/tests/reader_tests/test_oli_tirs_l1_tif.py
+++ b/satpy/tests/reader_tests/test_oli_tirs_l1_tif.py
@@ -373,7 +373,7 @@ def b4_file(l1_files_path, b4_data, l1_area):
     """Create the file for the b4 channel."""
     data = b4_data
     filename = l1_files_path / "LC08_L1GT_026200_20240502_20240513_02_T2_B4.TIF"
-    name = "b04"
+    name = "B4"
     create_tif_file(data, name, l1_area, filename)
     return os.fspath(filename)
 
@@ -382,7 +382,7 @@ def b11_file(l1_files_path, b11_data, l1_area):
     """Create the file for the b11 channel."""
     data = b11_data
     filename = l1_files_path / "LC08_L1GT_026200_20240502_20240513_02_T2_B11.TIF"
-    name = "b11"
+    name = "B11"
     create_tif_file(data, name, l1_area, filename)
     return os.fspath(filename)
 
@@ -421,31 +421,31 @@ class TestOLITIRSL1:
                                   process_level_correction="L1TP",
                                   spacecraft_id="08",
                                   data_type="C")
-        self.ftype_info = {"file_type": "granule_b04"}
+        self.ftype_info = {"file_type": "granule_B4"}
 
     def test_basicload(self, l1_area, b4_file, b11_file, mda_file):
         """Test loading a Landsat Scene."""
         scn = Scene(reader="oli_tirs_l1_tif", filenames=[b4_file,
                                                          b11_file,
                                                          mda_file])
-        scn.load(["b04", "b11"])
+        scn.load(["B4", "B11"])
 
         # Check dataset is loaded correctly
-        assert scn["b04"].shape == (100, 100)
-        assert scn["b04"].attrs["area"] == l1_area
-        assert scn["b04"].attrs["saturated"]
-        assert scn["b11"].shape == (100, 100)
-        assert scn["b11"].attrs["area"] == l1_area
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == l1_area
+        assert scn["B4"].attrs["saturated"]
+        assert scn["B11"].shape == (100, 100)
+        assert scn["B11"].attrs["area"] == l1_area
         with pytest.raises(KeyError, match="saturated"):
-            assert not scn["b11"].attrs["saturated"]
+            assert not scn["B11"].attrs["saturated"]
 
     def test_ch_startend(self, b4_file, sza_file, mda_file):
         """Test correct retrieval of start/end times."""
         scn = Scene(reader="oli_tirs_l1_tif", filenames=[b4_file, sza_file, mda_file])
         bnds = scn.available_dataset_names()
-        assert bnds == ["b04", "solar_zenith_angle"]
+        assert bnds == ["B4", "solar_zenith_angle"]
 
-        scn.load(["b04"])
+        scn.load(["B4"])
         assert scn.start_time == datetime(2024, 5, 2, 18, 0, 24, tzinfo=timezone.utc)
         assert scn.end_time == datetime(2024, 5, 2, 18, 0, 24, tzinfo=timezone.utc)
 
@@ -456,7 +456,7 @@ class TestOLITIRSL1:
         rdr = OLITIRSCHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
 
         # Check case with good file data and load request
-        rdr.get_dataset({"name": "b04", "calibration": "counts"}, {"standard_name": "test_data", "units": "test_units"})
+        rdr.get_dataset({"name": "B4", "calibration": "counts"}, {"standard_name": "test_data", "units": "test_units"})
 
     def test_loading_badfil(self, mda_file, b4_file):
         """Test loading a Landsat Scene with bad channel requests."""
@@ -466,8 +466,8 @@ class TestOLITIRSL1:
 
         ftype = {"standard_name": "test_data", "units": "test_units"}
         # Check case with request to load channel not matching filename
-        with pytest.raises(ValueError, match="Requested channel b05 does not match the reader channel b04"):
-            rdr.get_dataset({"name": "b05", "calibration": "counts"}, ftype)
+        with pytest.raises(ValueError, match="Requested channel B5 does not match the reader channel B4"):
+            rdr.get_dataset({"name": "B5", "calibration": "counts"}, ftype)
 
     def test_loading_badchan(self, mda_file, b11_file):
         """Test loading a Landsat Scene with bad channel requests."""
@@ -479,15 +479,15 @@ class TestOLITIRSL1:
 
         # Check loading invalid channel for data type
         rdr = OLITIRSCHReader(b11_file, bad_finfo, self.ftype_info, good_mda)
-        with pytest.raises(ValueError, match="Requested channel b04 is not available in this granule"):
-            rdr.get_dataset({"name": "b04", "calibration": "counts"}, ftype)
+        with pytest.raises(ValueError, match="Requested channel B4 is not available in this granule"):
+            rdr.get_dataset({"name": "B4", "calibration": "counts"}, ftype)
 
         bad_finfo["data_type"] = "O"
         ftype_b11 = self.ftype_info.copy()
-        ftype_b11["file_type"] = "granule_b11"
+        ftype_b11["file_type"] = "granule_B11"
         rdr = OLITIRSCHReader(b11_file, bad_finfo, ftype_b11, good_mda)
-        with pytest.raises(ValueError, match="Requested channel b11 is not available in this granule"):
-            rdr.get_dataset({"name": "b11", "calibration": "counts"}, ftype)
+        with pytest.raises(ValueError, match="Requested channel B11 is not available in this granule"):
+            rdr.get_dataset({"name": "B11", "calibration": "counts"}, ftype)
 
     def test_badfiles(self, mda_file, b4_file):
         """Test loading a Landsat Scene with bad data."""
@@ -520,13 +520,13 @@ class TestOLITIRSL1:
         from satpy import Scene
 
         scn = Scene(reader="oli_tirs_l1_tif", filenames=all_files)
-        scn.load(["b04", "b11"], calibration="counts")
-        np.testing.assert_allclose(scn["b04"].values, b4_data)
-        np.testing.assert_allclose(scn["b11"].values, b11_data)
-        assert scn["b04"].attrs["units"] == "1"
-        assert scn["b11"].attrs["units"] == "1"
-        assert scn["b04"].attrs["standard_name"] == "counts"
-        assert scn["b11"].attrs["standard_name"] == "counts"
+        scn.load(["B4", "B11"], calibration="counts")
+        np.testing.assert_allclose(scn["B4"].values, b4_data)
+        np.testing.assert_allclose(scn["B11"].values, b11_data)
+        assert scn["B4"].attrs["units"] == "1"
+        assert scn["B11"].attrs["units"] == "1"
+        assert scn["B4"].attrs["standard_name"] == "counts"
+        assert scn["B11"].attrs["standard_name"] == "counts"
 
     def test_calibration_radiance(self, all_files, b4_data, b11_data):
         """Test radiance calibration mode for the reader."""
@@ -535,13 +535,13 @@ class TestOLITIRSL1:
         exp_b11 = (b11_data * 0.0003342 + 0.100000).astype(np.float32)
 
         scn = Scene(reader="oli_tirs_l1_tif", filenames=all_files)
-        scn.load(["b04", "b11"], calibration="radiance")
-        assert scn["b04"].attrs["units"] == "W m-2 um-1 sr-1"
-        assert scn["b11"].attrs["units"] == "W m-2 um-1 sr-1"
-        assert scn["b04"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
-        assert scn["b11"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
-        np.testing.assert_allclose(scn["b04"].values, exp_b04, rtol=1e-4)
-        np.testing.assert_allclose(scn["b11"].values, exp_b11, rtol=1e-4)
+        scn.load(["B4", "B11"], calibration="radiance")
+        assert scn["B4"].attrs["units"] == "W m-2 um-1 sr-1"
+        assert scn["B11"].attrs["units"] == "W m-2 um-1 sr-1"
+        assert scn["B4"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
+        assert scn["B11"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
+        np.testing.assert_allclose(scn["B4"].values, exp_b04, rtol=1e-4)
+        np.testing.assert_allclose(scn["B11"].values, exp_b11, rtol=1e-4)
 
     def test_calibration_highlevel(self, all_files, b4_data, b11_data):
         """Test high level calibration modes for the reader."""
@@ -550,14 +550,14 @@ class TestOLITIRSL1:
         exp_b11 = (b11_data * 0.0003342 + 0.100000)
         exp_b11 = (1201.1442 / np.log((480.8883 / exp_b11) + 1)).astype(np.float32)
         scn = Scene(reader="oli_tirs_l1_tif", filenames=all_files)
-        scn.load(["b04", "b11"])
+        scn.load(["B4", "B11"])
 
-        assert scn["b04"].attrs["units"] == "%"
-        assert scn["b11"].attrs["units"] == "K"
-        assert scn["b04"].attrs["standard_name"] == "toa_bidirectional_reflectance"
-        assert scn["b11"].attrs["standard_name"] == "brightness_temperature"
-        np.testing.assert_allclose(np.array(scn["b04"].values), np.array(exp_b04), rtol=1e-4)
-        np.testing.assert_allclose(scn["b11"].values, exp_b11, rtol=1e-6)
+        assert scn["B4"].attrs["units"] == "%"
+        assert scn["B11"].attrs["units"] == "K"
+        assert scn["B4"].attrs["standard_name"] == "toa_bidirectional_reflectance"
+        assert scn["B11"].attrs["standard_name"] == "brightness_temperature"
+        np.testing.assert_allclose(np.array(scn["B4"].values), np.array(exp_b04), rtol=1e-4)
+        np.testing.assert_allclose(scn["B11"].values, exp_b11, rtol=1e-6)
 
     def test_angles(self, all_files, sza_data):
         """Test calibration modes for the reader."""
@@ -578,28 +578,28 @@ class TestOLITIRSL1:
         from satpy.readers.oli_tirs_l1_tif import OLITIRSMDReader
         mda = OLITIRSMDReader(mda_file, self.filename_info, {})
 
-        cal_test_dict = {"b01": (0.012357, -61.78647, 2e-05, -0.1),
-                         "b05": (0.0060172, -30.08607, 2e-05, -0.1),
-                         "b10": (0.0003342, 0.1, 774.8853, 1321.0789)}
+        cal_test_dict = {"B1": (0.012357, -61.78647, 2e-05, -0.1),
+                         "B5": (0.0060172, -30.08607, 2e-05, -0.1),
+                         "B10": (0.0003342, 0.1, 774.8853, 1321.0789)}
 
         assert mda.platform_name == "Landsat-8"
         assert mda.earth_sun_distance() == 1.0079981
-        assert mda.band_calibration["b01"] == cal_test_dict["b01"]
-        assert mda.band_calibration["b05"] == cal_test_dict["b05"]
-        assert mda.band_calibration["b10"] == cal_test_dict["b10"]
-        assert not mda.band_saturation["b01"]
-        assert mda.band_saturation["b04"]
-        assert not mda.band_saturation["b05"]
+        assert mda.band_calibration["B1"] == cal_test_dict["B1"]
+        assert mda.band_calibration["B5"] == cal_test_dict["B5"]
+        assert mda.band_calibration["B10"] == cal_test_dict["B10"]
+        assert not mda.band_saturation["B1"]
+        assert mda.band_saturation["B4"]
+        assert not mda.band_saturation["B5"]
         with pytest.raises(KeyError):
-            mda.band_saturation["b10"]
+            mda.band_saturation["B10"]
 
     def test_area_def(self, mda_file):
         """Check we can get the area defs properly."""
         from satpy.readers.oli_tirs_l1_tif import OLITIRSMDReader
         mda = OLITIRSMDReader(mda_file, self.filename_info, {})
 
-        standard_area = mda.build_area_def("b01")
-        pan_area = mda.build_area_def("b08")
+        standard_area = mda.build_area_def("B1")
+        pan_area = mda.build_area_def("B8")
 
         assert standard_area.area_extent == (619485.0, 2440485.0, 850515.0, 2675715.0)
         assert pan_area.area_extent == (619492.5, 2440492.5, 850507.5, 2675707.5)


### PR DESCRIPTION
The Landsat reader used different nomenclature for the band names to that used by Pyspectral. This PR updates the reader for compatibility with the pyspectral LUTs.

Note: Only Landsat-8 is supported by pyspectral at present, and the thermal bands are not included. A separate PR for pyspectral will include both thermal and Landsat-9 support.


 - [x] Tests added