### PR TITLE
Fix slack invite link in contributing docs

### DIFF
--- a/doc/source/dev_guide/CONTRIBUTING.rst
+++ b/doc/source/dev_guide/CONTRIBUTING.rst
@@ -92,7 +92,7 @@ How do I get help?
 The Satpy developers (and all other PyTroll package developers) monitor the:
 
 - `Mailing List <https://groups.google.com/group/pytroll>`_
-- `Slack chat <https://pytroll.slack.com/>`_ (get an `invitation <https://pytrollslackin.herokuapp.com/>`_)
+- `Slack chat <https://pytroll.slack.com/>`_ (see the `PyTroll website <https://pytroll.github.io/#getting-in-touch>`_ for more info)
 - `GitHub issues <https://github.com/pytroll/satpy/issues>`_
 
 How do I submit my changes?


### PR DESCRIPTION
@jsolbrig pointed this out. The contributing docs were pointing to the old heroku app for inviting yourself.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
