### PR TITLE
Fix satpy.readers import warnings and exception types

### DIFF
--- a/satpy/readers/__init__.py
+++ b/satpy/readers/__init__.py
@@ -19,7 +19,6 @@
 
 from __future__ import annotations
 
-from importlib import import_module
 from typing import Any
 
 from satpy.utils import _import_and_warn_new_location
@@ -43,6 +42,6 @@ def __getattr__(name: str) -> Any:
     new_module = IMPORT_PATHS.get(name)
 
     if new_module is None:
-        return import_module("."+name, package="satpy.readers")  # type: ignore
+        raise AttributeError(f"module {__name__} has no attribute '{name}'")
 
     return _import_and_warn_new_location(new_module, name)


### PR DESCRIPTION
This fixes an issue introduced in #3127. There were 3 primary issues:

1. The `__getattr__` in `satpy/readers/__init__.py` was returning an `ImportError` (`ModuleNotFoundError`) if you tried to access an attribute on `satpy.readers` that never existed there. This should be an `AttributeError` instead and has been updated in this PR.
2. The utility function for producing the warnings always said the original module path was `satpy.readers` even though it may have been `satpy.readers.abi_base` for example.
3. The import warning was produced even if the attribute was not going to be found in the new module. So if for example you did `import satpy.reader.abi_base` then did `satpy.readers.abi_base.__doesnt_exist__` then you'd get a warning even though that attribute/variable/object had never existed and was not moved. The warning was incorrect. This PR makes it so the warning is only produced when the attribute is found in the target module, otherwise AttributeError.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
