### PR TITLE
Fix `RatioCompositor` `standard_name` handling

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -300,6 +300,8 @@ class RatioCompositor(CompositeBase):
         projectables = self.match_data_arrays(projectables)
         info = combine_metadata(*projectables)
         info["name"] = self.attrs["name"]
+        if "standard_name" in self.attrs:
+            info["standard_name"] = self.attrs["standard_name"]
 
         proj = projectables[0] / projectables[1]
         proj.attrs = info

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -1230,7 +1230,7 @@ enhancements:
           max_stretch: [50, 50, 100]
 
   essl_low_level_moisture:
-    name: essl_low_level_moisture
+    standard_name: essl_low_level_moisture
     operations:
       - name: linear_stretch
         method: !!python/name:satpy.enhancements.stretch
@@ -1241,9 +1241,7 @@ enhancements:
     operations: []
 
   essl_colorized_low_level_moisture:
-    # this enhancement is only found if using name but not standard_name
-    # The colormap was developed by the European Severe Storms Laboratory (ESSL).
-    name: essl_colorized_low_level_moisture
+    standard_name: essl_colorized_low_level_moisture
     operations: &masked_llm
       - name: colorize
         method: !!python/name:satpy.enhancements.colorize
@@ -1355,7 +1353,6 @@ enhancements:
               - [255, 255, 191]
 
   masked_essl_colorized_low_level_moisture:
-    # this enhancement is only found if using standard_name but not name
     standard_name: masked_essl_colorized_low_level_moisture
     operations: *masked_llm
 


### PR DESCRIPTION
The `RatioCompositor` was keeping the `standard_name` of the input data. This PR changes it so that it is taken from the compositor attrs if present. This way the `standard_name` given in the composite definition YAML is replacing the `standard_name` of the combined input data.

Also, the enhancement configs for the ESSL Low Level Moisture where this was noticed have now `standard_name`s defined and the extra comments are removed.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
