### PR TITLE
Use maximum end time from attributes for time bounds

### DIFF
--- a/satpy/cf/coords.py
+++ b/satpy/cf/coords.py
@@ -319,7 +319,7 @@ class _TimeBoundsCalculator:
             bounds = [
                 (t[0], t[1]),
                 (t[1], t[2]),
-                (t[2], min_end_time_from_attrs)
+                (t[2], max_end_time_from_attrs)
             ]
 
         """
@@ -336,18 +336,18 @@ class _TimeBoundsCalculator:
     def _get_bounds_for_last_timestep(self):
         return [
             self.times[-1],
-            self._get_min_time_from_attrs("end_time")
+            self._get_time_from_attrs("end_time", max)
         ]
 
-    def _get_min_time_from_attrs(self, time_attr):
+    def _get_time_from_attrs(self, time_attr, min_or_max):
         times = [
             data_array.attrs.get(time_attr, None)
             for data_array in self.ds.data_vars.values()
         ]
-        min_time = min(
+        time = min_or_max(
             t for t in times if t is not None
         )
-        return np.datetime64(min_time, "ns")
+        return np.datetime64(time, "ns")
 
     def _get_bounds_single_timestep(self):
         """Get time bounds for a dataset with a single timestep.
@@ -356,6 +356,6 @@ class _TimeBoundsCalculator:
         start_time and end_time.
         """
         return [
-            [self._get_min_time_from_attrs("start_time"),
-             self._get_min_time_from_attrs("end_time")]
+            [self._get_time_from_attrs("start_time", min),
+             self._get_time_from_attrs("end_time", max)]
         ]

--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -308,9 +308,9 @@ class TestCFWriter:
         """Test minimum bounds."""
         scn = Scene()
         start_timeA = dt.datetime(2018, 5, 30, 10, 0)  # expected to be used
-        end_timeA = dt.datetime(2018, 5, 30, 10, 20)
+        end_timeA = dt.datetime(2018, 5, 30, 10, 15)
         start_timeB = dt.datetime(2018, 5, 30, 10, 3)
-        end_timeB = dt.datetime(2018, 5, 30, 10, 15)  # expected to be used
+        end_timeB = dt.datetime(2018, 5, 30, 10, 20)  # expected to be used
         test_arrayA = np.array([[1, 2], [3, 4]]).reshape(2, 2, 1)
         test_arrayB = np.array([[1, 2], [3, 5]]).reshape(2, 2, 1)
         scn["test-arrayA"] = xr.DataArray(test_arrayA,


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Change time bounds calculation so that the maximum end time from dataset attributes is used. Currently it is the minimum end time. In #3170 we discussed that the maximum would be more appropriate.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Tests added <!-- for all bug fixes or enhancements -->

