### PR TITLE
Update 'oci_l2_bgc' to allow .nc4 and .nc filename extensions

### DIFF
--- a/satpy/etc/readers/oci_l2_bgc.yaml
+++ b/satpy/etc/readers/oci_l2_bgc.yaml
@@ -12,7 +12,7 @@ file_types:
   bgc_nc:
     file_patterns:
     # Example: PACE_OCI.20240907T191809.L2.OC_BGC.V2_0.NRT.nc4
-      - '{platform:s}_{sensor:s}.{start_time:%Y%m%dT%H%M%S}.L2.OC_BGC.V{sw_version:s}.{processing_type:s}nc4'
+      - '{platform:s}_{sensor:s}.{start_time:%Y%m%dT%H%M%S}.L2.OC_BGC.V{sw_version:s}.{processing_type:s}nc{nc_version}'
     file_reader: !!python/name:satpy.readers.seadas_l2.SEADASL2NetCDFFileHandler
     geo_resolution: 1000
 


### PR DESCRIPTION
@kathys let me know that the files this reader is meant to read now come with a `.nc` extension. This PR fixes the reader to allow the older `.nc4` extension and the newer `.nc` extension.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
