### PR TITLE
Add a reader for NWC SAF GEO HRW data

### DIFF
--- a/satpy/etc/readers/nwcsaf-geo.yaml
+++ b/satpy/etc/readers/nwcsaf-geo.yaml
@@ -68,6 +68,10 @@ file_types:
         file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
         file_patterns: ['S_NWC_ASII-GW_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc']
 
+    nc_nwcsaf_geo_hrw:
+        file_reader: !!python/name:satpy.readers.nwcsaf_hrw_nc.NWCSAFGEOHRWFileHandler
+        file_patterns: ['S_NWC_HRW_{platform_id}_{region_id}_{start_time:%Y%m%dT%H%M%S}Z.nc']
+
 datasets:
 
 # ---- CMA products ------------

--- a/satpy/readers/nwcsaf_hrw_nc.py
+++ b/satpy/readers/nwcsaf_hrw_nc.py
@@ -95,12 +95,12 @@ class NWCSAFGEOHRWFileHandler(BaseFileHandler):
     def get_dataset(self, key, info):
         """Load a dataset."""
         logger.debug("Reading %s.", key["name"])
-        data = self.read_dataset(key, info)
+        data = self._read_dataset(key, info)
         data.attrs.update(info)
 
         return data
 
-    def read_dataset(self, dataset_key, info):
+    def _read_dataset(self, dataset_key, info):
         """Read a dataset."""
         dataset_name = dataset_key["name"]
         key_parts = dataset_name.split("_")

--- a/satpy/readers/nwcsaf_hrw_nc.py
+++ b/satpy/readers/nwcsaf_hrw_nc.py
@@ -36,7 +36,7 @@ By default the reader treats each imaging channel separately, and thus lists
     scn = Scene(reader="nwcsaf-geo", filenames=[filename])
     pprint.pprint(scn.available_dataset_names())
 
-This print all the available datasets. The truncated output of this is::
+This prints all the available datasets. The truncated output of this is::
 
     ['wind_hrvis_air_pressure',
      'wind_hrvis_air_pressure_correction',

--- a/satpy/readers/nwcsaf_hrw_nc.py
+++ b/satpy/readers/nwcsaf_hrw_nc.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2025- Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""NWC SAF GEO v2021 HRW.
+
+This is a reader for the High Resolution Winds (HRW) data produced with NWC SAF GEO.
+
+"""
+
+import datetime as dt
+import logging
+from contextlib import suppress
+
+import dask.array as da
+import h5py
+import xarray as xr
+
+from satpy.readers.file_handlers import BaseFileHandler
+from satpy.readers.nwcsaf_nc import PLATFORM_NAMES, SENSOR, read_nwcsaf_time
+from satpy.utils import get_chunk_size_limit
+
+logger = logging.getLogger(__name__)
+
+CHUNK_SIZE = get_chunk_size_limit()
+
+WIND_CHANNELS = [
+    "wind_hrvis",
+    "wind_ir108",
+    "wind_ir120",
+    "wind_vis06",
+    "wind_vis08",
+    "wind_wv062",
+    "wind_wv073",
+]
+
+class NWCSAFGEOHRWFileHandler(BaseFileHandler):
+    """A file handler class for NWC SAF GEO HRW files."""
+
+    def __init__(self, filename, filename_info, filetype_info):
+        """Initialize the file handler."""
+        super().__init__(filename, filename_info, filetype_info)
+
+        self.h5f = h5py.File(self.filename, "r")
+        self.filename_info = filename_info
+        self.filetype_info = filetype_info
+        self.platform_name = PLATFORM_NAMES.get(self.h5f.attrs["satellite_identifier"].astype(str))
+        self.sensor = SENSOR.get(self.platform_name, "seviri")
+        self.lons = {}
+        self.lats = {}
+        # Imaging period
+        self.period = None
+
+        # The resolution is given in kilometers, convert to meters
+        self.resolution = 1000 * self.h5f.attrs["spatial_resolution"].item()
+
+    def __del__(self):
+        """Close file handlers when we are done."""
+        with suppress(OSError):
+            self.h5f.close()
+
+    def available_datasets(self, configured_datasets=None):
+        """Form the names for the available datasets."""
+        for channel in WIND_CHANNELS:
+            dset = self.h5f[channel]
+            for measurand in dset.dtype.fields.keys():
+                if measurand == "trajectory":
+                    continue
+                ds_info = {
+                    "file_type": self.filetype_info["file_type"],
+                    "resolution": self.resolution,
+                    "name": channel + "_" + measurand,
+                }
+                if measurand not in ("longitude", "latitude"):
+                    ds_info["coordinates"] = (channel + "_longitude", channel + "_latitude")
+                if measurand == "longitude":
+                    ds_info["standard_name"] = "longitude"
+                if measurand == "latitude":
+                    ds_info["standard_name"] = "latitude"
+                yield True, ds_info
+
+    def get_dataset(self, key, info):
+        """Load a dataset."""
+        logger.debug("Reading %s.", key["name"])
+        data = self.read_dataset(key, info)
+        data.attrs.update(info)
+
+        return data
+
+    def read_dataset(self, dataset_key, info):
+        """Read a dataset."""
+        dataset_name = dataset_key["name"]
+        key_parts = dataset_name.split("_")
+        channel = "_".join(key_parts[:2])
+        if channel not in self.lons:
+            self._get_channel_coordinates(channel)
+        if self.period is None:
+            self.period = self.h5f[channel].attrs["time_period"].item()
+        measurand = "_".join(key_parts[2:])
+        try:
+            data = self.h5f[channel][measurand]
+        except ValueError:
+            logger.warning("Reading %s is not supported.", dataset_name)
+
+        xr_data = xr.DataArray(da.from_array(data, chunks=CHUNK_SIZE),
+                               name=dataset_name,
+                               dims=["y"])
+        xr_data[channel + "_longitude"] = ("y", self.lons[channel])
+        xr_data[channel + "_latitude"] = ("y", self.lats[channel])
+        xr_data.attrs.update(info)
+
+        return xr_data
+
+    def _get_channel_coordinates(self, channel):
+        self.lons[channel] = self.h5f[channel]["longitude"]
+        self.lats[channel] = self.h5f[channel]["latitude"]
+
+    @property
+    def start_time(self):
+        """Get the start time."""
+        return read_nwcsaf_time(self.h5f.attrs["nominal_product_time"])
+
+    @property
+    def end_time(self):
+        """Get the end time."""
+        if self.period is None:
+            return self.start_time
+        return self.start_time + dt.timedelta(minutes=self.period)

--- a/satpy/readers/nwcsaf_hrw_nc.py
+++ b/satpy/readers/nwcsaf_hrw_nc.py
@@ -27,6 +27,7 @@ from contextlib import suppress
 
 import dask.array as da
 import h5py
+import numpy as np
 import xarray as xr
 
 from satpy.readers.file_handlers import BaseFileHandler
@@ -50,13 +51,14 @@ WIND_CHANNELS = [
 class NWCSAFGEOHRWFileHandler(BaseFileHandler):
     """A file handler class for NWC SAF GEO HRW files."""
 
-    def __init__(self, filename, filename_info, filetype_info):
+    def __init__(self, filename, filename_info, filetype_info, merge_channels=False):
         """Initialize the file handler."""
         super().__init__(filename, filename_info, filetype_info)
 
         self.h5f = h5py.File(self.filename, "r")
         self.filename_info = filename_info
         self.filetype_info = filetype_info
+        self.merge_channels = merge_channels
         self.platform_name = PLATFORM_NAMES.get(self.h5f.attrs["satellite_identifier"].astype(str))
         self.sensor = SENSOR.get(self.platform_name, "seviri")
         self.lons = {}
@@ -75,6 +77,9 @@ class NWCSAFGEOHRWFileHandler(BaseFileHandler):
     def available_datasets(self, configured_datasets=None):
         """Form the names for the available datasets."""
         for channel in WIND_CHANNELS:
+            prefix = channel + "_"
+            if self.merge_channels:
+                prefix = ""
             dset = self.h5f[channel]
             for measurand in dset.dtype.fields.keys():
                 if measurand == "trajectory":
@@ -82,31 +87,79 @@ class NWCSAFGEOHRWFileHandler(BaseFileHandler):
                 ds_info = {
                     "file_type": self.filetype_info["file_type"],
                     "resolution": self.resolution,
-                    "name": channel + "_" + measurand,
+                    "name": prefix + measurand,
                 }
                 if measurand not in ("longitude", "latitude"):
-                    ds_info["coordinates"] = (channel + "_longitude", channel + "_latitude")
+                    ds_info["coordinates"] = (prefix + "longitude", prefix + "latitude")
                 if measurand == "longitude":
                     ds_info["standard_name"] = "longitude"
                 if measurand == "latitude":
                     ds_info["standard_name"] = "latitude"
                 yield True, ds_info
+            if self.merge_channels:
+                break
 
     def get_dataset(self, key, info):
         """Load a dataset."""
         logger.debug("Reading %s.", key["name"])
-        data = self._read_dataset(key, info)
+        if self.merge_channels:
+            data = self._read_merged_dataset(key, info)
+        else:
+            data = self._read_dataset(key, info)
         data.attrs.update(info)
 
         return data
+
+    def _read_merged_dataset(self, dataset_key, info):
+        """Read a dataset merged from every channel."""
+        dataset_name = dataset_key["name"]
+
+        data = []
+        collect_coords = True
+        if "merged" in self.lons:
+            collect_coords = False
+        for channel in WIND_CHANNELS:
+            if collect_coords:
+                self._read_channel_coordinates(channel)
+                self._append_merged_coordinates(channel)
+            if self.period is None:
+                self.period = self.h5f[channel].attrs["time_period"].item()
+            try:
+                data.append(self.h5f[channel][dataset_name])
+            except ValueError:
+                logger.warning("Reading %s is not supported.", dataset_name)
+
+        return self._create_xarray(
+            np.concat(data),
+            dataset_name,
+            np.concat(self.lons["merged"]),
+            np.concat(self.lats["merged"]),
+            info)
+
+    def _append_merged_coordinates(self, channel):
+        if "merged" not in self.lons:
+            self.lons["merged"] = []
+            self.lats["merged"] = []
+        self.lons["merged"].append(self.lons[channel])
+        self.lats["merged"].append(self.lats[channel])
+
+    @staticmethod
+    def _create_xarray(data, dataset_name, lons, lats, info, prefix=""):
+        xr_data = xr.DataArray(da.from_array(data, chunks=CHUNK_SIZE),
+                               name=dataset_name,
+                               dims=["y"])
+        xr_data[prefix + "longitude"] = ("y", lons)
+        xr_data[prefix + "latitude"] = ("y", lats)
+        xr_data.attrs.update(info)
+
+        return xr_data
 
     def _read_dataset(self, dataset_key, info):
         """Read a dataset."""
         dataset_name = dataset_key["name"]
         key_parts = dataset_name.split("_")
         channel = "_".join(key_parts[:2])
-        if channel not in self.lons:
-            self._get_channel_coordinates(channel)
+        self._read_channel_coordinates(channel)
         if self.period is None:
             self.period = self.h5f[channel].attrs["time_period"].item()
         measurand = "_".join(key_parts[2:])
@@ -115,18 +168,15 @@ class NWCSAFGEOHRWFileHandler(BaseFileHandler):
         except ValueError:
             logger.warning("Reading %s is not supported.", dataset_name)
 
-        xr_data = xr.DataArray(da.from_array(data, chunks=CHUNK_SIZE),
-                               name=dataset_name,
-                               dims=["y"])
-        xr_data[channel + "_longitude"] = ("y", self.lons[channel])
-        xr_data[channel + "_latitude"] = ("y", self.lats[channel])
-        xr_data.attrs.update(info)
+        prefix = channel + "_"
 
-        return xr_data
+        return self._create_xarray(data, dataset_name, self.lons[channel], self.lats[channel], info, prefix=prefix)
 
-    def _get_channel_coordinates(self, channel):
-        self.lons[channel] = self.h5f[channel]["longitude"]
-        self.lats[channel] = self.h5f[channel]["latitude"]
+
+    def _read_channel_coordinates(self, channel):
+        if channel not in self.lons:
+            self.lons[channel] = self.h5f[channel]["longitude"]
+            self.lats[channel] = self.h5f[channel]["latitude"]
 
     @property
     def start_time(self):

--- a/satpy/readers/nwcsaf_hrw_nc.py
+++ b/satpy/readers/nwcsaf_hrw_nc.py
@@ -197,9 +197,7 @@ class NWCSAFGEOHRWFileHandler(BaseFileHandler):
     def available_datasets(self, configured_datasets=None):
         """Form the names for the available datasets."""
         for channel in WIND_CHANNELS:
-            prefix = channel + "_"
-            if self.merge_channels:
-                prefix = ""
+            prefix = self._get_channel_prefix(channel)
             dset = self.h5f[channel]
             for measurand in dset.dtype.fields.keys():
                 if measurand == "trajectory":
@@ -208,6 +206,11 @@ class NWCSAFGEOHRWFileHandler(BaseFileHandler):
                 yield True, ds_info
             if self.merge_channels:
                 break
+
+    def _get_channel_prefix(self, channel):
+        if self.merge_channels:
+            return ""
+        return channel + "_"
 
     def _measurand_ds_info(self, prefix, measurand):
         ds_info = {

--- a/satpy/readers/nwcsaf_hrw_nc.py
+++ b/satpy/readers/nwcsaf_hrw_nc.py
@@ -204,20 +204,25 @@ class NWCSAFGEOHRWFileHandler(BaseFileHandler):
             for measurand in dset.dtype.fields.keys():
                 if measurand == "trajectory":
                     continue
-                ds_info = {
-                    "file_type": self.filetype_info["file_type"],
-                    "resolution": self.resolution,
-                    "name": prefix + measurand,
-                }
-                if measurand not in ("longitude", "latitude"):
-                    ds_info["coordinates"] = (prefix + "longitude", prefix + "latitude")
-                if measurand == "longitude":
-                    ds_info["standard_name"] = "longitude"
-                if measurand == "latitude":
-                    ds_info["standard_name"] = "latitude"
+                ds_info = self._measurand_ds_info(prefix, measurand)
                 yield True, ds_info
             if self.merge_channels:
                 break
+
+    def _measurand_ds_info(self, prefix, measurand):
+        ds_info = {
+            "file_type": self.filetype_info["file_type"],
+            "resolution": self.resolution,
+            "name": prefix + measurand,
+        }
+        if measurand not in ("longitude", "latitude"):
+            ds_info["coordinates"] = (prefix + "longitude", prefix + "latitude")
+        if measurand == "longitude":
+            ds_info["standard_name"] = "longitude"
+        if measurand == "latitude":
+            ds_info["standard_name"] = "latitude"
+
+        return ds_info
 
     def get_dataset(self, key, info):
         """Load a dataset."""

--- a/satpy/readers/nwcsaf_hrw_nc.py
+++ b/satpy/readers/nwcsaf_hrw_nc.py
@@ -61,7 +61,7 @@ class NWCSAFGEOHRWFileHandler(BaseFileHandler):
         self.sensor = SENSOR.get(self.platform_name, "seviri")
         self.lons = {}
         self.lats = {}
-        # Imaging period
+        # Imaging period, which is set after reading any data, and used to calculate end time
         self.period = None
 
         # The resolution is given in kilometers, convert to meters

--- a/satpy/readers/nwcsaf_hrw_nc.py
+++ b/satpy/readers/nwcsaf_hrw_nc.py
@@ -17,7 +17,85 @@
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """NWC SAF GEO v2021 HRW.
 
-This is a reader for the High Resolution Winds (HRW) data produced with NWC SAF GEO.
+This module contains the :class:`NWCSAFGEOHRWFileHandler` file handler for the High Resolution Winds (HRW)
+data produced with NWC SAF GEO.
+
+There are 37 different quantities in the files, and predicted trajectories for each
+observation. Reading of the trajectory data are not currently supported.
+
+The data in the files are grouped separately for each original imaging channel, which there are up to
+seven. The number of channels depends on the configuration of NWC SAF GEO software.
+
+By default the reader treats each imaging channel separately, and thus lists
+7 (channels) * 37 (variables) = 259 distinct datasets::
+
+    import pprint
+    from satpy import Scene
+
+    filename = "S_NWC_HRW_MSG3_MSG-N-BS_20250206T130000Z.nc"
+    scn = Scene(reader="nwcsaf-geo", filenames=[filename])
+    pprint.pprint(scn.available_dataset_names())
+
+This print all the available datasets. The truncated output of this is::
+
+    ['wind_hrvis_air_pressure',
+     'wind_hrvis_air_pressure_correction',
+     'wind_hrvis_air_pressure_error',
+     'wind_hrvis_air_pressure_nwp_at_best_fit_level',
+     'wind_hrvis_air_temperature',
+     ...
+     'wind_wv073_wind_speed',
+     'wind_wv073_wind_speed_difference_nwp_at_amv_level',
+     'wind_wv073_wind_speed_difference_nwp_at_best_fit_level',
+     'wind_wv073_wind_speed_nwp_at_amv_level',
+     'wind_wv073_wind_speed_nwp_at_best_fit_level']
+
+The channel name is used as a prefix for the datasets.
+
+It is also possible to merge all of these channel-by-channel datasets with a reader key-word argument::
+
+    scn = Scene(reader="nwcsaf-geo", filenames=[filename], reader_kwargs={"merge_channels": True})
+    pprint.pprint(scn.available_dataset_names())
+
+Full list of the printed datasets is::
+
+    ['air_pressure',
+     'air_pressure_correction',
+     'air_pressure_error',
+     'air_pressure_nwp_at_best_fit_level',
+     'air_temperature',
+     'cloud_type',
+     'correlation',
+     'correlation_test',
+     'height_assignment_method',
+     'latitude',
+     'latitude_increment',
+     'longitude',
+     'longitude_increment',
+     'number_of_winds',
+     'orographic_index',
+     'previous_wind_idx',
+     'quality_index_iwwg_value',
+     'quality_index_with_forecast',
+     'quality_index_without_forecast',
+     'quality_test',
+     'segment_x',
+     'segment_x_pix',
+     'segment_y',
+     'segment_y_pix',
+     'tracer_correlation_method',
+     'tracer_type',
+     'wind_from_direction',
+     'wind_from_direction_difference_nwp_at_amv_level',
+     'wind_from_direction_difference_nwp_at_best_fit_level',
+     'wind_from_direction_nwp_at_amv_level',
+     'wind_from_direction_nwp_at_best_fit_level',
+     'wind_idx',
+     'wind_speed',
+     'wind_speed_difference_nwp_at_amv_level',
+     'wind_speed_difference_nwp_at_best_fit_level',
+     'wind_speed_nwp_at_amv_level',
+     'wind_speed_nwp_at_best_fit_level']
 
 """
 

--- a/satpy/tests/reader_tests/test_nwcsaf_hrw_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_hrw_nc.py
@@ -1,0 +1,141 @@
+# Copyright (c) 2025- Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Unittests for NWC SAF GEO HRW reader."""
+
+import datetime as dt
+
+import h5py
+import numpy as np
+import pytest
+
+from satpy.readers.nwcsaf_hrw_nc import WIND_CHANNELS
+
+# This is the actual dtype of the trajectory items. We do not support it, so won't add this
+# complexity to the test file creation. It's here anyway if someone wants to add it.
+TRAJECTORY_DTYPE_ACTUAL = np.dtype([
+    ("latitude", "<f4"),
+    ("longitude", "<f4"),
+    ("latitude_increment", "<f4"),
+    ("longitude_increment", "<f4"),
+    ("air_temperature", "<f4"),
+    ("air_pressure", "<f4"),
+    ("air_pressure_error", "<f4"),
+    ("air_pressure_correction", "<f4"),
+    ("wind_speed", "<f4"),
+    ("wind_from_direction", "<f4"),
+    ("quality_index_with_forecast", "i1"),
+    ("quality_index_without_forecast", "i1"),
+    ("quality_index_iwwg_value", "i1"),
+    ("tracer_correlation_method", "i1"),
+    ("tracer_type", "i1"),
+    ("height_assignment_method", "i1"),
+    ("orographic_index", "i1"),
+    ("cloud_type", "i1"),
+    ("correlation", "i1")
+])
+
+WIND_DTYPES = [
+    ("wind_idx", np.dtype("uint32")),
+    ("previous_wind_idx", np.dtype("uint32")),
+    ("number_of_winds", np.dtype("uint8")),
+    ("correlation_test", np.dtype("uint8")),
+    ("quality_test", np.dtype("uint16")),
+    ("segment_x", np.dtype("uint32")),
+    ("segment_y", np.dtype("uint32")),
+    ("segment_x_pix", np.dtype("uint32")),
+    ("segment_y_pix", np.dtype("uint32")),
+    ("latitude", np.dtype("<f4")),
+    ("longitude", np.dtype("<f4")),
+    ("latitude_increment", np.dtype("<f4")),
+    ("longitude_increment", np.dtype("<f4")),
+    ("air_temperature", np.dtype("<f4")),
+    ("air_pressure", np.dtype("<f4")),
+    ("air_pressure_error", np.dtype("<f4")),
+    ("air_pressure_correction", np.dtype("<f4")),
+    ("air_pressure_nwp_at_best_fit_level", np.dtype("<f4")),
+    ("wind_speed", np.dtype("<f4")),
+    ("wind_from_direction", np.dtype("<f4")),
+    ("wind_speed_nwp_at_amv_level", np.dtype("<f4")),
+    ("wind_from_direction_nwp_at_amv_level", np.dtype("<f4")),
+    ("wind_speed_nwp_at_best_fit_level", np.dtype("<f4")),
+    ("wind_from_direction_nwp_at_best_fit_level", np.dtype("<f4")),
+    ("wind_speed_difference_nwp_at_amv_level", np.dtype("<f4")),
+    ("wind_from_direction_difference_nwp_at_amv_level", np.dtype("<f4")),
+    ("wind_speed_difference_nwp_at_best_fit_level", np.dtype("<f4")),
+    ("wind_from_direction_difference_nwp_at_best_fit_level", np.dtype("<f4")),
+    ("quality_index_with_forecast", np.dtype("uint8")),
+    ("quality_index_without_forecast", np.dtype("uint8")),
+    ("quality_index_iwwg_value", np.dtype("uint8")),
+    ("tracer_correlation_method", np.dtype("uint8")),
+    ("tracer_type", np.dtype("uint8")),
+    ("height_assignment_method", np.dtype("uint8")),
+    ("orographic_index", np.dtype("uint8")),
+    ("cloud_type", np.dtype("uint8")),
+    ("correlation", np.dtype("uint8")),
+]
+
+# Global attributes accessed by the file handler
+NOMINAL_PRODUCT_TIME = "2025-02-06T13:00:00Z"
+SPATIAL_RESOLUTION = np.array([3.], dtype=np.float32)
+SATELLITE_IDENTIFIER = np.bytes_("MSG3")
+# Dataset attributes accessed by the file handler
+PERIOD = np.array([15.], dtype=np.float32)
+
+NUM_OBS = 1234
+
+
+@pytest.fixture
+def hrw_file(tmp_path):
+    """Create a HRW data file."""
+    fname = tmp_path / "S_NWC_HRW_MSG3_MSG-N-BS_20250206T130000Z.nc"
+    with h5py.File(fname, "w") as h5f:
+        h5f.attrs["nominal_product_time"] = NOMINAL_PRODUCT_TIME
+        h5f.attrs["spatial_resolution"] = SPATIAL_RESOLUTION
+        h5f.attrs["satellite_identifier"] = SATELLITE_IDENTIFIER
+        for ch in WIND_CHANNELS:
+            _create_channel_dataset(h5f, ch)
+    return fname
+
+
+def _create_channel_dataset(h5f, name):
+    dset = h5f.create_dataset(name, shape=(NUM_OBS,), dtype=np.dtype(WIND_DTYPES))
+    dset.attrs["period"] = PERIOD
+    data = _create_data()
+    for i in range(NUM_OBS):
+        dset[i] = data
+
+
+def _create_data():
+    data = []
+    for key, dtype in WIND_DTYPES:
+        val = np.array(255 * np.random.random(), dtype=dtype).item()  # noqa
+        data.append(val)
+
+    return tuple(data)
+
+
+def test_hrw_handler_init(hrw_file):
+    """Test the filehandler initialization works."""
+    from satpy.readers.nwcsaf_hrw_nc import NWCSAFGEOHRWFileHandler
+
+    filename_info = {"platform_id": "MSG3", "region_id": "MSG-N-BS", "start_time": dt.datetime(2025, 2, 6, 13, 0)}
+    filetype_info = {"file_type": "nc_nwcsaf_geo_hrw"}
+    fh = NWCSAFGEOHRWFileHandler(hrw_file, filename_info, filetype_info)
+
+    assert fh.filename_info == filename_info
+    assert fh.filetype_info == filetype_info
+    assert fh.platform_name is not None
+    assert fh.sensor == "seviri"

--- a/satpy/tests/reader_tests/test_nwcsaf_hrw_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_hrw_nc.py
@@ -192,6 +192,7 @@ def _check_common_attrs(data):
     assert "wind_vis06_latitude" in data.coords
     assert data.dtype == np.float32
     assert data.values.dtype == np.float32
+    assert "units" in data.attrs
 
 
 def test_hrw_via_scene(hrw_file):

--- a/satpy/tests/reader_tests/test_nwcsaf_hrw_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_hrw_nc.py
@@ -100,10 +100,10 @@ FILENAME_INFO = {"platform_id": "MSG3", "region_id": "MSG-N-BS", "start_time": d
 FILETYPE_INFO = {"file_type": "nc_nwcsaf_geo_hrw"}
 
 
-@pytest.fixture
-def hrw_file(tmp_path):
+@pytest.fixture(scope="module")
+def hrw_file(tmp_path_factory):
     """Create a HRW data file."""
-    fname = tmp_path / "S_NWC_HRW_MSG3_MSG-N-BS_20250206T130000Z.nc"
+    fname = tmp_path_factory.mktemp("data") / "S_NWC_HRW_MSG3_MSG-N-BS_20250206T130000Z.nc"
     with h5py.File(fname, "w") as h5f:
         h5f.attrs["nominal_product_time"] = NOMINAL_PRODUCT_TIME
         h5f.attrs["spatial_resolution"] = SPATIAL_RESOLUTION

--- a/satpy/tests/reader_tests/test_nwcsaf_hrw_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_hrw_nc.py
@@ -94,7 +94,7 @@ SATELLITE_IDENTIFIER = np.bytes_("MSG3")
 # Dataset attributes accessed by the file handler
 TIME_PERIOD = np.array([15.], dtype=np.float32)
 
-NUM_OBS = 1234
+NUM_OBS = 123
 NUMBER_OF_DATASETS_WITHOUT_TRAJECTORIES = 259
 
 
@@ -184,6 +184,8 @@ def test_hrw_via_scene(hrw_file):
     scn.load(["wind_vis06_wind_from_direction"])
     data = scn["wind_vis06_wind_from_direction"]
 
+    assert scn.start_time == dt.datetime(2025, 2, 6, 13, 0)
+    assert scn.end_time == dt.datetime(2025, 2, 6, 13, 15)
     _check_scene_dataset_attrs(data)
     _check_common_attrs(data)
 


### PR DESCRIPTION
This PR adds a reader for the High Resolution Winds data from NWC SAF GEO.

The data structure is very complex, and due to the unsupported compound data type can't be opened with `xr.open_dataset()`. Because there are 259 datasets, I've made the dataset definitions dynamic instead of putting them into the reader YAML. The code is in a separate file because the internal structure is completely different to the other NWC SAF GEO products (see the linked issue).

By default the file handler reads the datasets separately for each imaging channel. That is, the datasets are named `wind_vis06_air_pressure`, `wind_hrvis_wind_speed`, and so on. The prefix is the name of the channel within the files.

The user can also supply `reader_kwargs={"merge_channels": True}` to collect all the data together. In this case the datasets are named without the prefix, such as `air_pressure`, `wind_speed`, etc.

 - [x] Closes #3052 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
