### PR TITLE
Add `fsspec` support to `"oli_tirs_l1_tif"` reader

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -64,6 +64,7 @@ The following people have made contributions to this project:
 - [Luca Merucci (lmeru)](https://github.com/lmeru)
 - [Lucas Meyer (LTMeyer)](https://github.com/LTMeyer)
 - [Zifeng Mo (Isotr0py)](https://github.com/Isotr0py)
+- [Mikhail Moskovchenko (simonreise)](https://github.com/simonreise)
 - [David Navia (dnaviap)](https://github.com/dnaviap)
 - [Ondrej Nedelcev (nedelceo)](https://github.com/nedelceo)
 - [Oana Nicola](https://github.com/)

--- a/satpy/etc/readers/oli_tirs_l1_tif.yaml
+++ b/satpy/etc/readers/oli_tirs_l1_tif.yaml
@@ -4,7 +4,7 @@ reader:
   long_name: Landsat-8/9 OLI/TIRS L1 data in GeoTIFF format.
   description: GeoTIFF reader for Landsat-8/9 OLI/TIRS L1 data.
   status: Beta
-  supports_fsspec: false
+  supports_fsspec: true
   sensors: oli_tirs
   default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader

--- a/satpy/readers/oli_tirs_l1_tif.py
+++ b/satpy/readers/oli_tirs_l1_tif.py
@@ -34,6 +34,7 @@ import numpy as np
 import xarray as xr
 
 from satpy.readers.core.file_handlers import BaseFileHandler
+from satpy.readers.core.remote import open_file_or_filename
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +110,7 @@ class OLITIRSCHReader(BaseFileHandler):
 
         logger.debug("Reading %s.", key["name"])
 
-        data = xr.open_dataarray(self.filename, engine="rasterio",
+        data = xr.open_dataarray(open_file_or_filename(self.filename), engine="rasterio",
                                  chunks={"band": 1,
                                          "y": "auto",
                                          "x": "auto"},
@@ -184,7 +185,7 @@ class OLITIRSMDReader(BaseFileHandler):
             raise ValueError("This reader only supports Landsat data")
         self.platform_name = PLATFORMS[filename_info["spacecraft_id"]]
         self._obs_date = filename_info["observation_date"]
-        self.root = ET.parse(self.filename)
+        self.root = ET.parse(open_file_or_filename(self.filename))
         self.process_level = filename_info["process_level_correction"]
         import bottleneck  # noqa
         import geotiepoints  # noqa

--- a/satpy/tests/reader_tests/test_oli_tirs_l1_tif.py
+++ b/satpy/tests/reader_tests/test_oli_tirs_l1_tif.py
@@ -409,14 +409,15 @@ def mda_file(l1_files_path):
 def all_files(b4_file, b11_file, mda_file, sza_file):
     """Return all the files."""
     return b4_file, b11_file, mda_file, sza_file
-    
-    
+
+
 @pytest.fixture(scope="session")
 def all_fsspec_files(b4_file, b11_file, mda_file, sza_file):
     """Return all the files as FSFile objects."""
     from fsspec.implementations.local import LocalFileSystem
+
     from satpy.readers.core.remote import FSFile
-    
+
     fs = LocalFileSystem()
     b4_file, b11_file, mda_file, sza_file = (
         FSFile(os.path.abspath(file), fs=fs)
@@ -617,7 +618,7 @@ class TestOLITIRSL1:
 
         assert standard_area.area_extent == (619485.0, 2440485.0, 850515.0, 2675715.0)
         assert pan_area.area_extent == (619492.5, 2440492.5, 850507.5, 2675707.5)
-    
+
     def test_basicload_remote(self, l1_area, all_fsspec_files):
         """Test loading a Landsat Scene from a fsspec filesystem."""
         scn = Scene(reader="oli_tirs_l1_tif", filenames=all_fsspec_files)


### PR DESCRIPTION
This PR adds `fsspec` support to `"oli_tirs_l1_tif"` reader (more details in the related issue)

I decided to use `open_file_or_filename` satpy internal function instead of the solution I proposed in the issue because it does almost the same and it is easier to use

I also added a test for fsspec objects

 - [x] Closes #3171 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
