### PR TITLE
Drop dependency on xarray-datatree

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -106,6 +106,5 @@ The following people have made contributions to this project:
 - [Clement Laplace (ClementLaplace)](https://github.com/ClementLaplace)
 - [Will Sharpe (wjsharpe)](https://github.com/wjsharpe)
 - [Sara Hörnquist (shornqui)](https://github.com/shornqui)
-- [Antonio Valentino](https://github.com/avalentino)
 - [Clément (ludwigvonkoopa)](https://github.com/ludwigVonKoopa)
 - [Xuanhan Lai (sgxl)](https://github.com/sgxl)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ seviri_l2_bufr = ["eccodes"]
 seviri_l2_grib = ["eccodes"]
 hsaf_grib = ["pygrib"]
 remote_reading = ["fsspec"]
-insat_3d = ["xarray-datatree"]
+insat_3d = ["xarray>=2024.10.0"]
 gms5-vissr_l1b = ["numba"]
 # Writers:
 cf = ["h5netcdf >= 0.7.3"]
@@ -87,7 +87,7 @@ satpos_from_tle = ["skyfield", "astropy"]
 tests = ["behave", "h5py", "netCDF4", "pyhdf", "imageio",
          "rasterio", "geoviews", "trollimage", "fsspec", "bottleneck",
          "rioxarray", "pytest", "pytest-lazy-fixtures", "defusedxml",
-         "s3fs", "eccodes", "h5netcdf", "xarray-datatree",
+         "s3fs", "eccodes", "h5netcdf", "xarray>=2024.10.0",
          "skyfield", "ephem", "pint-xarray", "astropy", "dask-image", "python-geotiepoints", "numba"]
 dev = ["satpy[doc,tests]"]
 


### PR DESCRIPTION
DataTree is now part of the xarray since v2024.10.0. An explicit dependency on the externap package
xarray-datatree is no lionger needed.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Add your name to `AUTHORS.md` if not there already
