### PR TITLE
Refactor "compute_relative_azimuth" to be more flexible

### DIFF
--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -333,12 +333,15 @@ def _geo_dask_to_data_array(arr: da.Array) -> xr.DataArray:
     return xr.DataArray(arr, dims=("y", "x"))
 
 
-def compute_relative_azimuth(sat_azi: xr.DataArray, sun_azi: xr.DataArray) -> xr.DataArray:
+def compute_relative_azimuth(
+        sat_azi: xr.DataArray | da.Array,
+        sun_azi: xr.DataArray | da.Array
+) -> xr.DataArray | da.Array:
     """Compute the relative azimuth angle.
 
     Args:
-        sat_azi: DataArray for the satellite azimuth angles, typically in 0-360 degree range.
-        sun_azi: DataArray for the solar azimuth angles, should be in same range as sat_azi.
+        sat_azi: DataArray or dask array for the satellite azimuth angles, typically in 0-360 degree range.
+        sun_azi: DataArray or dask array for the solar azimuth angles, should be in same range as sat_azi.
 
     Returns:
         A DataArray containing the relative azimuth angle in the 0-180 degree range.
@@ -348,9 +351,8 @@ def compute_relative_azimuth(sat_azi: xr.DataArray, sun_azi: xr.DataArray) -> xr
     Relative azimuth is 180 when sun and satellite are directly opposite each other (forward scatter).
     """
     ssadiff = np.absolute(sun_azi - sat_azi)
-    ssadiff = np.minimum(ssadiff, 360 - ssadiff)
-
-    return ssadiff
+    dtype = sun_azi.dtype.type
+    return np.minimum(ssadiff, dtype(360.0) - ssadiff)
 
 
 def get_angles(data_arr: xr.DataArray) -> tuple[xr.DataArray, xr.DataArray, xr.DataArray, xr.DataArray]:

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -340,11 +340,12 @@ def compute_relative_azimuth(
     """Compute the relative azimuth angle.
 
     Args:
-        sat_azi: DataArray or dask array for the satellite azimuth angles, typically in 0-360 degree range.
-        sun_azi: DataArray or dask array for the solar azimuth angles, should be in same range as sat_azi.
+        sat_azi: satellite azimuth angles typically in the 0-360 degree range.
+        sun_azi: solar azimuth angles in same range as sat_azi.
 
     Returns:
-        A DataArray containing the relative azimuth angle in the 0-180 degree range.
+        The relative azimuth angle or difference between solar and satellite
+        azimuth angles in the 0-180 degree range.
 
     NOTE: Relative azimuth is defined such that:
     Relative azimuth is 0 when sun and satellite are aligned on one side of a pixel (back scatter).

--- a/satpy/tests/modifier_tests/test_angles.py
+++ b/satpy/tests/modifier_tests/test_angles.py
@@ -380,6 +380,7 @@ class TestAngleGeneration:
             assert raa.attrs == {}
             assert raa.dims == saa.dims
         np.testing.assert_allclose(expected_raa, computed_raa, rtol=2e-7)
+        assert raa.chunks == saa.chunks
 
     @pytest.mark.parametrize("dtype", [np.float32, np.float64])
     def test_solazi_correction(self, dtype):


### PR DESCRIPTION
Similar to #3081, while debugging something unrelated I got annoyed at how many tasks were created for a simple task and decided to wrap the code in a map_blocks call. One complication is that @simonrp84 wrote this function to work for users calling it alone and passing `DataArray` objects, but the only use in Satpy itself is passing dask arrays. I thought about adding a decorator to handle the xarray -> dask conversion and back, but decided the if statements inside the function weren't that bad.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
