### PR TITLE
Remove co2_corrected modifier for METimage 3.74 µm

### DIFF
--- a/satpy/etc/composites/vii.yaml
+++ b/satpy/etc/composites/vii.yaml
@@ -87,7 +87,6 @@ composites:
       - compositor: !!python/name:satpy.composites.DifferenceCompositor
         prerequisites:
           - name: 'vii_3740'
-            modifiers: [ co2_corrected ]
           - name: 'vii_10690'
       - compositor: !!python/name:satpy.composites.DifferenceCompositor
         prerequisites:


### PR DESCRIPTION
Remove the co2_corrected modifier for the METimage 3.74 µm channel.  The CO₂ correction was developed specifically for the SEVIRI 3.9 µm channel and should not be applied to channels where the CO₂ impact is different / (mostly) absent.


