### PR TITLE
Fix AWIPS tiled writer not being computed properly when compute=False

### DIFF
--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -1252,6 +1252,7 @@ def to_nonempty_netcdf(dataset_to_save: xr.Dataset,
             message="saving variable [xy] with .* without any _FillValue.*",
             category=xr.SerializationWarning,
         )
+        LOG.info(f"Saving AWIPS tile {output_filename}...")
         dataset_to_save.to_netcdf(output_filename, mode=mode)
 
 

--- a/satpy/writers/core/compute.py
+++ b/satpy/writers/core/compute.py
@@ -128,6 +128,9 @@ def compute_writer_results(results):
     # one or more writers have targets that we need to close in the future
     if targets:
         delayeds.append(da.store(sources, targets, compute=False))
+    elif sources:
+        # array-like only, no targets (ex. reduce to a single map_blocks/blockwise func call)
+        da.compute(sources)
 
     if delayeds:
         # replace Delayed's graph optimization function with the Array function


### PR DESCRIPTION
The AWIPS tiled writer, as modified in #3186, returns only a list of dask arrays now. This results from switching from Delayed functions to a series of `blockwise` operations as recommended by dask maintainers. This allows dask to better optimize the dask graph including not re-computing tasks it has already computed.

The problem with these changes is that the `compute_writer_results` function that is used when `scn.save_datasets(..., compute=False)` is used doesn't properly handle source-only results. This PR fixes that.

A possible change to this that I'm considering: return the result of `dask.compute` for the source compute and possibly for the delayed compute. This should theoretically allow writers that write files to return the filename that was created. This is something I've wanted for a long time as it allows Satpy-based scripts to inform later processing steps (think bash pipes) of the files that are created. However with threaded dask schedulers you can't get completed tasks in the order they are completed (I think this is distributed only) so I might just update the AWIPS writer to have an option to print the path as part of it's `blockwise` function.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
