### PR TITLE
Limit setuptools-scm version to exclude 9.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ Twitter = "https://twitter.com/hashtag/satpy?src=hashtag_click"
 Mastodon = "https://fosstodon.org/tags/satpy"
 
 [build-system]
-requires = ["hatchling", "hatch-vcs"]
+requires = ["hatchling", "hatch-vcs", "setuptools-scm<9.0.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.metadata]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ Twitter = "https://twitter.com/hashtag/satpy?src=hashtag_click"
 Mastodon = "https://fosstodon.org/tags/satpy"
 
 [build-system]
-requires = ["hatchling", "hatch-vcs", "setuptools-scm<9.0.0"]
+requires = ["hatchling", "hatch-vcs", "setuptools-scm!=9.0.0"]
 build-backend = "hatchling.build"
 
 [tool.hatch.metadata]


### PR DESCRIPTION
There is a new version of `setuptools-scm` that doesn't work with `hatchling` giving the following error in CI:

```python
Obtaining file:///home/runner/work/satpy/satpy
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Installing backend dependencies: started
  Installing backend dependencies: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Preparing editable metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [32 lines of output]
      /tmp/pip-build-env-f1rjfm4s/overlay/lib/python3.11/site-packages/setuptools_scm/git.py:202: UserWarning: "/home/runner/work/satpy/satpy" is shallow and may cause errors
        warnings.warn(f'"{wd.path}" is shallow and may cause errors')
      Traceback (most recent call last):
        File "/home/runner/miniconda3/envs/test-environment/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 195, in prepare_metadata_for_build_editable
          hook = backend.prepare_metadata_for_build_editable
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      AttributeError: module 'hatchling.build' has no attribute 'prepare_metadata_for_build_editable'
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "/home/runner/miniconda3/envs/test-environment/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/home/runner/miniconda3/envs/test-environment/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/home/runner/miniconda3/envs/test-environment/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 204, in prepare_metadata_for_build_editable
          whl_basename = build_hook(metadata_directory, config_settings)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-f1rjfm4s/overlay/lib/python3.11/site-packages/hatchling/build.py", line 83, in build_editable
          return os.path.basename(next(builder.build(directory=wheel_directory, versions=['editable'])))
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-f1rjfm4s/overlay/lib/python3.11/site-packages/hatchling/builders/plugin/interface.py", line 147, in build
          build_hook.initialize(version, build_data)
        File "/tmp/pip-build-env-f1rjfm4s/overlay/lib/python3.11/site-packages/hatch_vcs/build_hook.py", line 35, in initialize
          dump_version(self.root, self.metadata.version, self.config_version_file, **kwargs)
        File "/tmp/pip-build-env-f1rjfm4s/overlay/lib/python3.11/site-packages/setuptools_scm/_integration/dump_version.py", line 77, in dump_version
          write_version_to_path(
        File "/tmp/pip-build-env-f1rjfm4s/overlay/lib/python3.11/site-packages/setuptools_scm/_integration/dump_version.py", line 111, in write_version_to_path
          content = final_template.format(version=version, version_tuple=version_tuple)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      KeyError: 'scm_version'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
Error: Process completed with exit code 1.
```

*EDIT*: There's a patch coming to `setuptools-scm` soon, so I updated the version limit so that it only excludes the affected version 9.0.0.
