### PR TITLE
add capability for M1 and M2 in MCMIP abi_l2_nc reader

### DIFF
--- a/satpy/etc/readers/abi_l2_nc.yaml
+++ b/satpy/etc/readers/abi_l2_nc.yaml
@@ -443,7 +443,7 @@ file_types:
 
   abi_l2_mcmip:
     file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-MCMIP{scene_abbr:1s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-MCMIP{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     observation_type: "MCMIP"
 
   abi_l2_acha:

--- a/satpy/etc/readers/abi_l2_nc.yaml
+++ b/satpy/etc/readers/abi_l2_nc.yaml
@@ -438,7 +438,7 @@ file_types:
 
   abi_l2_cmip_c16:
     file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
-    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:1s}-{scan_mode:2s}C16_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
+    file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-CMIP{scene_abbr:s}-{scan_mode:2s}C16_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     observation_type: "CMIP"
 
   abi_l2_mcmip:


### PR DESCRIPTION
This is in reference to and solves the problems stated in #3062 by adding functionality to support MCMIP mesoscale files being loaded in using the `abi_l2_nc` reader.


The following test was run and confirms the files are loaded correctly:

```python
import pyresample

import satpy
from satpy.scene import Scene
from satpy.utils import debug_on

print(f"satpy version: {satpy.__version__}")
print(f"pyresample version: {pyresample.__version__}")

debug_on()


file = [OR_ABI-L2-MCMIPM2-M6_G18_s20250431727563_e20250431728021_c20250431728094.nc"]

scn = Scene(filenames=file, reader="abi_l2_nc")
scn.load(["C01"])


print("\n", scn["C01"].attrs["scene_id"])
```

```
satpy version: 0.1.dev14471+gb6b4ef1.d20250212
pyresample version: 1.31.0

[DEBUG: 2025-02-12 10:03:39 : satpy.readers.yaml_reader] Reading ('C:\\Users\\jlubbers\\OneDrive - DOI\\Research\\Coding\\satpy\\satpy\\etc\\readers\\abi_l2_nc.yaml',)
[DEBUG: 2025-02-12 10:03:39 : satpy.readers.yaml_reader] Assigning to abi_l2_nc: ['C:\\Users\\jlubbers\\Desktop\\goes_test\\ops_test\\meso2\\OR_ABI-L2-MCMIPM2-M6_G18_s20250431727563_e20250431728021_c20250431728094.nc']
[DEBUG: 2025-02-12 10:03:39 : satpy.composites.config_loader] Looking for composites config file abi.yaml
[DEBUG: 2025-02-12 10:03:40 : pyorbital.tlefile] Path to the Pyorbital configuration (where e.g. platforms.txt is found): C:\Users\jlubbers\AppData\Local\mambaforge\envs\avogoes\Lib\site-packages\pyorbital\etc
[DEBUG: 2025-02-12 10:03:40 : satpy.composites.config_loader] Looking for composites config file visir.yaml
[DEBUG: 2025-02-12 10:03:40 : satpy.readers.abi_l2_nc] Reading in get_dataset CMI_C01.

 Mesoscale
```
