### PR TITLE
Add quality filtering to VIIRS EDR CldBaseHght

### DIFF
--- a/satpy/etc/readers/viirs_edr.yaml
+++ b/satpy/etc/readers/viirs_edr.yaml
@@ -37,7 +37,7 @@ file_types:
         file_patterns:
             - 'LST_{version}_{platform_shortname}_s{start_time:%Y%m%d%H%M%S%f}_e{end_time:%Y%m%d%H%M%S%f}_c{creation_time}.nc'
     jrr_cloudbase:
-        file_reader: !!python/name:satpy.readers.viirs_edr.VIIRSJRRFileHandler
+        file_reader: !!python/name:satpy.readers.viirs_edr.VIIRSCBHFilterHandler
         file_patterns:
             - 'JRR-CloudBase_{version}_{platform_shortname}_s{start_time:%Y%m%d%H%M%S%f}_e{end_time:%Y%m%d%H%M%S%f}_c{creation_time}.nc'
     jrr_clouddcomp:

--- a/satpy/readers/viirs_edr.py
+++ b/satpy/readers/viirs_edr.py
@@ -411,10 +411,10 @@ class VIIRSAODHandler(VIIRSJRRFileHandler):
 
 
 class VIIRSCBHFilterHandler(VIIRSJRRFileHandler):
-    """File handler for surface reflectance files with optional vegetation indexes."""
+    """File handler for CloudBase files."""
 
     def __init__(self, *args, filter_cbh: bool = True, **kwargs) -> None:
-        """Initialize file handler and keep track of vegetation index filtering."""
+        """Initialize file handler and keep track of filtering options."""
         super().__init__(*args, **kwargs)
         self._filter_cbh = filter_cbh
 

--- a/satpy/tests/reader_tests/test_viirs_edr.py
+++ b/satpy/tests/reader_tests/test_viirs_edr.py
@@ -288,7 +288,7 @@ def volcanic_ash_file(tmp_path_factory: TempPathFactory) -> Path:
 
 @pytest.fixture(scope="module")
 def cloud_base_file(tmp_path_factory: TempPathFactory) -> Path:
-    """Generate fake AOD VIIRs EDR file."""
+    """Generate fake CloudBase VIIRs EDR file."""
     fn = f"JRR-CloudBase_v3r2_npp_s{START_TIME:%Y%m%d%H%M%S}0_e{END_TIME:%Y%m%d%H%M%S}0_c202307231023395.nc"
     data_vars = _create_continuous_variables(
         ("CldBaseHght",),
@@ -506,7 +506,7 @@ class TestVIIRSJRRReader:
 
     @pytest.mark.parametrize("filter_cbh", [False, True])
     def test_get_dataset_cbh_filter(self, cloud_base_file, filter_cbh):
-        """Test retrieval of vegetation indices from surface reflectance files."""
+        """Test retrieval of cloud base height with and without filtering."""
         from satpy import Scene
 
         bytes_in_m_row = 4 * 3200


### PR DESCRIPTION
This adds a `filter_cbh` to a custom file handler for the "CloudBase" VIIRS EDR file. This was a requirement for my Polar2Grid project. I assume the QC is not applied as part of the fill value assignment in the algorithm software (I'm asking Kathy about this).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->