### PR TITLE
Add new QA band filename support to Landsat reader

### DIFF
--- a/satpy/etc/readers/oli_tirs_l1_tif.yaml
+++ b/satpy/etc/readers/oli_tirs_l1_tif.yaml
@@ -88,7 +88,7 @@ file_types:
     # QA Variables
     granule_qa:
         file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
-        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_QA.TIF']
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_QA.TIF', '{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_QA_PIXEL.TIF']
         requires: [l1_metadata]
     granule_qa_radsat:
         file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader


### PR DESCRIPTION
In the most of the new Landsat products the qa band have a suffix QA_PIXEL.tif instead of just QA.tif

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
