### PR TITLE
Fix MWR Polarisation

### DIFF
--- a/satpy/etc/readers/aws1_mwr_l1b_nc.yaml
+++ b/satpy/etc/readers/aws1_mwr_l1b_nc.yaml
@@ -57,7 +57,7 @@ datasets:
            central: 50.3
            bandwidth: 0.180
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -72,7 +72,7 @@ datasets:
            central: 52.8
            bandwidth: 0.400
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -87,7 +87,7 @@ datasets:
            central: 53.246
            bandwidth: 0.300
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -102,7 +102,7 @@ datasets:
            central: 53.596
            bandwidth: 0.370
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -117,7 +117,7 @@ datasets:
            central: 54.4
            bandwidth: 0.400
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -132,7 +132,7 @@ datasets:
            central: 54.94
            bandwidth: 0.400
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -147,7 +147,7 @@ datasets:
            central: 55.5
            bandwidth: 0.330
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -162,7 +162,7 @@ datasets:
            central: 57.290344
            bandwidth: 0.330
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -190,9 +190,9 @@ datasets:
         name: '10'
         frequency_range:
            central: 165.5
-           bandwidth: 2.700
+           bandwidth: 2.800
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 20000
         calibration:
           brightness_temperature:

--- a/satpy/etc/readers/aws1_mwr_l1c_nc.yaml
+++ b/satpy/etc/readers/aws1_mwr_l1c_nc.yaml
@@ -45,7 +45,7 @@ datasets:
            central: 50.3
            bandwidth: 0.180
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -59,7 +59,7 @@ datasets:
            central: 52.8
            bandwidth: 0.400
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -73,7 +73,7 @@ datasets:
            central: 53.246
            bandwidth: 0.300
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -87,7 +87,7 @@ datasets:
            central: 53.596
            bandwidth: 0.370
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -101,7 +101,7 @@ datasets:
            central: 54.4
            bandwidth: 0.400
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -115,7 +115,7 @@ datasets:
            central: 54.94
            bandwidth: 0.400
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -129,7 +129,7 @@ datasets:
            central: 55.5
            bandwidth: 0.330
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -143,7 +143,7 @@ datasets:
            central: 57.290344
            bandwidth: 0.330
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -169,9 +169,9 @@ datasets:
         name: '10'
         frequency_range:
            central: 165.5
-           bandwidth: 2.700
+           bandwidth: 2.800
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 20000
         calibration:
           brightness_temperature:

--- a/satpy/etc/readers/eps_sterna_mwr_l1b_nc.yaml
+++ b/satpy/etc/readers/eps_sterna_mwr_l1b_nc.yaml
@@ -57,7 +57,7 @@ datasets:
            central: 50.3
            bandwidth: 0.180
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -72,7 +72,7 @@ datasets:
            central: 52.8
            bandwidth: 0.400
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -87,7 +87,7 @@ datasets:
            central: 53.246
            bandwidth: 0.300
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -102,7 +102,7 @@ datasets:
            central: 53.596
            bandwidth: 0.370
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -117,7 +117,7 @@ datasets:
            central: 54.4
            bandwidth: 0.400
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -132,7 +132,7 @@ datasets:
            central: 54.94
            bandwidth: 0.400
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -147,7 +147,7 @@ datasets:
            central: 55.5
            bandwidth: 0.330
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -162,7 +162,7 @@ datasets:
            central: 57.290344
            bandwidth: 0.330
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 40000
         calibration:
           brightness_temperature:
@@ -190,9 +190,9 @@ datasets:
         name: '10'
         frequency_range:
            central: 165.5
-           bandwidth: 2.700
+           bandwidth: 2.800
            unit: GHz
-        polarization: 'QH'
+        polarization: 'QV'
         resolution: 20000
         calibration:
           brightness_temperature:


### PR DESCRIPTION
I noticed the readers for MWR on AWS (Arctic Weather Satellite) - L1B and L1C and EPS-Sterna (L1B) had the polarisation of several channels and bandwidth of 1 channel inaccurately described in the yaml files (it should be QV for all channels). 
- Changed all channels to polarisation: QV (some were listed as QH)
- Changed channel 10 bandwidth to 2800 (was 2700)
- values now match those given in OSCAR: https://space.oscar.wmo.int/instruments/view/mwr_aws, https://space.oscar.wmo.int/instruments/view/mwr_sterna

I have attempted this with much helpful support on the Satpy Stack channel: https://pytroll.slack.com/archives/C0LNH7LMB/p1738314449874509

- I have not tested this, but the changes are trivial
- This is my first PR - feedback is welcome!