### PR TITLE
Modified the issue with the calibration coefficient indices for FY-3 satellite data reader

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -106,3 +106,4 @@ The following people have made contributions to this project:
 - [Sara Hörnquist (shornqui)](https://github.com/shornqui)
 - [Antonio Valentino](https://github.com/avalentino)
 - [Clément (ludwigvonkoopa)](https://github.com/ludwigVonKoopa)
+- [Xuanhan Lai (sgxl)](https://github.com/sgxl)

--- a/satpy/etc/readers/mersi2_l1b.yaml
+++ b/satpy/etc/readers/mersi2_l1b.yaml
@@ -176,7 +176,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 0
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 0
+    calibration_index: 4
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -196,7 +196,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 1
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 1
+    calibration_index: 5
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -216,7 +216,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 2
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 2
+    calibration_index: 6
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -236,7 +236,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 3
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 3
+    calibration_index: 7
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -256,7 +256,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 4
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 4
+    calibration_index: 8
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -276,7 +276,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 5
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 5
+    calibration_index: 9
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -296,7 +296,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 6
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 6
+    calibration_index: 10
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -316,7 +316,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 7
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 7
+    calibration_index: 11
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -336,7 +336,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 8
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 8
+    calibration_index: 12
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -356,7 +356,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 9
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 9
+    calibration_index: 13
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -376,7 +376,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 10
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 10
+    calibration_index: 14
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -396,7 +396,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 11
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 11
+    calibration_index: 15
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -416,7 +416,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 12
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 12
+    calibration_index: 16
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -436,7 +436,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 13
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 13
+    calibration_index: 17
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -456,7 +456,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 14
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 14
+    calibration_index: 18
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -468,6 +468,8 @@ datasets:
       counts:
         units: "1"
         standard_name: counts
+
+  # Not sure how to get radiance for BT channels
   '20':
     name: '20'
     wavelength: [3.710, 3.800, 3.890]
@@ -482,9 +484,6 @@ datasets:
       brightness_temperature:
         units: "K"
         standard_name: toa_brightness_temperature
-      radiance:
-        units: 'mW/ (m2 cm-1 sr)'
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
         standard_name: counts
@@ -502,9 +501,6 @@ datasets:
       brightness_temperature:
         units: "K"
         standard_name: toa_brightness_temperature
-      radiance:
-        units: 'mW/ (m2 cm-1 sr)'
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
         standard_name: counts
@@ -522,9 +518,6 @@ datasets:
       brightness_temperature:
         units: "K"
         standard_name: toa_brightness_temperature
-      radiance:
-        units: 'mW/ (m2 cm-1 sr)'
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
         standard_name: counts
@@ -542,9 +535,6 @@ datasets:
       brightness_temperature:
         units: "K"
         standard_name: toa_brightness_temperature
-      radiance:
-        units: 'mW/ (m2 cm-1 sr)'
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
         standard_name: counts
@@ -568,9 +558,6 @@ datasets:
       brightness_temperature:
         units: "K"
         standard_name: toa_brightness_temperature
-      radiance:
-        units: 'mW/ (m2 cm-1 sr)'
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
         standard_name: counts
@@ -594,9 +581,6 @@ datasets:
       brightness_temperature:
         units: "K"
         standard_name: toa_brightness_temperature
-      radiance:
-        units: 'mW/ (m2 cm-1 sr)'
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
       counts:
         units: "1"
         standard_name: counts

--- a/satpy/etc/readers/mersi3_l1b.yaml
+++ b/satpy/etc/readers/mersi3_l1b.yaml
@@ -164,7 +164,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 0
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 0
+    calibration_index: 4
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -184,7 +184,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 1
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 1
+    calibration_index: 5
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -204,7 +204,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 2
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 2
+    calibration_index: 6
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -224,7 +224,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 3
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 3
+    calibration_index: 7
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -244,7 +244,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 4
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 4
+    calibration_index: 8
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -264,7 +264,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 5
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 5
+    calibration_index: 9
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -284,7 +284,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 6
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 6
+    calibration_index: 10
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -304,7 +304,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 7
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 7
+    calibration_index: 11
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -324,7 +324,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 8
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 8
+    calibration_index: 12
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -344,7 +344,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 9
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 9
+    calibration_index: 13
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -364,7 +364,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 10
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 10
+    calibration_index: 14
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -384,7 +384,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 11
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 11
+    calibration_index: 15
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -404,7 +404,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 12
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 12
+    calibration_index: 16
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -424,7 +424,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 13
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 13
+    calibration_index: 17
     coordinates: [longitude, latitude]
     calibration:
       reflectance:
@@ -444,7 +444,7 @@ datasets:
     file_key: Data/EV_1KM_RefSB
     band_index: 14
     calibration_key: Calibration/VIS_Cal_Coeff
-    calibration_index: 14
+    calibration_index: 18
     coordinates: [longitude, latitude]
     calibration:
       reflectance:


### PR DESCRIPTION
"There were issues with etc/readers/mersi2_l1b.yaml and etc/readers/mersi3_l1b.yaml. Minor code changes have been made:

According to the [MERSI data document](https://img.nsmc.org.cn/PORTAL/NSMC/DATASERVICE/DataFormat/FY3D/FY-3D_L1_Data_Instruction_MERSI-II(1KM).pdf), the 'calibration_index' in Satpy was incorrect. The VIS_Cal_Coeff dataset includes calibration coefficients for both 250m (Data/EV_250_Aggr.1KM_RefSB) and 1km (Data/EV_1KM_RefSB) bands. The calibration coefficients are ordered by band sequence. Previously, the calibration indices for Data/EV_1KM_RefSB started from 0, which is incorrect; they should start after the last index of the 250m visible band.

![image](https://github.com/user-attachments/assets/6033bb2b-c35d-4821-9da0-fd0e301f41d6)

Xuanhan Lai