### PR TITLE
Fix unit radiance attrs

### DIFF
--- a/satpy/dataset/metadata.py
+++ b/satpy/dataset/metadata.py
@@ -26,6 +26,7 @@ from operator import eq, is_
 
 import dask.array as da
 import numpy as np
+import xarray as xr
 
 from satpy.writers.utils import flatten_dict
 
@@ -200,8 +201,11 @@ def _all_arrays_equal(arrays):
 
     If the arrays are lazy, just check if they have the same identity.
     """
-    if isinstance(arrays[0].data, da.Array):
+    if isinstance(arrays[0], da.Array) or (
+    isinstance(arrays[0], xr.DataArray) and isinstance(arrays[0].data, da.Array)
+    ):
         return _all_identical(arrays)
+
     return _all_values_equal(arrays)
 
 

--- a/satpy/dataset/metadata.py
+++ b/satpy/dataset/metadata.py
@@ -24,6 +24,7 @@ from collections.abc import Collection
 from functools import partial, reduce
 from operator import eq, is_
 
+import dask.array as da
 import numpy as np
 
 from satpy.writers.utils import flatten_dict
@@ -199,7 +200,7 @@ def _all_arrays_equal(arrays):
 
     If the arrays are lazy, just check if they have the same identity.
     """
-    if hasattr(arrays[0], "compute"):
+    if isinstance(arrays[0].data, da.Array):
         return _all_identical(arrays)
     return _all_values_equal(arrays)
 

--- a/satpy/dataset/metadata.py
+++ b/satpy/dataset/metadata.py
@@ -199,7 +199,7 @@ def _all_arrays_equal(arrays):
 
     If the arrays are lazy, just check if they have the same identity.
     """
-    if hasattr(arrays[0], "chunks") and arrays[0].chunks is not None:
+    if getattr(arrays[0], "chunks", None) is not None:
         return _all_identical(arrays)
 
     return _all_values_equal(arrays)

--- a/satpy/dataset/metadata.py
+++ b/satpy/dataset/metadata.py
@@ -24,9 +24,7 @@ from collections.abc import Collection
 from functools import partial, reduce
 from operator import eq, is_
 
-import dask.array as da
 import numpy as np
-import xarray as xr
 
 from satpy.writers.utils import flatten_dict
 
@@ -201,9 +199,7 @@ def _all_arrays_equal(arrays):
 
     If the arrays are lazy, just check if they have the same identity.
     """
-    if isinstance(arrays[0], da.Array) or (
-    isinstance(arrays[0], xr.DataArray) and isinstance(arrays[0].data, da.Array)
-    ):
+    if hasattr(arrays[0], "chunks") and arrays[0].chunks is not None:
         return _all_identical(arrays)
 
     return _all_values_equal(arrays)

--- a/satpy/tests/reader_tests/test_fci_l1c_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_nc.py
@@ -288,7 +288,7 @@ def _get_test_calib_data_for_channel(data, ch_str):
         _get_test_calib_for_channel_ir(data, meas_path)
     elif ch_str.startswith("vis") or ch_str.startswith("nir"):
         _get_test_calib_for_channel_vis(data, meas_path)
-    data[meas_path + "/radiance_unit_conversion_coefficient"] = xr.DataArray(da.array(1234.56, dtype=np.float32))
+    data[meas_path + "/radiance_unit_conversion_coefficient"] = xr.DataArray(np.array(1234.56, dtype=np.float32))
 
 
 def _get_test_image_data_for_channel(data, ch_str, n_rows_cols):

--- a/satpy/tests/test_dataset.py
+++ b/satpy/tests/test_dataset.py
@@ -293,6 +293,22 @@ class TestCombineMetadata(unittest.TestCase):
         result = combine_metadata(*test_metadata)
         assert "valid_range" not in result
 
+    def test_combine_xarray_arrays(self):
+        """Test combining values that are non daskified xarray dataArrays."""
+        import xarray as xr
+
+        from satpy.dataset.metadata import combine_metadata
+
+        test_metadata = [{"valid_range": xr.DataArray(np.array([0., 0.00032], dtype=np.float32),
+                         attrs={"_FillValue": -9999})},
+                         {"valid_range": xr.DataArray(np.array([0., 0.00032], dtype=np.float32),
+                         attrs={"_FillValue": -9999})},
+                         {"valid_range": xr.DataArray(np.array([0., 0.00032], dtype=np.float32),
+                         attrs={"_FillValue": -9999})}]
+        result = combine_metadata(*test_metadata)
+        assert np.allclose(result["valid_range"], xr.DataArray(np.array([0., 0.00032], dtype=np.float32),
+                         attrs={"_FillValue": -9999}))
+
     def test_combine_real_world_mda(self):
         """Test with real data."""
         mda_objects = ({"_FillValue": np.nan,


### PR DESCRIPTION
This PR is dedicated to enable to have into the attributes the coefficient `radiance_unit_conversion_coefficient` when reading multiple files for `radiance` calibration.

 - [ ] Closes #3067  
 - [ ] Tests added in `test_fci_l1c_nc.py`

@ameraner  when we provide only one file the `combine_metadata` returns the content of the attributes directly as stated [here](https://github.com/pytroll/satpy/blob/main/satpy/dataset/metadata.py#L69-L71). In the other case the attributes of each files are compared between each other. As the coefficient `radiance_unit_conversion_coefficient` is a xarray.dataArray the comparison is done into this [function](https://github.com/pytroll/satpy/blob/main/satpy/dataset/metadata.py#L197-L204). According to this line  `if hasattr(arrays[0], "compute")` is considered as lazy array which is false in our case because it is a non daskified array. 

So I have change the criteria to check if it is a lazy array to `if isinstance(arrays[0].data, da.Array)`
