### PR TITLE
Add new ABI L2 "CPS" variable name for Cloud Particle Size

### DIFF
--- a/satpy/etc/readers/abi_l2_nc.yaml
+++ b/satpy/etc/readers/abi_l2_nc.yaml
@@ -211,6 +211,10 @@ datasets:
     name: PSDN
     file_type: abi_l2_cpsn
     file_key: PSD
+  cloud_particle_size_new:
+    name: CPS
+    file_type: abi_l2_cps
+    file_key: CPS
 
 # --- Cloud Top Pressure ---
   cloud_top_pressure:

--- a/satpy/etc/readers/abi_l2_nc.yaml
+++ b/satpy/etc/readers/abi_l2_nc.yaml
@@ -211,6 +211,8 @@ datasets:
     name: PSDN
     file_type: abi_l2_cpsn
     file_key: PSD
+
+  # new variable name since 18:51UTC December 04, 2023.
   cloud_particle_size_new:
     name: CPS
     file_type: abi_l2_cps


### PR DESCRIPTION
NOAA has changed the variable name of `cloud particle size` from `PSD` to `CPS` in the  GOES-R ABI l2 `OR_ABI-L2-CPS*` product files since 18:51UTC December 04, 2023.   
source: [GOES-16 and GOES-18 Software Build PR.13.01.00 Implementation](https://www.ospo.noaa.gov/data/messages/2023/12/MSG_20231204_1914.html)

> Dec04, 2023
>Update 4: Due to the ongoing anomaly causing an outage of all GOES-16 and GOES-18 ABI products going to PDA, a change in product generation strings has taken place. This change caused the PR.13.01.00 build to go live immediately upon the switch, or around 1851 UTC this afternoon rather than tomorrow at the previously listed times. 

>Update data variable name in Cloud Particle Size product - Up to now, the Cloud Particle Size product produced by the Cloud Optical and Microphysical Properties (COMP) algorithm, has incorrectly listed its primary variable as “Particle Size Distribution” (PSD). This is being updated in this release to properly refer to the product as “Cloud Particle Size” (CPS), which will also make it consistent with its output filename (i.e. OR_ABI-L2-CPS*).   


From NOAA's GOES-R open data on AWS, the first product files with new variable name are:
GOES-16 Meso1	:
`OR_ABI-L2-CPSM1-M6_G16_s20233381851251_e20233381851308_c20233381852188.nc`
GOES-16 Meso2 : 
`OR_ABI-L2-CPSM2-M6_G16_s20233381851551_e20233381852007_c20233381852465.nc`
GOES-16 CONUS :
`OR_ABI-L2-CPSC-M6_G16_s20233381851172_e20233381853545_c20233381857105.nc`
GOES-16 FULLDISK :
`OR_ABI-L2-CPSF-M6_G16_s20233381900205_e20233381909513_c20233381915549.nc`   

GOES-18 Meso1 : 
`OR_ABI-L2-CPSM1-M6_G18_s20233381852260_e20233381852317_c20233381853212.nc`
GOES-18 Meso2 : 
`OR_ABI-L2-CPSM2-M6_G18_s20233381851560_e20233381852017_c20233381853198.nc`
GOES-18 PACUS : 
`OR_ABI-L2-CPSC-M6_G18_s20233381856181_e20233381858554_c20233381901548.nc`
GOES-18 FULLDISK : 
`OR_ABI-L2-CPSF-M6_G16_s20233381900205_e20233381909513_c20233381915549.nc`

This PR add the new variable name `CPS` into the config file of abi_l2_nc reader, so that it can read `CPS` variable from `OR_ABI-L2-CPS*` L2 product files.   
Configuration fro `PSD` variable has not been changed to ensure backward compatibility.       
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

