### PR TITLE
Fix padding for FCI xx coverage

### DIFF
--- a/satpy/etc/readers/fci_l1c_nc.yaml
+++ b/satpy/etc/readers/fci_l1c_nc.yaml
@@ -6,7 +6,7 @@ reader:
     Reader for FCI L1c data in NetCDF4 format.
     Used to read Meteosat Third Generation (MTG) Flexible
     Combined Imager (FCI) L1c data.
-  status: Beta for full-disc and RSS FDHSI, HRFI, African dissemination format, IPDF-I and IQT-I processing facilities.
+  status: Beta for full-disc and RSS FDHSI, HRFI, African dissemination format, special scans, IDPF-I and IQT-I processing facilities.
   supports_fsspec: true
   reader: !!python/name:satpy.readers.yaml_reader.GEOVariableSegmentYAMLReader
   sensors: [fci]

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -25,22 +25,28 @@ on the MTG Imager (MTG-I) series of satellites, with the first satellite (MTG-I1
 launched on the 13th of December 2022.
 For more information about FCI, see `EUMETSAT`_.
 
-For simulated test data to be used with this reader, see `test data releases`_.
+To download data to be used with this reader, see `MTG data store guide`_.
 For the Product User Guide (PUG) of the FCI L1c data, see `PUG`_.
 
 .. note::
-    This reader supports data from both IDPF-I and IQT-I processing facilities.
+
     This reader currently supports Full Disk High Spectral Resolution Imagery
     (FDHSI), High Spatial Resolution Fast Imagery (HRFI) data in full-disc ("FD") or in RSS ("Q4") scanning mode.
-    In addition it also supports the L1C format for the African dissemination ("AF"), where each file
+    In addition, it also supports the L1C format for the African dissemination ("AF"), where each file
     contains the masked full-dic of a single channel see `AF PUG`_.
+    Experimental support for special scans, e.g. with coverage "xx", is also given.
+
+    This reader supports data from both IDPF-I and IQT-I processing facilities.
+
+
+.. note::
+
     If the user provides a list of both FDHSI and HRFI files from the same repeat cycle to the Satpy ``Scene``,
     Satpy will automatically read the channels from the source with the finest resolution,
     i.e. from the HRFI files for the vis_06, nir_22, ir_38, and ir_105 channels.
     If needed, the desired resolution can be explicitly requested using e.g.:
     ``scn.load(['vis_06'], resolution=1000)``.
 
-    Note that RSS data is not supported yet.
 
 Geolocation is based on information from the data files.  It uses:
 
@@ -108,10 +114,10 @@ All auxiliary data can be obtained by prepending the channel name such as
     If you use ``hdf5plugin``, make sure to add the line ``import hdf5plugin``
     at the top of your script.
 
-.. _AF PUG: https://www-cdn.eumetsat.int/files/2022-07/MTG%20EUMETCast%20Africa%20Product%20User%20Guide%20%5BAfricaPUG%5D_v2E.pdf
-.. _PUG: https://www-cdn.eumetsat.int/files/2020-07/pdf_mtg_fci_l1_pug.pdf
+.. _AF PUG: https://user.eumetsat.int/resources/user-guides/mtg-africa-data-service-guide  # noqa: E501
+.. _PUG: https://user.eumetsat.int/resources/user-guides/mtg-fci-level-1c-data-guide  # noqa: E501
 .. _EUMETSAT: https://user.eumetsat.int/resources/user-guides/mtg-fci-level-1c-data-guide  # noqa: E501
-.. _test data releases: https://www.eumetsat.int/mtg-test-data
+.. _MTG data store guide: https://user.eumetsat.int/resources/user-guides/data-store-mtg-data-access-guide  # noqa: E501
 """
 
 from __future__ import absolute_import, division, print_function, unicode_literals
@@ -229,6 +235,11 @@ class FCIL1cNCFileHandler(NetCDF4FsspecFileHandler):
             # change number of chunk from 0 to 1 so that the padding is not activated (chunk 1 is present and only 1
             # chunk is expected), as the African dissemination products come in one file per full disk.
             self.filename_info["count_in_repeat_cycle"] = 1
+
+        if self.filename_info["coverage"] == "xx":
+            # add one to the chunk numbering to activate the padding mechanism for special scans (expected to have less
+            # than 40 chunks, but still starting with 1)
+            self.filename_info["count_in_repeat_cycle"] += 1
 
         if self.filename_info["facility_or_tool"] == "IQTI":
             self.is_iqt = True

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -1382,8 +1382,10 @@ def _get_empty_segment_with_height(empty_segment, new_height, dim):
         # if current empty segment is too tall, slice the DataArray
         return empty_segment[:new_height, :]
     if empty_segment.shape[0] < new_height:
-        # if current empty segment is too short, concatenate a slice of the DataArray
-        return xr.concat([empty_segment, empty_segment[:new_height - empty_segment.shape[0], :]], dim=dim)
+        # if current empty segment is too short, pad to the new size using the empty segment values
+        return empty_segment.pad(pad_width={dim : (new_height - empty_segment.shape[0], 0)},
+                                 mode="constant",
+                                 constant_values=empty_segment[0, 0])
     return empty_segment
 
 

--- a/satpy/tests/reader_tests/test_fci_l1c_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_nc.py
@@ -1134,14 +1134,14 @@ class TestFCIL1cNCReader(ModuleTestFCIL1cNcReader):
                                                                                     datetime.datetime.strptime(
                                                                                          "2023-10-16 13:00:00",
                                                                                          "%Y-%m-%d %H:%M:%S"))),
-                              (lazy_fixture("FakeFCIFileHandlerFDHSIOtherCoverage_fixture"), (1, None,
+                              (lazy_fixture("FakeFCIFileHandlerFDHSIOtherCoverage_fixture"), (2, None,
                                                                                     datetime.datetime.strptime(
                                                                                          "2023-07-22 12:00:00",
                                                                                          "%Y-%m-%d %H:%M:%S"),
                                                                                     datetime.datetime.strptime(
                                                                                          "2023-07-22 12:00:27",
                                                                                          "%Y-%m-%d %H:%M:%S"))),
-                              (lazy_fixture("FakeFCIFileHandlerHRFIOtherCoverage_fixture"), (1, None,
+                              (lazy_fixture("FakeFCIFileHandlerHRFIOtherCoverage_fixture"), (2, None,
                                                                                     datetime.datetime.strptime(
                                                                                          "2023-07-22 12:00:00",
                                                                                          "%Y-%m-%d %H:%M:%S"),

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -1506,26 +1506,18 @@ class TestGEOVariableSegmentYAMLReader:
                                     call(*expected_call5)
                                     ])
 
-    def test_get_empty_segment_with_height(self):
-        """Test _get_empty_segment_with_height()."""
+    @pytest.mark.parametrize("new_height", [
+        139,  # same size
+        140,  # larger size
+        2000,  # much larger size
+        138, # smaller size
+        1, # much smaller size
+    ])
+    def test_get_empty_segment_with_height(self, new_height):
+        """Test _get_empty_segment_with_height() for different new heights."""
         from satpy.readers.yaml_reader import _get_empty_segment_with_height as geswh
 
-        dim = "y"
-
-        # check expansion of empty segment
         empty_segment = xr.DataArray(np.ones((139, 5568)), dims=["y", "x"])
-        new_height = 140
-        new_empty_segment = geswh(empty_segment, new_height, dim)
-        assert new_empty_segment.shape == (140, 5568)
-
-        # check reduction of empty segment
-        empty_segment = xr.DataArray(np.ones((140, 5568)), dims=["y", "x"])
-        new_height = 139
-        new_empty_segment = geswh(empty_segment, new_height, dim)
-        assert new_empty_segment.shape == (139, 5568)
-
-        # check that empty segment is not modified if it has the right height already
-        empty_segment = xr.DataArray(np.ones((140, 5568)), dims=["y", "x"])
-        new_height = 140
-        new_empty_segment = geswh(empty_segment, new_height, dim)
-        assert new_empty_segment is empty_segment
+        new_empty_segment = geswh(empty_segment, new_height, "y")
+        assert new_empty_segment.shape == (new_height, 5568)
+        assert (new_empty_segment == empty_segment[0,0]).all()

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -25,6 +25,7 @@ import unittest
 from tempfile import mkdtemp
 from unittest.mock import MagicMock, call, patch
 
+import dask.array as da
 import numpy as np
 import pytest
 import xarray as xr
@@ -1517,7 +1518,7 @@ class TestGEOVariableSegmentYAMLReader:
         """Test _get_empty_segment_with_height() for different new heights."""
         from satpy.readers.yaml_reader import _get_empty_segment_with_height as geswh
 
-        empty_segment = xr.DataArray(np.ones((139, 5568)), dims=["y", "x"])
+        empty_segment = xr.DataArray(da.ones((139, 5568)), dims=["y", "x"])
         new_empty_segment = geswh(empty_segment, new_height, "y")
         assert new_empty_segment.shape == (new_height, 5568)
         assert (new_empty_segment == empty_segment[0,0]).all()


### PR DESCRIPTION
This PR adds a modification to the `fci_l1c_nc` reader to activate the padding mechanism for special scans like `xx` (implemented in #3112 ).

In order for the padding to work in this special case, a modification/bugfix is also applied to the padding mechanism. In the previous implementation, a bigger missing empty segment was generated by concatenating two segments together. However, in some cases this was not enough (when the desired new empty segment was bigger than two concatenated segments). 
--> To solve this, instead of concatenating, we use the `pad` function to add arbitrarily big segments.

On a side, the documentation is also updated for new links and info.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
