### PR TITLE
Fix more invalid sphinx object references

### DIFF
--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -27,6 +27,7 @@ dependencies:
   - setuptools_scm
   - sphinx>=8.2.0
   - sphinx_rtd_theme
+  - sphinx-autodoc-typehints
   - trollsift
   - xarray
   - zarr

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -534,7 +534,7 @@ enhancement functions in Satpy.
 
 .. warning::
    If you define a composite with no matching enhancement, Satpy will by
-   default apply the :func:`~trollimage.xrimage.XRImage.stretch_linear` enhancement with
+   default apply the :meth:`~trollimage.xrimage.XRImage.stretch_linear` enhancement with
    cutoffs of 0.5% and 99.5%.  If you want no enhancement at all (maybe you
    are enhancing a composite based on :class:`DayNightCompositor` where
    the components have their own enhancements defined), you can use the `image_ready` standard name.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -74,6 +74,10 @@ autodoc_mock_imports = ["cf", "glymur", "h5netcdf", "holoviews", "imageio", "mip
                         "pygac", "pygrib", "pyhdf", "pyninjotiff",
                         "pyorbital", "pyspectral", "rasterio", "trollimage",
                         "zarr"]
+autodoc_type_aliases = {
+    "ArrayLike": "numpy.typing.ArrayLike",
+    "DTypeLike": "numpy.typing.DTypeLike",
+}
 autoclass_content = "both"  # append class __init__ docstring to the class docstring
 
 # auto generate reader table from reader config files
@@ -90,7 +94,7 @@ needs_sphinx = "8.2.0"
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx", "sphinx.ext.todo", "sphinx.ext.coverage",
               "sphinx.ext.doctest", "sphinx.ext.napoleon", "sphinx.ext.autosummary", "sphinx.ext.autosectionlabel",
               "doi_role", "sphinx.ext.viewcode", "sphinx.ext.apidoc",
-              "sphinx.ext.mathjax"]
+              "sphinx.ext.mathjax", "sphinx_autodoc_typehints"]
 
 # Autosectionlabel
 # Make sure target is unique
@@ -314,4 +318,5 @@ intersphinx_mapping = {
     "donfig": ("https://donfig.readthedocs.io/en/latest", None),
     "pooch": ("https://www.fatiando.org/pooch/latest/", None),
     "fsspec": ("https://filesystem-spec.readthedocs.io/en/latest/", None),
+    "asv": ("https://asv.readthedocs.io/en/latest", None),
 }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -78,6 +78,9 @@ autodoc_type_aliases = {
     "ArrayLike": "numpy.typing.ArrayLike",
     "DTypeLike": "numpy.typing.DTypeLike",
 }
+autodoc_default_options = {
+    "special-members": "__init__, __reduce_ex__",
+}
 autoclass_content = "both"  # append class __init__ docstring to the class docstring
 
 # auto generate reader table from reader config files
@@ -95,6 +98,8 @@ extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx", "sphinx.ext.todo",
               "sphinx.ext.doctest", "sphinx.ext.napoleon", "sphinx.ext.autosummary", "sphinx.ext.autosectionlabel",
               "doi_role", "sphinx.ext.viewcode", "sphinx.ext.apidoc",
               "sphinx.ext.mathjax", "sphinx_autodoc_typehints"]
+
+linkcheck_allowed_redirects: dict[str, str] = {}
 
 # Autosectionlabel
 # Make sure target is unique
@@ -122,7 +127,6 @@ apidoc_modules = [
 ]
 apidoc_separate_modules = True
 apidoc_include_private = True
-apidoc_automodule_options = {"members", "show-inheritance", "undoc-members", "special-members"}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/doc/source/dev_guide/custom_reader.rst
+++ b/doc/source/dev_guide/custom_reader.rst
@@ -551,13 +551,13 @@ better idea.
    please consider carefully what data type you should scale or calibrate your
    data to.
 
-   Single precision floats (`np.float32`) is a good compromise, as it has 23
+   Single precision floats (``np.float32``) is a good compromise, as it has 23
    significant bits (mantissa) and can thus represent 16 bit integers exactly,
    as well as keeping the memory footprint half of a double precision float.
 
    One commonly used method in readers is :meth:`xarray.DataArray.where` (to
-   mask invalid data) which can be coercing the data to `np.float64`. To ensure
-   for example that integer data is coerced to `np.float32` when
+   mask invalid data) which can be coercing the data to ``np.float64``. To ensure
+   for example that integer data is coerced to ``np.float32`` when
    :meth:`xarray.DataArray.where` is used, you can do::
 
      my_float_dataarray = my_int_dataarray.where(some_condition, np.float32(np.nan))

--- a/doc/source/dev_guide/xarray_migration.rst
+++ b/doc/source/dev_guide/xarray_migration.rst
@@ -252,8 +252,8 @@ possible to improve performance so `compute` should only be used when needed.
              1247.37586051,  1656.50487092,   978.28184726]])
 
 Dask also provides `cos`, `log` and other mathematical function, that you
-can use with `da.cos <dask.array.cos>` and
-`da.log <dask.array.log>`. However, since satpy uses xarrays as
+can use with :data:`da.cos <dask.array.cos>` and
+:data:`da.log <dask.array.log>`. However, since satpy uses xarrays as
 standard data structure, prefer the xarray functions when possible (they call
 in turn the dask counterparts when possible).
 

--- a/doc/source/dev_guide/xarray_migration.rst
+++ b/doc/source/dev_guide/xarray_migration.rst
@@ -252,8 +252,8 @@ possible to improve performance so `compute` should only be used when needed.
              1247.37586051,  1656.50487092,   978.28184726]])
 
 Dask also provides `cos`, `log` and other mathematical function, that you
-can use with :func:`da.cos <dask.array.cos>` and
-:func:`da.log <dask.array.log>`. However, since satpy uses xarrays as
+can use with `da.cos <dask.array.cos>` and
+`da.log <dask.array.log>`. However, since satpy uses xarrays as
 standard data structure, prefer the xarray functions when possible (they call
 in turn the dask counterparts when possible).
 
@@ -291,7 +291,7 @@ Map dask blocks to non-dask friendly functions
 
 If the complicated operation you need to perform can be vectorized and does
 not need the entire data array to do its operations you can use
-:func:`da.map_blocks <dask.array.core.map_blocks>` to get better performance
+:func:`da.map_blocks <dask.array.map_blocks>` to get better performance
 than creating a delayed function. Similar to delayed functions the inputs to
 the function are fully computed DataArrays or numpy arrays, but only the
 individual chunks of the dask array at a time. Note that ``map_blocks`` must
@@ -307,11 +307,11 @@ may be unserializable and can cause issues in some environments.
 Helpful functions
 *****************
 
-- :func:`~dask.array.core.map_blocks`
+- :func:`~dask.array.map_blocks`
 - :func:`~dask.array.map_overlap`
-- :func:`~dask.array.core.atop`
+- :func:`~dask.array.blockwise`
 - :func:`~dask.array.store`
-- :func:`~dask.array.tokenize`
+- ``dask.tokenize.tokenize``
 - :func:`~dask.compute`
 - :doc:`dask:delayed`
 - :func:`~dask.array.rechunk`

--- a/doc/source/reading.rst
+++ b/doc/source/reading.rst
@@ -63,32 +63,37 @@ SEVIRI L1.5 data readers
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.seviri_base
-    :noindex:
+   :noindex:
+   :no-special-members:
 
 SEVIRI HRIT format reader
 """""""""""""""""""""""""
 
 .. automodule:: satpy.readers.seviri_l1b_hrit
-    :noindex:
+   :noindex:
+   :no-special-members:
 
 SEVIRI Native format reader
 """""""""""""""""""""""""""
 
 .. automodule:: satpy.readers.seviri_l1b_native
-    :noindex:
+   :noindex:
+   :no-special-members:
 
 SEVIRI netCDF format reader
 """""""""""""""""""""""""""
 
 .. automodule:: satpy.readers.seviri_l1b_nc
-    :noindex:
+   :noindex:
+   :no-special-members:
 
 
 Other xRIT-based readers
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.hrit_base
-    :noindex:
+   :noindex:
+   :no-special-members:
 
 
 JMA HRIT format reader
@@ -96,49 +101,58 @@ JMA HRIT format reader
 
 
 .. automodule:: satpy.readers.hrit_jma
-    :noindex:
+   :noindex:
+   :no-special-members:
 
 GOES HRIT format reader
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.goes_imager_hrit
-    :noindex:
+   :noindex:
+   :no-special-members:
 
 Electro-L HRIT format reader
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.electrol_hrit
-    :noindex:
+   :noindex:
+   :no-special-members:
 
 hdf-eos based readers
 ^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.modis_l1b
-    :noindex:
+   :noindex:
+   :no-special-members:
 
 .. automodule:: satpy.readers.modis_l2
-    :noindex:
+   :noindex:
+   :no-special-members:
 
 satpy cf nc readers
 ^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.satpy_cf_nc
-    :noindex:
+   :noindex:
+   :no-special-members:
 
 hdf5 based readers
 ^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.agri_l1
-    :noindex:
+   :noindex:
+   :no-special-members:
 
 .. automodule:: satpy.readers.ghi_l1
-    :noindex:
+   :noindex:
+   :no-special-members:
 
 Arctica-M N1 HDF5 format reader
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: satpy.readers.msu_gsa_l1b
-    :noindex:
+   :noindex:
+   :no-special-members:
 
 
 Filter loaded files

--- a/doc/source/resample.rst
+++ b/doc/source/resample.rst
@@ -3,4 +3,6 @@ Resampling
 ==========
 
 .. automodule:: satpy.resample
-    :noindex:
+   :noindex:
+   :no-members:
+   :no-special-members:

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -76,7 +76,7 @@ class ZarrCacheHelper:
             use to determine if caching should be done.
         uncacheable_arg_types: Types that if present in the passed arguments
             should trigger caching to *not* happen. By default this includes
-            ``SwathDefinition``, ``xr.DataArray``, and ``da.Array`` objects.
+            ``SwathDefinition``, ``xr.DataArray``, and ``dask.array.Array`` objects.
         sanitize_args_func: Optional function to call to sanitize provided
             arguments before they are considered for caching. This can be used
             to make arguments more "cacheable" by replacing them with similar

--- a/satpy/multiscene/_multiscene.py
+++ b/satpy/multiscene/_multiscene.py
@@ -436,7 +436,7 @@ class MultiScene(object):
                 will attempt to process all scenes at once. This option should
                 be used with care to avoid memory issues when trying to
                 improve performance.
-            client (bool or dask.distributed.Client): Dask distributed client
+            client (bool or distributed.Client): Dask distributed client
                 to use for computation. If this is ``True`` (default) then
                 any existing clients will be used.
                 If this is ``False`` or ``None`` then a client will not be
@@ -677,7 +677,7 @@ class MultiScene(object):
                 ``(batch_size / 2)`` frames for the second dataset.
             ignore_missing (bool): Don't include a black frame when a dataset
                                    is missing from a child scene.
-            client (bool or dask.distributed.Client): Dask distributed client
+            client (bool or distributed.Client): Dask distributed client
                 to use for computation. If this is ``True`` (default) then
                 any existing clients will be used.
                 If this is ``False`` or ``None`` then a client will not be

--- a/satpy/readers/_geos_area.py
+++ b/satpy/readers/_geos_area.py
@@ -127,7 +127,7 @@ def get_area_definition(pdict, a_ext):
         a_ext: A four element tuple containing the area extent (scan angle)
                for the scene in radians
     Returns:
-        a_def: An area definition for the scene
+        An area definition for the scene
 
     .. note::
 

--- a/satpy/readers/eum_l2_bufr.py
+++ b/satpy/readers/eum_l2_bufr.py
@@ -290,7 +290,7 @@ class EumetsatL2BufrFileHandler(BaseFileHandler):
         """Construct a standardized AreaDefinition based on satellite, instrument, resolution and sub-satellite point.
 
         Returns:
-            AreaDefinition: A pyresample AreaDefinition object containing the area definition.
+            A pyresample AreaDefinition object containing the area definition.
 
         """
         area_naming_input_dict = {"platform_name": self.platform_name[:3].lower(),

--- a/satpy/readers/eum_l2_grib.py
+++ b/satpy/readers/eum_l2_grib.py
@@ -271,7 +271,7 @@ class EUML2GribFileHandler(BaseFileHandler):
             gid: The ID of the GRIB message.
 
         Returns:
-            DataArray: The array containing the retrieved values.
+            The DataArray containing the retrieved values.
         """
         # Data from GRIB message are read into an Xarray...
         xarr = xr.DataArray(da.from_array(ec.codes_get_values(

--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -250,7 +250,7 @@ class FciL2NCFileHandler(FciL2CommonFunctions, BaseFileHandler):
         """Compute the area definition.
 
         Returns:
-            AreaDefinition: A pyresample AreaDefinition object containing the area definition.
+            A pyresample AreaDefinition object containing the area definition.
 
         """
         area_extent = self._get_area_extent()
@@ -402,7 +402,7 @@ class FciL2NCSegmentFileHandler(FciL2CommonFunctions, BaseFileHandler):
         """Construct the area definition.
 
         Returns:
-            AreaDefinition: A pyresample AreaDefinition object containing the area definition.
+            A pyresample AreaDefinition object containing the area definition.
 
         """
         res = dataset_id["resolution"]

--- a/satpy/readers/ici_l1b_nc.py
+++ b/satpy/readers/ici_l1b_nc.py
@@ -292,13 +292,13 @@ class IciL1bNCFileHandler(NetCDF4FileHandler):
             b: temperature coefficient [K].
 
         Returns:
-            DataArray: array containing the calibrated brightness
+            array containing the calibrated brightness
                 temperature values.
 
         """
         return b + (a * C2 * cw / np.log(1 + C1 * cw ** 3 / radiance))
 
-    def _calibrate(self, variable, dataset_info):
+    def _calibrate(self, variable: xr.DataArray, dataset_info: dict) -> xr.DataArray:
         """Perform the calibration.
 
         Args:
@@ -306,7 +306,7 @@ class IciL1bNCFileHandler(NetCDF4FileHandler):
             dataset_info: dictionary of information about the dataset.
 
         Returns:
-            DataArray: array containing the calibrated values and all the
+            array containing the calibrated values and all the
                 original metadata.
 
         """
@@ -325,7 +325,7 @@ class IciL1bNCFileHandler(NetCDF4FileHandler):
 
         return calibrated_variable
 
-    def _orthorectify(self, variable, orthorect_data_name):
+    def _orthorectify(self, variable: xr.DataArray, orthorect_data_name: str) -> xr.DataArray:
         """Perform the orthorectification.
 
         Args:
@@ -335,7 +335,7 @@ class IciL1bNCFileHandler(NetCDF4FileHandler):
                 in the product.
 
         Returns:
-            DataArray: array containing the corrected values and all the
+            array containing the corrected values and all the
                 original metadata.
 
         """

--- a/satpy/readers/modis_l2.py
+++ b/satpy/readers/modis_l2.py
@@ -277,21 +277,18 @@ def _extract_two_byte_mask(data_a: np.ndarray, data_b: np.ndarray, bit_start: in
     return _bits_strip(bit_start, bit_count, byte_dataset)
 
 
-def _bits_strip(bit_start, bit_count, value):
+def _bits_strip(bit_start: int, bit_count: int, value: int) -> int:
     """Extract specified bit from bit representation of integer value.
 
-    Parameters
-    ----------
-    bit_start : int
-        Starting index of the bits to extract (first bit has index 0)
-    bit_count : int
-        Number of bits starting from bit_start to extract
-    value : int
-        Number from which to extract the bits
+    Args:
+        bit_start:
+            Starting index of the bits to extract (first bit has index 0)
+        bit_count:
+            Number of bits starting from bit_start to extract
+        value:
+            Number from which to extract the bits
 
     Returns:
-    -------
-        int
         Value of the extracted bits
 
     """

--- a/satpy/readers/seviri_base.py
+++ b/satpy/readers/seviri_base.py
@@ -202,6 +202,7 @@ from __future__ import annotations
 import datetime as dt
 import warnings
 from collections import namedtuple
+from collections.abc import Iterable, Sequence
 
 import dask.array as da
 import numpy as np
@@ -705,13 +706,13 @@ class SEVIRICalibrationHandler:
         return wishlist | ext_coefs
 
 
-def chebyshev(coefs, time, domain):
+def chebyshev(coefs: Sequence | np.ndarray, time: int | float, domain: Iterable):
     """Evaluate a Chebyshev Polynomial.
 
     Args:
-        coefs (list, np.array): Coefficients defining the polynomial
-        time (int, float): Time where to evaluate the polynomial
-        domain (list, tuple): Domain (or time interval) for which the polynomial is defined: [left, right]
+        coefs: Coefficients defining the polynomial
+        time: Time where to evaluate the polynomial
+        domain: Domain (or time interval) for which the polynomial is defined: [left, right]
     Reference: Appendix A in the MSG Level 1.5 Image Data Format Description.
 
     """

--- a/satpy/readers/utils.py
+++ b/satpy/readers/utils.py
@@ -42,11 +42,11 @@ LOGGER = logging.getLogger(__name__)
 CHUNK_SIZE = get_legacy_chunk_size()
 
 
-def np2str(value):
+def np2str(value: np.ndarray) -> str:
     """Convert an `numpy.string_` to str.
 
     Args:
-        value (ndarray): scalar or 1-element numpy array to convert
+        value: scalar or 1-element numpy array to convert
 
     Raises:
         ValueError: if value is array larger than 1-element, or it is not of

--- a/satpy/readers/vii_base_nc.py
+++ b/satpy/readers/vii_base_nc.py
@@ -22,6 +22,7 @@
 import datetime as dt
 import logging
 
+import xarray as xr
 from geotiepoints.viiinterpolator import tie_points_geo_interpolation, tie_points_interpolation
 
 from satpy.readers.netcdf_utils import NetCDF4FileHandler
@@ -113,15 +114,15 @@ class ViiNCBaseFileHandler(NetCDF4FileHandler):
         return variable
 
     @staticmethod
-    def _perform_interpolation(variable):
+    def _perform_interpolation(variable) -> xr.DataArray:
         """Perform the interpolation from tie points to pixel points.
 
         Args:
             variable: xarray DataArray containing the dataset to interpolate.
 
         Returns:
-            DataArray: array containing the interpolate values, all the original metadata
-                       and the updated dimension names.
+            array containing the interpolate values, all the original metadata
+            and the updated dimension names.
 
         """
         interpolated_values = tie_points_interpolation(

--- a/satpy/readers/vii_l1b_nc.py
+++ b/satpy/readers/vii_l1b_nc.py
@@ -29,6 +29,7 @@ This version is applicable for the vii test data V2 to be released in Jan 2022.
 import logging
 
 import numpy as np
+import xarray as xr
 
 from satpy.readers.vii_base_nc import ViiNCBaseFileHandler
 from satpy.readers.vii_utils import C1, C2, MEAN_EARTH_RADIUS
@@ -56,7 +57,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
         solar_zenith_angle_on_pixels_radians = np.radians(solar_zenith_angle_on_pixels)
         self.angle_factor = 1.0 / (np.cos(solar_zenith_angle_on_pixels_radians))
 
-    def _perform_calibration(self, variable, dataset_info):
+    def _perform_calibration(self, variable: xr.DataArray, dataset_info: dict) -> xr.DataArray:
         """Perform the calibration.
 
         Args:
@@ -64,7 +65,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
             dataset_info: dictionary of information about the dataset.
 
         Returns:
-            DataArray: array containing the calibrated values and all the original metadata.
+            array containing the calibrated values and all the original metadata.
 
         """
         calibration_name = dataset_info["calibration"]
@@ -91,7 +92,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
 
         return calibrated_variable
 
-    def _perform_orthorectification(self, variable, orthorect_data_name):
+    def _perform_orthorectification(self, variable: xr.DataArray, orthorect_data_name: str) -> xr.DataArray:
         """Perform the orthorectification.
 
         Args:
@@ -99,7 +100,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
             orthorect_data_name: name of the orthorectification correction data in the product.
 
         Returns:
-            DataArray: array containing the corrected values and all the original metadata.
+            array containing the corrected values and all the original metadata.
 
         """
         try:
@@ -112,7 +113,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
         return variable
 
     @staticmethod
-    def _calibrate_bt(radiance, cw, a, b):
+    def _calibrate_bt(radiance: np.ndarray, cw: float, a: float, b: float) -> np.ndarray:
         """Perform the calibration to brightness temperature.
 
         Args:
@@ -122,7 +123,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
             b: temperature coefficient [K].
 
         Returns:
-            numpy ndarray: array containing the calibrated brightness temperature values.
+            array containing the calibrated brightness temperature values.
 
         """
         log_expr = np.log(1.0 + C1 / ((cw ** 5) * radiance))
@@ -130,7 +131,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
         return bt_values
 
     @staticmethod
-    def _calibrate_refl(radiance, angle_factor, isi):
+    def _calibrate_refl(radiance: np.ndarray, angle_factor: np.ndarray, isi: float) -> np.ndarray:
         """Perform the calibration to reflectance.
 
         Args:
@@ -139,7 +140,7 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
             isi: integrated solar irradiance [W/(m2 * μm)].
 
         Returns:
-            numpy ndarray: array containing the calibrated reflectance values.
+            array containing the calibrated reflectance values.
 
         """
         refl_values = (np.pi / isi) * angle_factor * radiance * 100.0

--- a/satpy/readers/vii_l2_nc.py
+++ b/satpy/readers/vii_l2_nc.py
@@ -20,6 +20,8 @@
 
 import logging
 
+import xarray as xr
+
 from satpy.readers.vii_base_nc import ViiNCBaseFileHandler
 
 logger = logging.getLogger(__name__)
@@ -28,15 +30,15 @@ logger = logging.getLogger(__name__)
 class ViiL2NCFileHandler(ViiNCBaseFileHandler):
     """Reader class for VII L2 products in netCDF format."""
 
-    def _perform_orthorectification(self, variable, orthorect_data_name):
+    def _perform_orthorectification(self, variable: xr.DataArray, orthorect_data_name: str) -> xr.DataArray:
         """Perform the orthorectification.
 
         Args:
-            variable: xarray DataArray containing the dataset to correct for orthorectification.
+            variable: DataArray containing the dataset to correct for orthorectification.
             orthorect_data_name: name of the orthorectification correction data in the product.
 
         Returns:
-            DataArray: array containing the corrected values and all the original metadata.
+            array containing the corrected values and all the original metadata.
 
         """
         try:

--- a/satpy/readers/viirs_edr_active_fires.py
+++ b/satpy/readers/viirs_edr_active_fires.py
@@ -24,6 +24,7 @@ ASCII files.
 import dask.dataframe as dd
 import xarray as xr
 
+from satpy.dataset.dataid import DataID
 from satpy.readers.file_handlers import BaseFileHandler
 from satpy.readers.netcdf_utils import NetCDF4FileHandler
 
@@ -46,15 +47,15 @@ class VIIRSActiveFiresFileHandler(NetCDF4FileHandler):
             auto_maskandscale=auto_maskandscale, xarray_kwargs=xarray_kwargs)
         self.prefix = filetype_info.get("variable_prefix")
 
-    def get_dataset(self, dsid, dsinfo):  # noqa: D417
+    def get_dataset(self, dsid: DataID, dsinfo: dict) -> xr.DataArray:  # noqa: D417
         """Get requested data as DataArray.
 
         Args:
-            dsid: Dataset ID
-            param2: Dataset Information
+            dsid: DataID to load data for
+            dsinfo: Dataset information
 
         Returns:
-            Dask DataArray: Data
+            DataArray of the loaded variable
 
         """
         key = dsinfo.get("file_key", dsid["name"]).format(variable_prefix=self.prefix)

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -21,11 +21,12 @@ from __future__ import annotations
 import logging
 import os
 import warnings
+from collections.abc import Iterable
 from typing import Callable
 
 import numpy as np
 import xarray as xr
-from pyresample.geometry import AreaDefinition, BaseDefinition, SwathDefinition
+from pyresample.geometry import AreaDefinition, BaseDefinition, CoordinateDefinition, SwathDefinition
 from xarray import DataArray
 
 from satpy.composites import IncompatibleAreas
@@ -689,19 +690,23 @@ class Scene:
             new_scn._slice_datasets(dataset_ids, key, new_area)
         return new_scn
 
-    def crop(self, area=None, ll_bbox=None, xy_bbox=None, dataset_ids=None):
+    def crop(
+            self,
+            area: AreaDefinition | None = None,
+            ll_bbox: tuple[float, float, float, float] | None = None,
+            xy_bbox: tuple[float, float, float, float] | None = None,
+            dataset_ids: Iterable | None = None,
+    ) -> Scene:
         """Crop Scene to a specific Area boundary or bounding box.
 
         Args:
-            area (AreaDefinition): Area to crop the current Scene to
-            ll_bbox (tuple, list): 4-element tuple where values are in
-                                   lon/lat degrees. Elements are
-                                   ``(xmin, ymin, xmax, ymax)`` where X is
-                                   longitude and Y is latitude.
-            xy_bbox (tuple, list): Same as `ll_bbox` but elements are in
-                                   projection units.
-            dataset_ids (Iterable): DataIDs to include in the returned
-                                 `Scene`. Defaults to all datasets.
+            area: Area to crop the current Scene to
+            ll_bbox: 4-element tuple where values are in
+                lon/lat degrees. Elements are
+                ``(xmin, ymin, xmax, ymax)`` where X is
+                longitude and Y is latitude.
+            xy_bbox: Same as `ll_bbox` but elements are in projection units.
+            dataset_ids: DataIDs to include in the returned `Scene`. Defaults to all datasets.
 
         This method will attempt to intelligently slice the data to preserve
         relationships between datasets. For example, if we are cropping two
@@ -744,9 +749,9 @@ class Scene:
         new_coarsest_area, min_y_slice, min_x_slice = self._slice_area_from_bbox(
             coarsest_area, area, ll_bbox, xy_bbox)
         new_target_areas = {}
-        for src_area, dataset_ids in new_scn.iter_by_area():
+        for src_area, ids_on_area in new_scn.iter_by_area():
             if src_area is None:
-                for ds_id in dataset_ids:
+                for ds_id in ids_on_area:
                     new_scn._datasets[ds_id] = self[ds_id]
                 continue
 
@@ -763,7 +768,7 @@ class Scene:
                                 min_x_slice.stop * x_factor)
                 new_area = src_area[y_slice, x_slice]
                 slice_key = {"y": y_slice, "x": x_slice}
-                new_scn._slice_datasets(dataset_ids, slice_key, new_area)
+                new_scn._slice_datasets(ids_on_area, slice_key, new_area)
             else:
                 new_target_areas[src_area] = self._slice_area_from_bbox(
                     src_area, area, ll_bbox, xy_bbox
@@ -945,28 +950,35 @@ class Scene:
             LOG.info("Not reducing data before resampling.")
         return dataset, source_area
 
-    def resample(self, destination=None, datasets=None, generate=True,
-                 unload=True, resampler=None, reduce_data=True,
-                 **resample_kwargs):
+    def resample(
+            self,
+            destination: AreaDefinition | CoordinateDefinition | None = None,
+            datasets: Iterable | None = None,
+            generate: bool = True,
+            unload: bool = True,
+            resampler: str | None = None,
+            reduce_data: bool = True,
+            **resample_kwargs,
+    ) -> Scene:
         """Resample datasets and return a new scene.
 
         Args:
-            destination (AreaDefinition, GridDefinition): area definition to
+            destination: area definition to
                 resample to. If not specified then the area returned by
                 `Scene.finest_area()` will be used.
-            datasets (list): Limit datasets to resample to these specified
+            datasets: Limit datasets to resample to these specified
                 data arrays. By default all currently loaded
                 datasets are resampled.
-            generate (bool): Generate any requested composites that could not
+            generate: Generate any requested composites that could not
                 be previously due to incompatible areas (default: True).
-            unload (bool): Remove any datasets no longer needed after
+            unload: Remove any datasets no longer needed after
                 requested composites have been generated (default: True).
-            resampler (str): Name of resampling method to use. By default,
+            resampler: Name of resampling method to use. By default,
                 this is a nearest neighbor KDTree-based resampling
                 ('nearest'). Other possible values include 'native', 'ewa',
                 etc. See the :mod:`~satpy.resample` documentation for more
                 information.
-            reduce_data (bool): Reduce data by matching the input and output
+            reduce_data: Reduce data by matching the input and output
                 areas and slicing the data arrays (default: True)
             resample_kwargs: Remaining keyword arguments to pass to individual
                 resampler classes. See the individual resampler class
@@ -1117,55 +1129,54 @@ class Scene:
         ds.attrs = mdata
         return ds
 
-    def to_xarray(self,
-                  datasets=None,  # DataID
-                  header_attrs=None,
-                  exclude_attrs=None,
-                  flatten_attrs=False,
-                  pretty=True,
-                  include_lonlats=True,
-                  epoch=None,
-                  include_orig_name=True,
-                  numeric_name_prefix="CHANNEL_"):
+    def to_xarray(
+            self,
+            datasets: Iterable | None = None,
+            header_attrs: dict | None = None,
+            exclude_attrs: Iterable | None = None,
+            flatten_attrs: bool = False,
+            pretty: bool = True,
+            include_lonlats: bool = True,
+            epoch: str | None = None,
+            include_orig_name: bool = True,
+            numeric_name_prefix: str = "CHANNEL_",
+    ) -> xr.Datasaet:
         """Merge all xr.DataArray(s) of a satpy.Scene to a CF-compliant xarray object.
 
         If all Scene DataArrays are on the same area, it returns an xr.Dataset.
         If Scene DataArrays are on different areas, currently it fails, although
         in future we might return a DataTree object, grouped by area.
 
-        Parameters
-        ----------
-        datasets (Iterable, Optional):
-            List of Satpy Scene datasets to include in the output xr.Dataset.
-            Elements can be string name, a wavelength as a number, a DataID,
-            or DataQuery object.
-            If None (the default), it include all loaded Scene datasets.
-        header_attrs (dict, Optional):
-            Global attributes of the output xr.Dataset.
-        epoch (str, Optional):
-            Reference time for encoding the time coordinates (if available).
-            Example format: "seconds since 1970-01-01 00:00:00".
-            If None, the default reference time is defined using "from satpy.cf.coords import EPOCH"
-        flatten_attrs (bool, Optional):
-            If True, flatten dict-type attributes.
-        exclude_attrs (Iterable, Optional):
-            List of xr.DataArray attribute names to be excluded.
-        include_lonlats (bool, Optional):
-            If True, it includes 'latitude' and 'longitude' coordinates.
-            If the 'area' attribute is a SwathDefinition, it always includes
-            latitude and longitude coordinates.
-        pretty (bool, Optional):
-            Don't modify coordinate names, if possible. Makes the file prettier,
-            but possibly less consistent.
-        include_orig_name (bool, Optional).
-            Include the original dataset name as a variable attribute in the xr.Dataset.
-        numeric_name_prefix (str, Optional):
-            Prefix to add the each variable with name starting with a digit.
-            Use '' or None to leave this out.
+        Args:
+            datasets:
+                List of Satpy Scene datasets to include in the output xr.Dataset.
+                Elements can be string name, a wavelength as a number, a DataID,
+                or DataQuery object.
+                If None (the default), it include all loaded Scene datasets.
+            header_attrs:
+                Global attributes of the output xr.Dataset.
+            exclude_attrs:
+                List of xr.DataArray attribute names to be excluded.
+            flatten_attrs:
+                If True, flatten dict-type attributes.
+            pretty:
+                Don't modify coordinate names, if possible. Makes the file prettier,
+                but possibly less consistent.
+            include_lonlats:
+                If True, it includes 'latitude' and 'longitude' coordinates.
+                If the 'area' attribute is a SwathDefinition, it always includes
+                latitude and longitude coordinates.
+            epoch:
+                Reference time for encoding the time coordinates (if available).
+                Example format: "seconds since 1970-01-01 00:00:00".
+                If None, the default reference time is defined using "from satpy.cf.coords import EPOCH"
+            include_orig_name:
+                Include the original dataset name as a variable attribute in the xr.Dataset.
+            numeric_name_prefix:
+                Prefix to add the each variable with name starting with a digit.
+                Use '' or None to leave this out.
 
         Returns:
-        -------
-        ds, xr.Dataset
             A CF-compliant xr.Dataset
 
         """

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -18,6 +18,7 @@
 
 import datetime as dt
 import os
+from collections.abc import Mapping
 from contextlib import contextmanager
 from typing import Any
 from unittest import mock
@@ -302,8 +303,12 @@ def assert_maximum_dask_computes(max_computes=1):
         yield new_config
 
 
-def make_fake_scene(content_dict, daskify=False, area=True,
-                    common_attrs=None):
+def make_fake_scene(
+        content_dict: Mapping,
+        daskify: bool = False,
+        area: bool | BaseDefinition = True,
+        common_attrs: dict | None = None,
+) -> Scene:
     """Create a fake Scene.
 
     Create a fake Scene object from fake data.  Data are provided in
@@ -324,14 +329,14 @@ def make_fake_scene(content_dict, daskify=False, area=True,
     objects then this flag has no effect.
 
     Args:
-        content_dict (Mapping): Mapping where keys correspond to objects
+        content_dict: Mapping where keys correspond to objects
             accepted by ``Scene.__setitem__``, i.e. strings or DataID,
             and values may be either ``numpy.ndarray`` or
             ``xarray.DataArray``.
-        daskify (bool): optional, to use dask when converting
+        daskify: optional, to use dask when converting
             ``numpy.ndarray`` to ``xarray.DataArray``.  No effect when the
             values in ``content_dict`` are already ``xarray.DataArray``.
-        area (bool or BaseDefinition): Can be ``True``, ``False``, or an
+        area: Can be ``True``, ``False``, or an
             instance of ``pyresample.geometry.BaseDefinition`` such as
             ``AreaDefinition`` or ``SwathDefinition``.  If ``True``, which is
             the default, automatically generate areas with the name "test-area".
@@ -339,7 +344,7 @@ def make_fake_scene(content_dict, daskify=False, area=True,
             of ``pyresample.geometry.BaseDefinition``, those instances will be
             used for all generated fake datasets.  Warning: Passing an area as
             a string (``area="germ"``) is not supported.
-        common_attrs (Mapping): optional, additional attributes that will
+        common_attrs: optional, additional attributes that will
             be added to every dataset in the scene.
 
     Returns:

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -38,7 +38,7 @@ import xarray as xr
 import yaml
 from yaml import BaseLoader, UnsafeLoader
 
-from satpy._compat import DTypeLike
+from satpy._compat import ArrayLike, DTypeLike
 
 _is_logging_on = False
 TRACE_LEVEL = 5
@@ -178,15 +178,18 @@ def in_ipynb():
 # Spherical conversions
 
 
-def lonlat2xyz(lon, lat):
+def lonlat2xyz(
+        lon: ArrayLike,
+        lat: ArrayLike,
+) -> tuple[ArrayLike, ArrayLike, ArrayLike]:
     """Convert lon lat to cartesian.
 
     For a sphere with unit radius, convert the spherical coordinates
     longitude and latitude to cartesian coordinates.
 
     Args:
-        lon (numbers.Number or ArrayLike[numbers.Number]): Longitude in °.
-        lat (numbers.Number or ArrayLike[numbers.Number]): Latitude in °.
+        lon: Longitude in °.
+        lat: Latitude in °.
 
     Returns:
         (x, y, z) Cartesian coordinates [1]
@@ -199,21 +202,26 @@ def lonlat2xyz(lon, lat):
     return x, y, z
 
 
-def xyz2lonlat(x, y, z, asin=False):
+def xyz2lonlat(
+        x: ArrayLike,
+        y: ArrayLike,
+        z: ArrayLike,
+        asin: bool = False,
+) -> tuple[ArrayLike, ArrayLike]:
     """Convert cartesian to lon lat.
 
     For a sphere with unit radius, convert cartesian coordinates to spherical
     coordinates longitude and latitude.
 
     Args:
-        x (numbers.Number or ArrayLike[numbers.Number]): x-coordinate, unitless
-        y (numbers.Number or ArrayLike[numbers.Number]): y-coordinate, unitless
-        z (numbers.Number or ArrayLike[numbers.Number]): z-coordinate, unitless
-        asin (bool, Optional): If true, use arcsin for calculations.
+        x: x-coordinate, unitless
+        y: y-coordinate, unitless
+        z: z-coordinate, unitless
+        asin: If true, use arcsin for calculations.
             If false, use arctan2 for calculations.
 
     Returns:
-        (tuple): Longitude and latitude in °.
+        Longitude and latitude in °.
     """
     lon = np.rad2deg(np.arctan2(y, x))
     if asin:
@@ -573,7 +581,7 @@ def unify_chunks(*data_arrays: xr.DataArray) -> tuple[xr.DataArray, ...]:
     """Run :func:`xarray.unify_chunks` if input dimensions are all the same size.
 
     This is mostly used in :class:`satpy.composites.CompositeBase` to safe
-    guard against running :func:`dask.array.core.map_blocks` with arrays of
+    guard against running :func:`dask.array.map_blocks` with arrays of
     different chunk sizes. Doing so can cause unexpected results or errors.
     However, xarray's ``unify_chunks`` will raise an exception if dimensions
     of the provided DataArrays are different sizes. This is a common case for
@@ -887,15 +895,15 @@ def find_in_ancillary(data, dataset):
     return matches[0]
 
 
-def datetime64_to_pydatetime(dt64):
+def datetime64_to_pydatetime(dt64: np.datetime64) -> datetime.datetime:
     """Convert numpy.datetime64 timestamp to Python datetime.
 
     Discards nanosecond precision, because Python datetime only has microsecond
     precision.
 
     Args:
-        dt64 (np.datetime64): Timestamp to be converted
-    Returns (dt.datetime):
+        dt64: Timestamp to be converted
+    Returns:
         Converted timestamp
     """
     return dt64.astype("datetime64[us]").astype(datetime.datetime)

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -426,19 +426,29 @@ class NumberedTileGenerator(object):
 class LetteredTileGenerator(NumberedTileGenerator):
     """Helper class to generate per-tile metadata for lettered tiles."""
 
-    def __init__(self, area_definition, extents, sector_crs,  # noqa: D417
-                 cell_size=(2000000, 2000000),
-                 num_subtiles=None, use_sector_reference=False):
+    def __init__(
+            self,
+            area_definition: AreaDefinition,
+            extents: tuple[float, float, float, float],
+            sector_crs: CRS,
+            cell_size: tuple[int, int] = (2000000, 2000000),
+            num_subtiles: tuple[int, int] | None = None,
+            use_sector_reference: bool = False):
         """Initialize tile information for later generation.
 
         Args:
-            area_definition (AreaDefinition): Area of the data being saved.
-            extents (tuple): Four element tuple of the configured lettered
-                 area.
-            sector_crs (pyproj.CRS): CRS of the configured lettered sector
-                area.
-            cell_size (tuple): Two element tuple of resolution of each tile
+            area_definition: Area of the data being saved.
+            extents: Four element tuple of the configured lettered area.
+            sector_crs: CRS of the configured lettered sector area.
+            cell_size: Two element tuple of resolution of each tile
                 in sector projection units (y, x).
+            num_subtiles: Two element tuple of number of sub-tiles to create
+                for each larger lettered tile. Defaults to (2, 2).
+            use_sector_reference: If False (default), the data's geolocation
+                is used to determine where pixels should align. If True, the
+                data's geolocation is shifted by up to half a pixel to align
+                with the extents of the lettered grid/area.
+
         """
         # (row subtiles, col subtiles)
         self.num_subtiles = num_subtiles or (2, 2)

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -321,7 +321,7 @@ class CFWriter(Writer):
         """Convert the dataarray to something cf-compatible.
 
         Args:
-            dataarray (xr.DataArray):
+            dataarray (xarray.DataArray):
                 The data array to be converted.
             epoch (str):
                 Reference time for encoding of time coordinates.

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -15,21 +15,21 @@
 #
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
-"""GeoTIFF writer objects for creating GeoTIFF files from `DataArray` objects."""
+"""GeoTIFF writer objects for creating GeoTIFF files from :class:`xarray.DataArray` objects."""
 from __future__ import annotations
 
 import logging
-from typing import Any, Optional, Union
+from typing import Any
 
 import numpy as np
 
 # make sure we have rasterio even though we don't use it until trollimage
 # saves the image
 import rasterio  # noqa
+from numpy.typing import DTypeLike
 from trollimage.colormap import Colormap
 from trollimage.xrimage import XRImage
 
-from satpy._compat import DTypeLike
 from satpy.writers import ImageWriter
 
 LOG = logging.getLogger(__name__)
@@ -140,20 +140,20 @@ class GeoTIFFWriter(ImageWriter):
     def save_image(  # noqa: D417
             self,
             img: XRImage,
-            filename: Optional[str] = None,
+            filename: str | None = None,
             compute: bool = True,
-            dtype: Optional[DTypeLike] = None,
-            fill_value: Optional[Union[int, float]] = None,
+            dtype: DTypeLike | None = None,
+            fill_value: int | float | None = None,
             keep_palette: bool = False,
-            cmap: Optional[Colormap] = None,
-            tags: Optional[dict[str, Any]] = None,
-            overviews: Optional[list[int]] = None,
+            cmap: Colormap | None = None,
+            tags: dict[str, Any] | None = None,
+            overviews: list[int] | None = None,
             overviews_minsize: int = 256,
-            overviews_resampling: Optional[str] = None,
+            overviews_resampling: str | None = None,
             include_scale_offset: bool = False,
-            scale_offset_tags: Optional[tuple[str, str]] = None,
-            colormap_tag: Optional[str] = None,
-            driver: Optional[str] = None,
+            scale_offset_tags: tuple[str, str] | None = None,
+            colormap_tag: str | None = None,
+            driver: str | None = None,
             tiled: bool = True,
             **kwargs
     ):
@@ -162,12 +162,12 @@ class GeoTIFFWriter(ImageWriter):
         Note this writer requires the ``rasterio`` library to be installed.
 
         Args:
-            img (xarray.DataArray): Data to save to geotiff.
-            filename (str): Filename to save the image to. Defaults to
+            img: Data to save to geotiff.
+            filename: Filename to save the image to. Defaults to
                 ``filename`` passed during writer creation. Unlike the
                 creation ``filename`` keyword argument, this filename does not
                 get formatted with data attributes.
-            compute (bool): Compute dask arrays and save the image
+            compute: Compute dask arrays and save the image
                 immediately. If ``False`` then the return value can be passed
                 to :func:`~satpy.writers.compute_writer_results` to do the
                 computation. This is useful when multiple images may share
@@ -175,15 +175,15 @@ class GeoTIFFWriter(ImageWriter):
                 them multiple times. Defaults to ``True`` in the writer by
                 itself, but is typically passed as ``False`` by callers where
                 calculations can be combined.
-            dtype (DTypeLike): Numpy data type to save the image as.
+            dtype: Numpy data type to save the image as.
                 Defaults to 8-bit unsigned integer (``np.uint8``) or the data
                 type of the data to be saved if ``enhance=False``. If the
                 ``dtype`` argument is provided during writer creation then
                 that will be used as the default.
-            fill_value (float or int): Value to use where data values are
+            fill_value: Value to use where data values are
                 NaN/null. If this is specified in the writer configuration
                 file that value will be used as the default.
-            keep_palette (bool): Save palette/color table to geotiff.
+            keep_palette: Save palette/color table to geotiff.
                 To be used with images that were palettized with the
                 "palettize" enhancement. Setting this to ``True`` will cause
                 the colormap of the image to be written as a "color table" in
@@ -192,14 +192,14 @@ class GeoTIFFWriter(ImageWriter):
                 use the colormap used in the "palettize" operation.
                 See the ``cmap`` option for other options. This option defaults
                 to ``False`` and palettized images will be converted to RGB/A.
-            cmap (trollimage.colormap.Colormap or None): Colormap to save
+            cmap: Colormap to save
                 as a color table in the output geotiff. See ``keep_palette``
                 for more information. Defaults to the palette of the provided
                 ``img`` object. The colormap's range should be set to match
                 the index range of the palette
                 (ex. `cmap.set_range(0, len(colors))`).
-            tags (dict): Extra metadata to store in geotiff.
-            overviews (list): The reduction factors of the overviews to include
+            tags: Extra metadata to store in geotiff.
+            overviews: The reduction factors of the overviews to include
                 in the image, eg::
 
                     scn.save_datasets(overviews=[2, 4, 8, 16])
@@ -208,33 +208,33 @@ class GeoTIFFWriter(ImageWriter):
                 computed as powers of two until the last level has less
                 pixels than `overviews_minsize`.
                 Default is to not add overviews.
-            overviews_minsize (int): Minimum number of pixels for the smallest
+            overviews_minsize: Minimum number of pixels for the smallest
                 overview size generated when `overviews` is auto-generated.
                 Defaults to 256.
-            overviews_resampling (str): Resampling method
+            overviews_resampling: Resampling method
                 to use when generating overviews. This must be the name of an
                 enum value from :class:`rasterio.enums.Resampling` and
                 only takes effect if the `overviews` keyword argument is
                 provided. Common values include `nearest` (default),
                 `bilinear`, `average`, and many others. See the rasterio
                 documentation for more information.
-            scale_offset_tags (Tuple[str, str]): If set, include inclusion of
+            scale_offset_tags: If set, include inclusion of
                 scale and offset in the GeoTIFF headers in the GDALMetaData
                 tag.  The value of this argument should be a keyword argument
                 ``(scale_label, offset_label)``, for example, ``("scale",
                 "offset")``, indicating the labels to be used.
-            colormap_tag (Optional[str]): If set and the image being saved was
+            colormap_tag: If set and the image being saved was
                 colorized or palettized then a comma-separated version of the
                 colormap is saved to a custom geotiff tag with the provided
                 name. See :meth:`trollimage.colormap.Colormap.to_csv` for more
                 information.
-            driver (Optional[str]): Name of GDAL driver to use to save the
+            driver: Name of GDAL driver to use to save the
                 geotiff. If not specified or None (default) the "GTiff" driver
                 is used. Another common option is "COG" for Cloud Optimized
                 GeoTIFF. See GDAL documentation for more information.
-            tiled (bool): For performance this defaults to ``True``.
+            tiled: For performance this defaults to ``True``.
                 Pass ``False`` to created striped TIFF files.
-            include_scale_offset (bool): Deprecated.
+            include_scale_offset: Deprecated.
                 Use ``scale_offset_tags=("scale", "offset")`` to include scale
                 and offset tags.
 

--- a/satpy/writers/ninjotiff.py
+++ b/satpy/writers/ninjotiff.py
@@ -102,7 +102,7 @@ def convert_units(dataset, in_unit, out_unit):
     returns the input dataset.
 
     Args:
-        dataset (xarray DataArray):
+        dataset (xarray.DataArray):
             Dataarray for which to convert the units.
         in_unit (str):
             Unit for input data.


### PR DESCRIPTION
This is a continuation of #3120. This one is mostly targeting type annotations. A couple things I've done:

1. Switched some docstring types to be type annotations. Sphinx and its extensions were getting confused.
2. Started using a third-party "sphinx_autodoc_typehints" which seems to have better handling of things.
3. Took some liberties with type annotations that I wasn't sure about or were causing errors. The biggest one was the use of `numbers.Number` in satpy.utils as mypy got mad that we were multiplying a `Number` with an `int`. :shrug: 

Things I've noticed:

1. The switch to sphinx_autodoc_typehints got mad:

```
WARNING: error while formatting signature for satpy.readers.pmw_channels_definitions.FrequencyDoubleSideBandBase.__new__: Handler <function process_signature at 0x79f4572afe20> for event 'autodoc-process-signature' threw an exception (exception: 'NoneType' object has no attribute 'FrequencyDoubleSideBandBase') [autodoc]
WARNING: error while formatting signature for satpy.readers.pmw_channels_definitions.FrequencyQuadrupleSideBandBase.__new__: Handler <function process_signature at 0x79f4572afe20> for event 'autodoc-process-signature' threw an exception (exception: 'NoneType' object has no attribute 'FrequencyQuadrupleSideBandBase') [autodoc]
WARNING: error while formatting signature for satpy.readers.pmw_channels_definitions.FrequencyRangeBase.__new__: Handler <function process_signature at 0x79f4572afe20> for event 'autodoc-process-signature' threw an exception (exception: 'NoneType' object has no attribute 'FrequencyRangeBase') [autodoc]
```

NOTE: There are still 63 warnings left according to my local execution.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
