### PR TITLE
Add documentation on avoiding warnings when writing tests

### DIFF
--- a/doc/source/dev_guide/writing_tests.rst
+++ b/doc/source/dev_guide/writing_tests.rst
@@ -21,3 +21,56 @@ that are used in the module::
     # The following fixtures are not defined in this file, but are used and injected by Pytest:
     # - tmp_path
     # - fixture_defined_in_conftest.py
+
+Avoiding Warnings
+=================
+
+Satpy tries to avoid all warnings being emitted during tests. A warning
+(ex. UserWarning) being emitted during tests suggests there is a new
+or upcoming change that will affect Satpy or its users. At the time of
+writing Satpy does not fail when warnings are encountered but this may
+change in the future.
+
+Warnings encountered during testing should be handled in one of a couple
+different ways.
+
+1. Fix the underlying issue. For example, if a dependency is changing behavior
+then update Satpy's usage to not produce the warning.
+2. Catch the specific warning as part of the test. For example, if a test is
+expecting to produce the warning should be making sure that it is, do::
+
+   with pytest.warns(UserWarning, match="the warning message"):
+       # code being tested
+
+3. Ignore the error at the test level::
+
+   @pytest.mark.filterwarnings("ignore:the warning message:UserWarning")
+   def test_something():
+       # test code
+
+4. Ignore the warning globally. This is typically reserved for dependency
+changes that are expected to be removed in a future version. These are
+configured in the ``pyproject.toml`` in the root of the repository in the
+``tool.pytest.ini_options`` section. See existing warning filters there for
+examples.
+
+Other tips for avoiding warnings:
+
+* Create semi-realistic test data and avoid ``da.zeros`` or ``da.ones`` when
+creating test data. A simple option is to use ``arange``::
+
+  test_data = da.arange(100 * 200).reshape((100, 200)).rechunk(50)
+
+* If using pytest's ``parametrize`` functionality and only some of the
+parameters should produce a warning, use ``contextlib.nullcontext``::
+
+  exp_warning = pytest.warns(...) if condition else contextlib.nullcontext()
+  with exp_warning:
+      # code being tested
+
+Lastly, note that all Numpy "invalid value" warnings are ignored globally in
+the ``pyproject.toml`` file. So if your test involves NaNs in the data and
+you are expecting to see them or expecting to catch them then you may have
+to customize the warning filters with pytest's ``filterwarnings``. See
+:ref:`user_warnings_errors` for more details on what is recommended for
+users.

--- a/doc/source/dev_guide/writing_tests.rst
+++ b/doc/source/dev_guide/writing_tests.rst
@@ -44,9 +44,9 @@ expecting to produce the warning should be making sure that it is, do::
 
 3. Ignore the error at the test level::
 
-   @pytest.mark.filterwarnings("ignore:the warning message:UserWarning")
-   def test_something():
-       # test code
+    @pytest.mark.filterwarnings("ignore:the warning message:UserWarning")
+    def test_something():
+        # test code
 
 4. Ignore the warning globally. This is typically reserved for dependency
 changes that are expected to be removed in a future version. These are
@@ -57,16 +57,16 @@ examples.
 Other tips for avoiding warnings:
 
 * Create semi-realistic test data and avoid ``da.zeros`` or ``da.ones`` when
-creating test data. A simple option is to use ``arange``::
+  creating test data. A simple option is to use ``arange``::
 
-  test_data = da.arange(100 * 200).reshape((100, 200)).rechunk(50)
+    test_data = da.arange(100 * 200).reshape((100, 200)).rechunk(50)
 
 * If using pytest's ``parametrize`` functionality and only some of the
-parameters should produce a warning, use ``contextlib.nullcontext``::
+  parameters should produce a warning, use ``contextlib.nullcontext``::
 
-  exp_warning = pytest.warns(...) if condition else contextlib.nullcontext()
-  with exp_warning:
-      # code being tested
+    exp_warning = pytest.warns(...) if condition else contextlib.nullcontext()
+    with exp_warning:
+        # code being tested
 
 Lastly, note that all Numpy "invalid value" warnings are ignored globally in
 the ``pyproject.toml`` file. So if your test involves NaNs in the data and

--- a/doc/source/dev_guide/writing_tests.rst
+++ b/doc/source/dev_guide/writing_tests.rst
@@ -35,12 +35,13 @@ Warnings encountered during testing should be handled in one of a couple
 different ways.
 
 1. Fix the underlying issue. For example, if a dependency is changing behavior
-then update Satpy's usage to not produce the warning.
-2. Catch the specific warning as part of the test. For example, if a test is
-expecting to produce the warning should be making sure that it is, do::
+   then update Satpy's usage to not produce the warning.
 
-   with pytest.warns(UserWarning, match="the warning message"):
-       # code being tested
+2. Catch the specific warning as part of the test. For example, if a test is
+   expecting to produce the warning should be making sure that it is, do::
+
+    with pytest.warns(UserWarning, match="the warning message"):
+        # code being tested
 
 3. Ignore the error at the test level::
 
@@ -49,12 +50,12 @@ expecting to produce the warning should be making sure that it is, do::
         # test code
 
 4. Ignore the warning globally. This is typically reserved for dependency
-changes that are expected to be removed in a future version. These are
-configured in the ``pyproject.toml`` in the root of the repository in the
-``tool.pytest.ini_options`` section. See existing warning filters there for
-examples.
+   changes that are expected to be removed in a future version. These are
+   configured in the ``pyproject.toml`` in the root of the repository in the
+   ``tool.pytest.ini_options`` section. See existing warning filters there for
+   examples.
 
-Other tips for avoiding warnings:
+**Other warnings tips**
 
 * Create semi-realistic test data and avoid ``da.zeros`` or ``da.ones`` when
   creating test data. A simple option is to use ``arange``::

--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -275,6 +275,8 @@ To subset multi-resolution data consistently, use the :meth:`~satpy.scene.Scene.
   >>> vis006_llbox_meas = vis006_llbox.values
   >>> vis006_llbox_lon, vis006_llbox_lat = vis006_llbox.attrs['area'].get_lonlats()
 
+.. _user_warnings_errors:
+
 Warnings and Errors
 ===================
 


### PR DESCRIPTION
I had posted on slack about some things that I had learned while writing various PRs on removing warnings encountered during Satpy's tests being executed. @gerritholl ask that I write them down in the documentation so I've added them here. We should really check the final rendered version of the documentation site before merging this.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
