### PR TITLE
Fix dependency tree module using logger from node module

### DIFF
--- a/satpy/dependency_tree.py
+++ b/satpy/dependency_tree.py
@@ -26,7 +26,10 @@ import numpy as np
 from satpy import DataID, DatasetDict
 from satpy.dataset import ModifierTuple, create_filtered_query
 from satpy.dataset.data_dict import TooManyResults, get_key
-from satpy.node import EMPTY_LEAF_NAME, LOG, CompositorNode, MissingDependencies, Node, ReaderNode
+from satpy.node import EMPTY_LEAF_NAME, CompositorNode, MissingDependencies, Node, ReaderNode
+from satpy.utils import get_logger
+
+LOG = get_logger(__name__)
 
 
 class Tree:


### PR DESCRIPTION
Hopefully this helps debugging and learning of how enhancement decisions are made. With:

```python
from satpy.utils import trace_on
trace_on()

You'll get a lot of dependency tree trace logs but you'll also get enhancement traces now that look like this:

```
TRACE    : Checking 'name' level for 'cloud_type': True
TRACE    :   Checking 'reader' level for 'abi_l1b': False
TRACE    :   Checking 'reader' level for <wildcard>: False
TRACE    : Checking 'name' level for <wildcard>: True
TRACE    :   Checking 'reader' level for 'abi_l1b': False
TRACE    :   Checking 'reader' level for <wildcard>: True
TRACE    :     Checking 'platform_name' level for 'GOES-16': False
TRACE    :     Checking 'platform_name' level for <wildcard>: True
TRACE    :       Checking 'sensor' level for 'abi': True
TRACE    :         Checking 'standard_name' level for 'cloud_type': True
TRACE    :           Match key 'units' not in query dict
TRACE    :           Checking 'units' level for <wildcard>: True
TRACE    :             Found match!
TRACE    :             | sensor=abi
TRACE    :             | standard_name=cloud_type
```

If you want to print the enhancement decision tree you can do:

```python
from satpy.writers import Enhancer
enh = Enhancer()
# NOTE: This is not loading sensor-specific enhancement configs
# Need `enh.add_sensor_enhancements(["abi"])`
enh.enhancement_tree.print_tree()

```

And you'll get:

<details>

```
name=<wildcard>
  reader=<wildcard>
    platform_name=<wildcard>
      sensor=<wildcard>
        standard_name=<wildcard>
          units=<wildcard>
            | <global wildcard match>
        standard_name=toa_bidirectional_reflectance
          units=<wildcard>
            | standard_name=toa_bidirectional_reflectance
        standard_name=surface_bidirectional_reflectance
          units=<wildcard>
            | standard_name=surface_bidirectional_reflectance
        standard_name=true_color
          units=<wildcard>
            | standard_name=true_color
        standard_name=overview
          units=<wildcard>
            | standard_name=overview
        standard_name=ocean_color
          units=<wildcard>
            | standard_name=ocean_color
        standard_name=night_overview
          units=<wildcard>
            | standard_name=night_overview
        standard_name=natural_color
          units=<wildcard>
            | standard_name=natural_color
        standard_name=airmass
          units=<wildcard>
            | standard_name=airmass
        standard_name=green_snow
          units=<wildcard>
            | standard_name=green_snow
        standard_name=convection
          units=<wildcard>
            | standard_name=convection
        standard_name=dust
          units=<wildcard>
            | standard_name=dust
        standard_name=ash
          units=<wildcard>
            | standard_name=ash
        standard_name=fog
          units=<wildcard>
            | standard_name=fog
        standard_name=night_fog
          units=<wildcard>
            | standard_name=night_fog
        standard_name=snow
          units=<wildcard>
            | standard_name=snow
        standard_name=day_microphysics
          units=<wildcard>
            | standard_name=day_microphysics
        standard_name=day_microphysics_winter
          units=<wildcard>
            | standard_name=day_microphysics_winter
        standard_name=cloudtop
          units=<wildcard>
            | standard_name=cloudtop
        standard_name=sar-ice
          units=<wildcard>
            | standard_name=sar-ice
        standard_name=sar-ice-log
          units=<wildcard>
            | standard_name=sar-ice-log
        standard_name=sar-ice-legacy
          units=<wildcard>
            | standard_name=sar-ice-legacy
        standard_name=sar-land
          units=<wildcard>
            | standard_name=sar-land
        standard_name=sar-rgb
          units=<wildcard>
            | standard_name=sar-rgb
        standard_name=green-sar
          units=<wildcard>
            | standard_name=green-sar
        standard_name=sar-quick
          units=<wildcard>
            | standard_name=sar-quick
        standard_name=natural_with_night_fog
          units=<wildcard>
            | standard_name=natural_with_night_fog
        standard_name=cloudtype
          units=<wildcard>
            | standard_name=cloudtype
        standard_name=cloudmask
          units=<wildcard>
            | standard_name=cloudmask
        standard_name=pps_cma
          units=<wildcard>
            | standard_name=pps_cma
        standard_name=pps_ct
          units=<wildcard>
            | standard_name=pps_ct
        standard_name=pps_phase
          units=<wildcard>
            | standard_name=pps_phase
        standard_name=pps_ctth
          units=<wildcard>
            | standard_name=pps_ctth
        standard_name=pps_cmaprob
          units=<wildcard>
            | standard_name=pps_cmaprob
        standard_name=pps_cot
          units=<wildcard>
            | standard_name=pps_cot
        standard_name=pps_cwp
          units=<wildcard>
            | standard_name=pps_cwp
        standard_name=pps_iwp
          units=<wildcard>
            | standard_name=pps_iwp
        standard_name=pps_lwp
          units=<wildcard>
            | standard_name=pps_lwp
        standard_name=pps_cre
          units=<wildcard>
            | standard_name=pps_cre
        standard_name=cloudmask_extended
          units=<wildcard>
            | standard_name=cloudmask_extended
        standard_name=cloudmask_probability
          units=<wildcard>
            | standard_name=cloudmask_probability
        standard_name=cloud_top_height_geo
          units=<wildcard>
            | standard_name=cloud_top_height_geo
        standard_name=cloud_top_height_pps
          units=<wildcard>
            | standard_name=cloud_top_height_pps
        standard_name=cloud_top_pressure
          units=<wildcard>
            | standard_name=cloud_top_pressure
        standard_name=cloud_top_temperature
          units=<wildcard>
            | standard_name=cloud_top_temperature
        standard_name=cloud_top_phase
          units=<wildcard>
            | standard_name=cloud_top_phase
        standard_name=cloud_drop_effective_radius_geo
          units=<wildcard>
            | standard_name=cloud_drop_effective_radius_geo
        standard_name=cloud_drop_effective_radius_pps
          units=<wildcard>
            | standard_name=cloud_drop_effective_radius_pps
        standard_name=cloud_optical_thickness_geo
          units=<wildcard>
            | standard_name=cloud_optical_thickness_geo
        standard_name=cloud_optical_thickness_pps
          units=<wildcard>
            | standard_name=cloud_optical_thickness_pps
        standard_name=cloud_liquid_water_path
          units=<wildcard>
            | standard_name=cloud_liquid_water_path
        standard_name=cloud_ice_water_path
          units=<wildcard>
            | standard_name=cloud_ice_water_path
        standard_name=precipitation_probability
          units=<wildcard>
            | standard_name=precipitation_probability
        standard_name=convective_rain_rate
          units=<wildcard>
            | standard_name=convective_rain_rate
        standard_name=convective_precipitation_hourly_accumulation
          units=<wildcard>
            | standard_name=convective_precipitation_hourly_accumulation
        standard_name=total_precipitable_water
          units=<wildcard>
            | standard_name=total_precipitable_water
        standard_name=showalter_index
          units=<wildcard>
            | standard_name=showalter_index
        standard_name=lifted_index
          units=<wildcard>
            | standard_name=lifted_index
        standard_name=convection_initiation_prob30
          units=<wildcard>
            | standard_name=convection_initiation_prob30
        standard_name=convection_initiation_prob60
          units=<wildcard>
            | standard_name=convection_initiation_prob60
        standard_name=convection_initiation_prob90
          units=<wildcard>
            | standard_name=convection_initiation_prob90
        standard_name=rdt_cell_type
          units=<wildcard>
            | standard_name=rdt_cell_type
        standard_name=asii_prob
          units=<wildcard>
            | standard_name=asii_prob
        standard_name=day_microphysics_ahi
          units=<wildcard>
            | standard_name=day_microphysics_ahi
        standard_name=cloud_phase_distinction
          units=<wildcard>
            | standard_name=cloud_phase_distinction
        standard_name=water_vapors1
          units=<wildcard>
            | standard_name=water_vapors1
        standard_name=water_vapors2
          units=<wildcard>
            | standard_name=water_vapors2
        standard_name=ncc_radiance
          units=<wildcard>
            | standard_name=ncc_radiance
        standard_name=realistic_colors
          units=<wildcard>
            | standard_name=realistic_colors
        standard_name=snow_age
          units=<wildcard>
            | standard_name=snow_age
        standard_name=night_microphysics
          units=<wildcard>
            | standard_name=night_microphysics
        standard_name=24h_microphysics
          units=<wildcard>
            | standard_name=24h_microphysics
        standard_name=ir_overview
          units=<wildcard>
            | standard_name=ir_overview
        standard_name=ir108_3d
          units=<wildcard>
            | standard_name=ir108_3d
        standard_name=ir_cloud_day
          units=<wildcard>
            | standard_name=ir_cloud_day
        standard_name=geo_color_high_clouds
          units=<wildcard>
            | standard_name=geo_color_high_clouds
        standard_name=geo_color_low_clouds
          units=<wildcard>
            | standard_name=geo_color_low_clouds
        standard_name=geo_color_day_night_blend
          units=<wildcard>
            | standard_name=geo_color_day_night_blend
        standard_name=colorized_ir_clouds
          units=<wildcard>
            | standard_name=colorized_ir_clouds
        standard_name=vis_sharpened_ir
          units=<wildcard>
            | standard_name=vis_sharpened_ir
        standard_name=ir_sandwich
          units=<wildcard>
            | standard_name=ir_sandwich
        standard_name=natural_enh
          units=<wildcard>
            | standard_name=natural_enh
        standard_name=hrv_clouds
          units=<wildcard>
            | standard_name=hrv_clouds
        standard_name=hrv_fog
          units=<wildcard>
            | standard_name=hrv_fog
        standard_name=hrv_severe_storms
          units=<wildcard>
            | standard_name=hrv_severe_storms
        standard_name=hrv_severe_storms_masked
          units=<wildcard>
            | standard_name=hrv_severe_storms_masked
        standard_name=true_color_with_night_ir
          units=<wildcard>
            | standard_name=true_color_with_night_ir
        standard_name=night_background
          units=<wildcard>
            | standard_name=night_background
        standard_name=night_ir_alpha
          units=<wildcard>
            | standard_name=night_ir_alpha
        standard_name=night_ir_with_background
          units=<wildcard>
            | standard_name=night_ir_with_background
        standard_name=so2
          units=<wildcard>
            | standard_name=so2
        standard_name=tropical_airmass
          units=<wildcard>
            | standard_name=tropical_airmass
        standard_name=cimss_cloud_type
          units=<wildcard>
            | standard_name=cimss_cloud_type
        standard_name=cloud_phase
          units=<wildcard>
            | standard_name=cloud_phase
        standard_name=day_essl_low_level_moisture
          units=<wildcard>
            | standard_name=day_essl_low_level_moisture
        standard_name=masked_essl_colorized_low_level_moisture
          units=<wildcard>
            | standard_name=masked_essl_colorized_low_level_moisture
        standard_name=rocket_plume
          units=<wildcard>
            | standard_name=rocket_plume
        standard_name=true_color_reproduction_color_stretch
          units=<wildcard>
            | standard_name=true_color_reproduction_color_stretch
        standard_name=true_color_reproduction
          units=<wildcard>
            | standard_name=true_color_reproduction
        standard_name=imager_with_lightning
          units=<wildcard>
            | standard_name=imager_with_lightning
        standard_name=image_ready
          units=<wildcard>
            | standard_name=image_ready
        standard_name=mw183_humidity
          units=<wildcard>
            | standard_name=mw183_humidity
  reader=clavrx
    platform_name=<wildcard>
      sensor=<wildcard>
        standard_name=cloud_mask
          units=<wildcard>
            | reader=clavrx
            | standard_name=cloud_mask
name=true_color_crefl
  reader=<wildcard>
    platform_name=<wildcard>
      sensor=<wildcard>
        standard_name=true_color
          units=<wildcard>
            | name=true_color_crefl
            | standard_name=true_color
name=fire_temperature
  reader=<wildcard>
    platform_name=<wildcard>
      sensor=<wildcard>
        standard_name=fire_temperature
          units=<wildcard>
            | name=fire_temperature
            | standard_name=fire_temperature
name=fire_temperature_awips
  reader=<wildcard>
    platform_name=<wildcard>
      sensor=<wildcard>
        standard_name=fire_temperature
          units=<wildcard>
            | name=fire_temperature_awips
            | standard_name=fire_temperature
name=fire_temperature_eumetsat
  reader=<wildcard>
    platform_name=<wildcard>
      sensor=<wildcard>
        standard_name=fire_temperature
          units=<wildcard>
            | name=fire_temperature_eumetsat
            | standard_name=fire_temperature
name=fire_temperature_39refl
  reader=<wildcard>
    platform_name=<wildcard>
      sensor=<wildcard>
        standard_name=fire_temperature
          units=<wildcard>
            | name=fire_temperature_39refl
            | standard_name=fire_temperature
name=chlor_a
  reader=seadas_l2
    platform_name=<wildcard>
      sensor=<wildcard>
        standard_name=<wildcard>
          units=<wildcard>
            | name=chlor_a
            | reader=seadas_l2
  reader=oci_l2_bgc
    platform_name=<wildcard>
      sensor=<wildcard>
        standard_name=<wildcard>
          units=<wildcard>
            | name=chlor_a
            | reader=oci_l2_bgc
name=essl_low_level_moisture
  reader=<wildcard>
    platform_name=<wildcard>
      sensor=<wildcard>
        standard_name=<wildcard>
          units=<wildcard>
            | name=essl_low_level_moisture
name=essl_colorized_low_level_moisture
  reader=<wildcard>
    platform_name=<wildcard>
      sensor=<wildcard>
        standard_name=<wildcard>
          units=<wildcard>
            | name=essl_colorized_low_level_moisture

```

</details>

I still need to add tests.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
