### PR TITLE
Fix plugin tests not completely cleaning up after themselves

### DIFF
--- a/satpy/tests/test_config.py
+++ b/satpy/tests/test_config.py
@@ -289,8 +289,17 @@ def _create_yamlbased_plugin(
 class TestPluginsConfigs:
     """Test that plugins are working."""
 
-    def setup_method(self):
-        """Set up the test."""
+    @classmethod
+    def setup_class(cls):
+        """Set up the class of tests with a clean environment."""
+        cached_entry_point.cache_clear()
+
+    def teardown_method(self):
+        """Tear down the test.
+
+        Make sure we leave every test the way we started.
+
+        """
         cached_entry_point.cache_clear()
 
     def test_get_plugin_configs(self, fake_composite_plugin_etc_path):


### PR DESCRIPTION
We've had occasional test failures related to a missing "satpy_plugin". This seemed like a race condition by the `pytest-xdist` parallel test execution and some test corrupting other tests. Now that I tracked it down I think it could have happened if regular pytest execution ordered the tests differently. Basically the plugin tests were cleaning up the entry points cache *before* tests but they should have been doing it *after* the tests. This PR fixes that.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
