### PR TITLE
Fix 3D masks with size 1 dimension in MaskingCompositor

### DIFF
--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1908,6 +1908,9 @@ class MaskingCompositor(GenericCompositor):
         data_in = projectables[0]
         mask_in = projectables[1]
 
+        mask_in = mask_in.squeeze(drop=True)
+        mask_in = mask_in.round()  # Make sure to have whole numbers in case of smearing from resampling
+
         alpha_attrs = data_in.attrs.copy()
         data = self._select_data_bands(data_in)
 

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1908,6 +1908,7 @@ class MaskingCompositor(GenericCompositor):
         data_in = projectables[0]
         mask_in = projectables[1]
 
+        # remove "bands" dimension for single band masks (ex. "L")
         mask_in = mask_in.squeeze(drop=True)
 
         alpha_attrs = data_in.attrs.copy()

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -1909,7 +1909,6 @@ class MaskingCompositor(GenericCompositor):
         mask_in = projectables[1]
 
         mask_in = mask_in.squeeze(drop=True)
-        mask_in = mask_in.round()  # Make sure to have whole numbers in case of smearing from resampling
 
         alpha_attrs = data_in.attrs.copy()
         data = self._select_data_bands(data_in)

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -1792,7 +1792,7 @@ class TestMaskingCompositor:
         # Test with numerical transparency data using 3d test mask data which can not be squeezed
         comp = MaskingCompositor("name", conditions=conditions_v3,
                                  mode=mode)
-        with pytest.raises(ValueError, match=".*Received 3 dimension\(s\) but expected 2.*"):
+        with pytest.raises(ValueError, match=".*Received 3 dimension\\(s\\) but expected 2.*"):
             comp([test_data, test_value_3d_data_bands])
 
     def test_call_named_fields(self, conditions_v2, test_data, test_ct_data,

--- a/satpy/tests/test_composites.py
+++ b/satpy/tests/test_composites.py
@@ -1653,15 +1653,16 @@ class TestMaskingCompositor:
         return ct_data
 
     @pytest.fixture
-    def test_value_3d_data(self):
+    def value_3d_data(self):
         """Test 3D data array."""
         value_3d_data = da.array([[[1, 0, 0],
                                    [0, 1, 0],
                                    [0, 0, 1]]])
         value_3d_data = xr.DataArray(value_3d_data, dims=["bands", "y", "x"])
         return value_3d_data
+
     @pytest.fixture
-    def test_value_3d_data_bands(self):
+    def value_3d_data_bands(self):
         """Test 3D data array."""
         value_3d_data = da.array([[[1, 0, 0],
                                    [0, 1, 0],
@@ -1759,14 +1760,14 @@ class TestMaskingCompositor:
 
     @pytest.mark.parametrize("mode", ["LA", "RGBA"])
     def test_call_numerical_transparency_data_with_3d_mask_data(
-            self, test_data, test_value_3d_data, conditions_v3, mode):
+            self, test_data, value_3d_data, conditions_v3, mode):
         """Test call the compositor with numerical transparency data.
 
         Use parameterisation to test different image modes.
         """
         from satpy.composites import MaskingCompositor
 
-        reference_data_v3 = test_data.where(test_value_3d_data[0] > 0)
+        reference_data_v3 = test_data.where(value_3d_data[0] > 0)
         reference_alpha_v3 = xr.DataArray([[1., 0., 0.],
                                            [0., 1., 0.],
                                            [0., 0., 1.]])
@@ -1774,7 +1775,7 @@ class TestMaskingCompositor:
         # Test with numerical transparency data using 3d test mask data which can be squeezed
         comp = MaskingCompositor("name", conditions=conditions_v3,
                                  mode=mode)
-        res = comp([test_data, test_value_3d_data])
+        res = comp([test_data, value_3d_data])
         assert res.mode == mode
         for m in mode.rstrip("A"):
             np.testing.assert_allclose(res.sel(bands=m), reference_data_v3)
@@ -1782,7 +1783,7 @@ class TestMaskingCompositor:
 
     @pytest.mark.parametrize("mode", ["LA", "RGBA"])
     def test_call_numerical_transparency_data_with_3d_mask_data_exception(
-            self, test_data, test_value_3d_data_bands, conditions_v3, mode):
+            self, test_data, value_3d_data_bands, conditions_v3, mode):
         """Test call the compositor with numerical transparency data, too many dimensions to squeeze.
 
         Use parameterisation to test different image modes.
@@ -1793,7 +1794,7 @@ class TestMaskingCompositor:
         comp = MaskingCompositor("name", conditions=conditions_v3,
                                  mode=mode)
         with pytest.raises(ValueError, match=".*Received 3 dimension\\(s\\) but expected 2.*"):
-            comp([test_data, test_value_3d_data_bands])
+            comp([test_data, value_3d_data_bands])
 
     def test_call_named_fields(self, conditions_v2, test_data, test_ct_data,
                                reference_data, reference_alpha):


### PR DESCRIPTION
This PR fixes the `MaskingCompositor` when it is given a mask with 3 dimensions but one of those dimensions is of size 1. At the time of writing a mask input needs to only be 2D, but some compositors might produce a single band output ("L") which needs to be ignored in the `MaskingCompositor`.

 - [X] Closes #3092  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
