### PR TITLE
Prevent call to obj.__dict__ when obj is a compound variable.

### DIFF
--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -211,8 +211,8 @@ class NetCDF4FileHandler(BaseFileHandler):
             self.file_content[fc_key] = global_attrs[key] = value
         self.file_content["/attrs"] = global_attrs
 
-    @classmethod
-    def _get_object_attrs(cls, obj):
+    @staticmethod
+    def _get_object_attrs(obj):
         """Get object attributes using __dict__ but retrieve recoverable attributes on failure."""
         try:
             return obj.__dict__

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -224,7 +224,6 @@ class NetCDF4FileHandler(BaseFileHandler):
                     atts[attname] = obj.getncattr(attname)
                 except KeyError:
                     LOG.warning(f"Warning: Cannot load object ({obj.name}) attribute ({attname}).")
-                    pass
             return atts
 
     def _collect_attrs(self, name, obj):

--- a/satpy/readers/netcdf_utils.py
+++ b/satpy/readers/netcdf_utils.py
@@ -211,8 +211,21 @@ class NetCDF4FileHandler(BaseFileHandler):
             self.file_content[fc_key] = global_attrs[key] = value
         self.file_content["/attrs"] = global_attrs
 
-    def _get_object_attrs(self, obj):
-        return obj.__dict__
+    @classmethod
+    def _get_object_attrs(cls, obj):
+        """Get object attributes using __dict__ but retrieve recoverable attributes on failure."""
+        try:
+            return obj.__dict__
+        except KeyError:
+            # Maybe unrecognised datatype.
+            atts = {}
+            for attname in obj.ncattrs():
+                try:
+                    atts[attname] = obj.getncattr(attname)
+                except KeyError:
+                    LOG.warning(f"Warning: Cannot load object ({obj.name}) attribute ({attname}).")
+                    pass
+            return atts
 
     def _collect_attrs(self, name, obj):
         """Collect all the attributes for the provided file object."""


### PR DESCRIPTION
<!-- the NetCDF4FileHandler barfs when it tries to load attributes using __dict_ and the object is a compound variable -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #3066  -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
