### PR TITLE
Add ABI Blowing Snow RGB

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -806,3 +806,19 @@ composites:
     prerequisites:
       - geo_color_high_clouds
       - geo_color_background_with_low_clouds
+
+  blowing_snow:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    description: >
+      Blowing Snow RGB
+    references:
+      Quick Guide: https://rammb2.cira.colostate.edu/wp-content/uploads/2024/11/GOES-BlowingSnowRGB1_QuickGuide_24April2024.pdf
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: C02
+      - name: C05
+      - compositor: !!python/name:satpy.composites.DifferenceCompositor
+        prerequisites:
+          - name: C07
+          - name: C13
+    standard_name: blowing_snow

--- a/satpy/etc/enhancements/abi.yaml
+++ b/satpy/etc/enhancements/abi.yaml
@@ -273,3 +273,18 @@ enhancements:
           stretch: crude
           min_stretch: 0
           max_stretch: 500
+  blowing_snow:
+    ## RGB Recipe: https://rammb2.cira.colostate.edu/wp-content/uploads/2024/11/GOES-BlowingSnowRGB1_QuickGuide_24April2024.pdf
+    standard_name: blowing_snow
+    sensor: abi
+    operations:
+      - name: stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs:
+          stretch: crude
+          min_stretch: [0.0, 0.0, 0.0]
+          max_stretch: [50.0, 20.0, 30.0]
+      - name: gamma
+        method: !!python/name:satpy.enhancements.gamma
+        kwargs:
+          gamma: [0.7, 1.0, 0.7]


### PR DESCRIPTION
Adds the NASA/CIRA "Blowing Snow" RGB to the ABI composites. I only had one winter-ish dataset on my local computer so here's what the top looks like:

![image](https://github.com/user-attachments/assets/b288162f-981e-4fbd-9307-ee9e268d5fbc)


 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
