### PR TITLE
Fix incorrect wavelength for AHI B04

### DIFF
--- a/satpy/etc/readers/ahi_hrit.yaml
+++ b/satpy/etc/readers/ahi_hrit.yaml
@@ -271,7 +271,7 @@ datasets:
   B04:
     name: B04
     sensor: ahi
-    wavelength: [0.84, 0.86, 0.88]
+    wavelength: [0.85, 0.86, 0.87]
     resolution: 4000
     calibration:
       reflectance:

--- a/satpy/etc/readers/ahi_hrit.yaml
+++ b/satpy/etc/readers/ahi_hrit.yaml
@@ -271,7 +271,7 @@ datasets:
   B04:
     name: B04
     sensor: ahi
-    wavelength: [0.83, 0.85, 0.87]
+    wavelength: [0.84, 0.86, 0.88]
     resolution: 4000
     calibration:
       reflectance:

--- a/satpy/etc/readers/ahi_hsd.yaml
+++ b/satpy/etc/readers/ahi_hsd.yaml
@@ -68,7 +68,7 @@ datasets:
   B04:
     name: B04
     sensor: ahi
-    wavelength: [0.83, 0.85, 0.87]
+    wavelength: [0.84, 0.86, 0.88]
     resolution: 1000
     calibration:
       reflectance:

--- a/satpy/etc/readers/ahi_hsd.yaml
+++ b/satpy/etc/readers/ahi_hsd.yaml
@@ -68,7 +68,7 @@ datasets:
   B04:
     name: B04
     sensor: ahi
-    wavelength: [0.84, 0.86, 0.88]
+    wavelength: [0.85, 0.86, 0.87]
     resolution: 1000
     calibration:
       reflectance:

--- a/satpy/etc/readers/ahi_l1b_gridded_bin.yaml
+++ b/satpy/etc/readers/ahi_l1b_gridded_bin.yaml
@@ -60,7 +60,7 @@ datasets:
   B04:
     name: B04
     sensor: ahi
-    wavelength: [0.83, 0.85, 0.87]
+    wavelength: [0.85, 0.86, 0.87]
     resolution: 0.01
     calibration:
       reflectance:


### PR DESCRIPTION
According to https://www.data.jma.go.jp/mscweb/en/himawari89/space_segment/spsg_ahi.html the AHI B04 central wavelength should be 0.86, not 0.85. This PR fixes this value for AHI HSD and HRIT. I assume that this does not break anything with pyspectral's SRFs (CC @adybbroe @simonrp84).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
