### PR TITLE
Add ABI L2 SST data quality filtering

### DIFF
--- a/satpy/etc/readers/abi_l2_nc.yaml
+++ b/satpy/etc/readers/abi_l2_nc.yaml
@@ -558,7 +558,7 @@ file_types:
     observation_type: "DSR"
 
   abi_l2_sst:
-    file_reader: !!python/name:satpy.readers.abi_l2_nc.ABISST
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
     file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-SST{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     observation_type: "SST"
 

--- a/satpy/etc/readers/abi_l2_nc.yaml
+++ b/satpy/etc/readers/abi_l2_nc.yaml
@@ -558,7 +558,7 @@ file_types:
     observation_type: "DSR"
 
   abi_l2_sst:
-    file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
+    file_reader: !!python/name:satpy.readers.abi_l2_nc.ABISST
     file_patterns: ['{system_environment:2s}_{mission_id:3s}-L2-SST{scene_abbr:s}-{scan_mode:2s}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc']
     observation_type: "SST"
 

--- a/satpy/readers/abi_l2_nc.py
+++ b/satpy/readers/abi_l2_nc.py
@@ -21,16 +21,21 @@ Data Quality Filtering
 ^^^^^^^^^^^^^^^^^^^^^^
 
 Some variables can be filtered based on Data Quality Flags (DQF) in the
-data files. At the time of writing this is only possible for the SST
-product by specifying the file handler keyword argument
-``filter_sst=True``. When enabled SST pixels will only be valid where
-the ``DQF`` variable is 0 (high quality).
+data files. The flag meanings to retain, where others are marked as invalid,
+are specified with the file handler keyword argument ``filters=["good_quality_qf"]``.
+These invalid values are marked by NaN in the returned data for floating point arrays.
+The values in this list
+must match the entries in the "flag_meanings" attribute of the "DQF"
+variable in the file. By default no filtering is applied.
 
 """
 
 import logging
+import operator
+from functools import reduce
 
 import numpy as np
+import xarray as xr
 
 from satpy.readers.core.abi import NC_ABI_BASE
 
@@ -39,6 +44,12 @@ LOG = logging.getLogger(__name__)
 
 class NC_ABI_L2(NC_ABI_BASE):
     """Reader class for NOAA ABI l2+ products in netCDF format."""
+
+    def __init__(self, filename, filename_info, filetype_info,
+                 filters: list[str] | None = None, **kwargs):
+        """Initialize file handler and store filter_sst state."""
+        super().__init__(filename, filename_info, filetype_info, **kwargs)
+        self.filters = filters or []
 
     def get_dataset(self, key, info):
         """Load a dataset."""
@@ -50,6 +61,7 @@ class NC_ABI_L2(NC_ABI_BASE):
         variable.attrs.update(key.to_dict())
         self._update_data_arr_with_filename_attrs(variable)
         self._remove_problem_attrs(variable)
+        variable = self._filter_dqf(variable)
 
         # convert to satpy standard units
         if variable.attrs["units"] == "1" and key.get("calibration") == "reflectance":
@@ -70,9 +82,7 @@ class NC_ABI_L2(NC_ABI_BASE):
                 "satellite_nominal_altitude": float(self.nc["nominal_satellite_height"]) * 1000.,
             },
         })
-
-        if "flag_meanings" in variable.attrs:
-            variable.attrs["flag_meanings"] = variable.attrs["flag_meanings"].split(" ")
+        self._convert_flag_attrs(variable)
 
         # add in information from the filename that may be useful to the user
         for attr in ("scene_abbr", "scan_mode", "platform_shortname"):
@@ -88,6 +98,13 @@ class NC_ABI_L2(NC_ABI_BASE):
             variable.attrs[attr] = self.nc.attrs.get(attr)
 
     @staticmethod
+    def _convert_flag_attrs(variable: xr.DataArray) -> None:
+        if "flag_meanings" in variable.attrs:
+            variable.attrs["flag_meanings"] = variable.attrs["flag_meanings"].split(" ")
+        if "flag_values" in variable.attrs:
+            variable.attrs["flag_values"] = [int(val) for val in variable.attrs["flag_values"]]
+
+    @staticmethod
     def _remove_problem_attrs(variable):
         # remove attributes that could be confusing later
         if not np.issubdtype(variable.dtype, np.integer):
@@ -99,6 +116,24 @@ class NC_ABI_L2(NC_ABI_BASE):
         variable.attrs.pop("_Unsigned", None)
         variable.attrs.pop("valid_range", None)
         variable.attrs.pop("ancillary_variables", None)  # Can't currently load DQF
+
+    def _filter_dqf(self, variable: xr.DataArray) -> xr.DataArray:
+        if "DQF" not in self:
+            return variable
+        dqf = self["DQF"]
+        if "flag_meanings" not in dqf.attrs or "flag_values" not in dqf.attrs:
+            return variable
+
+        self._convert_flag_attrs(dqf)
+        flag_dict = dict(zip(dqf.attrs["flag_meanings"], dqf.attrs["flag_values"], strict=True))
+        values_to_keep = [flag_dict[flag_name] for flag_name in self.filters if flag_name in flag_dict]
+        if not values_to_keep:
+            # user didn't specify any filters for this variable
+            return variable
+
+        LOG.debug(f"Filtering {variable.attrs['name']} for DQF flags {values_to_keep!r}")
+        good_mask = reduce(operator.or_, [dqf == flag_value for flag_value in values_to_keep])
+        return variable.where(good_mask)
 
     def available_datasets(self, configured_datasets=None):
         """Add resolution to configured datasets."""
@@ -118,20 +153,3 @@ class NC_ABI_L2(NC_ABI_BASE):
                 # we don't know what to do with this
                 # see if another future file handler does
                 yield is_avail, ds_info
-
-
-class ABISST(NC_ABI_L2):
-    """Custom file handler for filtering SST by DQF."""
-
-    def __init__(self, filename, filename_info, filetype_info, filter_sst: bool = False, **kwargs):
-        """Initialize file handler and store filter_sst state."""
-        super().__init__(filename, filename_info, filetype_info, **kwargs)
-        self._filter_sst = filter_sst
-
-    def get_dataset(self, key, info):
-        """Load a dataset."""
-        variable = super().get_dataset(key, info)
-        if key["name"] == "SST" and self._filter_sst:
-            dqf = self["DQF"]
-            variable = variable.where(dqf == 0)
-        return variable

--- a/satpy/readers/core/abi.py
+++ b/satpy/readers/core/abi.py
@@ -48,7 +48,7 @@ PLATFORM_NAMES = {
 class NC_ABI_BASE(BaseFileHandler):
     """Base reader for ABI L1B  L2+ NetCDF4 files."""
 
-    def __init__(self, filename, filename_info, filetype_info):
+    def __init__(self, filename, filename_info, filetype_info, **kwargs):
         """Open the NetCDF file with xarray and prepare the Dataset for reading."""
         super(NC_ABI_BASE, self).__init__(filename, filename_info, filetype_info)
 

--- a/satpy/readers/core/abi.py
+++ b/satpy/readers/core/abi.py
@@ -131,6 +131,10 @@ class NC_ABI_BASE(BaseFileHandler):
 
         return data
 
+    def __contains__(self, item):
+        """Check if the specified variable exists in this file."""
+        return item in self.nc.variables
+
     def _adjust_data(self, data, item):
         """Adjust data with typing, scaling and filling."""
         factor = data.attrs.get("scale_factor", 1)


### PR DESCRIPTION
We have a user of Geo2Grid who wants to read ABI L2 SST data but wants to control if it is cloud cleared or not. The DQF flag ends up performing the equivalent of cloud clearing if you only include the high quality pixels (DQF == 0 only).

This PR adds the ability to do this where this filtering is off by default. This implementation is consistent with similar features I've implemented in other readers.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
