### PR TITLE
Fix adding time bounds to timeseries

### DIFF
--- a/satpy/cf/coords.py
+++ b/satpy/cf/coords.py
@@ -281,19 +281,70 @@ def _get_coordinates_list(data_arr: xr.DataArray) -> list[str]:
 
 def add_time_bounds_dimension(ds: xr.Dataset, time: str = "time") -> xr.Dataset:
     """Add time bound dimension to xr.Dataset."""
-    start_times = []
-    end_times = []
-    for _var_name, data_array in ds.items():
-        start_times.append(data_array.attrs.get("start_time", None))
-        end_times.append(data_array.attrs.get("end_time", None))
-
-    start_time = min(start_time for start_time in start_times
-                     if start_time is not None)
-    end_time = min(end_time for end_time in end_times
-                   if end_time is not None)
-    ds["time_bnds"] = xr.DataArray([[np.datetime64(start_time, "ns"),
-                                     np.datetime64(end_time, "ns")]],
-                                   dims=["time", "bnds_1d"])
+    time_bounds = _TimeBoundsCalculator().get_time_bounds(ds, time)
+    ds["time_bnds"] = time_bounds
     ds[time].attrs["bounds"] = "time_bnds"
     ds[time].attrs["standard_name"] = "time"
     return ds
+
+
+class _TimeBoundsCalculator:
+    def get_time_bounds(self, ds: xr.Dataset, time_dim: str) -> xr.DataArray:
+        """Get time bounds for the given dataset."""
+        if ds[time_dim].size > 1:
+            bounds = self._get_bounds_multiple_timesteps(ds, time_dim)
+        else:
+            bounds = self._get_bounds_single_timestep(ds)
+        return xr.DataArray(bounds, dims=[time_dim, "bnds_1d"])
+
+    def _get_bounds_multiple_timesteps(self, ds, time_dim):
+        """Get time bounds for a dataset with multiple timesteps.
+
+        Computes bounds based on time coordinates and for the last
+        timestep uses the "end_time" attribute. Example for 3
+        timesteps::
+
+            bounds = [
+                (t[0], t[1]),
+                (t[1], t[2]),
+                (t[2], min_end_time_from_attrs)
+            ]
+
+        """
+        bounds = self._get_bounds_for_all_but_last_timestep(ds, time_dim)
+        bounds.append(self._get_bounds_for_last_timestep(ds, time_dim))
+        return bounds
+
+    def _get_bounds_for_all_but_last_timestep(self, ds, time_dim):
+        times = ds[time_dim].values
+        return [
+            [times[i], times[i + 1]]
+            for i in range(len(times) - 1)
+        ]
+
+    def _get_bounds_for_last_timestep(self, ds, time_dim):
+        return [
+            ds[time_dim].values[-1],
+            self._get_min_time_from_attrs(ds, "end_time")
+        ]
+
+    def _get_min_time_from_attrs(self, ds, time_attr):
+        times = [
+            data_array.attrs.get(time_attr, None)
+            for data_array in ds.data_vars.values()
+        ]
+        min_time = min(
+            t for t in times if t is not None
+        )
+        return np.datetime64(min_time, "ns")
+
+    def _get_bounds_single_timestep(self, ds):
+        """Get time bounds for a dataset with a single timestep.
+
+        Computes time bounds entirely from dataset attributes
+        start_time and end_time.
+        """
+        return [
+            [self._get_min_time_from_attrs(ds, "start_time"),
+             self._get_min_time_from_attrs(ds, "end_time")]
+        ]

--- a/satpy/tests/cf_tests/test_coords.py
+++ b/satpy/tests/cf_tests/test_coords.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """CF processing of time information (coordinates and dimensions)."""
+import datetime as dt
 import logging
 
 import numpy as np
@@ -30,6 +31,77 @@ from pyresample import AreaDefinition
 
 class TestCFtime:
     """Test cases for CF time dimension and coordinates."""
+
+    @pytest.fixture
+    def times(self):
+        """Get time coordinate."""
+        return np.array(["2018-05-30T10:00:00", "2018-05-30T10:15:00"], dtype="datetime64[ns]")
+
+    @pytest.fixture
+    def data_array_with_attrs(self, times):
+        """Make fake data array with time attributes."""
+        return xr.DataArray(
+            np.array([[1, 2], [3, 4]]),
+            dims=["time", "y"],
+            coords={"time": times},
+            attrs={
+                "start_time": dt.datetime(2018, 5, 30, 10),
+                "end_time": dt.datetime(2018,5, 30, 10, 28, 33)
+            }
+        )
+
+    @pytest.fixture
+    def data_array_without_attrs(self, data_array_with_attrs):
+        """Make fake data array without attributes."""
+        arr = data_array_with_attrs.copy()
+        arr.attrs = {}
+        return arr
+
+    @pytest.fixture
+    def fake_dataset(self, data_array_with_attrs, data_array_without_attrs):
+        """Make fake dataset."""
+        return xr.Dataset(
+            {
+                "with_attrs": data_array_with_attrs,
+                "without_attrs": data_array_without_attrs
+            }
+        )
+
+    @pytest.fixture
+    def dataset_exp(self, times, data_array_with_attrs, data_array_without_attrs):
+        """Make expected dataset with time bounds."""
+        time_bounds_exp = xr.DataArray(
+            np.array([
+                ["2018-05-30T10:00:00", "2018-05-30T10:15:00"],
+                ["2018-05-30T10:15:00", "2018-05-30T10:28:33"]
+            ], dtype="datetime64[ns]"),
+            dims=("time", "bnds_1d"),
+            coords={"time": times},
+            name="time_bnds"
+        )
+        return xr.Dataset(
+            {
+                "with_attrs": data_array_with_attrs,
+                "without_attrs": data_array_without_attrs,
+                "time_bnds": time_bounds_exp
+            },
+            coords={
+                "time": xr.DataArray(
+                    times,
+                    dims="time",
+                    attrs={
+                        "bounds": "time_bnds",
+                        "standard_name": "time"
+                    }
+                )
+            }
+        )
+
+    def test_adding_time_bounds_to_timeseries(self, fake_dataset, dataset_exp):
+        """Test adding time bounds for multiple timesteps."""
+        from satpy.cf.coords import add_time_bounds_dimension
+        ds_with_bounds = add_time_bounds_dimension(fake_dataset)
+        xr.testing.assert_identical(ds_with_bounds, dataset_exp)
 
     def test_add_time_bounds_dimension(self):
         """Test addition of CF-compliant time attributes."""
@@ -50,8 +122,6 @@ class TestCFtime:
         assert "time_bnds" in list(ds.data_vars)
         assert "bounds" in ds["time"].attrs
         assert "standard_name" in ds["time"].attrs
-
-    # set_cf_time_info
 
 
 class TestCFcoords:


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
This is an attempt to fix #3167 . For datasets with multiple timesteps, compute time bounds based on time coordinates, except for the last timestep where `end_time` from dataset attributes is used. Example with 3 timesteps (`t` is the time coordinate)

```
[
    (t[0], t[1]),
    (t[1], t[2]),
    (t[2], min. end time from dataset attributes)
]
```

For datasets with a single timestep, the bounds remain unchanged

```
[
    (min. start time from dataset attributes, min. end time from dataset attributes)
]
```

I'm a bit confused about the usage of minimum for the end time here. I would have expected the maximum end time. Maybe someone has a clue?


<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Closes #3167 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [X] Tests added <!-- for all bug fixes or enhancements -->

