### PR TITLE
Bugfix the VIIRS lowres version of the day-microphysics.

### DIFF
--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -405,7 +405,7 @@ composites:
     - name: M07
       modifiers: [sunz_corrected]
     - name: M12
-      modifiers: [nir_reflectance]
+      modifiers: [nir_reflectance_lowres]
     - M15
     standard_name: day_microphysics
 


### PR DESCRIPTION
This PR fixes a bug with the VIIRS low-resolution day-microphysics RGB using M-band.

It should use only M-bands! Currently it use the default nir-refelctance dataset, and that will then use the I-bands to try derive this. It should be forced to using the M bands.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
