### PR TITLE
Fix LightningTimeCompositor failing when data outside of the time range is passed

### DIFF
--- a/satpy/tests/compositor_tests/test_lightning.py
+++ b/satpy/tests/compositor_tests/test_lightning.py
@@ -31,7 +31,7 @@ from satpy.composites.lightning import LightningTimeCompositor
 def test_flash_age_compositor():
     """Test the flash_age compsitor by comparing two xarrays object."""
     comp = LightningTimeCompositor("flash_age",prerequisites=["flash_time"],
-                                   standard_name="ligthning_time",
+                                   standard_name="lightning_time",
                                    time_range=60,
                                    reference_time="end_time")
     attrs_flash_age = {"variable_name": "flash_time","name": "flash_time",

--- a/satpy/tests/compositor_tests/test_lightning.py
+++ b/satpy/tests/compositor_tests/test_lightning.py
@@ -31,7 +31,7 @@ from satpy.composites.lightning import LightningTimeCompositor
 def test_flash_age_compositor():
     """Test the flash_age compsitor by comparing two xarrays object."""
     comp = LightningTimeCompositor("flash_age",prerequisites=["flash_time"],
-                                   standard_name="ligtning_time",
+                                   standard_name="ligthning_time",
                                    time_range=60,
                                    reference_time="end_time")
     attrs_flash_age = {"variable_name": "flash_time","name": "flash_time",
@@ -40,29 +40,30 @@ def test_flash_age_compositor():
     flash_age_value = da.array(["2024-08-01T09:00:00",
             "2024-08-01T10:00:00", "2024-08-01T10:30:00","2024-08-01T11:00:00"], dtype="datetime64[ns]")
     flash_age = xr.DataArray(
-    flash_age_value,
-    dims=["y"],
-    coords={
-        "crs": "8B +proj=longlat +ellps=WGS84 +type=crs"
-    },attrs = attrs_flash_age,name="flash_time")
+        flash_age_value,
+        dims=["y"],
+        coords={
+            "crs": "8B +proj=longlat +ellps=WGS84 +type=crs"},
+        attrs = attrs_flash_age,
+        name="flash_time")
     res = comp([flash_age])
     expected_attrs = {"variable_name": "flash_time","name": "lightning_time",
                        "start_time": datetime.datetime(2024, 8, 1, 10, 50, 0),
                        "end_time": datetime.datetime(2024, 8, 1, 11, 0, 0),"reader": "li_l2_nc",
-                       "standard_name": "ligtning_time"
+                       "standard_name": "lightning_time"
                        }
-    expected_array = xr.DataArray(
-    da.array([np.nan, 0.0,0.5,1.0]),
-    dims=["y"],
-    coords={
-        "crs": "8B +proj=longlat +ellps=WGS84 +type=crs"
-    },attrs = expected_attrs,name="flash_time")
+    expected_array = xr.DataArray(da.array([np.nan, 0.0,0.5,1.0]),
+                                  dims=["y"],
+                                  coords={
+                                      "crs": "8B +proj=longlat +ellps=WGS84 +type=crs"},
+                                  attrs = expected_attrs,
+                                  name="flash_time")
     xr.testing.assert_equal(res,expected_array)
 
 def test_empty_array_error(caplog):
     """Test when the filtered array is empty."""
     comp = LightningTimeCompositor("flash_age",prerequisites=["flash_time"],
-                                   standard_name="ligtning_time",
+                                   standard_name="lightning_time",
                                    time_range=60,
                                    reference_time="end_time")
     attrs_flash_age = {"variable_name": "flash_time","name": "flash_time",
@@ -70,12 +71,12 @@ def test_empty_array_error(caplog):
                        "end_time": datetime.datetime(2024, 8, 1, 11, 0, 0),
                        "reader": "li_l2_nc"}
     flash_age_value = da.array(["2024-08-01T09:00:00"], dtype="datetime64[ns]")
-    flash_age = xr.DataArray(
-    flash_age_value,
-    dims=["y"],
-    coords={
-        "crs": "8B +proj=longlat +ellps=WGS84 +type=crs"
-    },attrs = attrs_flash_age,name="flash_time")
+    flash_age = xr.DataArray(flash_age_value,
+                             dims=["y"],
+                             coords={
+                                 "crs": "8B +proj=longlat +ellps=WGS84 +type=crs"},
+                             attrs = attrs_flash_age,
+                             name="flash_time")
     with caplog.at_level(logging.WARNING):
         _ = comp([flash_age])
     # Assert that the log contains the expected warning message

--- a/satpy/tests/compositor_tests/test_lightning.py
+++ b/satpy/tests/compositor_tests/test_lightning.py
@@ -23,7 +23,6 @@ import logging
 
 import dask.array as da
 import numpy as np
-import pytest
 import xarray as xr
 
 from satpy.composites.lightning import LightningTimeCompositor
@@ -53,7 +52,7 @@ def test_flash_age_compositor():
                        "standard_name": "ligtning_time"
                        }
     expected_array = xr.DataArray(
-    da.array([0.0,0.5,1.0]),
+    da.array([np.nan, 0.0,0.5,1.0]),
     dims=["y"],
     coords={
         "crs": "8B +proj=longlat +ellps=WGS84 +type=crs"
@@ -77,17 +76,10 @@ def test_empty_array_error(caplog):
     coords={
         "crs": "8B +proj=longlat +ellps=WGS84 +type=crs"
     },attrs = attrs_flash_age,name="flash_time")
-    with caplog.at_level(logging.ERROR):
-        # Simulate the operation that raises the exception
-        with pytest.raises(ValueError, match="data size is zero") as excinfo:
-            _ = comp([flash_age])
-
-    # Assert the exception message
-    assert str(excinfo.value) == (
-        f"Invalid data: data size is zero. All flash_age events occurred before "
-        f"the specified start time ({attrs_flash_age['start_time']})."
-    )
-    assert "All the flash_age events happened before 2024-08-01T10:00:00" in caplog.text
+    with caplog.at_level(logging.WARNING):
+        _ = comp([flash_age])
+    # Assert that the log contains the expected warning message
+    assert "All the flash_age events happened before" in caplog.text
 
 def test_update_missing_metadata():
     """Test the _update_missing_metadata method."""


### PR DESCRIPTION
This PR fixes the LightningTimeCompositor (implemented in  https://github.com/pytroll/satpy/pull/2895) that was causing failures when the input data contained lightning times outside of the time range.

The compositor was using `drop=True` when filtering lightnings outside the defined time_range. This was causing a mismatch in dimension between the lightning data array and the latitude/longitudes arrays due to the dropped entries, so that resampling operations were failing due to shape/chunks mismatch.

By removing  `drop=True` also the explicit computation of the condition array could be removed.

On a side, this PR also reduces the handling of empty data from an error to a warning, and fixes some language/typos in the docstrings.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
