### PR TITLE
Added more Landsat readers

### DIFF
--- a/satpy/etc/readers/etm_l1_tif.yaml
+++ b/satpy/etc/readers/etm_l1_tif.yaml
@@ -1,11 +1,11 @@
 reader:
-  name: oli_tirs_l1_tif
-  short_name: OLI/TIRS L1 GeoTIFF
-  long_name: Landsat-8/9 OLI/TIRS L1 data in GeoTIFF format.
-  description: GeoTIFF reader for Landsat-8/9 OLI/TIRS L1 data.
+  name: etm_l1_tif
+  short_name: ETM+ L1 GeoTIFF
+  long_name: Landsat-7 ETM+ L1 data in GeoTIFF format.
+  description: GeoTIFF reader for Landsat-7 ETM+ L1 data.
   status: Beta
   supports_fsspec: true
-  sensors: oli_tirs
+  sensors: etm+
   default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
   data_identification_keys:
@@ -27,100 +27,136 @@ reader:
       type: !!python/name:satpy.dataset.dataid.ModifierTuple
 
 file_types:
-    # Bands on the OLI subsystem
+    # Spectral bands
     granule_B1:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B1.TIF']
         requires: [l1_metadata]
 
     granule_B2:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B2.TIF']
         requires: [l1_metadata]
 
     granule_B3:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B3.TIF']
         requires: [l1_metadata]
 
     granule_B4:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B4.TIF']
         requires: [l1_metadata]
 
     granule_B5:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B5.TIF']
         requires: [l1_metadata]
 
-    granule_B6:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
-        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B6.TIF']
-        requires: [l1_metadata]
-
     granule_B7:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B7.TIF']
         requires: [l1_metadata]
 
     granule_B8:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B8.TIF']
         requires: [l1_metadata]
 
-    granule_B9:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
-        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B9.TIF']
+    # Thermal bands
+    granule_B6_VCID_1:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B6_VCID_1.TIF']
         requires: [l1_metadata]
 
-    # Bands on the TIRS subsystem
-    granule_B10:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
-        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B10.TIF']
-        requires: [l1_metadata]
-
-    granule_B11:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
-        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B11.TIF']
+    granule_B6_VCID_2:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B6_VCID_2.TIF']
         requires: [l1_metadata]
 
     # Geometry datasets
     granule_sza:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SZA.TIF']
         requires: [l1_metadata]
     granule_saa:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SAA.TIF']
         requires: [l1_metadata]
     granule_vza:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_VZA.TIF']
         requires: [l1_metadata]
     granule_vaa:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_VAA.TIF']
+        requires: [l1_metadata]
+
+    # Gap masks
+    granule_B1_GM:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_GM_B1.TIF']
+        requires: [l1_metadata]
+
+    granule_B2_GM:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_GM_B2.TIF']
+        requires: [l1_metadata]
+
+    granule_B3_GM:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_GM_B3.TIF']
+        requires: [l1_metadata]
+
+    granule_B4_GM:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_GM_B4.TIF']
+        requires: [l1_metadata]
+
+    granule_B5_GM:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_GM_B5.TIF']
+        requires: [l1_metadata]
+
+    granule_B6_VCID_1_GM:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_GM_B6_VCID_1.TIF']
+        requires: [l1_metadata]
+
+    granule_B6_VCID_2_GM:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_GM_B6_VCID_2.TIF']
+        requires: [l1_metadata]
+
+    granule_B7_GM:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_GM_B7.TIF']
+        requires: [l1_metadata]
+
+    granule_B8_GM:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_GM_B8.TIF']
         requires: [l1_metadata]
 
     # QA Variables
     granule_qa:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA.TIF', '{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA_PIXEL.TIF']
         requires: [l1_metadata]
     granule_qa_radsat:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
-        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA_RADSAT.TIF']
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_QA_RADSAT.TIF']
         requires: [l1_metadata]
 
     l1_metadata:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSMDReader
-        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_MTL.xml']
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETMMDReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_MTL.xml']
 
 datasets:
   B1:
     name: B1
-    sensor: oli_tirs
-    wavelength: [0.435, 0.443, 0.451]
+    sensor: etm+
+    wavelength: [0.441, 0.477, 0.514]
     resolution: 30
     calibration:
       reflectance:
@@ -136,8 +172,8 @@ datasets:
 
   B2:
     name: B2
-    sensor: oli_tirs
-    wavelength: [0.452, 0.482, 0.512]
+    sensor: etm+
+    wavelength: [0.519, 0.560, 0.601]
     resolution: 30
     calibration:
       reflectance:
@@ -153,8 +189,8 @@ datasets:
 
   B3:
     name: B3
-    sensor: oli_tirs
-    wavelength: [0.533, 0.561, 0.590]
+    sensor: etm+
+    wavelength: [0.631, 0.661, 0.692]
     resolution: 30
     calibration:
       reflectance:
@@ -170,8 +206,8 @@ datasets:
 
   B4:
     name: B4
-    sensor: oli_tirs
-    wavelength: [0.636, 0.654, 0.673]
+    sensor: etm+
+    wavelength: [0.772, 0.835, 0.898]
     resolution: 30
     calibration:
       reflectance:
@@ -187,8 +223,8 @@ datasets:
 
   B5:
     name: B5
-    sensor: oli_tirs
-    wavelength: [0.851, 0.865, 0.879]
+    sensor: etm+
+    wavelength: [1.547, 1.648, 1.749]
     resolution: 30
     calibration:
       reflectance:
@@ -202,27 +238,10 @@ datasets:
         units: "1"
     file_type: granule_B5
 
-  B6:
-    name: B6
-    sensor: oli_tirs
-    wavelength: [1.566, 1.608, 1.651]
-    resolution: 30
-    calibration:
-      reflectance:
-        standard_name: toa_bidirectional_reflectance
-        units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
-      counts:
-        standard_name: counts
-        units: "1"
-    file_type: granule_B6
-
   B7:
     name: B7
-    sensor: oli_tirs
-    wavelength: [2.107, 2.200, 2.294]
+    sensor: etm+
+    wavelength: [2.064, 2.204, 2.345]
     resolution: 30
     calibration:
       reflectance:
@@ -238,8 +257,8 @@ datasets:
 
   B8:
     name: B8
-    sensor: oli_tirs
-    wavelength: [0.503, 0.589, 0.676]
+    sensor: etm+
+    wavelength: [0.520, 0.710, 0.900]
     resolution: 15
     calibration:
       reflectance:
@@ -253,28 +272,11 @@ datasets:
         units: "1"
     file_type: granule_B8
 
-  B9:
-    name: B9
-    sensor: oli_tirs
-    wavelength: [1.363, 1.373, 1.384]
-    resolution: 30
-    calibration:
-      reflectance:
-        standard_name: toa_bidirectional_reflectance
-        units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
-      counts:
-        standard_name: counts
-        units: "1"
-    file_type: granule_B9
-
-  # Channels on the TIRS instrument
-  B10:
-    name: B10
-    sensor: oli_tirs
-    wavelength: [10.6, 10.888, 11.19]
+  # Thermal bands
+  B6_VCID_1:
+    name: B6_VCID_1
+    sensor: etm+
+    wavelength: [10.40, 11.45, 12.50]
     resolution: 30
     calibration:
       brightness_temperature:
@@ -286,12 +288,12 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: granule_B10
+    file_type: granule_B6_VCID_1
 
-  B11:
-    name: B11
-    sensor: oli_tirs
-    wavelength: [11.5, 11.981, 12.51]
+  B6_VCID_2:
+    name: B6_VCID_2
+    sensor: etm+
+    wavelength: [10.40, 11.45, 12.50]
     resolution: 30
     calibration:
       brightness_temperature:
@@ -303,25 +305,25 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: granule_B11
+    file_type: granule_B6_VCID_2
 
   # QA Variables
   qa:
     name: qa
-    sensor: oli_tirs
+    sensor: etm+
     resolution: 30
     file_type: granule_qa
 
   qa_radsat:
     name: qa_radsat
-    sensor: oli_tirs
+    sensor: etm+
     resolution: 30
     file_type: granule_qa_radsat
 
   # Angles datasets
   solar_zenith_angle:
     name: solar_zenith_angle
-    sensor: oli_tirs
+    sensor: etm+
     standard_name: solar_zenith_angle
     resolution: 30
     units: "degrees"
@@ -329,7 +331,7 @@ datasets:
 
   solar_azimuth_angle:
     name: solar_azimuth_angle
-    sensor: oli_tirs
+    sensor: etm+
     standard_name: solar_azimuth_angle
     resolution: 30
     units: "degrees"
@@ -337,7 +339,7 @@ datasets:
 
   satellite_zenith_angle:
     name: satellite_zenith_angle
-    sensor: oli_tirs
+    sensor: etm+
     standard_name: viewing_zenith_angle
     resolution: 30
     units: "degrees"
@@ -345,8 +347,64 @@ datasets:
 
   satellite_azimuth_angle:
     name: satellite_azimuth_angle
-    sensor: oli_tirs
+    sensor: etm+
     standard_name: viewing_azimuth_angle
     resolution: 30
     units: "degrees"
     file_type: granule_vaa
+
+  # Gap masks
+  B1_GM:
+    name: B1_GM
+    sensor: etm+
+    resolution: 30
+    file_type: granule_B1_GM
+
+  B2_GM:
+    name: B2_GM
+    sensor: etm+
+    resolution: 30
+    file_type: granule_B2_GM
+
+  B3_GM:
+    name: B3_GM
+    sensor: etm+
+    resolution: 30
+    file_type: granule_B3_GM
+
+  B4_GM:
+    name: B4_GM
+    sensor: etm+
+    resolution: 30
+    file_type: granule_B4_GM
+
+  B5_GM:
+    name: B5_GM
+    sensor: etm+
+    resolution: 30
+    file_type: granule_B5_GM
+
+  B6_VCID_1_GM:
+    name: B6_VCID_1_GM
+    sensor: etm+
+    resolution: 30
+    file_type: granule_B6_VCID_1_GM
+
+  B6_VCID_2_GM:
+    name: B6_VCID_2_GM
+    sensor: etm+
+    resolution: 30
+    file_type: granule_B6_VCID_2_GM
+
+
+  B7_GM:
+    name: B7_GM
+    sensor: etm+
+    resolution: 30
+    file_type: granule_B7_GM
+
+  B8_GM:
+    name: B8_GM
+    sensor: etm+
+    resolution: 15
+    file_type: granule_B8_GM

--- a/satpy/etc/readers/etm_l2_tif.yaml
+++ b/satpy/etc/readers/etm_l2_tif.yaml
@@ -1,0 +1,359 @@
+reader:
+  name: etm_l2_tif
+  short_name: ETM+ L2 GeoTIFF
+  long_name: Landsat-7 ETM+ L2 data in GeoTIFF format.
+  description: GeoTIFF reader for Landsat-7 ETM+ L2 data.
+  status: Beta
+  supports_fsspec: true
+  sensors: etm+
+  default_channels: []
+  reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
+  data_identification_keys:
+    name:
+      required: true
+    wavelength:
+      type: !!python/name:satpy.dataset.dataid.WavelengthRange
+    resolution:
+      transitive: false
+    calibration:
+      enum:
+        - reflectance
+        - brightness_temperature
+        - qa_brightness_temperature
+        - radiance
+        - emissivity
+        - cloud_distance
+        - atmospheric_transmittance
+        - counts
+      transitive: true
+    modifiers:
+      default: []
+      type: !!python/name:satpy.dataset.dataid.ModifierTuple
+
+file_types:
+    # Spectral bands
+    granule_B1:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B1.TIF']
+        requires: [l1_metadata]
+
+    granule_B2:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B2.TIF']
+        requires: [l1_metadata]
+
+    granule_B3:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B3.TIF']
+        requires: [l1_metadata]
+
+    granule_B4:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B4.TIF']
+        requires: [l1_metadata]
+
+    granule_B5:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B5.TIF']
+        requires: [l1_metadata]
+
+    granule_B7:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B7.TIF']
+        requires: [l1_metadata]
+
+    # Thermal bands
+    granule_B6:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_B6.TIF']
+        requires: [l1_metadata]
+
+    granule_TRAD:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_TRAD.TIF']
+        requires: [l1_metadata]
+
+    granule_DRAD:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_DRAD.TIF']
+        requires: [l1_metadata]
+
+    granule_URAD:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_URAD.TIF']
+        requires: [l1_metadata]
+
+    granule_ATRAN:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_ATRAN.TIF']
+        requires: [l1_metadata]
+
+    granule_EMIS:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_EMIS.TIF']
+        requires: [l1_metadata]
+
+    granule_EMSD:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_EMSD.TIF']
+        requires: [l1_metadata]
+
+    granule_CDIST:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_CDIST.TIF']
+        requires: [l1_metadata]
+
+    # QA Variables
+    granule_qa:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA.TIF', '{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA_PIXEL.TIF']
+        requires: [l1_metadata]
+    granule_qa_radsat:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA_RADSAT.TIF']
+        requires: [l1_metadata]
+    granule_qa_atmos_opacity:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_ATMOS_OPACITY.TIF']
+        requires: [l1_metadata]
+    granule_qa_cloud:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_CLOUD_QA.TIF']
+        requires: [l1_metadata]
+    granule_qa_st:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_QA.TIF']
+        requires: [l1_metadata]
+
+    l1_metadata:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.ETML2MDReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_MTL.xml']
+
+datasets:
+  B1:
+    name: B1
+    sensor: etm+
+    wavelength: [0.441, 0.477, 0.514]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B1
+
+  B2:
+    name: B2
+    sensor: etm+
+    wavelength: [0.519, 0.560, 0.601]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B2
+
+  B3:
+    name: B3
+    sensor: etm+
+    wavelength: [0.631, 0.661, 0.692]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B3
+
+  B4:
+    name: B4
+    sensor: etm+
+    wavelength: [0.772, 0.835, 0.898]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B4
+
+  B5:
+    name: B5
+    sensor: etm+
+    wavelength: [1.547, 1.648, 1.749]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B5
+
+  B7:
+    name: B7
+    sensor: etm+
+    wavelength: [2.064, 2.204, 2.345]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B7
+
+  # Thermal bands
+  B6:
+    name: B6
+    sensor: etm+
+    wavelength: [10.40, 11.45, 12.50]
+    resolution: 30
+    calibration:
+      brightness_temperature:
+        standard_name: brightness_temperature
+        units: "K"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B6
+
+  TRAD:
+    name: TRAD
+    sensor: etm+
+    resolution: 30
+    calibration:
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_TRAD
+
+  DRAD:
+    name: DRAD
+    sensor: etm+
+    resolution: 30
+    calibration:
+      radiance:
+        standard_name: downwelling_radiance_per_unit_wavelength_in_air
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_DRAD
+
+  URAD:
+    name: URAD
+    sensor: etm+
+    resolution: 30
+    calibration:
+      radiance:
+        standard_name: surface_upwelling_radiance_per_unit_wavelength_in_air
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_URAD
+
+  ATRAN:
+    name: ATRAN
+    sensor: etm+
+    resolution: 30
+    calibration:
+      atmospheric_transmittance:
+        standard_name: atmospheric_transmittance
+        units: "1"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_ATRAN
+
+  EMIS:
+    name: EMIS
+    sensor: etm+
+    resolution: 30
+    calibration:
+      emissivity:
+        standard_name: surface_longwave_emissivity
+        units: "1"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_EMIS
+
+  EMSD:
+    name: EMSD
+    sensor: etm+
+    resolution: 30
+    calibration:
+      emissivity:
+        standard_name: surface_longwave_emissivity
+        units: "1"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_EMSD
+
+  CDIST:
+    name: CDIST
+    sensor: etm+
+    resolution: 30
+    calibration:
+      cloud_distance:
+        standard_name: distance_to_cloud
+        units: "km"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_CDIST
+
+  # QA Variables
+  qa:
+    name: qa
+    sensor: etm+
+    resolution: 30
+    file_type: granule_qa
+
+  qa_radsat:
+    name: qa_radsat
+    sensor: etm+
+    resolution: 30
+    file_type: granule_qa_radsat
+
+  qa_atmos_opacity:
+    name: qa_atmos_opacity
+    sensor: etm+
+    resolution: 30
+    file_type: granule_qa_atmos_opacity
+
+  qa_cloud:
+    name: qa_cloud
+    sensor: etm+
+    resolution: 30
+    file_type: granule_qa_cloud
+
+  qa_st:
+    name: qa_st
+    sensor: etm+
+    resolution: 30
+    calibration:
+      qa_brightness_temperature:
+        standard_name: brightness_temperature
+        units: "K"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_qa_st

--- a/satpy/etc/readers/mss_l1_tif.yaml
+++ b/satpy/etc/readers/mss_l1_tif.yaml
@@ -1,0 +1,211 @@
+reader:
+  name: mss_l1_tif
+  short_name: MSS L1 GeoTIFF
+  long_name: Landsat-1/2/3/4/5 MSS L1 data in GeoTIFF format.
+  description: GeoTIFF reader for Landsat-1/2/3/4/5 MSS L1 data.
+  status: Beta
+  supports_fsspec: true
+  sensors: mss
+  default_channels: []
+  reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
+  data_identification_keys:
+    name:
+      required: true
+    wavelength:
+      type: !!python/name:satpy.dataset.dataid.WavelengthRange
+    resolution:
+      transitive: false
+    calibration:
+      enum:
+        - reflectance
+        - radiance
+        - counts
+      transitive: true
+    modifiers:
+      default: []
+      type: !!python/name:satpy.dataset.dataid.ModifierTuple
+
+file_types:
+    # Spectral bands
+
+    granule_B1:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.MSSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B1.TIF']
+        requires: [l1_metadata]
+
+    granule_B2:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.MSSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B2.TIF']
+        requires: [l1_metadata]
+
+    granule_B3:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.MSSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B3.TIF']
+        requires: [l1_metadata]
+
+    granule_B4:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.MSSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B4.TIF']
+        requires: [l1_metadata]
+
+    granule_B5:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.MSSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B5.TIF']
+        requires: [l1_metadata]
+
+    granule_B6:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.MSSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B6.TIF']
+        requires: [l1_metadata]
+
+    granule_B7:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.MSSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B7.TIF']
+        requires: [l1_metadata]
+
+    # QA Variables
+    granule_qa:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.MSSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA.TIF', '{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA_PIXEL.TIF']
+        requires: [l1_metadata]
+    granule_qa_radsat:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.MSSCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA_RADSAT.TIF']
+        requires: [l1_metadata]
+
+    l1_metadata:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.MSSMDReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_MTL.xml']
+
+datasets:
+  B1:
+    name: B1
+    sensor: mss
+    wavelength: [0.5, 0.45, 0.6]
+    resolution: 60
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B1
+
+  B2:
+    name: B2
+    sensor: mss
+    wavelength: [0.6, 0.65, 0.7]
+    resolution: 60
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B2
+
+  B3:
+    name: B3
+    sensor: mss
+    wavelength: [0.7, 0.75, 0.8]
+    resolution: 60
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B3
+
+  B4:
+    name: B4
+    sensor: mss
+    wavelength: [0.5, 0.55, 0.6]
+    resolution: 60
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B4
+
+  B5:
+    name: B5
+    sensor: mss
+    wavelength: [0.6, 0.65, 0.7]
+    resolution: 60
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B5
+
+  B6:
+    name: B6
+    sensor: mss
+    wavelength: [0.7, 0.75, 0.8]
+    resolution: 60
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B6
+
+  B7:
+    name: B7
+    sensor: mss
+    wavelength: [0.8, 0.95, 1.1]
+    resolution: 60
+    calibration:
+      reflectance:
+        standard_name: toa_bidirectional_reflectance
+        units: "%"
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B7
+
+  # QA Variables
+  qa:
+    name: qa
+    sensor: mss
+    resolution: 60
+    file_type: granule_qa
+
+  qa_radsat:
+    name: qa_radsat
+    sensor: mss
+    resolution: 60
+    file_type: granule_qa_radsat

--- a/satpy/etc/readers/oli_tirs_l2_tif.yaml
+++ b/satpy/etc/readers/oli_tirs_l2_tif.yaml
@@ -1,0 +1,368 @@
+reader:
+  name: oli_tirs_l2_tif
+  short_name: OLI/TIRS L2 GeoTIFF
+  long_name: Landsat-8/9 OLI/TIRS L2 data in GeoTIFF format.
+  description: GeoTIFF reader for Landsat-8/9 OLI/TIRS L2 data.
+  status: Beta
+  supports_fsspec: true
+  sensors: oli_tirs
+  default_channels: []
+  reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
+  data_identification_keys:
+    name:
+      required: true
+    wavelength:
+      type: !!python/name:satpy.dataset.dataid.WavelengthRange
+    resolution:
+      transitive: false
+    calibration:
+      enum:
+        - reflectance
+        - brightness_temperature
+        - qa_brightness_temperature
+        - radiance
+        - emissivity
+        - cloud_distance
+        - atmospheric_transmittance
+        - counts
+      transitive: true
+    modifiers:
+      default: []
+      type: !!python/name:satpy.dataset.dataid.ModifierTuple
+
+file_types:
+    # Bands on the OLI subsystem
+    granule_B1:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B1.TIF']
+        requires: [l1_metadata]
+
+    granule_B2:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B2.TIF']
+        requires: [l1_metadata]
+
+    granule_B3:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B3.TIF']
+        requires: [l1_metadata]
+
+    granule_B4:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B4.TIF']
+        requires: [l1_metadata]
+
+    granule_B5:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B5.TIF']
+        requires: [l1_metadata]
+
+    granule_B6:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B6.TIF']
+        requires: [l1_metadata]
+
+    granule_B7:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B7.TIF']
+        requires: [l1_metadata]
+
+    # Bands on the TIRS subsystem
+    granule_B10:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_B10.TIF']
+        requires: [l1_metadata]
+
+    granule_TRAD:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_TRAD.TIF']
+        requires: [l1_metadata]
+
+    granule_DRAD:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_DRAD.TIF']
+        requires: [l1_metadata]
+
+    granule_URAD:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_URAD.TIF']
+        requires: [l1_metadata]
+
+    granule_ATRAN:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_ATRAN.TIF']
+        requires: [l1_metadata]
+
+    granule_EMIS:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_EMIS.TIF']
+        requires: [l1_metadata]
+
+    granule_EMSD:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_EMSD.TIF']
+        requires: [l1_metadata]
+
+    granule_CDIST:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_CDIST.TIF']
+        requires: [l1_metadata]
+
+    # QA Variables
+    granule_qa:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA.TIF', '{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA_PIXEL.TIF']
+        requires: [l1_metadata]
+    granule_qa_radsat:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA_RADSAT.TIF']
+        requires: [l1_metadata]
+    granule_qa_aerosol:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_SR_QA_AEROSOL.TIF']
+        requires: [l1_metadata]
+    granule_qa_st:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_ST_QA.TIF']
+        requires: [l1_metadata]
+
+    l1_metadata:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSL2MDReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category}_MTL.xml']
+
+datasets:
+  B1:
+    name: B1
+    sensor: oli_tirs
+    wavelength: [0.435, 0.443, 0.451]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B1
+
+  B2:
+    name: B2
+    sensor: oli_tirs
+    wavelength: [0.452, 0.482, 0.512]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B2
+
+  B3:
+    name: B3
+    sensor: oli_tirs
+    wavelength: [0.533, 0.561, 0.590]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B3
+
+  B4:
+    name: B4
+    sensor: oli_tirs
+    wavelength: [0.636, 0.654, 0.673]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B4
+
+  B5:
+    name: B5
+    sensor: oli_tirs
+    wavelength: [0.851, 0.865, 0.879]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B5
+
+  B6:
+    name: B6
+    sensor: oli_tirs
+    wavelength: [1.566, 1.608, 1.651]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B6
+
+  B7:
+    name: B7
+    sensor: oli_tirs
+    wavelength: [2.107, 2.200, 2.294]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B7
+
+  # Channels on the TIRS instrument
+  B10:
+    name: B10
+    sensor: oli_tirs
+    wavelength: [10.6, 10.888, 11.19]
+    resolution: 30
+    calibration:
+      brightness_temperature:
+        standard_name: brightness_temperature
+        units: "K"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B10
+
+  TRAD:
+    name: TRAD
+    sensor: oli_tirs
+    resolution: 30
+    calibration:
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_TRAD
+
+  DRAD:
+    name: DRAD
+    sensor: oli_tirs
+    resolution: 30
+    calibration:
+      radiance:
+        standard_name: downwelling_radiance_per_unit_wavelength_in_air
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_DRAD
+
+  URAD:
+    name: URAD
+    sensor: oli_tirs
+    resolution: 30
+    calibration:
+      radiance:
+        standard_name: surface_upwelling_radiance_per_unit_wavelength_in_air
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_URAD
+
+  ATRAN:
+    name: ATRAN
+    sensor: oli_tirs
+    resolution: 30
+    calibration:
+      atmospheric_transmittance:
+        standard_name: atmospheric_transmittance
+        units: "1"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_ATRAN
+
+  EMIS:
+    name: EMIS
+    sensor: oli_tirs
+    resolution: 30
+    calibration:
+      emissivity:
+        standard_name: surface_longwave_emissivity
+        units: "1"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_EMIS
+
+  EMSD:
+    name: EMSD
+    sensor: oli_tirs
+    resolution: 30
+    calibration:
+      emissivity:
+        standard_name: surface_longwave_emissivity
+        units: "1"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_EMSD
+
+  CDIST:
+    name: CDIST
+    sensor: oli_tirs
+    resolution: 30
+    calibration:
+      cloud_distance:
+        standard_name: distance_to_cloud
+        units: "km"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_CDIST
+
+  # QA Variables
+  qa:
+    name: qa
+    sensor: oli_tirs
+    resolution: 30
+    file_type: granule_qa
+
+  qa_radsat:
+    name: qa_radsat
+    sensor: oli_tirs
+    resolution: 30
+    file_type: granule_qa_radsat
+
+  qa_aerosol:
+    name: qa_aerosol
+    sensor: oli_tirs
+    resolution: 30
+    file_type: granule_qa_aerosol
+
+  qa_st:
+    name: qa_st
+    sensor: oli_tirs
+    resolution: 30
+    calibration:
+      qa_brightness_temperature:
+        standard_name: brightness_temperature
+        units: "K"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_qa_st

--- a/satpy/etc/readers/tm_l1_tif.yaml
+++ b/satpy/etc/readers/tm_l1_tif.yaml
@@ -1,11 +1,11 @@
 reader:
-  name: oli_tirs_l1_tif
-  short_name: OLI/TIRS L1 GeoTIFF
-  long_name: Landsat-8/9 OLI/TIRS L1 data in GeoTIFF format.
-  description: GeoTIFF reader for Landsat-8/9 OLI/TIRS L1 data.
+  name: tm_l1_tif
+  short_name: TM L1 GeoTIFF
+  long_name: Landsat-4/5 TM L1 data in GeoTIFF format.
+  description: GeoTIFF reader for Landsat-4/5 TM L1 data.
   status: Beta
   supports_fsspec: true
-  sensors: oli_tirs
+  sensors: tm
   default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
   data_identification_keys:
@@ -27,100 +27,80 @@ reader:
       type: !!python/name:satpy.dataset.dataid.ModifierTuple
 
 file_types:
-    # Bands on the OLI subsystem
+    # Spectral bands
     granule_B1:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B1.TIF']
         requires: [l1_metadata]
 
     granule_B2:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B2.TIF']
         requires: [l1_metadata]
 
     granule_B3:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B3.TIF']
         requires: [l1_metadata]
 
     granule_B4:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B4.TIF']
         requires: [l1_metadata]
 
     granule_B5:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B5.TIF']
         requires: [l1_metadata]
 
-    granule_B6:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
-        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B6.TIF']
-        requires: [l1_metadata]
-
     granule_B7:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B7.TIF']
         requires: [l1_metadata]
 
-    granule_B8:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
-        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B8.TIF']
-        requires: [l1_metadata]
-
-    granule_B9:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
-        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B9.TIF']
-        requires: [l1_metadata]
-
-    # Bands on the TIRS subsystem
-    granule_B10:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
-        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B10.TIF']
-        requires: [l1_metadata]
-
-    granule_B11:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
-        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B11.TIF']
+    # Thermal bands
+    granule_B6:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TMCHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_B6.TIF']
         requires: [l1_metadata]
 
     # Geometry datasets
     granule_sza:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SZA.TIF']
         requires: [l1_metadata]
     granule_saa:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SAA.TIF']
         requires: [l1_metadata]
     granule_vza:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_VZA.TIF']
         requires: [l1_metadata]
     granule_vaa:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_VAA.TIF']
         requires: [l1_metadata]
 
     # QA Variables
     granule_qa:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA.TIF', '{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA_PIXEL.TIF']
         requires: [l1_metadata]
     granule_qa_radsat:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSCHReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TMCHReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA_RADSAT.TIF']
         requires: [l1_metadata]
 
     l1_metadata:
-        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.OLITIRSMDReader
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TMMDReader
         file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_MTL.xml']
 
 datasets:
   B1:
     name: B1
-    sensor: oli_tirs
-    wavelength: [0.435, 0.443, 0.451]
+    sensor: tm
+    wavelength: [0.450, 0.48, 0.520]
     resolution: 30
     calibration:
       reflectance:
@@ -136,8 +116,8 @@ datasets:
 
   B2:
     name: B2
-    sensor: oli_tirs
-    wavelength: [0.452, 0.482, 0.512]
+    sensor: tm
+    wavelength: [0.520, 0.560, 0.600]
     resolution: 30
     calibration:
       reflectance:
@@ -153,8 +133,8 @@ datasets:
 
   B3:
     name: B3
-    sensor: oli_tirs
-    wavelength: [0.533, 0.561, 0.590]
+    sensor: tm
+    wavelength: [0.630, 0.660, 0.690]
     resolution: 30
     calibration:
       reflectance:
@@ -170,8 +150,8 @@ datasets:
 
   B4:
     name: B4
-    sensor: oli_tirs
-    wavelength: [0.636, 0.654, 0.673]
+    sensor: tm
+    wavelength: [0.760, 0.780, 0.900]
     resolution: 30
     calibration:
       reflectance:
@@ -187,8 +167,8 @@ datasets:
 
   B5:
     name: B5
-    sensor: oli_tirs
-    wavelength: [0.851, 0.865, 0.879]
+    sensor: tm
+    wavelength: [1.550, 1.650, 1.750]
     resolution: 30
     calibration:
       reflectance:
@@ -202,27 +182,10 @@ datasets:
         units: "1"
     file_type: granule_B5
 
-  B6:
-    name: B6
-    sensor: oli_tirs
-    wavelength: [1.566, 1.608, 1.651]
-    resolution: 30
-    calibration:
-      reflectance:
-        standard_name: toa_bidirectional_reflectance
-        units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
-      counts:
-        standard_name: counts
-        units: "1"
-    file_type: granule_B6
-
   B7:
     name: B7
-    sensor: oli_tirs
-    wavelength: [2.107, 2.200, 2.294]
+    sensor: tm
+    wavelength: [2.080, 2.215, 2.350]
     resolution: 30
     calibration:
       reflectance:
@@ -236,45 +199,11 @@ datasets:
         units: "1"
     file_type: granule_B7
 
-  B8:
-    name: B8
-    sensor: oli_tirs
-    wavelength: [0.503, 0.589, 0.676]
-    resolution: 15
-    calibration:
-      reflectance:
-        standard_name: toa_bidirectional_reflectance
-        units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
-      counts:
-        standard_name: counts
-        units: "1"
-    file_type: granule_B8
-
-  B9:
-    name: B9
-    sensor: oli_tirs
-    wavelength: [1.363, 1.373, 1.384]
-    resolution: 30
-    calibration:
-      reflectance:
-        standard_name: toa_bidirectional_reflectance
-        units: "%"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
-      counts:
-        standard_name: counts
-        units: "1"
-    file_type: granule_B9
-
-  # Channels on the TIRS instrument
-  B10:
-    name: B10
-    sensor: oli_tirs
-    wavelength: [10.6, 10.888, 11.19]
+  # Thermal bands
+  B6:
+    name: B6
+    sensor: tm
+    wavelength: [10.40, 11.45, 12.50]
     resolution: 30
     calibration:
       brightness_temperature:
@@ -286,42 +215,25 @@ datasets:
       counts:
         standard_name: counts
         units: "1"
-    file_type: granule_B10
-
-  B11:
-    name: B11
-    sensor: oli_tirs
-    wavelength: [11.5, 11.981, 12.51]
-    resolution: 30
-    calibration:
-      brightness_temperature:
-        standard_name: brightness_temperature
-        units: "K"
-      radiance:
-        standard_name: toa_outgoing_radiance_per_unit_wavelength
-        units: W m-2 um-1 sr-1
-      counts:
-        standard_name: counts
-        units: "1"
-    file_type: granule_B11
+    file_type: granule_B6
 
   # QA Variables
   qa:
     name: qa
-    sensor: oli_tirs
+    sensor: tm
     resolution: 30
     file_type: granule_qa
 
   qa_radsat:
     name: qa_radsat
-    sensor: oli_tirs
+    sensor: tm
     resolution: 30
     file_type: granule_qa_radsat
 
   # Angles datasets
   solar_zenith_angle:
     name: solar_zenith_angle
-    sensor: oli_tirs
+    sensor: tm
     standard_name: solar_zenith_angle
     resolution: 30
     units: "degrees"
@@ -329,7 +241,7 @@ datasets:
 
   solar_azimuth_angle:
     name: solar_azimuth_angle
-    sensor: oli_tirs
+    sensor: tm
     standard_name: solar_azimuth_angle
     resolution: 30
     units: "degrees"
@@ -337,7 +249,7 @@ datasets:
 
   satellite_zenith_angle:
     name: satellite_zenith_angle
-    sensor: oli_tirs
+    sensor: tm
     standard_name: viewing_zenith_angle
     resolution: 30
     units: "degrees"
@@ -345,7 +257,7 @@ datasets:
 
   satellite_azimuth_angle:
     name: satellite_azimuth_angle
-    sensor: oli_tirs
+    sensor: tm
     standard_name: viewing_azimuth_angle
     resolution: 30
     units: "degrees"

--- a/satpy/etc/readers/tm_l2_tif.yaml
+++ b/satpy/etc/readers/tm_l2_tif.yaml
@@ -1,0 +1,359 @@
+reader:
+  name: tm_l2_tif
+  short_name: TM L2 GeoTIFF
+  long_name: Landsat-4/5 TM L2 data in GeoTIFF format.
+  description: GeoTIFF reader for Landsat-4/5 TM L2 data.
+  status: Beta
+  supports_fsspec: true
+  sensors: tm
+  default_channels: []
+  reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
+  data_identification_keys:
+    name:
+      required: true
+    wavelength:
+      type: !!python/name:satpy.dataset.dataid.WavelengthRange
+    resolution:
+      transitive: false
+    calibration:
+      enum:
+        - reflectance
+        - brightness_temperature
+        - qa_brightness_temperature
+        - radiance
+        - emissivity
+        - cloud_distance
+        - atmospheric_transmittance
+        - counts
+      transitive: true
+    modifiers:
+      default: []
+      type: !!python/name:satpy.dataset.dataid.ModifierTuple
+
+file_types:
+    # Spectral bands
+    granule_B1:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B1.TIF']
+        requires: [l1_metadata]
+
+    granule_B2:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B2.TIF']
+        requires: [l1_metadata]
+
+    granule_B3:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B3.TIF']
+        requires: [l1_metadata]
+
+    granule_B4:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B4.TIF']
+        requires: [l1_metadata]
+
+    granule_B5:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B5.TIF']
+        requires: [l1_metadata]
+
+    granule_B7:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_B7.TIF']
+        requires: [l1_metadata]
+
+    # Thermal bands
+    granule_B6:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_B6.TIF']
+        requires: [l1_metadata]
+
+    granule_TRAD:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_TRAD.TIF']
+        requires: [l1_metadata]
+
+    granule_DRAD:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_DRAD.TIF']
+        requires: [l1_metadata]
+
+    granule_URAD:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_URAD.TIF']
+        requires: [l1_metadata]
+
+    granule_ATRAN:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_ATRAN.TIF']
+        requires: [l1_metadata]
+
+    granule_EMIS:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_EMIS.TIF']
+        requires: [l1_metadata]
+
+    granule_EMSD:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_EMSD.TIF']
+        requires: [l1_metadata]
+
+    granule_CDIST:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_CDIST.TIF']
+        requires: [l1_metadata]
+
+    # QA Variables
+    granule_qa:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA.TIF', '{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA_PIXEL.TIF']
+        requires: [l1_metadata]
+    granule_qa_radsat:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_QA_RADSAT.TIF']
+        requires: [l1_metadata]
+    granule_qa_atmos_opacity:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_ATMOS_OPACITY.TIF']
+        requires: [l1_metadata]
+    granule_qa_cloud:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_SR_CLOUD_QA.TIF']
+        requires: [l1_metadata]
+    granule_qa_st:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2CHReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_ST_QA.TIF']
+        requires: [l1_metadata]
+
+    l1_metadata:
+        file_reader: !!python/name:satpy.readers.oli_tirs_l1_tif.TML2MDReader
+        file_patterns: ['{platform_type:1s}{data_type:1s}{spacecraft_id:2s}_{process_level_correction:4s}_{tilepath:3s}{tilerow:3s}_{observation_date:%Y%m%d}_{processing_date:%Y%m%d}_{collection_id:2s}_{collection_category:2s}_MTL.xml']
+
+datasets:
+  B1:
+    name: B1
+    sensor: tm
+    wavelength: [0.450, 0.48, 0.520]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B1
+
+  B2:
+    name: B2
+    sensor: tm
+    wavelength: [0.520, 0.560, 0.600]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B2
+
+  B3:
+    name: B3
+    sensor: tm
+    wavelength: [0.630, 0.660, 0.690]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B3
+
+  B4:
+    name: B4
+    sensor: tm
+    wavelength: [0.760, 0.780, 0.900]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B4
+
+  B5:
+    name: B5
+    sensor: tm
+    wavelength: [1.550, 1.650, 1.750]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B5
+
+  B7:
+    name: B7
+    sensor: tm
+    wavelength: [2.080, 2.215, 2.350]
+    resolution: 30
+    calibration:
+      reflectance:
+        standard_name: surface_bidirectional_reflectance
+        units: "%"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B7
+
+  # Thermal bands
+  B6:
+    name: B6
+    sensor: tm
+    wavelength: [10.40, 11.45, 12.50]
+    resolution: 30
+    calibration:
+      brightness_temperature:
+        standard_name: brightness_temperature
+        units: "K"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_B6
+
+  TRAD:
+    name: TRAD
+    sensor: tm
+    resolution: 30
+    calibration:
+      radiance:
+        standard_name: toa_outgoing_radiance_per_unit_wavelength
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_TRAD
+
+  DRAD:
+    name: DRAD
+    sensor: tm
+    resolution: 30
+    calibration:
+      radiance:
+        standard_name: downwelling_radiance_per_unit_wavelength_in_air
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_DRAD
+
+  URAD:
+    name: URAD
+    sensor: tm
+    resolution: 30
+    calibration:
+      radiance:
+        standard_name: surface_upwelling_radiance_per_unit_wavelength_in_air
+        units: W m-2 um-1 sr-1
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_URAD
+
+  ATRAN:
+    name: ATRAN
+    sensor: tm
+    resolution: 30
+    calibration:
+      atmospheric_transmittance:
+        standard_name: atmospheric_transmittance
+        units: "1"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_ATRAN
+
+  EMIS:
+    name: EMIS
+    sensor: tm
+    resolution: 30
+    calibration:
+      emissivity:
+        standard_name: surface_longwave_emissivity
+        units: "1"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_EMIS
+
+  EMSD:
+    name: EMSD
+    sensor: tm
+    resolution: 30
+    calibration:
+      emissivity:
+        standard_name: surface_longwave_emissivity
+        units: "1"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_EMSD
+
+  CDIST:
+    name: CDIST
+    sensor: tm
+    resolution: 30
+    calibration:
+      cloud_distance:
+        standard_name: distance_to_cloud
+        units: "km"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_CDIST
+
+  # QA Variables
+  qa:
+    name: qa
+    sensor: tm
+    resolution: 30
+    file_type: granule_qa
+
+  qa_radsat:
+    name: qa_radsat
+    sensor: tm
+    resolution: 30
+    file_type: granule_qa_radsat
+
+  qa_atmos_opacity:
+    name: qa_atmos_opacity
+    sensor: tm
+    resolution: 30
+    file_type: granule_qa_atmos_opacity
+
+  qa_cloud:
+    name: qa_cloud
+    sensor: tm
+    resolution: 30
+    file_type: granule_qa_cloud
+
+  qa_st:
+    name: qa_st
+    sensor: tm
+    resolution: 30
+    calibration:
+      qa_brightness_temperature:
+        standard_name: brightness_temperature
+        units: "K"
+      counts:
+        standard_name: counts
+        units: "1"
+    file_type: granule_qa_st

--- a/satpy/tests/reader_tests/test_etm_l1_tif.py
+++ b/satpy/tests/reader_tests/test_etm_l1_tif.py
@@ -1,0 +1,635 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Unittests for generic image reader."""
+
+import os
+from datetime import datetime, timezone
+
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+from pyresample.geometry import AreaDefinition
+
+from satpy import Scene
+
+metadata_text = b"""<?xml version="1.0" encoding="UTF-8"?>
+<LANDSAT_METADATA_FILE>
+  <PRODUCT_CONTENTS>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P9TU80IG</DIGITAL_OBJECT_IDENTIFIER>
+    <LANDSAT_PRODUCT_ID>LE07_L1TP_230080_20231208_20240103_02_T1</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L1TP</PROCESSING_LEVEL>
+    <COLLECTION_NUMBER>02</COLLECTION_NUMBER>
+    <COLLECTION_CATEGORY>T1</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <FILE_NAME_BAND_1>LE07_L1TP_230080_20231208_20240103_02_T1_B1.TIF</FILE_NAME_BAND_1>
+    <FILE_NAME_BAND_2>LE07_L1TP_230080_20231208_20240103_02_T1_B2.TIF</FILE_NAME_BAND_2>
+    <FILE_NAME_BAND_3>LE07_L1TP_230080_20231208_20240103_02_T1_B3.TIF</FILE_NAME_BAND_3>
+    <FILE_NAME_BAND_4>LE07_L1TP_230080_20231208_20240103_02_T1_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_BAND_5>LE07_L1TP_230080_20231208_20240103_02_T1_B5.TIF</FILE_NAME_BAND_5>
+    <FILE_NAME_BAND_6_VCID_1>LE07_L1TP_230080_20231208_20240103_02_T1_B6_VCID_1.TIF</FILE_NAME_BAND_6_VCID_1>
+    <FILE_NAME_BAND_6_VCID_2>LE07_L1TP_230080_20231208_20240103_02_T1_B6_VCID_2.TIF</FILE_NAME_BAND_6_VCID_2>
+    <FILE_NAME_BAND_7>LE07_L1TP_230080_20231208_20240103_02_T1_B7.TIF</FILE_NAME_BAND_7>
+    <FILE_NAME_BAND_8>LE07_L1TP_230080_20231208_20240103_02_T1_B8.TIF</FILE_NAME_BAND_8>
+    <FILE_NAME_QUALITY_L1_PIXEL>LE07_L1TP_230080_20231208_20240103_02_T1_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LE07_L1TP_230080_20231208_20240103_02_T1_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_GROUND_CONTROL_POINT>LE07_L1TP_230080_20231208_20240103_02_T1_GCP.txt</FILE_NAME_GROUND_CONTROL_POINT>
+    <FILE_NAME_ANGLE_COEFFICIENT>LE07_L1TP_230080_20231208_20240103_02_T1_ANG.txt</FILE_NAME_ANGLE_COEFFICIENT>
+    <FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>LE07_L1TP_230080_20231208_20240103_02_T1_VAA.TIF</FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>LE07_L1TP_230080_20231208_20240103_02_T1_VZA.TIF</FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>LE07_L1TP_230080_20231208_20240103_02_T1_SAA.TIF</FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>LE07_L1TP_230080_20231208_20240103_02_T1_SZA.TIF</FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>
+    <FILE_NAME_METADATA_ODL>LE07_L1TP_230080_20231208_20240103_02_T1_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LE07_L1TP_230080_20231208_20240103_02_T1_MTL.xml</FILE_NAME_METADATA_XML>
+    <DATA_TYPE_BAND_1>UINT8</DATA_TYPE_BAND_1>
+    <DATA_TYPE_BAND_2>UINT8</DATA_TYPE_BAND_2>
+    <DATA_TYPE_BAND_3>UINT8</DATA_TYPE_BAND_3>
+    <DATA_TYPE_BAND_4>UINT8</DATA_TYPE_BAND_4>
+    <DATA_TYPE_BAND_5>UINT8</DATA_TYPE_BAND_5>
+    <DATA_TYPE_BAND_6_VCID_1>UINT8</DATA_TYPE_BAND_6_VCID_1>
+    <DATA_TYPE_BAND_6_VCID_2>UINT8</DATA_TYPE_BAND_6_VCID_2>
+    <DATA_TYPE_BAND_7>UINT8</DATA_TYPE_BAND_7>
+    <DATA_TYPE_BAND_8>UINT8</DATA_TYPE_BAND_8>
+    <DATA_TYPE_QUALITY_L1_PIXEL>UINT16</DATA_TYPE_QUALITY_L1_PIXEL>
+    <DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>UINT16</DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <DATA_TYPE_ANGLE_SENSOR_AZIMUTH_BAND_4>INT16</DATA_TYPE_ANGLE_SENSOR_AZIMUTH_BAND_4>
+    <DATA_TYPE_ANGLE_SENSOR_ZENITH_BAND_4>INT16</DATA_TYPE_ANGLE_SENSOR_ZENITH_BAND_4>
+    <DATA_TYPE_ANGLE_SOLAR_AZIMUTH_BAND_4>INT16</DATA_TYPE_ANGLE_SOLAR_AZIMUTH_BAND_4>
+    <DATA_TYPE_ANGLE_SOLAR_ZENITH_BAND_4>INT16</DATA_TYPE_ANGLE_SOLAR_ZENITH_BAND_4>
+  </PRODUCT_CONTENTS>
+  <IMAGE_ATTRIBUTES>
+    <SPACECRAFT_ID>LANDSAT_7</SPACECRAFT_ID>
+    <SENSOR_ID>ETM</SENSOR_ID>
+    <WRS_TYPE>2</WRS_TYPE>
+    <WRS_PATH>230</WRS_PATH>
+    <WRS_ROW>080</WRS_ROW>
+    <DATE_ACQUIRED>2023-12-08</DATE_ACQUIRED>
+    <SCENE_CENTER_TIME>11:44:51.2868783Z</SCENE_CENTER_TIME>
+    <STATION_ID>ASN</STATION_ID>
+    <CLOUD_COVER>10.00</CLOUD_COVER>
+    <CLOUD_COVER_LAND>10.00</CLOUD_COVER_LAND>
+    <IMAGE_QUALITY>9</IMAGE_QUALITY>
+    <SATURATION_BAND_1>N</SATURATION_BAND_1>
+    <SATURATION_BAND_2>Y</SATURATION_BAND_2>
+    <SATURATION_BAND_3>Y</SATURATION_BAND_3>
+    <SATURATION_BAND_4>Y</SATURATION_BAND_4>
+    <SATURATION_BAND_5>N</SATURATION_BAND_5>
+    <SATURATION_BAND_6_VCID_1>N</SATURATION_BAND_6_VCID_1>
+    <SATURATION_BAND_6_VCID_2>N</SATURATION_BAND_6_VCID_2>
+    <SATURATION_BAND_7>Y</SATURATION_BAND_7>
+    <SATURATION_BAND_8>N</SATURATION_BAND_8>
+    <SUN_AZIMUTH>100.58959827</SUN_AZIMUTH>
+    <SUN_ELEVATION>30.88235160</SUN_ELEVATION>
+    <EARTH_SUN_DISTANCE>0.9850987</EARTH_SUN_DISTANCE>
+    <SENSOR_MODE>BUMPER</SENSOR_MODE>
+    <SENSOR_MODE_SLC>OFF</SENSOR_MODE_SLC>
+    <SENSOR_ANOMALIES>NONE</SENSOR_ANOMALIES>
+  </IMAGE_ATTRIBUTES>
+  <PROJECTION_ATTRIBUTES>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>20</UTM_ZONE>
+    <GRID_CELL_SIZE_PANCHROMATIC>15.00</GRID_CELL_SIZE_PANCHROMATIC>
+    <GRID_CELL_SIZE_REFLECTIVE>30.00</GRID_CELL_SIZE_REFLECTIVE>
+    <GRID_CELL_SIZE_THERMAL>30.00</GRID_CELL_SIZE_THERMAL>
+    <PANCHROMATIC_LINES>200</PANCHROMATIC_LINES>
+    <PANCHROMATIC_SAMPLES>200</PANCHROMATIC_SAMPLES>
+    <REFLECTIVE_LINES>100</REFLECTIVE_LINES>
+    <REFLECTIVE_SAMPLES>100</REFLECTIVE_SAMPLES>
+    <THERMAL_LINES>100</THERMAL_LINES>
+    <THERMAL_SAMPLES>100</THERMAL_SAMPLES>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <CORNER_UL_LAT_PRODUCT>-27.92335</CORNER_UL_LAT_PRODUCT>
+    <CORNER_UL_LON_PRODUCT>-65.63282</CORNER_UL_LON_PRODUCT>
+    <CORNER_UR_LAT_PRODUCT>-27.94841</CORNER_UR_LAT_PRODUCT>
+    <CORNER_UR_LON_PRODUCT>-63.17282</CORNER_UR_LON_PRODUCT>
+    <CORNER_LL_LAT_PRODUCT>-29.81408</CORNER_LL_LAT_PRODUCT>
+    <CORNER_LL_LON_PRODUCT>-65.68095</CORNER_LL_LON_PRODUCT>
+    <CORNER_LR_LAT_PRODUCT>-29.84118</CORNER_LR_LAT_PRODUCT>
+    <CORNER_LR_LON_PRODUCT>-63.17598</CORNER_LR_LON_PRODUCT>
+    <CORNER_UL_PROJECTION_X_PRODUCT>240900.000</CORNER_UL_PROJECTION_X_PRODUCT>
+    <CORNER_UL_PROJECTION_Y_PRODUCT>-3091500.000</CORNER_UL_PROJECTION_Y_PRODUCT>
+    <CORNER_UR_PROJECTION_X_PRODUCT>483000.000</CORNER_UR_PROJECTION_X_PRODUCT>
+    <CORNER_UR_PROJECTION_Y_PRODUCT>-3091500.000</CORNER_UR_PROJECTION_Y_PRODUCT>
+    <CORNER_LL_PROJECTION_X_PRODUCT>240900.000</CORNER_LL_PROJECTION_X_PRODUCT>
+    <CORNER_LL_PROJECTION_Y_PRODUCT>-3301200.000</CORNER_LL_PROJECTION_Y_PRODUCT>
+    <CORNER_LR_PROJECTION_X_PRODUCT>483000.000</CORNER_LR_PROJECTION_X_PRODUCT>
+    <CORNER_LR_PROJECTION_Y_PRODUCT>-3301200.000</CORNER_LR_PROJECTION_Y_PRODUCT>
+  </PROJECTION_ATTRIBUTES>
+  <LEVEL1_PROCESSING_RECORD>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P9TU80IG</DIGITAL_OBJECT_IDENTIFIER>
+    <REQUEST_ID>1832924_00398</REQUEST_ID>
+    <LANDSAT_SCENE_ID>LE72300802023342ASN00</LANDSAT_SCENE_ID>
+    <LANDSAT_PRODUCT_ID>LE07_L1TP_230080_20231208_20240103_02_T1</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L1TP</PROCESSING_LEVEL>
+    <COLLECTION_CATEGORY>T1</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <DATE_PRODUCT_GENERATED>2024-01-03T11:31:35Z</DATE_PRODUCT_GENERATED>
+    <PROCESSING_SOFTWARE_VERSION>LPGS_16.3.1</PROCESSING_SOFTWARE_VERSION>
+    <FILE_NAME_BAND_1>LE07_L1TP_230080_20231208_20240103_02_T1_B1.TIF</FILE_NAME_BAND_1>
+    <FILE_NAME_BAND_2>LE07_L1TP_230080_20231208_20240103_02_T1_B2.TIF</FILE_NAME_BAND_2>
+    <FILE_NAME_BAND_3>LE07_L1TP_230080_20231208_20240103_02_T1_B3.TIF</FILE_NAME_BAND_3>
+    <FILE_NAME_BAND_4>LE07_L1TP_230080_20231208_20240103_02_T1_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_BAND_5>LE07_L1TP_230080_20231208_20240103_02_T1_B5.TIF</FILE_NAME_BAND_5>
+    <FILE_NAME_BAND_6_VCID_1>LE07_L1TP_230080_20231208_20240103_02_T1_B6_VCID_1.TIF</FILE_NAME_BAND_6_VCID_1>
+    <FILE_NAME_BAND_6_VCID_2>LE07_L1TP_230080_20231208_20240103_02_T1_B6_VCID_2.TIF</FILE_NAME_BAND_6_VCID_2>
+    <FILE_NAME_BAND_7>LE07_L1TP_230080_20231208_20240103_02_T1_B7.TIF</FILE_NAME_BAND_7>
+    <FILE_NAME_BAND_8>LE07_L1TP_230080_20231208_20240103_02_T1_B8.TIF</FILE_NAME_BAND_8>
+    <FILE_NAME_QUALITY_L1_PIXEL>LE07_L1TP_230080_20231208_20240103_02_T1_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LE07_L1TP_230080_20231208_20240103_02_T1_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_GROUND_CONTROL_POINT>LE07_L1TP_230080_20231208_20240103_02_T1_GCP.txt</FILE_NAME_GROUND_CONTROL_POINT>
+    <FILE_NAME_ANGLE_COEFFICIENT>LE07_L1TP_230080_20231208_20240103_02_T1_ANG.txt</FILE_NAME_ANGLE_COEFFICIENT>
+    <FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>LE07_L1TP_230080_20231208_20240103_02_T1_VAA.TIF</FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>LE07_L1TP_230080_20231208_20240103_02_T1_VZA.TIF</FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>LE07_L1TP_230080_20231208_20240103_02_T1_SAA.TIF</FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>LE07_L1TP_230080_20231208_20240103_02_T1_SZA.TIF</FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>
+    <FILE_NAME_METADATA_ODL>LE07_L1TP_230080_20231208_20240103_02_T1_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LE07_L1TP_230080_20231208_20240103_02_T1_MTL.xml</FILE_NAME_METADATA_XML>
+    <FILE_NAME_CPF>LE07CPF_20231001_20231231_02.07</FILE_NAME_CPF>
+    <DATA_SOURCE_ELEVATION>GLS2000</DATA_SOURCE_ELEVATION>
+    <GROUND_CONTROL_POINTS_VERSION>5</GROUND_CONTROL_POINTS_VERSION>
+    <GROUND_CONTROL_POINTS_MODEL>590</GROUND_CONTROL_POINTS_MODEL>
+    <GEOMETRIC_RMSE_MODEL>4.218</GEOMETRIC_RMSE_MODEL>
+    <GEOMETRIC_RMSE_MODEL_Y>3.115</GEOMETRIC_RMSE_MODEL_Y>
+    <GEOMETRIC_RMSE_MODEL_X>2.844</GEOMETRIC_RMSE_MODEL_X>
+    <EPHEMERIS_TYPE>DEFINITIVE</EPHEMERIS_TYPE>
+  </LEVEL1_PROCESSING_RECORD>
+  <LEVEL1_MIN_MAX_RADIANCE>
+    <RADIANCE_MAXIMUM_BAND_1>191.600</RADIANCE_MAXIMUM_BAND_1>
+    <RADIANCE_MINIMUM_BAND_1>-6.200</RADIANCE_MINIMUM_BAND_1>
+    <RADIANCE_MAXIMUM_BAND_2>196.500</RADIANCE_MAXIMUM_BAND_2>
+    <RADIANCE_MINIMUM_BAND_2>-6.400</RADIANCE_MINIMUM_BAND_2>
+    <RADIANCE_MAXIMUM_BAND_3>152.900</RADIANCE_MAXIMUM_BAND_3>
+    <RADIANCE_MINIMUM_BAND_3>-5.000</RADIANCE_MINIMUM_BAND_3>
+    <RADIANCE_MAXIMUM_BAND_4>241.100</RADIANCE_MAXIMUM_BAND_4>
+    <RADIANCE_MINIMUM_BAND_4>-5.100</RADIANCE_MINIMUM_BAND_4>
+    <RADIANCE_MAXIMUM_BAND_5>31.060</RADIANCE_MAXIMUM_BAND_5>
+    <RADIANCE_MINIMUM_BAND_5>-1.000</RADIANCE_MINIMUM_BAND_5>
+    <RADIANCE_MAXIMUM_BAND_6_VCID_1>17.040</RADIANCE_MAXIMUM_BAND_6_VCID_1>
+    <RADIANCE_MINIMUM_BAND_6_VCID_1>0.000</RADIANCE_MINIMUM_BAND_6_VCID_1>
+    <RADIANCE_MAXIMUM_BAND_6_VCID_2>12.650</RADIANCE_MAXIMUM_BAND_6_VCID_2>
+    <RADIANCE_MINIMUM_BAND_6_VCID_2>3.200</RADIANCE_MINIMUM_BAND_6_VCID_2>
+    <RADIANCE_MAXIMUM_BAND_7>10.800</RADIANCE_MAXIMUM_BAND_7>
+    <RADIANCE_MINIMUM_BAND_7>-0.350</RADIANCE_MINIMUM_BAND_7>
+    <RADIANCE_MAXIMUM_BAND_8>243.100</RADIANCE_MAXIMUM_BAND_8>
+    <RADIANCE_MINIMUM_BAND_8>-4.700</RADIANCE_MINIMUM_BAND_8>
+  </LEVEL1_MIN_MAX_RADIANCE>
+  <LEVEL1_MIN_MAX_REFLECTANCE>
+    <REFLECTANCE_MAXIMUM_BAND_1>0.286898</REFLECTANCE_MAXIMUM_BAND_1>
+    <REFLECTANCE_MINIMUM_BAND_1>-0.009284</REFLECTANCE_MINIMUM_BAND_1>
+    <REFLECTANCE_MAXIMUM_BAND_2>0.322771</REFLECTANCE_MAXIMUM_BAND_2>
+    <REFLECTANCE_MINIMUM_BAND_2>-0.010513</REFLECTANCE_MINIMUM_BAND_2>
+    <REFLECTANCE_MAXIMUM_BAND_3>0.305666</REFLECTANCE_MAXIMUM_BAND_3>
+    <REFLECTANCE_MINIMUM_BAND_3>-0.009996</REFLECTANCE_MINIMUM_BAND_3>
+    <REFLECTANCE_MAXIMUM_BAND_4>0.686305</REFLECTANCE_MAXIMUM_BAND_4>
+    <REFLECTANCE_MINIMUM_BAND_4>-0.014517</REFLECTANCE_MINIMUM_BAND_4>
+    <REFLECTANCE_MAXIMUM_BAND_5>0.427308</REFLECTANCE_MAXIMUM_BAND_5>
+    <REFLECTANCE_MINIMUM_BAND_5>-0.013758</REFLECTANCE_MINIMUM_BAND_5>
+    <REFLECTANCE_MAXIMUM_BAND_7>0.404690</REFLECTANCE_MAXIMUM_BAND_7>
+    <REFLECTANCE_MINIMUM_BAND_7>-0.013115</REFLECTANCE_MINIMUM_BAND_7>
+    <REFLECTANCE_MAXIMUM_BAND_8>0.561888</REFLECTANCE_MAXIMUM_BAND_8>
+    <REFLECTANCE_MINIMUM_BAND_8>-0.010863</REFLECTANCE_MINIMUM_BAND_8>
+  </LEVEL1_MIN_MAX_REFLECTANCE>
+  <LEVEL1_MIN_MAX_PIXEL_VALUE>
+    <QUANTIZE_CAL_MAX_BAND_1>255</QUANTIZE_CAL_MAX_BAND_1>
+    <QUANTIZE_CAL_MIN_BAND_1>1</QUANTIZE_CAL_MIN_BAND_1>
+    <QUANTIZE_CAL_MAX_BAND_2>255</QUANTIZE_CAL_MAX_BAND_2>
+    <QUANTIZE_CAL_MIN_BAND_2>1</QUANTIZE_CAL_MIN_BAND_2>
+    <QUANTIZE_CAL_MAX_BAND_3>255</QUANTIZE_CAL_MAX_BAND_3>
+    <QUANTIZE_CAL_MIN_BAND_3>1</QUANTIZE_CAL_MIN_BAND_3>
+    <QUANTIZE_CAL_MAX_BAND_4>255</QUANTIZE_CAL_MAX_BAND_4>
+    <QUANTIZE_CAL_MIN_BAND_4>1</QUANTIZE_CAL_MIN_BAND_4>
+    <QUANTIZE_CAL_MAX_BAND_5>255</QUANTIZE_CAL_MAX_BAND_5>
+    <QUANTIZE_CAL_MIN_BAND_5>1</QUANTIZE_CAL_MIN_BAND_5>
+    <QUANTIZE_CAL_MAX_BAND_6_VCID_1>255</QUANTIZE_CAL_MAX_BAND_6_VCID_1>
+    <QUANTIZE_CAL_MIN_BAND_6_VCID_1>1</QUANTIZE_CAL_MIN_BAND_6_VCID_1>
+    <QUANTIZE_CAL_MAX_BAND_6_VCID_2>255</QUANTIZE_CAL_MAX_BAND_6_VCID_2>
+    <QUANTIZE_CAL_MIN_BAND_6_VCID_2>1</QUANTIZE_CAL_MIN_BAND_6_VCID_2>
+    <QUANTIZE_CAL_MAX_BAND_7>255</QUANTIZE_CAL_MAX_BAND_7>
+    <QUANTIZE_CAL_MIN_BAND_7>1</QUANTIZE_CAL_MIN_BAND_7>
+    <QUANTIZE_CAL_MAX_BAND_8>255</QUANTIZE_CAL_MAX_BAND_8>
+    <QUANTIZE_CAL_MIN_BAND_8>1</QUANTIZE_CAL_MIN_BAND_8>
+  </LEVEL1_MIN_MAX_PIXEL_VALUE>
+  <LEVEL1_RADIOMETRIC_RESCALING>
+    <RADIANCE_MULT_BAND_1>7.7874E-01</RADIANCE_MULT_BAND_1>
+    <RADIANCE_MULT_BAND_2>7.9882E-01</RADIANCE_MULT_BAND_2>
+    <RADIANCE_MULT_BAND_3>6.2165E-01</RADIANCE_MULT_BAND_3>
+    <RADIANCE_MULT_BAND_4>9.6929E-01</RADIANCE_MULT_BAND_4>
+    <RADIANCE_MULT_BAND_5>1.2622E-01</RADIANCE_MULT_BAND_5>
+    <RADIANCE_MULT_BAND_6_VCID_1>6.7087E-02</RADIANCE_MULT_BAND_6_VCID_1>
+    <RADIANCE_MULT_BAND_6_VCID_2>3.7205E-02</RADIANCE_MULT_BAND_6_VCID_2>
+    <RADIANCE_MULT_BAND_7>4.3898E-02</RADIANCE_MULT_BAND_7>
+    <RADIANCE_MULT_BAND_8>9.7559E-01</RADIANCE_MULT_BAND_8>
+    <RADIANCE_ADD_BAND_1>-6.97874</RADIANCE_ADD_BAND_1>
+    <RADIANCE_ADD_BAND_2>-7.19882</RADIANCE_ADD_BAND_2>
+    <RADIANCE_ADD_BAND_3>-5.62165</RADIANCE_ADD_BAND_3>
+    <RADIANCE_ADD_BAND_4>-6.06929</RADIANCE_ADD_BAND_4>
+    <RADIANCE_ADD_BAND_5>-1.12622</RADIANCE_ADD_BAND_5>
+    <RADIANCE_ADD_BAND_6_VCID_1>-0.06709</RADIANCE_ADD_BAND_6_VCID_1>
+    <RADIANCE_ADD_BAND_6_VCID_2>3.16280</RADIANCE_ADD_BAND_6_VCID_2>
+    <RADIANCE_ADD_BAND_7>-0.39390</RADIANCE_ADD_BAND_7>
+    <RADIANCE_ADD_BAND_8>-5.67559</RADIANCE_ADD_BAND_8>
+    <REFLECTANCE_MULT_BAND_1>1.1661E-03</REFLECTANCE_MULT_BAND_1>
+    <REFLECTANCE_MULT_BAND_2>1.3121E-03</REFLECTANCE_MULT_BAND_2>
+    <REFLECTANCE_MULT_BAND_3>1.2428E-03</REFLECTANCE_MULT_BAND_3>
+    <REFLECTANCE_MULT_BAND_4>2.7591E-03</REFLECTANCE_MULT_BAND_4>
+    <REFLECTANCE_MULT_BAND_5>1.7365E-03</REFLECTANCE_MULT_BAND_5>
+    <REFLECTANCE_MULT_BAND_7>1.6449E-03</REFLECTANCE_MULT_BAND_7>
+    <REFLECTANCE_MULT_BAND_8>2.2549E-03</REFLECTANCE_MULT_BAND_8>
+    <REFLECTANCE_ADD_BAND_1>-0.010450</REFLECTANCE_ADD_BAND_1>
+    <REFLECTANCE_ADD_BAND_2>-0.011825</REFLECTANCE_ADD_BAND_2>
+    <REFLECTANCE_ADD_BAND_3>-0.011238</REFLECTANCE_ADD_BAND_3>
+    <REFLECTANCE_ADD_BAND_4>-0.017277</REFLECTANCE_ADD_BAND_4>
+    <REFLECTANCE_ADD_BAND_5>-0.015494</REFLECTANCE_ADD_BAND_5>
+    <REFLECTANCE_ADD_BAND_7>-0.014760</REFLECTANCE_ADD_BAND_7>
+    <REFLECTANCE_ADD_BAND_8>-0.013118</REFLECTANCE_ADD_BAND_8>
+  </LEVEL1_RADIOMETRIC_RESCALING>
+  <LEVEL1_THERMAL_CONSTANTS>
+    <K1_CONSTANT_BAND_6_VCID_1>666.09</K1_CONSTANT_BAND_6_VCID_1>
+    <K2_CONSTANT_BAND_6_VCID_1>1282.71</K2_CONSTANT_BAND_6_VCID_1>
+    <K1_CONSTANT_BAND_6_VCID_2>666.09</K1_CONSTANT_BAND_6_VCID_2>
+    <K2_CONSTANT_BAND_6_VCID_2>1282.71</K2_CONSTANT_BAND_6_VCID_2>
+  </LEVEL1_THERMAL_CONSTANTS>
+  <LEVEL1_PROJECTION_PARAMETERS>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>20</UTM_ZONE>
+    <GRID_CELL_SIZE_PANCHROMATIC>15.00</GRID_CELL_SIZE_PANCHROMATIC>
+    <GRID_CELL_SIZE_REFLECTIVE>30.00</GRID_CELL_SIZE_REFLECTIVE>
+    <GRID_CELL_SIZE_THERMAL>30.00</GRID_CELL_SIZE_THERMAL>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <RESAMPLING_OPTION>CUBIC_CONVOLUTION</RESAMPLING_OPTION>
+    <SCAN_GAP_INTERPOLATION>2.0</SCAN_GAP_INTERPOLATION>
+  </LEVEL1_PROJECTION_PARAMETERS>
+  <PRODUCT_PARAMETERS>
+    <CORRECTION_GAIN_BAND_1>CPF</CORRECTION_GAIN_BAND_1>
+    <CORRECTION_GAIN_BAND_2>CPF</CORRECTION_GAIN_BAND_2>
+    <CORRECTION_GAIN_BAND_3>CPF</CORRECTION_GAIN_BAND_3>
+    <CORRECTION_GAIN_BAND_4>CPF</CORRECTION_GAIN_BAND_4>
+    <CORRECTION_GAIN_BAND_5>CPF</CORRECTION_GAIN_BAND_5>
+    <CORRECTION_GAIN_BAND_6_VCID_1>CPF</CORRECTION_GAIN_BAND_6_VCID_1>
+    <CORRECTION_GAIN_BAND_6_VCID_2>CPF</CORRECTION_GAIN_BAND_6_VCID_2>
+    <CORRECTION_GAIN_BAND_7>CPF</CORRECTION_GAIN_BAND_7>
+    <CORRECTION_GAIN_BAND_8>CPF</CORRECTION_GAIN_BAND_8>
+    <CORRECTION_BIAS_BAND_1>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_1>
+    <CORRECTION_BIAS_BAND_2>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_2>
+    <CORRECTION_BIAS_BAND_3>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_3>
+    <CORRECTION_BIAS_BAND_4>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_4>
+    <CORRECTION_BIAS_BAND_5>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_5>
+    <CORRECTION_BIAS_BAND_6_VCID_1>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_6_VCID_1>
+    <CORRECTION_BIAS_BAND_6_VCID_2>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_6_VCID_2>
+    <CORRECTION_BIAS_BAND_7>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_7>
+    <CORRECTION_BIAS_BAND_8>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_8>
+    <GAIN_BAND_1>H</GAIN_BAND_1>
+    <GAIN_BAND_2>H</GAIN_BAND_2>
+    <GAIN_BAND_3>H</GAIN_BAND_3>
+    <GAIN_BAND_4>L</GAIN_BAND_4>
+    <GAIN_BAND_5>H</GAIN_BAND_5>
+    <GAIN_BAND_6_VCID_1>L</GAIN_BAND_6_VCID_1>
+    <GAIN_BAND_6_VCID_2>H</GAIN_BAND_6_VCID_2>
+    <GAIN_BAND_7>H</GAIN_BAND_7>
+    <GAIN_BAND_8>L</GAIN_BAND_8>
+    <GAIN_CHANGE_BAND_1>HH</GAIN_CHANGE_BAND_1>
+    <GAIN_CHANGE_BAND_2>HH</GAIN_CHANGE_BAND_2>
+    <GAIN_CHANGE_BAND_3>HH</GAIN_CHANGE_BAND_3>
+    <GAIN_CHANGE_BAND_4>LL</GAIN_CHANGE_BAND_4>
+    <GAIN_CHANGE_BAND_5>HH</GAIN_CHANGE_BAND_5>
+    <GAIN_CHANGE_BAND_6_VCID_1>LL</GAIN_CHANGE_BAND_6_VCID_1>
+    <GAIN_CHANGE_BAND_6_VCID_2>HH</GAIN_CHANGE_BAND_6_VCID_2>
+    <GAIN_CHANGE_BAND_7>HH</GAIN_CHANGE_BAND_7>
+    <GAIN_CHANGE_BAND_8>LL</GAIN_CHANGE_BAND_8>
+    <GAIN_CHANGE_SCAN_BAND_1>0</GAIN_CHANGE_SCAN_BAND_1>
+    <GAIN_CHANGE_SCAN_BAND_2>0</GAIN_CHANGE_SCAN_BAND_2>
+    <GAIN_CHANGE_SCAN_BAND_3>0</GAIN_CHANGE_SCAN_BAND_3>
+    <GAIN_CHANGE_SCAN_BAND_4>0</GAIN_CHANGE_SCAN_BAND_4>
+    <GAIN_CHANGE_SCAN_BAND_5>0</GAIN_CHANGE_SCAN_BAND_5>
+    <GAIN_CHANGE_SCAN_BAND_6_VCID_1>0</GAIN_CHANGE_SCAN_BAND_6_VCID_1>
+    <GAIN_CHANGE_SCAN_BAND_6_VCID_2>0</GAIN_CHANGE_SCAN_BAND_6_VCID_2>
+    <GAIN_CHANGE_SCAN_BAND_7>0</GAIN_CHANGE_SCAN_BAND_7>
+    <GAIN_CHANGE_SCAN_BAND_8>0</GAIN_CHANGE_SCAN_BAND_8>
+  </PRODUCT_PARAMETERS>
+</LANDSAT_METADATA_FILE>
+"""
+
+
+x_size = 100
+y_size = 100
+date = datetime(2023, 12, 8, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="session")
+def area():
+    """Get the landsat 1 area def."""
+    pcs_id = "WGS84 / UTM zone 20N"
+    proj4_dict = {"proj": "utm", "zone": 20, "datum": "WGS84", "units": "m", "no_defs": None, "type": "crs"}
+    area_extent = (240885.0, -3301215.0, 483015.0, -3091485.0)
+    return AreaDefinition("geotiff_area", pcs_id, pcs_id,
+                          proj4_dict, x_size, y_size,
+                          area_extent)
+
+
+@pytest.fixture(scope="session")
+def b4_data():
+    """Get the data for the b4 channel."""
+    return da.random.randint(12000, 16000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+@pytest.fixture(scope="session")
+def b6_data():
+    """Get the data for the b6 channel."""
+    return da.random.randint(8000, 14000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+@pytest.fixture(scope="session")
+def sza_data():
+    """Get the data for the sza."""
+    return da.random.randint(1, 10000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+def create_tif_file(data, name, area, filename):
+    """Create a tif file."""
+    data_array = xr.DataArray(data,
+                              dims=("y", "x"),
+                              attrs={"name": name,
+                                     "start_time": date})
+    scn = Scene()
+    scn["band_data"] = data_array
+    scn["band_data"].attrs["area"] = area
+    scn.save_dataset("band_data", writer="geotiff", enhance=False, fill_value=0,
+                     filename=os.fspath(filename))
+
+
+@pytest.fixture(scope="session")
+def files_path(tmp_path_factory):
+    """Create the path for l1 files."""
+    return tmp_path_factory.mktemp("etm_l1_files")
+
+
+@pytest.fixture(scope="session")
+def b4_file(files_path, b4_data, area):
+    """Create the file for the b4 channel."""
+    data = b4_data
+    filename = files_path / "LE07_L1TP_230080_20231208_20240103_02_T1_B4.TIF"
+    name = "B4"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+@pytest.fixture(scope="session")
+def b6_file(files_path, b6_data, area):
+    """Create the file for the b6 channel."""
+    data = b6_data
+    filename = files_path / "LE07_L1TP_230080_20231208_20240103_02_T1_B6_VCID_1.TIF"
+    name = "B6_VCID_1"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+@pytest.fixture(scope="session")
+def sza_file(files_path, sza_data, area):
+    """Create the file for the sza."""
+    data = sza_data
+    filename = files_path / "LE07_L1TP_230080_20231208_20240103_02_T1_SZA.TIF"
+    name = "sza"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+
+@pytest.fixture(scope="session")
+def mda_file(files_path):
+    """Create the metadata xml file."""
+    filename = files_path / "LE07_L1TP_230080_20231208_20240103_02_T1_MTL.xml"
+    with open(filename, "wb") as f:
+        f.write(metadata_text)
+    return os.fspath(filename)
+
+
+@pytest.fixture(scope="session")
+def all_files(b4_file, b6_file, mda_file, sza_file):
+    """Return all the files."""
+    return b4_file, b6_file, mda_file, sza_file
+
+
+@pytest.fixture(scope="session")
+def all_fs_files(b4_file, b6_file, mda_file, sza_file):
+    """Return all the files as FSFile objects."""
+    from fsspec.implementations.local import LocalFileSystem
+
+    from satpy.readers.core.remote import FSFile
+
+    fs = LocalFileSystem()
+    b4_file, b6_file, mda_file, sza_file = (
+        FSFile(os.path.abspath(file), fs=fs)
+        for file in [b4_file, b6_file, mda_file, sza_file]
+    )
+    return b4_file, b6_file, mda_file, sza_file
+
+
+class TestETML1:
+    """Test generic image reader."""
+
+    def setup_method(self, tmp_path):
+        """Set up the filename and filetype info dicts.."""
+        self.filename_info = dict(observation_date=datetime(2023, 12, 8),
+                                  platform_type="L",
+                                  process_level_correction="L1TP",
+                                  spacecraft_id="07",
+                                  data_type="E",
+                                  collection_id="02")
+        self.ftype_info = {"file_type": "granule_B4"}
+
+    def test_basicload(self, area, b4_file, b6_file, mda_file):
+        """Test loading a Landsat Scene."""
+        scn = Scene(reader="etm_l1_tif", filenames=[b4_file,
+                                                    b6_file,
+                                                    mda_file])
+        scn.load(["B4", "B6_VCID_1"])
+
+        # Check dataset is loaded correctly
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == area
+        assert scn["B4"].attrs["saturated"]
+        assert scn["B6_VCID_1"].shape == (100, 100)
+        assert scn["B6_VCID_1"].attrs["area"] == area
+        assert not scn["B6_VCID_1"].attrs["saturated"]
+
+    def test_ch_startend(self, b4_file, sza_file, mda_file):
+        """Test correct retrieval of start/end times."""
+        scn = Scene(reader="etm_l1_tif", filenames=[b4_file,
+                                                    sza_file,
+                                                    mda_file])
+        bnds = scn.available_dataset_names()
+        assert bnds == ["B4", "solar_zenith_angle"]
+
+        scn.load(["B4"])
+        assert scn.start_time == datetime(2023, 12, 8, 11, 44, 51, tzinfo=timezone.utc)
+        assert scn.end_time == datetime(2023, 12, 8, 11, 44, 51, tzinfo=timezone.utc)
+
+    def test_loading_gd(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with good channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import ETMCHReader, ETMMDReader
+        good_mda = ETMMDReader(mda_file, self.filename_info, {})
+        rdr = ETMCHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        # Check case with good file data and load request
+        rdr.get_dataset({"name": "B4", "calibration": "counts"}, {"standard_name": "test_data", "units": "test_units"})
+
+    def test_loading_badfil(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with bad channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import ETMCHReader, ETMMDReader
+        good_mda = ETMMDReader(mda_file, self.filename_info, {})
+        rdr = ETMCHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+        # Check case with request to load channel not matching filename
+        with pytest.raises(ValueError, match="Requested channel B5 does not match the reader channel B4"):
+            rdr.get_dataset({"name": "B5", "calibration": "counts"}, ftype)
+
+    def test_badfiles(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with bad data."""
+        from satpy.readers.oli_tirs_l1_tif import ETMCHReader, ETMMDReader
+        bad_fname_info = self.filename_info.copy()
+        bad_fname_info["platform_type"] = "B"
+
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+
+        # Test that metadata reader initialises with correct filename
+        good_mda = ETMMDReader(mda_file, self.filename_info, ftype)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            ETMMDReader(mda_file, bad_fname_info, ftype)
+
+        # Test that metadata reader initialises with correct filename
+        ETMCHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            ETMCHReader(b4_file, bad_fname_info, self.ftype_info, good_mda)
+        bad_ftype_info = self.ftype_info.copy()
+        bad_ftype_info["file_type"] = "granule-b05"
+        with pytest.raises(ValueError, match="Invalid file type: granule-b05"):
+            ETMCHReader(b4_file, self.filename_info, bad_ftype_info, good_mda)
+
+    def test_calibration_counts(self, all_files, b4_data, b6_data):
+        """Test counts calibration mode for the reader."""
+        from satpy import Scene
+
+        scn = Scene(reader="etm_l1_tif", filenames=all_files)
+        scn.load(["B4", "B6_VCID_1"], calibration="counts")
+        np.testing.assert_allclose(scn["B4"].values, b4_data)
+        np.testing.assert_allclose(scn["B6_VCID_1"].values, b6_data)
+        assert scn["B4"].attrs["units"] == "1"
+        assert scn["B6_VCID_1"].attrs["units"] == "1"
+        assert scn["B4"].attrs["standard_name"] == "counts"
+        assert scn["B6_VCID_1"].attrs["standard_name"] == "counts"
+
+    def test_calibration_radiance(self, all_files, b4_data, b6_data):
+        """Test radiance calibration mode for the reader."""
+        from satpy import Scene
+        exp_b04 = (b4_data * 9.6929e-01 - 6.06929).astype(np.float32)
+        exp_b6 = (b6_data * 6.7087e-02 - 0.06709).astype(np.float32)
+
+        scn = Scene(reader="etm_l1_tif", filenames=all_files)
+        scn.load(["B4", "B6_VCID_1"], calibration="radiance")
+        assert scn["B4"].attrs["units"] == "W m-2 um-1 sr-1"
+        assert scn["B6_VCID_1"].attrs["units"] == "W m-2 um-1 sr-1"
+        assert scn["B4"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
+        assert scn["B6_VCID_1"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
+        np.testing.assert_allclose(scn["B4"].values, exp_b04, rtol=1e-4)
+        np.testing.assert_allclose(scn["B6_VCID_1"].values, exp_b6, rtol=1e-4)
+
+    def test_calibration_highlevel(self, all_files, b4_data, b6_data):
+        """Test high level calibration modes for the reader."""
+        from satpy import Scene
+        exp_b04 = (b4_data * 2.7591e-03 - 0.017277).astype(np.float32) * 100
+        exp_b6 = (b6_data * 6.7087e-02 - 0.06709).astype(np.float32)
+        exp_b6 = (1282.71 / np.log((666.09 / exp_b6) + 1)).astype(np.float32)
+        scn = Scene(reader="etm_l1_tif", filenames=all_files)
+        scn.load(["B4", "B6_VCID_1"])
+
+        assert scn["B4"].attrs["units"] == "%"
+        assert scn["B6_VCID_1"].attrs["units"] == "K"
+        assert scn["B4"].attrs["standard_name"] == "toa_bidirectional_reflectance"
+        assert scn["B6_VCID_1"].attrs["standard_name"] == "brightness_temperature"
+        np.testing.assert_allclose(np.array(scn["B4"].values), np.array(exp_b04), rtol=1e-4)
+        np.testing.assert_allclose(scn["B6_VCID_1"].values, exp_b6, rtol=1e-6)
+
+    def test_angles(self, all_files, sza_data):
+        """Test calibration modes for the reader."""
+        from satpy import Scene
+
+        # Check angles are calculated correctly
+        scn = Scene(reader="etm_l1_tif", filenames=all_files)
+        scn.load(["solar_zenith_angle"])
+        assert scn["solar_zenith_angle"].attrs["units"] == "degrees"
+        assert scn["solar_zenith_angle"].attrs["standard_name"] == "solar_zenith_angle"
+        np.testing.assert_allclose(scn["solar_zenith_angle"].values * 100,
+                                   np.array(sza_data),
+                                   atol=0.01,
+                                   rtol=1e-3)
+
+    def test_metadata(self, mda_file):
+        """Check that metadata values loaded correctly."""
+        from satpy.readers.oli_tirs_l1_tif import ETMMDReader
+        mda = ETMMDReader(mda_file, self.filename_info, {})
+
+        cal_test_dict = {"B1": (7.7874e-01, -6.97874, 1.1661e-03, -0.010450),
+                         "B5": (1.2622e-01, -1.12622, 1.7365e-03, -0.015494),
+                         "B6_VCID_2": (3.7205e-02, 3.16280, 666.09, 1282.71)}
+
+        assert mda.platform_name == "Landsat-7"
+        assert mda.earth_sun_distance() == 0.9850987
+        assert mda.band_calibration["B1"] == cal_test_dict["B1"]
+        assert mda.band_calibration["B5"] == cal_test_dict["B5"]
+        assert mda.band_calibration["B6_VCID_2"] == cal_test_dict["B6_VCID_2"]
+        assert not mda.band_saturation["B1"]
+        assert mda.band_saturation["B4"]
+        assert not mda.band_saturation["B5"]
+        assert not mda.band_saturation["B6_VCID_2"]
+
+    def test_area_def(self, mda_file):
+        """Check we can get the area defs properly."""
+        from satpy.readers.oli_tirs_l1_tif import ETMMDReader
+        mda = ETMMDReader(mda_file, self.filename_info, {})
+
+        standard_area = mda.build_area_def("B1")
+        pan_area = mda.build_area_def("B8")
+
+        assert standard_area.area_extent == (240885.0, -3301215.0, 483015.0, -3091485.0)
+        assert pan_area.area_extent == (240892.5, -3301207.5, 483007.5, -3091492.5)
+
+    def test_basicload_remote(self, area, all_fs_files):
+        """Test loading a Landsat Scene from a fsspec filesystem."""
+        scn = Scene(reader="etm_l1_tif", filenames=all_fs_files)
+        scn.load(["B4", "B6_VCID_1"])
+
+        # Check dataset is loaded correctly
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == area
+        assert scn["B4"].attrs["saturated"]
+        assert scn["B6_VCID_1"].shape == (100, 100)
+        assert scn["B6_VCID_1"].attrs["area"] == area
+        assert not scn["B6_VCID_1"].attrs["saturated"]

--- a/satpy/tests/reader_tests/test_etm_l2_tif.py
+++ b/satpy/tests/reader_tests/test_etm_l2_tif.py
@@ -1,0 +1,678 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Unittests for generic image reader."""
+
+import os
+from datetime import datetime, timezone
+
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+from pyresample.geometry import AreaDefinition
+
+from satpy import Scene
+
+metadata_text = b"""<?xml version="1.0" encoding="UTF-8"?>
+<LANDSAT_METADATA_FILE>
+  <PRODUCT_CONTENTS>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P9C7I13B</DIGITAL_OBJECT_IDENTIFIER>
+    <LANDSAT_PRODUCT_ID>LE07_L2SP_028030_20230817_20230912_02_T1</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L2SP</PROCESSING_LEVEL>
+    <COLLECTION_NUMBER>02</COLLECTION_NUMBER>
+    <COLLECTION_CATEGORY>T1</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <FILE_NAME_BAND_1>LE07_L2SP_028030_20230817_20230912_02_T1_SR_B1.TIF</FILE_NAME_BAND_1>
+    <FILE_NAME_BAND_2>LE07_L2SP_028030_20230817_20230912_02_T1_SR_B2.TIF</FILE_NAME_BAND_2>
+    <FILE_NAME_BAND_3>LE07_L2SP_028030_20230817_20230912_02_T1_SR_B3.TIF</FILE_NAME_BAND_3>
+    <FILE_NAME_BAND_4>LE07_L2SP_028030_20230817_20230912_02_T1_SR_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_BAND_5>LE07_L2SP_028030_20230817_20230912_02_T1_SR_B5.TIF</FILE_NAME_BAND_5>
+    <FILE_NAME_BAND_ST_B6>LE07_L2SP_028030_20230817_20230912_02_T1_ST_B6.TIF</FILE_NAME_BAND_ST_B6>
+    <FILE_NAME_BAND_7>LE07_L2SP_028030_20230817_20230912_02_T1_SR_B7.TIF</FILE_NAME_BAND_7>
+    <FILE_NAME_THERMAL_RADIANCE>LE07_L2SP_028030_20230817_20230912_02_T1_ST_TRAD.TIF</FILE_NAME_THERMAL_RADIANCE>
+    <FILE_NAME_UPWELL_RADIANCE>LE07_L2SP_028030_20230817_20230912_02_T1_ST_URAD.TIF</FILE_NAME_UPWELL_RADIANCE>
+    <FILE_NAME_DOWNWELL_RADIANCE>LE07_L2SP_028030_20230817_20230912_02_T1_ST_DRAD.TIF</FILE_NAME_DOWNWELL_RADIANCE>
+    <FILE_NAME_ATMOSPHERIC_TRANSMITTANCE>LE07_L2SP_028030_20230817_20230912_02_T1_ST_ATRAN.TIF</FILE_NAME_ATMOSPHERIC_TRANSMITTANCE>
+    <FILE_NAME_EMISSIVITY>LE07_L2SP_028030_20230817_20230912_02_T1_ST_EMIS.TIF</FILE_NAME_EMISSIVITY>
+    <FILE_NAME_EMISSIVITY_STDEV>LE07_L2SP_028030_20230817_20230912_02_T1_ST_EMSD.TIF</FILE_NAME_EMISSIVITY_STDEV>
+    <FILE_NAME_CLOUD_DISTANCE>LE07_L2SP_028030_20230817_20230912_02_T1_ST_CDIST.TIF</FILE_NAME_CLOUD_DISTANCE>
+    <FILE_NAME_ATMOSPHERIC_OPACITY>LE07_L2SP_028030_20230817_20230912_02_T1_SR_ATMOS_OPACITY.TIF</FILE_NAME_ATMOSPHERIC_OPACITY>
+    <FILE_NAME_QUALITY_L2_SURFACE_REFLECTANCE_CLOUD>LE07_L2SP_028030_20230817_20230912_02_T1_SR_CLOUD_QA.TIF</FILE_NAME_QUALITY_L2_SURFACE_REFLECTANCE_CLOUD>
+    <FILE_NAME_QUALITY_L2_SURFACE_TEMPERATURE>LE07_L2SP_028030_20230817_20230912_02_T1_ST_QA.TIF</FILE_NAME_QUALITY_L2_SURFACE_TEMPERATURE>
+    <FILE_NAME_QUALITY_L1_PIXEL>LE07_L2SP_028030_20230817_20230912_02_T1_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LE07_L2SP_028030_20230817_20230912_02_T1_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_ANGLE_COEFFICIENT>LE07_L2SP_028030_20230817_20230912_02_T1_ANG.txt</FILE_NAME_ANGLE_COEFFICIENT>
+    <FILE_NAME_METADATA_ODL>LE07_L2SP_028030_20230817_20230912_02_T1_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LE07_L2SP_028030_20230817_20230912_02_T1_MTL.xml</FILE_NAME_METADATA_XML>
+    <DATA_TYPE_BAND_1>UINT16</DATA_TYPE_BAND_1>
+    <DATA_TYPE_BAND_2>UINT16</DATA_TYPE_BAND_2>
+    <DATA_TYPE_BAND_3>UINT16</DATA_TYPE_BAND_3>
+    <DATA_TYPE_BAND_4>UINT16</DATA_TYPE_BAND_4>
+    <DATA_TYPE_BAND_5>UINT16</DATA_TYPE_BAND_5>
+    <DATA_TYPE_BAND_ST_B6>UINT16</DATA_TYPE_BAND_ST_B6>
+    <DATA_TYPE_BAND_7>UINT16</DATA_TYPE_BAND_7>
+    <DATA_TYPE_THERMAL_RADIANCE>INT16</DATA_TYPE_THERMAL_RADIANCE>
+    <DATA_TYPE_UPWELL_RADIANCE>INT16</DATA_TYPE_UPWELL_RADIANCE>
+    <DATA_TYPE_DOWNWELL_RADIANCE>INT16</DATA_TYPE_DOWNWELL_RADIANCE>
+    <DATA_TYPE_ATMOSPHERIC_TRANSMITTANCE>INT16</DATA_TYPE_ATMOSPHERIC_TRANSMITTANCE>
+    <DATA_TYPE_EMISSIVITY>INT16</DATA_TYPE_EMISSIVITY>
+    <DATA_TYPE_EMISSIVITY_STDEV>INT16</DATA_TYPE_EMISSIVITY_STDEV>
+    <DATA_TYPE_CLOUD_DISTANCE>INT16</DATA_TYPE_CLOUD_DISTANCE>
+    <DATA_TYPE_ATMOSPHERIC_OPACITY>INT16</DATA_TYPE_ATMOSPHERIC_OPACITY>
+    <DATA_TYPE_QUALITY_L2_SURFACE_REFLECTANCE_CLOUD>UINT8</DATA_TYPE_QUALITY_L2_SURFACE_REFLECTANCE_CLOUD>
+    <DATA_TYPE_QUALITY_L2_SURFACE_TEMPERATURE>INT16</DATA_TYPE_QUALITY_L2_SURFACE_TEMPERATURE>
+    <DATA_TYPE_QUALITY_L1_PIXEL>UINT16</DATA_TYPE_QUALITY_L1_PIXEL>
+    <DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>UINT16</DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>
+  </PRODUCT_CONTENTS>
+  <IMAGE_ATTRIBUTES>
+    <SPACECRAFT_ID>LANDSAT_7</SPACECRAFT_ID>
+    <SENSOR_ID>ETM</SENSOR_ID>
+    <WRS_TYPE>2</WRS_TYPE>
+    <WRS_PATH>028</WRS_PATH>
+    <WRS_ROW>030</WRS_ROW>
+    <DATE_ACQUIRED>2023-08-17</DATE_ACQUIRED>
+    <SCENE_CENTER_TIME>14:54:20.0400998Z</SCENE_CENTER_TIME>
+    <STATION_ID>ASN</STATION_ID>
+    <CLOUD_COVER>0.00</CLOUD_COVER>
+    <CLOUD_COVER_LAND>0.00</CLOUD_COVER_LAND>
+    <IMAGE_QUALITY>9</IMAGE_QUALITY>
+    <SATURATION_BAND_1>N</SATURATION_BAND_1>
+    <SATURATION_BAND_2>Y</SATURATION_BAND_2>
+    <SATURATION_BAND_3>Y</SATURATION_BAND_3>
+    <SATURATION_BAND_4>Y</SATURATION_BAND_4>
+    <SATURATION_BAND_5>N</SATURATION_BAND_5>
+    <SATURATION_BAND_6_VCID_1>N</SATURATION_BAND_6_VCID_1>
+    <SATURATION_BAND_6_VCID_2>Y</SATURATION_BAND_6_VCID_2>
+    <SATURATION_BAND_7>Y</SATURATION_BAND_7>
+    <SATURATION_BAND_8>N</SATURATION_BAND_8>
+    <SUN_AZIMUTH>105.82706424</SUN_AZIMUTH>
+    <SUN_ELEVATION>35.09902700</SUN_ELEVATION>
+    <EARTH_SUN_DISTANCE>1.0124651</EARTH_SUN_DISTANCE>
+    <SENSOR_MODE>BUMPER</SENSOR_MODE>
+    <SENSOR_MODE_SLC>OFF</SENSOR_MODE_SLC>
+    <SENSOR_ANOMALIES>NONE</SENSOR_ANOMALIES>
+  </IMAGE_ATTRIBUTES>
+  <PROJECTION_ATTRIBUTES>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>15</UTM_ZONE>
+    <GRID_CELL_SIZE_REFLECTIVE>30.00</GRID_CELL_SIZE_REFLECTIVE>
+    <GRID_CELL_SIZE_THERMAL>30.00</GRID_CELL_SIZE_THERMAL>
+    <REFLECTIVE_LINES>100</REFLECTIVE_LINES>
+    <REFLECTIVE_SAMPLES>100</REFLECTIVE_SAMPLES>
+    <THERMAL_LINES>100</THERMAL_LINES>
+    <THERMAL_SAMPLES>100</THERMAL_SAMPLES>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <CORNER_UL_LAT_PRODUCT>44.17250</CORNER_UL_LAT_PRODUCT>
+    <CORNER_UL_LON_PRODUCT>-98.18108</CORNER_UL_LON_PRODUCT>
+    <CORNER_UR_LAT_PRODUCT>44.27187</CORNER_UR_LAT_PRODUCT>
+    <CORNER_UR_LON_PRODUCT>-95.04367</CORNER_UR_LON_PRODUCT>
+    <CORNER_LL_LAT_PRODUCT>42.17058</CORNER_LL_LAT_PRODUCT>
+    <CORNER_LL_LON_PRODUCT>-98.01413</CORNER_LL_LON_PRODUCT>
+    <CORNER_LR_LAT_PRODUCT>42.26326</CORNER_LR_LAT_PRODUCT>
+    <CORNER_LR_LON_PRODUCT>-94.97752</CORNER_LR_LON_PRODUCT>
+    <CORNER_UL_PROJECTION_X_PRODUCT>85800.000</CORNER_UL_PROJECTION_X_PRODUCT>
+    <CORNER_UL_PROJECTION_Y_PRODUCT>4904100.000</CORNER_UL_PROJECTION_Y_PRODUCT>
+    <CORNER_UR_PROJECTION_X_PRODUCT>336900.000</CORNER_UR_PROJECTION_X_PRODUCT>
+    <CORNER_UR_PROJECTION_Y_PRODUCT>4904100.000</CORNER_UR_PROJECTION_Y_PRODUCT>
+    <CORNER_LL_PROJECTION_X_PRODUCT>85800.000</CORNER_LL_PROJECTION_X_PRODUCT>
+    <CORNER_LL_PROJECTION_Y_PRODUCT>4680900.000</CORNER_LL_PROJECTION_Y_PRODUCT>
+    <CORNER_LR_PROJECTION_X_PRODUCT>336900.000</CORNER_LR_PROJECTION_X_PRODUCT>
+    <CORNER_LR_PROJECTION_Y_PRODUCT>4680900.000</CORNER_LR_PROJECTION_Y_PRODUCT>
+  </PROJECTION_ATTRIBUTES>
+  <LEVEL2_PROCESSING_RECORD>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P9C7I13B</DIGITAL_OBJECT_IDENTIFIER>
+    <REQUEST_ID>1786896_00133</REQUEST_ID>
+    <LANDSAT_PRODUCT_ID>LE07_L2SP_028030_20230817_20230912_02_T1</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L2SP</PROCESSING_LEVEL>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <DATE_PRODUCT_GENERATED>2023-09-12T21:14:59Z</DATE_PRODUCT_GENERATED>
+    <PROCESSING_SOFTWARE_VERSION>LPGS_16.3.0</PROCESSING_SOFTWARE_VERSION>
+    <ALGORITHM_SOURCE_SURFACE_REFLECTANCE>LEDAPS_3.4.0</ALGORITHM_SOURCE_SURFACE_REFLECTANCE>
+    <DATA_SOURCE_OZONE>TOMS</DATA_SOURCE_OZONE>
+    <DATA_SOURCE_PRESSURE>NCEP</DATA_SOURCE_PRESSURE>
+    <DATA_SOURCE_WATER_VAPOR>NCEP</DATA_SOURCE_WATER_VAPOR>
+    <DATA_SOURCE_AIR_TEMPERATURE>NCEP</DATA_SOURCE_AIR_TEMPERATURE>
+    <ALGORITHM_SOURCE_SURFACE_TEMPERATURE>st_1.5.0</ALGORITHM_SOURCE_SURFACE_TEMPERATURE>
+    <DATA_SOURCE_REANALYSIS>GEOS-5 FP-IT</DATA_SOURCE_REANALYSIS>
+  </LEVEL2_PROCESSING_RECORD>
+  <LEVEL2_SURFACE_REFLECTANCE_PARAMETERS>
+    <REFLECTANCE_MAXIMUM_BAND_1>1.602213</REFLECTANCE_MAXIMUM_BAND_1>
+    <REFLECTANCE_MINIMUM_BAND_1>-0.199972</REFLECTANCE_MINIMUM_BAND_1>
+    <REFLECTANCE_MAXIMUM_BAND_2>1.602213</REFLECTANCE_MAXIMUM_BAND_2>
+    <REFLECTANCE_MINIMUM_BAND_2>-0.199972</REFLECTANCE_MINIMUM_BAND_2>
+    <REFLECTANCE_MAXIMUM_BAND_3>1.602213</REFLECTANCE_MAXIMUM_BAND_3>
+    <REFLECTANCE_MINIMUM_BAND_3>-0.199972</REFLECTANCE_MINIMUM_BAND_3>
+    <REFLECTANCE_MAXIMUM_BAND_4>1.602213</REFLECTANCE_MAXIMUM_BAND_4>
+    <REFLECTANCE_MINIMUM_BAND_4>-0.199972</REFLECTANCE_MINIMUM_BAND_4>
+    <REFLECTANCE_MAXIMUM_BAND_5>1.602213</REFLECTANCE_MAXIMUM_BAND_5>
+    <REFLECTANCE_MINIMUM_BAND_5>-0.199972</REFLECTANCE_MINIMUM_BAND_5>
+    <REFLECTANCE_MAXIMUM_BAND_7>1.602213</REFLECTANCE_MAXIMUM_BAND_7>
+    <REFLECTANCE_MINIMUM_BAND_7>-0.199972</REFLECTANCE_MINIMUM_BAND_7>
+    <QUANTIZE_CAL_MAX_BAND_1>65535</QUANTIZE_CAL_MAX_BAND_1>
+    <QUANTIZE_CAL_MIN_BAND_1>1</QUANTIZE_CAL_MIN_BAND_1>
+    <QUANTIZE_CAL_MAX_BAND_2>65535</QUANTIZE_CAL_MAX_BAND_2>
+    <QUANTIZE_CAL_MIN_BAND_2>1</QUANTIZE_CAL_MIN_BAND_2>
+    <QUANTIZE_CAL_MAX_BAND_3>65535</QUANTIZE_CAL_MAX_BAND_3>
+    <QUANTIZE_CAL_MIN_BAND_3>1</QUANTIZE_CAL_MIN_BAND_3>
+    <QUANTIZE_CAL_MAX_BAND_4>65535</QUANTIZE_CAL_MAX_BAND_4>
+    <QUANTIZE_CAL_MIN_BAND_4>1</QUANTIZE_CAL_MIN_BAND_4>
+    <QUANTIZE_CAL_MAX_BAND_5>65535</QUANTIZE_CAL_MAX_BAND_5>
+    <QUANTIZE_CAL_MIN_BAND_5>1</QUANTIZE_CAL_MIN_BAND_5>
+    <QUANTIZE_CAL_MAX_BAND_7>65535</QUANTIZE_CAL_MAX_BAND_7>
+    <QUANTIZE_CAL_MIN_BAND_7>1</QUANTIZE_CAL_MIN_BAND_7>
+    <REFLECTANCE_MULT_BAND_1>2.75e-05</REFLECTANCE_MULT_BAND_1>
+    <REFLECTANCE_MULT_BAND_2>2.75e-05</REFLECTANCE_MULT_BAND_2>
+    <REFLECTANCE_MULT_BAND_3>2.75e-05</REFLECTANCE_MULT_BAND_3>
+    <REFLECTANCE_MULT_BAND_4>2.75e-05</REFLECTANCE_MULT_BAND_4>
+    <REFLECTANCE_MULT_BAND_5>2.75e-05</REFLECTANCE_MULT_BAND_5>
+    <REFLECTANCE_MULT_BAND_7>2.75e-05</REFLECTANCE_MULT_BAND_7>
+    <REFLECTANCE_ADD_BAND_1>-0.2</REFLECTANCE_ADD_BAND_1>
+    <REFLECTANCE_ADD_BAND_2>-0.2</REFLECTANCE_ADD_BAND_2>
+    <REFLECTANCE_ADD_BAND_3>-0.2</REFLECTANCE_ADD_BAND_3>
+    <REFLECTANCE_ADD_BAND_4>-0.2</REFLECTANCE_ADD_BAND_4>
+    <REFLECTANCE_ADD_BAND_5>-0.2</REFLECTANCE_ADD_BAND_5>
+    <REFLECTANCE_ADD_BAND_7>-0.2</REFLECTANCE_ADD_BAND_7>
+  </LEVEL2_SURFACE_REFLECTANCE_PARAMETERS>
+  <LEVEL2_SURFACE_TEMPERATURE_PARAMETERS>
+    <TEMPERATURE_MAXIMUM_BAND_ST_B6>372.999941</TEMPERATURE_MAXIMUM_BAND_ST_B6>
+    <TEMPERATURE_MINIMUM_BAND_ST_B6>149.003418</TEMPERATURE_MINIMUM_BAND_ST_B6>
+    <QUANTIZE_CAL_MAXIMUM_BAND_ST_B6>65535</QUANTIZE_CAL_MAXIMUM_BAND_ST_B6>
+    <QUANTIZE_CAL_MINIMUM_BAND_ST_B6>1</QUANTIZE_CAL_MINIMUM_BAND_ST_B6>
+    <TEMPERATURE_MULT_BAND_ST_B6>0.00341802</TEMPERATURE_MULT_BAND_ST_B6>
+    <TEMPERATURE_ADD_BAND_ST_B6>149.0</TEMPERATURE_ADD_BAND_ST_B6>
+  </LEVEL2_SURFACE_TEMPERATURE_PARAMETERS>
+  <LEVEL1_PROCESSING_RECORD>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P9TU80IG</DIGITAL_OBJECT_IDENTIFIER>
+    <REQUEST_ID>1786896_00133</REQUEST_ID>
+    <LANDSAT_SCENE_ID>LE70280302023229ASN00</LANDSAT_SCENE_ID>
+    <LANDSAT_PRODUCT_ID>LE07_L1TP_028030_20230817_20230912_02_T1</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L1TP</PROCESSING_LEVEL>
+    <COLLECTION_CATEGORY>T1</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <DATE_PRODUCT_GENERATED>2023-09-12T21:03:18Z</DATE_PRODUCT_GENERATED>
+    <PROCESSING_SOFTWARE_VERSION>LPGS_16.3.0</PROCESSING_SOFTWARE_VERSION>
+    <FILE_NAME_BAND_1>LE07_L1TP_028030_20230817_20230912_02_T1_B1.TIF</FILE_NAME_BAND_1>
+    <FILE_NAME_BAND_2>LE07_L1TP_028030_20230817_20230912_02_T1_B2.TIF</FILE_NAME_BAND_2>
+    <FILE_NAME_BAND_3>LE07_L1TP_028030_20230817_20230912_02_T1_B3.TIF</FILE_NAME_BAND_3>
+    <FILE_NAME_BAND_4>LE07_L1TP_028030_20230817_20230912_02_T1_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_BAND_5>LE07_L1TP_028030_20230817_20230912_02_T1_B5.TIF</FILE_NAME_BAND_5>
+    <FILE_NAME_BAND_6_VCID_1>LE07_L1TP_028030_20230817_20230912_02_T1_B6_VCID_1.TIF</FILE_NAME_BAND_6_VCID_1>
+    <FILE_NAME_BAND_6_VCID_2>LE07_L1TP_028030_20230817_20230912_02_T1_B6_VCID_2.TIF</FILE_NAME_BAND_6_VCID_2>
+    <FILE_NAME_BAND_7>LE07_L1TP_028030_20230817_20230912_02_T1_B7.TIF</FILE_NAME_BAND_7>
+    <FILE_NAME_BAND_8>LE07_L1TP_028030_20230817_20230912_02_T1_B8.TIF</FILE_NAME_BAND_8>
+    <FILE_NAME_QUALITY_L1_PIXEL>LE07_L1TP_028030_20230817_20230912_02_T1_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LE07_L1TP_028030_20230817_20230912_02_T1_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_GROUND_CONTROL_POINT>LE07_L1TP_028030_20230817_20230912_02_T1_GCP.txt</FILE_NAME_GROUND_CONTROL_POINT>
+    <FILE_NAME_ANGLE_COEFFICIENT>LE07_L1TP_028030_20230817_20230912_02_T1_ANG.txt</FILE_NAME_ANGLE_COEFFICIENT>
+    <FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>LE07_L1TP_028030_20230817_20230912_02_T1_VAA.TIF</FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>LE07_L1TP_028030_20230817_20230912_02_T1_VZA.TIF</FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>LE07_L1TP_028030_20230817_20230912_02_T1_SAA.TIF</FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>LE07_L1TP_028030_20230817_20230912_02_T1_SZA.TIF</FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>
+    <FILE_NAME_METADATA_ODL>LE07_L1TP_028030_20230817_20230912_02_T1_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LE07_L1TP_028030_20230817_20230912_02_T1_MTL.xml</FILE_NAME_METADATA_XML>
+    <FILE_NAME_CPF>LE07CPF_20230701_20230930_02.05</FILE_NAME_CPF>
+    <DATA_SOURCE_ELEVATION>GLS2000</DATA_SOURCE_ELEVATION>
+    <GROUND_CONTROL_POINTS_VERSION>5</GROUND_CONTROL_POINTS_VERSION>
+    <GROUND_CONTROL_POINTS_MODEL>435</GROUND_CONTROL_POINTS_MODEL>
+    <GEOMETRIC_RMSE_MODEL>5.332</GEOMETRIC_RMSE_MODEL>
+    <GEOMETRIC_RMSE_MODEL_Y>4.119</GEOMETRIC_RMSE_MODEL_Y>
+    <GEOMETRIC_RMSE_MODEL_X>3.386</GEOMETRIC_RMSE_MODEL_X>
+    <EPHEMERIS_TYPE>DEFINITIVE</EPHEMERIS_TYPE>
+  </LEVEL1_PROCESSING_RECORD>
+  <LEVEL1_MIN_MAX_RADIANCE>
+    <RADIANCE_MAXIMUM_BAND_1>191.600</RADIANCE_MAXIMUM_BAND_1>
+    <RADIANCE_MINIMUM_BAND_1>-6.200</RADIANCE_MINIMUM_BAND_1>
+    <RADIANCE_MAXIMUM_BAND_2>196.500</RADIANCE_MAXIMUM_BAND_2>
+    <RADIANCE_MINIMUM_BAND_2>-6.400</RADIANCE_MINIMUM_BAND_2>
+    <RADIANCE_MAXIMUM_BAND_3>152.900</RADIANCE_MAXIMUM_BAND_3>
+    <RADIANCE_MINIMUM_BAND_3>-5.000</RADIANCE_MINIMUM_BAND_3>
+    <RADIANCE_MAXIMUM_BAND_4>241.100</RADIANCE_MAXIMUM_BAND_4>
+    <RADIANCE_MINIMUM_BAND_4>-5.100</RADIANCE_MINIMUM_BAND_4>
+    <RADIANCE_MAXIMUM_BAND_5>31.060</RADIANCE_MAXIMUM_BAND_5>
+    <RADIANCE_MINIMUM_BAND_5>-1.000</RADIANCE_MINIMUM_BAND_5>
+    <RADIANCE_MAXIMUM_BAND_6_VCID_1>17.040</RADIANCE_MAXIMUM_BAND_6_VCID_1>
+    <RADIANCE_MINIMUM_BAND_6_VCID_1>0.000</RADIANCE_MINIMUM_BAND_6_VCID_1>
+    <RADIANCE_MAXIMUM_BAND_6_VCID_2>12.650</RADIANCE_MAXIMUM_BAND_6_VCID_2>
+    <RADIANCE_MINIMUM_BAND_6_VCID_2>3.200</RADIANCE_MINIMUM_BAND_6_VCID_2>
+    <RADIANCE_MAXIMUM_BAND_7>16.540</RADIANCE_MAXIMUM_BAND_7>
+    <RADIANCE_MINIMUM_BAND_7>-0.350</RADIANCE_MINIMUM_BAND_7>
+    <RADIANCE_MAXIMUM_BAND_8>243.100</RADIANCE_MAXIMUM_BAND_8>
+    <RADIANCE_MINIMUM_BAND_8>-4.700</RADIANCE_MINIMUM_BAND_8>
+  </LEVEL1_MIN_MAX_RADIANCE>
+  <LEVEL1_MIN_MAX_REFLECTANCE>
+    <REFLECTANCE_MAXIMUM_BAND_1>0.303059</REFLECTANCE_MAXIMUM_BAND_1>
+    <REFLECTANCE_MINIMUM_BAND_1>-0.009807</REFLECTANCE_MINIMUM_BAND_1>
+    <REFLECTANCE_MAXIMUM_BAND_2>0.340953</REFLECTANCE_MAXIMUM_BAND_2>
+    <REFLECTANCE_MINIMUM_BAND_2>-0.011105</REFLECTANCE_MINIMUM_BAND_2>
+    <REFLECTANCE_MAXIMUM_BAND_3>0.322885</REFLECTANCE_MAXIMUM_BAND_3>
+    <REFLECTANCE_MINIMUM_BAND_3>-0.010559</REFLECTANCE_MINIMUM_BAND_3>
+    <REFLECTANCE_MAXIMUM_BAND_4>0.724966</REFLECTANCE_MAXIMUM_BAND_4>
+    <REFLECTANCE_MINIMUM_BAND_4>-0.015335</REFLECTANCE_MINIMUM_BAND_4>
+    <REFLECTANCE_MAXIMUM_BAND_5>0.451379</REFLECTANCE_MAXIMUM_BAND_5>
+    <REFLECTANCE_MINIMUM_BAND_5>-0.014532</REFLECTANCE_MINIMUM_BAND_5>
+    <REFLECTANCE_MAXIMUM_BAND_7>0.654688</REFLECTANCE_MAXIMUM_BAND_7>
+    <REFLECTANCE_MINIMUM_BAND_7>-0.013854</REFLECTANCE_MINIMUM_BAND_7>
+    <REFLECTANCE_MAXIMUM_BAND_8>0.593540</REFLECTANCE_MAXIMUM_BAND_8>
+    <REFLECTANCE_MINIMUM_BAND_8>-0.011475</REFLECTANCE_MINIMUM_BAND_8>
+  </LEVEL1_MIN_MAX_REFLECTANCE>
+  <LEVEL1_MIN_MAX_PIXEL_VALUE>
+    <QUANTIZE_CAL_MAX_BAND_1>255</QUANTIZE_CAL_MAX_BAND_1>
+    <QUANTIZE_CAL_MIN_BAND_1>1</QUANTIZE_CAL_MIN_BAND_1>
+    <QUANTIZE_CAL_MAX_BAND_2>255</QUANTIZE_CAL_MAX_BAND_2>
+    <QUANTIZE_CAL_MIN_BAND_2>1</QUANTIZE_CAL_MIN_BAND_2>
+    <QUANTIZE_CAL_MAX_BAND_3>255</QUANTIZE_CAL_MAX_BAND_3>
+    <QUANTIZE_CAL_MIN_BAND_3>1</QUANTIZE_CAL_MIN_BAND_3>
+    <QUANTIZE_CAL_MAX_BAND_4>255</QUANTIZE_CAL_MAX_BAND_4>
+    <QUANTIZE_CAL_MIN_BAND_4>1</QUANTIZE_CAL_MIN_BAND_4>
+    <QUANTIZE_CAL_MAX_BAND_5>255</QUANTIZE_CAL_MAX_BAND_5>
+    <QUANTIZE_CAL_MIN_BAND_5>1</QUANTIZE_CAL_MIN_BAND_5>
+    <QUANTIZE_CAL_MAX_BAND_6_VCID_1>255</QUANTIZE_CAL_MAX_BAND_6_VCID_1>
+    <QUANTIZE_CAL_MIN_BAND_6_VCID_1>1</QUANTIZE_CAL_MIN_BAND_6_VCID_1>
+    <QUANTIZE_CAL_MAX_BAND_6_VCID_2>255</QUANTIZE_CAL_MAX_BAND_6_VCID_2>
+    <QUANTIZE_CAL_MIN_BAND_6_VCID_2>1</QUANTIZE_CAL_MIN_BAND_6_VCID_2>
+    <QUANTIZE_CAL_MAX_BAND_7>255</QUANTIZE_CAL_MAX_BAND_7>
+    <QUANTIZE_CAL_MIN_BAND_7>1</QUANTIZE_CAL_MIN_BAND_7>
+    <QUANTIZE_CAL_MAX_BAND_8>255</QUANTIZE_CAL_MAX_BAND_8>
+    <QUANTIZE_CAL_MIN_BAND_8>1</QUANTIZE_CAL_MIN_BAND_8>
+  </LEVEL1_MIN_MAX_PIXEL_VALUE>
+  <LEVEL1_RADIOMETRIC_RESCALING>
+    <RADIANCE_MULT_BAND_1>7.7874E-01</RADIANCE_MULT_BAND_1>
+    <RADIANCE_MULT_BAND_2>7.9882E-01</RADIANCE_MULT_BAND_2>
+    <RADIANCE_MULT_BAND_3>6.2165E-01</RADIANCE_MULT_BAND_3>
+    <RADIANCE_MULT_BAND_4>9.6929E-01</RADIANCE_MULT_BAND_4>
+    <RADIANCE_MULT_BAND_5>1.2622E-01</RADIANCE_MULT_BAND_5>
+    <RADIANCE_MULT_BAND_6_VCID_1>6.7087E-02</RADIANCE_MULT_BAND_6_VCID_1>
+    <RADIANCE_MULT_BAND_6_VCID_2>3.7205E-02</RADIANCE_MULT_BAND_6_VCID_2>
+    <RADIANCE_MULT_BAND_7>6.6496E-02</RADIANCE_MULT_BAND_7>
+    <RADIANCE_MULT_BAND_8>9.7559E-01</RADIANCE_MULT_BAND_8>
+    <RADIANCE_ADD_BAND_1>-6.97874</RADIANCE_ADD_BAND_1>
+    <RADIANCE_ADD_BAND_2>-7.19882</RADIANCE_ADD_BAND_2>
+    <RADIANCE_ADD_BAND_3>-5.62165</RADIANCE_ADD_BAND_3>
+    <RADIANCE_ADD_BAND_4>-6.06929</RADIANCE_ADD_BAND_4>
+    <RADIANCE_ADD_BAND_5>-1.12622</RADIANCE_ADD_BAND_5>
+    <RADIANCE_ADD_BAND_6_VCID_1>-0.06709</RADIANCE_ADD_BAND_6_VCID_1>
+    <RADIANCE_ADD_BAND_6_VCID_2>3.16280</RADIANCE_ADD_BAND_6_VCID_2>
+    <RADIANCE_ADD_BAND_7>-0.41650</RADIANCE_ADD_BAND_7>
+    <RADIANCE_ADD_BAND_8>-5.67559</RADIANCE_ADD_BAND_8>
+    <REFLECTANCE_MULT_BAND_1>1.2318E-03</REFLECTANCE_MULT_BAND_1>
+    <REFLECTANCE_MULT_BAND_2>1.3861E-03</REFLECTANCE_MULT_BAND_2>
+    <REFLECTANCE_MULT_BAND_3>1.3128E-03</REFLECTANCE_MULT_BAND_3>
+    <REFLECTANCE_MULT_BAND_4>2.9146E-03</REFLECTANCE_MULT_BAND_4>
+    <REFLECTANCE_MULT_BAND_5>1.8343E-03</REFLECTANCE_MULT_BAND_5>
+    <REFLECTANCE_MULT_BAND_7>2.6321E-03</REFLECTANCE_MULT_BAND_7>
+    <REFLECTANCE_MULT_BAND_8>2.3820E-03</REFLECTANCE_MULT_BAND_8>
+    <REFLECTANCE_ADD_BAND_1>-0.011038</REFLECTANCE_ADD_BAND_1>
+    <REFLECTANCE_ADD_BAND_2>-0.012491</REFLECTANCE_ADD_BAND_2>
+    <REFLECTANCE_ADD_BAND_3>-0.011871</REFLECTANCE_ADD_BAND_3>
+    <REFLECTANCE_ADD_BAND_4>-0.018250</REFLECTANCE_ADD_BAND_4>
+    <REFLECTANCE_ADD_BAND_5>-0.016367</REFLECTANCE_ADD_BAND_5>
+    <REFLECTANCE_ADD_BAND_7>-0.016486</REFLECTANCE_ADD_BAND_7>
+    <REFLECTANCE_ADD_BAND_8>-0.013857</REFLECTANCE_ADD_BAND_8>
+  </LEVEL1_RADIOMETRIC_RESCALING>
+  <LEVEL1_THERMAL_CONSTANTS>
+    <K1_CONSTANT_BAND_6_VCID_1>666.09</K1_CONSTANT_BAND_6_VCID_1>
+    <K2_CONSTANT_BAND_6_VCID_1>1282.71</K2_CONSTANT_BAND_6_VCID_1>
+    <K1_CONSTANT_BAND_6_VCID_2>666.09</K1_CONSTANT_BAND_6_VCID_2>
+    <K2_CONSTANT_BAND_6_VCID_2>1282.71</K2_CONSTANT_BAND_6_VCID_2>
+  </LEVEL1_THERMAL_CONSTANTS>
+  <LEVEL1_PROJECTION_PARAMETERS>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>15</UTM_ZONE>
+    <GRID_CELL_SIZE_PANCHROMATIC>15.00</GRID_CELL_SIZE_PANCHROMATIC>
+    <GRID_CELL_SIZE_REFLECTIVE>30.00</GRID_CELL_SIZE_REFLECTIVE>
+    <GRID_CELL_SIZE_THERMAL>30.00</GRID_CELL_SIZE_THERMAL>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <RESAMPLING_OPTION>CUBIC_CONVOLUTION</RESAMPLING_OPTION>
+    <SCAN_GAP_INTERPOLATION>2.0</SCAN_GAP_INTERPOLATION>
+  </LEVEL1_PROJECTION_PARAMETERS>
+  <PRODUCT_PARAMETERS>
+    <CORRECTION_GAIN_BAND_1>CPF</CORRECTION_GAIN_BAND_1>
+    <CORRECTION_GAIN_BAND_2>CPF</CORRECTION_GAIN_BAND_2>
+    <CORRECTION_GAIN_BAND_3>CPF</CORRECTION_GAIN_BAND_3>
+    <CORRECTION_GAIN_BAND_4>CPF</CORRECTION_GAIN_BAND_4>
+    <CORRECTION_GAIN_BAND_5>CPF</CORRECTION_GAIN_BAND_5>
+    <CORRECTION_GAIN_BAND_6_VCID_1>CPF</CORRECTION_GAIN_BAND_6_VCID_1>
+    <CORRECTION_GAIN_BAND_6_VCID_2>CPF</CORRECTION_GAIN_BAND_6_VCID_2>
+    <CORRECTION_GAIN_BAND_7>CPF</CORRECTION_GAIN_BAND_7>
+    <CORRECTION_GAIN_BAND_8>CPF</CORRECTION_GAIN_BAND_8>
+    <CORRECTION_BIAS_BAND_1>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_1>
+    <CORRECTION_BIAS_BAND_2>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_2>
+    <CORRECTION_BIAS_BAND_3>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_3>
+    <CORRECTION_BIAS_BAND_4>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_4>
+    <CORRECTION_BIAS_BAND_5>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_5>
+    <CORRECTION_BIAS_BAND_6_VCID_1>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_6_VCID_1>
+    <CORRECTION_BIAS_BAND_6_VCID_2>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_6_VCID_2>
+    <CORRECTION_BIAS_BAND_7>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_7>
+    <CORRECTION_BIAS_BAND_8>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_8>
+    <GAIN_BAND_1>H</GAIN_BAND_1>
+    <GAIN_BAND_2>H</GAIN_BAND_2>
+    <GAIN_BAND_3>H</GAIN_BAND_3>
+    <GAIN_BAND_4>L</GAIN_BAND_4>
+    <GAIN_BAND_5>H</GAIN_BAND_5>
+    <GAIN_BAND_6_VCID_1>L</GAIN_BAND_6_VCID_1>
+    <GAIN_BAND_6_VCID_2>H</GAIN_BAND_6_VCID_2>
+    <GAIN_BAND_7>L</GAIN_BAND_7>
+    <GAIN_BAND_8>L</GAIN_BAND_8>
+    <GAIN_CHANGE_BAND_1>HH</GAIN_CHANGE_BAND_1>
+    <GAIN_CHANGE_BAND_2>HH</GAIN_CHANGE_BAND_2>
+    <GAIN_CHANGE_BAND_3>HH</GAIN_CHANGE_BAND_3>
+    <GAIN_CHANGE_BAND_4>LL</GAIN_CHANGE_BAND_4>
+    <GAIN_CHANGE_BAND_5>HH</GAIN_CHANGE_BAND_5>
+    <GAIN_CHANGE_BAND_6_VCID_1>LL</GAIN_CHANGE_BAND_6_VCID_1>
+    <GAIN_CHANGE_BAND_6_VCID_2>HH</GAIN_CHANGE_BAND_6_VCID_2>
+    <GAIN_CHANGE_BAND_7>LL</GAIN_CHANGE_BAND_7>
+    <GAIN_CHANGE_BAND_8>LL</GAIN_CHANGE_BAND_8>
+    <GAIN_CHANGE_SCAN_BAND_1>0</GAIN_CHANGE_SCAN_BAND_1>
+    <GAIN_CHANGE_SCAN_BAND_2>0</GAIN_CHANGE_SCAN_BAND_2>
+    <GAIN_CHANGE_SCAN_BAND_3>0</GAIN_CHANGE_SCAN_BAND_3>
+    <GAIN_CHANGE_SCAN_BAND_4>0</GAIN_CHANGE_SCAN_BAND_4>
+    <GAIN_CHANGE_SCAN_BAND_5>0</GAIN_CHANGE_SCAN_BAND_5>
+    <GAIN_CHANGE_SCAN_BAND_6_VCID_1>0</GAIN_CHANGE_SCAN_BAND_6_VCID_1>
+    <GAIN_CHANGE_SCAN_BAND_6_VCID_2>0</GAIN_CHANGE_SCAN_BAND_6_VCID_2>
+    <GAIN_CHANGE_SCAN_BAND_7>0</GAIN_CHANGE_SCAN_BAND_7>
+    <GAIN_CHANGE_SCAN_BAND_8>0</GAIN_CHANGE_SCAN_BAND_8>
+  </PRODUCT_PARAMETERS>
+</LANDSAT_METADATA_FILE>
+"""
+
+
+x_size = 100
+y_size = 100
+date = datetime(2023, 8, 17, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="session")
+def area():
+    """Get the landsat 1 area def."""
+    pcs_id = "WGS84 / UTM zone 15N"
+    proj4_dict = {"proj": "utm", "zone": 15, "datum": "WGS84", "units": "m", "no_defs": None, "type": "crs"}
+    area_extent = (85785.0, 4680885.0, 336915.0, 4904115.0)
+    return AreaDefinition("geotiff_area", pcs_id, pcs_id,
+                          proj4_dict, x_size, y_size,
+                          area_extent)
+
+
+@pytest.fixture(scope="session")
+def b4_data():
+    """Get the data for the b4 channel."""
+    return da.random.randint(12000, 16000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+@pytest.fixture(scope="session")
+def b6_data():
+    """Get the data for the b6 channel."""
+    return da.random.randint(8000, 14000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+@pytest.fixture(scope="session")
+def rad_data():
+    """Get the data for the radiance channel."""
+    return da.random.randint(1, 10000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+def create_tif_file(data, name, area, filename):
+    """Create a tif file."""
+    data_array = xr.DataArray(data,
+                              dims=("y", "x"),
+                              attrs={"name": name,
+                                     "start_time": date})
+    scn = Scene()
+    scn["band_data"] = data_array
+    scn["band_data"].attrs["area"] = area
+    scn.save_dataset("band_data", writer="geotiff", enhance=False, fill_value=0,
+                     filename=os.fspath(filename))
+
+
+@pytest.fixture(scope="session")
+def files_path(tmp_path_factory):
+    """Create the path for l1 files."""
+    return tmp_path_factory.mktemp("etm_l2_files")
+
+
+@pytest.fixture(scope="session")
+def b4_file(files_path, b4_data, area):
+    """Create the file for the b4 channel."""
+    data = b4_data
+    filename = files_path / "LE07_L2SP_028030_20230817_20230912_02_T1_SR_B4.TIF"
+    name = "B4"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+@pytest.fixture(scope="session")
+def b6_file(files_path, b6_data, area):
+    """Create the file for the b6 channel."""
+    data = b6_data
+    filename = files_path / "LE07_L2SP_028030_20230817_20230912_02_T1_ST_B6.TIF"
+    name = "B6"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+@pytest.fixture(scope="session")
+def rad_file(files_path, rad_data, area):
+    """Create the file for the sza."""
+    data = rad_data
+    filename = files_path / "LE07_L2SP_028030_20230817_20230912_02_T1_ST_TRAD.TIF"
+    name = "TRAD"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+
+@pytest.fixture(scope="session")
+def mda_file(files_path):
+    """Create the metadata xml file."""
+    filename = files_path / "LE07_L2SP_028030_20230817_20230912_02_T1_MTL.xml"
+    with open(filename, "wb") as f:
+        f.write(metadata_text)
+    return os.fspath(filename)
+
+
+@pytest.fixture(scope="session")
+def all_files(b4_file, b6_file, mda_file, rad_file):
+    """Return all the files."""
+    return b4_file, b6_file, mda_file, rad_file
+
+
+@pytest.fixture(scope="session")
+def all_fsspec_files(b4_file, b6_file, mda_file, rad_file):
+    """Return all the files as FSFile objects."""
+    from fsspec.implementations.local import LocalFileSystem
+
+    from satpy.readers.core.remote import FSFile
+
+    fs = LocalFileSystem()
+    b4_file, b6_file, mda_file, rad_file = (
+        FSFile(os.path.abspath(file), fs=fs)
+        for file in [b4_file, b6_file, mda_file, rad_file]
+    )
+    return b4_file, b6_file, mda_file, rad_file
+
+
+class TestETML2:
+    """Test generic image reader."""
+
+    def setup_method(self, tmp_path):
+        """Set up the filename and filetype info dicts.."""
+        self.filename_info = dict(observation_date=datetime(2023, 8, 17),
+                                  platform_type="L",
+                                  process_level_correction="L2SP",
+                                  spacecraft_id="07",
+                                  data_type="E",
+                                  collection_id="02")
+        self.ftype_info = {"file_type": "granule_B4"}
+
+    def test_basicload(self, area, b4_file, b6_file, mda_file):
+        """Test loading a Landsat Scene."""
+        scn = Scene(reader="etm_l2_tif", filenames=[b4_file,
+                                                    b6_file,
+                                                    mda_file])
+        scn.load(["B4", "B6"])
+
+        # Check dataset is loaded correctly
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == area
+        assert scn["B4"].attrs["saturated"]
+        assert scn["B6"].shape == (100, 100)
+        assert scn["B6"].attrs["area"] == area
+        with pytest.raises(KeyError, match="saturated"):
+            assert not scn["B6"].attrs["saturated"]
+
+    def test_ch_startend(self, b4_file, mda_file):
+        """Test correct retrieval of start/end times."""
+        scn = Scene(reader="etm_l2_tif", filenames=[b4_file, mda_file])
+        bnds = scn.available_dataset_names()
+        assert bnds == ["B4"]
+
+        scn.load(["B4"])
+        assert scn.start_time == datetime(2023, 8, 17, 14, 54, 20, tzinfo=timezone.utc)
+        assert scn.end_time == datetime(2023, 8, 17, 14, 54, 20, tzinfo=timezone.utc)
+
+    def test_loading_gd(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with good channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import ETML2CHReader, ETML2MDReader
+        good_mda = ETML2MDReader(mda_file, self.filename_info, {})
+        rdr = ETML2CHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        # Check case with good file data and load request
+        rdr.get_dataset({"name": "B4", "calibration": "counts"}, {"standard_name": "test_data", "units": "test_units"})
+
+    def test_loading_badfil(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with bad channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import ETML2CHReader, ETML2MDReader
+        good_mda = ETML2MDReader(mda_file, self.filename_info, {})
+        rdr = ETML2CHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+        # Check case with request to load channel not matching filename
+        with pytest.raises(ValueError, match="Requested channel B5 does not match the reader channel B4"):
+            rdr.get_dataset({"name": "B5", "calibration": "counts"}, ftype)
+
+    def test_badfiles(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with bad data."""
+        from satpy.readers.oli_tirs_l1_tif import ETML2CHReader, ETML2MDReader
+        bad_fname_info = self.filename_info.copy()
+        bad_fname_info["platform_type"] = "B"
+
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+
+        # Test that metadata reader initialises with correct filename
+        good_mda = ETML2MDReader(mda_file, self.filename_info, ftype)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            ETML2MDReader(mda_file, bad_fname_info, ftype)
+
+        # Test that metadata reader initialises with correct filename
+        ETML2CHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            ETML2CHReader(b4_file, bad_fname_info, self.ftype_info, good_mda)
+        bad_ftype_info = self.ftype_info.copy()
+        bad_ftype_info["file_type"] = "granule-b05"
+        with pytest.raises(ValueError, match="Invalid file type: granule-b05"):
+            ETML2CHReader(b4_file, self.filename_info, bad_ftype_info, good_mda)
+
+    def test_calibration_counts(self, all_files, b4_data, b6_data, rad_data):
+        """Test counts calibration mode for the reader."""
+        from satpy import Scene
+
+        scn = Scene(reader="etm_l2_tif", filenames=all_files)
+        scn.load(["B4", "B6", "TRAD"], calibration="counts")
+        np.testing.assert_allclose(scn["B4"].values, b4_data)
+        np.testing.assert_allclose(scn["B6"].values, b6_data)
+        np.testing.assert_allclose(scn["TRAD"].values, rad_data)
+        assert scn["B4"].attrs["units"] == "1"
+        assert scn["B6"].attrs["units"] == "1"
+        assert scn["TRAD"].attrs["units"] == "1"
+        assert scn["B4"].attrs["standard_name"] == "counts"
+        assert scn["B6"].attrs["standard_name"] == "counts"
+        assert scn["TRAD"].attrs["standard_name"] == "counts"
+
+    def test_calibration_highlevel(self, all_files, b4_data, b6_data, rad_data):
+        """Test high level calibration modes for the reader."""
+        from satpy import Scene
+        exp_b04 = (b4_data * 2.75e-05 - 0.2).astype(np.float32) * 100
+        exp_b6 = (b6_data * 0.00341802 + 149.0).astype(np.float32)
+        exp_rad = (rad_data * 0.001).astype(np.float32)
+        scn = Scene(reader="etm_l2_tif", filenames=all_files)
+        scn.load(["B4", "B6", "TRAD"])
+
+        assert scn["B4"].attrs["units"] == "%"
+        assert scn["B6"].attrs["units"] == "K"
+        assert scn["TRAD"].attrs["units"] == "W m-2 um-1 sr-1"
+        assert scn["B4"].attrs["standard_name"] == "surface_bidirectional_reflectance"
+        assert scn["B6"].attrs["standard_name"] == "brightness_temperature"
+        assert scn["TRAD"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
+        np.testing.assert_allclose(np.array(scn["B4"].values), np.array(exp_b04), rtol=1e-4)
+        np.testing.assert_allclose(scn["B6"].values, exp_b6, rtol=1e-6)
+        np.testing.assert_allclose(scn["TRAD"].values, exp_rad, rtol=1e-6)
+
+    def test_metadata(self, mda_file):
+        """Check that metadata values loaded correctly."""
+        from satpy.readers.oli_tirs_l1_tif import ETML2MDReader
+        mda = ETML2MDReader(mda_file, self.filename_info, {})
+
+        cal_test_dict = {"B1": (2.75e-05, -0.2),
+                         "B5": (2.75e-05, -0.2),
+                         "B6": (0.00341802, 149.0)}
+
+        assert mda.platform_name == "Landsat-7"
+        assert mda.earth_sun_distance() == 1.0124651
+        assert mda.band_calibration["B1"] == cal_test_dict["B1"]
+        assert mda.band_calibration["B5"] == cal_test_dict["B5"]
+        assert mda.band_calibration["B6"] == cal_test_dict["B6"]
+        assert not mda.band_saturation["B1"]
+        assert mda.band_saturation["B4"]
+        assert not mda.band_saturation["B5"]
+        with pytest.raises(KeyError):
+            mda.band_saturation["B6"]
+
+    def test_area_def(self, mda_file):
+        """Check we can get the area defs properly."""
+        from satpy.readers.oli_tirs_l1_tif import ETML2MDReader
+        mda = ETML2MDReader(mda_file, self.filename_info, {})
+
+        standard_area = mda.build_area_def("B1")
+
+        assert standard_area.area_extent == (85785.0, 4680885.0, 336915.0, 4904115.0)
+
+    def test_basicload_remote(self, area, all_fsspec_files):
+        """Test loading a Landsat Scene from a fsspec filesystem."""
+        scn = Scene(reader="etm_l2_tif", filenames=all_fsspec_files)
+        scn.load(["B4", "B6"])
+
+        # Check dataset is loaded correctly
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == area
+        assert scn["B4"].attrs["saturated"]
+        assert scn["B6"].shape == (100, 100)
+        assert scn["B6"].attrs["area"] == area
+        with pytest.raises(KeyError, match="saturated"):
+            assert not scn["B6"].attrs["saturated"]

--- a/satpy/tests/reader_tests/test_mss_l1_tif.py
+++ b/satpy/tests/reader_tests/test_mss_l1_tif.py
@@ -1,0 +1,856 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Unittests for generic image reader."""
+
+import os
+from datetime import datetime, timezone
+
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+from pyresample.geometry import AreaDefinition
+
+from satpy import Scene
+
+l1_metadata_text = b"""<?xml version="1.0" encoding="UTF-8"?>
+<LANDSAT_METADATA_FILE>
+  <PRODUCT_CONTENTS>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P9AF14YV</DIGITAL_OBJECT_IDENTIFIER>
+    <LANDSAT_PRODUCT_ID>LM01_L1TP_032030_19720729_20200909_02_T2</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L1TP</PROCESSING_LEVEL>
+    <COLLECTION_NUMBER>02</COLLECTION_NUMBER>
+    <COLLECTION_CATEGORY>T2</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <FILE_NAME_BAND_4>LM01_L1TP_032030_19720729_20200909_02_T2_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_BAND_5>LM01_L1TP_032030_19720729_20200909_02_T2_B5.TIF</FILE_NAME_BAND_5>
+    <FILE_NAME_BAND_6>LM01_L1TP_032030_19720729_20200909_02_T2_B6.TIF</FILE_NAME_BAND_6>
+    <FILE_NAME_BAND_7>LM01_L1TP_032030_19720729_20200909_02_T2_B7.TIF</FILE_NAME_BAND_7>
+    <FILE_NAME_QUALITY_L1_PIXEL>LM01_L1TP_032030_19720729_20200909_02_T2_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LM01_L1TP_032030_19720729_20200909_02_T2_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_GROUND_CONTROL_POINT>LM01_L1TP_032030_19720729_20200909_02_T2_GCP.txt</FILE_NAME_GROUND_CONTROL_POINT>
+    <FILE_NAME_METADATA_ODL>LM01_L1TP_032030_19720729_20200909_02_T2_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LM01_L1TP_032030_19720729_20200909_02_T2_MTL.xml</FILE_NAME_METADATA_XML>
+    <FILE_NAME_VERIFY_REPORT>LM01_L1TP_032030_19720729_20200909_02_T2_VER.txt</FILE_NAME_VERIFY_REPORT>
+    <FILE_NAME_VERIFY_BROWSE>LM01_L1TP_032030_19720729_20200909_02_T2_VER.jpg</FILE_NAME_VERIFY_BROWSE>
+    <DATA_TYPE_BAND_4>UINT8</DATA_TYPE_BAND_4>
+    <DATA_TYPE_BAND_5>UINT8</DATA_TYPE_BAND_5>
+    <DATA_TYPE_BAND_6>UINT8</DATA_TYPE_BAND_6>
+    <DATA_TYPE_BAND_7>UINT8</DATA_TYPE_BAND_7>
+    <DATA_TYPE_QUALITY_L1_PIXEL>UINT16</DATA_TYPE_QUALITY_L1_PIXEL>
+    <DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>UINT16</DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <PRESENT_BAND_4>Y</PRESENT_BAND_4>
+    <PRESENT_BAND_5>Y</PRESENT_BAND_5>
+    <PRESENT_BAND_6>Y</PRESENT_BAND_6>
+    <PRESENT_BAND_7>Y</PRESENT_BAND_7>
+  </PRODUCT_CONTENTS>
+  <IMAGE_ATTRIBUTES>
+    <SPACECRAFT_ID>LANDSAT_1</SPACECRAFT_ID>
+    <SENSOR_ID>MSS</SENSOR_ID>
+    <WRS_TYPE>1</WRS_TYPE>
+    <WRS_PATH>032</WRS_PATH>
+    <WRS_ROW>030</WRS_ROW>
+    <DATE_ACQUIRED>1972-07-29</DATE_ACQUIRED>
+    <SCENE_CENTER_TIME>16:49:31.7330000Z</SCENE_CENTER_TIME>
+    <STATION_ID>AAA</STATION_ID>
+    <CLOUD_COVER>0.00</CLOUD_COVER>
+    <CLOUD_COVER_LAND>0.00</CLOUD_COVER_LAND>
+    <IMAGE_QUALITY>-1</IMAGE_QUALITY>
+    <SATURATION_BAND_4>N</SATURATION_BAND_4>
+    <SATURATION_BAND_5>Y</SATURATION_BAND_5>
+    <SATURATION_BAND_6>Y</SATURATION_BAND_6>
+    <SATURATION_BAND_7>N</SATURATION_BAND_7>
+    <SUN_AZIMUTH>128.00842031</SUN_AZIMUTH>
+    <SUN_ELEVATION>56.29977419</SUN_ELEVATION>
+    <EARTH_SUN_DISTANCE>1.0152109</EARTH_SUN_DISTANCE>
+  </IMAGE_ATTRIBUTES>
+  <PROJECTION_ATTRIBUTES>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>14</UTM_ZONE>
+    <GRID_CELL_SIZE_REFLECTIVE>60.00</GRID_CELL_SIZE_REFLECTIVE>
+    <REFLECTIVE_LINES>100</REFLECTIVE_LINES>
+    <REFLECTIVE_SAMPLES>100</REFLECTIVE_SAMPLES>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <CORNER_UL_LAT_PRODUCT>44.14255</CORNER_UL_LAT_PRODUCT>
+    <CORNER_UL_LON_PRODUCT>-99.72341</CORNER_UL_LON_PRODUCT>
+    <CORNER_UR_LAT_PRODUCT>44.12425</CORNER_UR_LAT_PRODUCT>
+    <CORNER_UR_LON_PRODUCT>-96.83145</CORNER_UR_LON_PRODUCT>
+    <CORNER_LL_LAT_PRODUCT>42.15821</CORNER_LL_LAT_PRODUCT>
+    <CORNER_LL_LON_PRODUCT>-99.70038</CORNER_LL_LON_PRODUCT>
+    <CORNER_LR_LAT_PRODUCT>42.14114</CORNER_LR_LAT_PRODUCT>
+    <CORNER_LR_LON_PRODUCT>-96.90044</CORNER_LR_LON_PRODUCT>
+    <CORNER_UL_PROJECTION_X_PRODUCT>442140.000</CORNER_UL_PROJECTION_X_PRODUCT>
+    <CORNER_UL_PROJECTION_Y_PRODUCT>4887960.000</CORNER_UL_PROJECTION_Y_PRODUCT>
+    <CORNER_UR_PROJECTION_X_PRODUCT>673500.000</CORNER_UR_PROJECTION_X_PRODUCT>
+    <CORNER_UR_PROJECTION_Y_PRODUCT>4887960.000</CORNER_UR_PROJECTION_Y_PRODUCT>
+    <CORNER_LL_PROJECTION_X_PRODUCT>442140.000</CORNER_LL_PROJECTION_X_PRODUCT>
+    <CORNER_LL_PROJECTION_Y_PRODUCT>4667580.000</CORNER_LL_PROJECTION_Y_PRODUCT>
+    <CORNER_LR_PROJECTION_X_PRODUCT>673500.000</CORNER_LR_PROJECTION_X_PRODUCT>
+    <CORNER_LR_PROJECTION_Y_PRODUCT>4667580.000</CORNER_LR_PROJECTION_Y_PRODUCT>
+  </PROJECTION_ATTRIBUTES>
+  <LEVEL1_PROCESSING_RECORD>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P9AF14YV</DIGITAL_OBJECT_IDENTIFIER>
+    <REQUEST_ID>L2</REQUEST_ID>
+    <LANDSAT_SCENE_ID>LM10320301972211AAA04</LANDSAT_SCENE_ID>
+    <LANDSAT_PRODUCT_ID>LM01_L1TP_032030_19720729_20200909_02_T2</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L1TP</PROCESSING_LEVEL>
+    <COLLECTION_CATEGORY>T2</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <DATE_PRODUCT_GENERATED>2020-09-09T16:01:31Z</DATE_PRODUCT_GENERATED>
+    <PROCESSING_SOFTWARE_VERSION>LPGS_15.3.1c</PROCESSING_SOFTWARE_VERSION>
+    <FILE_NAME_BAND_4>LM01_L1TP_032030_19720729_20200909_02_T2_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_BAND_5>LM01_L1TP_032030_19720729_20200909_02_T2_B5.TIF</FILE_NAME_BAND_5>
+    <FILE_NAME_BAND_6>LM01_L1TP_032030_19720729_20200909_02_T2_B6.TIF</FILE_NAME_BAND_6>
+    <FILE_NAME_BAND_7>LM01_L1TP_032030_19720729_20200909_02_T2_B7.TIF</FILE_NAME_BAND_7>
+    <FILE_NAME_QUALITY_L1_PIXEL>LM01_L1TP_032030_19720729_20200909_02_T2_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LM01_L1TP_032030_19720729_20200909_02_T2_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_GROUND_CONTROL_POINT>LM01_L1TP_032030_19720729_20200909_02_T2_GCP.txt</FILE_NAME_GROUND_CONTROL_POINT>
+    <FILE_NAME_METADATA_ODL>LM01_L1TP_032030_19720729_20200909_02_T2_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LM01_L1TP_032030_19720729_20200909_02_T2_MTL.xml</FILE_NAME_METADATA_XML>
+    <FILE_NAME_CPF>LM01CPF_19720723_19780107_02.01</FILE_NAME_CPF>
+    <FILE_NAME_VERIFY_REPORT>LM01_L1TP_032030_19720729_20200909_02_T2_VER.txt</FILE_NAME_VERIFY_REPORT>
+    <FILE_NAME_VERIFY_BROWSE>LM01_L1TP_032030_19720729_20200909_02_T2_VER.jpg</FILE_NAME_VERIFY_BROWSE>
+    <DATA_SOURCE_ELEVATION>GLS2000</DATA_SOURCE_ELEVATION>
+    <GROUND_CONTROL_POINTS_VERSION>5</GROUND_CONTROL_POINTS_VERSION>
+    <GROUND_CONTROL_POINTS_MODEL>26</GROUND_CONTROL_POINTS_MODEL>
+    <GEOMETRIC_RMSE_MODEL>80.835</GEOMETRIC_RMSE_MODEL>
+    <GEOMETRIC_RMSE_MODEL_Y>37.450</GEOMETRIC_RMSE_MODEL_Y>
+    <GEOMETRIC_RMSE_MODEL_X>71.636</GEOMETRIC_RMSE_MODEL_X>
+    <GROUND_CONTROL_POINTS_VERIFY>53</GROUND_CONTROL_POINTS_VERIFY>
+    <GEOMETRIC_RMSE_VERIFY>0.944</GEOMETRIC_RMSE_VERIFY>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_UL>0.770</GEOMETRIC_RMSE_VERIFY_QUAD_UL>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_UR>1.495</GEOMETRIC_RMSE_VERIFY_QUAD_UR>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_LL>0.842</GEOMETRIC_RMSE_VERIFY_QUAD_LL>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_LR>1.049</GEOMETRIC_RMSE_VERIFY_QUAD_LR>
+    <EPHEMERIS_TYPE>PREDICTIVE</EPHEMERIS_TYPE>
+  </LEVEL1_PROCESSING_RECORD>
+  <LEVEL1_MIN_MAX_RADIANCE>
+    <RADIANCE_MAXIMUM_BAND_4>225.200</RADIANCE_MAXIMUM_BAND_4>
+    <RADIANCE_MINIMUM_BAND_4>-17.600</RADIANCE_MINIMUM_BAND_4>
+    <RADIANCE_MAXIMUM_BAND_5>164.600</RADIANCE_MAXIMUM_BAND_5>
+    <RADIANCE_MINIMUM_BAND_5>-0.100</RADIANCE_MINIMUM_BAND_5>
+    <RADIANCE_MAXIMUM_BAND_6>165.600</RADIANCE_MAXIMUM_BAND_6>
+    <RADIANCE_MINIMUM_BAND_6>-0.100</RADIANCE_MINIMUM_BAND_6>
+    <RADIANCE_MAXIMUM_BAND_7>154.600</RADIANCE_MAXIMUM_BAND_7>
+    <RADIANCE_MINIMUM_BAND_7>0.000</RADIANCE_MINIMUM_BAND_7>
+  </LEVEL1_MIN_MAX_RADIANCE>
+  <LEVEL1_MIN_MAX_REFLECTANCE>
+    <REFLECTANCE_MAXIMUM_BAND_4>0.407132</REFLECTANCE_MAXIMUM_BAND_4>
+    <REFLECTANCE_MINIMUM_BAND_4>-0.031818</REFLECTANCE_MINIMUM_BAND_4>
+    <REFLECTANCE_MAXIMUM_BAND_5>0.346752</REFLECTANCE_MAXIMUM_BAND_5>
+    <REFLECTANCE_MINIMUM_BAND_5>-0.000211</REFLECTANCE_MINIMUM_BAND_5>
+    <REFLECTANCE_MAXIMUM_BAND_6>0.420875</REFLECTANCE_MAXIMUM_BAND_6>
+    <REFLECTANCE_MINIMUM_BAND_6>-0.000254</REFLECTANCE_MINIMUM_BAND_6>
+    <REFLECTANCE_MAXIMUM_BAND_7>0.591490</REFLECTANCE_MAXIMUM_BAND_7>
+    <REFLECTANCE_MINIMUM_BAND_7>0.000000</REFLECTANCE_MINIMUM_BAND_7>
+  </LEVEL1_MIN_MAX_REFLECTANCE>
+  <LEVEL1_MIN_MAX_PIXEL_VALUE>
+    <QUANTIZE_CAL_MAX_BAND_4>255</QUANTIZE_CAL_MAX_BAND_4>
+    <QUANTIZE_CAL_MIN_BAND_4>1</QUANTIZE_CAL_MIN_BAND_4>
+    <QUANTIZE_CAL_MAX_BAND_5>255</QUANTIZE_CAL_MAX_BAND_5>
+    <QUANTIZE_CAL_MIN_BAND_5>1</QUANTIZE_CAL_MIN_BAND_5>
+    <QUANTIZE_CAL_MAX_BAND_6>255</QUANTIZE_CAL_MAX_BAND_6>
+    <QUANTIZE_CAL_MIN_BAND_6>1</QUANTIZE_CAL_MIN_BAND_6>
+    <QUANTIZE_CAL_MAX_BAND_7>255</QUANTIZE_CAL_MAX_BAND_7>
+    <QUANTIZE_CAL_MIN_BAND_7>1</QUANTIZE_CAL_MIN_BAND_7>
+  </LEVEL1_MIN_MAX_PIXEL_VALUE>
+  <LEVEL1_RADIOMETRIC_RESCALING>
+    <RADIANCE_MULT_BAND_4>9.5591E-01</RADIANCE_MULT_BAND_4>
+    <RADIANCE_MULT_BAND_5>6.4843E-01</RADIANCE_MULT_BAND_5>
+    <RADIANCE_MULT_BAND_6>6.5236E-01</RADIANCE_MULT_BAND_6>
+    <RADIANCE_MULT_BAND_7>6.0866E-01</RADIANCE_MULT_BAND_7>
+    <RADIANCE_ADD_BAND_4>-18.55591</RADIANCE_ADD_BAND_4>
+    <RADIANCE_ADD_BAND_5>-0.74843</RADIANCE_ADD_BAND_5>
+    <RADIANCE_ADD_BAND_6>-0.75236</RADIANCE_ADD_BAND_6>
+    <RADIANCE_ADD_BAND_7>-0.60866</RADIANCE_ADD_BAND_7>
+    <REFLECTANCE_MULT_BAND_4>1.7282E-03</REFLECTANCE_MULT_BAND_4>
+    <REFLECTANCE_MULT_BAND_5>1.3660E-03</REFLECTANCE_MULT_BAND_5>
+    <REFLECTANCE_MULT_BAND_6>1.6580E-03</REFLECTANCE_MULT_BAND_6>
+    <REFLECTANCE_MULT_BAND_7>2.3287E-03</REFLECTANCE_MULT_BAND_7>
+    <REFLECTANCE_ADD_BAND_4>-0.033547</REFLECTANCE_ADD_BAND_4>
+    <REFLECTANCE_ADD_BAND_5>-0.001577</REFLECTANCE_ADD_BAND_5>
+    <REFLECTANCE_ADD_BAND_6>-0.001912</REFLECTANCE_ADD_BAND_6>
+    <REFLECTANCE_ADD_BAND_7>-0.002329</REFLECTANCE_ADD_BAND_7>
+  </LEVEL1_RADIOMETRIC_RESCALING>
+  <LEVEL1_PROJECTION_PARAMETERS>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>14</UTM_ZONE>
+    <GRID_CELL_SIZE_REFLECTIVE>60.00</GRID_CELL_SIZE_REFLECTIVE>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <RESAMPLING_OPTION>CUBIC_CONVOLUTION</RESAMPLING_OPTION>
+    <MAP_PROJECTION_L0RA>SOM</MAP_PROJECTION_L0RA>
+  </LEVEL1_PROJECTION_PARAMETERS>
+  <PRODUCT_PARAMETERS>
+    <DATA_TYPE_L0RP>MSSX_L0RP</DATA_TYPE_L0RP>
+    <CORRECTION_GAIN_BAND_4>CPF</CORRECTION_GAIN_BAND_4>
+    <CORRECTION_GAIN_BAND_5>CPF</CORRECTION_GAIN_BAND_5>
+    <CORRECTION_GAIN_BAND_6>CPF</CORRECTION_GAIN_BAND_6>
+    <CORRECTION_GAIN_BAND_7>CPF</CORRECTION_GAIN_BAND_7>
+    <GAIN_BAND_4>L</GAIN_BAND_4>
+    <GAIN_BAND_5>L</GAIN_BAND_5>
+    <GAIN_BAND_6>L</GAIN_BAND_6>
+    <GAIN_BAND_7>L</GAIN_BAND_7>
+  </PRODUCT_PARAMETERS>
+</LANDSAT_METADATA_FILE>
+"""
+
+
+l4_metadata_text = b"""<?xml version="1.0" encoding="UTF-8"?>
+<LANDSAT_METADATA_FILE>
+  <PRODUCT_CONTENTS>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P9AF14YV</DIGITAL_OBJECT_IDENTIFIER>
+    <LANDSAT_PRODUCT_ID>LM04_L1TP_029030_19840415_20200903_02_T2</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L1TP</PROCESSING_LEVEL>
+    <COLLECTION_NUMBER>02</COLLECTION_NUMBER>
+    <COLLECTION_CATEGORY>T2</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <FILE_NAME_BAND_1>LM04_L1TP_029030_19840415_20200903_02_T2_B1.TIF</FILE_NAME_BAND_1>
+    <FILE_NAME_BAND_2>LM04_L1TP_029030_19840415_20200903_02_T2_B2.TIF</FILE_NAME_BAND_2>
+    <FILE_NAME_BAND_3>LM04_L1TP_029030_19840415_20200903_02_T2_B3.TIF</FILE_NAME_BAND_3>
+    <FILE_NAME_BAND_4>LM04_L1TP_029030_19840415_20200903_02_T2_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_QUALITY_L1_PIXEL>LM04_L1TP_029030_19840415_20200903_02_T2_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LM04_L1TP_029030_19840415_20200903_02_T2_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_GROUND_CONTROL_POINT>LM04_L1TP_029030_19840415_20200903_02_T2_GCP.txt</FILE_NAME_GROUND_CONTROL_POINT>
+    <FILE_NAME_METADATA_ODL>LM04_L1TP_029030_19840415_20200903_02_T2_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LM04_L1TP_029030_19840415_20200903_02_T2_MTL.xml</FILE_NAME_METADATA_XML>
+    <FILE_NAME_VERIFY_REPORT>LM04_L1TP_029030_19840415_20200903_02_T2_VER.txt</FILE_NAME_VERIFY_REPORT>
+    <FILE_NAME_VERIFY_BROWSE>LM04_L1TP_029030_19840415_20200903_02_T2_VER.jpg</FILE_NAME_VERIFY_BROWSE>
+    <DATA_TYPE_BAND_1>UINT8</DATA_TYPE_BAND_1>
+    <DATA_TYPE_BAND_2>UINT8</DATA_TYPE_BAND_2>
+    <DATA_TYPE_BAND_3>UINT8</DATA_TYPE_BAND_3>
+    <DATA_TYPE_BAND_4>UINT8</DATA_TYPE_BAND_4>
+    <DATA_TYPE_QUALITY_L1_PIXEL>UINT16</DATA_TYPE_QUALITY_L1_PIXEL>
+    <DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>UINT16</DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <PRESENT_BAND_1>Y</PRESENT_BAND_1>
+    <PRESENT_BAND_2>Y</PRESENT_BAND_2>
+    <PRESENT_BAND_3>Y</PRESENT_BAND_3>
+    <PRESENT_BAND_4>Y</PRESENT_BAND_4>
+  </PRODUCT_CONTENTS>
+  <IMAGE_ATTRIBUTES>
+    <SPACECRAFT_ID>LANDSAT_4</SPACECRAFT_ID>
+    <SENSOR_ID>MSS</SENSOR_ID>
+    <WRS_TYPE>2</WRS_TYPE>
+    <WRS_PATH>029</WRS_PATH>
+    <WRS_ROW>030</WRS_ROW>
+    <DATE_ACQUIRED>1984-04-15</DATE_ACQUIRED>
+    <SCENE_CENTER_TIME>16:38:15.9750000Z</SCENE_CENTER_TIME>
+    <STATION_ID>AAA</STATION_ID>
+    <CLOUD_COVER>2.00</CLOUD_COVER>
+    <CLOUD_COVER_LAND>2.00</CLOUD_COVER_LAND>
+    <IMAGE_QUALITY>5</IMAGE_QUALITY>
+    <SATURATION_BAND_1>N</SATURATION_BAND_1>
+    <SATURATION_BAND_2>Y</SATURATION_BAND_2>
+    <SATURATION_BAND_3>Y</SATURATION_BAND_3>
+    <SATURATION_BAND_4>N</SATURATION_BAND_4>
+    <SUN_AZIMUTH>135.96433420</SUN_AZIMUTH>
+    <SUN_ELEVATION>49.08760662</SUN_ELEVATION>
+    <EARTH_SUN_DISTANCE>1.0035512</EARTH_SUN_DISTANCE>
+  </IMAGE_ATTRIBUTES>
+  <PROJECTION_ATTRIBUTES>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>14</UTM_ZONE>
+    <GRID_CELL_SIZE_REFLECTIVE>60.00</GRID_CELL_SIZE_REFLECTIVE>
+    <REFLECTIVE_LINES>100</REFLECTIVE_LINES>
+    <REFLECTIVE_SAMPLES>100</REFLECTIVE_SAMPLES>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <CORNER_UL_LAT_PRODUCT>44.14698</CORNER_UL_LAT_PRODUCT>
+    <CORNER_UL_LON_PRODUCT>-98.49910</CORNER_UL_LON_PRODUCT>
+    <CORNER_UR_LAT_PRODUCT>44.09661</CORNER_UR_LAT_PRODUCT>
+    <CORNER_UR_LON_PRODUCT>-95.57170</CORNER_UR_LON_PRODUCT>
+    <CORNER_LL_LAT_PRODUCT>42.27118</CORNER_LL_LAT_PRODUCT>
+    <CORNER_LL_LON_PRODUCT>-98.51422</CORNER_LL_LON_PRODUCT>
+    <CORNER_LR_LAT_PRODUCT>42.22399</CORNER_LR_LAT_PRODUCT>
+    <CORNER_LR_LON_PRODUCT>-95.67495</CORNER_LR_LON_PRODUCT>
+    <CORNER_UL_PROJECTION_X_PRODUCT>540060.000</CORNER_UL_PROJECTION_X_PRODUCT>
+    <CORNER_UL_PROJECTION_Y_PRODUCT>4888320.000</CORNER_UL_PROJECTION_Y_PRODUCT>
+    <CORNER_UR_PROJECTION_X_PRODUCT>774420.000</CORNER_UR_PROJECTION_X_PRODUCT>
+    <CORNER_UR_PROJECTION_Y_PRODUCT>4888320.000</CORNER_UR_PROJECTION_Y_PRODUCT>
+    <CORNER_LL_PROJECTION_X_PRODUCT>540060.000</CORNER_LL_PROJECTION_X_PRODUCT>
+    <CORNER_LL_PROJECTION_Y_PRODUCT>4680000.000</CORNER_LL_PROJECTION_Y_PRODUCT>
+    <CORNER_LR_PROJECTION_X_PRODUCT>774420.000</CORNER_LR_PROJECTION_X_PRODUCT>
+    <CORNER_LR_PROJECTION_Y_PRODUCT>4680000.000</CORNER_LR_PROJECTION_Y_PRODUCT>
+  </PROJECTION_ATTRIBUTES>
+  <LEVEL1_PROCESSING_RECORD>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P9AF14YV</DIGITAL_OBJECT_IDENTIFIER>
+    <REQUEST_ID>L2</REQUEST_ID>
+    <LANDSAT_SCENE_ID>LM40290301984106AAA03</LANDSAT_SCENE_ID>
+    <LANDSAT_PRODUCT_ID>LM04_L1TP_029030_19840415_20200903_02_T2</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L1TP</PROCESSING_LEVEL>
+    <COLLECTION_CATEGORY>T2</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <DATE_PRODUCT_GENERATED>2020-09-03T04:50:06Z</DATE_PRODUCT_GENERATED>
+    <PROCESSING_SOFTWARE_VERSION>LPGS_15.3.1c</PROCESSING_SOFTWARE_VERSION>
+    <FILE_NAME_BAND_1>LM04_L1TP_029030_19840415_20200903_02_T2_B1.TIF</FILE_NAME_BAND_1>
+    <FILE_NAME_BAND_2>LM04_L1TP_029030_19840415_20200903_02_T2_B2.TIF</FILE_NAME_BAND_2>
+    <FILE_NAME_BAND_3>LM04_L1TP_029030_19840415_20200903_02_T2_B3.TIF</FILE_NAME_BAND_3>
+    <FILE_NAME_BAND_4>LM04_L1TP_029030_19840415_20200903_02_T2_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_QUALITY_L1_PIXEL>LM04_L1TP_029030_19840415_20200903_02_T2_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LM04_L1TP_029030_19840415_20200903_02_T2_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_GROUND_CONTROL_POINT>LM04_L1TP_029030_19840415_20200903_02_T2_GCP.txt</FILE_NAME_GROUND_CONTROL_POINT>
+    <FILE_NAME_METADATA_ODL>LM04_L1TP_029030_19840415_20200903_02_T2_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LM04_L1TP_029030_19840415_20200903_02_T2_MTL.xml</FILE_NAME_METADATA_XML>
+    <FILE_NAME_CPF>LM04CPF_19830401_19931231_02.01</FILE_NAME_CPF>
+    <FILE_NAME_VERIFY_REPORT>LM04_L1TP_029030_19840415_20200903_02_T2_VER.txt</FILE_NAME_VERIFY_REPORT>
+    <FILE_NAME_VERIFY_BROWSE>LM04_L1TP_029030_19840415_20200903_02_T2_VER.jpg</FILE_NAME_VERIFY_BROWSE>
+    <DATA_SOURCE_ELEVATION>GLS2000</DATA_SOURCE_ELEVATION>
+    <GROUND_CONTROL_POINTS_VERSION>5</GROUND_CONTROL_POINTS_VERSION>
+    <GROUND_CONTROL_POINTS_MODEL>201</GROUND_CONTROL_POINTS_MODEL>
+    <GEOMETRIC_RMSE_MODEL>19.942</GEOMETRIC_RMSE_MODEL>
+    <GEOMETRIC_RMSE_MODEL_Y>14.470</GEOMETRIC_RMSE_MODEL_Y>
+    <GEOMETRIC_RMSE_MODEL_X>13.722</GEOMETRIC_RMSE_MODEL_X>
+    <GROUND_CONTROL_POINTS_VERIFY>348</GROUND_CONTROL_POINTS_VERIFY>
+    <GEOMETRIC_RMSE_VERIFY>0.275</GEOMETRIC_RMSE_VERIFY>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_UL>0.259</GEOMETRIC_RMSE_VERIFY_QUAD_UL>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_UR>0.344</GEOMETRIC_RMSE_VERIFY_QUAD_UR>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_LL>0.291</GEOMETRIC_RMSE_VERIFY_QUAD_LL>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_LR>0.302</GEOMETRIC_RMSE_VERIFY_QUAD_LR>
+    <EPHEMERIS_TYPE>PREDICTIVE</EPHEMERIS_TYPE>
+  </LEVEL1_PROCESSING_RECORD>
+  <LEVEL1_MIN_MAX_RADIANCE>
+    <RADIANCE_MAXIMUM_BAND_1>226.100</RADIANCE_MAXIMUM_BAND_1>
+    <RADIANCE_MINIMUM_BAND_1>3.800</RADIANCE_MINIMUM_BAND_1>
+    <RADIANCE_MAXIMUM_BAND_2>161.200</RADIANCE_MAXIMUM_BAND_2>
+    <RADIANCE_MINIMUM_BAND_2>3.700</RADIANCE_MINIMUM_BAND_2>
+    <RADIANCE_MAXIMUM_BAND_3>144.600</RADIANCE_MAXIMUM_BAND_3>
+    <RADIANCE_MINIMUM_BAND_3>5.100</RADIANCE_MINIMUM_BAND_3>
+    <RADIANCE_MAXIMUM_BAND_4>125.300</RADIANCE_MAXIMUM_BAND_4>
+    <RADIANCE_MINIMUM_BAND_4>4.300</RADIANCE_MINIMUM_BAND_4>
+  </LEVEL1_MIN_MAX_RADIANCE>
+  <LEVEL1_MIN_MAX_REFLECTANCE>
+    <REFLECTANCE_MAXIMUM_BAND_1>0.405078</REFLECTANCE_MAXIMUM_BAND_1>
+    <REFLECTANCE_MINIMUM_BAND_1>0.006808</REFLECTANCE_MINIMUM_BAND_1>
+    <REFLECTANCE_MAXIMUM_BAND_2>0.334445</REFLECTANCE_MAXIMUM_BAND_2>
+    <REFLECTANCE_MINIMUM_BAND_2>0.007676</REFLECTANCE_MINIMUM_BAND_2>
+    <REFLECTANCE_MAXIMUM_BAND_3>0.370451</REFLECTANCE_MAXIMUM_BAND_3>
+    <REFLECTANCE_MINIMUM_BAND_3>0.013066</REFLECTANCE_MINIMUM_BAND_3>
+    <REFLECTANCE_MAXIMUM_BAND_4>0.472236</REFLECTANCE_MAXIMUM_BAND_4>
+    <REFLECTANCE_MINIMUM_BAND_4>0.016206</REFLECTANCE_MINIMUM_BAND_4>
+  </LEVEL1_MIN_MAX_REFLECTANCE>
+  <LEVEL1_MIN_MAX_PIXEL_VALUE>
+    <QUANTIZE_CAL_MAX_BAND_1>255</QUANTIZE_CAL_MAX_BAND_1>
+    <QUANTIZE_CAL_MIN_BAND_1>1</QUANTIZE_CAL_MIN_BAND_1>
+    <QUANTIZE_CAL_MAX_BAND_2>255</QUANTIZE_CAL_MAX_BAND_2>
+    <QUANTIZE_CAL_MIN_BAND_2>1</QUANTIZE_CAL_MIN_BAND_2>
+    <QUANTIZE_CAL_MAX_BAND_3>255</QUANTIZE_CAL_MAX_BAND_3>
+    <QUANTIZE_CAL_MIN_BAND_3>1</QUANTIZE_CAL_MIN_BAND_3>
+    <QUANTIZE_CAL_MAX_BAND_4>255</QUANTIZE_CAL_MAX_BAND_4>
+    <QUANTIZE_CAL_MIN_BAND_4>1</QUANTIZE_CAL_MIN_BAND_4>
+  </LEVEL1_MIN_MAX_PIXEL_VALUE>
+  <LEVEL1_RADIOMETRIC_RESCALING>
+    <RADIANCE_MULT_BAND_1>8.7520E-01</RADIANCE_MULT_BAND_1>
+    <RADIANCE_MULT_BAND_2>6.2008E-01</RADIANCE_MULT_BAND_2>
+    <RADIANCE_MULT_BAND_3>5.4921E-01</RADIANCE_MULT_BAND_3>
+    <RADIANCE_MULT_BAND_4>4.7638E-01</RADIANCE_MULT_BAND_4>
+    <RADIANCE_ADD_BAND_1>2.92480</RADIANCE_ADD_BAND_1>
+    <RADIANCE_ADD_BAND_2>3.07992</RADIANCE_ADD_BAND_2>
+    <RADIANCE_ADD_BAND_3>4.55079</RADIANCE_ADD_BAND_3>
+    <RADIANCE_ADD_BAND_4>3.82362</RADIANCE_ADD_BAND_4>
+    <REFLECTANCE_MULT_BAND_1>1.5680E-03</REFLECTANCE_MULT_BAND_1>
+    <REFLECTANCE_MULT_BAND_2>1.2865E-03</REFLECTANCE_MULT_BAND_2>
+    <REFLECTANCE_MULT_BAND_3>1.4070E-03</REFLECTANCE_MULT_BAND_3>
+    <REFLECTANCE_MULT_BAND_4>1.7954E-03</REFLECTANCE_MULT_BAND_4>
+    <REFLECTANCE_ADD_BAND_1>0.005240</REFLECTANCE_ADD_BAND_1>
+    <REFLECTANCE_ADD_BAND_2>0.006390</REFLECTANCE_ADD_BAND_2>
+    <REFLECTANCE_ADD_BAND_3>0.011659</REFLECTANCE_ADD_BAND_3>
+    <REFLECTANCE_ADD_BAND_4>0.014411</REFLECTANCE_ADD_BAND_4>
+  </LEVEL1_RADIOMETRIC_RESCALING>
+  <LEVEL1_PROJECTION_PARAMETERS>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>14</UTM_ZONE>
+    <GRID_CELL_SIZE_REFLECTIVE>60.00</GRID_CELL_SIZE_REFLECTIVE>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <RESAMPLING_OPTION>CUBIC_CONVOLUTION</RESAMPLING_OPTION>
+    <MAP_PROJECTION_L0RA>SOM</MAP_PROJECTION_L0RA>
+  </LEVEL1_PROJECTION_PARAMETERS>
+  <PRODUCT_PARAMETERS>
+    <DATA_TYPE_L0RP>MSSA_L0RP</DATA_TYPE_L0RP>
+    <CORRECTION_GAIN_BAND_1>CPF</CORRECTION_GAIN_BAND_1>
+    <CORRECTION_GAIN_BAND_2>CPF</CORRECTION_GAIN_BAND_2>
+    <CORRECTION_GAIN_BAND_3>CPF</CORRECTION_GAIN_BAND_3>
+    <CORRECTION_GAIN_BAND_4>CPF</CORRECTION_GAIN_BAND_4>
+    <GAIN_BAND_1>L</GAIN_BAND_1>
+    <GAIN_BAND_2>L</GAIN_BAND_2>
+    <GAIN_BAND_3>L</GAIN_BAND_3>
+    <GAIN_BAND_4>L</GAIN_BAND_4>
+  </PRODUCT_PARAMETERS>
+</LANDSAT_METADATA_FILE>
+"""
+
+
+x_size = 100
+y_size = 100
+date_l1 = datetime(1972, 7, 29, tzinfo=timezone.utc)
+date_l4 = datetime(1984, 4, 15, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="session")
+def l1_area():
+    """Get the landsat 1 area def."""
+    pcs_id = "WGS84 / UMSS zone 14N"
+    proj4_dict = {"proj": "utm", "zone": 14, "datum": "WGS84", "units": "m", "no_defs": None, "type": "crs"}
+    area_extent = (442110.0, 4667550.0, 673530.0, 4887990.0)
+    return AreaDefinition("geotiff_area", pcs_id, pcs_id,
+                          proj4_dict, x_size, y_size,
+                          area_extent)
+
+
+@pytest.fixture(scope="session")
+def l4_area():
+    """Get the landsat 1 area def."""
+    pcs_id = "WGS84 / UMSS zone 14N"
+    proj4_dict = {"proj": "utm", "zone": 14, "datum": "WGS84", "units": "m", "no_defs": None, "type": "crs"}
+    area_extent = (540030.0, 4679970.0, 774450.0, 4888350.0)
+    return AreaDefinition("geotiff_area", pcs_id, pcs_id,
+                          proj4_dict, x_size, y_size,
+                          area_extent)
+
+
+@pytest.fixture(scope="session")
+def b4_data():
+    """Get the data for the b4 channel."""
+    return da.random.randint(12000, 16000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+def create_tif_file(data, name, area, filename, date):
+    """Create a tif file."""
+    data_array = xr.DataArray(data,
+                              dims=("y", "x"),
+                              attrs={"name": name,
+                                     "start_time": date})
+    scn = Scene()
+    scn["band_data"] = data_array
+    scn["band_data"].attrs["area"] = area
+    scn.save_dataset("band_data", writer="geotiff", enhance=False, fill_value=0,
+                     filename=os.fspath(filename))
+
+
+@pytest.fixture(scope="session")
+def l1_files_path(tmp_path_factory):
+    """Create the path for l1 files."""
+    return tmp_path_factory.mktemp("mss_l1_files")
+
+
+@pytest.fixture(scope="session")
+def l4_files_path(tmp_path_factory):
+    """Create the path for l4 files."""
+    return tmp_path_factory.mktemp("mss_l4_files")
+
+
+@pytest.fixture(scope="session")
+def l1_b4_file(l1_files_path, b4_data, l1_area):
+    """Create the file for the b4 channel."""
+    data = b4_data
+    filename = l1_files_path / "LM01_L1TP_032030_19720729_20200909_02_T2_B4.TIF"
+    name = "B4"
+    create_tif_file(data, name, l1_area, filename, date_l1)
+    return os.fspath(filename)
+
+
+@pytest.fixture(scope="session")
+def l4_b4_file(l4_files_path, b4_data, l4_area):
+    """Create the file for the b4 channel."""
+    data = b4_data
+    filename = l4_files_path / "LM04_L1TP_029030_19840415_20200903_02_T2_B4.TIF"
+    name = "B4"
+    create_tif_file(data, name, l4_area, filename, date_l4)
+    return os.fspath(filename)
+
+
+@pytest.fixture(scope="session")
+def l1_mda_file(l1_files_path):
+    """Create the metadata xml file."""
+    filename = l1_files_path / "LM01_L1TP_032030_19720729_20200909_02_T2_MTL.xml"
+    with open(filename, "wb") as f:
+        f.write(l1_metadata_text)
+    return os.fspath(filename)
+
+
+@pytest.fixture(scope="session")
+def l4_mda_file(l4_files_path):
+    """Create the metadata xml file."""
+    filename = l4_files_path / "LM04_L1TP_029030_19840415_20200903_02_T2_MTL.xml"
+    with open(filename, "wb") as f:
+        f.write(l4_metadata_text)
+    return os.fspath(filename)
+
+
+@pytest.fixture(scope="session")
+def l1_all_files(l1_b4_file, l1_mda_file):
+    """Return all the files."""
+    return l1_b4_file, l1_mda_file
+
+
+@pytest.fixture(scope="session")
+def l4_all_files(l4_b4_file, l4_mda_file):
+    """Return all the files."""
+    return l4_b4_file, l4_mda_file
+
+
+@pytest.fixture(scope="session")
+def l1_all_fs_files(l1_b4_file, l1_mda_file):
+    """Return all the files as FSFile objects."""
+    from fsspec.implementations.local import LocalFileSystem
+
+    from satpy.readers.core.remote import FSFile
+
+    fs = LocalFileSystem()
+    l1_b4_file, l1_mda_file = (
+        FSFile(os.path.abspath(file), fs=fs)
+        for file in [l1_b4_file, l1_mda_file]
+    )
+    return l1_b4_file, l1_mda_file
+
+
+@pytest.fixture(scope="session")
+def l4_all_fs_files(l4_b4_file, l4_mda_file):
+    """Return all the files as FSFile objects."""
+    from fsspec.implementations.local import LocalFileSystem
+
+    from satpy.readers.core.remote import FSFile
+
+    fs = LocalFileSystem()
+    l4_b4_file, l4_mda_file = (
+        FSFile(os.path.abspath(file), fs=fs)
+        for file in [l4_b4_file, l4_mda_file]
+    )
+    return l4_b4_file, l4_mda_file
+
+
+class TestMSSL1_Landsat_1:
+    """Test generic image reader."""
+
+    def setup_method(self, tmp_path):
+        """Set up the filename and filetype info dicts.."""
+        self.filename_info = dict(observation_date=datetime(1972, 7, 29),
+                                  platform_type="L",
+                                  process_level_correction="L1TP",
+                                  spacecraft_id="01",
+                                  data_type="M",
+                                  collection_id="02")
+        self.ftype_info = {"file_type": "granule_B4"}
+
+    def test_basicload(self, l1_area, l1_b4_file, l1_mda_file):
+        """Test loading a Landsat Scene."""
+        scn = Scene(reader="mss_l1_tif", filenames=[l1_b4_file, l1_mda_file])
+        scn.load(["B4"])
+
+        # Check dataset is loaded correctly
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == l1_area
+        assert not scn["B4"].attrs["saturated"]
+        assert scn["B4"].attrs["_satpy_id"]["wavelength"].min == 0.5
+        assert scn["B4"].attrs["_satpy_id"]["wavelength"].central == 0.55
+        assert scn["B4"].attrs["_satpy_id"]["wavelength"].max == 0.6
+
+    def test_ch_startend(self, l1_b4_file, l1_mda_file):
+        """Test correct retrieval of start/end times."""
+        scn = Scene(reader="mss_l1_tif", filenames=[l1_b4_file, l1_mda_file])
+        bnds = scn.available_dataset_names()
+        assert bnds == ["B4"]
+
+        scn.load(["B4"])
+        assert scn.start_time == datetime(1972, 7, 29, 16, 49, 31, tzinfo=timezone.utc)
+        assert scn.end_time == datetime(1972, 7, 29, 16, 49, 31, tzinfo=timezone.utc)
+
+    def test_loading_gd(self, l1_mda_file, l1_b4_file):
+        """Test loading a Landsat Scene with good channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import MSSCHReader, MSSMDReader
+        good_mda = MSSMDReader(l1_mda_file, self.filename_info, {})
+        rdr = MSSCHReader(l1_b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        # Check case with good file data and load request
+        rdr.get_dataset({"name": "B4", "calibration": "counts"}, {"standard_name": "test_data", "units": "test_units"})
+
+    def test_loading_badfil(self, l1_mda_file, l1_b4_file):
+        """Test loading a Landsat Scene with bad channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import MSSCHReader, MSSMDReader
+        good_mda = MSSMDReader(l1_mda_file, self.filename_info, {})
+        rdr = MSSCHReader(l1_b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+        # Check case with request to load channel not matching filename
+        with pytest.raises(ValueError, match="Requested channel B5 does not match the reader channel B4"):
+            rdr.get_dataset({"name": "B5", "calibration": "counts"}, ftype)
+
+    def test_badfiles(self, l1_mda_file, l1_b4_file):
+        """Test loading a Landsat Scene with bad data."""
+        from satpy.readers.oli_tirs_l1_tif import MSSCHReader, MSSMDReader
+        bad_fname_info = self.filename_info.copy()
+        bad_fname_info["platform_type"] = "B"
+
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+
+        # Test that metadata reader initialises with correct filename
+        good_mda = MSSMDReader(l1_mda_file, self.filename_info, ftype)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            MSSMDReader(l1_mda_file, bad_fname_info, ftype)
+
+        # Test that metadata reader initialises with correct filename
+        MSSCHReader(l1_b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            MSSCHReader(l1_b4_file, bad_fname_info, self.ftype_info, good_mda)
+        bad_ftype_info = self.ftype_info.copy()
+        bad_ftype_info["file_type"] = "granule-b05"
+        with pytest.raises(ValueError, match="Invalid file type: granule-b05"):
+            MSSCHReader(l1_b4_file, self.filename_info, bad_ftype_info, good_mda)
+
+    def test_calibration_counts(self, l1_all_files, b4_data):
+        """Test counts calibration mode for the reader."""
+        from satpy import Scene
+
+        scn = Scene(reader="mss_l1_tif", filenames=l1_all_files)
+        scn.load(["B4"], calibration="counts")
+        np.testing.assert_allclose(scn["B4"].values, b4_data)
+        assert scn["B4"].attrs["units"] == "1"
+        assert scn["B4"].attrs["standard_name"] == "counts"
+
+    def test_calibration_radiance(self, l1_all_files, b4_data):
+        """Test radiance calibration mode for the reader."""
+        from satpy import Scene
+        exp_b04 = (b4_data * 9.5591e-01 - 18.55591).astype(np.float32)
+
+        scn = Scene(reader="mss_l1_tif", filenames=l1_all_files)
+        scn.load(["B4"], calibration="radiance")
+        assert scn["B4"].attrs["units"] == "W m-2 um-1 sr-1"
+        assert scn["B4"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
+        np.testing.assert_allclose(scn["B4"].values, exp_b04, rtol=1e-4)
+
+    def test_calibration_highlevel(self, l1_all_files, b4_data):
+        """Test high level calibration modes for the reader."""
+        from satpy import Scene
+        exp_b04 = (b4_data * 1.7282e-03 - 0.033547).astype(np.float32) * 100
+        scn = Scene(reader="mss_l1_tif", filenames=l1_all_files)
+        scn.load(["B4"])
+
+        assert scn["B4"].attrs["units"] == "%"
+        assert scn["B4"].attrs["standard_name"] == "toa_bidirectional_reflectance"
+        np.testing.assert_allclose(np.array(scn["B4"].values), np.array(exp_b04), rtol=1e-4)
+
+    def test_metadata(self, l1_mda_file):
+        """Check that metadata values loaded correctly."""
+        from satpy.readers.oli_tirs_l1_tif import MSSMDReader
+        mda = MSSMDReader(l1_mda_file, self.filename_info, {})
+
+        cal_test_dict = {"B5": (6.4843e-01, -0.74843, 1.3660e-03, -0.001577),
+                         "B6": (6.5236e-01, -0.75236, 1.6580e-03, -0.001912),
+                         "B7": (6.0866e-01, -0.60866, 2.3287e-03, -0.002329)}
+
+        assert mda.platform_name == "Landsat-1"
+        assert mda.earth_sun_distance() == 1.0152109
+        assert mda.band_calibration["B5"] == cal_test_dict["B5"]
+        assert mda.band_calibration["B6"] == cal_test_dict["B6"]
+        assert mda.band_calibration["B7"] == cal_test_dict["B7"]
+        assert not mda.band_saturation["B4"]
+        assert mda.band_saturation["B5"]
+        assert mda.band_saturation["B6"]
+        assert not mda.band_saturation["B7"]
+
+    def test_area_def(self, l1_mda_file):
+        """Check we can get the area defs properly."""
+        from satpy.readers.oli_tirs_l1_tif import MSSMDReader
+        mda = MSSMDReader(l1_mda_file, self.filename_info, {})
+
+        standard_area = mda.build_area_def("B4")
+
+        assert standard_area.area_extent == (442110.0, 4667550.0, 673530.0, 4887990.0)
+
+    def test_basicload_remote(self, l1_area, l1_all_fs_files):
+        """Test loading a Landsat Scene from a fsspec filesystem."""
+        scn = Scene(reader="mss_l1_tif", filenames=l1_all_fs_files)
+        scn.load(["B4"])
+
+        # Check dataset is loaded correctly
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == l1_area
+        assert not scn["B4"].attrs["saturated"]
+        assert scn["B4"].attrs["_satpy_id"]["wavelength"].min == 0.5
+        assert scn["B4"].attrs["_satpy_id"]["wavelength"].central == 0.55
+        assert scn["B4"].attrs["_satpy_id"]["wavelength"].max == 0.6
+
+
+class TestMSSL1_Landsat_4:
+    """Test generic image reader."""
+
+    def setup_method(self, tmp_path):
+        """Set up the filename and filetype info dicts.."""
+        self.filename_info = dict(observation_date=datetime(1984, 4, 15),
+                                  platform_type="L",
+                                  process_level_correction="L1TP",
+                                  spacecraft_id="04",
+                                  data_type="M",
+                                  collection_id="02")
+        self.ftype_info = {"file_type": "granule_B4"}
+
+    def test_basicload(self, l4_area, l4_b4_file, l4_mda_file):
+        """Test loading a Landsat Scene."""
+        scn = Scene(reader="mss_l1_tif", filenames=[l4_b4_file, l4_mda_file])
+        scn.load(["B4"])
+
+        # Check dataset is loaded correctly
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == l4_area
+        assert not scn["B4"].attrs["saturated"]
+        assert scn["B4"].attrs["_satpy_id"]["wavelength"].min == 0.8
+        assert scn["B4"].attrs["_satpy_id"]["wavelength"].central == 0.95
+        assert scn["B4"].attrs["_satpy_id"]["wavelength"].max == 1.1
+
+    def test_ch_startend(self, l4_b4_file, l4_mda_file):
+        """Test correct retrieval of start/end times."""
+        scn = Scene(reader="mss_l1_tif", filenames=[l4_b4_file, l4_mda_file])
+        bnds = scn.available_dataset_names()
+        assert bnds == ["B4"]
+
+        scn.load(["B4"])
+        assert scn.start_time == datetime(1984, 4, 15, 16, 38, 15, tzinfo=timezone.utc)
+        assert scn.end_time == datetime(1984, 4, 15, 16, 38, 15, tzinfo=timezone.utc)
+
+    def test_loading_gd(self, l4_mda_file, l4_b4_file):
+        """Test loading a Landsat Scene with good channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import MSSCHReader, MSSMDReader
+        good_mda = MSSMDReader(l4_mda_file, self.filename_info, {})
+        rdr = MSSCHReader(l4_b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        # Check case with good file data and load request
+        rdr.get_dataset({"name": "B4", "calibration": "counts"}, {"standard_name": "test_data", "units": "test_units"})
+
+    def test_loading_badfil(self, l4_mda_file, l4_b4_file):
+        """Test loading a Landsat Scene with bad channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import MSSCHReader, MSSMDReader
+        good_mda = MSSMDReader(l4_mda_file, self.filename_info, {})
+        rdr = MSSCHReader(l4_b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+        # Check case with request to load channel not matching filename
+        with pytest.raises(ValueError, match="Requested channel B5 does not match the reader channel B4"):
+            rdr.get_dataset({"name": "B5", "calibration": "counts"}, ftype)
+
+    def test_badfiles(self, l4_mda_file, l4_b4_file):
+        """Test loading a Landsat Scene with bad data."""
+        from satpy.readers.oli_tirs_l1_tif import MSSCHReader, MSSMDReader
+        bad_fname_info = self.filename_info.copy()
+        bad_fname_info["platform_type"] = "B"
+
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+
+        # Test that metadata reader initialises with correct filename
+        good_mda = MSSMDReader(l4_mda_file, self.filename_info, ftype)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            MSSMDReader(l4_mda_file, bad_fname_info, ftype)
+
+        # Test that metadata reader initialises with correct filename
+        MSSCHReader(l4_b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            MSSCHReader(l4_b4_file, bad_fname_info, self.ftype_info, good_mda)
+        bad_ftype_info = self.ftype_info.copy()
+        bad_ftype_info["file_type"] = "granule-b05"
+        with pytest.raises(ValueError, match="Invalid file type: granule-b05"):
+            MSSCHReader(l4_b4_file, self.filename_info, bad_ftype_info, good_mda)
+
+    def test_calibration_counts(self, l4_all_files, b4_data):
+        """Test counts calibration mode for the reader."""
+        from satpy import Scene
+
+        scn = Scene(reader="mss_l1_tif", filenames=l4_all_files)
+        scn.load(["B4"], calibration="counts")
+        np.testing.assert_allclose(scn["B4"].values, b4_data)
+        assert scn["B4"].attrs["units"] == "1"
+        assert scn["B4"].attrs["standard_name"] == "counts"
+
+    def test_calibration_radiance(self, l4_all_files, b4_data):
+        """Test radiance calibration mode for the reader."""
+        from satpy import Scene
+        exp_b04 = (b4_data * 4.7638e-01 + 3.82362).astype(np.float32)
+
+        scn = Scene(reader="mss_l1_tif", filenames=l4_all_files)
+        scn.load(["B4"], calibration="radiance")
+        assert scn["B4"].attrs["units"] == "W m-2 um-1 sr-1"
+        assert scn["B4"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
+        np.testing.assert_allclose(scn["B4"].values, exp_b04, rtol=1e-4)
+
+    def test_calibration_highlevel(self, l4_all_files, b4_data):
+        """Test high level calibration modes for the reader."""
+        from satpy import Scene
+        exp_b04 = (b4_data * 1.7954e-03 + 0.014411).astype(np.float32) * 100
+        scn = Scene(reader="mss_l1_tif", filenames=l4_all_files)
+        scn.load(["B4"])
+
+        assert scn["B4"].attrs["units"] == "%"
+        assert scn["B4"].attrs["standard_name"] == "toa_bidirectional_reflectance"
+        np.testing.assert_allclose(np.array(scn["B4"].values), np.array(exp_b04), rtol=1e-4)
+
+    def test_metadata(self, l4_mda_file):
+        """Check that metadata values loaded correctly."""
+        from satpy.readers.oli_tirs_l1_tif import MSSMDReader
+        mda = MSSMDReader(l4_mda_file, self.filename_info, {})
+
+        cal_test_dict = {"B1": (8.7520e-01, 2.92480, 1.5680e-03, 0.005240),
+                         "B2": (6.2008e-01, 3.07992, 1.2865e-03, 0.006390),
+                         "B3": (5.4921e-01, 4.55079, 1.4070e-03, 0.011659)}
+
+        assert mda.platform_name == "Landsat-4"
+        assert mda.earth_sun_distance() == 1.0035512
+        assert mda.band_calibration["B1"] == cal_test_dict["B1"]
+        assert mda.band_calibration["B2"] == cal_test_dict["B2"]
+        assert mda.band_calibration["B3"] == cal_test_dict["B3"]
+        assert not mda.band_saturation["B1"]
+        assert mda.band_saturation["B2"]
+        assert mda.band_saturation["B3"]
+        assert not mda.band_saturation["B4"]
+
+    def test_area_def(self, l4_mda_file):
+        """Check we can get the area defs properly."""
+        from satpy.readers.oli_tirs_l1_tif import MSSMDReader
+        mda = MSSMDReader(l4_mda_file, self.filename_info, {})
+
+        standard_area = mda.build_area_def("B4")
+
+        assert standard_area.area_extent == (540030.0, 4679970.0, 774450.0, 4888350.0)
+
+    def test_basicload_remote(self, l4_area, l4_all_fs_files):
+        """Test loading a Landsat Scene from a fsspec filesystem."""
+        scn = Scene(reader="mss_l1_tif", filenames=l4_all_fs_files)
+        scn.load(["B4"])
+
+        # Check dataset is loaded correctly
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == l4_area
+        assert not scn["B4"].attrs["saturated"]
+        assert scn["B4"].attrs["_satpy_id"]["wavelength"].min == 0.8
+        assert scn["B4"].attrs["_satpy_id"]["wavelength"].central == 0.95
+        assert scn["B4"].attrs["_satpy_id"]["wavelength"].max == 1.1

--- a/satpy/tests/reader_tests/test_oli_tirs_l2_tif.py
+++ b/satpy/tests/reader_tests/test_oli_tirs_l2_tif.py
@@ -1,0 +1,681 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Unittests for generic image reader."""
+
+import os
+from datetime import datetime, timezone
+
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+from pyresample.geometry import AreaDefinition
+
+from satpy import Scene
+
+metadata_text = b"""<?xml version="1.0" encoding="UTF-8"?>
+<LANDSAT_METADATA_FILE>
+  <PRODUCT_CONTENTS>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P9OGBGM6</DIGITAL_OBJECT_IDENTIFIER>
+    <LANDSAT_PRODUCT_ID>LC09_L2SP_029030_20240616_20240617_02_T1</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L2SP</PROCESSING_LEVEL>
+    <COLLECTION_NUMBER>02</COLLECTION_NUMBER>
+    <COLLECTION_CATEGORY>T1</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <FILE_NAME_BAND_1>LC09_L2SP_029030_20240616_20240617_02_T1_SR_B1.TIF</FILE_NAME_BAND_1>
+    <FILE_NAME_BAND_2>LC09_L2SP_029030_20240616_20240617_02_T1_SR_B2.TIF</FILE_NAME_BAND_2>
+    <FILE_NAME_BAND_3>LC09_L2SP_029030_20240616_20240617_02_T1_SR_B3.TIF</FILE_NAME_BAND_3>
+    <FILE_NAME_BAND_4>LC09_L2SP_029030_20240616_20240617_02_T1_SR_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_BAND_5>LC09_L2SP_029030_20240616_20240617_02_T1_SR_B5.TIF</FILE_NAME_BAND_5>
+    <FILE_NAME_BAND_6>LC09_L2SP_029030_20240616_20240617_02_T1_SR_B6.TIF</FILE_NAME_BAND_6>
+    <FILE_NAME_BAND_7>LC09_L2SP_029030_20240616_20240617_02_T1_SR_B7.TIF</FILE_NAME_BAND_7>
+    <FILE_NAME_BAND_ST_B10>LC09_L2SP_029030_20240616_20240617_02_T1_ST_B10.TIF</FILE_NAME_BAND_ST_B10>
+    <FILE_NAME_THERMAL_RADIANCE>LC09_L2SP_029030_20240616_20240617_02_T1_ST_TRAD.TIF</FILE_NAME_THERMAL_RADIANCE>
+    <FILE_NAME_UPWELL_RADIANCE>LC09_L2SP_029030_20240616_20240617_02_T1_ST_URAD.TIF</FILE_NAME_UPWELL_RADIANCE>
+    <FILE_NAME_DOWNWELL_RADIANCE>LC09_L2SP_029030_20240616_20240617_02_T1_ST_DRAD.TIF</FILE_NAME_DOWNWELL_RADIANCE>
+    <FILE_NAME_ATMOSPHERIC_TRANSMITTANCE>LC09_L2SP_029030_20240616_20240617_02_T1_ST_ATRAN.TIF</FILE_NAME_ATMOSPHERIC_TRANSMITTANCE>
+    <FILE_NAME_EMISSIVITY>LC09_L2SP_029030_20240616_20240617_02_T1_ST_EMIS.TIF</FILE_NAME_EMISSIVITY>
+    <FILE_NAME_EMISSIVITY_STDEV>LC09_L2SP_029030_20240616_20240617_02_T1_ST_EMSD.TIF</FILE_NAME_EMISSIVITY_STDEV>
+    <FILE_NAME_CLOUD_DISTANCE>LC09_L2SP_029030_20240616_20240617_02_T1_ST_CDIST.TIF</FILE_NAME_CLOUD_DISTANCE>
+    <FILE_NAME_QUALITY_L2_AEROSOL>LC09_L2SP_029030_20240616_20240617_02_T1_SR_QA_AEROSOL.TIF</FILE_NAME_QUALITY_L2_AEROSOL>
+    <FILE_NAME_QUALITY_L2_SURFACE_TEMPERATURE>LC09_L2SP_029030_20240616_20240617_02_T1_ST_QA.TIF</FILE_NAME_QUALITY_L2_SURFACE_TEMPERATURE>
+    <FILE_NAME_QUALITY_L1_PIXEL>LC09_L2SP_029030_20240616_20240617_02_T1_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LC09_L2SP_029030_20240616_20240617_02_T1_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_ANGLE_COEFFICIENT>LC09_L2SP_029030_20240616_20240617_02_T1_ANG.txt</FILE_NAME_ANGLE_COEFFICIENT>
+    <FILE_NAME_METADATA_ODL>LC09_L2SP_029030_20240616_20240617_02_T1_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LC09_L2SP_029030_20240616_20240617_02_T1_MTL.xml</FILE_NAME_METADATA_XML>
+    <DATA_TYPE_BAND_1>UINT16</DATA_TYPE_BAND_1>
+    <DATA_TYPE_BAND_2>UINT16</DATA_TYPE_BAND_2>
+    <DATA_TYPE_BAND_3>UINT16</DATA_TYPE_BAND_3>
+    <DATA_TYPE_BAND_4>UINT16</DATA_TYPE_BAND_4>
+    <DATA_TYPE_BAND_5>UINT16</DATA_TYPE_BAND_5>
+    <DATA_TYPE_BAND_6>UINT16</DATA_TYPE_BAND_6>
+    <DATA_TYPE_BAND_7>UINT16</DATA_TYPE_BAND_7>
+    <DATA_TYPE_BAND_ST_B10>UINT16</DATA_TYPE_BAND_ST_B10>
+    <DATA_TYPE_THERMAL_RADIANCE>INT16</DATA_TYPE_THERMAL_RADIANCE>
+    <DATA_TYPE_UPWELL_RADIANCE>INT16</DATA_TYPE_UPWELL_RADIANCE>
+    <DATA_TYPE_DOWNWELL_RADIANCE>INT16</DATA_TYPE_DOWNWELL_RADIANCE>
+    <DATA_TYPE_ATMOSPHERIC_TRANSMITTANCE>INT16</DATA_TYPE_ATMOSPHERIC_TRANSMITTANCE>
+    <DATA_TYPE_EMISSIVITY>INT16</DATA_TYPE_EMISSIVITY>
+    <DATA_TYPE_EMISSIVITY_STDEV>INT16</DATA_TYPE_EMISSIVITY_STDEV>
+    <DATA_TYPE_CLOUD_DISTANCE>INT16</DATA_TYPE_CLOUD_DISTANCE>
+    <DATA_TYPE_QUALITY_L2_AEROSOL>UINT8</DATA_TYPE_QUALITY_L2_AEROSOL>
+    <DATA_TYPE_QUALITY_L2_SURFACE_TEMPERATURE>INT16</DATA_TYPE_QUALITY_L2_SURFACE_TEMPERATURE>
+    <DATA_TYPE_QUALITY_L1_PIXEL>UINT16</DATA_TYPE_QUALITY_L1_PIXEL>
+    <DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>UINT16</DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>
+  </PRODUCT_CONTENTS>
+  <IMAGE_ATTRIBUTES>
+    <SPACECRAFT_ID>LANDSAT_9</SPACECRAFT_ID>
+    <SENSOR_ID>OLI_TIRS</SENSOR_ID>
+    <WRS_TYPE>2</WRS_TYPE>
+    <WRS_PATH>29</WRS_PATH>
+    <WRS_ROW>30</WRS_ROW>
+    <NADIR_OFFNADIR>NADIR</NADIR_OFFNADIR>
+    <TARGET_WRS_PATH>29</TARGET_WRS_PATH>
+    <TARGET_WRS_ROW>30</TARGET_WRS_ROW>
+    <DATE_ACQUIRED>2024-06-16</DATE_ACQUIRED>
+    <SCENE_CENTER_TIME>17:10:58.5278200Z</SCENE_CENTER_TIME>
+    <STATION_ID>LGN</STATION_ID>
+    <CLOUD_COVER>29.27</CLOUD_COVER>
+    <CLOUD_COVER_LAND>29.27</CLOUD_COVER_LAND>
+    <IMAGE_QUALITY_OLI>9</IMAGE_QUALITY_OLI>
+    <IMAGE_QUALITY_TIRS>9</IMAGE_QUALITY_TIRS>
+    <SATURATION_BAND_1>N</SATURATION_BAND_1>
+    <SATURATION_BAND_2>N</SATURATION_BAND_2>
+    <SATURATION_BAND_3>N</SATURATION_BAND_3>
+    <SATURATION_BAND_4>Y</SATURATION_BAND_4>
+    <SATURATION_BAND_5>N</SATURATION_BAND_5>
+    <SATURATION_BAND_6>Y</SATURATION_BAND_6>
+    <SATURATION_BAND_7>Y</SATURATION_BAND_7>
+    <SATURATION_BAND_8>N</SATURATION_BAND_8>
+    <SATURATION_BAND_9>N</SATURATION_BAND_9>
+    <ROLL_ANGLE>0.000</ROLL_ANGLE>
+    <SUN_AZIMUTH>134.43500878</SUN_AZIMUTH>
+    <SUN_ELEVATION>64.41443455</SUN_ELEVATION>
+    <EARTH_SUN_DISTANCE>1.0158933</EARTH_SUN_DISTANCE>
+  </IMAGE_ATTRIBUTES>
+  <PROJECTION_ATTRIBUTES>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>14</UTM_ZONE>
+    <GRID_CELL_SIZE_REFLECTIVE>30.00</GRID_CELL_SIZE_REFLECTIVE>
+    <GRID_CELL_SIZE_THERMAL>30.00</GRID_CELL_SIZE_THERMAL>
+    <REFLECTIVE_LINES>100</REFLECTIVE_LINES>
+    <REFLECTIVE_SAMPLES>100</REFLECTIVE_SAMPLES>
+    <THERMAL_LINES>100</THERMAL_LINES>
+    <THERMAL_SAMPLES>100</THERMAL_SAMPLES>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <CORNER_UL_LAT_PRODUCT>44.24610</CORNER_UL_LAT_PRODUCT>
+    <CORNER_UL_LON_PRODUCT>-98.56289</CORNER_UL_LON_PRODUCT>
+    <CORNER_UR_LAT_PRODUCT>44.19877</CORNER_UR_LAT_PRODUCT>
+    <CORNER_UR_LON_PRODUCT>-95.68366</CORNER_UR_LON_PRODUCT>
+    <CORNER_LL_LAT_PRODUCT>42.14174</CORNER_LL_LAT_PRODUCT>
+    <CORNER_LL_LON_PRODUCT>-98.57765</CORNER_LL_LON_PRODUCT>
+    <CORNER_LR_LAT_PRODUCT>42.09775</CORNER_LR_LAT_PRODUCT>
+    <CORNER_LR_LON_PRODUCT>-95.79546</CORNER_LR_LON_PRODUCT>
+    <CORNER_UL_PROJECTION_X_PRODUCT>534900.000</CORNER_UL_PROJECTION_X_PRODUCT>
+    <CORNER_UL_PROJECTION_Y_PRODUCT>4899300.000</CORNER_UL_PROJECTION_Y_PRODUCT>
+    <CORNER_UR_PROJECTION_X_PRODUCT>765000.000</CORNER_UR_PROJECTION_X_PRODUCT>
+    <CORNER_UR_PROJECTION_Y_PRODUCT>4899300.000</CORNER_UR_PROJECTION_Y_PRODUCT>
+    <CORNER_LL_PROJECTION_X_PRODUCT>534900.000</CORNER_LL_PROJECTION_X_PRODUCT>
+    <CORNER_LL_PROJECTION_Y_PRODUCT>4665600.000</CORNER_LL_PROJECTION_Y_PRODUCT>
+    <CORNER_LR_PROJECTION_X_PRODUCT>765000.000</CORNER_LR_PROJECTION_X_PRODUCT>
+    <CORNER_LR_PROJECTION_Y_PRODUCT>4665600.000</CORNER_LR_PROJECTION_Y_PRODUCT>
+  </PROJECTION_ATTRIBUTES>
+  <LEVEL2_PROCESSING_RECORD>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P9OGBGM6</DIGITAL_OBJECT_IDENTIFIER>
+    <REQUEST_ID>1898780_00011</REQUEST_ID>
+    <LANDSAT_PRODUCT_ID>LC09_L2SP_029030_20240616_20240617_02_T1</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L2SP</PROCESSING_LEVEL>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <DATE_PRODUCT_GENERATED>2024-06-17T11:12:45Z</DATE_PRODUCT_GENERATED>
+    <PROCESSING_SOFTWARE_VERSION>LPGS_16.4.0</PROCESSING_SOFTWARE_VERSION>
+    <ALGORITHM_SOURCE_SURFACE_REFLECTANCE>LaSRC_1.6.0</ALGORITHM_SOURCE_SURFACE_REFLECTANCE>
+    <DATA_SOURCE_OZONE>VIIRS</DATA_SOURCE_OZONE>
+    <DATA_SOURCE_PRESSURE>Calculated</DATA_SOURCE_PRESSURE>
+    <DATA_SOURCE_WATER_VAPOR>VIIRS</DATA_SOURCE_WATER_VAPOR>
+    <DATA_SOURCE_AIR_TEMPERATURE>VIIRS</DATA_SOURCE_AIR_TEMPERATURE>
+    <ALGORITHM_SOURCE_SURFACE_TEMPERATURE>st_1.5.0</ALGORITHM_SOURCE_SURFACE_TEMPERATURE>
+    <DATA_SOURCE_REANALYSIS>GEOS-5 IT</DATA_SOURCE_REANALYSIS>
+  </LEVEL2_PROCESSING_RECORD>
+  <LEVEL2_SURFACE_REFLECTANCE_PARAMETERS>
+    <REFLECTANCE_MAXIMUM_BAND_1>1.602213</REFLECTANCE_MAXIMUM_BAND_1>
+    <REFLECTANCE_MINIMUM_BAND_1>-0.199972</REFLECTANCE_MINIMUM_BAND_1>
+    <REFLECTANCE_MAXIMUM_BAND_2>1.602213</REFLECTANCE_MAXIMUM_BAND_2>
+    <REFLECTANCE_MINIMUM_BAND_2>-0.199972</REFLECTANCE_MINIMUM_BAND_2>
+    <REFLECTANCE_MAXIMUM_BAND_3>1.602213</REFLECTANCE_MAXIMUM_BAND_3>
+    <REFLECTANCE_MINIMUM_BAND_3>-0.199972</REFLECTANCE_MINIMUM_BAND_3>
+    <REFLECTANCE_MAXIMUM_BAND_4>1.602213</REFLECTANCE_MAXIMUM_BAND_4>
+    <REFLECTANCE_MINIMUM_BAND_4>-0.199972</REFLECTANCE_MINIMUM_BAND_4>
+    <REFLECTANCE_MAXIMUM_BAND_5>1.602213</REFLECTANCE_MAXIMUM_BAND_5>
+    <REFLECTANCE_MINIMUM_BAND_5>-0.199972</REFLECTANCE_MINIMUM_BAND_5>
+    <REFLECTANCE_MAXIMUM_BAND_6>1.602213</REFLECTANCE_MAXIMUM_BAND_6>
+    <REFLECTANCE_MINIMUM_BAND_6>-0.199972</REFLECTANCE_MINIMUM_BAND_6>
+    <REFLECTANCE_MAXIMUM_BAND_7>1.602213</REFLECTANCE_MAXIMUM_BAND_7>
+    <REFLECTANCE_MINIMUM_BAND_7>-0.199972</REFLECTANCE_MINIMUM_BAND_7>
+    <QUANTIZE_CAL_MAX_BAND_1>65535</QUANTIZE_CAL_MAX_BAND_1>
+    <QUANTIZE_CAL_MIN_BAND_1>1</QUANTIZE_CAL_MIN_BAND_1>
+    <QUANTIZE_CAL_MAX_BAND_2>65535</QUANTIZE_CAL_MAX_BAND_2>
+    <QUANTIZE_CAL_MIN_BAND_2>1</QUANTIZE_CAL_MIN_BAND_2>
+    <QUANTIZE_CAL_MAX_BAND_3>65535</QUANTIZE_CAL_MAX_BAND_3>
+    <QUANTIZE_CAL_MIN_BAND_3>1</QUANTIZE_CAL_MIN_BAND_3>
+    <QUANTIZE_CAL_MAX_BAND_4>65535</QUANTIZE_CAL_MAX_BAND_4>
+    <QUANTIZE_CAL_MIN_BAND_4>1</QUANTIZE_CAL_MIN_BAND_4>
+    <QUANTIZE_CAL_MAX_BAND_5>65535</QUANTIZE_CAL_MAX_BAND_5>
+    <QUANTIZE_CAL_MIN_BAND_5>1</QUANTIZE_CAL_MIN_BAND_5>
+    <QUANTIZE_CAL_MAX_BAND_6>65535</QUANTIZE_CAL_MAX_BAND_6>
+    <QUANTIZE_CAL_MIN_BAND_6>1</QUANTIZE_CAL_MIN_BAND_6>
+    <QUANTIZE_CAL_MAX_BAND_7>65535</QUANTIZE_CAL_MAX_BAND_7>
+    <QUANTIZE_CAL_MIN_BAND_7>1</QUANTIZE_CAL_MIN_BAND_7>
+    <REFLECTANCE_MULT_BAND_1>2.75e-05</REFLECTANCE_MULT_BAND_1>
+    <REFLECTANCE_MULT_BAND_2>2.75e-05</REFLECTANCE_MULT_BAND_2>
+    <REFLECTANCE_MULT_BAND_3>2.75e-05</REFLECTANCE_MULT_BAND_3>
+    <REFLECTANCE_MULT_BAND_4>2.75e-05</REFLECTANCE_MULT_BAND_4>
+    <REFLECTANCE_MULT_BAND_5>2.75e-05</REFLECTANCE_MULT_BAND_5>
+    <REFLECTANCE_MULT_BAND_6>2.75e-05</REFLECTANCE_MULT_BAND_6>
+    <REFLECTANCE_MULT_BAND_7>2.75e-05</REFLECTANCE_MULT_BAND_7>
+    <REFLECTANCE_ADD_BAND_1>-0.2</REFLECTANCE_ADD_BAND_1>
+    <REFLECTANCE_ADD_BAND_2>-0.2</REFLECTANCE_ADD_BAND_2>
+    <REFLECTANCE_ADD_BAND_3>-0.2</REFLECTANCE_ADD_BAND_3>
+    <REFLECTANCE_ADD_BAND_4>-0.2</REFLECTANCE_ADD_BAND_4>
+    <REFLECTANCE_ADD_BAND_5>-0.2</REFLECTANCE_ADD_BAND_5>
+    <REFLECTANCE_ADD_BAND_6>-0.2</REFLECTANCE_ADD_BAND_6>
+    <REFLECTANCE_ADD_BAND_7>-0.2</REFLECTANCE_ADD_BAND_7>
+  </LEVEL2_SURFACE_REFLECTANCE_PARAMETERS>
+  <LEVEL2_SURFACE_TEMPERATURE_PARAMETERS>
+    <TEMPERATURE_MAXIMUM_BAND_ST_B10>372.999941</TEMPERATURE_MAXIMUM_BAND_ST_B10>
+    <TEMPERATURE_MINIMUM_BAND_ST_B10>149.003418</TEMPERATURE_MINIMUM_BAND_ST_B10>
+    <QUANTIZE_CAL_MAXIMUM_BAND_ST_B10>65535</QUANTIZE_CAL_MAXIMUM_BAND_ST_B10>
+    <QUANTIZE_CAL_MINIMUM_BAND_ST_B10>1</QUANTIZE_CAL_MINIMUM_BAND_ST_B10>
+    <TEMPERATURE_MULT_BAND_ST_B10>0.00341802</TEMPERATURE_MULT_BAND_ST_B10>
+    <TEMPERATURE_ADD_BAND_ST_B10>149.0</TEMPERATURE_ADD_BAND_ST_B10>
+  </LEVEL2_SURFACE_TEMPERATURE_PARAMETERS>
+  <LEVEL1_PROCESSING_RECORD>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P975CC9B</DIGITAL_OBJECT_IDENTIFIER>
+    <REQUEST_ID>1898675_00011</REQUEST_ID>
+    <LANDSAT_SCENE_ID>LC90290302024168LGN00</LANDSAT_SCENE_ID>
+    <LANDSAT_PRODUCT_ID>LC09_L1TP_029030_20240616_20240616_02_T1</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L1TP</PROCESSING_LEVEL>
+    <COLLECTION_CATEGORY>T1</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <DATE_PRODUCT_GENERATED>2024-06-16T22:54:36Z</DATE_PRODUCT_GENERATED>
+    <PROCESSING_SOFTWARE_VERSION>LPGS_16.4.0</PROCESSING_SOFTWARE_VERSION>
+    <FILE_NAME_BAND_1>LC09_L1TP_029030_20240616_20240616_02_T1_B1.TIF</FILE_NAME_BAND_1>
+    <FILE_NAME_BAND_2>LC09_L1TP_029030_20240616_20240616_02_T1_B2.TIF</FILE_NAME_BAND_2>
+    <FILE_NAME_BAND_3>LC09_L1TP_029030_20240616_20240616_02_T1_B3.TIF</FILE_NAME_BAND_3>
+    <FILE_NAME_BAND_4>LC09_L1TP_029030_20240616_20240616_02_T1_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_BAND_5>LC09_L1TP_029030_20240616_20240616_02_T1_B5.TIF</FILE_NAME_BAND_5>
+    <FILE_NAME_BAND_6>LC09_L1TP_029030_20240616_20240616_02_T1_B6.TIF</FILE_NAME_BAND_6>
+    <FILE_NAME_BAND_7>LC09_L1TP_029030_20240616_20240616_02_T1_B7.TIF</FILE_NAME_BAND_7>
+    <FILE_NAME_BAND_8>LC09_L1TP_029030_20240616_20240616_02_T1_B8.TIF</FILE_NAME_BAND_8>
+    <FILE_NAME_BAND_9>LC09_L1TP_029030_20240616_20240616_02_T1_B9.TIF</FILE_NAME_BAND_9>
+    <FILE_NAME_BAND_10>LC09_L1TP_029030_20240616_20240616_02_T1_B10.TIF</FILE_NAME_BAND_10>
+    <FILE_NAME_BAND_11>LC09_L1TP_029030_20240616_20240616_02_T1_B11.TIF</FILE_NAME_BAND_11>
+    <FILE_NAME_QUALITY_L1_PIXEL>LC09_L1TP_029030_20240616_20240616_02_T1_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LC09_L1TP_029030_20240616_20240616_02_T1_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_ANGLE_COEFFICIENT>LC09_L1TP_029030_20240616_20240616_02_T1_ANG.txt</FILE_NAME_ANGLE_COEFFICIENT>
+    <FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>LC09_L1TP_029030_20240616_20240616_02_T1_VAA.TIF</FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>LC09_L1TP_029030_20240616_20240616_02_T1_VZA.TIF</FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>LC09_L1TP_029030_20240616_20240616_02_T1_SAA.TIF</FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>LC09_L1TP_029030_20240616_20240616_02_T1_SZA.TIF</FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>
+    <FILE_NAME_METADATA_ODL>LC09_L1TP_029030_20240616_20240616_02_T1_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LC09_L1TP_029030_20240616_20240616_02_T1_MTL.xml</FILE_NAME_METADATA_XML>
+    <FILE_NAME_CPF>LC09CPF_20240401_20240630_02.02</FILE_NAME_CPF>
+    <FILE_NAME_BPF_OLI>LO9BPF20240616165050_20240616171843.02</FILE_NAME_BPF_OLI>
+    <FILE_NAME_BPF_TIRS>LT9BPF20240616164559_20240616182452.01</FILE_NAME_BPF_TIRS>
+    <FILE_NAME_RLUT>LC09RLUT_20230701_20531231_02_10.h5</FILE_NAME_RLUT>
+    <DATA_SOURCE_ELEVATION>GLS2000</DATA_SOURCE_ELEVATION>
+    <GROUND_CONTROL_POINTS_VERSION>5</GROUND_CONTROL_POINTS_VERSION>
+    <GROUND_CONTROL_POINTS_MODEL>160</GROUND_CONTROL_POINTS_MODEL>
+    <GEOMETRIC_RMSE_MODEL>7.390</GEOMETRIC_RMSE_MODEL>
+    <GEOMETRIC_RMSE_MODEL_Y>5.361</GEOMETRIC_RMSE_MODEL_Y>
+    <GEOMETRIC_RMSE_MODEL_X>5.086</GEOMETRIC_RMSE_MODEL_X>
+  </LEVEL1_PROCESSING_RECORD>
+  <LEVEL1_MIN_MAX_RADIANCE>
+    <RADIANCE_MAXIMUM_BAND_1>734.06683</RADIANCE_MAXIMUM_BAND_1>
+    <RADIANCE_MINIMUM_BAND_1>-60.61948</RADIANCE_MINIMUM_BAND_1>
+    <RADIANCE_MAXIMUM_BAND_2>753.94604</RADIANCE_MAXIMUM_BAND_2>
+    <RADIANCE_MINIMUM_BAND_2>-62.26111</RADIANCE_MINIMUM_BAND_2>
+    <RADIANCE_MAXIMUM_BAND_3>695.55688</RADIANCE_MAXIMUM_BAND_3>
+    <RADIANCE_MINIMUM_BAND_3>-57.43931</RADIANCE_MINIMUM_BAND_3>
+    <RADIANCE_MAXIMUM_BAND_4>586.00403</RADIANCE_MAXIMUM_BAND_4>
+    <RADIANCE_MINIMUM_BAND_4>-48.39240</RADIANCE_MINIMUM_BAND_4>
+    <RADIANCE_MAXIMUM_BAND_5>359.16302</RADIANCE_MAXIMUM_BAND_5>
+    <RADIANCE_MINIMUM_BAND_5>-29.65980</RADIANCE_MINIMUM_BAND_5>
+    <RADIANCE_MAXIMUM_BAND_6>89.27634</RADIANCE_MAXIMUM_BAND_6>
+    <RADIANCE_MINIMUM_BAND_6>-7.37247</RADIANCE_MINIMUM_BAND_6>
+    <RADIANCE_MAXIMUM_BAND_7>30.08380</RADIANCE_MAXIMUM_BAND_7>
+    <RADIANCE_MINIMUM_BAND_7>-2.48433</RADIANCE_MINIMUM_BAND_7>
+    <RADIANCE_MAXIMUM_BAND_8>661.33466</RADIANCE_MAXIMUM_BAND_8>
+    <RADIANCE_MINIMUM_BAND_8>-54.61323</RADIANCE_MINIMUM_BAND_8>
+    <RADIANCE_MAXIMUM_BAND_9>140.38083</RADIANCE_MAXIMUM_BAND_9>
+    <RADIANCE_MINIMUM_BAND_9>-11.59269</RADIANCE_MINIMUM_BAND_9>
+    <RADIANCE_MAXIMUM_BAND_10>25.00330</RADIANCE_MAXIMUM_BAND_10>
+    <RADIANCE_MINIMUM_BAND_10>0.10038</RADIANCE_MINIMUM_BAND_10>
+    <RADIANCE_MAXIMUM_BAND_11>22.97172</RADIANCE_MAXIMUM_BAND_11>
+    <RADIANCE_MINIMUM_BAND_11>0.10035</RADIANCE_MINIMUM_BAND_11>
+  </LEVEL1_MIN_MAX_RADIANCE>
+  <LEVEL1_MIN_MAX_REFLECTANCE>
+    <REFLECTANCE_MAXIMUM_BAND_1>1.210700</REFLECTANCE_MAXIMUM_BAND_1>
+    <REFLECTANCE_MINIMUM_BAND_1>-0.099980</REFLECTANCE_MINIMUM_BAND_1>
+    <REFLECTANCE_MAXIMUM_BAND_2>1.210700</REFLECTANCE_MAXIMUM_BAND_2>
+    <REFLECTANCE_MINIMUM_BAND_2>-0.099980</REFLECTANCE_MINIMUM_BAND_2>
+    <REFLECTANCE_MAXIMUM_BAND_3>1.210700</REFLECTANCE_MAXIMUM_BAND_3>
+    <REFLECTANCE_MINIMUM_BAND_3>-0.099980</REFLECTANCE_MINIMUM_BAND_3>
+    <REFLECTANCE_MAXIMUM_BAND_4>1.210700</REFLECTANCE_MAXIMUM_BAND_4>
+    <REFLECTANCE_MINIMUM_BAND_4>-0.099980</REFLECTANCE_MINIMUM_BAND_4>
+    <REFLECTANCE_MAXIMUM_BAND_5>1.210700</REFLECTANCE_MAXIMUM_BAND_5>
+    <REFLECTANCE_MINIMUM_BAND_5>-0.099980</REFLECTANCE_MINIMUM_BAND_5>
+    <REFLECTANCE_MAXIMUM_BAND_6>1.210700</REFLECTANCE_MAXIMUM_BAND_6>
+    <REFLECTANCE_MINIMUM_BAND_6>-0.099980</REFLECTANCE_MINIMUM_BAND_6>
+    <REFLECTANCE_MAXIMUM_BAND_7>1.210700</REFLECTANCE_MAXIMUM_BAND_7>
+    <REFLECTANCE_MINIMUM_BAND_7>-0.099980</REFLECTANCE_MINIMUM_BAND_7>
+    <REFLECTANCE_MAXIMUM_BAND_8>1.210700</REFLECTANCE_MAXIMUM_BAND_8>
+    <REFLECTANCE_MINIMUM_BAND_8>-0.099980</REFLECTANCE_MINIMUM_BAND_8>
+    <REFLECTANCE_MAXIMUM_BAND_9>1.210700</REFLECTANCE_MAXIMUM_BAND_9>
+    <REFLECTANCE_MINIMUM_BAND_9>-0.099980</REFLECTANCE_MINIMUM_BAND_9>
+  </LEVEL1_MIN_MAX_REFLECTANCE>
+  <LEVEL1_MIN_MAX_PIXEL_VALUE>
+    <QUANTIZE_CAL_MAX_BAND_1>65535</QUANTIZE_CAL_MAX_BAND_1>
+    <QUANTIZE_CAL_MIN_BAND_1>1</QUANTIZE_CAL_MIN_BAND_1>
+    <QUANTIZE_CAL_MAX_BAND_2>65535</QUANTIZE_CAL_MAX_BAND_2>
+    <QUANTIZE_CAL_MIN_BAND_2>1</QUANTIZE_CAL_MIN_BAND_2>
+    <QUANTIZE_CAL_MAX_BAND_3>65535</QUANTIZE_CAL_MAX_BAND_3>
+    <QUANTIZE_CAL_MIN_BAND_3>1</QUANTIZE_CAL_MIN_BAND_3>
+    <QUANTIZE_CAL_MAX_BAND_4>65535</QUANTIZE_CAL_MAX_BAND_4>
+    <QUANTIZE_CAL_MIN_BAND_4>1</QUANTIZE_CAL_MIN_BAND_4>
+    <QUANTIZE_CAL_MAX_BAND_5>65535</QUANTIZE_CAL_MAX_BAND_5>
+    <QUANTIZE_CAL_MIN_BAND_5>1</QUANTIZE_CAL_MIN_BAND_5>
+    <QUANTIZE_CAL_MAX_BAND_6>65535</QUANTIZE_CAL_MAX_BAND_6>
+    <QUANTIZE_CAL_MIN_BAND_6>1</QUANTIZE_CAL_MIN_BAND_6>
+    <QUANTIZE_CAL_MAX_BAND_7>65535</QUANTIZE_CAL_MAX_BAND_7>
+    <QUANTIZE_CAL_MIN_BAND_7>1</QUANTIZE_CAL_MIN_BAND_7>
+    <QUANTIZE_CAL_MAX_BAND_8>65535</QUANTIZE_CAL_MAX_BAND_8>
+    <QUANTIZE_CAL_MIN_BAND_8>1</QUANTIZE_CAL_MIN_BAND_8>
+    <QUANTIZE_CAL_MAX_BAND_9>65535</QUANTIZE_CAL_MAX_BAND_9>
+    <QUANTIZE_CAL_MIN_BAND_9>1</QUANTIZE_CAL_MIN_BAND_9>
+    <QUANTIZE_CAL_MAX_BAND_10>65535</QUANTIZE_CAL_MAX_BAND_10>
+    <QUANTIZE_CAL_MIN_BAND_10>1</QUANTIZE_CAL_MIN_BAND_10>
+    <QUANTIZE_CAL_MAX_BAND_11>65535</QUANTIZE_CAL_MAX_BAND_11>
+    <QUANTIZE_CAL_MIN_BAND_11>1</QUANTIZE_CAL_MIN_BAND_11>
+  </LEVEL1_MIN_MAX_PIXEL_VALUE>
+  <LEVEL1_RADIOMETRIC_RESCALING>
+    <RADIANCE_MULT_BAND_1>1.2126E-02</RADIANCE_MULT_BAND_1>
+    <RADIANCE_MULT_BAND_2>1.2455E-02</RADIANCE_MULT_BAND_2>
+    <RADIANCE_MULT_BAND_3>1.1490E-02</RADIANCE_MULT_BAND_3>
+    <RADIANCE_MULT_BAND_4>9.6804E-03</RADIANCE_MULT_BAND_4>
+    <RADIANCE_MULT_BAND_5>5.9331E-03</RADIANCE_MULT_BAND_5>
+    <RADIANCE_MULT_BAND_6>1.4748E-03</RADIANCE_MULT_BAND_6>
+    <RADIANCE_MULT_BAND_7>4.9697E-04</RADIANCE_MULT_BAND_7>
+    <RADIANCE_MULT_BAND_8>1.0925E-02</RADIANCE_MULT_BAND_8>
+    <RADIANCE_MULT_BAND_9>2.3190E-03</RADIANCE_MULT_BAND_9>
+    <RADIANCE_MULT_BAND_10>3.8000E-04</RADIANCE_MULT_BAND_10>
+    <RADIANCE_MULT_BAND_11>3.4900E-04</RADIANCE_MULT_BAND_11>
+    <RADIANCE_ADD_BAND_1>-60.63160</RADIANCE_ADD_BAND_1>
+    <RADIANCE_ADD_BAND_2>-62.27356</RADIANCE_ADD_BAND_2>
+    <RADIANCE_ADD_BAND_3>-57.45080</RADIANCE_ADD_BAND_3>
+    <RADIANCE_ADD_BAND_4>-48.40208</RADIANCE_ADD_BAND_4>
+    <RADIANCE_ADD_BAND_5>-29.66573</RADIANCE_ADD_BAND_5>
+    <RADIANCE_ADD_BAND_6>-7.37394</RADIANCE_ADD_BAND_6>
+    <RADIANCE_ADD_BAND_7>-2.48483</RADIANCE_ADD_BAND_7>
+    <RADIANCE_ADD_BAND_8>-54.62416</RADIANCE_ADD_BAND_8>
+    <RADIANCE_ADD_BAND_9>-11.59501</RADIANCE_ADD_BAND_9>
+    <RADIANCE_ADD_BAND_10>0.10000</RADIANCE_ADD_BAND_10>
+    <RADIANCE_ADD_BAND_11>0.10000</RADIANCE_ADD_BAND_11>
+    <REFLECTANCE_MULT_BAND_1>2.0000E-05</REFLECTANCE_MULT_BAND_1>
+    <REFLECTANCE_MULT_BAND_2>2.0000E-05</REFLECTANCE_MULT_BAND_2>
+    <REFLECTANCE_MULT_BAND_3>2.0000E-05</REFLECTANCE_MULT_BAND_3>
+    <REFLECTANCE_MULT_BAND_4>2.0000E-05</REFLECTANCE_MULT_BAND_4>
+    <REFLECTANCE_MULT_BAND_5>2.0000E-05</REFLECTANCE_MULT_BAND_5>
+    <REFLECTANCE_MULT_BAND_6>2.0000E-05</REFLECTANCE_MULT_BAND_6>
+    <REFLECTANCE_MULT_BAND_7>2.0000E-05</REFLECTANCE_MULT_BAND_7>
+    <REFLECTANCE_MULT_BAND_8>2.0000E-05</REFLECTANCE_MULT_BAND_8>
+    <REFLECTANCE_MULT_BAND_9>2.0000E-05</REFLECTANCE_MULT_BAND_9>
+    <REFLECTANCE_ADD_BAND_1>-0.100000</REFLECTANCE_ADD_BAND_1>
+    <REFLECTANCE_ADD_BAND_2>-0.100000</REFLECTANCE_ADD_BAND_2>
+    <REFLECTANCE_ADD_BAND_3>-0.100000</REFLECTANCE_ADD_BAND_3>
+    <REFLECTANCE_ADD_BAND_4>-0.100000</REFLECTANCE_ADD_BAND_4>
+    <REFLECTANCE_ADD_BAND_5>-0.100000</REFLECTANCE_ADD_BAND_5>
+    <REFLECTANCE_ADD_BAND_6>-0.100000</REFLECTANCE_ADD_BAND_6>
+    <REFLECTANCE_ADD_BAND_7>-0.100000</REFLECTANCE_ADD_BAND_7>
+    <REFLECTANCE_ADD_BAND_8>-0.100000</REFLECTANCE_ADD_BAND_8>
+    <REFLECTANCE_ADD_BAND_9>-0.100000</REFLECTANCE_ADD_BAND_9>
+  </LEVEL1_RADIOMETRIC_RESCALING>
+  <LEVEL1_THERMAL_CONSTANTS>
+    <K1_CONSTANT_BAND_10>799.0284</K1_CONSTANT_BAND_10>
+    <K2_CONSTANT_BAND_10>1329.2405</K2_CONSTANT_BAND_10>
+    <K1_CONSTANT_BAND_11>475.6581</K1_CONSTANT_BAND_11>
+    <K2_CONSTANT_BAND_11>1198.3494</K2_CONSTANT_BAND_11>
+  </LEVEL1_THERMAL_CONSTANTS>
+  <LEVEL1_PROJECTION_PARAMETERS>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>14</UTM_ZONE>
+    <GRID_CELL_SIZE_PANCHROMATIC>15.00</GRID_CELL_SIZE_PANCHROMATIC>
+    <GRID_CELL_SIZE_REFLECTIVE>30.00</GRID_CELL_SIZE_REFLECTIVE>
+    <GRID_CELL_SIZE_THERMAL>30.00</GRID_CELL_SIZE_THERMAL>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <RESAMPLING_OPTION>CUBIC_CONVOLUTION</RESAMPLING_OPTION>
+  </LEVEL1_PROJECTION_PARAMETERS>
+</LANDSAT_METADATA_FILE>
+"""
+
+
+x_size = 100
+y_size = 100
+date = datetime(2024, 6, 16, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="session")
+def area():
+    """Get the landsat 1 area def."""
+    pcs_id = "WGS84 / UTM zone 14N"
+    proj4_dict = {"proj": "utm", "zone": 14, "datum": "WGS84", "units": "m", "no_defs": None, "type": "crs"}
+    area_extent = (534885.0, 4665585.0, 765015.0, 4899315.0)
+    return AreaDefinition("geotiff_area", pcs_id, pcs_id,
+                          proj4_dict, x_size, y_size,
+                          area_extent)
+
+
+@pytest.fixture(scope="session")
+def b4_data():
+    """Get the data for the b4 channel."""
+    return da.random.randint(12000, 16000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+@pytest.fixture(scope="session")
+def b10_data():
+    """Get the data for the b11 channel."""
+    return da.random.randint(8000, 14000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+@pytest.fixture(scope="session")
+def rad_data():
+    """Get the data for the radiance channel."""
+    return da.random.randint(1, 10000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+def create_tif_file(data, name, area, filename):
+    """Create a tif file."""
+    data_array = xr.DataArray(data,
+                              dims=("y", "x"),
+                              attrs={"name": name,
+                                     "start_time": date})
+    scn = Scene()
+    scn["band_data"] = data_array
+    scn["band_data"].attrs["area"] = area
+    scn.save_dataset("band_data", writer="geotiff", enhance=False, fill_value=0,
+                     filename=os.fspath(filename))
+
+
+@pytest.fixture(scope="session")
+def files_path(tmp_path_factory):
+    """Create the path for l1 files."""
+    return tmp_path_factory.mktemp("oli_tirs_l2_files")
+
+
+@pytest.fixture(scope="session")
+def b4_file(files_path, b4_data, area):
+    """Create the file for the b4 channel."""
+    data = b4_data
+    filename = files_path / "LC09_L2SP_029030_20240616_20240617_02_T1_SR_B4.TIF"
+    name = "B4"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+@pytest.fixture(scope="session")
+def b10_file(files_path, b10_data, area):
+    """Create the file for the b11 channel."""
+    data = b10_data
+    filename = files_path / "LC09_L2SP_029030_20240616_20240617_02_T1_ST_B10.TIF"
+    name = "B10"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+@pytest.fixture(scope="session")
+def rad_file(files_path, rad_data, area):
+    """Create the file for the sza."""
+    data = rad_data
+    filename = files_path / "LC09_L2SP_029030_20240616_20240617_02_T1_ST_TRAD.TIF"
+    name = "TRAD"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+
+@pytest.fixture(scope="session")
+def mda_file(files_path):
+    """Create the metadata xml file."""
+    filename = files_path / "LC09_L2SP_029030_20240616_20240617_02_T1_MTL.xml"
+    with open(filename, "wb") as f:
+        f.write(metadata_text)
+    return os.fspath(filename)
+
+
+@pytest.fixture(scope="session")
+def all_files(b4_file, b10_file, mda_file, rad_file):
+    """Return all the files."""
+    return b4_file, b10_file, mda_file, rad_file
+
+
+@pytest.fixture(scope="session")
+def all_fsspec_files(b4_file, b10_file, mda_file, rad_file):
+    """Return all the files as FSFile objects."""
+    from fsspec.implementations.local import LocalFileSystem
+
+    from satpy.readers.core.remote import FSFile
+
+    fs = LocalFileSystem()
+    b4_file, b10_file, mda_file, rad_file = (
+        FSFile(os.path.abspath(file), fs=fs)
+        for file in [b4_file, b10_file, mda_file, rad_file]
+    )
+    return b4_file, b10_file, mda_file, rad_file
+
+
+class TestOLITIRSL2:
+    """Test generic image reader."""
+
+    def setup_method(self, tmp_path):
+        """Set up the filename and filetype info dicts.."""
+        self.filename_info = dict(observation_date=datetime(2024, 5, 3),
+                                  platform_type="L",
+                                  process_level_correction="L2SP",
+                                  spacecraft_id="09",
+                                  data_type="C",
+                                  collection_id="02")
+        self.ftype_info = {"file_type": "granule_B4"}
+
+    def test_basicload(self, area, b4_file, b10_file, mda_file):
+        """Test loading a Landsat Scene."""
+        scn = Scene(reader="oli_tirs_l2_tif", filenames=[b4_file,
+                                                         b10_file,
+                                                         mda_file])
+        scn.load(["B4", "B10"])
+
+        # Check dataset is loaded correctly
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == area
+        assert scn["B4"].attrs["saturated"]
+        assert scn["B10"].shape == (100, 100)
+        assert scn["B10"].attrs["area"] == area
+        with pytest.raises(KeyError, match="saturated"):
+            assert not scn["B10"].attrs["saturated"]
+
+    def test_ch_startend(self, b4_file, mda_file):
+        """Test correct retrieval of start/end times."""
+        scn = Scene(reader="oli_tirs_l2_tif", filenames=[b4_file, mda_file])
+        bnds = scn.available_dataset_names()
+        assert bnds == ["B4"]
+
+        scn.load(["B4"])
+        assert scn.start_time == datetime(2024, 6, 16, 17, 10, 58, tzinfo=timezone.utc)
+        assert scn.end_time == datetime(2024, 6, 16, 17, 10, 58, tzinfo=timezone.utc)
+
+    def test_loading_gd(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with good channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import OLITIRSL2CHReader, OLITIRSL2MDReader
+        good_mda = OLITIRSL2MDReader(mda_file, self.filename_info, {})
+        rdr = OLITIRSL2CHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        # Check case with good file data and load request
+        rdr.get_dataset({"name": "B4", "calibration": "counts"}, {"standard_name": "test_data", "units": "test_units"})
+
+    def test_loading_badfil(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with bad channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import OLITIRSL2CHReader, OLITIRSL2MDReader
+        good_mda = OLITIRSL2MDReader(mda_file, self.filename_info, {})
+        rdr = OLITIRSL2CHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+        # Check case with request to load channel not matching filename
+        with pytest.raises(ValueError, match="Requested channel B5 does not match the reader channel B4"):
+            rdr.get_dataset({"name": "B5", "calibration": "counts"}, ftype)
+
+    def test_loading_badchan(self, mda_file, b10_file):
+        """Test loading a Landsat Scene with bad channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import OLITIRSL2CHReader, OLITIRSL2MDReader
+        good_mda = OLITIRSL2MDReader(mda_file, self.filename_info, {})
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+        bad_finfo = self.filename_info.copy()
+        bad_finfo["data_type"] = "T"
+
+        # Check loading invalid channel for data type
+        rdr = OLITIRSL2CHReader(b10_file, bad_finfo, self.ftype_info, good_mda)
+        with pytest.raises(ValueError, match="Requested channel B4 is not available in this granule"):
+            rdr.get_dataset({"name": "B4", "calibration": "counts"}, ftype)
+
+        bad_finfo["data_type"] = "O"
+        ftype_b10 = self.ftype_info.copy()
+        ftype_b10["file_type"] = "granule_B10"
+        rdr = OLITIRSL2CHReader(b10_file, bad_finfo, ftype_b10, good_mda)
+        with pytest.raises(ValueError, match="Requested channel B10 is not available in this granule"):
+            rdr.get_dataset({"name": "B10", "calibration": "counts"}, ftype)
+
+    def test_badfiles(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with bad data."""
+        from satpy.readers.oli_tirs_l1_tif import OLITIRSL2CHReader, OLITIRSL2MDReader
+        bad_fname_info = self.filename_info.copy()
+        bad_fname_info["platform_type"] = "B"
+
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+
+        # Test that metadata reader initialises with correct filename
+        good_mda = OLITIRSL2MDReader(mda_file, self.filename_info, ftype)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            OLITIRSL2MDReader(mda_file, bad_fname_info, ftype)
+
+        # Test that metadata reader initialises with correct filename
+        OLITIRSL2CHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            OLITIRSL2CHReader(b4_file, bad_fname_info, self.ftype_info, good_mda)
+        bad_ftype_info = self.ftype_info.copy()
+        bad_ftype_info["file_type"] = "granule-b05"
+        with pytest.raises(ValueError, match="Invalid file type: granule-b05"):
+            OLITIRSL2CHReader(b4_file, self.filename_info, bad_ftype_info, good_mda)
+
+    def test_calibration_counts(self, all_files, b4_data, b10_data, rad_data):
+        """Test counts calibration mode for the reader."""
+        from satpy import Scene
+
+        scn = Scene(reader="oli_tirs_l2_tif", filenames=all_files)
+        scn.load(["B4", "B10", "TRAD"], calibration="counts")
+        np.testing.assert_allclose(scn["B4"].values, b4_data)
+        np.testing.assert_allclose(scn["B10"].values, b10_data)
+        np.testing.assert_allclose(scn["TRAD"].values, rad_data)
+        assert scn["B4"].attrs["units"] == "1"
+        assert scn["B10"].attrs["units"] == "1"
+        assert scn["TRAD"].attrs["units"] == "1"
+        assert scn["B4"].attrs["standard_name"] == "counts"
+        assert scn["B10"].attrs["standard_name"] == "counts"
+        assert scn["TRAD"].attrs["standard_name"] == "counts"
+
+    def test_calibration_highlevel(self, all_files, b4_data, b10_data, rad_data):
+        """Test high level calibration modes for the reader."""
+        from satpy import Scene
+        exp_b04 = (b4_data * 2.75e-05 - 0.2).astype(np.float32) * 100
+        exp_b10 = (b10_data * 0.00341802 + 149.0).astype(np.float32)
+        exp_rad = (rad_data * 0.001).astype(np.float32)
+        scn = Scene(reader="oli_tirs_l2_tif", filenames=all_files)
+        scn.load(["B4", "B10", "TRAD"])
+
+        assert scn["B4"].attrs["units"] == "%"
+        assert scn["B10"].attrs["units"] == "K"
+        assert scn["TRAD"].attrs["units"] == "W m-2 um-1 sr-1"
+        assert scn["B4"].attrs["standard_name"] == "surface_bidirectional_reflectance"
+        assert scn["B10"].attrs["standard_name"] == "brightness_temperature"
+        assert scn["TRAD"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
+        np.testing.assert_allclose(np.array(scn["B4"].values), np.array(exp_b04), rtol=1e-4)
+        np.testing.assert_allclose(scn["B10"].values, exp_b10, rtol=1e-6)
+        np.testing.assert_allclose(scn["TRAD"].values, exp_rad, rtol=1e-6)
+
+    def test_metadata(self, mda_file):
+        """Check that metadata values loaded correctly."""
+        from satpy.readers.oli_tirs_l1_tif import OLITIRSL2MDReader
+        mda = OLITIRSL2MDReader(mda_file, self.filename_info, {})
+
+        cal_test_dict = {"B1": (2.75e-05, -0.2),
+                         "B5": (2.75e-05, -0.2),
+                         "B10": (0.00341802, 149.0)}
+
+        assert mda.platform_name == "Landsat-9"
+        assert mda.earth_sun_distance() == 1.0158933
+        assert mda.band_calibration["B1"] == cal_test_dict["B1"]
+        assert mda.band_calibration["B5"] == cal_test_dict["B5"]
+        assert mda.band_calibration["B10"] == cal_test_dict["B10"]
+        assert not mda.band_saturation["B1"]
+        assert mda.band_saturation["B4"]
+        assert not mda.band_saturation["B5"]
+        with pytest.raises(KeyError):
+            mda.band_saturation["B10"]
+
+    def test_area_def(self, mda_file):
+        """Check we can get the area defs properly."""
+        from satpy.readers.oli_tirs_l1_tif import OLITIRSL2MDReader
+        mda = OLITIRSL2MDReader(mda_file, self.filename_info, {})
+
+        standard_area = mda.build_area_def("B1")
+
+        assert standard_area.area_extent == (534885.0, 4665585.0, 765015.0, 4899315.0)
+
+    def test_basicload_remote(self, area, all_fsspec_files):
+        """Test loading a Landsat Scene from a fsspec filesystem."""
+        scn = Scene(reader="oli_tirs_l2_tif", filenames=all_fsspec_files)
+        scn.load(["B4", "B10"])
+
+        # Check dataset is loaded correctly
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == area
+        assert scn["B4"].attrs["saturated"]
+        assert scn["B10"].shape == (100, 100)
+        assert scn["B10"].attrs["area"] == area
+        with pytest.raises(KeyError, match="saturated"):
+            assert not scn["B10"].attrs["saturated"]

--- a/satpy/tests/reader_tests/test_tm_l1_tif.py
+++ b/satpy/tests/reader_tests/test_tm_l1_tif.py
@@ -1,0 +1,583 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Unittests for generic image reader."""
+
+import os
+from datetime import datetime, timezone
+
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+from pyresample.geometry import AreaDefinition
+
+from satpy import Scene
+
+metadata_text = b"""<?xml version="1.0" encoding="UTF-8"?>
+<LANDSAT_METADATA_FILE>
+  <PRODUCT_CONTENTS>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P918ROHC</DIGITAL_OBJECT_IDENTIFIER>
+    <LANDSAT_PRODUCT_ID>LT04_L1TP_143021_19890818_20200916_02_T1</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L1TP</PROCESSING_LEVEL>
+    <COLLECTION_NUMBER>02</COLLECTION_NUMBER>
+    <COLLECTION_CATEGORY>T1</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <FILE_NAME_BAND_1>LT04_L1TP_143021_19890818_20200916_02_T1_B1.TIF</FILE_NAME_BAND_1>
+    <FILE_NAME_BAND_2>LT04_L1TP_143021_19890818_20200916_02_T1_B2.TIF</FILE_NAME_BAND_2>
+    <FILE_NAME_BAND_3>LT04_L1TP_143021_19890818_20200916_02_T1_B3.TIF</FILE_NAME_BAND_3>
+    <FILE_NAME_BAND_4>LT04_L1TP_143021_19890818_20200916_02_T1_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_BAND_5>LT04_L1TP_143021_19890818_20200916_02_T1_B5.TIF</FILE_NAME_BAND_5>
+    <FILE_NAME_BAND_6>LT04_L1TP_143021_19890818_20200916_02_T1_B6.TIF</FILE_NAME_BAND_6>
+    <FILE_NAME_BAND_7>LT04_L1TP_143021_19890818_20200916_02_T1_B7.TIF</FILE_NAME_BAND_7>
+    <FILE_NAME_QUALITY_L1_PIXEL>LT04_L1TP_143021_19890818_20200916_02_T1_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LT04_L1TP_143021_19890818_20200916_02_T1_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_GROUND_CONTROL_POINT>LT04_L1TP_143021_19890818_20200916_02_T1_GCP.txt</FILE_NAME_GROUND_CONTROL_POINT>
+    <FILE_NAME_ANGLE_COEFFICIENT>LT04_L1TP_143021_19890818_20200916_02_T1_ANG.txt</FILE_NAME_ANGLE_COEFFICIENT>
+    <FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>LT04_L1TP_143021_19890818_20200916_02_T1_VAA.TIF</FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>LT04_L1TP_143021_19890818_20200916_02_T1_VZA.TIF</FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>LT04_L1TP_143021_19890818_20200916_02_T1_SAA.TIF</FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>LT04_L1TP_143021_19890818_20200916_02_T1_SZA.TIF</FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>
+    <FILE_NAME_METADATA_ODL>LT04_L1TP_143021_19890818_20200916_02_T1_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LT04_L1TP_143021_19890818_20200916_02_T1_MTL.xml</FILE_NAME_METADATA_XML>
+    <FILE_NAME_VERIFY_REPORT>LT04_L1TP_143021_19890818_20200916_02_T1_VER.txt</FILE_NAME_VERIFY_REPORT>
+    <FILE_NAME_VERIFY_BROWSE>LT04_L1TP_143021_19890818_20200916_02_T1_VER.jpg</FILE_NAME_VERIFY_BROWSE>
+    <DATA_TYPE_BAND_1>UINT8</DATA_TYPE_BAND_1>
+    <DATA_TYPE_BAND_2>UINT8</DATA_TYPE_BAND_2>
+    <DATA_TYPE_BAND_3>UINT8</DATA_TYPE_BAND_3>
+    <DATA_TYPE_BAND_4>UINT8</DATA_TYPE_BAND_4>
+    <DATA_TYPE_BAND_5>UINT8</DATA_TYPE_BAND_5>
+    <DATA_TYPE_BAND_6>UINT8</DATA_TYPE_BAND_6>
+    <DATA_TYPE_BAND_7>UINT8</DATA_TYPE_BAND_7>
+    <DATA_TYPE_QUALITY_L1_PIXEL>UINT16</DATA_TYPE_QUALITY_L1_PIXEL>
+    <DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>UINT16</DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <DATA_TYPE_ANGLE_SENSOR_AZIMUTH_BAND_4>INT16</DATA_TYPE_ANGLE_SENSOR_AZIMUTH_BAND_4>
+    <DATA_TYPE_ANGLE_SENSOR_ZENITH_BAND_4>INT16</DATA_TYPE_ANGLE_SENSOR_ZENITH_BAND_4>
+    <DATA_TYPE_ANGLE_SOLAR_AZIMUTH_BAND_4>INT16</DATA_TYPE_ANGLE_SOLAR_AZIMUTH_BAND_4>
+    <DATA_TYPE_ANGLE_SOLAR_ZENITH_BAND_4>INT16</DATA_TYPE_ANGLE_SOLAR_ZENITH_BAND_4>
+  </PRODUCT_CONTENTS>
+  <IMAGE_ATTRIBUTES>
+    <SPACECRAFT_ID>LANDSAT_4</SPACECRAFT_ID>
+    <SENSOR_ID>TM</SENSOR_ID>
+    <WRS_TYPE>2</WRS_TYPE>
+    <WRS_PATH>143</WRS_PATH>
+    <WRS_ROW>021</WRS_ROW>
+    <DATE_ACQUIRED>1989-08-18</DATE_ACQUIRED>
+    <SCENE_CENTER_TIME>04:26:11.9550880Z</SCENE_CENTER_TIME>
+    <STATION_ID>XXX</STATION_ID>
+    <CLOUD_COVER>10.00</CLOUD_COVER>
+    <CLOUD_COVER_LAND>10.00</CLOUD_COVER_LAND>
+    <IMAGE_QUALITY>9</IMAGE_QUALITY>
+    <SATURATION_BAND_1>N</SATURATION_BAND_1>
+    <SATURATION_BAND_2>Y</SATURATION_BAND_2>
+    <SATURATION_BAND_3>Y</SATURATION_BAND_3>
+    <SATURATION_BAND_4>Y</SATURATION_BAND_4>
+    <SATURATION_BAND_5>N</SATURATION_BAND_5>
+    <SATURATION_BAND_6>N</SATURATION_BAND_6>
+    <SATURATION_BAND_7>Y</SATURATION_BAND_7>
+    <SUN_AZIMUTH>149.14166856</SUN_AZIMUTH>
+    <SUN_ELEVATION>43.85182285</SUN_ELEVATION>
+    <EARTH_SUN_DISTANCE>1.0122057</EARTH_SUN_DISTANCE>
+    <SENSOR_MODE>SAM</SENSOR_MODE>
+    <SENSOR_MODE_SLC>ON</SENSOR_MODE_SLC>
+    <SENSOR_ANOMALIES>NONE</SENSOR_ANOMALIES>
+  </IMAGE_ATTRIBUTES>
+  <PROJECTION_ATTRIBUTES>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>46</UTM_ZONE>
+    <GRID_CELL_SIZE_REFLECTIVE>30.00</GRID_CELL_SIZE_REFLECTIVE>
+    <GRID_CELL_SIZE_THERMAL>30.00</GRID_CELL_SIZE_THERMAL>
+    <REFLECTIVE_LINES>100</REFLECTIVE_LINES>
+    <REFLECTIVE_SAMPLES>100</REFLECTIVE_SAMPLES>
+    <THERMAL_LINES>100</THERMAL_LINES>
+    <THERMAL_SAMPLES>100</THERMAL_SAMPLES>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <CORNER_UL_LAT_PRODUCT>56.91211</CORNER_UL_LAT_PRODUCT>
+    <CORNER_UL_LON_PRODUCT>90.07952</CORNER_UL_LON_PRODUCT>
+    <CORNER_UR_LAT_PRODUCT>56.94129</CORNER_UR_LAT_PRODUCT>
+    <CORNER_UR_LON_PRODUCT>94.11108</CORNER_UR_LON_PRODUCT>
+    <CORNER_LL_LAT_PRODUCT>54.88218</CORNER_LL_LAT_PRODUCT>
+    <CORNER_LL_LON_PRODUCT>90.22826</CORNER_LL_LON_PRODUCT>
+    <CORNER_LR_LAT_PRODUCT>54.90923</CORNER_LR_LAT_PRODUCT>
+    <CORNER_LR_LON_PRODUCT>94.05441</CORNER_LR_LON_PRODUCT>
+    <CORNER_UL_PROJECTION_X_PRODUCT>322200.000</CORNER_UL_PROJECTION_X_PRODUCT>
+    <CORNER_UL_PROJECTION_Y_PRODUCT>6311400.000</CORNER_UL_PROJECTION_Y_PRODUCT>
+    <CORNER_UR_PROJECTION_X_PRODUCT>567600.000</CORNER_UR_PROJECTION_X_PRODUCT>
+    <CORNER_UR_PROJECTION_Y_PRODUCT>6311400.000</CORNER_UR_PROJECTION_Y_PRODUCT>
+    <CORNER_LL_PROJECTION_X_PRODUCT>322200.000</CORNER_LL_PROJECTION_X_PRODUCT>
+    <CORNER_LL_PROJECTION_Y_PRODUCT>6085200.000</CORNER_LL_PROJECTION_Y_PRODUCT>
+    <CORNER_LR_PROJECTION_X_PRODUCT>567600.000</CORNER_LR_PROJECTION_X_PRODUCT>
+    <CORNER_LR_PROJECTION_Y_PRODUCT>6085200.000</CORNER_LR_PROJECTION_Y_PRODUCT>
+  </PROJECTION_ATTRIBUTES>
+  <LEVEL1_PROCESSING_RECORD>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P918ROHC</DIGITAL_OBJECT_IDENTIFIER>
+    <REQUEST_ID>L2</REQUEST_ID>
+    <LANDSAT_SCENE_ID>LT41430211989230XXX02</LANDSAT_SCENE_ID>
+    <LANDSAT_PRODUCT_ID>LT04_L1TP_143021_19890818_20200916_02_T1</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L1TP</PROCESSING_LEVEL>
+    <COLLECTION_CATEGORY>T1</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <DATE_PRODUCT_GENERATED>2020-09-16T12:08:23Z</DATE_PRODUCT_GENERATED>
+    <PROCESSING_SOFTWARE_VERSION>LPGS_15.3.1c</PROCESSING_SOFTWARE_VERSION>
+    <FILE_NAME_BAND_1>LT04_L1TP_143021_19890818_20200916_02_T1_B1.TIF</FILE_NAME_BAND_1>
+    <FILE_NAME_BAND_2>LT04_L1TP_143021_19890818_20200916_02_T1_B2.TIF</FILE_NAME_BAND_2>
+    <FILE_NAME_BAND_3>LT04_L1TP_143021_19890818_20200916_02_T1_B3.TIF</FILE_NAME_BAND_3>
+    <FILE_NAME_BAND_4>LT04_L1TP_143021_19890818_20200916_02_T1_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_BAND_5>LT04_L1TP_143021_19890818_20200916_02_T1_B5.TIF</FILE_NAME_BAND_5>
+    <FILE_NAME_BAND_6>LT04_L1TP_143021_19890818_20200916_02_T1_B6.TIF</FILE_NAME_BAND_6>
+    <FILE_NAME_BAND_7>LT04_L1TP_143021_19890818_20200916_02_T1_B7.TIF</FILE_NAME_BAND_7>
+    <FILE_NAME_QUALITY_L1_PIXEL>LT04_L1TP_143021_19890818_20200916_02_T1_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LT04_L1TP_143021_19890818_20200916_02_T1_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_GROUND_CONTROL_POINT>LT04_L1TP_143021_19890818_20200916_02_T1_GCP.txt</FILE_NAME_GROUND_CONTROL_POINT>
+    <FILE_NAME_ANGLE_COEFFICIENT>LT04_L1TP_143021_19890818_20200916_02_T1_ANG.txt</FILE_NAME_ANGLE_COEFFICIENT>
+    <FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>LT04_L1TP_143021_19890818_20200916_02_T1_VAA.TIF</FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>LT04_L1TP_143021_19890818_20200916_02_T1_VZA.TIF</FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>LT04_L1TP_143021_19890818_20200916_02_T1_SAA.TIF</FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>LT04_L1TP_143021_19890818_20200916_02_T1_SZA.TIF</FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>
+    <FILE_NAME_METADATA_ODL>LT04_L1TP_143021_19890818_20200916_02_T1_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LT04_L1TP_143021_19890818_20200916_02_T1_MTL.xml</FILE_NAME_METADATA_XML>
+    <FILE_NAME_CPF>LT04CPF_19890701_19890930_02.01</FILE_NAME_CPF>
+    <FILE_NAME_VERIFY_REPORT>LT04_L1TP_143021_19890818_20200916_02_T1_VER.txt</FILE_NAME_VERIFY_REPORT>
+    <FILE_NAME_VERIFY_BROWSE>LT04_L1TP_143021_19890818_20200916_02_T1_VER.jpg</FILE_NAME_VERIFY_BROWSE>
+    <DATA_SOURCE_ELEVATION>GLS2000</DATA_SOURCE_ELEVATION>
+    <GROUND_CONTROL_POINTS_VERSION>5</GROUND_CONTROL_POINTS_VERSION>
+    <GROUND_CONTROL_POINTS_MODEL>918</GROUND_CONTROL_POINTS_MODEL>
+    <GEOMETRIC_RMSE_MODEL>4.609</GEOMETRIC_RMSE_MODEL>
+    <GEOMETRIC_RMSE_MODEL_Y>3.369</GEOMETRIC_RMSE_MODEL_Y>
+    <GEOMETRIC_RMSE_MODEL_X>3.145</GEOMETRIC_RMSE_MODEL_X>
+    <GROUND_CONTROL_POINTS_VERIFY>2236</GROUND_CONTROL_POINTS_VERIFY>
+    <GEOMETRIC_RMSE_VERIFY>0.233</GEOMETRIC_RMSE_VERIFY>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_UL>0.195</GEOMETRIC_RMSE_VERIFY_QUAD_UL>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_UR>0.211</GEOMETRIC_RMSE_VERIFY_QUAD_UR>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_LL>0.296</GEOMETRIC_RMSE_VERIFY_QUAD_LL>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_LR>0.247</GEOMETRIC_RMSE_VERIFY_QUAD_LR>
+    <EPHEMERIS_TYPE>DEFINITIVE</EPHEMERIS_TYPE>
+  </LEVEL1_PROCESSING_RECORD>
+  <LEVEL1_MIN_MAX_RADIANCE>
+    <RADIANCE_MAXIMUM_BAND_1>171.000</RADIANCE_MAXIMUM_BAND_1>
+    <RADIANCE_MINIMUM_BAND_1>-1.520</RADIANCE_MINIMUM_BAND_1>
+    <RADIANCE_MAXIMUM_BAND_2>336.000</RADIANCE_MAXIMUM_BAND_2>
+    <RADIANCE_MINIMUM_BAND_2>-2.840</RADIANCE_MINIMUM_BAND_2>
+    <RADIANCE_MAXIMUM_BAND_3>254.000</RADIANCE_MAXIMUM_BAND_3>
+    <RADIANCE_MINIMUM_BAND_3>-1.170</RADIANCE_MINIMUM_BAND_3>
+    <RADIANCE_MAXIMUM_BAND_4>221.000</RADIANCE_MAXIMUM_BAND_4>
+    <RADIANCE_MINIMUM_BAND_4>-1.510</RADIANCE_MINIMUM_BAND_4>
+    <RADIANCE_MAXIMUM_BAND_5>31.400</RADIANCE_MAXIMUM_BAND_5>
+    <RADIANCE_MINIMUM_BAND_5>-0.370</RADIANCE_MINIMUM_BAND_5>
+    <RADIANCE_MAXIMUM_BAND_6>15.303</RADIANCE_MAXIMUM_BAND_6>
+    <RADIANCE_MINIMUM_BAND_6>1.238</RADIANCE_MINIMUM_BAND_6>
+    <RADIANCE_MAXIMUM_BAND_7>16.600</RADIANCE_MAXIMUM_BAND_7>
+    <RADIANCE_MINIMUM_BAND_7>-0.150</RADIANCE_MINIMUM_BAND_7>
+  </LEVEL1_MIN_MAX_RADIANCE>
+  <LEVEL1_MIN_MAX_REFLECTANCE>
+    <REFLECTANCE_MAXIMUM_BAND_1>0.283277</REFLECTANCE_MAXIMUM_BAND_1>
+    <REFLECTANCE_MINIMUM_BAND_1>-0.002518</REFLECTANCE_MINIMUM_BAND_1>
+    <REFLECTANCE_MAXIMUM_BAND_2>0.615188</REFLECTANCE_MAXIMUM_BAND_2>
+    <REFLECTANCE_MINIMUM_BAND_2>-0.005200</REFLECTANCE_MINIMUM_BAND_2>
+    <REFLECTANCE_MAXIMUM_BAND_3>0.550547</REFLECTANCE_MAXIMUM_BAND_3>
+    <REFLECTANCE_MINIMUM_BAND_3>-0.002536</REFLECTANCE_MINIMUM_BAND_3>
+    <REFLECTANCE_MAXIMUM_BAND_4>0.688620</REFLECTANCE_MAXIMUM_BAND_4>
+    <REFLECTANCE_MINIMUM_BAND_4>-0.004705</REFLECTANCE_MINIMUM_BAND_4>
+    <REFLECTANCE_MAXIMUM_BAND_5>0.455881</REFLECTANCE_MAXIMUM_BAND_5>
+    <REFLECTANCE_MINIMUM_BAND_5>-0.005372</REFLECTANCE_MINIMUM_BAND_5>
+    <REFLECTANCE_MAXIMUM_BAND_7>0.641894</REFLECTANCE_MAXIMUM_BAND_7>
+    <REFLECTANCE_MINIMUM_BAND_7>-0.005800</REFLECTANCE_MINIMUM_BAND_7>
+  </LEVEL1_MIN_MAX_REFLECTANCE>
+  <LEVEL1_MIN_MAX_PIXEL_VALUE>
+    <QUANTIZE_CAL_MAX_BAND_1>255</QUANTIZE_CAL_MAX_BAND_1>
+    <QUANTIZE_CAL_MIN_BAND_1>1</QUANTIZE_CAL_MIN_BAND_1>
+    <QUANTIZE_CAL_MAX_BAND_2>255</QUANTIZE_CAL_MAX_BAND_2>
+    <QUANTIZE_CAL_MIN_BAND_2>1</QUANTIZE_CAL_MIN_BAND_2>
+    <QUANTIZE_CAL_MAX_BAND_3>255</QUANTIZE_CAL_MAX_BAND_3>
+    <QUANTIZE_CAL_MIN_BAND_3>1</QUANTIZE_CAL_MIN_BAND_3>
+    <QUANTIZE_CAL_MAX_BAND_4>255</QUANTIZE_CAL_MAX_BAND_4>
+    <QUANTIZE_CAL_MIN_BAND_4>1</QUANTIZE_CAL_MIN_BAND_4>
+    <QUANTIZE_CAL_MAX_BAND_5>255</QUANTIZE_CAL_MAX_BAND_5>
+    <QUANTIZE_CAL_MIN_BAND_5>1</QUANTIZE_CAL_MIN_BAND_5>
+    <QUANTIZE_CAL_MAX_BAND_6>255</QUANTIZE_CAL_MAX_BAND_6>
+    <QUANTIZE_CAL_MIN_BAND_6>1</QUANTIZE_CAL_MIN_BAND_6>
+    <QUANTIZE_CAL_MAX_BAND_7>255</QUANTIZE_CAL_MAX_BAND_7>
+    <QUANTIZE_CAL_MIN_BAND_7>1</QUANTIZE_CAL_MIN_BAND_7>
+  </LEVEL1_MIN_MAX_PIXEL_VALUE>
+  <LEVEL1_RADIOMETRIC_RESCALING>
+    <RADIANCE_MULT_BAND_1>6.7921E-01</RADIANCE_MULT_BAND_1>
+    <RADIANCE_MULT_BAND_2>1.3340E+00</RADIANCE_MULT_BAND_2>
+    <RADIANCE_MULT_BAND_3>1.0046E+00</RADIANCE_MULT_BAND_3>
+    <RADIANCE_MULT_BAND_4>8.7602E-01</RADIANCE_MULT_BAND_4>
+    <RADIANCE_MULT_BAND_5>1.2508E-01</RADIANCE_MULT_BAND_5>
+    <RADIANCE_MULT_BAND_6>5.5375E-02</RADIANCE_MULT_BAND_6>
+    <RADIANCE_MULT_BAND_7>6.5945E-02</RADIANCE_MULT_BAND_7>
+    <RADIANCE_ADD_BAND_1>-2.19921</RADIANCE_ADD_BAND_1>
+    <RADIANCE_ADD_BAND_2>-4.17402</RADIANCE_ADD_BAND_2>
+    <RADIANCE_ADD_BAND_3>-2.17461</RADIANCE_ADD_BAND_3>
+    <RADIANCE_ADD_BAND_4>-2.38602</RADIANCE_ADD_BAND_4>
+    <RADIANCE_ADD_BAND_5>-0.49508</RADIANCE_ADD_BAND_5>
+    <RADIANCE_ADD_BAND_6>1.18243</RADIANCE_ADD_BAND_6>
+    <RADIANCE_ADD_BAND_7>-0.21594</RADIANCE_ADD_BAND_7>
+    <REFLECTANCE_MULT_BAND_1>1.1252E-03</REFLECTANCE_MULT_BAND_1>
+    <REFLECTANCE_MULT_BAND_2>2.4425E-03</REFLECTANCE_MULT_BAND_2>
+    <REFLECTANCE_MULT_BAND_3>2.1775E-03</REFLECTANCE_MULT_BAND_3>
+    <REFLECTANCE_MULT_BAND_4>2.7296E-03</REFLECTANCE_MULT_BAND_4>
+    <REFLECTANCE_MULT_BAND_5>1.8160E-03</REFLECTANCE_MULT_BAND_5>
+    <REFLECTANCE_MULT_BAND_7>2.5500E-03</REFLECTANCE_MULT_BAND_7>
+    <REFLECTANCE_ADD_BAND_1>-0.003643</REFLECTANCE_ADD_BAND_1>
+    <REFLECTANCE_ADD_BAND_2>-0.007642</REFLECTANCE_ADD_BAND_2>
+    <REFLECTANCE_ADD_BAND_3>-0.004713</REFLECTANCE_ADD_BAND_3>
+    <REFLECTANCE_ADD_BAND_4>-0.007435</REFLECTANCE_ADD_BAND_4>
+    <REFLECTANCE_ADD_BAND_5>-0.007188</REFLECTANCE_ADD_BAND_5>
+    <REFLECTANCE_ADD_BAND_7>-0.008350</REFLECTANCE_ADD_BAND_7>
+  </LEVEL1_RADIOMETRIC_RESCALING>
+  <LEVEL1_THERMAL_CONSTANTS>
+    <K1_CONSTANT_BAND_6>671.62</K1_CONSTANT_BAND_6>
+    <K2_CONSTANT_BAND_6>1284.30</K2_CONSTANT_BAND_6>
+  </LEVEL1_THERMAL_CONSTANTS>
+  <LEVEL1_PROJECTION_PARAMETERS>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>46</UTM_ZONE>
+    <GRID_CELL_SIZE_REFLECTIVE>30.00</GRID_CELL_SIZE_REFLECTIVE>
+    <GRID_CELL_SIZE_THERMAL>30.00</GRID_CELL_SIZE_THERMAL>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <RESAMPLING_OPTION>CUBIC_CONVOLUTION</RESAMPLING_OPTION>
+    <MAP_PROJECTION_L0RA>NA</MAP_PROJECTION_L0RA>
+  </LEVEL1_PROJECTION_PARAMETERS>
+  <PRODUCT_PARAMETERS>
+    <DATA_TYPE_L0RP>TMR_L0RP</DATA_TYPE_L0RP>
+    <CORRECTION_GAIN_BAND_1>CPF</CORRECTION_GAIN_BAND_1>
+    <CORRECTION_GAIN_BAND_2>CPF</CORRECTION_GAIN_BAND_2>
+    <CORRECTION_GAIN_BAND_3>CPF</CORRECTION_GAIN_BAND_3>
+    <CORRECTION_GAIN_BAND_4>CPF</CORRECTION_GAIN_BAND_4>
+    <CORRECTION_GAIN_BAND_5>CPF</CORRECTION_GAIN_BAND_5>
+    <CORRECTION_GAIN_BAND_6>INTERNAL_CALIBRATION</CORRECTION_GAIN_BAND_6>
+    <CORRECTION_GAIN_BAND_7>CPF</CORRECTION_GAIN_BAND_7>
+    <CORRECTION_BIAS_BAND_1>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_1>
+    <CORRECTION_BIAS_BAND_2>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_2>
+    <CORRECTION_BIAS_BAND_3>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_3>
+    <CORRECTION_BIAS_BAND_4>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_4>
+    <CORRECTION_BIAS_BAND_5>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_5>
+    <CORRECTION_BIAS_BAND_6>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_6>
+    <CORRECTION_BIAS_BAND_7>INTERNAL_CALIBRATION</CORRECTION_BIAS_BAND_7>
+  </PRODUCT_PARAMETERS>
+</LANDSAT_METADATA_FILE>
+"""
+
+
+x_size = 100
+y_size = 100
+date = datetime(1989, 8, 18, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="session")
+def area():
+    """Get the landsat 1 area def."""
+    pcs_id = "WGS84 / UTM zone 46N"
+    proj4_dict = {"proj": "utm", "zone": 46, "datum": "WGS84", "units": "m", "no_defs": None, "type": "crs"}
+    area_extent = (322185.0, 6085185.0, 567615.0, 6311415.0)
+    return AreaDefinition("geotiff_area", pcs_id, pcs_id,
+                          proj4_dict, x_size, y_size,
+                          area_extent)
+
+
+@pytest.fixture(scope="session")
+def b4_data():
+    """Get the data for the b4 channel."""
+    return da.random.randint(12000, 16000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+@pytest.fixture(scope="session")
+def b6_data():
+    """Get the data for the b6 channel."""
+    return da.random.randint(8000, 14000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+@pytest.fixture(scope="session")
+def sza_data():
+    """Get the data for the sza."""
+    return da.random.randint(1, 10000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+def create_tif_file(data, name, area, filename):
+    """Create a tif file."""
+    data_array = xr.DataArray(data,
+                              dims=("y", "x"),
+                              attrs={"name": name,
+                                     "start_time": date})
+    scn = Scene()
+    scn["band_data"] = data_array
+    scn["band_data"].attrs["area"] = area
+    scn.save_dataset("band_data", writer="geotiff", enhance=False, fill_value=0,
+                     filename=os.fspath(filename))
+
+
+@pytest.fixture(scope="session")
+def files_path(tmp_path_factory):
+    """Create the path for l1 files."""
+    return tmp_path_factory.mktemp("tm_l1_files")
+
+
+@pytest.fixture(scope="session")
+def b4_file(files_path, b4_data, area):
+    """Create the file for the b4 channel."""
+    data = b4_data
+    filename = files_path / "LT04_L1TP_143021_19890818_20200916_02_T1_B4.TIF"
+    name = "B4"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+@pytest.fixture(scope="session")
+def b6_file(files_path, b6_data, area):
+    """Create the file for the b6 channel."""
+    data = b6_data
+    filename = files_path / "LT04_L1TP_143021_19890818_20200916_02_T1_B6.TIF"
+    name = "B6"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+@pytest.fixture(scope="session")
+def sza_file(files_path, sza_data, area):
+    """Create the file for the sza."""
+    data = sza_data
+    filename = files_path / "LT04_L1TP_143021_19890818_20200916_02_T1_SZA.TIF"
+    name = "sza"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+
+@pytest.fixture(scope="session")
+def mda_file(files_path):
+    """Create the metadata xml file."""
+    filename = files_path / "LT04_L1TP_143021_19890818_20200916_02_T1_MTL.xml"
+    with open(filename, "wb") as f:
+        f.write(metadata_text)
+    return os.fspath(filename)
+
+
+@pytest.fixture(scope="session")
+def all_files(b4_file, b6_file, mda_file, sza_file):
+    """Return all the files."""
+    return b4_file, b6_file, mda_file, sza_file
+
+
+@pytest.fixture(scope="session")
+def all_fs_files(b4_file, b6_file, mda_file, sza_file):
+    """Return all the files as FSFile objects."""
+    from fsspec.implementations.local import LocalFileSystem
+
+    from satpy.readers.core.remote import FSFile
+
+    fs = LocalFileSystem()
+    b4_file, b6_file, mda_file, sza_file = (
+        FSFile(os.path.abspath(file), fs=fs)
+        for file in [b4_file, b6_file, mda_file, sza_file]
+    )
+    return b4_file, b6_file, mda_file, sza_file
+
+
+class TestTML1:
+    """Test generic image reader."""
+
+    def setup_method(self, tmp_path):
+        """Set up the filename and filetype info dicts.."""
+        self.filename_info = dict(observation_date=datetime(1989, 8, 18),
+                                  platform_type="L",
+                                  process_level_correction="L1TP",
+                                  spacecraft_id="04",
+                                  data_type="T",
+                                  collection_id="02")
+        self.ftype_info = {"file_type": "granule_B4"}
+
+    def test_basicload(self, area, b4_file, b6_file, mda_file):
+        """Test loading a Landsat Scene."""
+        scn = Scene(reader="tm_l1_tif", filenames=[b4_file,
+                                                   b6_file,
+                                                   mda_file])
+        scn.load(["B4", "B6"])
+
+        # Check dataset is loaded correctly
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == area
+        assert scn["B4"].attrs["saturated"]
+        assert scn["B6"].shape == (100, 100)
+        assert scn["B6"].attrs["area"] == area
+        assert not scn["B6"].attrs["saturated"]
+
+    def test_ch_startend(self, b4_file, sza_file, mda_file):
+        """Test correct retrieval of start/end times."""
+        scn = Scene(reader="tm_l1_tif", filenames=[b4_file,
+                                                   sza_file,
+                                                   mda_file])
+        bnds = scn.available_dataset_names()
+        assert bnds == ["B4", "solar_zenith_angle"]
+
+        scn.load(["B4"])
+        assert scn.start_time == datetime(1989, 8, 18, 4, 26, 11, tzinfo=timezone.utc)
+        assert scn.end_time == datetime(1989, 8, 18, 4, 26, 11, tzinfo=timezone.utc)
+
+    def test_loading_gd(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with good channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import TMCHReader, TMMDReader
+        good_mda = TMMDReader(mda_file, self.filename_info, {})
+        rdr = TMCHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        # Check case with good file data and load request
+        rdr.get_dataset({"name": "B4", "calibration": "counts"}, {"standard_name": "test_data", "units": "test_units"})
+
+    def test_loading_badfil(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with bad channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import TMCHReader, TMMDReader
+        good_mda = TMMDReader(mda_file, self.filename_info, {})
+        rdr = TMCHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+        # Check case with request to load channel not matching filename
+        with pytest.raises(ValueError, match="Requested channel B5 does not match the reader channel B4"):
+            rdr.get_dataset({"name": "B5", "calibration": "counts"}, ftype)
+
+    def test_badfiles(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with bad data."""
+        from satpy.readers.oli_tirs_l1_tif import TMCHReader, TMMDReader
+        bad_fname_info = self.filename_info.copy()
+        bad_fname_info["platform_type"] = "B"
+
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+
+        # Test that metadata reader initialises with correct filename
+        good_mda = TMMDReader(mda_file, self.filename_info, ftype)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            TMMDReader(mda_file, bad_fname_info, ftype)
+
+        # Test that metadata reader initialises with correct filename
+        TMCHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            TMCHReader(b4_file, bad_fname_info, self.ftype_info, good_mda)
+        bad_ftype_info = self.ftype_info.copy()
+        bad_ftype_info["file_type"] = "granule-b05"
+        with pytest.raises(ValueError, match="Invalid file type: granule-b05"):
+            TMCHReader(b4_file, self.filename_info, bad_ftype_info, good_mda)
+
+    def test_calibration_counts(self, all_files, b4_data, b6_data):
+        """Test counts calibration mode for the reader."""
+        from satpy import Scene
+
+        scn = Scene(reader="tm_l1_tif", filenames=all_files)
+        scn.load(["B4", "B6"], calibration="counts")
+        np.testing.assert_allclose(scn["B4"].values, b4_data)
+        np.testing.assert_allclose(scn["B6"].values, b6_data)
+        assert scn["B4"].attrs["units"] == "1"
+        assert scn["B6"].attrs["units"] == "1"
+        assert scn["B4"].attrs["standard_name"] == "counts"
+        assert scn["B6"].attrs["standard_name"] == "counts"
+
+    def test_calibration_radiance(self, all_files, b4_data, b6_data):
+        """Test radiance calibration mode for the reader."""
+        from satpy import Scene
+        exp_b04 = (b4_data * 8.7602e-01 - 2.38602).astype(np.float32)
+        exp_b6 = (b6_data * 5.5375e-02 + 1.18243).astype(np.float32)
+
+        scn = Scene(reader="tm_l1_tif", filenames=all_files)
+        scn.load(["B4", "B6"], calibration="radiance")
+        assert scn["B4"].attrs["units"] == "W m-2 um-1 sr-1"
+        assert scn["B6"].attrs["units"] == "W m-2 um-1 sr-1"
+        assert scn["B4"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
+        assert scn["B6"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
+        np.testing.assert_allclose(scn["B4"].values, exp_b04, rtol=1e-4)
+        np.testing.assert_allclose(scn["B6"].values, exp_b6, rtol=1e-4)
+
+    def test_calibration_highlevel(self, all_files, b4_data, b6_data):
+        """Test high level calibration modes for the reader."""
+        from satpy import Scene
+        exp_b04 = (b4_data * 2.7296e-03 - 0.007435).astype(np.float32) * 100
+        exp_b6 = (b6_data * 5.5375e-02 + 1.18243).astype(np.float32)
+        exp_b6 = (1284.30 / np.log((671.62 / exp_b6) + 1)).astype(np.float32)
+        scn = Scene(reader="tm_l1_tif", filenames=all_files)
+        scn.load(["B4", "B6"])
+
+        assert scn["B4"].attrs["units"] == "%"
+        assert scn["B6"].attrs["units"] == "K"
+        assert scn["B4"].attrs["standard_name"] == "toa_bidirectional_reflectance"
+        assert scn["B6"].attrs["standard_name"] == "brightness_temperature"
+        np.testing.assert_allclose(np.array(scn["B4"].values), np.array(exp_b04), rtol=1e-4)
+        np.testing.assert_allclose(scn["B6"].values, exp_b6, rtol=1e-6)
+
+    def test_angles(self, all_files, sza_data):
+        """Test calibration modes for the reader."""
+        from satpy import Scene
+
+        # Check angles are calculated correctly
+        scn = Scene(reader="tm_l1_tif", filenames=all_files)
+        scn.load(["solar_zenith_angle"])
+        assert scn["solar_zenith_angle"].attrs["units"] == "degrees"
+        assert scn["solar_zenith_angle"].attrs["standard_name"] == "solar_zenith_angle"
+        np.testing.assert_allclose(scn["solar_zenith_angle"].values * 100,
+                                   np.array(sza_data),
+                                   atol=0.01,
+                                   rtol=1e-3)
+
+    def test_metadata(self, mda_file):
+        """Check that metadata values loaded correctly."""
+        from satpy.readers.oli_tirs_l1_tif import TMMDReader
+        mda = TMMDReader(mda_file, self.filename_info, {})
+
+        cal_test_dict = {"B1": (6.7921e-01, -2.19921, 1.1252e-03, -0.003643),
+                         "B5": (1.2508e-01, -0.49508, 1.8160e-03, -0.007188),
+                         "B6": (5.5375e-02, 1.18243, 671.62, 1284.30)}
+
+        assert mda.platform_name == "Landsat-4"
+        assert mda.earth_sun_distance() == 1.0122057
+        assert mda.band_calibration["B1"] == cal_test_dict["B1"]
+        assert mda.band_calibration["B5"] == cal_test_dict["B5"]
+        assert mda.band_calibration["B6"] == cal_test_dict["B6"]
+        assert not mda.band_saturation["B1"]
+        assert mda.band_saturation["B4"]
+        assert not mda.band_saturation["B5"]
+        assert not mda.band_saturation["B6"]
+
+    def test_area_def(self, mda_file):
+        """Check we can get the area defs properly."""
+        from satpy.readers.oli_tirs_l1_tif import TMMDReader
+        mda = TMMDReader(mda_file, self.filename_info, {})
+
+        standard_area = mda.build_area_def("B1")
+
+        assert standard_area.area_extent == (322185.0, 6085185.0, 567615.0, 6311415.0)
+
+    def test_basicload_remote(self, area, all_fs_files):
+        """Test loading a Landsat Scene from a fsspec filesystem."""
+        scn = Scene(reader="tm_l1_tif", filenames=all_fs_files)
+        scn.load(["B4", "B6"])
+
+        # Check dataset is loaded correctly
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == area
+        assert scn["B4"].attrs["saturated"]
+        assert scn["B6"].shape == (100, 100)
+        assert scn["B6"].attrs["area"] == area
+        assert not scn["B6"].attrs["saturated"]

--- a/satpy/tests/reader_tests/test_tm_l2_tif.py
+++ b/satpy/tests/reader_tests/test_tm_l2_tif.py
@@ -1,0 +1,630 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Satpy developers
+#
+# This file is part of satpy.
+#
+# satpy is free software: you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation, either version 3 of the License, or (at your option) any later
+# version.
+#
+# satpy is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with
+# satpy.  If not, see <http://www.gnu.org/licenses/>.
+"""Unittests for generic image reader."""
+
+import os
+from datetime import datetime, timezone
+
+import dask.array as da
+import numpy as np
+import pytest
+import xarray as xr
+from pyresample.geometry import AreaDefinition
+
+from satpy import Scene
+
+metadata_text = b"""<?xml version="1.0" encoding="UTF-8"?>
+<LANDSAT_METADATA_FILE>
+  <PRODUCT_CONTENTS>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P9IAXOVV</DIGITAL_OBJECT_IDENTIFIER>
+    <LANDSAT_PRODUCT_ID>LT05_L2SP_165054_20110817_20200820_02_T1</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L2SP</PROCESSING_LEVEL>
+    <COLLECTION_NUMBER>02</COLLECTION_NUMBER>
+    <COLLECTION_CATEGORY>T1</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <FILE_NAME_BAND_1>LT05_L2SP_165054_20110817_20200820_02_T1_SR_B1.TIF</FILE_NAME_BAND_1>
+    <FILE_NAME_BAND_2>LT05_L2SP_165054_20110817_20200820_02_T1_SR_B2.TIF</FILE_NAME_BAND_2>
+    <FILE_NAME_BAND_3>LT05_L2SP_165054_20110817_20200820_02_T1_SR_B3.TIF</FILE_NAME_BAND_3>
+    <FILE_NAME_BAND_4>LT05_L2SP_165054_20110817_20200820_02_T1_SR_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_BAND_5>LT05_L2SP_165054_20110817_20200820_02_T1_SR_B5.TIF</FILE_NAME_BAND_5>
+    <FILE_NAME_BAND_ST_B6>LT05_L2SP_165054_20110817_20200820_02_T1_ST_B6.TIF</FILE_NAME_BAND_ST_B6>
+    <FILE_NAME_BAND_7>LT05_L2SP_165054_20110817_20200820_02_T1_SR_B7.TIF</FILE_NAME_BAND_7>
+    <FILE_NAME_THERMAL_RADIANCE>LT05_L2SP_165054_20110817_20200820_02_T1_ST_TRAD.TIF</FILE_NAME_THERMAL_RADIANCE>
+    <FILE_NAME_UPWELL_RADIANCE>LT05_L2SP_165054_20110817_20200820_02_T1_ST_URAD.TIF</FILE_NAME_UPWELL_RADIANCE>
+    <FILE_NAME_DOWNWELL_RADIANCE>LT05_L2SP_165054_20110817_20200820_02_T1_ST_DRAD.TIF</FILE_NAME_DOWNWELL_RADIANCE>
+    <FILE_NAME_ATMOSPHERIC_TRANSMITTANCE>LT05_L2SP_165054_20110817_20200820_02_T1_ST_ATRAN.TIF</FILE_NAME_ATMOSPHERIC_TRANSMITTANCE>
+    <FILE_NAME_EMISSIVITY>LT05_L2SP_165054_20110817_20200820_02_T1_ST_EMIS.TIF</FILE_NAME_EMISSIVITY>
+    <FILE_NAME_EMISSIVITY_STDEV>LT05_L2SP_165054_20110817_20200820_02_T1_ST_EMSD.TIF</FILE_NAME_EMISSIVITY_STDEV>
+    <FILE_NAME_CLOUD_DISTANCE>LT05_L2SP_165054_20110817_20200820_02_T1_ST_CDIST.TIF</FILE_NAME_CLOUD_DISTANCE>
+    <FILE_NAME_ATMOSPHERIC_OPACITY>LT05_L2SP_165054_20110817_20200820_02_T1_SR_ATMOS_OPACITY.TIF</FILE_NAME_ATMOSPHERIC_OPACITY>
+    <FILE_NAME_QUALITY_L2_SURFACE_REFLECTANCE_CLOUD>LT05_L2SP_165054_20110817_20200820_02_T1_SR_CLOUD_QA.TIF</FILE_NAME_QUALITY_L2_SURFACE_REFLECTANCE_CLOUD>
+    <FILE_NAME_QUALITY_L2_SURFACE_TEMPERATURE>LT05_L2SP_165054_20110817_20200820_02_T1_ST_QA.TIF</FILE_NAME_QUALITY_L2_SURFACE_TEMPERATURE>
+    <FILE_NAME_QUALITY_L1_PIXEL>LT05_L2SP_165054_20110817_20200820_02_T1_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LT05_L2SP_165054_20110817_20200820_02_T1_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_ANGLE_COEFFICIENT>LT05_L2SP_165054_20110817_20200820_02_T1_ANG.txt</FILE_NAME_ANGLE_COEFFICIENT>
+    <FILE_NAME_METADATA_ODL>LT05_L2SP_165054_20110817_20200820_02_T1_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LT05_L2SP_165054_20110817_20200820_02_T1_MTL.xml</FILE_NAME_METADATA_XML>
+    <DATA_TYPE_BAND_1>UINT16</DATA_TYPE_BAND_1>
+    <DATA_TYPE_BAND_2>UINT16</DATA_TYPE_BAND_2>
+    <DATA_TYPE_BAND_3>UINT16</DATA_TYPE_BAND_3>
+    <DATA_TYPE_BAND_4>UINT16</DATA_TYPE_BAND_4>
+    <DATA_TYPE_BAND_5>UINT16</DATA_TYPE_BAND_5>
+    <DATA_TYPE_BAND_ST_B6>UINT16</DATA_TYPE_BAND_ST_B6>
+    <DATA_TYPE_BAND_7>UINT16</DATA_TYPE_BAND_7>
+    <DATA_TYPE_THERMAL_RADIANCE>INT16</DATA_TYPE_THERMAL_RADIANCE>
+    <DATA_TYPE_UPWELL_RADIANCE>INT16</DATA_TYPE_UPWELL_RADIANCE>
+    <DATA_TYPE_DOWNWELL_RADIANCE>INT16</DATA_TYPE_DOWNWELL_RADIANCE>
+    <DATA_TYPE_ATMOSPHERIC_TRANSMITTANCE>INT16</DATA_TYPE_ATMOSPHERIC_TRANSMITTANCE>
+    <DATA_TYPE_EMISSIVITY>INT16</DATA_TYPE_EMISSIVITY>
+    <DATA_TYPE_EMISSIVITY_STDEV>INT16</DATA_TYPE_EMISSIVITY_STDEV>
+    <DATA_TYPE_CLOUD_DISTANCE>INT16</DATA_TYPE_CLOUD_DISTANCE>
+    <DATA_TYPE_ATMOSPHERIC_OPACITY>INT16</DATA_TYPE_ATMOSPHERIC_OPACITY>
+    <DATA_TYPE_QUALITY_L2_SURFACE_REFLECTANCE_CLOUD>UINT8</DATA_TYPE_QUALITY_L2_SURFACE_REFLECTANCE_CLOUD>
+    <DATA_TYPE_QUALITY_L2_SURFACE_TEMPERATURE>INT16</DATA_TYPE_QUALITY_L2_SURFACE_TEMPERATURE>
+    <DATA_TYPE_QUALITY_L1_PIXEL>UINT16</DATA_TYPE_QUALITY_L1_PIXEL>
+    <DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>UINT16</DATA_TYPE_QUALITY_L1_RADIOMETRIC_SATURATION>
+  </PRODUCT_CONTENTS>
+  <IMAGE_ATTRIBUTES>
+    <SPACECRAFT_ID>LANDSAT_5</SPACECRAFT_ID>
+    <SENSOR_ID>TM</SENSOR_ID>
+    <WRS_TYPE>2</WRS_TYPE>
+    <WRS_PATH>165</WRS_PATH>
+    <WRS_ROW>054</WRS_ROW>
+    <DATE_ACQUIRED>2011-08-17</DATE_ACQUIRED>
+    <SCENE_CENTER_TIME>07:10:40.4500880Z</SCENE_CENTER_TIME>
+    <STATION_ID>MLK</STATION_ID>
+    <CLOUD_COVER>1.00</CLOUD_COVER>
+    <CLOUD_COVER_LAND>1.00</CLOUD_COVER_LAND>
+    <IMAGE_QUALITY>9</IMAGE_QUALITY>
+    <SATURATION_BAND_1>N</SATURATION_BAND_1>
+    <SATURATION_BAND_2>N</SATURATION_BAND_2>
+    <SATURATION_BAND_3>Y</SATURATION_BAND_3>
+    <SATURATION_BAND_4>Y</SATURATION_BAND_4>
+    <SATURATION_BAND_5>N</SATURATION_BAND_5>
+    <SATURATION_BAND_6>N</SATURATION_BAND_6>
+    <SATURATION_BAND_7>Y</SATURATION_BAND_7>
+    <SUN_AZIMUTH>77.85712345</SUN_AZIMUTH>
+    <SUN_ELEVATION>60.67425636</SUN_ELEVATION>
+    <EARTH_SUN_DISTANCE>1.0125021</EARTH_SUN_DISTANCE>
+    <SENSOR_MODE>BUMPER</SENSOR_MODE>
+    <SENSOR_MODE_SLC>ON</SENSOR_MODE_SLC>
+    <SENSOR_ANOMALIES>NONE</SENSOR_ANOMALIES>
+  </IMAGE_ATTRIBUTES>
+  <PROJECTION_ATTRIBUTES>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>38</UTM_ZONE>
+    <GRID_CELL_SIZE_REFLECTIVE>30.00</GRID_CELL_SIZE_REFLECTIVE>
+    <GRID_CELL_SIZE_THERMAL>30.00</GRID_CELL_SIZE_THERMAL>
+    <REFLECTIVE_LINES>100</REFLECTIVE_LINES>
+    <REFLECTIVE_SAMPLES>100</REFLECTIVE_SAMPLES>
+    <THERMAL_LINES>100</THERMAL_LINES>
+    <THERMAL_SAMPLES>100</THERMAL_SAMPLES>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <CORNER_UL_LAT_PRODUCT>9.62203</CORNER_UL_LAT_PRODUCT>
+    <CORNER_UL_LON_PRODUCT>42.79763</CORNER_UL_LON_PRODUCT>
+    <CORNER_UR_LAT_PRODUCT>9.62905</CORNER_UR_LAT_PRODUCT>
+    <CORNER_UR_LON_PRODUCT>44.95716</CORNER_UR_LON_PRODUCT>
+    <CORNER_LL_LAT_PRODUCT>7.73207</CORNER_LL_LAT_PRODUCT>
+    <CORNER_LL_LON_PRODUCT>42.80862</CORNER_LL_LON_PRODUCT>
+    <CORNER_LR_LAT_PRODUCT>7.73769</CORNER_LR_LAT_PRODUCT>
+    <CORNER_LR_LON_PRODUCT>44.95738</CORNER_LR_LON_PRODUCT>
+    <CORNER_UL_PROJECTION_X_PRODUCT>258300.000</CORNER_UL_PROJECTION_X_PRODUCT>
+    <CORNER_UL_PROJECTION_Y_PRODUCT>1064400.000</CORNER_UL_PROJECTION_Y_PRODUCT>
+    <CORNER_UR_PROJECTION_X_PRODUCT>495300.000</CORNER_UR_PROJECTION_X_PRODUCT>
+    <CORNER_UR_PROJECTION_Y_PRODUCT>1064400.000</CORNER_UR_PROJECTION_Y_PRODUCT>
+    <CORNER_LL_PROJECTION_X_PRODUCT>258300.000</CORNER_LL_PROJECTION_X_PRODUCT>
+    <CORNER_LL_PROJECTION_Y_PRODUCT>855300.000</CORNER_LL_PROJECTION_Y_PRODUCT>
+    <CORNER_LR_PROJECTION_X_PRODUCT>495300.000</CORNER_LR_PROJECTION_X_PRODUCT>
+    <CORNER_LR_PROJECTION_Y_PRODUCT>855300.000</CORNER_LR_PROJECTION_Y_PRODUCT>
+  </PROJECTION_ATTRIBUTES>
+  <LEVEL2_PROCESSING_RECORD>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P9IAXOVV</DIGITAL_OBJECT_IDENTIFIER>
+    <REQUEST_ID>L2</REQUEST_ID>
+    <LANDSAT_PRODUCT_ID>LT05_L2SP_165054_20110817_20200820_02_T1</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L2SP</PROCESSING_LEVEL>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <DATE_PRODUCT_GENERATED>2020-08-20T17:04:37Z</DATE_PRODUCT_GENERATED>
+    <PROCESSING_SOFTWARE_VERSION>LPGS_15.3.1c</PROCESSING_SOFTWARE_VERSION>
+    <ALGORITHM_SOURCE_SURFACE_REFLECTANCE>LEDAPS_3.4.0</ALGORITHM_SOURCE_SURFACE_REFLECTANCE>
+    <DATA_SOURCE_OZONE>TOMS</DATA_SOURCE_OZONE>
+    <DATA_SOURCE_PRESSURE>NCEP</DATA_SOURCE_PRESSURE>
+    <DATA_SOURCE_WATER_VAPOR>NCEP</DATA_SOURCE_WATER_VAPOR>
+    <DATA_SOURCE_AIR_TEMPERATURE>NCEP</DATA_SOURCE_AIR_TEMPERATURE>
+    <ALGORITHM_SOURCE_SURFACE_TEMPERATURE>st_1.3.0</ALGORITHM_SOURCE_SURFACE_TEMPERATURE>
+    <DATA_SOURCE_REANALYSIS>GEOS-5 FP-IT</DATA_SOURCE_REANALYSIS>
+  </LEVEL2_PROCESSING_RECORD>
+  <LEVEL2_SURFACE_REFLECTANCE_PARAMETERS>
+    <REFLECTANCE_MAXIMUM_BAND_1>1.602213</REFLECTANCE_MAXIMUM_BAND_1>
+    <REFLECTANCE_MINIMUM_BAND_1>-0.199972</REFLECTANCE_MINIMUM_BAND_1>
+    <REFLECTANCE_MAXIMUM_BAND_2>1.602213</REFLECTANCE_MAXIMUM_BAND_2>
+    <REFLECTANCE_MINIMUM_BAND_2>-0.199972</REFLECTANCE_MINIMUM_BAND_2>
+    <REFLECTANCE_MAXIMUM_BAND_3>1.602213</REFLECTANCE_MAXIMUM_BAND_3>
+    <REFLECTANCE_MINIMUM_BAND_3>-0.199972</REFLECTANCE_MINIMUM_BAND_3>
+    <REFLECTANCE_MAXIMUM_BAND_4>1.602213</REFLECTANCE_MAXIMUM_BAND_4>
+    <REFLECTANCE_MINIMUM_BAND_4>-0.199972</REFLECTANCE_MINIMUM_BAND_4>
+    <REFLECTANCE_MAXIMUM_BAND_5>1.602213</REFLECTANCE_MAXIMUM_BAND_5>
+    <REFLECTANCE_MINIMUM_BAND_5>-0.199972</REFLECTANCE_MINIMUM_BAND_5>
+    <REFLECTANCE_MAXIMUM_BAND_7>1.602213</REFLECTANCE_MAXIMUM_BAND_7>
+    <REFLECTANCE_MINIMUM_BAND_7>-0.199972</REFLECTANCE_MINIMUM_BAND_7>
+    <QUANTIZE_CAL_MAX_BAND_1>65535</QUANTIZE_CAL_MAX_BAND_1>
+    <QUANTIZE_CAL_MIN_BAND_1>1</QUANTIZE_CAL_MIN_BAND_1>
+    <QUANTIZE_CAL_MAX_BAND_2>65535</QUANTIZE_CAL_MAX_BAND_2>
+    <QUANTIZE_CAL_MIN_BAND_2>1</QUANTIZE_CAL_MIN_BAND_2>
+    <QUANTIZE_CAL_MAX_BAND_3>65535</QUANTIZE_CAL_MAX_BAND_3>
+    <QUANTIZE_CAL_MIN_BAND_3>1</QUANTIZE_CAL_MIN_BAND_3>
+    <QUANTIZE_CAL_MAX_BAND_4>65535</QUANTIZE_CAL_MAX_BAND_4>
+    <QUANTIZE_CAL_MIN_BAND_4>1</QUANTIZE_CAL_MIN_BAND_4>
+    <QUANTIZE_CAL_MAX_BAND_5>65535</QUANTIZE_CAL_MAX_BAND_5>
+    <QUANTIZE_CAL_MIN_BAND_5>1</QUANTIZE_CAL_MIN_BAND_5>
+    <QUANTIZE_CAL_MAX_BAND_7>65535</QUANTIZE_CAL_MAX_BAND_7>
+    <QUANTIZE_CAL_MIN_BAND_7>1</QUANTIZE_CAL_MIN_BAND_7>
+    <REFLECTANCE_MULT_BAND_1>2.75e-05</REFLECTANCE_MULT_BAND_1>
+    <REFLECTANCE_MULT_BAND_2>2.75e-05</REFLECTANCE_MULT_BAND_2>
+    <REFLECTANCE_MULT_BAND_3>2.75e-05</REFLECTANCE_MULT_BAND_3>
+    <REFLECTANCE_MULT_BAND_4>2.75e-05</REFLECTANCE_MULT_BAND_4>
+    <REFLECTANCE_MULT_BAND_5>2.75e-05</REFLECTANCE_MULT_BAND_5>
+    <REFLECTANCE_MULT_BAND_7>2.75e-05</REFLECTANCE_MULT_BAND_7>
+    <REFLECTANCE_ADD_BAND_1>-0.2</REFLECTANCE_ADD_BAND_1>
+    <REFLECTANCE_ADD_BAND_2>-0.2</REFLECTANCE_ADD_BAND_2>
+    <REFLECTANCE_ADD_BAND_3>-0.2</REFLECTANCE_ADD_BAND_3>
+    <REFLECTANCE_ADD_BAND_4>-0.2</REFLECTANCE_ADD_BAND_4>
+    <REFLECTANCE_ADD_BAND_5>-0.2</REFLECTANCE_ADD_BAND_5>
+    <REFLECTANCE_ADD_BAND_7>-0.2</REFLECTANCE_ADD_BAND_7>
+  </LEVEL2_SURFACE_REFLECTANCE_PARAMETERS>
+  <LEVEL2_SURFACE_TEMPERATURE_PARAMETERS>
+    <TEMPERATURE_MAXIMUM_BAND_ST_B6>372.999941</TEMPERATURE_MAXIMUM_BAND_ST_B6>
+    <TEMPERATURE_MINIMUM_BAND_ST_B6>149.003418</TEMPERATURE_MINIMUM_BAND_ST_B6>
+    <QUANTIZE_CAL_MAXIMUM_BAND_ST_B6>65535</QUANTIZE_CAL_MAXIMUM_BAND_ST_B6>
+    <QUANTIZE_CAL_MINIMUM_BAND_ST_B6>1</QUANTIZE_CAL_MINIMUM_BAND_ST_B6>
+    <TEMPERATURE_MULT_BAND_ST_B6>0.00341802</TEMPERATURE_MULT_BAND_ST_B6>
+    <TEMPERATURE_ADD_BAND_ST_B6>149.0</TEMPERATURE_ADD_BAND_ST_B6>
+  </LEVEL2_SURFACE_TEMPERATURE_PARAMETERS>
+  <LEVEL1_PROCESSING_RECORD>
+    <ORIGIN>Image courtesy of the U.S. Geological Survey</ORIGIN>
+    <DIGITAL_OBJECT_IDENTIFIER>https://doi.org/10.5066/P918ROHC</DIGITAL_OBJECT_IDENTIFIER>
+    <REQUEST_ID>L2</REQUEST_ID>
+    <LANDSAT_SCENE_ID>LT51650542011229MLK00</LANDSAT_SCENE_ID>
+    <LANDSAT_PRODUCT_ID>LT05_L1TP_165054_20110817_20200820_02_T1</LANDSAT_PRODUCT_ID>
+    <PROCESSING_LEVEL>L1TP</PROCESSING_LEVEL>
+    <COLLECTION_CATEGORY>T1</COLLECTION_CATEGORY>
+    <OUTPUT_FORMAT>GEOTIFF</OUTPUT_FORMAT>
+    <DATE_PRODUCT_GENERATED>2020-08-20T16:50:14Z</DATE_PRODUCT_GENERATED>
+    <PROCESSING_SOFTWARE_VERSION>LPGS_15.3.1c</PROCESSING_SOFTWARE_VERSION>
+    <FILE_NAME_BAND_1>LT05_L1TP_165054_20110817_20200820_02_T1_B1.TIF</FILE_NAME_BAND_1>
+    <FILE_NAME_BAND_2>LT05_L1TP_165054_20110817_20200820_02_T1_B2.TIF</FILE_NAME_BAND_2>
+    <FILE_NAME_BAND_3>LT05_L1TP_165054_20110817_20200820_02_T1_B3.TIF</FILE_NAME_BAND_3>
+    <FILE_NAME_BAND_4>LT05_L1TP_165054_20110817_20200820_02_T1_B4.TIF</FILE_NAME_BAND_4>
+    <FILE_NAME_BAND_5>LT05_L1TP_165054_20110817_20200820_02_T1_B5.TIF</FILE_NAME_BAND_5>
+    <FILE_NAME_BAND_6>LT05_L1TP_165054_20110817_20200820_02_T1_B6.TIF</FILE_NAME_BAND_6>
+    <FILE_NAME_BAND_7>LT05_L1TP_165054_20110817_20200820_02_T1_B7.TIF</FILE_NAME_BAND_7>
+    <FILE_NAME_QUALITY_L1_PIXEL>LT05_L1TP_165054_20110817_20200820_02_T1_QA_PIXEL.TIF</FILE_NAME_QUALITY_L1_PIXEL>
+    <FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>LT05_L1TP_165054_20110817_20200820_02_T1_QA_RADSAT.TIF</FILE_NAME_QUALITY_L1_RADIOMETRIC_SATURATION>
+    <FILE_NAME_GROUND_CONTROL_POINT>LT05_L1TP_165054_20110817_20200820_02_T1_GCP.txt</FILE_NAME_GROUND_CONTROL_POINT>
+    <FILE_NAME_ANGLE_COEFFICIENT>LT05_L1TP_165054_20110817_20200820_02_T1_ANG.txt</FILE_NAME_ANGLE_COEFFICIENT>
+    <FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>LT05_L1TP_165054_20110817_20200820_02_T1_VAA.TIF</FILE_NAME_ANGLE_SENSOR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>LT05_L1TP_165054_20110817_20200820_02_T1_VZA.TIF</FILE_NAME_ANGLE_SENSOR_ZENITH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>LT05_L1TP_165054_20110817_20200820_02_T1_SAA.TIF</FILE_NAME_ANGLE_SOLAR_AZIMUTH_BAND_4>
+    <FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>LT05_L1TP_165054_20110817_20200820_02_T1_SZA.TIF</FILE_NAME_ANGLE_SOLAR_ZENITH_BAND_4>
+    <FILE_NAME_METADATA_ODL>LT05_L1TP_165054_20110817_20200820_02_T1_MTL.txt</FILE_NAME_METADATA_ODL>
+    <FILE_NAME_METADATA_XML>LT05_L1TP_165054_20110817_20200820_02_T1_MTL.xml</FILE_NAME_METADATA_XML>
+    <FILE_NAME_CPF>LT05CPF_20110701_20110930_02.01</FILE_NAME_CPF>
+    <FILE_NAME_VERIFY_REPORT>LT05_L1TP_165054_20110817_20200820_02_T1_VER.txt</FILE_NAME_VERIFY_REPORT>
+    <FILE_NAME_VERIFY_BROWSE>LT05_L1TP_165054_20110817_20200820_02_T1_VER.jpg</FILE_NAME_VERIFY_BROWSE>
+    <DATA_SOURCE_ELEVATION>GLS2000</DATA_SOURCE_ELEVATION>
+    <GROUND_CONTROL_POINTS_VERSION>5</GROUND_CONTROL_POINTS_VERSION>
+    <GROUND_CONTROL_POINTS_MODEL>996</GROUND_CONTROL_POINTS_MODEL>
+    <GEOMETRIC_RMSE_MODEL>3.460</GEOMETRIC_RMSE_MODEL>
+    <GEOMETRIC_RMSE_MODEL_Y>2.368</GEOMETRIC_RMSE_MODEL_Y>
+    <GEOMETRIC_RMSE_MODEL_X>2.523</GEOMETRIC_RMSE_MODEL_X>
+    <GROUND_CONTROL_POINTS_VERIFY>2414</GROUND_CONTROL_POINTS_VERIFY>
+    <GEOMETRIC_RMSE_VERIFY>0.223</GEOMETRIC_RMSE_VERIFY>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_UL>0.338</GEOMETRIC_RMSE_VERIFY_QUAD_UL>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_UR>0.267</GEOMETRIC_RMSE_VERIFY_QUAD_UR>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_LL>0.219</GEOMETRIC_RMSE_VERIFY_QUAD_LL>
+    <GEOMETRIC_RMSE_VERIFY_QUAD_LR>0.130</GEOMETRIC_RMSE_VERIFY_QUAD_LR>
+    <EPHEMERIS_TYPE>DEFINITIVE</EPHEMERIS_TYPE>
+  </LEVEL1_PROCESSING_RECORD>
+  <LEVEL1_MIN_MAX_RADIANCE>
+    <RADIANCE_MAXIMUM_BAND_1>193.000</RADIANCE_MAXIMUM_BAND_1>
+    <RADIANCE_MINIMUM_BAND_1>-1.520</RADIANCE_MINIMUM_BAND_1>
+    <RADIANCE_MAXIMUM_BAND_2>365.000</RADIANCE_MAXIMUM_BAND_2>
+    <RADIANCE_MINIMUM_BAND_2>-2.840</RADIANCE_MINIMUM_BAND_2>
+    <RADIANCE_MAXIMUM_BAND_3>264.000</RADIANCE_MAXIMUM_BAND_3>
+    <RADIANCE_MINIMUM_BAND_3>-1.170</RADIANCE_MINIMUM_BAND_3>
+    <RADIANCE_MAXIMUM_BAND_4>221.000</RADIANCE_MAXIMUM_BAND_4>
+    <RADIANCE_MINIMUM_BAND_4>-1.510</RADIANCE_MINIMUM_BAND_4>
+    <RADIANCE_MAXIMUM_BAND_5>30.200</RADIANCE_MAXIMUM_BAND_5>
+    <RADIANCE_MINIMUM_BAND_5>-0.370</RADIANCE_MINIMUM_BAND_5>
+    <RADIANCE_MAXIMUM_BAND_6>15.303</RADIANCE_MAXIMUM_BAND_6>
+    <RADIANCE_MINIMUM_BAND_6>1.238</RADIANCE_MINIMUM_BAND_6>
+    <RADIANCE_MAXIMUM_BAND_7>16.500</RADIANCE_MAXIMUM_BAND_7>
+    <RADIANCE_MINIMUM_BAND_7>-0.150</RADIANCE_MINIMUM_BAND_7>
+  </LEVEL1_MIN_MAX_RADIANCE>
+  <LEVEL1_MIN_MAX_REFLECTANCE>
+    <REFLECTANCE_MAXIMUM_BAND_1>0.319744</REFLECTANCE_MAXIMUM_BAND_1>
+    <REFLECTANCE_MINIMUM_BAND_1>-0.002518</REFLECTANCE_MINIMUM_BAND_1>
+    <REFLECTANCE_MAXIMUM_BAND_2>0.668296</REFLECTANCE_MAXIMUM_BAND_2>
+    <REFLECTANCE_MINIMUM_BAND_2>-0.005200</REFLECTANCE_MINIMUM_BAND_2>
+    <REFLECTANCE_MAXIMUM_BAND_3>0.570636</REFLECTANCE_MAXIMUM_BAND_3>
+    <REFLECTANCE_MINIMUM_BAND_3>-0.002529</REFLECTANCE_MINIMUM_BAND_3>
+    <REFLECTANCE_MAXIMUM_BAND_4>0.689023</REFLECTANCE_MAXIMUM_BAND_4>
+    <REFLECTANCE_MINIMUM_BAND_4>-0.004708</REFLECTANCE_MINIMUM_BAND_4>
+    <REFLECTANCE_MAXIMUM_BAND_5>0.464042</REFLECTANCE_MAXIMUM_BAND_5>
+    <REFLECTANCE_MINIMUM_BAND_5>-0.005685</REFLECTANCE_MINIMUM_BAND_5>
+    <REFLECTANCE_MAXIMUM_BAND_7>0.646164</REFLECTANCE_MAXIMUM_BAND_7>
+    <REFLECTANCE_MINIMUM_BAND_7>-0.005874</REFLECTANCE_MINIMUM_BAND_7>
+  </LEVEL1_MIN_MAX_REFLECTANCE>
+  <LEVEL1_MIN_MAX_PIXEL_VALUE>
+    <QUANTIZE_CAL_MAX_BAND_1>255</QUANTIZE_CAL_MAX_BAND_1>
+    <QUANTIZE_CAL_MIN_BAND_1>1</QUANTIZE_CAL_MIN_BAND_1>
+    <QUANTIZE_CAL_MAX_BAND_2>255</QUANTIZE_CAL_MAX_BAND_2>
+    <QUANTIZE_CAL_MIN_BAND_2>1</QUANTIZE_CAL_MIN_BAND_2>
+    <QUANTIZE_CAL_MAX_BAND_3>255</QUANTIZE_CAL_MAX_BAND_3>
+    <QUANTIZE_CAL_MIN_BAND_3>1</QUANTIZE_CAL_MIN_BAND_3>
+    <QUANTIZE_CAL_MAX_BAND_4>255</QUANTIZE_CAL_MAX_BAND_4>
+    <QUANTIZE_CAL_MIN_BAND_4>1</QUANTIZE_CAL_MIN_BAND_4>
+    <QUANTIZE_CAL_MAX_BAND_5>255</QUANTIZE_CAL_MAX_BAND_5>
+    <QUANTIZE_CAL_MIN_BAND_5>1</QUANTIZE_CAL_MIN_BAND_5>
+    <QUANTIZE_CAL_MAX_BAND_6>255</QUANTIZE_CAL_MAX_BAND_6>
+    <QUANTIZE_CAL_MIN_BAND_6>1</QUANTIZE_CAL_MIN_BAND_6>
+    <QUANTIZE_CAL_MAX_BAND_7>255</QUANTIZE_CAL_MAX_BAND_7>
+    <QUANTIZE_CAL_MIN_BAND_7>1</QUANTIZE_CAL_MIN_BAND_7>
+  </LEVEL1_MIN_MAX_PIXEL_VALUE>
+  <LEVEL1_RADIOMETRIC_RESCALING>
+    <RADIANCE_MULT_BAND_1>7.6583E-01</RADIANCE_MULT_BAND_1>
+    <RADIANCE_MULT_BAND_2>1.4482E+00</RADIANCE_MULT_BAND_2>
+    <RADIANCE_MULT_BAND_3>1.0440E+00</RADIANCE_MULT_BAND_3>
+    <RADIANCE_MULT_BAND_4>8.7602E-01</RADIANCE_MULT_BAND_4>
+    <RADIANCE_MULT_BAND_5>1.2035E-01</RADIANCE_MULT_BAND_5>
+    <RADIANCE_MULT_BAND_6>5.5375E-02</RADIANCE_MULT_BAND_6>
+    <RADIANCE_MULT_BAND_7>6.5551E-02</RADIANCE_MULT_BAND_7>
+    <RADIANCE_ADD_BAND_1>-2.28583</RADIANCE_ADD_BAND_1>
+    <RADIANCE_ADD_BAND_2>-4.28819</RADIANCE_ADD_BAND_2>
+    <RADIANCE_ADD_BAND_3>-2.21398</RADIANCE_ADD_BAND_3>
+    <RADIANCE_ADD_BAND_4>-2.38602</RADIANCE_ADD_BAND_4>
+    <RADIANCE_ADD_BAND_5>-0.49035</RADIANCE_ADD_BAND_5>
+    <RADIANCE_ADD_BAND_6>1.18243</RADIANCE_ADD_BAND_6>
+    <RADIANCE_ADD_BAND_7>-0.21555</RADIANCE_ADD_BAND_7>
+    <REFLECTANCE_MULT_BAND_1>1.2687E-03</REFLECTANCE_MULT_BAND_1>
+    <REFLECTANCE_MULT_BAND_2>2.6516E-03</REFLECTANCE_MULT_BAND_2>
+    <REFLECTANCE_MULT_BAND_3>2.2566E-03</REFLECTANCE_MULT_BAND_3>
+    <REFLECTANCE_MULT_BAND_4>2.7312E-03</REFLECTANCE_MULT_BAND_4>
+    <REFLECTANCE_MULT_BAND_5>1.8493E-03</REFLECTANCE_MULT_BAND_5>
+    <REFLECTANCE_MULT_BAND_7>2.5671E-03</REFLECTANCE_MULT_BAND_7>
+    <REFLECTANCE_ADD_BAND_1>-0.003787</REFLECTANCE_ADD_BAND_1>
+    <REFLECTANCE_ADD_BAND_2>-0.007851</REFLECTANCE_ADD_BAND_2>
+    <REFLECTANCE_ADD_BAND_3>-0.004786</REFLECTANCE_ADD_BAND_3>
+    <REFLECTANCE_ADD_BAND_4>-0.007439</REFLECTANCE_ADD_BAND_4>
+    <REFLECTANCE_ADD_BAND_5>-0.007535</REFLECTANCE_ADD_BAND_5>
+    <REFLECTANCE_ADD_BAND_7>-0.008441</REFLECTANCE_ADD_BAND_7>
+  </LEVEL1_RADIOMETRIC_RESCALING>
+  <LEVEL1_THERMAL_CONSTANTS>
+    <K1_CONSTANT_BAND_6>607.76</K1_CONSTANT_BAND_6>
+    <K2_CONSTANT_BAND_6>1260.56</K2_CONSTANT_BAND_6>
+  </LEVEL1_THERMAL_CONSTANTS>
+  <LEVEL1_PROJECTION_PARAMETERS>
+    <MAP_PROJECTION>UTM</MAP_PROJECTION>
+    <DATUM>WGS84</DATUM>
+    <ELLIPSOID>WGS84</ELLIPSOID>
+    <UTM_ZONE>38</UTM_ZONE>
+    <GRID_CELL_SIZE_REFLECTIVE>30.00</GRID_CELL_SIZE_REFLECTIVE>
+    <GRID_CELL_SIZE_THERMAL>30.00</GRID_CELL_SIZE_THERMAL>
+    <ORIENTATION>NORTH_UP</ORIENTATION>
+    <RESAMPLING_OPTION>CUBIC_CONVOLUTION</RESAMPLING_OPTION>
+    <MAP_PROJECTION_L0RA>NA</MAP_PROJECTION_L0RA>
+  </LEVEL1_PROJECTION_PARAMETERS>
+  <PRODUCT_PARAMETERS>
+    <DATA_TYPE_L0RP>TMR_L0RP</DATA_TYPE_L0RP>
+    <CORRECTION_GAIN_BAND_1>CPF</CORRECTION_GAIN_BAND_1>
+    <CORRECTION_GAIN_BAND_2>CPF</CORRECTION_GAIN_BAND_2>
+    <CORRECTION_GAIN_BAND_3>CPF</CORRECTION_GAIN_BAND_3>
+    <CORRECTION_GAIN_BAND_4>CPF</CORRECTION_GAIN_BAND_4>
+    <CORRECTION_GAIN_BAND_5>CPF</CORRECTION_GAIN_BAND_5>
+    <CORRECTION_GAIN_BAND_6>INTERNAL_CALIBRATION</CORRECTION_GAIN_BAND_6>
+    <CORRECTION_GAIN_BAND_7>CPF</CORRECTION_GAIN_BAND_7>
+    <CORRECTION_BIAS_BAND_1>CPF</CORRECTION_BIAS_BAND_1>
+    <CORRECTION_BIAS_BAND_2>CPF</CORRECTION_BIAS_BAND_2>
+    <CORRECTION_BIAS_BAND_3>CPF</CORRECTION_BIAS_BAND_3>
+    <CORRECTION_BIAS_BAND_4>CPF</CORRECTION_BIAS_BAND_4>
+    <CORRECTION_BIAS_BAND_5>CPF</CORRECTION_BIAS_BAND_5>
+    <CORRECTION_BIAS_BAND_6>CPF</CORRECTION_BIAS_BAND_6>
+    <CORRECTION_BIAS_BAND_7>CPF</CORRECTION_BIAS_BAND_7>
+  </PRODUCT_PARAMETERS>
+</LANDSAT_METADATA_FILE>
+"""
+
+
+x_size = 100
+y_size = 100
+date = datetime(2011, 8, 17, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="session")
+def area():
+    """Get the landsat 1 area def."""
+    pcs_id = "WGS84 / UTM zone 38N"
+    proj4_dict = {"proj": "utm", "zone": 38, "datum": "WGS84", "units": "m", "no_defs": None, "type": "crs"}
+    area_extent = (258285.0, 855285.0, 495315.0, 1064415.0)
+    return AreaDefinition("geotiff_area", pcs_id, pcs_id,
+                          proj4_dict, x_size, y_size,
+                          area_extent)
+
+
+@pytest.fixture(scope="session")
+def b4_data():
+    """Get the data for the b4 channel."""
+    return da.random.randint(12000, 16000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+@pytest.fixture(scope="session")
+def b6_data():
+    """Get the data for the b6 channel."""
+    return da.random.randint(8000, 14000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+@pytest.fixture(scope="session")
+def rad_data():
+    """Get the data for the radiance channel."""
+    return da.random.randint(1, 10000,
+                             size=(y_size, x_size),
+                             chunks=(50, 50)).astype(np.uint16)
+
+
+def create_tif_file(data, name, area, filename):
+    """Create a tif file."""
+    data_array = xr.DataArray(data,
+                              dims=("y", "x"),
+                              attrs={"name": name,
+                                     "start_time": date})
+    scn = Scene()
+    scn["band_data"] = data_array
+    scn["band_data"].attrs["area"] = area
+    scn.save_dataset("band_data", writer="geotiff", enhance=False, fill_value=0,
+                     filename=os.fspath(filename))
+
+
+@pytest.fixture(scope="session")
+def files_path(tmp_path_factory):
+    """Create the path for l1 files."""
+    return tmp_path_factory.mktemp("tm_l2_files")
+
+
+@pytest.fixture(scope="session")
+def b4_file(files_path, b4_data, area):
+    """Create the file for the b4 channel."""
+    data = b4_data
+    filename = files_path / "LT05_L2SP_165054_20110817_20200820_02_T1_SR_B4.TIF"
+    name = "B4"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+@pytest.fixture(scope="session")
+def b6_file(files_path, b6_data, area):
+    """Create the file for the b6 channel."""
+    data = b6_data
+    filename = files_path / "LT05_L2SP_165054_20110817_20200820_02_T1_ST_B6.TIF"
+    name = "B6"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+@pytest.fixture(scope="session")
+def rad_file(files_path, rad_data, area):
+    """Create the file for the sza."""
+    data = rad_data
+    filename = files_path / "LT05_L2SP_165054_20110817_20200820_02_T1_ST_TRAD.TIF"
+    name = "TRAD"
+    create_tif_file(data, name, area, filename)
+    return os.fspath(filename)
+
+
+@pytest.fixture(scope="session")
+def mda_file(files_path):
+    """Create the metadata xml file."""
+    filename = files_path / "LT05_L2SP_165054_20110817_20200820_02_T1_MTL.xml"
+    with open(filename, "wb") as f:
+        f.write(metadata_text)
+    return os.fspath(filename)
+
+
+@pytest.fixture(scope="session")
+def all_files(b4_file, b6_file, mda_file, rad_file):
+    """Return all the files."""
+    return b4_file, b6_file, mda_file, rad_file
+
+
+@pytest.fixture(scope="session")
+def all_fsspec_files(b4_file, b6_file, mda_file, rad_file):
+    """Return all the files as FSFile objects."""
+    from fsspec.implementations.local import LocalFileSystem
+
+    from satpy.readers.core.remote import FSFile
+
+    fs = LocalFileSystem()
+    b4_file, b6_file, mda_file, rad_file = (
+        FSFile(os.path.abspath(file), fs=fs)
+        for file in [b4_file, b6_file, mda_file, rad_file]
+    )
+    return b4_file, b6_file, mda_file, rad_file
+
+
+class TestTML2:
+    """Test generic image reader."""
+
+    def setup_method(self, tmp_path):
+        """Set up the filename and filetype info dicts.."""
+        self.filename_info = dict(observation_date=datetime(2011, 8, 17),
+                                  platform_type="L",
+                                  process_level_correction="L2SP",
+                                  spacecraft_id="05",
+                                  data_type="T",
+                                  collection_id="02")
+        self.ftype_info = {"file_type": "granule_B4"}
+
+    def test_basicload(self, area, b4_file, b6_file, mda_file):
+        """Test loading a Landsat Scene."""
+        scn = Scene(reader="tm_l2_tif", filenames=[b4_file,
+                                                   b6_file,
+                                                   mda_file])
+        scn.load(["B4", "B6"])
+
+        # Check dataset is loaded correctly
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == area
+        assert scn["B4"].attrs["saturated"]
+        assert scn["B6"].shape == (100, 100)
+        assert scn["B6"].attrs["area"] == area
+        assert not scn["B6"].attrs["saturated"]
+
+    def test_ch_startend(self, b4_file, mda_file):
+        """Test correct retrieval of start/end times."""
+        scn = Scene(reader="tm_l2_tif", filenames=[b4_file, mda_file])
+        bnds = scn.available_dataset_names()
+        assert bnds == ["B4"]
+
+        scn.load(["B4"])
+        assert scn.start_time == datetime(2011, 8, 17, 7, 10, 40, tzinfo=timezone.utc)
+        assert scn.end_time == datetime(2011, 8, 17, 7, 10, 40, tzinfo=timezone.utc)
+
+    def test_loading_gd(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with good channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import TML2CHReader, TML2MDReader
+        good_mda = TML2MDReader(mda_file, self.filename_info, {})
+        rdr = TML2CHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        # Check case with good file data and load request
+        rdr.get_dataset({"name": "B4", "calibration": "counts"}, {"standard_name": "test_data", "units": "test_units"})
+
+    def test_loading_badfil(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with bad channel requests."""
+        from satpy.readers.oli_tirs_l1_tif import TML2CHReader, TML2MDReader
+        good_mda = TML2MDReader(mda_file, self.filename_info, {})
+        rdr = TML2CHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+        # Check case with request to load channel not matching filename
+        with pytest.raises(ValueError, match="Requested channel B5 does not match the reader channel B4"):
+            rdr.get_dataset({"name": "B5", "calibration": "counts"}, ftype)
+
+    def test_badfiles(self, mda_file, b4_file):
+        """Test loading a Landsat Scene with bad data."""
+        from satpy.readers.oli_tirs_l1_tif import TML2CHReader, TML2MDReader
+        bad_fname_info = self.filename_info.copy()
+        bad_fname_info["platform_type"] = "B"
+
+        ftype = {"standard_name": "test_data", "units": "test_units"}
+
+        # Test that metadata reader initialises with correct filename
+        good_mda = TML2MDReader(mda_file, self.filename_info, ftype)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            TML2MDReader(mda_file, bad_fname_info, ftype)
+
+        # Test that metadata reader initialises with correct filename
+        TML2CHReader(b4_file, self.filename_info, self.ftype_info, good_mda)
+
+        # Check metadata reader fails if platform type is wrong
+        with pytest.raises(ValueError, match="This reader only supports Landsat data"):
+            TML2CHReader(b4_file, bad_fname_info, self.ftype_info, good_mda)
+        bad_ftype_info = self.ftype_info.copy()
+        bad_ftype_info["file_type"] = "granule-b05"
+        with pytest.raises(ValueError, match="Invalid file type: granule-b05"):
+            TML2CHReader(b4_file, self.filename_info, bad_ftype_info, good_mda)
+
+    def test_calibration_counts(self, all_files, b4_data, b6_data, rad_data):
+        """Test counts calibration mode for the reader."""
+        from satpy import Scene
+
+        scn = Scene(reader="tm_l2_tif", filenames=all_files)
+        scn.load(["B4", "B6", "TRAD"], calibration="counts")
+        np.testing.assert_allclose(scn["B4"].values, b4_data)
+        np.testing.assert_allclose(scn["B6"].values, b6_data)
+        np.testing.assert_allclose(scn["TRAD"].values, rad_data)
+        assert scn["B4"].attrs["units"] == "1"
+        assert scn["B6"].attrs["units"] == "1"
+        assert scn["TRAD"].attrs["units"] == "1"
+        assert scn["B4"].attrs["standard_name"] == "counts"
+        assert scn["B6"].attrs["standard_name"] == "counts"
+        assert scn["TRAD"].attrs["standard_name"] == "counts"
+
+    def test_calibration_highlevel(self, all_files, b4_data, b6_data, rad_data):
+        """Test high level calibration modes for the reader."""
+        from satpy import Scene
+        exp_b04 = (b4_data * 2.75e-05 - 0.2).astype(np.float32) * 100
+        exp_b6 = (b6_data * 0.00341802 + 149.0).astype(np.float32)
+        exp_rad = (rad_data * 0.001).astype(np.float32)
+        scn = Scene(reader="tm_l2_tif", filenames=all_files)
+        scn.load(["B4", "B6", "TRAD"])
+
+        assert scn["B4"].attrs["units"] == "%"
+        assert scn["B6"].attrs["units"] == "K"
+        assert scn["TRAD"].attrs["units"] == "W m-2 um-1 sr-1"
+        assert scn["B4"].attrs["standard_name"] == "surface_bidirectional_reflectance"
+        assert scn["B6"].attrs["standard_name"] == "brightness_temperature"
+        assert scn["TRAD"].attrs["standard_name"] == "toa_outgoing_radiance_per_unit_wavelength"
+        np.testing.assert_allclose(np.array(scn["B4"].values), np.array(exp_b04), rtol=1e-4)
+        np.testing.assert_allclose(scn["B6"].values, exp_b6, rtol=1e-6)
+        np.testing.assert_allclose(scn["TRAD"].values, exp_rad, rtol=1e-6)
+
+    def test_metadata(self, mda_file):
+        """Check that metadata values loaded correctly."""
+        from satpy.readers.oli_tirs_l1_tif import TML2MDReader
+        mda = TML2MDReader(mda_file, self.filename_info, {})
+
+        cal_test_dict = {"B1": (2.75e-05, -0.2),
+                         "B5": (2.75e-05, -0.2),
+                         "B6": (0.00341802, 149.0)}
+
+        assert mda.platform_name == "Landsat-5"
+        assert mda.earth_sun_distance() == 1.0125021
+        assert mda.band_calibration["B1"] == cal_test_dict["B1"]
+        assert mda.band_calibration["B5"] == cal_test_dict["B5"]
+        assert mda.band_calibration["B6"] == cal_test_dict["B6"]
+        assert not mda.band_saturation["B1"]
+        assert mda.band_saturation["B4"]
+        assert not mda.band_saturation["B5"]
+        assert not mda.band_saturation["B6"]
+
+    def test_area_def(self, mda_file):
+        """Check we can get the area defs properly."""
+        from satpy.readers.oli_tirs_l1_tif import TML2MDReader
+        mda = TML2MDReader(mda_file, self.filename_info, {})
+
+        standard_area = mda.build_area_def("B1")
+
+        assert standard_area.area_extent == (258285.0, 855285.0, 495315.0, 1064415.0)
+
+    def test_basicload_remote(self, area, all_fsspec_files):
+        """Test loading a Landsat Scene from a fsspec filesystem."""
+        scn = Scene(reader="tm_l2_tif", filenames=all_fsspec_files)
+        scn.load(["B4", "B6"])
+
+        # Check dataset is loaded correctly
+        assert scn["B4"].shape == (100, 100)
+        assert scn["B4"].attrs["area"] == area
+        assert scn["B4"].attrs["saturated"]
+        assert scn["B6"].shape == (100, 100)
+        assert scn["B6"].attrs["area"] == area
+        assert not scn["B6"].attrs["saturated"]


### PR DESCRIPTION
# Landsat readers

## Overview

This PR adds readers for Landsat OLI-TIRS L2, ETM+ L1-2, TM L1-2 and MSS products.

All these readers are mostly based on the existing Landsat OLI-TIRS L1 reader.

## Readers

Landsat reader classes are hierarchially organized into a nested structure of classes where

- `BaseLandsatReader` class contains `__init__` and `get_dataset` functions. Their logic is mostly copied from the original reader, with few additions and bug fixes.

- Landsat readers for L1 and L2 classes contain calibration logic, which is the same for every sensor, but differs for L1 and L2 products. L1 logic is copied from the existing reader. 

**Note**: I moved the \* 0.001 scaling logic for `TRAD`, `URAD`, `CDIST` etc bands to calibration. Maybe it belongs to `get_dataset` function, just like `ang` bands \* 0.01 scaling in L1 reader? Or should I move `ang` bands \*0.01 scaling to calibrations also?

- The product readers. They mostly contain attributes like spectral and thermal band list and sensor name. But `MSSCHReader` also contains the `available_datasets` functions that dynamically sets B4 wavelength (see yamls section for more info)

## YAMLs

I created YAML files for every reader.

They are all based on the OLI-TIRS L1 YAML file.

What was updated or needs additional checking:

- Reader namings. Should etm+ reader be named "etm_lx_tif" or "etm_plus_lx_tif"?

- `data_identification_keys` section was added to the head of the file to add custom calibration support to L2 products. Is that necessary? Should custom calibrations be implemented in any other way?

- `{collection_category}` was limited to `{collection_category:2s}` because otherwise L2 product and Landsat-7 (which also contains GM bands) search was faulty. AFAIK collection category can contain only 2 symbols, but if not, it can cause errors.

- QA band namings: see #3176

- calibration `standard_names` and `units` probably should be double-checked

- `wavelength` was added or updated according to official Landsat Data Format Control Books. But probably also should be double-checked.

- Again, custom calibrations at band definitions at `datasets` section. Are they added the right way?

- `MSS` bands. In Landsat 1/2/3 MSS products bands are named B4, B5, B6, B7 and in Landsat 4/5 MSS products the same bands are named B1, B2, B3, B4. Now MSS reader just read the bands and their names as-is. The issue with `B4` band being `green` in Landsat 1/2/3 and `nir` in Landsat 4/5 is solved by changing `wavelength` in `available_datasets` function in the reader. But is it the right way to handle such issues? Maybe there is a better way to solve that problem? Or maybe separate readers for Landsat 1/2/3 and Landsat 4/5 MSS products should be added?

- Also, some docs say that Landsat-3 had a thermal band B8, but it failed just after the launch. I am not sure, if any products with B8 actually exist and if it should be added to band list.

## Tests

I added separate test files for every reader. They are mostly just the adapted versions of the OLI-TIRS L1 test file. The differences are:

- L2 product test files test `TRAD` file instead of `sza` file

- Products other than OLI-TIRS do not have `test_loading_badchan` test, because they do not have products with only spectral or only thermal bands, so they can not face such errors

- MSS test tests both Landsat-1 and Landsat-4 products and tests if B4 wavelength is set correctly

- Other small differences

Maybe any other tests should be added?