### PR TITLE
Use token kwarg in dask map_blocks call instead of name

### DIFF
--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -361,7 +361,7 @@ def compute_relative_azimuth(
         sat_azi, sun_azi,
         dtype=sat_azi.dtype,
         meta=np.array((), dtype=sat_azi.dtype),
-        name="relative_azimuth",
+        token="relative_azimuth",  # nosec: B106
     )
     if xarray_dims is None:
         return rel_azi

--- a/satpy/readers/core/hdfeos.py
+++ b/satpy/readers/core/hdfeos.py
@@ -463,7 +463,7 @@ def _scale_and_mask_data_array(data_arr: xr.DataArray, is_category: bool = False
         data_arr.data,
         dtype=dtype,
         meta=np.array((), dtype=dtype),
-        name="scale_and_mask",
+        token="scale_and_mask",  # nosec: B106
         scale_factor=scale_factor,
         add_offset=add_offset,
         fill_value=fill_value,


### PR DESCRIPTION
See https://github.com/dask/dask/pull/11952

I used name= because token= was deprecated. This has been reverted in dask now and the desired behavior of defining a task name prefix is through the token kwarg to map_blocks.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
