### PR TITLE
Fix CF writer crashing with netcdf development version

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -528,12 +528,19 @@ class TestNetcdfEncodingKwargs:
             assert f["test-array"].dtype == expected["dtype"]
             assert f["test-array"].encoding["complevel"] == expected["complevel"]
 
-    def test_warning_if_backends_dont_match(self, scene, filename, monkeypatch):
+    @pytest.mark.parametrize(
+        "versions",
+        [
+            {"netCDF4": "1.5.0", "libnetcdf": "4.9.1-development"},
+            {"netCDF4": "1.6.0", "libnetcdf": "invalid-version"}
+        ]
+    )
+    def test_warning_if_backends_dont_match(self, scene, filename, monkeypatch, versions):
         """Test warning if backends don't match."""
         import netCDF4
         with monkeypatch.context() as m:
-            m.setattr(netCDF4, "__version__", "1.5.0")
-            m.setattr(netCDF4, "__netcdf4libversion__", "4.9.1")
+            m.setattr(netCDF4, "__version__", versions["netCDF4"])
+            m.setattr(netCDF4, "__netcdf4libversion__", versions["libnetcdf"])
             with pytest.warns(UserWarning, match=r"Backend version mismatch"):
                 scene.save_datasets(filename=filename, writer="cf")
 
@@ -542,7 +549,7 @@ class TestNetcdfEncodingKwargs:
         import netCDF4
         with monkeypatch.context() as m:
             m.setattr(netCDF4, "__version__", "1.6.0")
-            m.setattr(netCDF4, "__netcdf4libversion__", "4.9.0-development")
+            m.setattr(netCDF4, "__netcdf4libversion__", "4.9.0")
             m.setattr(xr, "__version__", "2022.12.0")
             with warnings.catch_warnings():
                 scene.save_datasets(filename=filename, writer="cf")

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -542,7 +542,7 @@ class TestNetcdfEncodingKwargs:
         import netCDF4
         with monkeypatch.context() as m:
             m.setattr(netCDF4, "__version__", "1.6.0")
-            m.setattr(netCDF4, "__netcdf4libversion__", "4.9.0")
+            m.setattr(netCDF4, "__netcdf4libversion__", "4.9.0-development")
             m.setattr(xr, "__version__", "2022.12.0")
             with warnings.catch_warnings():
                 scene.save_datasets(filename=filename, writer="cf")

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -158,7 +158,7 @@ import warnings
 
 import numpy as np
 import xarray as xr
-from packaging.version import Version
+from packaging.version import InvalidVersion, Version
 
 from satpy.cf.coords import EPOCH  # noqa: F401 (for backward compatibility)
 from satpy.writers import Writer
@@ -390,11 +390,26 @@ def _backend_versions_match():
 
 def _get_backend_versions():
     import netCDF4
-
-    # Make libnetcdf development version compatible with PEP440
-    libnetcdf_version = netCDF4.__netcdf4libversion__.replace("development", "dev")
+    libnetcdf_version = _parse_libnetcdf_version(
+        netCDF4.__netcdf4libversion__
+    )
     return {
         "netCDF4": Version(netCDF4.__version__),
-        "libnetcdf": Version(libnetcdf_version),
+        "libnetcdf": libnetcdf_version,
         "xarray": Version(xr.__version__)
     }
+
+
+def _parse_libnetcdf_version(version_str):
+    # Make libnetcdf development version compatible with PEP440
+    version_str = version_str.replace("development", "dev")
+    try:
+        return Version(version_str)
+    except InvalidVersion:
+        warnings.warn(
+            f"Unable to parse netcdf-c version {version_str}, "
+            f"using 0.0.0 as fallback",
+            UserWarning,
+            stacklevel=3
+        )
+        return Version("0.0.0")

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -390,8 +390,11 @@ def _backend_versions_match():
 
 def _get_backend_versions():
     import netCDF4
+
+    # Make libnetcdf development version compatible with PEP440
+    libnetcdf_version = netCDF4.__netcdf4libversion__.replace("development", "dev")
     return {
         "netCDF4": Version(netCDF4.__version__),
-        "libnetcdf": Version(netCDF4.__netcdf4libversion__),
+        "libnetcdf": Version(libnetcdf_version),
         "xarray": Version(xr.__version__)
     }


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Fix CF writer crashing with netcdf development version. I'm not so happy with the string replacement, but it's the best I came up with. Alternatives:

- `LooseVersion` from distutils, but that's deprecated and not comparable with `packaging.version.Version`
- Report the issue upstream. But I don't think there's a big chance for success. The netcdf-C library probably won't care about PEP440 and the netCDF4 Python module will probably want to keep the original value.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Closes #2960 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [X] Tests added <!-- for all bug fixes or enhancements -->

