### PR TITLE
Remove unnecessary dask task compute check in test utility scheduler

### DIFF
--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -18,7 +18,6 @@
 
 import datetime as dt
 import os
-from collections import defaultdict
 from collections.abc import Mapping
 from contextlib import contextmanager
 from typing import Any
@@ -281,12 +280,10 @@ class FakeFileHandler(BaseFileHandler):
 class CustomScheduler:
     """Scheduler raising an exception if data are computed too many times."""
 
-    def __init__(self, max_computes: int = 1, expect_duplicate_computes: bool = False):
+    def __init__(self, max_computes: int = 1):
         """Set starting and maximum compute counts."""
         self.max_computes = max_computes
         self.total_computes = 0
-        self.task_counts: dict[Any, int] = defaultdict(lambda: 0)
-        self.expect_duplicate_computes = expect_duplicate_computes
 
     def __call__(self, dsk, keys, **kwargs):
         """Compute dask task and keep track of number of times we do so."""
@@ -296,14 +293,6 @@ class CustomScheduler:
             raise RuntimeError("Too many dask computations were scheduled: "
                                "{}".format(self.total_computes))
 
-        for key in keys:
-            self.task_counts[key] += 1
-            if not self.expect_duplicate_computes and self.task_counts[key] > self.max_computes:
-                raise RuntimeError(
-                    f"Task {key} is being computed more than once. This is "
-                    f"typically caused by dask incorrectly optimizing dask "
-                    f"graphs. This could be a bug in dask or expected if "
-                    f"passing Arrays to Delayed functions. ")
         return dask.get(dsk, keys, **kwargs)
 
 


### PR DESCRIPTION
I had added the functionality in the CustomScheduler used in Satpy's tests to make sure that a task wasn't computed multiple times. I had thought that I tested it and that it worked as expected, but it turns out it only checks the top-level key that is requested. It is also causing issues like in #3199 where older versions of dask are providing keys as lists that are unhashable. Overall, let's just get rid of this.

@avalentino if you don't want to wait for the next Satpy release you could take the patch/diff from this PR and apply it. I do think upgrading *dask* would help, but anyway. The breakage is in the tests only, not the Satpy package itself.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
