### PR TITLE
Update MODIS L1b reader with additional geoinfo datasets

### DIFF
--- a/satpy/etc/readers/modis_l1b.yaml
+++ b/satpy/etc/readers/modis_l1b.yaml
@@ -486,6 +486,34 @@ datasets:
     coordinates: [longitude, latitude]
     file_type: [hdf_eos_geo, hdf_eos_data_1000m]
 
+  land_sea_mask:
+    name: land_sea_mask
+    sensor: modis
+    resolution: 1000
+    coordinates: [longitude, latitude]
+    file_type: [hdf_eos_geo]
+
+  height:
+    name: height
+    sensor: modis
+    resolution: 1000
+    coordinates: [longitude, latitude]
+    file_type: [hdf_eos_geo]
+
+  range:
+    name: range
+    sensor: modis
+    resolution: 1000
+    coordinates: [longitude, latitude]
+    file_type: [hdf_eos_geo]
+
+  waterpresent:
+    name: waterpresent
+    sensor: modis
+    resolution: 1000
+    coordinates: [longitude, latitude]
+    file_type: [hdf_eos_geo]
+
 
 file_types:
   hdf_eos_data_250m:

--- a/satpy/readers/hdfeos_base.py
+++ b/satpy/readers/hdfeos_base.py
@@ -333,6 +333,10 @@ class HDFEOSGeoReader(HDFEOSBaseFileReader):
         "satellite_zenith_angle": ("SensorZenith", "Sensor_Zenith"),
         "solar_azimuth_angle": ("SolarAzimuth", "SolarAzimuth"),
         "solar_zenith_angle": ("SolarZenith", "Solar_Zenith"),
+        "water_present": "WaterPresent",
+        "land_sea_mask": "Land/SeaMask",
+        "height": "Height",
+        "range": "Range",
     }
 
     def __init__(self, filename, filename_info, filetype_info, **kwargs):


### PR DESCRIPTION
The MODIS L1b reader misses a few useful datasets from the MOD03 files. This PR adds the most commonly used of those datasets:
`land_water_mask`, `height`, `range`, `water_present`.

 - [ ] Tests passing<!-- for all bug fixes or enhancements -->
