### PR TITLE
Add missing metadata to 'ahi_l2_nc' reader

### DIFF
--- a/satpy/readers/ahi_l2_nc.py
+++ b/satpy/readers/ahi_l2_nc.py
@@ -104,6 +104,11 @@ class HIML2NCFileHandler(BaseFileHandler):
         variable = variable.drop_vars("Latitude")
         variable = variable.drop_vars("Longitude")
 
+        variable.attrs["sensor"] = self.sensor
+        variable.attrs["platform_name"] = self.platform_name
+        variable.attrs["platform_shortname"] = self.platform_shortname
+        variable.attrs["start_time"] = self.start_time
+        variable.attrs["end_time"] = self.end_time
         variable.attrs.update(key.to_dict())
         return variable
 

--- a/satpy/tests/reader_tests/test_ahi_l2_nc.py
+++ b/satpy/tests/reader_tests/test_ahi_l2_nc.py
@@ -110,4 +110,10 @@ def test_load_data(himl2_filename):
     fh = ahil2_filehandler(himl2_filename)
     clmk_id = make_dataid(name="cloudmask")
     clmk = fh.get_dataset(clmk_id, {"file_key": "CloudMask"})
-    assert np.allclose(clmk.data, clmk_data)
+    np.testing.assert_allclose(clmk.data, clmk_data)
+    assert clmk.dtype == np.uint16
+    assert clmk.attrs["sensor"] == "ahi"
+    assert clmk.attrs["platform_name"] == "Himawari-9"
+    assert clmk.attrs["platform_shortname"] == "h09"
+    assert isinstance(clmk.attrs["start_time"], dt.datetime)
+    assert isinstance(clmk.attrs["end_time"], dt.datetime)


### PR DESCRIPTION
While testing the reader for someone else, I noticed there is almost no metadata in the DataArrays returned by the ahi_l2_nc reader. This PR adds a minimal set to make things function or that were easy to add from existing properties on the file handler code.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
