### PR TITLE
Remove attempt to Rayleigh correct the VIIRS I02 band 

### DIFF
--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -232,7 +232,7 @@ composites:
       modifiers: [sunz_corrected, rayleigh_corrected]
     optional_prerequisites:
     - name: I02
-      modifiers: [sunz_corrected_iband, rayleigh_corrected_iband]
+      modifiers: [sunz_corrected_iband]
     standard_name: false_color
     high_resolution_band: green
 


### PR DESCRIPTION
Remove attempt to Rayleigh correct the VIIRS I02 band for the false-color RGB. The band is beyond 0.8 micron and there is effectively no rayleigh scattering in this band. Pyspectral cannot correct this anyhow.

We get warning messages in our production, like this:
`WARNING  pyspectral.rayleigh] Effective wavelength for band I02 outside nominal 400-800 nm range!`


 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
