### PR TITLE
Remove version limit on pytest in CI

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -43,7 +43,7 @@ dependencies:
   - python-eccodes
   # 2.19.1 seems to cause library linking issues
   - eccodes>=2.20
-  - pytest<8.0.0
+  - pytest
   - pytest-cov
   - fsspec
   - botocore>=1.33

--- a/satpy/tests/modifier_tests/test_parallax.py
+++ b/satpy/tests/modifier_tests/test_parallax.py
@@ -18,6 +18,7 @@ import logging
 import math
 import os
 import unittest.mock
+import warnings
 
 import dask.array as da
 import dask.config
@@ -368,13 +369,13 @@ class TestParallaxCorrectionClass:
             resolution=res2,
             area_extent=[-1, -1, 1, 1])
 
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             sc = make_fake_scene(
                     {"CTH_clear": np.full(area1.shape, np.nan)},
                     daskify=False,
                     area=area1,
                     common_attrs=_get_attrs(0, 0, 35_000))
-        assert len(record) == 0
 
         corrector = ParallaxCorrection(area2)
         new_area = corrector(sc["CTH_clear"])


### PR DESCRIPTION
This was added due to pytest-lazy-fixture but the replacement package pytest-lazy-fixtures fixes compatibility.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
