### PR TITLE
Update sphinx to use new sphinx.ext.apidoc extension

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,7 +139,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           flags: behaviourtests
-          file: ./coverage.xml
+          files: ./coverage.xml
           env_vars: OS,PYTHON_VERSION,UNSTABLE
 
   coveralls:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,7 +118,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           flags: unittests
-          file: ./coverage.xml
+          files: ./coverage.xml
           env_vars: OS,PYTHON_VERSION,UNSTABLE
 
       - name: Coveralls Parallel

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -29,7 +29,6 @@ help:
 
 clean:
 	-rm -rf $(BUILDDIR)/*
-	-rm -rf source/api/*.rst
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -25,9 +25,8 @@ dependencies:
   - rioxarray
   - setuptools
   - setuptools_scm
-  - sphinx
+  - sphinx>=8.2.0
   - sphinx_rtd_theme
-  - sphinxcontrib-apidoc
   - trollsift
   - xarray
   - zarr

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -82,11 +82,14 @@ with open("reader_table.rst", mode="w") as f:
 
 # -- General configuration -----------------------------------------------------
 
+# sphinxcontrib.apidoc was added to sphinx in 8.2.0 as sphinx.etx.apidoc
+needs_sphinx = "8.2.0"
+
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx", "sphinx.ext.todo", "sphinx.ext.coverage",
               "sphinx.ext.doctest", "sphinx.ext.napoleon", "sphinx.ext.autosummary", "sphinx.ext.autosectionlabel",
-              "doi_role", "sphinx.ext.viewcode", "sphinxcontrib.apidoc",
+              "doi_role", "sphinx.ext.viewcode", "sphinx.ext.apidoc",
               "sphinx.ext.mathjax"]
 
 # Autosectionlabel
@@ -95,18 +98,19 @@ autosectionlabel_prefix_document = True
 autosectionlabel_maxdepth = 3
 
 # API docs
-apidoc_module_dir = "../../satpy"
-apidoc_output_dir = "api"
-apidoc_excluded_paths = [
-    "readers/caliop_l2_cloud.py",
-    "readers/ghrsst_l3c_sst.py",
-    "readers/li_l2.py",
-    "readers/scatsat1_l2b.py",
+apidoc_modules = [
+    {
+        "path": "../../satpy",
+        "destination": "api/",
+        "exclude_patterns": [
+            "../../satpy/readers/caliop_l2_cloud.py",
+            "../../satpy/readers/ghrsst_l3c_sst.py",
+            "../../satpy/readers/scatsat1_l2b.py",
+        ],
+    },
 ]
 apidoc_separate_modules = True
-apidoc_extra_args = [
-    "--private",
-]
+apidoc_include_private = True
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -297,7 +301,7 @@ intersphinx_mapping = {
     "scipy": ("https://scipy.github.io/devdocs", None),
     "trollimage": ("https://trollimage.readthedocs.io/en/stable", None),
     "trollsift": ("https://trollsift.readthedocs.io/en/stable", None),
-    "xarray": ("https://xarray.pydata.org/en/stable", None),
+    "xarray": ("https://docs.xarray.dev/en/stable", None),
     "rasterio": ("https://rasterio.readthedocs.io/en/latest", None),
     "donfig": ("https://donfig.readthedocs.io/en/latest", None),
     "pooch": ("https://www.fatiando.org/pooch/latest/", None),

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -106,6 +106,13 @@ apidoc_modules = [
             "../../satpy/readers/caliop_l2_cloud.py",
             "../../satpy/readers/ghrsst_l3c_sst.py",
             "../../satpy/readers/scatsat1_l2b.py",
+            # Prefer to not document test modules. Most users will look at
+            # source code if needed and we want to avoid documentation builds
+            # suffering from import-time test data creation. We want to keep
+            # things contributors might be interested in like satpy.tests.utils.
+            "../../satpy/tests/test_*.py",
+            "../../satpy/tests/**/test_*.py",
+            "../../satpy/tests/**/_*.py",
         ],
     },
 ]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -112,7 +112,6 @@ apidoc_modules = [
             # things contributors might be interested in like satpy.tests.utils.
             "../../satpy/tests/test_*.py",
             "../../satpy/tests/**/test_*.py",
-            "../../satpy/tests/**/_*.py",
         ],
     },
 ]


### PR DESCRIPTION
Updates sphinx to 8.2 which adds a sphinx.ext.apidoc extension and replaces sphinxcontrib.apidoc. I also turned off documenting most test modules which cuts off ~30 seconds (50%) of execution time and ~2GB of memory usage (80%).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
