### PR TITLE
Deprecate "cira_day_convection" in favor of "convection"

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -353,7 +353,8 @@ composites:
 
   cira_day_convection:
     compositor: !!python/name:satpy.composites.GenericCompositor
-    standard_name: cira_day_convection
+    deprecation_warning: "'cira_day_convection' is deprecated. Use 'convection' instead."
+    standard_name: convection
     description: >
       The Day Convection RGB emphasizes convection with strong updrafts and small ice particles
       indicative of severe storms. Bright yellow in the RGB indicates strong updrafts prior
@@ -482,7 +483,9 @@ composites:
 
   convection:
     description: >
-      Day Convection RGB, for GOESR: NASA, NOAA
+      The Day Convection RGB emphasizes convection with strong updrafts and small ice particles
+      indicative of severe storms. Bright yellow in the RGB indicates strong updrafts prior
+      to the mature storm stage.
     references:
       CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_GOESR_DayConvectionRGB_final.pdf
     compositor: !!python/name:satpy.composites.GenericCompositor

--- a/satpy/etc/enhancements/abi.yaml
+++ b/satpy/etc/enhancements/abi.yaml
@@ -59,16 +59,6 @@ enhancements:
         kwargs:
           gamma: [0.4, 1, 1]
 
-  cira_day_convection:
-    standard_name: cira_day_convection
-    operations:
-      - name: stretch
-        method: !!python/name:satpy.enhancements.stretch
-        kwargs:
-          stretch: crude
-          min_stretch: [-35.0, -5.0, -75.0]
-          max_stretch: [5.0, 60.0, 25.0]
-
   cimss_cloud_type:
     standard_name: cimss_cloud_type
     operations:


### PR DESCRIPTION
Added in https://github.com/pytroll/satpy/pull/1251 but was identified as a duplicate from the convection RGB added in #564 but was merged anyway out of impatience it seems.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
