### PR TITLE
Fix seviri_l2_grib end_time property bug.

### DIFF
--- a/satpy/readers/eum_l2_grib.py
+++ b/satpy/readers/eum_l2_grib.py
@@ -78,8 +78,12 @@ class EUML2GribFileHandler(BaseFileHandler):
     def end_time(self):
         """Return the sensing end time."""
         if self.sensor == "seviri":
-            delta = SEVIRI_REPEAT_CYCLE_DURATION_RSS if self._ssp_lon == 9.5 else SEVIRI_REPEAT_CYCLE_DURATION
-            return self.start_time + dt.timedelta(minutes=delta)
+            try:
+                delta = SEVIRI_REPEAT_CYCLE_DURATION_RSS if self._ssp_lon == 9.5 else SEVIRI_REPEAT_CYCLE_DURATION
+                return self.start_time + dt.timedelta(minutes=delta)
+            except AttributeError:
+                # If dataset and metadata (ssp_lon) have not yet been loaded, return None
+                return None
         elif self.sensor == "fci":
             return self.filename_info["end_time"]
 

--- a/satpy/tests/reader_tests/test_eum_l2_grib.py
+++ b/satpy/tests/reader_tests/test_eum_l2_grib.py
@@ -133,11 +133,15 @@ def test_seviri_data_reading(da_, xr_, setup_reader):
 
             dataset_id = make_dataid(name="dummmy", resolution=3000)
 
+            # Check that end_time is None for SEVIRI before the dataset has been loaded
+            assert reader.end_time is None
+
             common_checks(ec_, reader, mock_file, dataset_id)
 
-            # Check end_time
+            # Check that end_time is now a valid datetime.datetime object after the dataset has been loaded
             assert reader.end_time == datetime.datetime(year=2020, month=10, day=20,
                                                         hour=19, minute=50, second=0)
+
 
             # Checks the correct execution of the _get_global_attributes and _get_metadata_from_msg functions
             attributes = reader._get_attributes()
@@ -234,11 +238,11 @@ def test_fci_data_reading(da_, xr_, setup_reader):
 
             dataset_id = make_dataid(name="dummmy", resolution=2000)
 
-            common_checks(ec_, reader, mock_file, dataset_id)
-
             # Check end_time
             assert reader.end_time == datetime.datetime(year=2020, month=10, day=20,
                                                         hour=19, minute=50, second=0)
+
+            common_checks(ec_, reader, mock_file, dataset_id)
 
             # Checks the correct execution of the _get_global_attributes and _get_metadata_from_msg functions
             attributes = reader._get_attributes()


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
As described in #2942, the changes in https://github.com/pytroll/satpy/pull/2717 lead to the `end_time` property not working for SEVIRI data, since we now use the sub-satellite point to determine the scanning mode and thus the temporal resolution used to determine the `end_time` from the `start_time` (prior to https://github.com/pytroll/satpy/pull/2717 it was always set to 15 minutes, which is incorrect for RSS data). However, the `self._ssp_lon` attribute is only available after a dataset and its metadata have been loaded and thus an `AttributeError` was raised during `Scene` initialization. This was not covered by the unit test and a human error lead to the bug being unnoticed also when testing with real data.

This PR adapts the `end_time` property to return `None` if no dataset has been loaded, meaning that `_ssp_lon` is not available. As soon as a dataset has been loaded, both `scn.end_time` and `scn[dataset].attrs['end_time']` will have valid and correct `datetime.datetime` objects. The unit test has been adapted to cover this bug.

 - [X] Closes #2942 
 - [X] Tests adapted to capture this bug

