### PR TITLE
Remove unneeded call to private scipy function in SAR reader

### DIFF
--- a/satpy/readers/sar_c_safe.py
+++ b/satpy/readers/sar_c_safe.py
@@ -511,15 +511,14 @@ def intp(grid_x, grid_y, interpolator):
 
 def interpolate_xarray_linear(xpoints, ypoints, values, shape, chunks=CHUNK_SIZE):
     """Interpolate linearly, generating a dask array."""
-    from scipy.interpolate.interpnd import LinearNDInterpolator, _ndim_coords_from_arrays
+    from scipy.interpolate.interpnd import LinearNDInterpolator
 
     if isinstance(chunks, (list, tuple)):
         vchunks, hchunks = chunks
     else:
         vchunks, hchunks = chunks, chunks
-
-    points = _ndim_coords_from_arrays(np.vstack((np.asarray(ypoints, dtype=np.uint16),
-                                                 np.asarray(xpoints, dtype=np.uint16))).T)
+    points = np.vstack((np.asarray(ypoints, dtype=np.uint16),
+                        np.asarray(xpoints, dtype=np.uint16))).T
 
     interpolator = LinearNDInterpolator(points, values)
 


### PR DESCRIPTION
This PR removes an unneeded call (!) from a private (!) scipy function in the SAR reader. Said function has moreover been removed from newer scipy, making the experimental ci jobs crash.
