### PR TITLE
Add more datasets to IASI L2 reader

### DIFF
--- a/satpy/etc/readers/iasi_l2.yaml
+++ b/satpy/etc/readers/iasi_l2.yaml
@@ -156,6 +156,49 @@ datasets:
     resolution: 12000
     coordinates: [longitude, latitude]
 
+  amsu_instrument_flags:
+    name: amsu_instrument_flags
+    file_type: iasi_l2_hdf5
+    units: "1"
+    resolution: 12000
+    coordinates: [longitude, latitude]
+
+  iasi_instrument_flags:
+    name: iasi_instrument_flags
+    file_type: iasi_l2_hdf5
+    units: "1"
+    resolution: 12000
+    coordinates: [longitude, latitude]
+
+  mhs_instrument_flags:
+    name: mhs_instrument_flags
+    file_type: iasi_l2_hdf5
+    units: "1"
+    resolution: 12000
+    coordinates: [longitude, latitude]
+
+  observation_minus_calculation:
+    name: observation_minus_calculation
+    file_type: iasi_l2_hdf5
+    units: "K"
+    resolution: 12000
+    coordinates: [longitude, latitude]
+
+  surface_elevation:
+    name: surface_elevation
+    file_type: iasi_l2_hdf5
+    units: "m"
+    resolution: 12000
+    coordinates: [longitude, latitude]
+
+  surface_elevation_std:
+    name: surface_elevation_std
+    file_type: iasi_l2_hdf5
+    units: "m"
+    resolution: 12000
+    coordinates: [longitude, latitude]
+
+
 file_types:
   iasi_l2_hdf5:
     file_reader: !!python/name:satpy.readers.iasi_l2.IASIL2HDF5

--- a/satpy/readers/iasi_l2.py
+++ b/satpy/readers/iasi_l2.py
@@ -150,7 +150,7 @@ def read_dataset(fid, key):
         dims = ["y", "x", "level"]
     else:
         dims = ["y", "x"]
-    data = xr.DataArray(da.from_array(dset[()], chunks=CHUNK_SIZE),
+    data = xr.DataArray(da.from_array(_harmonize_data(dset[()]), chunks=CHUNK_SIZE),
                         name=key["name"], dims=dims)
     if data.dtype == np.float32:
         data = xr.where(data > 1e30, np.nan, data)
@@ -176,6 +176,14 @@ def _get_names_and_group(key):
         raise KeyError(f"Unsupported name: {key}")
 
     return names, group
+
+
+def _harmonize_data(arr):
+    if arr.shape[1] == 30:
+        # This is specifically for AMSU flags that have not been repeated for the IASI footprints
+        return np.repeat(arr, 4, axis=1)
+    return arr
+
 
 def read_geo(fid, key):
     """Read geolocation and related datasets."""

--- a/satpy/tests/reader_tests/test_iasi_l2.py
+++ b/satpy/tests/reader_tests/test_iasi_l2.py
@@ -19,7 +19,6 @@
 
 import math
 import os
-import unittest
 
 import numpy as np
 import pytest
@@ -126,10 +125,10 @@ def save_test_data(path):
                         TEST_DATA[grp][dset]["attrs"][attr]
 
 
-class TestIasiL2(unittest.TestCase):
+class TestIasiL2:
     """Test IASI L2 reader."""
 
-    def setUp(self):
+    def setup_method(self):
         """Create temporary data to test on."""
         import datetime as dt
         import tempfile
@@ -151,7 +150,7 @@ class TestIasiL2(unittest.TestCase):
                            "file_type": "iasi_l2_hdf5"}
         self.reader = IASIL2HDF5(self.fname, self.fname_info, self.ftype_info)
 
-    def tearDown(self):
+    def teardown_method(self):
         """Remove the temporary directory created for a test."""
         try:
             import shutil

--- a/satpy/tests/reader_tests/test_iasi_l2.py
+++ b/satpy/tests/reader_tests/test_iasi_l2.py
@@ -27,22 +27,23 @@ import xarray as xr
 
 SCAN_WIDTH = 120
 NUM_LEVELS = 138
-NUM_SCANLINES = 1
+NUM_SCANLINES = 10
 FNAME = "W_XX-EUMETSAT-kan,iasi,metopb+kan_C_EUMS_20170920103559_IASI_PW3_02_M01_20170920102217Z_20170920102912Z.hdf"
 # Structure for the test data, to be written to HDF5 file
 TEST_DATA = {
-    # Not implemented in the reader
-    "Amsu": {
-        "FLG_AMSUBAD": {"data": np.zeros((NUM_SCANLINES, 30), dtype=np.uint8),
-                        "attrs": {}}
-    },
-    # Not implemented in the reader
     "INFO": {
         "OmC": {"data": np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
                 "attrs": {"long_name": "Cloud signal. Predicted average window channel 'Obs minus Calc",
                           "units": "K"}},
+        "FLG_AMSUBAD": {"data": np.zeros((NUM_SCANLINES, 30), dtype=np.uint8),
+                        "attrs": {}},
+        "FLG_IASIBAD": {"data": np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.uint8),
+                        "attrs": {}},
+        "FLG_MHSBAD": {"data": np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.uint8),
+                        "attrs": {}},
+        # Not implemented in the reader
         "mdist": {"data": np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
-                  "attrs": {}}
+                  "attrs": {}},
     },
     "L1C": {
         "Latitude": {"data": np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
@@ -53,26 +54,20 @@ TEST_DATA = {
                        "attrs": {"units": "degrees"}},
         "SatZenith": {"data": np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
                       "attrs": {"units": "degrees"}},
-        "SensingTime_day": {"data": np.array([6472], dtype=np.uint16),
+        "SensingTime_day": {"data": 6472 * np.ones(NUM_SCANLINES, dtype=np.uint16),
                             "attrs": {}},
-        "SensingTime_msec": {"data": np.array([37337532], dtype=np.uint32),
+        "SensingTime_msec": {"data": np.arange(37337532, 37338532, 100, dtype=np.uint32),
                              "attrs": {}},
         "SunAzimuth": {"data": np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
                        "attrs": {"units": "degrees"}},
         "SunZenith": {"data": np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
                       "attrs": {"units": "degrees"}},
     },
-    # Not implemented in the reader
     "Maps": {
         "Height": {"data": np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
                    "attrs": {"units": "m"}},
         "HeightStd": {"data": np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.float32),
                       "attrs": {"units": "m"}},
-    },
-    # Not implemented in the reader
-    "Mhs": {
-        "FLG_MHSBAD": {"data": np.zeros((NUM_SCANLINES, SCAN_WIDTH), dtype=np.uint8),
-                       "attrs": {}}
     },
     "PWLR": {
         "E": {"data": np.zeros((NUM_SCANLINES, SCAN_WIDTH, 10), dtype=np.float32),

--- a/satpy/tests/reader_tests/test_iasi_l2.py
+++ b/satpy/tests/reader_tests/test_iasi_l2.py
@@ -269,6 +269,25 @@ class TestIasiL2:
             assert np.unique(times[0, i * 4:i * 4 + 4]).size == 1
         assert np.unique(times[0, :]).size == SCAN_WIDTH / 4
 
+    @pytest.mark.parametrize(("dset", "dtype", "units"), [
+        ("amsu_instrument_flags", np.uint8, None),
+        ("iasi_instrument_flags", np.uint8, None),
+        ("mhs_instrument_flags", np.uint8, None),
+        ("observation_minus_calculation", np.float32, "K"),
+        ("surface_elevation", np.float32, "m"),
+        ("surface_elevation_std", np.float32, "m")
+        ])
+    def test_get_info_and_maps(self, dset, dtype, units):
+        """Test datasets in INFO and Maps groups are read."""
+        from satpy.tests.utils import make_dataid
+        info = {"eggs": "spam"}
+        key = make_dataid(name=dset)
+        data = self.reader.get_dataset(key, info).compute()
+        assert data.shape == (NUM_SCANLINES, SCAN_WIDTH)
+        assert data.dtype == dtype
+        if units:
+            assert data.attrs["units"] == units
+
     def test_read_dataset(self):
         """Test read_dataset() function."""
         import h5py


### PR DESCRIPTION
This PR adds datasets from `/INFO/` and `/Maps/` groups to the IASI L2 reader.

Also the IASI L2 tests were converted to pytest.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
