### PR TITLE
Fix invalid documentation references to python objects

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -111,7 +111,7 @@ being visualized.
    an image with mode RGB when enhanced.  To produce an image with mode P, use
    the :class:`SingleBandCompositor` with an associated
    :func:`~satpy.enhancements.palettize` enhancement and pass ``keep_palette=True``
-   to :meth:`~satpy.Scene.save_datasets`.  If the colormap is sourced from
+   to :meth:`Scene.save_datasets <satpy.scene.Scene.save_datasets>`.  If the colormap is sourced from
    the same dataset as the dataset to be palettized, it must be contained
    in the auxiliary datasets.
 
@@ -119,7 +119,7 @@ being visualized.
    :class:`PaletteCompositor` have been migrated to use
    :class:`SingleBandCompositor` instead.  This has no impact on resulting
    images unless ``keep_palette=True`` is passed to
-   :meth:`~satpy.Scene.save_datasets`, but the loaded composite now has only
+   :meth:`Scene.save_datasets <satpy.scene.Scene.save_datasets>`, but the loaded composite now has only
    one band (previously three).
 
 DayNightCompositor

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -112,6 +112,7 @@ apidoc_modules = [
             # things contributors might be interested in like satpy.tests.utils.
             "../../satpy/tests/test_*.py",
             "../../satpy/tests/**/test_*.py",
+            "../../satpy/tests/*_tests/*",
         ],
     },
 ]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -117,6 +117,7 @@ apidoc_modules = [
 ]
 apidoc_separate_modules = True
 apidoc_include_private = True
+apidoc_automodule_options = {"members", "show-inheritance", "undoc-members", "special-members"}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/doc/source/dev_guide/aux_data.rst
+++ b/doc/source/dev_guide/aux_data.rst
@@ -40,7 +40,7 @@ component like readers, writers, and compositors. The lower-level
 :func:`~satpy.aux_download.register_file` function can be used for any other
 use case.
 
-The :class:`~satpy.aux_download.DataMixIn` class is automatically included
+The :class:`~satpy.aux_download.DataDownloadMixin` class is automatically included
 in the :class:`~satpy.readers.yaml_reader.FileYAMLReader` and
 :class:`~satpy.writers.Writer` base classes. For any other component (like
 a compositor) you should include it as another parent class:

--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -500,7 +500,7 @@ needs to implement a few methods:
    :doc:`remote_file_support`.
 
  - the ``get_area_def`` method, that takes as single argument the
-   :class:`~satpy.dataset.DataID` for which we want
+   :class:`DataID <satpy.dataset.dataid.DataID>` for which we want
    the area. It should return a :class:`~pyresample.geometry.AreaDefinition`
    object. For data that cannot be geolocated with an area
    definition, the pixel coordinates will be loaded using the

--- a/doc/source/dev_guide/plugins.rst
+++ b/doc/source/dev_guide/plugins.rst
@@ -71,7 +71,7 @@ A plugin package should consist of three main parts:
    * composites and modifiers: :class:`~satpy.composites.CompositeBase` for
      any generic compositor and :class:`~satpy.composites.GenericCompositor`
      for any composite that represents an image (RGB, L, etc). For modifiers,
-     use :class:`~satpy.modifiers.ModifierBase`.
+     use :class:`~satpy.modifiers.base.ModifierBase`.
    * enhancements: Although not required, consider using
      :func:`satpy.enhancements.apply_enhancement`.
    * writers: :class:`~satpy.writers.Writer`

--- a/doc/source/dev_guide/plugins.rst
+++ b/doc/source/dev_guide/plugins.rst
@@ -72,8 +72,6 @@ A plugin package should consist of three main parts:
      any generic compositor and :class:`~satpy.composites.GenericCompositor`
      for any composite that represents an image (RGB, L, etc). For modifiers,
      use :class:`~satpy.modifiers.base.ModifierBase`.
-   * enhancements: Although not required, consider using
-     :func:`satpy.enhancements.apply_enhancement`.
    * writers: :class:`~satpy.writers.Writer`
 
    Lastly, this directory should be structured like a standard python package.

--- a/doc/source/dev_guide/satpy_internals.rst
+++ b/doc/source/dev_guide/satpy_internals.rst
@@ -55,7 +55,7 @@ As an example here is the definition of the first one in yaml:
       name:
         required: true
       wavelength:
-        type: !!python/name:satpy.dataset.WavelengthRange
+        type: !!python/name:satpy.dataset.dataid.WavelengthRange
       resolution:
       calibration:
         enum:
@@ -92,7 +92,7 @@ be a dictionary very similar to the yaml code. Here is the same example as above
 
   .. code-block:: python
 
-    from satpy.dataset import WavelengthRange, ModifierTuple
+    from satpy.dataset.dataid import WavelengthRange, ModifierTuple
 
     id_keys_config = {'name': {
                           'required': True,
@@ -126,7 +126,7 @@ to implement a few methods:
  - `__hash__`, `__eq__` and `__ne__` methods
  - a `distance` method the tells how "far" an instance of this class is from it's argument.
 
-An example of such a class is the :class:`WavelengthRange <satpy.dataset.WavelengthRange>` class.
+An example of such a class is the :class:`WavelengthRange <satpy.dataset.dataid.WavelengthRange>` class.
 Through its implementation, it allows us to use the wavelength in a query to find out which of the
 DataID in a list which has its central wavelength closest to that query for example.
 

--- a/doc/source/enhancements.rst
+++ b/doc/source/enhancements.rst
@@ -100,7 +100,7 @@ implementation depends on the following keys:
 6. ``units``
 
 For low-level implementation details see the
-:class:`~satpy.writers.EnhancementDecisionTree` class.
+:class:`~satpy.enhancements.enhancer.EnhancementDecisionTree` class.
 
 The example YAML in the above section specified one of these keys,
 ``standard_name``.
@@ -277,7 +277,7 @@ You should then see log messages like the following::
     TRACE    :             | sensor=abi
     TRACE    :             | standard_name=cloud_type
 
-Additionally, you can directly load the :class:`~satpy.writers.Enhancer`
+Additionally, you can directly load the :class:`~satpy.enhancements.enhancer.Enhancer`
 object used by Satpy and print the entire "tree" and attempt to follow the
 path to match your particular DataArray's metadata:
 
@@ -587,7 +587,7 @@ Or more complex enhancement functions in Satpy (described above):
    object and the DataArray underneath inplace. So although the ``img =``
    is unnecessary it is recommended for future compatibility if this changes.
 
-Finally, the :class:`~trollimage.xrimageXRImage` class supports showing an
+Finally, the :class:`~trollimage.xrimage.XRImage` class supports showing an
 image in your system's image viewer:
 
 .. code-block:: python

--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -65,7 +65,7 @@ Scenes contained in a MultiScene can be combined in different ways.
 Stacking scenes
 ***************
 
-The code below uses the :meth:`~satpy.multiscene.MultiScene.blend` method of
+The code below uses the :meth:`satpy.multiscene._multiscene.MultiScene.blend` method of
 the ``MultiScene`` object to stack two separate orbits from a VIIRS sensor. By
 default the ``blend`` method will use the :func:`~satpy.multiscene.stack`
 function which uses the first dataset as the base of the image and then

--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -27,7 +27,7 @@ providing the scene objects,
     >>> mscn = MultiScene(scenes)
     >>> mscn.load(['I04'])
 
-or by using the :meth:`MultiScene.from_files <satpy.multiscene.MultiScene.from_files>`
+or by using the :meth:`MultiScene.from_files <satpy.multiscene._multiscene.MultiScene.from_files>`
 class method to create a ``MultiScene`` from a series of files. This uses the
 :func:`~satpy.readers.group_files` utility function to group files by start
 time or other filenames parameters.
@@ -65,9 +65,9 @@ Scenes contained in a MultiScene can be combined in different ways.
 Stacking scenes
 ***************
 
-The code below uses the :meth:`satpy.multiscene._multiscene.MultiScene.blend` method of
+The code below uses the :meth:`MultiScene.blend <satpy.multiscene._multiscene.MultiScene.blend>` method of
 the ``MultiScene`` object to stack two separate orbits from a VIIRS sensor. By
-default the ``blend`` method will use the :func:`~satpy.multiscene.stack`
+default the ``blend`` method will use the :func:`satpy.multiscene.stack <satpy.multiscene._blend_funcs.stack>`
 function which uses the first dataset as the base of the image and then
 iteratively overlays the remaining datasets on top.
 
@@ -101,8 +101,8 @@ frequent.
 This weighted blending can be accomplished via the use of the builtin
 :func:`~functools.partial` function (see `Partial
 <https://docs.python.org/3/library/functools.html#partial-objects>`_) and the
-default :func:`~satpy.multiscene.stack` function. The
-:func:`~satpy.multiscene.stack` function can take the optional argument
+default :func:`satpy.multiscene.stack <satpy.multiscene._blend_funcs.stack>` function. The
+:func:`satpy.multiscene.stack <satpy.multiscene._blend_funcs.stack>` function can take the optional argument
 `weights` (`None` on default) which should be a sequence (of length equal to
 the number of scenes being blended) of arrays with pixel weights.
 
@@ -134,7 +134,7 @@ Grouping Similar Datasets
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 By default, ``MultiScene`` only operates on datasets shared by all scenes.
-Use the :meth:`~satpy.multiscene.MultiScene.group` method to specify groups
+Use the :meth:`MultiScene.group <satpy.multiscene._multiscene.MultiScene.group>` method to specify groups
 of datasets that shall be treated equally by ``MultiScene``, even if their
 names or wavelengths are different.
 
@@ -173,8 +173,8 @@ You can access the results via ``blended['IR_group']``.
 Timeseries
 **********
 
-Using the :meth:`~satpy.multiscene.MultiScene.blend` method with the
-:func:`~satpy.multiscene.timeseries` function will combine
+Using the :meth:`MultiScene.blend <satpy.multiscene._multiscene.MultiScene.blend>` method with the
+:func:`satpy.multiscene.timeseries <satpy.multiscene._blend_funcs.timeseries>` function will combine
 multiple scenes from different time slots by time. A single `Scene` with each
 dataset/channel extended by the time dimension will be returned. If used
 together with the :meth:`~satpy.scene.Scene.to_geoviews` method, creation of
@@ -262,7 +262,7 @@ Saving multiple scenes
 ----------------------
 
 The ``MultiScene`` object includes a
-:meth:`~satpy.multiscene.MultiScene.save_datasets` method for saving the
+:meth:`MultiScene.save_datasets <satpy.multiscene._multiscene.MultiScene.save_datasets>` method for saving the
 data from multiple Scenes to disk. By default this will operate on one Scene
 at a time, but similar to the ``save_animation`` method above this method can
 accept a dask distributed ``Client`` object via the ``client`` keyword
@@ -282,7 +282,7 @@ Combining multiple readers
 
 .. versionadded:: 0.23
 
-The :meth:`~satpy.multiscene.MultiScene.from_files` constructor allows to
+The :meth:`MultiScene.from_files <satpy.multiscene._multiscene.MultiScene.from_files>` constructor allows to
 automatically combine multiple readers into a single MultiScene.  It is no
 longer necessary for the user to create the :class:`~satpy.scene.Scene`
 objects themselves.  For example, you can combine Advanced Baseline
@@ -312,7 +312,7 @@ both readers:
     >>> ms.save_animation("/path/for/output/{name:s}_{start_time:%Y%m%d_%H%M}.mp4")
 
 In this example, we pass to
-:meth:`~satpy.multiscene.MultiScene.from_files` the additional parameters
+:meth:`MultiScene.from_files <satpy.multiscene._multiscene.MultiScene.from_files>` the additional parameters
 ``ensure_all_readers=True, group_keys=["start_time"], time_threshold=30``
 so we only get scenes at times that both ABI and GLM have a file starting
 within 30 seconds from each other, and ignore all other differences for

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -172,7 +172,7 @@ Calculations based on loaded datasets/channels can easily be assigned to a new d
     >>> global_scene.show("ndvi")
 
 When doing calculations Xarray, by default, will drop all attributes so attributes need to be
-copied over by hand. The :func:`~satpy.dataset.combine_metadata` function can assist with this task.
+copied over by hand. The :func:`~satpy.dataset.metadata.combine_metadata` function can assist with this task.
 Assigning additional custom metadata is also possible.
 
     >>> from satpy.dataset import combine_metadata

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -172,7 +172,7 @@ Calculations based on loaded datasets/channels can easily be assigned to a new d
     >>> global_scene.show("ndvi")
 
 When doing calculations Xarray, by default, will drop all attributes so attributes need to be
-copied over by hand. The :func:`~satpy.dataset.metadata.combine_metadata` function can assist with this task.
+copied over by hand. The :func:`combine_metadata <satpy.dataset.metadata.combine_metadata>` function can assist with this task.
 Assigning additional custom metadata is also possible.
 
     >>> from satpy.dataset import combine_metadata

--- a/doc/source/reading.rst
+++ b/doc/source/reading.rst
@@ -168,7 +168,7 @@ to them. By default Satpy will provide the version of the dataset with the
 highest resolution and the highest level of calibration (brightness
 temperature or reflectance over radiance). It is also possible to request one
 of these exact versions of a dataset by using the
-:class:`~satpy.dataset.DataQuery` class::
+:class:`~satpy.dataset.dataid.DataQuery` class::
 
     >>> from satpy import DataQuery
     >>> my_channel_id = DataQuery(name='IR_016', calibration='radiance')

--- a/satpy/_scene_converters.py
+++ b/satpy/_scene_converters.py
@@ -42,18 +42,18 @@ def to_geoviews(scn, gvtype=None, datasets=None,
         """Convert satpy Scene to geoviews.
 
         Args:
-            scn (satpy.Scene): Satpy Scene.
+            scn (satpy.scene.Scene): Satpy Scene.
             gvtype (gv plot type):
                 One of gv.Image, gv.LineContours, gv.FilledContours, gv.Points
-                Default to :class:`geoviews.Image`.
+                Default to :class:`geoviews.element.geo.Image`.
                 See Geoviews documentation for details.
             datasets (list): Limit included products to these datasets
             kdims (list of str):
                 Key dimensions. See geoviews documentation for more information.
-            vdims (list of str, optional):
+            vdims (list of str, Optional):
                 Value dimensions. See geoviews documentation for more information.
                 If not given defaults to first data variable
-            dynamic (bool, optional): Load and compute data on-the-fly during
+            dynamic (bool, Optional): Load and compute data on-the-fly during
                 visualization. Default is ``False``. See
                 https://holoviews.org/user_guide/Gridded_Datasets.html#working-with-xarray-data-types
                 for more information. Has no effect when data to be visualized
@@ -99,7 +99,7 @@ def to_hvplot(scn, datasets=None, *args, **kwargs):
         """Convert satpy Scene to Hvplot. The method could not be used with composites of swath data.
 
         Args:
-            scn (satpy.Scene): Satpy Scene.
+            scn (satpy.scene.Scene): Satpy Scene.
             datasets (list): Limit included products to these datasets.
             args: Arguments coming from hvplot
             kwargs: hvplot options dictionary.
@@ -190,31 +190,31 @@ def to_xarray(scn,
     in future we might return a DataTree object, grouped by area.
 
     Args:
-        scn (satpy.Scene): Satpy Scene.
-        datasets (iterable, optional): List of Satpy Scene datasets to include in
+        scn (satpy.scene.Scene): Satpy Scene.
+        datasets (Iterable, Optional): List of Satpy Scene datasets to include in
             the output xr.Dataset. Elements can be string name, a wavelength as a
             number, a DataID, or DataQuery object. If None (the default), it
             includes all loaded Scene datasets.
         header_attrs: Global attributes of the output xr.Dataset.
-        epoch (str, optional): Reference time for encoding the time coordinates
+        epoch (str, Optional): Reference time for encoding the time coordinates
             (if available). Format example: "seconds since 1970-01-01 00:00:00".
             If None, the default reference time is retrieved using
             "from satpy.cf_writer import EPOCH".
-        flatten_attrs (bool, optional): If True, flatten dict-type attributes.
-        exclude_attrs (list, optional): List of xr.DataArray attribute names to
+        flatten_attrs (bool, Optional): If True, flatten dict-type attributes.
+        exclude_attrs (list, Optional): List of xr.DataArray attribute names to
             be excluded.
-        include_lonlats (bool, optional): If True, includes 'latitude' and
+        include_lonlats (bool, Optional): If True, includes 'latitude' and
             'longitude' coordinates. If the 'area' attribute is a SwathDefinition,
             it always includes latitude and longitude coordinates.
-        pretty (bool, optional): Don't modify coordinate names, if possible. Makes
+        pretty (bool, Optional): Don't modify coordinate names, if possible. Makes
             the file prettier, but possibly less consistent.
-        include_orig_name (bool, optional): Include the original dataset name as a
+        include_orig_name (bool, Optional): Include the original dataset name as a
             variable attribute in the xr.Dataset.
-        numeric_name_prefix (str, optional): Prefix to add to each variable with
+        numeric_name_prefix (str, Optional): Prefix to add to each variable with
             name starting with a digit. Use '' or None to leave this out.
 
     Returns:
-        xr.Dataset: A CF-compliant xr.Dataset
+        xarray.Dataset: A CF-compliant xr.Dataset
 
     """
     from satpy.cf.datasets import collect_cf_datasets

--- a/satpy/aux_download.py
+++ b/satpy/aux_download.py
@@ -53,7 +53,7 @@ def register_file(url, filename, component_type=None, known_hash=None):
     Returns:
         Cache key that can be used to retrieve the file later. The cache key
         consists of the ``component_type`` and provided ``filename``. This
-        should be passed to :func:`satpy.aux_download_retrieve` when the
+        should be passed to :func:`satpy.aux_download.retrieve` when the
         file will be used.
 
     """

--- a/satpy/cf/attrs.py
+++ b/satpy/cf/attrs.py
@@ -85,7 +85,7 @@ def _encode_object(obj):
     """Try to encode `obj` as a netCDF/Zarr compatible datatype which most closely resembles the object's nature.
 
     Raises:
-        ValueError if no such datatype could be found
+        ValueError: if no such datatype could be found
     """
     is_nonbool_int = isinstance(obj, int) and not isinstance(obj, (bool, np.bool_))
     is_encode_type = isinstance(obj, (float, str, np.integer, np.floating))

--- a/satpy/cf/data_array.py
+++ b/satpy/cf/data_array.py
@@ -63,18 +63,18 @@ def make_cf_data_array(dataarray,
     """Make the xr.DataArray CF-compliant.
 
     Args:
-        dataarray (xr.DataArray): The data array to be made CF-compliant.
-        epoch (str, optional): Reference time for encoding of time coordinates.
+        dataarray (xarray.DataArray): The data array to be made CF-compliant.
+        epoch (str, Optional): Reference time for encoding of time coordinates.
             If None, the default reference time is defined using `from satpy.cf.coords import EPOCH`.
-        flatten_attrs (bool, optional): If True, flatten dict-type attributes. Defaults to False.
-        exclude_attrs (list, optional): List of dataset attributes to be excluded. Defaults to None.
-        include_orig_name (bool, optional): Include the original dataset name in the netcdf variable attributes.
+        flatten_attrs (bool, Optional): If True, flatten dict-type attributes. Defaults to False.
+        exclude_attrs (list, Optional): List of dataset attributes to be excluded. Defaults to None.
+        include_orig_name (bool, Optional): Include the original dataset name in the netcdf variable attributes.
             Defaults to True.
-        numeric_name_prefix (str, optional): Prepend dataset name with this if starting with a digit.
+        numeric_name_prefix (str, Optional): Prepend dataset name with this if starting with a digit.
             Defaults to ``"CHANNEL_"``.
 
     Returns:
-        xr.DataArray: A CF-compliant xr.DataArray.
+        xarray.DataArray: A CF-compliant xr.DataArray.
     """
     dataarray = _preprocess_data_array_name(dataarray=dataarray,
                                             numeric_name_prefix=numeric_name_prefix,

--- a/satpy/cf/datasets.py
+++ b/satpy/cf/datasets.py
@@ -68,22 +68,22 @@ def _collect_cf_dataset(list_dataarrays,
 
     Args:
         list_dataarrays (list): List of DataArrays to make CF compliant and merge into an xr.Dataset.
-        epoch (str, optional): Reference time for encoding the time coordinates.
+        epoch (str, Optional): Reference time for encoding the time coordinates.
             Example format: "seconds since 1970-01-01 00:00:00".
             If None, the default reference time is defined using `from satpy.cf.coords import EPOCH`.
-        flatten_attrs (bool, optional): If True, flatten dict-type attributes.
-        exclude_attrs (list, optional): List of xr.DataArray attribute names to be excluded.
-        include_lonlats (bool, optional): If True, includes 'latitude' and 'longitude' coordinates also for a
+        flatten_attrs (bool, Optional): If True, flatten dict-type attributes.
+        exclude_attrs (list, Optional): List of xr.DataArray attribute names to be excluded.
+        include_lonlats (bool, Optional): If True, includes 'latitude' and 'longitude' coordinates also for a
             satpy.Scene defined on an AreaDefinition.
             If the 'area' attribute is a SwathDefinition, it always includes latitude and longitude coordinates.
-        pretty (bool, optional): Don't modify coordinate names, if possible.
+        pretty (bool, Optional): Don't modify coordinate names, if possible.
             Makes the file prettier, but possibly less consistent.
-        include_orig_name (bool, optional): Include the original dataset name as a variable attribute in the xr.Dataset.
-        numeric_name_prefix (str, optional): Prefix to add to each variable with a name starting with a digit.
+        include_orig_name (bool, Optional): Include the original dataset name as a variable attribute in the xr.Dataset.
+        numeric_name_prefix (str, Optional): Prefix to add to each variable with a name starting with a digit.
             Use '' or None to leave this out.
 
     Returns:
-        xr.Dataset: A partially CF-compliant xr.Dataset.
+        xarray.Dataset: A partially CF-compliant xr.Dataset.
     """
     from satpy.cf.area import area2cf
     from satpy.cf.coords import (
@@ -179,20 +179,20 @@ def collect_cf_datasets(list_dataarrays,
     Args:
         list_dataarrays (list): List of DataArrays to make CF compliant and merge into groups of xr.Datasets.
         header_attrs (dict): Global attributes of the output xr.Dataset.
-        epoch (str, optional): Reference time for encoding the time coordinates.
+        epoch (str, Optional): Reference time for encoding the time coordinates.
             Example format: "seconds since 1970-01-01 00:00:00".
             If None, the default reference time is retrieved using `from satpy.cf.coords import EPOCH`.
-        flatten_attrs (bool, optional): If True, flatten dict-type attributes.
-        exclude_attrs (list, optional): List of xr.DataArray attribute names to be excluded.
-        include_lonlats (bool, optional): If True, includes 'latitude' and 'longitude' coordinates also
+        flatten_attrs (bool, Optional): If True, flatten dict-type attributes.
+        exclude_attrs (list, Optional): List of xr.DataArray attribute names to be excluded.
+        include_lonlats (bool, Optional): If True, includes 'latitude' and 'longitude' coordinates also
             for a satpy.Scene defined on an AreaDefinition.
             If the 'area' attribute is a SwathDefinition, it always includes latitude and longitude coordinates.
-        pretty (bool, optional): Don't modify coordinate names, if possible.
+        pretty (bool, Optional): Don't modify coordinate names, if possible.
             Makes the file prettier, but possibly less consistent.
-        include_orig_name (bool, optional): Include the original dataset name as a variable attribute in the xr.Dataset.
-        numeric_name_prefix (str, optional): Prefix to add to each variable with a name starting with a digit.
+        include_orig_name (bool, Optional): Include the original dataset name as a variable attribute in the xr.Dataset.
+        numeric_name_prefix (str, Optional): Prefix to add to each variable with a name starting with a digit.
             Use '' or None to leave this out.
-        groups (dict, optional): Group datasets according to the given assignment:
+        groups (dict, Optional): Group datasets according to the given assignment:
             `{'<group_name>': ['dataset_name1', 'dataset_name2', ...]}`.
             Used to create grouped netCDFs using the CF_Writer. If None, no groups will be created.
 

--- a/satpy/composites/__init__.py
+++ b/satpy/composites/__init__.py
@@ -98,7 +98,7 @@ class CompositeBase:
     represents something different than the inputs that went into the
     operation.
 
-    See the :class:`~satpy.composites.ModifierBase` class for information
+    See the :class:`~satpy.modifiers.base.ModifierBase` class for information
     on the similar concept of "modifiers".
 
     """
@@ -171,11 +171,10 @@ class CompositeBase:
         :func:`satpy.utils.unify_chunks`).
 
         Args:
-            data_arrays (List[arrays]): Arrays to be checked
+            data_arrays: Arrays to be checked
 
         Returns:
-            data_arrays (List[arrays]):
-                Arrays with negligible non-dimensional coordinates removed.
+            Arrays with negligible non-dimensional coordinates removed.
 
         Raises:
             :class:`IncompatibleAreas`:
@@ -239,7 +238,7 @@ class CompositeBase:
         :attr:`NEGLIGIBLE_COORDS` module attribute.
 
         Args:
-            data_arrays (List[arrays]): Arrays to be checked
+            data_arrays: Arrays to be checked
         """
         new_arrays = []
         for ds in data_arrays:
@@ -707,7 +706,7 @@ class DayNightCompositor(GenericCompositor):
                              blending of the given channels
             lim_high (float): upper limit of Sun zenith angle for the
                              blending of the given channels
-            day_night (string): "day_night" means both day and night portions will be kept
+            day_night (str): "day_night" means both day and night portions will be kept
                                 "day_only" means only day portion will be kept
                                 "night_only" means only night portion will be kept
             include_alpha (bool): This only affects the "day only" or "night only" result.

--- a/satpy/composites/abi.py
+++ b/satpy/composites/abi.py
@@ -47,7 +47,7 @@ class SimulatedGreen(GenericCompositor):
 
         Args:
             name (str): Name of this composite
-            fractions (iterable): Fractions of each input band to include in the result.
+            fractions (Iterable): Fractions of each input band to include in the result.
 
         """
         self.fractions = fractions

--- a/satpy/composites/agri.py
+++ b/satpy/composites/agri.py
@@ -47,7 +47,7 @@ class SimulatedRed(GenericCompositor):
 
         Args:
             name (str): Name of this composite
-            fractions (iterable): Fractions of each input band to include in the result.
+            fractions (Iterable): Fractions of each input band to include in the result.
 
         """
         self.fractions = fractions

--- a/satpy/composites/config_loader.py
+++ b/satpy/composites/config_loader.py
@@ -255,7 +255,7 @@ def load_compositor_configs_for_sensor(sensor_name: str) -> tuple[dict[str, dict
             config files.
 
     Returns:
-        (comps, mods, data_id_keys): Where `comps` is a dictionary:
+        tuple: (comps, mods, data_id_keys), Where `comps` is a dictionary:
 
                 composite ID -> compositor object
 
@@ -285,11 +285,11 @@ def load_compositor_configs_for_sensors(sensor_names: Iterable[str]) -> tuple[di
     """Load compositor and modifier configuration files for the specified sensors.
 
     Args:
-        sensor_names (list of strings): Sensor names that have matching
+        sensor_names: Sensor names that have matching
             ``sensor_name.yaml`` config files.
 
     Returns:
-        (comps, mods): Where `comps` is a dictionary:
+        tuple: (comps, mods), Where `comps` is a dictionary:
 
                 sensor_name -> composite ID -> compositor object
 

--- a/satpy/composites/lightning.py
+++ b/satpy/composites/lightning.py
@@ -44,7 +44,7 @@ class LightningTimeCompositor(CompositeBase):
           self.reference_time_attr = self.attrs["reference_time"]
 
 
-      def _normalize_time(self, data:xr.DataArray, attrs:dict) -> xr.DataArray:
+      def _normalize_time(self, data: xr.DataArray, attrs: dict) -> xr.DataArray:
           """Normalize the time in the range between [end_time, end_time - time_range].
 
           The range of the normalised data is between 0 and 1 where 0 corresponds to the date end_time - time_range
@@ -53,11 +53,11 @@ class LightningTimeCompositor(CompositeBase):
           The dates that are earlier to end_time - time_range are set to NaN.
 
           Args:
-              data (xr.DataArray): datas containing dates to be normalised
-              attrs (dict): Attributes suited to the flash_age composite
+              data: datas containing dates to be normalised
+              attrs: Attributes suited to the flash_age composite
 
           Returns:
-              xr.DataArray: Normalised time
+              Normalised time
           """
           # Compute the maximum time value
           end_time = np.array(np.datetime64(data.attrs[self.reference_time_attr]))
@@ -83,14 +83,14 @@ class LightningTimeCompositor(CompositeBase):
               if key not in existing_attrs and val is not None:
                   existing_attrs[key] = val
 
-      def _redefine_metadata(self,attrs:dict)->dict:
+      def _redefine_metadata(self, attrs: dict) -> dict:
           """Modify the standard_name and name metadatas.
 
           Args:
-              attrs (dict): data's attributes
+              attrs: data's attributes
 
           Returns:
-              dict: updated attributes
+              updated attributes
           """
           attrs["name"] = self.standard_name
           attrs["standard_name"] = self.standard_name

--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -63,8 +63,9 @@ class HistogramDNB(CompositeBase):
     def __call__(self, datasets, **info):
         """Create the composite by scaling the DNB data using a histogram equalization method.
 
-        :param datasets: 2-element tuple (Day/Night Band data, Solar Zenith Angle data)
-        :param **info: Miscellaneous metadata for the newly produced composite
+        Args:
+            datasets: 2-element tuple (Day/Night Band data, Solar Zenith Angle data)
+            info: Miscellaneous metadata for the newly produced composite
         """
         if len(datasets) != 2:
             raise ValueError("Expected 2 datasets, got %d" % (len(datasets), ))
@@ -83,12 +84,12 @@ class HistogramDNB(CompositeBase):
         output_dataset.attrs = info
         return output_dataset
 
-    def _run_dnb_normalization(self, dnb_data, sza_data):
+    def _run_dnb_normalization(self, dnb_data: np.ndarray, sza_data: np.ndarray) -> np.ndarray:
         """Scale the DNB data using a histogram equalization method.
 
         Args:
-            dnb_data (ndarray): Day/Night Band data array
-            sza_data (ndarray): Solar Zenith Angle data array
+            dnb_data: Day/Night Band data array
+            sza_data: Solar Zenith Angle data array
 
         """
         # convert dask arrays to DataArray objects

--- a/satpy/dataset/data_dict.py
+++ b/satpy/dataset/data_dict.py
@@ -36,7 +36,7 @@ def get_best_dataset_key(key, choices):
 
     Args:
         key (DataQuery): Query parameters to sort `choices` by.
-        choices (iterable): `DataID` objects to sort through to determine
+        choices (Iterable): `DataID` objects to sort through to determine
                             the best dataset.
 
     Returns: List of best `DataID`s from `choices`. If there is more

--- a/satpy/dataset/dataid.py
+++ b/satpy/dataset/dataid.py
@@ -63,7 +63,7 @@ class ValueList(IntEnum):
     def _unpickle(cls, enum_name, enum_members, enum_member):
         """Create dynamic class that was previously pickled.
 
-        See :meth:`__reduce_ex__` for implementation details.
+        See :meth:`ValueList.__reduce_ex__` for implementation details.
 
         """
         enum_cls = cls(enum_name, enum_members)
@@ -102,11 +102,11 @@ class WavelengthRange(wlklass):
     that two ranges are comparable.
     """
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         """Return if two wavelengths are equal.
 
         Args:
-            other (tuple or scalar): (min wl, nominal wl, max wl) or scalar wl
+            other: (min wl, nominal wl, max wl) or scalar wl
 
         Return:
             True if other is a scalar and min <= other <= max, or if other is

--- a/satpy/dataset/metadata.py
+++ b/satpy/dataset/metadata.py
@@ -148,7 +148,7 @@ def average_datetimes(datetime_list):
         time zone (UTC).
 
     Args:
-        datetime_list (iterable): Datetime objects to average
+        datetime_list (Iterable): Datetime objects to average
 
     Returns: Average datetime as a datetime object
 

--- a/satpy/decision_tree.py
+++ b/satpy/decision_tree.py
@@ -33,7 +33,7 @@ class DecisionTree:
     additional keys that could be useful when matched. This class will
     search these decisions and return the one with the most matching
     parameters to the attributes passed to the
-    :meth:`~satpy.writers.DecisionTree.find_match` method.
+    :meth:`~DecisionTree.find_match` method.
 
     Note that decision sections are provided as a dict instead of a list
     so that they can be overwritten or updated by doing the equivalent

--- a/satpy/dependency_tree.py
+++ b/satpy/dependency_tree.py
@@ -525,7 +525,7 @@ class DependencyTree(Tree):
 
         Args:
             parent (Node): Compositor node to add these prerequisites under
-            prereqs (sequence): Strings (names), floats (wavelengths),
+            prereqs (Sequence): Strings (names), floats (wavelengths),
                                 DataQuerys or Nodes to analyze.
 
         """
@@ -539,7 +539,7 @@ class DependencyTree(Tree):
 
         Args:
             parent (Node): Compositor node to add these prerequisites under
-            prereqs (sequence): Strings (names), floats (wavelengths), or
+            prereqs (Sequence): Strings (names), floats (wavelengths), or
                                 DataQuerys to analyze.
 
         """
@@ -557,7 +557,7 @@ class DependencyTree(Tree):
 
         Args:
             parent (Node): Compositor node to add these prerequisites under
-            prereqs (sequence): Strings (names), floats (wavelengths),
+            prereqs (Sequence): Strings (names), floats (wavelengths),
                                 DataQuerys or Nodes to analyze.
 
         """

--- a/satpy/enhancements/__init__.py
+++ b/satpy/enhancements/__init__.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Enhancements."""
+from __future__ import annotations
 
 import logging
 import os
@@ -117,7 +118,7 @@ def on_dask_array(func):
 
 
 def using_map_blocks(func):
-    """Run the provided function using :func:`dask.array.core.map_blocks`.
+    """Run the provided function using :func:`dask.array.map_blocks`.
 
     This means dask will call the provided function with a single chunk
     as a numpy array.
@@ -556,7 +557,7 @@ def btemp_threshold(img, min_in, max_in, threshold, threshold_out=None, **kwargs
     tool called AWIPS.
 
     Args:
-        img (XRImage): Image object to be scaled
+        img (trollimage.xrimage.XRImage): Image object to be scaled
         min_in (float): Minimum input value to scale
         max_in (float): Maximum input value to scale
         threshold (float): Input value where to split data in to two regions

--- a/satpy/modifiers/parallax.py
+++ b/satpy/modifiers/parallax.py
@@ -94,14 +94,14 @@ def get_parallax_corrected_lonlats(sat_lon, sat_lat, sat_alt, lon, lat, height):
         The Earth radius from pyresample is reported in km.
 
     Args:
-        sat_lon (number): Satellite longitude in geodetic coordinates [degrees]
-        sat_lat (number): Satellite latitude in geodetic coordinates [degrees]
-        sat_alt (number): Satellite altitude above the Earth surface [m]
-        lon (array or number): Longitudes of pixel or pixels to be corrected,
+        sat_lon (numbers.Number): Satellite longitude in geodetic coordinates [degrees]
+        sat_lat (numbers.Number): Satellite latitude in geodetic coordinates [degrees]
+        sat_alt (numbers.Number): Satellite altitude above the Earth surface [m]
+        lon (array or numbers.Number): Longitudes of pixel or pixels to be corrected,
             in geodetic coordinates [degrees]
-        lat (array or number): Latitudes of pixel/pixels to be corrected, in
+        lat (array or numbers.Number): Latitudes of pixel/pixels to be corrected, in
             geodetic coordinates [degrees]
-        height (array or number): Heights of pixels on which the correction
+        height (array or numbers.Number): Heights of pixels on which the correction
             will be based.  Typically this is the cloud top height. [m]
 
     Returns:
@@ -142,14 +142,14 @@ def _get_parallax_shift_xyz(sat_lon, sat_lat, sat_alt, lon, lat, parallax_distan
     cartesian coordinates:
 
     Args:
-        sat_lon (number): Satellite longitude in geodetic coordinates [degrees]
-        sat_lat (number): Satellite latitude in geodetic coordinates [degrees]
-        sat_alt (number): Satellite altitude above the Earth surface [m]
-        lon (array or number): Longitudes of pixel or pixels to be corrected,
+        sat_lon (numbers.Number): Satellite longitude in geodetic coordinates [degrees]
+        sat_lat (numbers.Number): Satellite latitude in geodetic coordinates [degrees]
+        sat_alt (numbers.Number): Satellite altitude above the Earth surface [m]
+        lon (array or numbers.Number): Longitudes of pixel or pixels to be corrected,
             in geodetic coordinates [degrees]
-        lat (array or number): Latitudes of pixel/pixels to be corrected, in
+        lat (array or numbers.Number): Latitudes of pixel/pixels to be corrected, in
             geodetic coordinates [degrees]
-        parallax_distance (array or number): Cloud to ground distance with parallax
+        parallax_distance (array or numbers.Number): Cloud to ground distance with parallax
             effect [m].
 
     Returns:
@@ -255,7 +255,7 @@ class ParallaxCorrection:
         """Initialise parallax correction class.
 
         Args:
-            base_area (:class:`~pyresample.AreaDefinition`): Area for which calculated
+            base_area (pyresample.geometry.AreaDefinition): Area for which calculated
                 geolocation will be calculated.
             debug_mode (bool): Store diagnostic information in
                 self.diagnostics.  This attribute always apply to the most
@@ -294,18 +294,18 @@ class ParallaxCorrection:
         but get geolocation NaN.
 
         Args:
-            cth_dataset (:class:`~xarray.DataArray`): Cloud top height in
+            cth_dataset (xarray.DataArray): Cloud top height in
                 meters.  The variable attributes must contain an ``area``
                 attribute describing the geolocation in a pyresample-aware way,
                 and they must contain satellite orbital parameters.  The
                 dimensions must be ``(y, x)``.  For best performance, this
                 should be a dask-based :class:`~xarray.DataArray`.
-            cth_resampler (string, optional): Resampler to use when resampling the
+            cth_resampler (str, Optional): Resampler to use when resampling the
                 (cloud top) height to the base area.  Defaults to "nearest".
-            cth_radius_of_influence (number, optional): Radius of influence to use when
+            cth_radius_of_influence (numbers.Number, Optional): Radius of influence to use when
                 resampling the (cloud top) height to the base area.  Defaults
                 to 50000.
-            lonlat_chunks (int, optional): Chunking to use when calculating lon/lats.
+            lonlat_chunks (int, Optional): Chunking to use when calculating lon/lats.
                 Probably the default (1024) should be fine.
 
         Returns:

--- a/satpy/modifiers/parallax.py
+++ b/satpy/modifiers/parallax.py
@@ -126,7 +126,7 @@ def get_surface_parallax_displacement(
     identical to :func:`get_parallax_corrected_lonlats`.
 
     Returns:
-        number or array: parallax displacement in meter
+        (numbers.Number, array): parallax displacement in meters
     """
     (corr_lon, corr_lat) = get_parallax_corrected_lonlats(sat_lon, sat_lat, sat_alt, lon, lat, height)
     # Get parallax displacement

--- a/satpy/multiscene/_multiscene.py
+++ b/satpy/multiscene/_multiscene.py
@@ -50,7 +50,7 @@ def _group_datasets_in_scenes(scenes, groups):
     """Group different datasets in multiple scenes by adding aliases.
 
     Args:
-        scenes (iterable): Scenes to be processed.
+        scenes (Iterable): Scenes to be processed.
         groups (dict): Groups of datasets that shall be treated equally by
             MultiScene. Keys specify the groups, values specify the dataset
             names to be grouped. For example::
@@ -163,7 +163,7 @@ class MultiScene(object):
         """Initialize MultiScene and validate sub-scenes.
 
         Args:
-            scenes (iterable):
+            scenes (Iterable):
                 `Scene` objects to operate on (optional)
 
         .. note::
@@ -209,7 +209,7 @@ class MultiScene(object):
                 readers have at least one file.  If False (default), include
                 all scenes where at least one reader has at least one file.
             scene_kwargs: additional arguments to pass on to
-                :func:`Scene.__init__` for each created scene.
+                :func:`satpy.scene.Scene.__init__` for each created scene.
 
         This uses the :func:`satpy.readers.group_files` function to group
         files. See this function for more details on additional possible
@@ -337,8 +337,9 @@ class MultiScene(object):
         dataset (:class:`xarray.DataArray` object).  The blend method
         then assigns those datasets to the blended scene.
 
-        Blending functions provided in this module are :func:`stack`
-        (the default), :func:`timeseries`, and :func:`temporal_rgb`, but the Python built-in
+        Blending functions provided in this module are :func:`satpy.multiscene._blend_funcs.stack`
+        (the default), :func:`satpy.multiscene._blend_funcs.timeseries`, and
+        :func:`satpy.multiscene._blend_funcs.temporal_rgb`, but the Python built-in
         function :func:`sum` also works and may be appropriate for
         some types of data.
 

--- a/satpy/node.py
+++ b/satpy/node.py
@@ -62,7 +62,7 @@ class Node:
         """Flatten tree structure to a one level dictionary.
 
         Args:
-            d (dict, optional): output dictionary to update
+            d (dict, Optional): output dictionary to update
 
         Returns:
             dict: Node.name -> Node. The returned dictionary includes the

--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -57,7 +57,7 @@ def group_files(files_to_sort, reader=None, time_threshold=10,
     ``filenames``, a series `Scene` objects can be easily created.
 
     Args:
-        files_to_sort (iterable): File paths to sort in to group
+        files_to_sort (Iterable): File paths to sort in to group
         reader (str or Collection[str]): Reader or readers whose file patterns
             should be used to sort files.  If not given, try all readers (slow,
             adding a list of readers is strongly recommended).
@@ -203,8 +203,8 @@ def _get_sorted_file_groups(all_file_keys, time_threshold):  # noqa: D417
     listed in each list item are considered to be grouped within the same time.
 
     Args:
-        all_file_keys, as returned by _get_file_keys_for_reader_files
-        time_threshold: temporal threshold
+        (Iterable) all_file_keys: as returned by _get_file_keys_for_reader_files
+        (numbers.Number) time_threshold: temporal threshold in seconds
 
     Returns:
         List[Mapping[Tuple, Mapping[str, List[str]]]], as described
@@ -448,8 +448,8 @@ def find_files_and_readers(start_time=None, end_time=None, base_dir=None,
     {'abi_l1b': [...]}
 
     Args:
-        start_time (datetime): Limit used files by starting time.
-        end_time (datetime): Limit used files by ending time.
+        start_time (datetime.datetime): Limit used files by starting time.
+        end_time (datetime.datetime): Limit used files by ending time.
         base_dir (str): The directory to search for files containing the
                         data to load. Defaults to the current directory.
         reader (str or list): The name of the reader to use for loading the data or a list of names.
@@ -502,12 +502,12 @@ def _get_loadables_for_reader_config(base_dir, reader, sensor, reader_configs,
     Helper for find_files_and_readers.
 
     Args:
-        base_dir: as for `find_files_and_readers`
-        reader: as for `find_files_and_readers`
-        sensor: as for `find_files_and_readers`
-        reader_configs: reader metadata such as returned by
-            `configs_for_reader`.
-        reader_kwargs: Keyword arguments to be passed to reader.
+        base_dir (str): as for `find_files_and_readers`
+        reader (str): as for `find_files_and_readers`
+        sensor (str): as for `find_files_and_readers`
+        reader_configs (dict): reader metadata such as returned by
+                               `configs_for_reader`.
+        reader_kwargs (dict): Keyword arguments to be passed to reader.
         fs (FileSystem): as for `find_files_and_readers`
     """
     sensor_supported = False
@@ -537,7 +537,7 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None):
     """Create specified readers and assign files to them.
 
     Args:
-        filenames (iterable or dict): A sequence of files that will be used to load data from. A ``dict`` object
+        filenames (Iterable or dict): A sequence of files that will be used to load data from. A ``dict`` object
                                       should map reader names to a list of filenames for that reader.
         reader (str or list): The name of the reader to use for loading the data or a list of names.
         reader_kwargs (dict): Keyword arguments to pass to specific reader instances.
@@ -677,7 +677,7 @@ def _get_reader_kwargs(reader, reader_kwargs):
 class FSFile(os.PathLike):
     """Implementation of a PathLike file object, that can be opened.
 
-    Giving the filenames to :class:`Scene` with valid transfer protocols will automatically
+    Giving the filenames to :class:`Scene <satpy.scene.Scene>` with valid transfer protocols will automatically
     use this class so manual usage of this class is needed mainly for fine-grained control.
 
     This class is made to be used in conjuction with fsspec or s3fs. For example::
@@ -701,12 +701,12 @@ class FSFile(os.PathLike):
         """Initialise the FSFile instance.
 
         Args:
-            file (str, Pathlike, or OpenFile):
+            file (str, os.Pathlike, or OpenFile):
                 String, object implementing the `os.PathLike` protocol, or
                 an `fsspec.OpenFile` instance.  If passed an instance of
                 `fsspec.OpenFile`, the following argument ``fs`` has no
                 effect.
-            fs (fsspec filesystem, optional)
+            fs (fsspec filesystem, Optional)
                 Object implementing the fsspec filesystem protocol.
         """
         self._fs_open_kwargs = _get_fs_open_kwargs(file)

--- a/satpy/readers/_geos_area.py
+++ b/satpy/readers/_geos_area.py
@@ -45,13 +45,13 @@ def make_ext(ll_x, ur_x, ll_y, ur_y, h):
     """Create the area extent from computed ll and ur.
 
     Args:
-        ll_x: The lower left x coordinate (m)
-        ur_x: The upper right x coordinate (m)
-        ll_y: The lower left y coordinate (m)
-        ur_y: The upper right y coordinate (m)
-        h: The satellite altitude above the Earth's surface
+        ll_x (numbers.Number): The lower left x coordinate (m)
+        ur_x (numbers.Number): The upper right x coordinate (m)
+        ll_y (numbers.Number): The lower left y coordinate (m)
+        ur_y (numbers.Number): The upper right y coordinate (m)
+        h (numbers.Number): The satellite altitude above the Earth's surface
     Returns:
-        aex: An area extent for the scene
+        (tuple[numbers.Number]): An area extent for the scene
 
     """
     aex = (np.deg2rad(ll_x) * h, np.deg2rad(ll_y) * h,
@@ -64,18 +64,18 @@ def get_area_extent(pdict):
     """Get the area extent seen by a geostationary satellite.
 
     Args:
-        pdict: A dictionary containing common parameters:
-            nlines: Number of lines in image
-            ncols: Number of columns in image
-            cfac: Column scaling factor
-            lfac: Line scaling factor
-            coff: Column offset factor
-            loff: Line offset factor
-            scandir: 'N2S' for standard (N->S), 'S2N' for inverse (S->N)
-            h: Altitude of satellite above the Earth's surface (m)
+        pdict (dict): A dictionary containing common parameters:
+            nlines (numbers.Number): Number of lines in image
+            ncols (numbers.Number): Number of columns in image
+            cfac (numbers.Number): Column scaling factor
+            lfac (numbers.Number): Line scaling factor
+            coff (numbers.Number): Column offset factor
+            loff (numbers.Number): Line offset factor
+            scandir(str): 'N2S' for standard (N->S), 'S2N' for inverse (S->N)
+            h (numbers.Number): Altitude of satellite above the Earth's surface (m)
 
     Returns:
-        aex: An area extent for the scene
+        (tuple[numbers.Number]): An area extent for the scene
 
     """
     # count starts at 1

--- a/satpy/readers/amsr2_l2_gaasp.py
+++ b/satpy/readers/amsr2_l2_gaasp.py
@@ -234,7 +234,7 @@ class GAASPFileHandler(BaseFileHandler):
     def available_datasets(self, configured_datasets=None):
         """Dynamically discover what variables can be loaded from this file.
 
-        See :meth:`satpy.readers.file_handlers.BaseHandler.available_datasets`
+        See :meth:`satpy.readers.file_handlers.BaseFileHandler.available_datasets`
         for more information.
 
         """

--- a/satpy/readers/clavrx.py
+++ b/satpy/readers/clavrx.py
@@ -491,7 +491,7 @@ class CLAVRXNetCDFFileHandler(_CLAVRxHelper, BaseFileHandler):
     def available_datasets(self, configured_datasets=None):
         """Dynamically discover what variables can be loaded from this file.
 
-        See :meth:`satpy.readers.file_handlers.BaseHandler.available_datasets`
+        See :meth:`satpy.readers.file_handlers.BaseFileHandler.available_datasets`
         for more information.
 
         """

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -195,8 +195,8 @@ class FCIL1cNCFileHandler(NetCDF4FsspecFileHandler):
 
     This class implements the Meteosat Third Generation (MTG) Flexible
     Combined Imager (FCI) Level-1c NetCDF reader.
-    It is designed to be used through the :class:`~satpy.Scene`
-    class using the :mod:`~satpy.Scene.load` method with the reader
+    It is designed to be used through the :class:`satpy.Scene <satpy.scene.Scene>`
+    class using the :mod:`Scene.load <satpy.scene.Scene.load>` method with the reader
     ``"fci_l1c_nc"``.
 
     """

--- a/satpy/readers/file_handlers.py
+++ b/satpy/readers/file_handlers.py
@@ -191,7 +191,7 @@ class BaseFileHandler:
         This method should **not** update values of the dataset information
         dictionary **unless** this file handler has a matching file type
         (the data could be loaded from this object in the future) and at least
-        **one** :class:`satpy.dataset.DataID` key is also modified.
+        **one** :class:`satpy.dataset.dataid.DataID` key is also modified.
         Otherwise, this file type may override the information provided by
         a more preferred file type (as specified in the YAML file).
         It is recommended that any non-ID metadata be updated during the

--- a/satpy/readers/goes_imager_nc.py
+++ b/satpy/readers/goes_imager_nc.py
@@ -1352,7 +1352,7 @@ def test_coefs(ir_url, vis_url):
         vis_url: Path or URL to HTML page with VIS coefficients
 
     Raises:
-        ValueError if coefficients don't match the reference
+        (Exception) ValueError: if coefficients don't match the reference
     """
     reader = GOESCoefficientReader(ir_url=ir_url, vis_url=vis_url)
 

--- a/satpy/readers/hrit_jma.py
+++ b/satpy/readers/hrit_jma.py
@@ -318,7 +318,7 @@ class HRITJMAFileHandler(HRITFileHandler):
             sensor (str) : Sensor name from YAML dataset definition
 
         Raises:
-            ValueError if they don't match
+            (Exception) ValueError: if they don't match
 
         """
         ref_sensor = SENSORS.get(self.platform, None)

--- a/satpy/readers/mirs.py
+++ b/satpy/readers/mirs.py
@@ -436,7 +436,7 @@ class MiRSL2ncHandler(BaseFileHandler):
     def available_datasets(self, configured_datasets=None):
         """Dynamically discover what variables can be loaded from this file.
 
-        See :meth:`satpy.readers.file_handlers.BaseHandler.available_datasets`
+        See :meth:`satpy.readers.file_handlers.BaseFileHandler.available_datasets`
         for more information.
 
         """

--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -245,7 +245,7 @@ class VISCalibrator:
         Args:
             coefs:
                 Calibration coefficients.
-            solar_zenith_angle (optional):
+            solar_zenith_angle (numbers.Number, Optional):
                 Solar zenith angle. Only required for calibration to
                 reflectance.
         """

--- a/satpy/readers/mwr_l1c.py
+++ b/satpy/readers/mwr_l1c.py
@@ -49,8 +49,8 @@ class AWS_MWR_L1CFile(AWS_EPS_Sterna_BaseFileHandler):
     """Class implementing the AWS L1c Filehandler.
 
     This class implements the ESA Arctic Weather Satellite (AWS) Level-1b
-    NetCDF reader. It is designed to be used through the :class:`~satpy.Scene`
-    class using the :mod:`~satpy.Scene.load` method with the reader
+    NetCDF reader. It is designed to be used through the :class:`Scene <satpy.scene.Scene>`
+    class using the :mod:`Scene.load <satpy.scene.Scene.load>` method with the reader
     ``"aws_l1c_nc"``.
 
     """

--- a/satpy/readers/mws_l1b.py
+++ b/satpy/readers/mws_l1b.py
@@ -75,7 +75,7 @@ class MWSL1BFile(NetCDF4FileHandler):
 
     This class implements the European Polar System Second Generation (EPS-SG)
     Microwave Sounder (MWS) Level-1b NetCDF reader.  It is designed to be used
-    through the :class:`~satpy.Scene` class using the :mod:`~satpy.Scene.load`
+    through the :class:`Scene <satpy.scene.Scene>` class using the :mod:`Scene.load <satpy.scene.Scene.load>`
     method with the reader ``"mws_l1b_nc"``.
 
     """

--- a/satpy/readers/nucaps.py
+++ b/satpy/readers/nucaps.py
@@ -241,8 +241,8 @@ class NUCAPSReader(FileYAMLReader):
         """Configure reader behavior.
 
         Args:
-            mask_surface (boolean): mask anything below the surface pressure
-            mask_quality (boolean): mask anything where the `Quality_Flag` metadata is ``!= 1``.
+            mask_surface (bool): mask anything below the surface pressure
+            mask_quality (bool): mask anything where the `Quality_Flag` metadata is ``!= 1``.
 
         """
         self.pressure_dataset_names = defaultdict(list)

--- a/satpy/readers/pmw_channels_definitions.py
+++ b/satpy/readers/pmw_channels_definitions.py
@@ -94,13 +94,13 @@ class FrequencyQuadrupleSideBand(FrequencyBandBaseArithmetics, FrequencyQuadrupl
         """Return if two channel frequencies are equal.
 
         Args:
-            other (tuple or scalar): (central frq, side band frq, side-side band frq,
-            and band width frq) or scalar frq
+            other (tuple[numbers.Number] or numbers.Number): (central frq, side band frq, side-side band frq,
+                and band width frq) or scalar frq
 
         Return:
-            True if other is a scalar and min <= other <= max, or if other is a
-            tuple equal to self, or if other is a number contained by self.
-            False otherwise.
+            (bool): True if other is a scalar and min <= other <= max, or if other is a
+                tuple equal to self, or if other is a number contained by self.
+                False otherwise.
 
         """
         if other is None:
@@ -223,12 +223,13 @@ class FrequencyDoubleSideBand(FrequencyBandBaseArithmetics, FrequencyDoubleSideB
         """Return if two channel frequencies are equal.
 
         Args:
-            other (tuple or scalar): (central frq, side band frq and band width frq) or scalar frq
+            other (tuple[numbers.Number] or numbers.Number): (central frq, side band frq and band width frq)
+                or scalar frq
 
         Return:
-            True if other is a scalar and min <= other <= max, or if other is a
-            tuple equal to self, or if other is a number contained by self.
-            False otherwise.
+            (bool): True if other is a scalar and min <= other <= max, or if other is a
+                tuple equal to self, or if other is a number contained by self.
+                False otherwise.
 
         """
         if other is None:
@@ -352,12 +353,12 @@ class FrequencyRange(FrequencyBandBaseArithmetics, FrequencyRangeBase):
         """Check wether two channel frequencies are equal.
 
         Args:
-            other (tuple or scalar): (central frq, band width frq) or scalar frq
+            other (tuple[numbers.Number] or numbers.Number): (central frq, band width frq) or scalar frq
 
         Return:
-            True if other is a scalar and min <= other <= max, or if other is a
-            tuple equal to self, or if other is a number contained by self.
-            False otherwise.
+            (bool): True if other is a scalar and min <= other <= max, or if other is a
+                tuple equal to self, or if other is a number contained by self.
+                False otherwise.
 
         """
         if other is None:

--- a/satpy/readers/sar_c_safe.py
+++ b/satpy/readers/sar_c_safe.py
@@ -622,11 +622,8 @@ class SAFEGRD(BaseFileHandler):
     def _get_lonlatalts_uncached(self):
         """Obtain GCPs and construct latitude and longitude arrays.
 
-        Args:
-           band (gdal band): Measurement band which comes with GCP's
-           array_shape (tuple) : The size of the data array
         Returns:
-           coordinates (tuple): A tuple with longitude and latitude arrays
+           (tuple): A tuple with longitude and latitude arrays
         """
         shape = self._data.shape
 
@@ -657,13 +654,10 @@ class SAFEGRD(BaseFileHandler):
     def get_gcps(self):
         """Read GCP from the GDAL band.
 
-        Args:
-           band (gdal band): Measurement band which comes with GCP's
-           coordinates (tuple): A tuple with longitude and latitude arrays
-
         Returns:
-           points (tuple): Pixel and Line indices 1d arrays
-           gcp_coords (tuple): longitude and latitude 1d arrays
+           (tuple) Pixel and Line indices 1d arrays
+           (tuple) longitude and latitude 1d arrays
+           (tuple) ground control points and crs
 
         """
         gcps = get_gcps_from_array(self._data)

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -443,9 +443,9 @@ def get_cds_time(days, msecs):
     1958-01-01 00:00 is interpreted as fill value and will be replaced by NaT (Not a Time).
 
     Args:
-        days (int, either scalar or numpy.ndarray):
+        days (int, numpy.ndarray):
             Days since 1958-01-01
-        msecs (int, either scalar or numpy.ndarray):
+        msecs (int, numpy.ndarray):
             Milliseconds of the day
 
     Returns:

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -207,11 +207,11 @@ def unzip_file(filename: str | FSFile, prefix=None):
 
     Args:
         filename: The local/remote file to unzip.
-        prefix (str, optional): If file is one of many segments of data, prefix random filename
-        for correct sorting. This is normally the segment number.
+        prefix (str, Optional): If file is one of many segments of data, prefix random filename
+                                for correct sorting. This is normally the segment number.
 
     Returns:
-        Temporary filename path for decompressed file or None.
+        (pathlib.Path, None) Temporary filename path for decompressed file if available.
 
     """
     if isinstance(filename, str):
@@ -225,11 +225,11 @@ def _unzip_local_file(filename: str, prefix=None):
 
     Args:
         filename: The file to unzip.
-        prefix (str, optional): If file is one of many segments of data, prefix random filename
-        for correct sorting. This is normally the segment number.
+        prefix (str, Optional): If file is one of many segments of data, prefix random filename
+                                for correct sorting. This is normally the segment number.
 
     Returns:
-        Temporary filename path for decompressed file or None.
+        (pathlib.Path, None) Temporary filename path for decompressed file if available.
 
     """
     if not os.fspath(filename).endswith("bz2"):
@@ -306,11 +306,11 @@ def _unzip_FSFile(filename: FSFile, prefix=None):
 
     Args:
         filename: The FSFile to unzip.
-        prefix (str, optional): If file is one of many segments of data, prefix random filename
-        for correct sorting. This is normally the segment number.
+        prefix (str, Optional): If file is one of many segments of data, prefix random filename
+                                for correct sorting. This is normally the segment number.
 
     Returns:
-        Temporary filename path for decompressed file or None.
+        (os.Pathlike, None) Temporary filename path for decompressed file if available.
 
     """
     fdn, tmpfilepath = tempfile.mkstemp(prefix=prefix,
@@ -370,8 +370,9 @@ def fromfile(filename, dtype, count=1, offset=0):
     Args:
         filename: Either the name of the file to read or a :class:`satpy.readers.FSFile` object.
         dtype: The data type of the numpy array
-        count (Optional, default ``1``): Number of items to read
-        offset (Optional, default ``0``): Starting point for reading the buffer from
+        count (Optional): Number of items to read. Default ``1``
+        offset (Optional): Starting point for reading the buffer from.
+                           Default ``0``
 
     Returns:
         The content of the filename as a numpy array with the given data type.

--- a/satpy/readers/viirs_sdr.py
+++ b/satpy/readers/viirs_sdr.py
@@ -190,10 +190,10 @@ class VIIRSSDRReader(FileYAMLReader):
         """Initialize file reader and adjust geolocation preferences.
 
         Args:
-            config_files (iterable): yaml config files passed to base class
-            use_tc (boolean): If `True` use the terrain corrected
-                              files. If `False`, switch to non-TC files. If
-                              `None` (default), use TC if available, non-TC otherwise.
+            config_files (Iterable): yaml config files passed to base class
+            use_tc (bool): If `True` use the terrain corrected
+                           files. If `False`, switch to non-TC files. If
+                           `None` (default), use TC if available, non-TC otherwise.
 
         """
         super().__init__(config_files, **kwargs)

--- a/satpy/readers/yaml_reader.py
+++ b/satpy/readers/yaml_reader.py
@@ -546,9 +546,9 @@ class FileYAMLReader(GenericYAMLReader, DataDownloadMixin):
         We assume here requirements are available.
 
         Raises:
-            KeyError, if no handler for the given requirements is available.
-            RuntimeError, if there is a handler for the given requirements,
-            but it doesn't match the filename info.
+            (Exception) `KeyError`: if no handler for the given requirements is available.
+            (Exception) `RuntimeError`: if there is a handler for the given requirements,
+                                        but it doesn't match the filename info.
 
         """
         req_fh = []
@@ -912,14 +912,14 @@ class FileYAMLReader(GenericYAMLReader, DataDownloadMixin):
                 provided key. Loadable datasets are always searched first,
                 but if ``available_only=False`` (default) then all known
                 datasets will be searched.
-            kwargs: See :func:`satpy.readers.get_key` for more information about
+            kwargs: See :func:`satpy.dataset.data_dict.get_key` for more information about
                 kwargs.
 
         Returns:
             Best matching DataID to the provided ``key``.
 
         Raises:
-            KeyError: if no key match is found.
+            (Exception) KeyError: if no key match is found.
 
         """
         try:
@@ -1157,7 +1157,7 @@ class GEOSegmentYAMLReader(GEOFlippableFileYAMLReader):
     This reader pads the data to full geostationary disk if necessary.
 
     This reader uses an optional ``pad_data`` keyword argument that can be
-    passed to :meth:`Scene.load` to control if padding is done (True by
+    passed to :meth:`satpy.scene.Scene.load` to control if padding is done (True by
     default). Passing `pad_data=False` will return data unpadded.
 
     When using this class in a reader's YAML configuration, segmented file

--- a/satpy/resample.py
+++ b/satpy/resample.py
@@ -873,10 +873,10 @@ class BucketAvg(BucketResamplerBase):
 
     Parameters
     ----------
-    fill_value : float (default: np.nan)
+    fill_value : (float) default `np.nan`)
         Fill value to mark missing/invalid values in the input data,
         as well as in the binned and averaged output data.
-    skipna : boolean (default: True)
+    skipna : (bool) default `True`
         If True, skips missing values (as marked by NaN or `fill_value`) for the average calculation
         (similarly to Numpy's `nanmean`). Buckets containing only missing values are set to fill_value.
         If False, sets the bucket to fill_value if one or more missing values are present in the bucket
@@ -891,7 +891,7 @@ class BucketAvg(BucketResamplerBase):
         Args:
             data (numpy.Array, dask.Array): Data to be resampled
             fill_value (numpy.nan, int): fill_value. Defaults to numpy.nan
-            skipna (boolean): Skip NA's. Default `True`
+            skipna (bool): Skip NA's. Default `True`
 
         Returns:
             dask.Array
@@ -920,9 +920,9 @@ class BucketSum(BucketResamplerBase):
 
     Parameters
     ----------
-    fill_value : float (default: np.nan)
+    fill_value : (float) default `np.nan`
         Fill value for missing data
-    skipna : boolean (default: True)
+    skipna : (bool) default `True`
         If True, skips NaN values for the sum calculation
         (similarly to Numpy's `nansum`). Buckets containing only NaN are set to zero.
         If False, sets the bucket to NaN if one or more NaN values are present in the bucket

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -119,7 +119,7 @@ class Scene:
 
 
         Args:
-            filenames (iterable or dict): A sequence of files that will be used to load data from. A ``dict`` object
+            filenames (Iterable or dict): A sequence of files that will be used to load data from. A ``dict`` object
                                           should map reader names to a list of filenames for that reader.
             reader (str or list): The name of the reader to use for loading the data or a list of names.
             filter_parameters (dict): Specify loaded file filtering parameters.
@@ -250,13 +250,13 @@ class Scene:
         """Compare areas for the provided datasets.
 
         Args:
-            datasets (iterable): Datasets whose areas will be compared. Can
+            datasets (Iterable): Datasets whose areas will be compared. Can
                                  be either `xarray.DataArray` objects or
                                  identifiers to get the DataArrays from the
                                  current Scene. Defaults to all datasets.
                                  This can also be a series of area objects,
                                  typically AreaDefinitions.
-            compare_func (callable): `min` or `max` or other function used to
+            compare_func (Callable): `min` or `max` or other function used to
                                      compare the dataset's areas.
 
         """
@@ -326,7 +326,7 @@ class Scene:
         """Get highest resolution area for the provided datasets.
 
         Args:
-            datasets (iterable): Datasets whose areas will be compared. Can
+            datasets (Iterable): Datasets whose areas will be compared. Can
                                  be either `xarray.DataArray` objects or
                                  identifiers to get the DataArrays from the
                                  current Scene. Defaults to all datasets.
@@ -340,7 +340,7 @@ class Scene:
         Deprecated.  Use :meth:`finest_area` instead.
 
         Args:
-            datasets (iterable): Datasets whose areas will be compared. Can
+            datasets (Iterable): Datasets whose areas will be compared. Can
                                  be either `xarray.DataArray` objects or
                                  identifiers to get the DataArrays from the
                                  current Scene. Defaults to all datasets.
@@ -357,7 +357,7 @@ class Scene:
         """Get lowest resolution area for the provided datasets.
 
         Args:
-            datasets (iterable): Datasets whose areas will be compared. Can
+            datasets (Iterable): Datasets whose areas will be compared. Can
                                  be either `xarray.DataArray` objects or
                                  identifiers to get the DataArrays from the
                                  current Scene. Defaults to all datasets.
@@ -371,7 +371,7 @@ class Scene:
         Deprecated.  Use :meth:`coarsest_area` instead.
 
         Args:
-            datasets (iterable): Datasets whose areas will be compared. Can
+            datasets (Iterable): Datasets whose areas will be compared. Can
                                  be either `xarray.DataArray` objects or
                                  identifiers to get the DataArrays from the
                                  current Scene. Defaults to all datasets.
@@ -400,10 +400,10 @@ class Scene:
         composite dataset IDs, pass ``composites=True``.
 
         Args:
-            reader_name (str, optional): Name of reader for which to return
+            reader_name (str, Optional): Name of reader for which to return
                 dataset IDs.  If not passed, return dataset IDs for all
                 readers.
-            composites (bool, optional): If True, return dataset IDs including
+            composites (bool, Optional): If True, return dataset IDs including
                 composites.  If False (default), return only non-composite
                 dataset IDs.
 
@@ -433,10 +433,10 @@ class Scene:
         argument ``composites=True`` is passed.
 
         Args:
-            reader_name (str, optional): Name of reader for which to return
+            reader_name (str, Optional): Name of reader for which to return
                 dataset IDs.  If not passed, return dataset names for all
                 readers.
-            composites (bool, optional): If True, return dataset IDs including
+            composites (bool, Optional): If True, return dataset IDs including
                 composites.  If False (default), return only non-composite
                 dataset names.
 
@@ -451,10 +451,10 @@ class Scene:
         Excludes composites unless ``composites=True`` is passed.
 
         Args:
-            reader_name (str, optional): Name of reader for which to return
+            reader_name (str, Optional): Name of reader for which to return
                 dataset IDs.  If not passed, return dataset IDs for all
                 readers.
-            composites (bool, optional): If True, return dataset IDs including
+            composites (bool, Optional): If True, return dataset IDs including
                 composites.  If False (default), return only non-composite
                 dataset IDs.
 
@@ -488,10 +488,10 @@ class Scene:
         Excludes composites unless ``composites=True`` is passed.
 
         Args:
-            reader_name (str, optional): Name of reader for which to return
+            reader_name (str, Optional): Name of reader for which to return
                 dataset IDs.  If not passed, return dataset names for all
                 readers.
-            composites (bool, optional): If True, return dataset IDs including
+            composites (bool, Optional): If True, return dataset IDs including
                 composites.  If False (default), return only non-composite
                 dataset names.
 
@@ -700,7 +700,7 @@ class Scene:
                                    longitude and Y is latitude.
             xy_bbox (tuple, list): Same as `ll_bbox` but elements are in
                                    projection units.
-            dataset_ids (iterable): DataIDs to include in the returned
+            dataset_ids (Iterable): DataIDs to include in the returned
                                  `Scene`. Defaults to all datasets.
 
         This method will attempt to intelligently slice the data to preserve
@@ -775,9 +775,9 @@ class Scene:
         """Create an aggregated version of the Scene.
 
         Args:
-            dataset_ids (iterable): DataIDs to include in the returned
+            dataset_ids (Iterable): DataIDs to include in the returned
                                     `Scene`. Defaults to all datasets.
-            func (string, callable): Function to apply on each aggregation window. One of
+            func (str, Callable): Function to apply on each aggregation window. One of
                            'mean', 'sum', 'min', 'max', 'median', 'argmin',
                            'argmax', 'prod', 'std', 'var' strings or a custom
                            function. 'mean' is the default.
@@ -996,7 +996,7 @@ class Scene:
             dataset_id (DataID, DataQuery or str):
                 Either a DataID, a DataQuery or a string, that refers to a data
                 array that has been previously loaded using Scene.load.
-            overlay (dict, optional):
+            overlay (dict, Optional):
                 Add an overlay before showing the image.  The keys/values for
                 this dictionary are as the arguments for
                 :meth:`~satpy.writers.add_overlay`.  The dictionary should
@@ -1020,7 +1020,7 @@ class Scene:
         """Convert satpy Scene to geoviews.
 
         Args:
-            scn (satpy.Scene): Satpy Scene.
+            scn (satpy.scene.Scene): Satpy Scene.
             gvtype (gv plot type):
                 One of gv.Image, gv.LineContours, gv.FilledContours, gv.Points
                 Default to :class:`geoviews.Image`.
@@ -1028,10 +1028,10 @@ class Scene:
             datasets (list): Limit included products to these datasets
             kdims (list of str):
                 Key dimensions. See geoviews documentation for more information.
-            vdims (list of str, optional):
+            vdims (list of str, Optional):
                 Value dimensions. See geoviews documentation for more information.
                 If not given defaults to first data variable
-            dynamic (bool, optional): Load and compute data on-the-fly during
+            dynamic (bool, Optional): Load and compute data on-the-fly during
                 visualization. Default is ``False``. See
                 https://holoviews.org/user_guide/Gridded_Datasets.html#working-with-xarray-data-types
                 for more information. Has no effect when data to be visualized
@@ -1054,7 +1054,7 @@ class Scene:
         """Convert satpy Scene to Hvplot. The method could not be used with composites of swath data.
 
         Args:
-            scn (satpy.Scene): Satpy Scene.
+            scn (satpy.scene.Scene): Satpy Scene.
             datasets (list): Limit included products to these datasets.
             args: Arguments coming from hvplot
             kwargs: hvplot options dictionary.
@@ -1135,31 +1135,31 @@ class Scene:
 
         Parameters
         ----------
-        datasets (iterable):
+        datasets (Iterable, Optional):
             List of Satpy Scene datasets to include in the output xr.Dataset.
             Elements can be string name, a wavelength as a number, a DataID,
             or DataQuery object.
             If None (the default), it include all loaded Scene datasets.
-        header_attrs:
+        header_attrs (dict, Optional):
             Global attributes of the output xr.Dataset.
-        epoch (str):
+        epoch (str, Optional):
             Reference time for encoding the time coordinates (if available).
             Example format: "seconds since 1970-01-01 00:00:00".
             If None, the default reference time is defined using "from satpy.cf.coords import EPOCH"
-        flatten_attrs (bool):
+        flatten_attrs (bool, Optional):
             If True, flatten dict-type attributes.
-        exclude_attrs (list):
+        exclude_attrs (Iterable, Optional):
             List of xr.DataArray attribute names to be excluded.
-        include_lonlats (bool):
+        include_lonlats (bool, Optional):
             If True, it includes 'latitude' and 'longitude' coordinates.
             If the 'area' attribute is a SwathDefinition, it always includes
             latitude and longitude coordinates.
-        pretty (bool):
+        pretty (bool, Optional):
             Don't modify coordinate names, if possible. Makes the file prettier,
             but possibly less consistent.
-        include_orig_name (bool).
+        include_orig_name (bool, Optional).
             Include the original dataset name as a variable attribute in the xr.Dataset.
-        numeric_name_prefix (str):
+        numeric_name_prefix (str, Optional):
             Prefix to add the each variable with name starting with a digit.
             Use '' or None to leave this out.
 
@@ -1193,7 +1193,7 @@ class Scene:
         """Save the ``dataset_id`` to file using ``writer``.
 
         Args:
-            dataset_id (str or Number or DataID or DataQuery): Identifier for
+            dataset_id (str or numbers.Number or DataID or DataQuery): Identifier for
                 the dataset to save to disk.
             filename (str): Optionally specify the filename to save this
                             dataset to. It may include string formatting
@@ -1258,7 +1258,7 @@ class Scene:
                             dataset to. It may include string formatting
                             patterns that will be filled in by dataset
                             attributes.
-            datasets (iterable): Limit written products to these datasets.
+            datasets (Iterable): Limit written products to these datasets.
                 Elements can be string name, a wavelength as a number, a
                 DataID, or DataQuery object.
             compute (bool): If `True` (default), compute all of the saves to
@@ -1390,7 +1390,7 @@ class Scene:
         generate composites that have yet to be generated.
 
         Args:
-            keepables (iterable): DataIDs to keep whether they are needed
+            keepables (Iterable): DataIDs to keep whether they are needed
                                   or not.
 
         """
@@ -1416,7 +1416,7 @@ class Scene:
         Loaded `DataArray` objects are created and stored in the Scene object.
 
         Args:
-            wishlist (iterable): List of names (str), wavelengths (float),
+            wishlist (Iterable): List of names (str), wavelengths (float),
                 DataQuery objects or DataID of the requested datasets to load.
                 See `available_dataset_ids()` for what datasets are available.
             calibration (list | str): Calibration levels to limit available
@@ -1633,7 +1633,7 @@ class Scene:
         Args:
             comp_id (DataID): DataID for the composite whose
                                  prerequisites are being collected.
-            prereq_nodes (sequence of Nodes): Prerequisites to collect
+            prereq_nodes (Sequence[Node]): Prerequisites to collect
             keepables (set): `set` to update if any prerequisites can't
                              be loaded at this time (see
                              `_generate_composite`).

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -87,9 +87,9 @@ def convert_file_content_to_data_array(file_content, attrs=tuple(),
 
     Args:
         file_content (dict): Dictionary of string file keys to fake file data.
-        attrs (iterable): Series of attributes to copy to DataArray object from
+        attrs (Iterable): Series of attributes to copy to DataArray object from
             file content dictionary. Defaults to no attributes.
-        dims (iterable): Dimension names to use for resulting DataArrays.
+        dims (Iterable): Dimension names to use for resulting DataArrays.
             The second to last dimension is used for 1D arrays, so for
             dims of ``('z', 'y', 'x')`` this would use ``'y'``. Otherwise, the
             dimensions are used starting with the last, so 2D arrays are

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -185,8 +185,8 @@ def lonlat2xyz(lon, lat):
     longitude and latitude to cartesian coordinates.
 
     Args:
-        lon (number or array of numbers): Longitude in °.
-        lat (number or array of numbers): Latitude in °.
+        lon (numbers.Number or ArrayLike[numbers.Number]): Longitude in °.
+        lat (numbers.Number or ArrayLike[numbers.Number]): Latitude in °.
 
     Returns:
         (x, y, z) Cartesian coordinates [1]
@@ -206,14 +206,14 @@ def xyz2lonlat(x, y, z, asin=False):
     coordinates longitude and latitude.
 
     Args:
-        x (number or array of numbers): x-coordinate, unitless
-        y (number or array of numbers): y-coordinate, unitless
-        z (number or array of numbers): z-coordinate, unitless
-        asin (optional, bool): If true, use arcsin for calculations.
+        x (numbers.Number or ArrayLike[numbers.Number]): x-coordinate, unitless
+        y (numbers.Number or ArrayLike[numbers.Number]): y-coordinate, unitless
+        z (numbers.Number or ArrayLike[numbers.Number]): z-coordinate, unitless
+        asin (bool, Optional): If true, use arcsin for calculations.
             If false, use arctan2 for calculations.
 
     Returns:
-        (lon, lat): Longitude and latitude in °.
+        (tuple): Longitude and latitude in °.
     """
     lon = np.rad2deg(np.arctan2(y, x))
     if asin:

--- a/satpy/writers/__init__.py
+++ b/satpy/writers/__init__.py
@@ -557,14 +557,14 @@ def group_results_by_output_file(sources, targets):
 
     Args:
         sources: List of sources (typically dask.array) as returned by
-            :meth:`Scene.save_datasets`.
+            :meth:`Scene.save_datasets <satpy.scene.Scene.save_datasets>`.
         targets: List of targets (should be ``RIODataset`` or ``RIOTag``) as
-            returned by :meth:`Scene.save_datasets`.
+            returned by :meth:`Scene.save_datasets <satpy.scene.Scene.save_datasets>`.
 
     Returns:
         List of ``Tuple(List[sources], List[targets])`` with a length equal to
         the number of output files planned to be written by
-        :meth:`Scene.save_datasets`.
+        :meth:`Scene.save_datasets <satpy.scene.Scene.save_datasets>`.
     """
     ofs = {}
     for (src, targ) in zip(sources, targets):
@@ -580,7 +580,7 @@ def compute_writer_results(results):
     """Compute all the given dask graphs `results` so that the files are saved.
 
     Args:
-        results (iterable): Iterable of dask graphs resulting from calls to
+        results (Iterable): Iterable of dask graphs resulting from calls to
                             `scn.save_datasets(..., compute=False)`
     """
     if not results:
@@ -733,7 +733,7 @@ class Writer(Plugin, DataDownloadMixin):
         this simply calls `save_dataset` for each dataset provided.
 
         Args:
-            datasets (iterable): Iterable of `xarray.DataArray` objects to
+            datasets (Iterable): Iterable of `xarray.DataArray` objects to
                                  save using this writer.
             compute (bool): If `True` (default), compute all the saves to
                             disk. If `False` then the return value is either
@@ -845,7 +845,7 @@ class ImageWriter(Writer):
                 if further custom enhancement is needed.
 
             kwargs (dict): Additional keyword arguments to pass to the
-                :class:`~satpy.writer.Writer` base class.
+                :class:`~satpy.writers.Writer` base class.
 
         .. versionchanged:: 0.10
 

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -779,8 +779,9 @@ class NetCDFTemplate:
                 `value` and `raw_key` are both ``None`` and `attr_name`
                 is ``"my_attr"``, then the method ``self._my_attr`` will be
                 called as ``return self._my_attr(input_metadata)``.
-                See :meth:`NetCDFTemplate.render_global_attributes` for
-                additional information (prefix is ``"_global_"``).
+                See :meth:`NetCDFTemplate.render_global_attributes
+                <satpy.writers.awips_tiled.NetCDFTemplate._render_global_attributes>`
+                for additional information (prefix is ``"_global_"``).
 
         """
         if raw_value is not None:
@@ -1520,10 +1521,10 @@ class AWIPSTiledWriter(Writer):
         """Write a series of DataArray objects to multiple NetCDF4 Tile files.
 
         Args:
-            datasets (iterable): Series of gridded :class:`~xarray.DataArray`
+            datasets (Iterable): Series of gridded :class:`~xarray.DataArray`
                 objects with the necessary metadata to be converted to a valid
                 tile product file.
-            sector_id (str): Name of the region or sector that the provided
+            sector_id (str, Optional): Name of the region or sector that the provided
                 data is on. This name will be written to the NetCDF file and
                 will be used as the sector in the AWIPS client for the 'polar'
                 template. For lettered
@@ -1531,53 +1532,53 @@ class AWIPSTiledWriter(Writer):
                 YAML. This is required for some templates (ex. default 'polar'
                 template) but is defined as a keyword argument
                 for better error handling in Satpy.
-            source_name (str): Name of producer of these files (ex. "SSEC").
+            source_name (str, Optional): Name of producer of these files (ex. "SSEC").
                 This name is used to create the output filename for some
                 templates.
-            environment_prefix (str): Prefix of filenames for some templates.
+            environment_prefix (str, Optional): Prefix of filenames for some templates.
                 For operational real-time data this is usually "OR", "OT" for
                 test data, "IR" for test system real-time data, and "IT" for
                 test system test data. This defaults to "DR" for "Developer
                 Real-time" to avoid anyone accidentally producing files that
                 could be mistaken for the operational system.
-            tile_count (tuple): For numbered tiles only, how many tile rows
+            tile_count (tuple, Optional): For numbered tiles only, how many tile rows
                 and tile columns to produce. Default to ``(1, 1)``, a single
                 giant tile. Either ``tile_count``, ``tile_size``, or
                 ``lettered_grid`` should be specified.
-            tile_size (tuple): For numbered tiles only, how many pixels each
+            tile_size (tuple, Optional): For numbered tiles only, how many pixels each
                 tile should be. This takes precedence over ``tile_count`` if
                 specified. Either ``tile_count``, ``tile_size``, or
                 ``lettered_grid`` should be specified.
-            lettered_grid (bool): Whether to use a preconfigured grid and
+            lettered_grid (bool, Optional): Whether to use a preconfigured grid and
                 label tiles with letters and numbers instead of only numbers.
                 For example, tiles will be named "A01", "A02", "B01", and so
                 on in the first row of data and continue on to "A03", "A04",
                 and "B03" in the default case where ``num_subtiles`` is (2, 2).
                 Letters start in the upper-left corner and will go from A up to
                 Z, if necessary.
-            num_subtiles (tuple): For lettered tiles only, how many rows and
+            num_subtiles (tuple, Optional): For lettered tiles only, how many rows and
                 columns to split each lettered tile in to. By default 2 rows
                 and 2 columns will be created. For example, the tile for
                 letter "A" will have "A01" and "A02" in the top row and "A03"
                 and "A04" in the second row.
-            use_end_time (bool): Instead of using the ``start_time`` for the
+            use_end_time (bool, Optional): Instead of using the ``start_time`` for the
                 product filename and time written to the file, use the
                 ``end_time``. This is useful for multi-day composites where
                 the ``end_time`` is a better representation of what data is
                 in the file.
-            use_sector_reference (bool): For lettered tiles only, whether to
+            use_sector_reference (bool, Optional): For lettered tiles only, whether to
                 shift the data locations to align with the preconfigured
                 grid's pixels. By default this is False meaning that the
                 grid's tiles will be shifted to align with the data locations.
                 If True, the data is shifted. At most the data will be shifted
                 by 0.5 pixels. See :mod:`satpy.writers.awips_tiled` for more
                 information.
-            template (str or dict): Name of the template configured in the
+            template (str or dict, Optional): Name of the template configured in the
                 writer YAML file. This can also be a dictionary with a full
                 template configuration. See the :mod:`satpy.writers.awips_tiled`
                 documentation for more information on templates. Defaults to
                 the 'polar' builtin template.
-            check_categories (bool): Whether category and flag products should
+            check_categories (bool, Optional): Whether category and flag products should
                 be included in the checks for empty or not empty tiles. In
                 some cases (ex. data quality flags) category products may look
                 like all valid data (a non-empty tile) but shouldn't be used
@@ -1585,11 +1586,11 @@ class AWIPSTiledWriter(Writer):
                 versus non-existent). Default is True. Set to False to ignore
                 category (integer dtype or "flag_meanings" defined) when
                 checking for valid data.
-            extra_global_attrs (dict): Additional global attributes to be
+            extra_global_attrs (dict, Optional): Additional global attributes to be
                 added to every produced file. These attributes are applied
                 at the end of template rendering and will therefore overwrite
                 template generated values with the same global attribute name.
-            compute (bool): Compute and write the output immediately using
+            compute (bool, Optional): Compute and write the output immediately using
                 dask. Default to ``False``.
 
         """

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -245,19 +245,19 @@ class CFWriter(Writer):
                 The group name `None` corresponds to the root of the file, i.e., no group will be created.
                 Warning: The results will not be fully CF compliant!
             header_attrs: Global attributes to be included.
-            engine (str, optional): Module to be used for writing netCDF files. Follows xarray's
+            engine (str, Optional): Module to be used for writing netCDF files. Follows xarray's
                 :meth:`~xarray.Dataset.to_netcdf` engine choices with a preference for 'netcdf4'.
-            epoch (str, optional): Reference time for encoding of time coordinates.
+            epoch (str, Optional): Reference time for encoding of time coordinates.
                 If None, the default reference time is defined using `from satpy.cf.coords import EPOCH`.
-            flatten_attrs (bool, optional): If True, flatten dict-type attributes.
-            exclude_attrs (list, optional): List of dataset attributes to be excluded.
-            include_lonlats (bool, optional): Always include latitude and longitude coordinates,
+            flatten_attrs (bool, Optional): If True, flatten dict-type attributes.
+            exclude_attrs (list, Optional): List of dataset attributes to be excluded.
+            include_lonlats (bool, Optional): Always include latitude and longitude coordinates,
                 even for datasets with area definition.
-            pretty (bool, optional): Don't modify coordinate names, if possible.
+            pretty (bool, Optional): Don't modify coordinate names, if possible.
                 Makes the file prettier, but possibly less consistent.
-            include_orig_name (bool, optional): Include the original dataset name as a variable
+            include_orig_name (bool, Optional): Include the original dataset name as a variable
                 attribute in the final netCDF.
-            numeric_name_prefix (str, optional): Prefix to add to each variable with a name starting with a digit.
+            numeric_name_prefix (str, Optional): Prefix to add to each variable with a name starting with a digit.
                 Use '' or None to leave this out.
         """
         from satpy.cf.datasets import collect_cf_datasets

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -234,7 +234,7 @@ class GeoTIFFWriter(ImageWriter):
                 GeoTIFF. See GDAL documentation for more information.
             tiled (bool): For performance this defaults to ``True``.
                 Pass ``False`` to created striped TIFF files.
-            include_scale_offset (deprecated, bool): Deprecated.
+            include_scale_offset (bool): Deprecated.
                 Use ``scale_offset_tags=("scale", "offset")`` to include scale
                 and offset tags.
 


### PR DESCRIPTION
This was mentioned on slack, but our documentation has a lot of invalid references. Sphinx does not show these warnings by default. You can see them by adding `-n` to the sphinx-build call. This PR, at the time of writing, only fixes a small portion of the 300+ warnings. I don't want to turn on these warning by default as there are some that are really difficult to make work correctly or depend on the upstream package documenting things.

Edit: Below is the list of remaining warnings:

<details>

```
/home/davidh/repos/git/satpy/doc/source/api/satpy._scene_converters.rst:2: WARNING: py:class reference target not found: gv plot type [ref.class]
/home/davidh/repos/git/satpy/satpy/_scene_converters.py:docstring of satpy._scene_converters.to_geoviews:5: WARNING: py:class reference target not found: geoviews.element.geo.Image [ref.class]
/home/davidh/repos/git/satpy/satpy/enhancements/__init__.py:docstring of satpy.enhancements.piecewise_linear_stretch:1: WARNING: py:class reference target not found: numpy._typing._array_like._SupportsArray [ref.class]
/home/davidh/repos/git/satpy/satpy/enhancements/__init__.py:docstring of satpy.enhancements.piecewise_linear_stretch:1: WARNING: py:class reference target not found: numpy._typing._nested_sequence._NestedSequence [ref.class]
/home/davidh/repos/git/satpy/satpy/enhancements/__init__.py:docstring of satpy.enhancements.piecewise_linear_stretch:1: WARNING: py:class reference target not found: numpy._typing._array_like._SupportsArray [ref.class]
/home/davidh/repos/git/satpy/satpy/enhancements/__init__.py:docstring of satpy.enhancements.piecewise_linear_stretch:1: WARNING: py:class reference target not found: numpy._typing._nested_sequence._NestedSequence [ref.class]
/home/davidh/repos/git/satpy/satpy/enhancements/__init__.py:docstring of satpy.enhancements.piecewise_linear_stretch:1: WARNING: py:class reference target not found: numpy._typing._array_like._SupportsArray [ref.class]
/home/davidh/repos/git/satpy/satpy/enhancements/__init__.py:docstring of satpy.enhancements.piecewise_linear_stretch:1: WARNING: py:class reference target not found: numpy._typing._nested_sequence._NestedSequence [ref.class]
/home/davidh/repos/git/satpy/satpy/enhancements/__init__.py:docstring of satpy.enhancements.piecewise_linear_stretch:1: WARNING: py:class reference target not found: numpy._typing._array_like._SupportsArray [ref.class]
/home/davidh/repos/git/satpy/satpy/enhancements/__init__.py:docstring of satpy.enhancements.piecewise_linear_stretch:1: WARNING: py:class reference target not found: numpy._typing._nested_sequence._NestedSequence [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.modifiers.parallax.rst:2: WARNING: py:class reference target not found: array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.modifiers.parallax.rst:2: WARNING: py:class reference target not found: number [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.modifiers.parallax.rst:2: WARNING: py:class reference target not found: array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.modifiers.parallax.rst:2: WARNING: py:class reference target not found: number [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.modifiers.parallax.rst:2: WARNING: py:class reference target not found: array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.modifiers.parallax.rst:2: WARNING: py:class reference target not found: number [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.modifiers.parallax.rst:2: WARNING: py:class reference target not found: array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.modifiers.parallax.rst:2: WARNING: py:class reference target not found: number [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.modifiers.parallax.rst:2: WARNING: py:class reference target not found: array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.modifiers.parallax.rst:2: WARNING: py:class reference target not found: number [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.modifiers.parallax.rst:2: WARNING: py:class reference target not found: array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.modifiers.parallax.rst:2: WARNING: py:class reference target not found: number [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.modifiers.parallax.rst:2: WARNING: py:class reference target not found: number [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.modifiers.parallax.rst:2: WARNING: py:class reference target not found: array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.multiscene._multiscene.rst:2: WARNING: py:class reference target not found: dask.distributed.Client [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.multiscene._multiscene.rst:2: WARNING: py:class reference target not found: dask.distributed.Client [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.node.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/__init__.py:docstring of satpy.readers.FSFile:3: WARNING: py:class reference target not found: Scene [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.rst:143: WARNING: py:class reference target not found: Pathlike [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.rst:143: WARNING: py:class reference target not found: OpenFile [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.rst:143: WARNING: py:class reference target not found: fsspec filesystem [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.rst:143: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.rst:143: WARNING: py:class reference target not found: FileSystem [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/__init__.py:docstring of satpy.readers._get_sorted_file_groups:: WARNING: py:class reference target not found: as returned by [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.rst:143: WARNING: py:class reference target not found: yaml.BaseLoader [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.rst:143: WARNING: py:class reference target not found: yaml.FullLoader [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.rst:143: WARNING: py:class reference target not found: yaml.UnsafeLoader [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.rst:143: WARNING: py:class reference target not found: datetime [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.rst:143: WARNING: py:class reference target not found: datetime [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.rst:143: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/__init__.py:docstring of satpy.readers.load_readers:: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers._geos_area.rst:2: WARNING: py:class reference target not found: a_def [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers._geos_area.rst:2: WARNING: py:class reference target not found: aex [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers._geos_area.rst:2: WARNING: py:class reference target not found: aex [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/amsr2_l2_gaasp.py:docstring of satpy.readers.amsr2_l2_gaasp.GAASPFileHandler.available_datasets:3: WARNING: py:meth reference target not found: satpy.readers.file_handlers.BaseHandler.available_datasets [ref.meth]
/home/davidh/repos/git/satpy/satpy/readers/clavrx.py:docstring of satpy.readers.clavrx.CLAVRXNetCDFFileHandler.available_datasets:3: WARNING: py:meth reference target not found: satpy.readers.file_handlers.BaseHandler.available_datasets [ref.meth]
/home/davidh/repos/git/satpy/satpy/readers/clavrx.py:docstring of satpy.readers.clavrx._CLAVRxHelper._read_pug_fixed_grid:1: WARNING: py:class reference target not found: netCDF4.Variable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.eum_l2_bufr.rst:2: WARNING: py:class reference target not found: AreaDefinition [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.eum_l2_grib.rst:2: WARNING: py:class reference target not found: DataArray [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/fci_l1c_nc.py:docstring of satpy.readers.fci_l1c_nc.FCIL1cNCFileHandler:3: WARNING: py:class reference target not found: satpy.Scene [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/fci_l1c_nc.py:docstring of satpy.readers.fci_l1c_nc.FCIL1cNCFileHandler:3: WARNING: py:mod reference target not found: satpy.Scene.load [ref.mod]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.fci_l2_nc.rst:2: WARNING: py:class reference target not found: AreaDefinition [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.fci_l2_nc.rst:2: WARNING: py:class reference target not found: AreaDefinition [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/file_handlers.py:docstring of satpy.readers.file_handlers.BaseFileHandler.available_datasets:9: WARNING: py:class reference target not found: satpy.dataset.DataID [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/fy4_base.py:docstring of satpy.readers.fy4_base.FY4Base._apply_lut:1: WARNING: py:class reference target not found: numpy.float32 [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/goes_imager_hrit.py:docstring of satpy.readers.goes_imager_hrit._epoch_doy_offset_from_sgs_time:1: WARNING: py:class reference target not found: numpy._typing._array_like._SupportsArray [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/goes_imager_hrit.py:docstring of satpy.readers.goes_imager_hrit._epoch_doy_offset_from_sgs_time:1: WARNING: py:class reference target not found: numpy._typing._nested_sequence._NestedSequence [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/goes_imager_hrit.py:docstring of satpy.readers.goes_imager_hrit._epoch_doy_offset_from_sgs_time:1: WARNING: py:class reference target not found: numpy._typing._array_like._SupportsArray [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/goes_imager_hrit.py:docstring of satpy.readers.goes_imager_hrit._epoch_doy_offset_from_sgs_time:1: WARNING: py:class reference target not found: numpy._typing._nested_sequence._NestedSequence [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/goes_imager_hrit.py:docstring of satpy.readers.goes_imager_hrit._epoch_year_from_sgs_time:1: WARNING: py:class reference target not found: numpy._typing._array_like._SupportsArray [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/goes_imager_hrit.py:docstring of satpy.readers.goes_imager_hrit._epoch_year_from_sgs_time:1: WARNING: py:class reference target not found: numpy._typing._nested_sequence._NestedSequence [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/goes_imager_hrit.py:docstring of satpy.readers.goes_imager_hrit._epoch_year_from_sgs_time:1: WARNING: py:class reference target not found: numpy._typing._array_like._SupportsArray [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/goes_imager_hrit.py:docstring of satpy.readers.goes_imager_hrit._epoch_year_from_sgs_time:1: WARNING: py:class reference target not found: numpy._typing._nested_sequence._NestedSequence [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/goes_imager_hrit.py:docstring of satpy.readers.goes_imager_hrit.make_sgs_time:1: WARNING: py:class reference target not found: numpy._typing._array_like._SupportsArray [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/goes_imager_hrit.py:docstring of satpy.readers.goes_imager_hrit.make_sgs_time:1: WARNING: py:class reference target not found: numpy._typing._nested_sequence._NestedSequence [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/goes_imager_hrit.py:docstring of satpy.readers.goes_imager_hrit.make_sgs_time:1: WARNING: py:class reference target not found: numpy._typing._array_like._SupportsArray [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/goes_imager_hrit.py:docstring of satpy.readers.goes_imager_hrit.make_sgs_time:1: WARNING: py:class reference target not found: numpy._typing._nested_sequence._NestedSequence [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.goes_imager_nc.rst:2: WARNING: py:exc reference target not found: ValueError if coefficients don't match the reference [ref.exc]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.hrit_jma.rst:2: WARNING: py:exc reference target not found: ValueError if they don't match [ref.exc]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.ici_l1b_nc.rst:2: WARNING: py:class reference target not found: DataArray [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.ici_l1b_nc.rst:2: WARNING: py:class reference target not found: DataArray [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.ici_l1b_nc.rst:2: WARNING: py:class reference target not found: DataArray [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/mirs.py:docstring of satpy.readers.mirs.MiRSL2ncHandler.available_datasets:3: WARNING: py:meth reference target not found: satpy.readers.file_handlers.BaseHandler.available_datasets [ref.meth]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.mviri_l1b_fiduceo_nc.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.mviri_l1b_fiduceo_nc.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/mwr_l1c.py:docstring of satpy.readers.mwr_l1c.AWS_MWR_L1CFile:3: WARNING: py:class reference target not found: satpy.Scene [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/mwr_l1c.py:docstring of satpy.readers.mwr_l1c.AWS_MWR_L1CFile:3: WARNING: py:mod reference target not found: satpy.Scene.load [ref.mod]
/home/davidh/repos/git/satpy/satpy/readers/mws_l1b.py:docstring of satpy.readers.mws_l1b.MWSL1BFile:3: WARNING: py:class reference target not found: satpy.Scene [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/mws_l1b.py:docstring of satpy.readers.mws_l1b.MWSL1BFile:3: WARNING: py:mod reference target not found: satpy.Scene.load [ref.mod]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.nucaps.rst:2: WARNING: py:class reference target not found: boolean [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.nucaps.rst:2: WARNING: py:class reference target not found: boolean [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.nucaps.rst:2: WARNING: py:class reference target not found: boolean [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.nucaps.rst:2: WARNING: py:class reference target not found: boolean [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.pmw_channels_definitions.rst:2: WARNING: py:class reference target not found: scalar [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.pmw_channels_definitions.rst:2: WARNING: py:class reference target not found: scalar [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.pmw_channels_definitions.rst:2: WARNING: py:class reference target not found: and band width frq [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.pmw_channels_definitions.rst:2: WARNING: py:class reference target not found: scalar [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.pmw_channels_definitions.rst:2: WARNING: py:class reference target not found: scalar [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.sar_c_safe.rst:2: WARNING: py:class reference target not found: gdal band [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.sar_c_safe.rst:2: WARNING: py:class reference target not found: coordinates [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.sar_c_safe.rst:2: WARNING: py:class reference target not found: gdal band [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.sar_c_safe.rst:2: WARNING: py:class reference target not found: points [ref.class]
/home/davidh/repos/git/satpy/satpy/readers/seviri_base.py:docstring of satpy.readers.seviri_base.chebyshev:: WARNING: py:class reference target not found: np.array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.seviri_base.rst:2: WARNING: py:class reference target not found: either scalar [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.seviri_base.rst:2: WARNING: py:class reference target not found: either scalar [ref.class]
<unknown>:1: WARNING: py:class reference target not found: numpy.uint8 [ref.class]
<unknown>:1: WARNING: py:class reference target not found: numpy.uint8 [ref.class]
<unknown>:1: WARNING: py:class reference target not found: numpy.uint16 [ref.class]
<unknown>:1: WARNING: py:class reference target not found: numpy.uint32 [ref.class]
<unknown>:1: WARNING: py:class reference target not found: numpy.uint8 [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.utils.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.utils.rst:2: WARNING: py:class reference target not found: for correct sorting. This is normally the segment [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.utils.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.utils.rst:2: WARNING: py:class reference target not found: for correct sorting. This is normally the segment [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.utils.rst:2: WARNING: py:class reference target not found: ndarray [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.utils.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.utils.rst:2: WARNING: py:class reference target not found: for correct sorting. This is normally the segment [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.vii_base_nc.rst:2: WARNING: py:class reference target not found: DataArray [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.vii_l1b_nc.rst:2: WARNING: py:class reference target not found: numpy ndarray [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.vii_l1b_nc.rst:2: WARNING: py:class reference target not found: numpy ndarray [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.vii_l1b_nc.rst:2: WARNING: py:class reference target not found: DataArray [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.vii_l1b_nc.rst:2: WARNING: py:class reference target not found: DataArray [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.vii_l2_nc.rst:2: WARNING: py:class reference target not found: DataArray [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.viirs_edr_active_fires.rst:2: WARNING: py:class reference target not found: Dask DataArray [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.viirs_sdr.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.viirs_sdr.rst:2: WARNING: py:class reference target not found: boolean [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.viirs_sdr.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.viirs_sdr.rst:2: WARNING: py:class reference target not found: boolean [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.yaml_reader.rst:2: WARNING: py:class reference target not found: FileSystem [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.yaml_reader.rst:2: WARNING: py:exc reference target not found: if no handler for the given requirements is available. [ref.exc]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.yaml_reader.rst:2: WARNING: py:exc reference target not found: if there is a handler for the given requirements [ref.exc]
/home/davidh/repos/git/satpy/doc/source/api/satpy.readers.yaml_reader.rst:2: WARNING: py:exc reference target not found: but it doesn't match the filename info. [ref.exc]
/home/davidh/repos/git/satpy/satpy/readers/yaml_reader.py:docstring of satpy.readers.yaml_reader.FileYAMLReader.get_dataset_key:16: WARNING: py:func reference target not found: satpy.readers.get_key [ref.func]
/home/davidh/repos/git/satpy/satpy/readers/yaml_reader.py:docstring of satpy.readers.yaml_reader.GEOSegmentYAMLReader:5: WARNING: py:meth reference target not found: Scene.load [ref.meth]
/home/davidh/repos/git/satpy/satpy/resample.py:docstring of satpy.resample:18: WARNING: py:class reference target not found: pyresample.ewa.DaskEWAResampler [ref.class]
/home/davidh/repos/git/satpy/satpy/resample.py:docstring of satpy.resample:18: WARNING: py:class reference target not found: pyresample.ewa.LegacyDaskEWAResampler [ref.class]
/home/davidh/repos/git/satpy/satpy/resample.py:docstring of satpy.resample:18: WARNING: py:meth reference target not found: pyresample.gradient.create_gradient_search_resampler [ref.meth]
/home/davidh/repos/git/satpy/doc/source/api/satpy.resample.rst:2: WARNING: py:class reference target not found: default: np.nan [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.resample.rst:2: WARNING: py:class reference target not found: boolean [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.resample.rst:2: WARNING: py:class reference target not found: default: True [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.resample.rst:2: WARNING: py:class reference target not found: numpy.Array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.resample.rst:2: WARNING: py:class reference target not found: dask.Array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.resample.rst:2: WARNING: py:class reference target not found: numpy.nan [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.resample.rst:2: WARNING: py:class reference target not found: boolean [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.resample.rst:2: WARNING: py:class reference target not found: default: np.nan [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.resample.rst:2: WARNING: py:class reference target not found: boolean [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.resample.rst:2: WARNING: py:class reference target not found: default: True [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: callable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: sequence [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: Nodes [ref.class]
/home/davidh/repos/git/satpy/satpy/scene.py:docstring of satpy.scene.Scene.aggregate:: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/satpy/scene.py:docstring of satpy.scene.Scene.aggregate:: WARNING: py:class reference target not found: string [ref.class]
/home/davidh/repos/git/satpy/satpy/scene.py:docstring of satpy.scene.Scene.aggregate:: WARNING: py:class reference target not found: callable [ref.class]
/home/davidh/repos/git/satpy/satpy/scene.py:docstring of satpy.scene.Scene.all_dataset_ids:: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/satpy/scene.py:docstring of satpy.scene.Scene.all_dataset_ids:: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/satpy/scene.py:docstring of satpy.scene.Scene.all_dataset_names:: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/satpy/scene.py:docstring of satpy.scene.Scene.all_dataset_names:: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/satpy/scene.py:docstring of satpy.scene.Scene.available_dataset_ids:: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/satpy/scene.py:docstring of satpy.scene.Scene.available_dataset_ids:: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/satpy/scene.py:docstring of satpy.scene.Scene.available_dataset_names:: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/satpy/scene.py:docstring of satpy.scene.Scene.available_dataset_names:: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: AreaDefinition [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: AreaDefinition [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: GridDefinition [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: Number [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: satpy.Scene [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: gv plot type [ref.class]
/home/davidh/repos/git/satpy/satpy/scene.py:docstring of satpy.scene.Scene.to_geoviews:5: WARNING: py:class reference target not found: geoviews.Image [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/satpy/scene.py:docstring of satpy.scene.Scene.to_hvplot:: WARNING: py:class reference target not found: satpy.Scene [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: datasets [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: numeric_name_prefix [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: pretty [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: exclude_attrs [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: include_orig_name [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.scene.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/satpy/tests/reader_tests/_li_test_utils.py:docstring of satpy.tests.reader_tests._li_test_utils.FakeLIFileHandlerBase:1: WARNING: py:class reference target not found: satpy.tests.reader_tests.test_netcdf_utils.FakeNetCDF4FileHandler [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.tests.utils.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.tests.utils.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.tests.utils.rst:2: WARNING: py:class reference target not found: BaseDefinition [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: np.datetime64 [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: number [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: numbers [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: number [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: numbers [ref.class]
/home/davidh/repos/git/satpy/satpy/utils.py:docstring of satpy.utils.normalize_low_res_chunks:1: WARNING: py:class reference target not found: numpy._typing._dtype_like._SupportsDType [ref.class]
/home/davidh/repos/git/satpy/satpy/utils.py:docstring of satpy.utils.normalize_low_res_chunks:1: WARNING: py:class reference target not found: numpy._typing._dtype_like._DTypeDict [ref.class]
/home/davidh/repos/git/satpy/satpy/utils.py:docstring of satpy.utils.unify_chunks:3: WARNING: py:func reference target not found: dask.array.core.map_blocks [ref.func]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: number [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: numbers [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: number [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: numbers [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: number [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: array [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: numbers [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: lon [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.utils.rst:2: WARNING: py:class reference target not found: lat [ref.class]
/home/davidh/repos/git/satpy/satpy/writers/__init__.py:docstring of satpy.writers.ImageWriter:32: WARNING: py:class reference target not found: satpy.writer.Writer [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.rst:20: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.rst:20: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/satpy/writers/__init__.py:docstring of satpy.writers.group_results_by_output_file:42: WARNING: py:meth reference target not found: Scene.save_datasets [ref.meth]
/home/davidh/repos/git/satpy/satpy/writers/__init__.py:docstring of satpy.writers.group_results_by_output_file:44: WARNING: py:meth reference target not found: Scene.save_datasets [ref.meth]
/home/davidh/repos/git/satpy/satpy/writers/__init__.py:docstring of satpy.writers.group_results_by_output_file:47: WARNING: py:meth reference target not found: Scene.save_datasets [ref.meth]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.awips_tiled.rst:2: WARNING: py:class reference target not found: iterable [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.awips_tiled.rst:2: WARNING: py:class reference target not found: AreaDefinition [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.awips_tiled.rst:2: WARNING: py:class reference target not found: pyproj.CRS [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.awips_tiled.rst:2: WARNING: py:class reference target not found: AreaDefinition [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.awips_tiled.rst:2: WARNING: py:class reference target not found: pyproj.CRS [ref.class]
/home/davidh/repos/git/satpy/satpy/writers/awips_tiled.py:docstring of satpy.writers.awips_tiled.NetCDFTemplate.get_attr_value:33: WARNING: py:meth reference target not found: NetCDFTemplate.render_global_attributes [ref.meth]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.cf_writer.rst:2: WARNING: py:class reference target not found: xr.DataArray [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.cf_writer.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.cf_writer.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.cf_writer.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.cf_writer.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.cf_writer.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.cf_writer.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.cf_writer.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.cf_writer.rst:2: WARNING: py:class reference target not found: optional [ref.class]
/home/davidh/repos/git/satpy/satpy/writers/geotiff.py:docstring of satpy.writers.geotiff.GeoTIFFWriter.save_image:1: WARNING: py:class reference target not found: numpy._typing._dtype_like._SupportsDType [ref.class]
/home/davidh/repos/git/satpy/satpy/writers/geotiff.py:docstring of satpy.writers.geotiff.GeoTIFFWriter.save_image:1: WARNING: py:class reference target not found: numpy._typing._dtype_like._DTypeDict [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.geotiff.rst:2: WARNING: py:class reference target not found: DTypeLike [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.geotiff.rst:2: WARNING: py:class reference target not found: deprecated [ref.class]
/home/davidh/repos/git/satpy/doc/source/api/satpy.writers.ninjotiff.rst:2: WARNING: py:class reference target not found: xarray DataArray [ref.class]
/home/davidh/repos/git/satpy/doc/source/composites.rst:110: WARNING: py:meth reference target not found: satpy.Scene.save_datasets [ref.meth]
/home/davidh/repos/git/satpy/doc/source/composites.rst:118: WARNING: py:meth reference target not found: satpy.Scene.save_datasets [ref.meth]
/home/davidh/repos/git/satpy/doc/source/composites.rst:536: WARNING: py:func reference target not found: trollimage.xrimage.XRImage.stretch_linear [ref.func]
/home/davidh/repos/git/satpy/doc/source/dev_guide/aux_data.rst:43: WARNING: py:class reference target not found: satpy.aux_download.DataMixIn [ref.class]
/home/davidh/repos/git/satpy/doc/source/dev_guide/custom_reader.rst:502: WARNING: py:class reference target not found: satpy.dataset.DataID [ref.class]
/home/davidh/repos/git/satpy/doc/source/dev_guide/index.rst:104: WARNING: py:mod reference target not found: asv [ref.mod]
/home/davidh/repos/git/satpy/doc/source/dev_guide/plugins.rst:71: WARNING: py:class reference target not found: satpy.modifiers.ModifierBase [ref.class]
/home/davidh/repos/git/satpy/doc/source/dev_guide/plugins.rst:75: WARNING: py:func reference target not found: satpy.enhancements.apply_enhancement [ref.func]
/home/davidh/repos/git/satpy/doc/source/dev_guide/satpy_internals.rst:129: WARNING: py:class reference target not found: satpy.dataset.WavelengthRange [ref.class]
/home/davidh/repos/git/satpy/doc/source/dev_guide/xarray_migration.rst:254: WARNING: py:func reference target not found: dask.array.cos [ref.func]
/home/davidh/repos/git/satpy/doc/source/dev_guide/xarray_migration.rst:254: WARNING: py:func reference target not found: dask.array.log [ref.func]
/home/davidh/repos/git/satpy/doc/source/dev_guide/xarray_migration.rst:292: WARNING: py:func reference target not found: dask.array.core.map_blocks [ref.func]
/home/davidh/repos/git/satpy/doc/source/dev_guide/xarray_migration.rst:310: WARNING: py:func reference target not found: dask.array.core.map_blocks [ref.func]
/home/davidh/repos/git/satpy/doc/source/dev_guide/xarray_migration.rst:312: WARNING: py:func reference target not found: dask.array.core.atop [ref.func]
/home/davidh/repos/git/satpy/doc/source/dev_guide/xarray_migration.rst:314: WARNING: py:func reference target not found: dask.array.tokenize [ref.func]
/home/davidh/repos/git/satpy/doc/source/enhancements.rst:102: WARNING: py:class reference target not found: satpy.writers.EnhancementDecisionTree [ref.class]
/home/davidh/repos/git/satpy/doc/source/enhancements.rst:280: WARNING: py:class reference target not found: satpy.writers.Enhancer [ref.class]
/home/davidh/repos/git/satpy/doc/source/enhancements.rst:590: WARNING: py:class reference target not found: trollimage.xrimageXRImage [ref.class]
/home/davidh/repos/git/satpy/doc/source/multiscene.rst:30: WARNING: py:meth reference target not found: satpy.multiscene.MultiScene.from_files [ref.meth]
/home/davidh/repos/git/satpy/doc/source/multiscene.rst:68: WARNING: py:func reference target not found: satpy.multiscene.stack [ref.func]
/home/davidh/repos/git/satpy/doc/source/multiscene.rst:101: WARNING: py:func reference target not found: satpy.multiscene.stack [ref.func]
/home/davidh/repos/git/satpy/doc/source/multiscene.rst:101: WARNING: py:func reference target not found: satpy.multiscene.stack [ref.func]
/home/davidh/repos/git/satpy/doc/source/multiscene.rst:136: WARNING: py:meth reference target not found: satpy.multiscene.MultiScene.group [ref.meth]
/home/davidh/repos/git/satpy/doc/source/multiscene.rst:176: WARNING: py:meth reference target not found: satpy.multiscene.MultiScene.blend [ref.meth]
/home/davidh/repos/git/satpy/doc/source/multiscene.rst:176: WARNING: py:func reference target not found: satpy.multiscene.timeseries [ref.func]
/home/davidh/repos/git/satpy/doc/source/multiscene.rst:264: WARNING: py:meth reference target not found: satpy.multiscene.MultiScene.save_datasets [ref.meth]
/home/davidh/repos/git/satpy/doc/source/multiscene.rst:285: WARNING: py:meth reference target not found: satpy.multiscene.MultiScene.from_files [ref.meth]
/home/davidh/repos/git/satpy/doc/source/multiscene.rst:314: WARNING: py:meth reference target not found: satpy.multiscene.MultiScene.from_files [ref.meth]
/home/davidh/repos/git/satpy/doc/source/quickstart.rst:174: WARNING: py:func reference target not found: satpy.dataset.combine_metadata [ref.func]
/home/davidh/repos/git/satpy/doc/source/reading.rst:163: WARNING: py:class reference target not found: satpy.dataset.DataQuery [ref.class]
/home/davidh/repos/git/satpy/satpy/resample.py:docstring of satpy.resample:18: WARNING: py:class reference target not found: pyresample.ewa.DaskEWAResampler [ref.class]
/home/davidh/repos/git/satpy/satpy/resample.py:docstring of satpy.resample:18: WARNING: py:class reference target not found: pyresample.ewa.LegacyDaskEWAResampler [ref.class]
/home/davidh/repos/git/satpy/satpy/resample.py:docstring of satpy.resample:18: WARNING: py:meth reference target not found: pyresample.gradient.create_gradient_search_resampler [ref.meth]

```

</details>

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
