### PR TITLE
Add SWIR composite to Sentinel-2/MSI.

### DIFF
--- a/satpy/etc/composites/msi.yaml
+++ b/satpy/etc/composites/msi.yaml
@@ -414,6 +414,25 @@ composites:
       transparency: 100
     standard_name: ndsi_msi
 
+  dataspace_swir:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'B12'
+        modifiers: [effective_solar_pathlength_corrected]
+      - name: 'B8A'
+        modifiers: [effective_solar_pathlength_corrected]
+      - name: 'B04'
+        modifiers: [effective_solar_pathlength_corrected, rayleigh_corrected]
+    standard_name: natural_color
+
+  dataspace_swir_uncorr:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    prerequisites:
+      - name: 'B12'
+      - name: 'B8A'
+      - name: 'B04'
+    standard_name: natural_color
+
   ndsi_with_true_color:
     compositor: !!python/name:satpy.composites.BackgroundCompositor
     prerequisites:


### PR DESCRIPTION
This PR adds a SWIR composite (B12, B8a, B4) to the Sentinel-2/MSI reader. The composite is taken from the one available on the Copernicus Dataspace Ecosystem and will produce similar output. Both corrected and uncorrected versions are available:
`scn.load(['dataspace_swir_uncorr', 'dataspace_swir'])`

Example image:
![OUT_SMA](https://github.com/user-attachments/assets/d0124a0b-0b9d-4028-a06e-39445e50ab17)