### PR TITLE
Add hrv_clouds composite to FCI

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -20,6 +20,7 @@ The following people have made contributions to this project:
 - [Pierre de Buyl (pdebuyl)](https://github.com/pdebuyl)
 - [Eric Bruning (deeplycloudy)](https://github.com/deeplycloudy)
 - [Manuel Carranza (manucarran)](https://github.com/manucarran)
+- [Guido Cioni (guidocioni)](https://github.com/guidocioni)
 - [Lorenzo Clementi (loreclem)](https://github.com/loreclem)
 - [Colin Duff (ColinDuff)](https://github.com/ColinDuff)
 - [Radar, Satellite and Nowcasting Division (meteoswiss-mdr)](https://github.com/meteoswiss-mdr)

--- a/satpy/etc/composites/fci.yaml
+++ b/satpy/etc/composites/fci.yaml
@@ -87,6 +87,18 @@ composites:
         modifiers: [sunz_corrected]
     standard_name: toa_bidirectional_reflectance
 
+  ### Non-official HRV Clouds composite similar to SEVIRI
+  ### Both HRFI and FDHSI can be used to generate it
+  hrv_clouds:
+    compositor: !!python/name:satpy.composites.GenericCompositor
+    standard_name: hrv_clouds
+    prerequisites:
+      - name: vis_06
+        modifiers: [sunz_corrected]
+      - name: vis_06
+        modifiers: [sunz_corrected]
+      - ir_105
+
   ### True Color
   true_color:
     compositor: !!python/name:satpy.composites.SelfSharpenedRGB


### PR DESCRIPTION
This feature adds the possibility of creating the hrv_clouds composite also with FCI data. 

 - [x] Closes [#2935](https://github.com/pytroll/satpy/issues/2935)