### PR TITLE
Fix MODIS readers chunking compatibility with newer dask

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
           activate-environment: test-environment
           channels: conda-forge
+          conda-remove-defaults: true
+          channel-priority: strict
 
       - name: Set cache environment variables
         shell: bash -l {0}

--- a/satpy/readers/hdfeos_base.py
+++ b/satpy/readers/hdfeos_base.py
@@ -238,7 +238,7 @@ class HDFEOSBaseFileReader(BaseFileHandler):
         return normalize_low_res_chunks(
             (1,) * num_nonyx_dims + ("auto", -1),
             var_shape,
-            (1,) * num_nonyx_dims + (scan_length_250m, -1),
+            (1,) * num_nonyx_dims + (scan_length_250m, var_shape[-1]),
             (1,) * num_nonyx_dims + (res_multiplier, res_multiplier),
             np.float32,
         )


### PR DESCRIPTION
Triggered by changes in dask (see https://github.com/dask/dask/issues/11341), but I think the main issue is that I was specifying `previous_chunks` with `-1` which I can understand would be confusing if dask assumes "yeah this is what the chunks are now".

This should fix unstable tests related to MODIS readers.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
