### PR TITLE
Fix ACSPO reader using binary operations on signed integers

### DIFF
--- a/satpy/tests/reader_tests/test_acspo.py
+++ b/satpy/tests/reader_tests/test_acspo.py
@@ -93,7 +93,7 @@ class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
 
         file_content["l2p_flags"] = np.zeros(
             (1, DEFAULT_FILE_SHAPE[0], DEFAULT_FILE_SHAPE[1]),
-            dtype=np.uint16)
+            dtype=np.int16)
 
         convert_file_content_to_data_array(file_content, dims=("time", "nj", "ni"))
         return file_content


### PR DESCRIPTION
Fix bug in the ACSPO reader where newer versions of xarray raise an exception if you try to do a bitwise operation on a signed integer. Not sure why but the ACSPO "l2p_flags" variable is a signed integer instead of an unsigned integer even though it is a bit mask.

This PR fixes the tests (which failed) to represent the data in real files and then fixes the bug by casting the flags to the unsigned version of their signed type.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
