### PR TITLE
Add VolcanicAsh product to VIIRS EDR reader

### DIFF
--- a/satpy/etc/readers/viirs_edr.yaml
+++ b/satpy/etc/readers/viirs_edr.yaml
@@ -64,6 +64,12 @@ file_types:
         file_reader: !!python/name:satpy.readers.viirs_edr.VIIRSJRRFileHandler
         file_patterns:
             - 'JRR-IceAge_{version}_{platform_shortname}_s{start_time:%Y%m%d%H%M%S%f}_e{end_time:%Y%m%d%H%M%S%f}_c{creation_time}.nc'
+    jrr_volcanicash:
+        file_reader: !!python/name:satpy.readers.viirs_edr.VIIRSJRRFileHandler
+        drop_variables:
+          - Det_QF_Size
+        file_patterns:
+            - 'JRR-VolcanicAsh_{version}_{platform_shortname}_s{start_time:%Y%m%d%H%M%S%f}_e{end_time:%Y%m%d%H%M%S%f}_c{creation_time}.nc'
 
 
 datasets:

--- a/satpy/readers/viirs_edr.py
+++ b/satpy/readers/viirs_edr.py
@@ -98,9 +98,11 @@ class VIIRSJRRFileHandler(BaseFileHandler):
         # use entire scans as chunks
         row_chunks_m = max(get_chunk_size_limit() // 4 // M_COLS, 1)  # 32-bit floats
         row_chunks_i = row_chunks_m * 2
+        drop_variables = filetype_info.get("drop_variables", None)
         self.nc = xr.open_dataset(self.filename,
                                   decode_cf=True,
                                   mask_and_scale=True,
+                                  drop_variables=drop_variables,
                                   chunks={
                                       "Columns": -1,
                                       "Rows": row_chunks_m,


### PR DESCRIPTION
This PR adds the VolcanicAsh product to `viirs_edr` reader.

The files I have (v3r0) can't be opened unless `Det_QF_Size` variable is dropped. I *think* this is becaus the same name is used as a dimension. For this, I added a possibility to drop variables defined in the reader YAML. The testing is a bit of a kludge, as the only way I could think of was to make `Det_QF_Size` a 2D variable instead of the scalar it is, and check that it is not in the available dataset listing.

The error coming from XArray without `drop_variables` is `ValueError: dimension 'Det_QF_Size' already exists as a scalar variable`.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
