### PR TITLE
Fix geos proj parameters for Insat 3d satellites

### DIFF
--- a/satpy/readers/insat3d_img_l1b_h5.py
+++ b/satpy/readers/insat3d_img_l1b_h5.py
@@ -179,7 +179,10 @@ class Insat3DIMGL1BH5FileHandler(BaseFileHandler):
         #fov = self.datatree.attrs["Field_of_View(degrees)"]
         fov = 18
         cfac = 2 ** 16 / (fov / cols)
-        lfac = 2 ** 16 / (fov / lines)
+
+        # From reverse engineering metadata from a netcdf file, we discovered
+        # the lfac is actually the same as cfac, ie dependend on cols, not lines!
+        lfac = 2 ** 16 / (fov / cols)
 
         h = self.datatree.attrs["Observed_Altitude(km)"] * 1000
         # WGS 84

--- a/satpy/readers/insat3d_img_l1b_h5.py
+++ b/satpy/readers/insat3d_img_l1b_h5.py
@@ -181,7 +181,7 @@ class Insat3DIMGL1BH5FileHandler(BaseFileHandler):
         cfac = 2 ** 16 / (fov / cols)
 
         # From reverse engineering metadata from a netcdf file, we discovered
-        # the lfac is actually the same as cfac, ie dependend on cols, not lines!
+        # the lfac is actually the same as cfac, ie dependent on cols, not lines!
         lfac = 2 ** 16 / (fov / cols)
 
         h = self.datatree.attrs["Observed_Altitude(km)"] * 1000

--- a/satpy/readers/insat3d_img_l1b_h5.py
+++ b/satpy/readers/insat3d_img_l1b_h5.py
@@ -194,8 +194,8 @@ class Insat3DIMGL1BH5FileHandler(BaseFileHandler):
         pdict = {
             "cfac": cfac,
             "lfac": lfac,
-            "coff": cols / 2,
-            "loff": lines / 2,
+            "coff": cols // 2 + 1,
+            "loff": lines // 2,
             "ncols": cols,
             "nlines": lines,
             "scandir": "N2S",

--- a/satpy/tests/reader_tests/test_insat3d_img_l1b_h5.py
+++ b/satpy/tests/reader_tests/test_insat3d_img_l1b_h5.py
@@ -280,8 +280,8 @@ def test_filehandler_returns_area(insat_filehandler):
     area_def = fh.get_area_def(ds_id)
     _ = area_def.get_lonlats(chunks=1000)
     assert subsatellite_longitude == area_def.crs.to_cf()["longitude_of_projection_origin"]
-    np.testing.assert_allclose(area_def.area_extent, [-5618068.510660236, -5640108.009097205,
-                                                      5622075.692194229, 5644115.1906312])
+    np.testing.assert_allclose(area_def.area_extent, [-5620072.101427, -5640108.009097,
+                                                      5620072.101427, 5644115.190631])
 
 
 def test_filehandler_has_start_and_end_time(insat_filehandler):

--- a/satpy/tests/reader_tests/test_insat3d_img_l1b_h5.py
+++ b/satpy/tests/reader_tests/test_insat3d_img_l1b_h5.py
@@ -280,6 +280,8 @@ def test_filehandler_returns_area(insat_filehandler):
     area_def = fh.get_area_def(ds_id)
     _ = area_def.get_lonlats(chunks=1000)
     assert subsatellite_longitude == area_def.crs.to_cf()["longitude_of_projection_origin"]
+    np.testing.assert_allclose(area_def.area_extent, [-5618068.510660236, -5640108.009097205,
+                                                      5622075.692194229, 5644115.1906312])
 
 
 def test_filehandler_has_start_and_end_time(insat_filehandler):


### PR DESCRIPTION
This PR fixes the `lfac` parameter for the area computation of the Insat 3d satellites.

 - [x] Tests added <!-- for all bug fixes or enhancements -->

