### PR TITLE
Fix dtype promotion in `SunZenithReduction`

### DIFF
--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -583,7 +583,7 @@ def _sunzen_reduction_ndarray(data: np.ndarray,
 
     # invert the reduction factor such that minimum reduction is done at `limit` and gradually increases towards max_sza
     with np.errstate(invalid="ignore"):  # we expect space pixels to be invalid
-        reduction_factor = 1. - np.log(reduction_factor + 1) / np.log(2, dtype=data.dtype)
+        reduction_factor = 1. - np.log2(reduction_factor + 1)
 
     # apply non-linearity to the reduction factor for a non-linear reduction of the signal. This can be used for a
     # slower or faster transision to higher/lower fractions at the ndvi extremes. If strength equals 1.0, this

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -572,7 +572,6 @@ def sunzen_reduction(data: da.Array,
     return da.map_blocks(_sunzen_reduction_ndarray, data, sunz, limit, max_sza, strength,
                          meta=np.array((), dtype=data.dtype), chunks=data.chunks)
 
-
 def _sunzen_reduction_ndarray(data: np.ndarray,
                               sunz: np.ndarray,
                               limit: float,
@@ -584,7 +583,7 @@ def _sunzen_reduction_ndarray(data: np.ndarray,
 
     # invert the reduction factor such that minimum reduction is done at `limit` and gradually increases towards max_sza
     with np.errstate(invalid="ignore"):  # we expect space pixels to be invalid
-        reduction_factor = 1. - np.log(reduction_factor + 1) / np.log(2)
+        reduction_factor = 1. - np.log(reduction_factor + 1) / np.log(2, dtype=data.dtype)
 
     # apply non-linearity to the reduction factor for a non-linear reduction of the signal. This can be used for a
     # slower or faster transision to higher/lower fractions at the ndvi extremes. If strength equals 1.0, this

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -202,7 +202,9 @@ class TestSunZenithReducer:
         res = self.default((sunz_ds1.astype(dtype), sunz_sza.astype(dtype)), test_attr="test")
         expected = np.array([[0.02916261, 0.02839063], [0.02949383, 0.02871911]], dtype=dtype)
         assert res.dtype == dtype
-        np.testing.assert_allclose(res.values,
+        values = res.values
+        assert values.dtype == dtype
+        np.testing.assert_allclose(values,
                                    expected,
                                    rtol=2e-5)
 
@@ -212,7 +214,9 @@ class TestSunZenithReducer:
         res = self.custom((sunz_ds1.astype(dtype), sunz_sza.astype(dtype)), test_attr="test")
         expected = np.array([[0.01041319, 0.01030033], [0.01046164, 0.01034834]], dtype=dtype)
         assert res.dtype == dtype
-        np.testing.assert_allclose(res.values,
+        values = res.values
+        assert values.dtype == dtype
+        np.testing.assert_allclose(values,
                                    expected,
                                    rtol=1e-5)
 

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -179,18 +179,24 @@ class TestSunZenithReducer:
         cls.custom = SunZenithReducer(name="sza_reduction_test_custom", modifiers=tuple(),
                                       correction_limit=70, max_sza=95, strength=3.0)
 
-    def test_default_settings(self, sunz_ds1, sunz_sza):
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_default_settings(self, sunz_ds1, sunz_sza, dtype):
         """Test default settings with sza data available."""
-        res = self.default((sunz_ds1, sunz_sza), test_attr="test")
+        res = self.default((sunz_ds1.astype(dtype), sunz_sza.astype(dtype)), test_attr="test")
+        expected = np.array([[0.02916261, 0.02839063], [0.02949383, 0.02871911]], dtype=dtype)
+        assert res.dtype == dtype
         np.testing.assert_allclose(res.values,
-                                   np.array([[0.02916261, 0.02839063], [0.02949383, 0.02871911]]),
-                                   rtol=1e-5)
+                                   expected,
+                                   rtol=2e-5)
 
-    def test_custom_settings(self, sunz_ds1, sunz_sza):
+    @pytest.mark.parametrize("dtype", [np.float32, np.float64])
+    def test_custom_settings(self, sunz_ds1, sunz_sza, dtype):
         """Test custom settings with sza data available."""
-        res = self.custom((sunz_ds1, sunz_sza), test_attr="test")
+        res = self.custom((sunz_ds1.astype(dtype), sunz_sza.astype(dtype)), test_attr="test")
+        expected = np.array([[0.01041319, 0.01030033], [0.01046164, 0.01034834]], dtype=dtype)
+        assert res.dtype == dtype
         np.testing.assert_allclose(res.values,
-                                   np.array([[0.01041319, 0.01030033], [0.01046164, 0.01034834]]),
+                                   expected,
                                    rtol=1e-5)
 
     def test_invalid_max_sza(self, sunz_ds1, sunz_sza):


### PR DESCRIPTION
The `SunZenithReduction` modifier used for example in the built-in FCI `true_color` composite has a division with `np.log(2)` that changes the `float32` input data to `float64`. This PR is a simple fix for that.

The upcasting is hidden behind some other part of the code because even without this fix the completed product was `float32`.

 - [x] Tests added <!-- for all bug fixes or enhancements -->

This small change also reduced the memory usage for my 12-composite set by roughly 800 MB.

With `main`:
![Screenshot 2024-10-24 at 10-01-12 Bokeh Plot](https://github.com/user-attachments/assets/5411f5f1-fa7a-48ca-a658-1e9292d45acc)

With this PR:
![Screenshot 2024-10-24 at 10-01-18 Bokeh Plot](https://github.com/user-attachments/assets/4e6249b9-a28c-4972-9907-823e04fb3d40)
