### PR TITLE
DOC: Clarify satpy.yaml use with nested dictionaries

### DIFF
--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -51,7 +51,11 @@ value. For example:
 
     cache_dir: "/tmp"
     data_dir: "/tmp"
+    readers:
+      clip_negative_radiances: True
 
+Note that a dotted configuration key (such as ``readers.clip_negative_radiances``)
+should be written into ``satpy.yaml`` as a nested dictionary, such as in the example above.
 Lastly, it is possible to specify an additional config path to the above
 options by setting the environment variable ``SATPY_CONFIG``. The file
 specified with this environment variable will be added last after all of the


### PR DESCRIPTION
In the satpy config documentation, clarify how dotted keys such as `readers.clip_negative_radiances` should be configured in `satpy.yaml`.

 - [x] Fully documented
