### PR TITLE
Change sensor attribute to lowercase in FCI L2 NetCDF reader

### DIFF
--- a/doc/source/reading.rst
+++ b/doc/source/reading.rst
@@ -300,6 +300,9 @@ time etc. The following attributes are standardized across all readers:
   :class:`~pyresample.geometry.SwathDefinition` if data is geolocated. Areas are used for gridded
   projected data and Swaths when data must be described by individual longitude/latitude
   coordinates. See the Coordinates section below.
+* ``sensor``: The name of the sensor that recorded the data. For full support through Satpy this
+  should be all lowercase. If the dataset is the result of observations from multiple sensors a
+  ``set`` object can be used to specify more than one sensor name.
 * ``reader``: The name of the Satpy reader that produced the dataset.
 * ``orbital_parameters``: Dictionary of orbital parameters describing the satellite's position.
   See the :ref:`orbital_parameters` section below for more information.

--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -48,7 +48,7 @@ class FciL2CommonFunctions(object):
     @property
     def sensor_name(self):
         """Return instrument name."""
-        return self.nc.attrs["data_source"]
+        return self.nc.attrs["data_source"].lower()
 
     @property
     def ssp_lon(self):

--- a/satpy/tests/reader_tests/test_fci_l2_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l2_nc.py
@@ -68,8 +68,8 @@ class TestFciL2NCFileHandler(unittest.TestCase):
             nc.createDimension("maximum_number_of_layers", 2)
 
             # add global attributes
-            nc.data_source = "test_data_source"
-            nc.platform = "test_platform"
+            nc.data_source = "TEST_DATA_SOURCE"
+            nc.platform = "TEST_PLATFORM"
 
             # Add datasets
             x = nc.createVariable("x", np.float32, dimensions=("number_of_columns",))
@@ -121,17 +121,17 @@ class TestFciL2NCFileHandler(unittest.TestCase):
 
     def test_all_basic(self):
         """Test all basic functionalities."""
-        assert self.fh.spacecraft_name == "test_platform"
+        assert self.fh.spacecraft_name == "TEST_PLATFORM"
         assert self.fh.sensor_name == "test_data_source"
         assert self.fh.ssp_lon == 0.0
 
         global_attributes = self.fh._get_global_attributes()
         expected_global_attributes = {
             "filename": self.test_file,
-            "spacecraft_name": "test_platform",
+            "spacecraft_name": "TEST_PLATFORM",
             "ssp_lon": 0.0,
             "sensor": "test_data_source",
-            "platform_name": "test_platform"
+            "platform_name": "TEST_PLATFORM"
         }
         assert global_attributes == expected_global_attributes
 
@@ -184,7 +184,7 @@ class TestFciL2NCFileHandler(unittest.TestCase):
                                        "fill_value": -999,
                                        "file_type": "test_file_type"})
         np.testing.assert_allclose(dataset.values, 2 * np.ones((100, 10)))
-        assert dataset.attrs["spacecraft_name"] == "test_platform"
+        assert dataset.attrs["spacecraft_name"] == "TEST_PLATFORM"
 
     def test_dataset_with_invalid_filekey(self):
         """Test the correct execution of the get_dataset function with an invalid nc_key."""
@@ -283,8 +283,8 @@ class TestFciL2NCSegmentFileHandler(unittest.TestCase):
             nc.createDimension("number_of_categories", 6)
 
             # add global attributes
-            nc.data_source = "test_fci_data_source"
-            nc.platform = "test_fci_platform"
+            nc.data_source = "TEST_FCI_DATA_SOURCE"
+            nc.platform = "TEST_FCI_PLATFORM"
 
             # Add datasets
             x = nc.createVariable("x", np.float32, dimensions=("number_of_FoR_cols",))
@@ -326,7 +326,7 @@ class TestFciL2NCSegmentFileHandler(unittest.TestCase):
         """Test all basic functionalities."""
         self.fh = FciL2NCSegmentFileHandler(filename=self.seg_test_file, filename_info={}, filetype_info={})
 
-        assert self.fh.spacecraft_name == "test_fci_platform"
+        assert self.fh.spacecraft_name == "TEST_FCI_PLATFORM"
         assert self.fh.sensor_name == "test_fci_data_source"
         assert self.fh.ssp_lon == 0.0
 
@@ -334,10 +334,10 @@ class TestFciL2NCSegmentFileHandler(unittest.TestCase):
 
         expected_global_attributes = {
             "filename": self.seg_test_file,
-            "spacecraft_name": "test_fci_platform",
+            "spacecraft_name": "TEST_FCI_PLATFORM",
             "ssp_lon": 0.0,
             "sensor": "test_fci_data_source",
-            "platform_name": "test_fci_platform"
+            "platform_name": "TEST_FCI_PLATFORM"
         }
         assert global_attributes == expected_global_attributes
 
@@ -498,8 +498,8 @@ class TestFciL2NCReadingByteData(unittest.TestCase):
             nc_byte.createDimension("number_of_rows", 1)
 
             # add global attributes
-            nc_byte.data_source = "test_data_source"
-            nc_byte.platform = "test_platform"
+            nc_byte.data_source = "TEST_DATA_SOURCE"
+            nc_byte.platform = "TEST_PLATFORM"
 
             # Add datasets
             x = nc_byte.createVariable("x", np.float32, dimensions=("number_of_columns",))
@@ -571,8 +571,8 @@ def amv_file(tmp_path_factory):
         nc.createDimension("number_of_winds", 50000)
 
         # add global attributes
-        nc.data_source = "test_data_source"
-        nc.platform = "test_platform"
+        nc.data_source = "TEST_DATA_SOURCE"
+        nc.platform = "TEST_PLATFORM"
 
         # Add datasets
         latitude = nc.createVariable("latitude", np.float32, dimensions=("number_of_winds",))
@@ -612,16 +612,16 @@ class TestFciL2NCAMVFileHandler:
 
     def test_all_basic(self, amv_filehandler, amv_file):
         """Test all basic functionalities."""
-        assert amv_filehandler.spacecraft_name == "test_platform"
+        assert amv_filehandler.spacecraft_name == "TEST_PLATFORM"
         assert amv_filehandler.sensor_name == "test_data_source"
         assert amv_filehandler.ssp_lon == 0.0
 
         global_attributes = amv_filehandler._get_global_attributes(product_type="amv")
         expected_global_attributes = {
             "filename": amv_file,
-            "spacecraft_name": "test_platform",
+            "spacecraft_name": "TEST_PLATFORM",
             "sensor": "test_data_source",
-            "platform_name": "test_platform",
+            "platform_name": "TEST_PLATFORM",
             "channel": "test_channel",
             "ssp_lon": 0.0,
         }


### PR DESCRIPTION
Following a discussion on slack (https://pytroll.slack.com/archives/CK9TPLCG0/p1737127470400239 and https://pytroll.slack.com/archives/C0LNH7LMB/p1737561433643359), this PR changes the `sensor` name dataset attribute in the FCI L2 NetCDF reader (`fci_l2_nc`) from uppercase to lowercase. This is needed in order to identify instrument specific composites and enhancements. I also modified the tests to mimic the real files where there sensor and platform information are stored in uppercase in the file metadata, such that we can also check that the `sensor` attribute is still returned with lowercase.

As discussed on slack, it could be worthwhile updating the documentation as well. However, I'm a bit confused and therefore not sure what and how to update. In the documentation for adding custom readers (https://satpy.readthedocs.io/en/v0.53.0/dev_guide/custom_reader.html) it says that the sensor(s) listed in the yaml file, "must be all lowercase letters for full support throughout in Satpy". However, this was already the case before the PR:

```
reader:
  name: fci_l2_nc
  short_name: FCI L2 NetCDF4
  long_name: MTG FCI L2 data in netCDF4 format
  description: Reader for EUMETSAT MTG FCI L2 files in NetCDF4 format.
  status: Alpha
  supports_fsspec: false
  sensors: [fci]
  reader: !!python/name:satpy.readers.yaml_reader.GEOFlippableFileYAMLReader
```

Hence, it seems like this is not enough and that the `sensor` attribute of the dataset also has to be in lowercase, which is not mentioned here: https://satpy.readthedocs.io/en/stable/reading.html#dataset-metadata (`sensor` is not even listed as mandatory metadata/attribute). Hence, my question is whether there is any link between the sensor(s) listed in the yaml file and the sensor attribute added as metadata to a dataset? To me it seems like it's not the case, and if so we might want to add a note under the dataset metadata (https://satpy.readthedocs.io/en/stable/reading.html#dataset-metadata), similar to what we have for the reader yaml-file, e.g. something like this:

"`sensor` - name of the sensor. For full support throughout in Satpy this must be all lowercase letters."


 - [X] Tests adapted
 - [ ] Fully documented 
