### PR TITLE
Remove leading white space in flag_meanings entry in fci_l2_nc.yaml

### DIFF
--- a/satpy/etc/readers/fci_l2_nc.yaml
+++ b/satpy/etc/readers/fci_l2_nc.yaml
@@ -1129,7 +1129,7 @@ datasets:
     nc_key: cloud_mask_test_result
     extract_byte: 0
     flag_values: [0,1]
-    flag_meanings: ['No snow/ice detected',' Snow/ice detected']
+    flag_meanings: ['No snow/ice detected','Snow/ice detected']
 
   cloud_test_cmt1:
     name: cloud_test_cmt1


### PR DESCRIPTION
This PR removes a trailing white space in one of the flag_meanings entries for one of the EUM-internal datasets (cloud mask test results) in the `fci_l2_nc` reader.
