### PR TITLE
Remove duplicate reader documentation list

### DIFF
--- a/doc/source/reading.rst
+++ b/doc/source/reading.rst
@@ -59,106 +59,13 @@ Reader Table
 Documentation for specific readers
 ----------------------------------
 
-SEVIRI L1.5 data readers
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: satpy.readers.core.seviri
-   :noindex:
-   :no-special-members:
-
-SEVIRI HRIT format reader
-"""""""""""""""""""""""""
-
-.. automodule:: satpy.readers.seviri_l1b_hrit
-   :noindex:
-   :no-special-members:
-
-SEVIRI Native format reader
-"""""""""""""""""""""""""""
-
-.. automodule:: satpy.readers.seviri_l1b_native
-   :noindex:
-   :no-special-members:
-
-SEVIRI netCDF format reader
-"""""""""""""""""""""""""""
-
-.. automodule:: satpy.readers.seviri_l1b_nc
-   :noindex:
-   :no-special-members:
-
-
-Other xRIT-based readers
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: satpy.readers.hrit_base
-   :noindex:
-   :no-special-members:
-
-
-JMA HRIT format reader
-^^^^^^^^^^^^^^^^^^^^^^
-
-
-.. automodule:: satpy.readers.hrit_jma
-   :noindex:
-   :no-special-members:
-
-GOES HRIT format reader
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: satpy.readers.goes_imager_hrit
-   :noindex:
-   :no-special-members:
-
-Electro-L HRIT format reader
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: satpy.readers.electrol_hrit
-   :noindex:
-   :no-special-members:
-
-hdf-eos based readers
-^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: satpy.readers.modis_l1b
-   :noindex:
-   :no-special-members:
-
-.. automodule:: satpy.readers.modis_l2
-   :noindex:
-   :no-special-members:
-
-satpy cf nc readers
-^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: satpy.readers.satpy_cf_nc
-   :noindex:
-   :no-special-members:
-
-hdf5 based readers
-^^^^^^^^^^^^^^^^^^
-
-.. automodule:: satpy.readers.agri_l1
-   :noindex:
-   :no-special-members:
-
-.. automodule:: satpy.readers.ghi_l1
-   :noindex:
-   :no-special-members:
-
-Arctica-M N1 HDF5 format reader
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: satpy.readers.msu_gsa_l1b
-   :noindex:
-   :no-special-members:
-
-
-Filter loaded files
-===================
-
-Coming soon...
+Implementation details including unique keyword arguments for specific readers
+can be found in the :doc:`Readers API documentation <api/satpy.readers>`. Note
+that this documentation is for the Python modules and may be shared by
+multiple reader instances. For example, the ``satpy.readers.core.seviri`` module
+is used by most (if not all) of the SEVIRI instrument readers. Most shared Python
+modules can be found in the
+:doc:`readers "core" subpackage <api/satpy.readers.core>`.
 
 Load data
 =========


### PR DESCRIPTION
I've never been happy with this particular list of reader modules. It makes sense in principle that you'd want to link users to documentation for specific reader implementations (how calibration is done, extra keyword arguments they could provide, etc). However, the way it had to be done and is removed in this PR had a few problems:

1. The rendered "reading" document gets very long
2. It is manually managed and does not include *most* readers and probably never should given the length.
3. Is a duplicate of what's in the API documentation. I will admit that the API documentation isn't pretty.
4. Python modules are not 1:1 with reader instances and sometimes a single reader instance consists of multiple python modules (specific code + base code).
5. It is/was hard to tell where one reader's section ended and another began.

Feel free to disagree with me, but if you do then we really need to discuss ways to improve the current way it is documented.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
