### PR TITLE
Update VIIRS composites to use map_blocks instead of delayed

### DIFF
--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -24,7 +24,6 @@ import datetime as dt
 import logging
 import math
 
-import dask
 import dask.array as da
 import numpy as np
 import xarray as xr
@@ -72,9 +71,14 @@ class HistogramDNB(CompositeBase):
 
         dnb_data = datasets[0]
         sza_data = datasets[1]
-        delayed = dask.delayed(self._run_dnb_normalization)(dnb_data.data, sza_data.data)
+        output_data = da.map_blocks(
+            self._run_dnb_normalization,
+            dnb_data.data.rechunk(dnb_data.shape),
+            sza_data.data.rechunk(sza_data.shape),
+            dtype=dnb_data.dtype,
+            meta=np.ndarray((), dtype=dnb_data.dtype),
+        )
         output_dataset = dnb_data.copy()
-        output_data = da.from_delayed(delayed, dnb_data.shape, dnb_data.dtype)
         output_dataset.data = output_data.rechunk(dnb_data.data.chunks)
 
         info = dnb_data.attrs.copy()
@@ -297,9 +301,16 @@ class ERFDNB(CompositeBase):
         # Update from Curtis Seaman, increase max radiance curve until less
         # than 0.5% is saturated
         if self.saturation_correction:
-            delayed = dask.delayed(self._saturation_correction)(output_dataset.data, unit_factor, min_val, max_val)
-            output_dataset.data = da.from_delayed(delayed, output_dataset.shape, output_dataset.dtype)
-            output_dataset.data = output_dataset.data.rechunk(dnb_data.data.chunks)
+            output_data = da.map_blocks(
+                self._saturation_correction,
+                output_dataset.data.rechunk(output_dataset.shape),
+                unit_factor,
+                min_val,
+                max_val,
+                dtype=output_dataset.dtype,
+                meta=np.ndarray((), dtype=output_dataset.dtype),
+            )
+            output_dataset.data = output_data.rechunk(dnb_data.data.chunks)
         else:
             inner_sqrt = (output_dataset - min_val) / (max_val - min_val)
             # clip negative values to 0 before the sqrt

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -26,6 +26,8 @@ import pytest
 import xarray as xr
 from pyresample.geometry import AreaDefinition
 
+from satpy.tests.utils import assert_maximum_dask_computes
+
 
 class TestVIIRSComposites:
     """Test various VIIRS-specific composites."""
@@ -93,10 +95,11 @@ class TestVIIRSComposites:
         """Test the 'histogram_dnb' compositor."""
         from satpy.composites.viirs import HistogramDNB
 
-        comp = HistogramDNB("histogram_dnb", prerequisites=("dnb",),
-                            standard_name="toa_outgoing_radiance_per_"
-                                          "unit_wavelength")
-        res = comp((dnb, sza))
+        with assert_maximum_dask_computes(max_computes=0):
+            comp = HistogramDNB("histogram_dnb", prerequisites=("dnb",),
+                                standard_name="toa_outgoing_radiance_per_"
+                                              "unit_wavelength")
+            res = comp((dnb, sza))
         assert isinstance(res, xr.DataArray)
         assert isinstance(res.data, da.Array)
         assert res.attrs["name"] == "histogram_dnb"
@@ -109,10 +112,11 @@ class TestVIIRSComposites:
         """Test the 'adaptive_dnb' compositor."""
         from satpy.composites.viirs import AdaptiveDNB
 
-        comp = AdaptiveDNB("adaptive_dnb", prerequisites=("dnb",),
-                           standard_name="toa_outgoing_radiance_per_"
-                                         "unit_wavelength")
-        res = comp((dnb, sza))
+        with assert_maximum_dask_computes(max_computes=0):
+            comp = AdaptiveDNB("adaptive_dnb", prerequisites=("dnb",),
+                               standard_name="toa_outgoing_radiance_per_"
+                                             "unit_wavelength")
+            res = comp((dnb, sza))
         assert isinstance(res, xr.DataArray)
         assert isinstance(res.data, da.Array)
         assert res.attrs["name"] == "adaptive_dnb"
@@ -124,13 +128,14 @@ class TestVIIRSComposites:
         """Test the 'hncc_dnb' compositor."""
         from satpy.composites.viirs import NCCZinke
 
-        comp = NCCZinke("hncc_dnb", prerequisites=("dnb",),
-                        standard_name="toa_outgoing_radiance_per_"
-                                      "unit_wavelength")
-        mif = xr.DataArray(da.zeros((5,), chunks=5) + 0.1,
-                           dims=("y",),
-                           attrs={"name": "moon_illumination_fraction", "area": area})
-        res = comp((dnb, sza, lza, mif))
+        with assert_maximum_dask_computes(max_computes=0):
+            comp = NCCZinke("hncc_dnb", prerequisites=("dnb",),
+                            standard_name="toa_outgoing_radiance_per_"
+                                          "unit_wavelength")
+            mif = xr.DataArray(da.zeros((5,), chunks=5) + 0.1,
+                               dims=("y",),
+                               attrs={"name": "moon_illumination_fraction", "area": area})
+            res = comp((dnb, sza, lza, mif))
         assert isinstance(res, xr.DataArray)
         assert isinstance(res.data, da.Array)
         assert res.attrs["name"] == "hncc_dnb"
@@ -149,10 +154,11 @@ class TestVIIRSComposites:
         """Test the 'hncc_dnb' compositor when no moon phase data is provided."""
         from satpy.composites.viirs import NCCZinke
 
-        comp = NCCZinke("hncc_dnb", prerequisites=("dnb",),
-                        standard_name="toa_outgoing_radiance_per_"
-                                      "unit_wavelength")
-        res = comp((dnb, sza, lza))
+        with assert_maximum_dask_computes(max_computes=0):
+            comp = NCCZinke("hncc_dnb", prerequisites=("dnb",),
+                            standard_name="toa_outgoing_radiance_per_"
+                                          "unit_wavelength")
+            res = comp((dnb, sza, lza))
         assert isinstance(res, xr.DataArray)
         assert isinstance(res.data, da.Array)
         assert res.attrs["name"] == "hncc_dnb"
@@ -170,10 +176,6 @@ class TestVIIRSComposites:
         """Test the 'dynamic_dnb' or ERF DNB compositor."""
         from satpy.composites.viirs import ERFDNB
 
-        comp = ERFDNB("dynamic_dnb", prerequisites=("dnb",),
-                      saturation_correction=saturation_correction,
-                      standard_name="toa_outgoing_radiance_per_"
-                                    "unit_wavelength")
         # dnb is different from in the other tests, so don't use the fixture
         # here
         dnb = np.zeros(area.shape) + 0.25
@@ -190,7 +192,13 @@ class TestVIIRSComposites:
         mif = xr.DataArray(da.zeros((5,), chunks=5) + 0.1,
                            dims=("y",),
                            attrs={"name": "moon_illumination_fraction", "area": area})
-        res = comp((c01, sza, lza, mif))
+
+        with assert_maximum_dask_computes(max_computes=0):
+            comp = ERFDNB("dynamic_dnb", prerequisites=("dnb",),
+                          saturation_correction=saturation_correction,
+                          standard_name="toa_outgoing_radiance_per_"
+                                        "unit_wavelength")
+            res = comp((c01, sza, lza, mif))
         assert isinstance(res, xr.DataArray)
         assert isinstance(res.data, da.Array)
         assert res.attrs["name"] == "dynamic_dnb"
@@ -221,11 +229,12 @@ class TestVIIRSComposites:
                        "calibration": "reflectance",
                        "units": "%"})
            for i in range(7, 12))
-        comp = SnowAge(
-                "snow_age",
-                prerequisites=("M07", "M08", "M09", "M10", "M11",),
-                standard_name="snow_age")
-        res = comp(projectables)
+        with assert_maximum_dask_computes(max_computes=0):
+            comp = SnowAge(
+                    "snow_age",
+                    prerequisites=("M07", "M08", "M09", "M10", "M11",),
+                    standard_name="snow_age")
+            res = comp(projectables)
         assert isinstance(res, xr.DataArray)
         assert isinstance(res.data, da.Array)
         assert res.attrs["name"] == "snow_age"


### PR DESCRIPTION
As part of the ongoing delayed replacement (see #3152), this PR replaces the VIIRS composite usage of dask's delayed with map_blocks and rechunking.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
