### PR TITLE
Optimize AWIPS Tiled writer and remove use of dask delayed

### DIFF
--- a/satpy/resample/kdtree.py
+++ b/satpy/resample/kdtree.py
@@ -144,7 +144,7 @@ class KDTreeResampler(PRBaseResampler):
             filename = self._create_cache_filename(
                 cache_dir, prefix="nn_lut-",
                 mask=mask_name, **kwargs)
-            fid = zarr.open(filename, "r")
+            fid = zarr.open(filename, mode="r")
             cache = np.array(fid[idx_name])
             if idx_name == "valid_input_index":
                 # valid input index array needs to be boolean

--- a/satpy/tests/enhancement_tests/test_enhancements.py
+++ b/satpy/tests/enhancement_tests/test_enhancements.py
@@ -26,6 +26,7 @@ import pytest
 import xarray as xr
 
 from satpy.enhancements import create_colormap, on_dask_array, on_separate_bands, using_map_blocks
+from satpy.tests.utils import assert_maximum_dask_computes
 
 # NOTE:
 # The following fixtures are not defined in this file, but are used and injected by Pytest:
@@ -35,7 +36,8 @@ from satpy.enhancements import create_colormap, on_dask_array, on_separate_bands
 def run_and_check_enhancement(func, data, expected, **kwargs):
     """Perform basic checks that apply to multiple tests."""
     pre_attrs = data.attrs
-    img = _get_enhanced_image(func, data, **kwargs)
+    with assert_maximum_dask_computes(max_computes=0):
+        img = _get_enhanced_image(func, data, **kwargs)
 
     _assert_image(img, pre_attrs, func.__name__, "palettes" in kwargs)
     _assert_image_data(img, expected)

--- a/satpy/tests/test_readers.py
+++ b/satpy/tests/test_readers.py
@@ -573,8 +573,9 @@ class TestFindFilesAndReaders:
         assert list(ri.keys()) == ["viirs_sdr"]
         assert ri["viirs_sdr"] == [viirs_file]
 
-    def test_sensor_no_files(self):
+    def test_sensor_no_files(self, tmp_path, monkeypatch):
         """Test that readers for the current sensor are loaded."""
+        monkeypatch.chdir(tmp_path)
         # we can't easily know how many readers satpy has that support
         # 'viirs' so we just pass it and hope that this works
         with pytest.raises(ValueError, match="No supported files found"):

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -18,6 +18,7 @@
 
 import datetime as dt
 import os
+from collections import defaultdict
 from collections.abc import Mapping
 from contextlib import contextmanager
 from typing import Any
@@ -277,13 +278,15 @@ class FakeFileHandler(BaseFileHandler):
             yield is_avail, ds_info
 
 
-class CustomScheduler(object):
+class CustomScheduler:
     """Scheduler raising an exception if data are computed too many times."""
 
-    def __init__(self, max_computes=1):
+    def __init__(self, max_computes: int = 1, expect_duplicate_computes: bool = False):
         """Set starting and maximum compute counts."""
         self.max_computes = max_computes
         self.total_computes = 0
+        self.task_counts: dict[Any, int] = defaultdict(lambda: 0)
+        self.expect_duplicate_computes = expect_duplicate_computes
 
     def __call__(self, dsk, keys, **kwargs):
         """Compute dask task and keep track of number of times we do so."""
@@ -292,6 +295,15 @@ class CustomScheduler(object):
         if self.total_computes > self.max_computes:
             raise RuntimeError("Too many dask computations were scheduled: "
                                "{}".format(self.total_computes))
+
+        for key in keys:
+            self.task_counts[key] += 1
+            if not self.expect_duplicate_computes and self.task_counts[key] > self.max_computes:
+                raise RuntimeError(
+                    f"Task {key} is being computed more than once. This is "
+                    f"typically caused by dask incorrectly optimizing dask "
+                    f"graphs. This could be a bug in dask or expected if "
+                    f"passing Arrays to Delayed functions. ")
         return dask.get(dsk, keys, **kwargs)
 
 

--- a/satpy/tests/writer_tests/test_awips_tiled.py
+++ b/satpy/tests/writer_tests/test_awips_tiled.py
@@ -23,7 +23,6 @@ import os
 import shutil
 from glob import glob
 
-import dask
 import dask.array as da
 import numpy as np
 import pytest
@@ -336,13 +335,8 @@ class TestAWIPSTiledWriter:
         data2 = da.from_array(data2, chunks=500)
         ds2 = _get_test_lcc_data(data2, area_def2)
         w = AWIPSTiledWriter(base_dir=second_base_dir, compress=True)
-        # HACK: The _copy_to_existing function hangs when opening the output
-        #   file multiple times...sometimes. If we limit dask to one worker
-        #   it seems to work fine.
-        # FIXME: Try removing this
         with assert_maximum_dask_computes(max_computes=1):
-            with dask.config.set(num_workers=1):
-                w.save_datasets([ds2], sector_id="LCC", source_name="TESTS", tile_count=(3, 3), lettered_grid=True)
+            w.save_datasets([ds2], sector_id="LCC", source_name="TESTS", tile_count=(3, 3), lettered_grid=True)
         all_files = glob(os.path.join(second_base_dir, "TESTS_AII*.nc"))
         # 16 original tiles + 4 new tiles
         assert len(all_files) == 20

--- a/satpy/tests/writer_tests/test_awips_tiled.py
+++ b/satpy/tests/writer_tests/test_awips_tiled.py
@@ -221,7 +221,7 @@ class TestAWIPSTiledWriter:
     )
     def test_basic_numbered_tiles(self, tile_count, tile_size, tmp_path):
         """Test creating a multiple numbered tiles."""
-        from satpy.tests.utils import CustomScheduler
+        from satpy.tests.utils import assert_maximum_dask_computes
         from satpy.writers.awips_tiled import AWIPSTiledWriter
         data = _get_test_data()
         area_def = _get_test_area()
@@ -236,11 +236,11 @@ class TestAWIPSTiledWriter:
         )
         should_error = tile_count is None and tile_size is None
         if should_error:
-            with dask.config.set(scheduler=CustomScheduler(0)), \
+            with assert_maximum_dask_computes(max_computes=0), \
                  pytest.raises(ValueError, match=r"Either.*tile_count.*"):
                 w.save_datasets([input_data_arr], **save_kwargs)
         else:
-            with dask.config.set(scheduler=CustomScheduler(1 * 2)):  # precompute=*2
+            with assert_maximum_dask_computes(max_computes=1):
                 w.save_datasets([input_data_arr], **save_kwargs)
 
         all_files = glob(os.path.join(str(tmp_path), "TESTS_AII*.nc"))

--- a/satpy/tests/writer_tests/test_awips_tiled.py
+++ b/satpy/tests/writer_tests/test_awips_tiled.py
@@ -30,6 +30,8 @@ import pytest
 import xarray as xr
 from pyproj import CRS
 
+from satpy.tests.utils import assert_maximum_dask_computes
+
 START_TIME = dt.datetime(2018, 1, 1, 12, 0, 0)
 END_TIME = START_TIME + dt.timedelta(minutes=20)
 
@@ -180,7 +182,8 @@ class TestAWIPSTiledWriter:
         data = _get_test_data()
         area_def = _get_test_area()
         input_data_arr = _get_test_lcc_data(data, area_def, extra_attrs)
-        with caplog.at_level(logging.DEBUG):
+        with assert_maximum_dask_computes(max_computes=1), \
+                caplog.at_level(logging.DEBUG):
             w = AWIPSTiledWriter(base_dir=str(tmp_path), compress=True)
             if use_save_dataset:
                 w.save_dataset(input_data_arr, sector_id="TEST", source_name="TESTS")
@@ -221,7 +224,6 @@ class TestAWIPSTiledWriter:
     )
     def test_basic_numbered_tiles(self, tile_count, tile_size, tmp_path):
         """Test creating a multiple numbered tiles."""
-        from satpy.tests.utils import assert_maximum_dask_computes
         from satpy.writers.awips_tiled import AWIPSTiledWriter
         data = _get_test_data()
         area_def = _get_test_area()
@@ -265,7 +267,8 @@ class TestAWIPSTiledWriter:
                                   extents=(-1000000., -1500000., 1000000., 1500000.))
         ds = _get_test_lcc_data(data, area_def)
         # tile_count should be ignored since we specified lettered_grid
-        w.save_datasets([ds], sector_id="LCC", source_name="TESTS", tile_count=(3, 3), lettered_grid=True)
+        with assert_maximum_dask_computes(max_computes=1):
+            w.save_datasets([ds], sector_id="LCC", source_name="TESTS", tile_count=(3, 3), lettered_grid=True)
         all_files = glob(os.path.join(str(tmp_path), "TESTS_AII*.nc"))
         assert len(all_files) == 16
         for fn in all_files:
@@ -284,7 +287,8 @@ class TestAWIPSTiledWriter:
                                   extents=(-1000000., -1500000., 1000000., 1500000.))
         ds = _get_test_lcc_data(data, area_def)
         # tile_count should be ignored since we specified lettered_grid
-        w.save_datasets([ds], sector_id="LCC", source_name="TESTS", tile_count=(3, 3), lettered_grid=True)
+        with assert_maximum_dask_computes(max_computes=1):
+            w.save_datasets([ds], sector_id="LCC", source_name="TESTS", tile_count=(3, 3), lettered_grid=True)
         all_files = sorted(glob(os.path.join(str(tmp_path), "TESTS_AII*.nc")))
         assert len(all_files) == 24
         assert "TC02" in all_files[0]  # the first tile should be TC02
@@ -308,7 +312,8 @@ class TestAWIPSTiledWriter:
                                   extents=(-1000000., -1500000., 1000000., 1500000.))
         ds = _get_test_lcc_data(data, area_def)
         # tile_count should be ignored since we specified lettered_grid
-        w.save_datasets([ds], sector_id="LCC", source_name="TESTS", tile_count=(3, 3), lettered_grid=True)
+        with assert_maximum_dask_computes(max_computes=1):
+            w.save_datasets([ds], sector_id="LCC", source_name="TESTS", tile_count=(3, 3), lettered_grid=True)
         all_files = sorted(glob(os.path.join(first_base_dir, "TESTS_AII*.nc")))
         assert len(all_files) == 16
         first_files = []
@@ -334,8 +339,10 @@ class TestAWIPSTiledWriter:
         # HACK: The _copy_to_existing function hangs when opening the output
         #   file multiple times...sometimes. If we limit dask to one worker
         #   it seems to work fine.
-        with dask.config.set(num_workers=1):
-            w.save_datasets([ds2], sector_id="LCC", source_name="TESTS", tile_count=(3, 3), lettered_grid=True)
+        # FIXME: Try removing this
+        with assert_maximum_dask_computes(max_computes=1):
+            with dask.config.set(num_workers=1):
+                w.save_datasets([ds2], sector_id="LCC", source_name="TESTS", tile_count=(3, 3), lettered_grid=True)
         all_files = glob(os.path.join(second_base_dir, "TESTS_AII*.nc"))
         # 16 original tiles + 4 new tiles
         assert len(all_files) == 20
@@ -369,9 +376,10 @@ class TestAWIPSTiledWriter:
         area_def = _get_test_area(shape=(2000, 1000),
                                   extents=(-1000000., -1500000., 1000000., 1500000.))
         ds = _get_test_lcc_data(data, area_def)
-        w.save_datasets([ds], sector_id="LCC", source_name="TESTS",
-                        lettered_grid=True, use_sector_reference=True,
-                        use_end_time=True)
+        with assert_maximum_dask_computes(max_computes=1):
+            w.save_datasets([ds], sector_id="LCC", source_name="TESTS",
+                            lettered_grid=True, use_sector_reference=True,
+                            use_end_time=True)
         all_files = glob(os.path.join(str(tmp_path), "TESTS_AII*.nc"))
         assert len(all_files) == 16
         for fn in all_files:
@@ -389,7 +397,8 @@ class TestAWIPSTiledWriter:
         area_def = _get_test_area(shape=(2000, 1000),
                                   extents=(4000000., 5000000., 5000000., 6000000.))
         ds = _get_test_lcc_data(data, area_def)
-        w.save_datasets([ds], sector_id="LCC", source_name="TESTS", tile_count=(3, 3), lettered_grid=True)
+        with assert_maximum_dask_computes(max_computes=1):
+            w.save_datasets([ds], sector_id="LCC", source_name="TESTS", tile_count=(3, 3), lettered_grid=True)
         # No files created
         all_files = glob(os.path.join(str(tmp_path), "TESTS_AII*.nc"))
         assert not all_files
@@ -402,7 +411,8 @@ class TestAWIPSTiledWriter:
         area_def = _get_test_area(shape=(2000, 1000),
                                   extents=(-1000000., -1500000., 1000000., 1500000.))
         ds = _get_test_lcc_data(data, area_def)
-        w.save_datasets([ds], sector_id="LCC", source_name="TESTS", tile_count=(3, 3), lettered_grid=True)
+        with assert_maximum_dask_computes(max_computes=1):
+            w.save_datasets([ds], sector_id="LCC", source_name="TESTS", tile_count=(3, 3), lettered_grid=True)
         # No files created - all NaNs should result in no tiles being created
         all_files = glob(os.path.join(str(tmp_path), "TESTS_AII*.nc"))
         assert not all_files
@@ -415,7 +425,8 @@ class TestAWIPSTiledWriter:
         area_def = _get_test_area(shape=(2000, 1000),
                                   extents=(-1000000., -1500000., 1000000., 1500000.))
         ds = _get_test_lcc_data(data, area_def)
-        with pytest.raises(KeyError):
+        with assert_maximum_dask_computes(max_computes=1), \
+                pytest.raises(KeyError):
             w.save_datasets([ds],
                             sector_id="LCC",
                             source_name="TESTS",
@@ -432,7 +443,8 @@ class TestAWIPSTiledWriter:
         ds = ds.rename(dict((old, new) for old, new in zip(ds.dims, ["bands", "y", "x"])))
         ds.coords["bands"] = ["R", "G", "B"]
 
-        w.save_datasets([ds], sector_id="TEST", source_name="TESTS", tile_count=(3, 3))
+        with assert_maximum_dask_computes(max_computes=1):
+            w.save_datasets([ds], sector_id="TEST", source_name="TESTS", tile_count=(3, 3))
         chan_files = glob(os.path.join(str(tmp_path), "TESTS_AII*test_ds_R*.nc"))
         all_files = chan_files[:]
         assert len(chan_files) == 9
@@ -495,7 +507,8 @@ class TestAWIPSTiledWriter:
             "_FillValue": 1,
         })
 
-        with pytest.warns(UserWarning, match="Production location attribute "):
+        with assert_maximum_dask_computes(max_computes=1), \
+                pytest.warns(UserWarning, match="Production location attribute "):
             w.save_datasets([ds1, ds2, ds3, dqf], sector_id="TEST", source_name="TESTS",
                             tile_count=(3, 3), template="glm_l2_rad{}".format(sector.lower()),
                             **extra_kwargs)

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -1232,7 +1232,14 @@ def to_nonempty_netcdf(dataset_to_save: xr.Dataset,
         mode = "a"
     else:
         mode = "w"
-    dataset_to_save.to_netcdf(output_filename, mode=mode)
+    with warnings.catch_warnings():
+        # this is an expected warning as CF convention tells us not to have a _FillValue for coordinate variables
+        warnings.filterwarnings(
+            "ignore",
+            message="saving variable [xy] with .* without any _FillValue.*",
+            category=xr.SerializationWarning,
+        )
+        dataset_to_save.to_netcdf(output_filename, mode=mode)
 
 
 def tile_filler(data_arr_data, tile_shape, tile_slices, fill_value):

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -1650,21 +1650,26 @@ def _save_tile_data_arrays(
             "".join(str(dim) for dim in data_arr.dims),
         )
     )
-    return da.blockwise(
+    # Convert xarray's internal dict-like objects to pure dicts so dask
+    # tokenizing doesn't try generic object tokenization
+    all_attrs = [dict(data_arr.attrs) for data_arr in data_arrs]
+    all_coords = [dict(data_arr.coords) for data_arr in data_arrs]
+    res = da.blockwise(
         _save_tile_block,
         "a",
         *data_arr_dims_pairs,
         new_axes={"a": 1},
         meta=np.ndarray((), dtype=object),
         dtype=object,
-        all_attrs=[data_arr.attrs for data_arr in data_arrs],
-        all_coords=[data_arr.coords for data_arr in data_arrs],
+        all_attrs=all_attrs,
+        all_coords=all_coords,
         template=template,
         compress=compress,
         check_categories=check_categories,
         output_filename=output_filename,
         render_kwargs=render_kwargs,
     )
+    return res
 
 
 def _save_tile_block(

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -957,9 +957,8 @@ class AWIPSNetCDFTemplate(NetCDFTemplate):
         if org is not None:
             prod_location = org
         else:
-            LOG.warning("environment ORGANIZATION not set for .production_location attribute, using hostname")
             import socket
-            prod_location = socket.gethostname()  # FUTURE: something more correct but this will do for now
+            prod_location = socket.gethostname()
 
         if len(prod_location) > 31:
             warnings.warn(


### PR DESCRIPTION
This is a major rewrite of how the AWIPS tiled (`awips_tiled`). Previously I had a lot of hacks to workaround xarray or dask hanging. Recent advise from dask maintainers is to not passing Array objects to Delayed functions so in this PR I removed that in favor of a call to `blockwise`. I also removed (hopefully) various hacks that won't be needed any longer. I also caught that dask was computing things multiple times with various solutions I tried to implement and ended up filing a bug report with dask on that, but for some reason this particular implementation in this PR does not suffer from that.

This PR also ignores some expected warnings from xarray about saving coordinate variables to a NetCDF file without a `_FillValue`. This is CF standard so expected.

I still have some type annotations and other things I'd like to add but this is ready for review.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
