### PR TITLE
Fix deprecated codecov action parameter use and limit sphinx in documentation rendering

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,7 +139,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           flags: behaviourtests
-          file: ./coverage.xml
+          files: ./coverage.xml
           env_vars: OS,PYTHON_VERSION,UNSTABLE
 
   coveralls:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,7 +118,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           flags: unittests
-          file: ./coverage.xml
+          files: ./coverage.xml
           env_vars: OS,PYTHON_VERSION,UNSTABLE
 
       - name: Coveralls Parallel

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - rioxarray
   - setuptools
   - setuptools_scm
-  - sphinx
+  - sphinx!=8.2.0
   - sphinx_rtd_theme
   - sphinxcontrib-apidoc
   - trollsift


### PR DESCRIPTION
Replacement for #3068. In that PR I started updating sphinx usage to 8.2.0 and then realized there is a memory leak in 8.2.0 that causes RTD builds to fail. In this PR I keep the CI warning fix, but limit sphinx so 8.2.0 isn't used.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
