### PR TITLE
Remove the application of Rayleigh correction above 0.8 micron on the Geo sats

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -36,7 +36,7 @@ composites:
       - name: C02
         modifiers: [sunz_corrected, rayleigh_corrected_crefl]
       - name: C03
-        modifiers: [sunz_corrected, rayleigh_corrected_crefl]
+        modifiers: [sunz_corrected]
     standard_name: toa_bidirectional_reflectance
 
   green_raw:
@@ -710,7 +710,7 @@ composites:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
       - name: C03
-        modifiers: [sunz_corrected, rayleigh_corrected]
+        modifiers: [sunz_corrected]
       - name: C02
         modifiers: [sunz_corrected, rayleigh_corrected]
       - name: green

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -218,7 +218,7 @@ composites:
     - wavelength: 0.85
       modifiers: [sunz_corrected]
     - wavelength: 0.635
-      modifiers: [sunz_corrected, rayleigh_corrected]
+      modifiers: [sunz_corrected]
     high_resolution_band: blue
     standard_name: natural_color
 

--- a/satpy/etc/composites/ahi.yaml
+++ b/satpy/etc/composites/ahi.yaml
@@ -214,11 +214,11 @@ composites:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
     - wavelength: 1.63
-      modifiers: [sunz_corrected] #, rayleigh_corrected]
+      modifiers: [sunz_corrected]
     - wavelength: 0.85
-      modifiers: [sunz_corrected] #, rayleigh_corrected]
+      modifiers: [sunz_corrected]
     - wavelength: 0.635
-      modifiers: [sunz_corrected] #, rayleigh_corrected]
+      modifiers: [sunz_corrected, rayleigh_corrected]
     high_resolution_band: blue
     standard_name: natural_color
 
@@ -302,34 +302,6 @@ composites:
       - name: reproduced_green_uncorr
       - name: B01
     standard_name: true_color_reproduction_color_stretch
-
-#  true_color_reducedsize_land:
-#    compositor: !!python/name:satpy.composites.GenericCompositor
-#    prerequisites:
-#    - wavelength: 0.65
-#      modifiers: [reducer4, effective_solar_pathlength_corrected,
-#                  rayleigh_corrected_reducedsize_land]
-#    - wavelength: 0.51
-#      modifiers: [reducer2, vegetation_corrected_reduced, effective_solar_pathlength_corrected,
-#                  rayleigh_corrected_reducedsize_land]
-#    - wavelength: 0.46
-#      modifiers: [reducer2, effective_solar_pathlength_corrected,
-#                  rayleigh_corrected_reducedsize_land]
-#    standard_name: true_color
-#
-#  true_color_reducedsize_marine_tropical:
-#    compositor: !!python/name:satpy.composites.GenericCompositor
-#    prerequisites:
-#    - wavelength: 0.65
-#      modifiers: [reducer4, effective_solar_pathlength_corrected,
-#                  rayleigh_corrected_reducedsize_marine_tropical]
-#    - wavelength: 0.51
-#      modifiers: [reducer2, vegetation_corrected_reduced, effective_solar_pathlength_corrected,
-#                  rayleigh_corrected_reducedsize_marine_tropical]
-#    - wavelength: 0.46
-#      modifiers: [reducer2, effective_solar_pathlength_corrected,
-#                  rayleigh_corrected_reducedsize_marine_tropical]
-#    standard_name: true_color
 
   day_microphysics_eum:
     compositor: !!python/name:satpy.composites.GenericCompositor

--- a/satpy/etc/composites/ami.yaml
+++ b/satpy/etc/composites/ami.yaml
@@ -137,11 +137,11 @@ composites:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB
     prerequisites:
       - name: NR016
-        modifiers: [sunz_corrected] #, rayleigh_corrected]
+        modifiers: [sunz_corrected]
       - name: VI008
-        modifiers: [sunz_corrected] #, rayleigh_corrected]
+        modifiers: [sunz_corrected]
       - name: VI006
-        modifiers: [sunz_corrected] #, rayleigh_corrected]
+        modifiers: [sunz_corrected, rayleigh_corrected]
     high_resolution_band: blue
     standard_name: natural_color
 

--- a/satpy/etc/composites/ami.yaml
+++ b/satpy/etc/composites/ami.yaml
@@ -141,7 +141,7 @@ composites:
       - name: VI008
         modifiers: [sunz_corrected]
       - name: VI006
-        modifiers: [sunz_corrected, rayleigh_corrected]
+        modifiers: [sunz_corrected]
     high_resolution_band: blue
     standard_name: natural_color
 


### PR DESCRIPTION
This PR removes the attempt to apply Rayleigh correction above 0.8 micron on the Geo sats, where it has no effect anyhow.

It also adds back the rayleigh correction at two places, both for the natual-color RGB on ABI and AHI, where it was commented out - don't know for what reason it was taken away? Maybe that needs clarification?

This PR is similar to #2970 - that did the same for VIIRS

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
