### PR TITLE
add treshhold tuned fire temperature rgb for europe

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -34,6 +34,7 @@ The following people have made contributions to this project:
 - [Andrea Grillini (AppLEaDaY)](https://github.com/AppLEaDaY)
 - [Blanka Gvozdikova (gvozdikb)](https://github.com/gvozdikb)
 - [Nina Håkansson (ninahakansson)](https://github.com/ninahakansson)
+- [Alexander Halbig (alexhalbig)](https://github.com/alexhalbig) - Deutscher Wetterdienst
 - [Ulrich Hamann](https://github.com/)
 - [Mitch Herbertson (mherbertson)](https://github.com/mherbertson)
 - [Gerrit Holl (gerritholl)](https://github.com/gerritholl) - Deutscher Wetterdienst

--- a/satpy/etc/composites/fci.yaml
+++ b/satpy/etc/composites/fci.yaml
@@ -431,7 +431,7 @@ composites:
       - cloud_phase
       - night_ir105
 
-  fire_temperature:
+  fire_temperature: &fire
     standard_name: fire_temperature_fci
     compositor: !!python/name:satpy.composites.core.GenericCompositor
     description: >
@@ -449,6 +449,10 @@ composites:
       - name: ir_38
       - name: nir_22
       - name: nir_16
+
+  fire_temperature_fci_contrast_tuned:
+    <<: *fire
+    standard_name: fire_temperature_fci_contrast_tuned
 
   fire_temperature_38refl:
     standard_name: fire_temperature_fci_38refl

--- a/satpy/etc/enhancements/fci.yaml
+++ b/satpy/etc/enhancements/fci.yaml
@@ -32,6 +32,25 @@ enhancements:
         kwargs:
           gamma: [0.4, 1, 1]
 
+  fire_temperature_fci_contrast_tuned:
+    standard_name: fire_temperature_fci_contrast_tuned
+    description: >
+      This enhancement is tuned for more contrast with case studies over europe. 
+      Surface signal are stongly reduced by using a lower limit at 20 °C instead of 0°C and using 0.2 gamma.
+      Intra-fire distiction is improved by lowering the maximum tresholds for yellow and white signals. 
+    operations:
+      - name: stretch
+        method: !!python/name:satpy.enhancements.stretch
+        kwargs:
+          stretch: crude
+          min_stretch: [293.15, 0.0, 0.0]
+          max_stretch: [333.15, 50.0, 60.0]
+      - name: gamma
+        method: !!python/name:satpy.enhancements.gamma
+        kwargs:
+          gamma: [0.2, 1, 1]
+
+
   fire_temperature_fci_38refl:
     standard_name: fire_temperature_fci_38refl
     operations:


### PR DESCRIPTION
This enhancement is tuned for more contrast with case studies over europe. Surface signal are stongly reduced by using a lower limit at 20 °C instead of 0°C and using 0.2 gamma. Intra-fire distiction is improved by lowering the maximum tresholds for yellow and white signals.

<!-- Describe what your PR does, and why -->
<img width="2797" height="920" alt="FT_Vergleich" src="https://github.com/user-attachments/assets/19c3d69b-f45d-4169-b412-c12cf5aba967" />
On the right is the standard recipe, on the left the tuned one. In the middle is the tuned masked with L2 FIR fire mask product. I systematically looked at the pixel values for forest fires across Europe in histograms and adjusted the thresholds so that a) earlier saturation can take place in channel 2.2 and 1.6 for better intra-fire differentiation. (Previously, the maximum saturation was never reached in all evaluated case studies). b) I adjusted the threshold of 3.8 to avoid the diurnal temperature variation in the red beam over land.
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Add your name to `AUTHORS.md` if not there already
