### PR TITLE
Refactor MODIS readers to avoid extra dask tasks

### DIFF
--- a/satpy/readers/modis_l1b.py
+++ b/satpy/readers/modis_l1b.py
@@ -280,7 +280,8 @@ def calibrate_refl(array, attributes, index):
     offset = np.float32(attributes["reflectance_offsets"][index])
     scale = np.float32(attributes["reflectance_scales"][index])
     # convert to reflectance and convert from 1 to %
-    array = (array - offset) * scale * 100
+    array = (array - offset)
+    array = array * (scale * 100)  # avoid extra dask tasks by combining scalars
     return array
 
 


### PR DESCRIPTION
I was using the `modis_l1b` reader for debugging something dask related and got annoyed at how many tasks were in the task graph for simple reading functionality. This PR rewrites some of these things to avoid the repetitive tasks (scaling and fill value checks) and the confusing tasks (angle offsets for lonlat2xyz compatibility). I was tempted to also apply changes like this to all the calibration and uncertainty checks, but overall these changes don't affect performance much so I plan to leave these other changes for a future where I (or someone else) is annoyed by all the tasks being shown by dask.

Note: I did these while debugging other things so it is possible the code is not the cleanest and needs more cleanup, but the tests pass so I think that's a good start.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
