### PR TITLE
update oci l2 BGC file pattern, make netCDF version optional in the file ext format

### DIFF
--- a/satpy/etc/readers/oci_l2_bgc.yaml
+++ b/satpy/etc/readers/oci_l2_bgc.yaml
@@ -12,7 +12,7 @@ file_types:
   bgc_nc:
     file_patterns:
     # Example: PACE_OCI.20240907T191809.L2.OC_BGC.V2_0.NRT.nc4
-      - '{platform:s}_{sensor:s}.{start_time:%Y%m%dT%H%M%S}.L2.OC_BGC.V{sw_version:s}.{processing_type:s}nc4'
+      - '{platform:s}_{sensor:s}.{start_time:%Y%m%dT%H%M%S}.L2.OC_BGC.V{sw_version:s}.{processing_type:s}nc{nc_version}'
     file_reader: !!python/name:satpy.readers.seadas_l2.SEADASL2NetCDFFileHandler
     geo_resolution: 1000
 


### PR DESCRIPTION
When I test the PACE OCI L2 BGC reader, I have found the file extension of the data product files I have downloaded from NASA Earthdata is `.nc` instead `.nc4` as the file pattern definition in the oci_l2_bgc reader.    
This PR make the netCDF version in the file pattern optional in the config file to deal with this scenario.   

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
