### PR TITLE
Remove sun glint masking in VIIRS EDR NDVI/EVI filtering

### DIFF
--- a/satpy/readers/viirs_edr.py
+++ b/satpy/readers/viirs_edr.py
@@ -348,7 +348,7 @@ class VIIRSSurfaceReflectanceWithVIHandler(VIIRSJRRFileHandler):
     def _get_veg_index_good_mask(self) -> da.Array:
         # each mask array should be TRUE when pixels are UNACCEPTABLE
         qf1 = self.nc["QF1 Surface Reflectance"]
-        has_sun_glint = (qf1 & 0b11000000) > 0
+        # has_sun_glint = (qf1 & 0b11000000) > 0
         is_cloudy = (qf1 & 0b00001100) > 0  # mask everything but "confident clear"
         cloud_quality = (qf1 & 0b00000011) < 0b10
 
@@ -363,7 +363,7 @@ class VIIRSSurfaceReflectanceWithVIHandler(VIIRSJRRFileHandler):
         adjacent_to_cloud = (qf7 & 0b00000010) > 0
 
         bad_mask = (
-                has_sun_glint |
+                # has_sun_glint |
                 is_cloudy |
                 cloud_quality |
                 has_snow_or_ice |

--- a/satpy/tests/reader_tests/test_viirs_edr.py
+++ b/satpy/tests/reader_tests/test_viirs_edr.py
@@ -191,7 +191,8 @@ def _create_veg_index_variables() -> dict[str, xr.DataArray]:
         bad_qf_start = 4  # 0.5x the last test pixel set in "vi_data" above (I-band versus M-band index)
         if qf_num == 1:
             qf_data[:, :] |= 0b00000010  # medium cloud mask quality everywhere
-            qf_data[0, bad_qf_start] |= 0b11000000  # sun glint
+            # qf_data[0, bad_qf_start] |= 0b11000000  # sun glint
+            qf_data[0, bad_qf_start] |= 0b00001100  # cloudy
             qf_data[0, bad_qf_start + 1] |= 0b00001100  # cloudy
             qf_data[0, bad_qf_start + 2] = 0b00000001  # low cloud mask quality
         elif qf_num == 2:


### PR DESCRIPTION
New versions of the LSR software (NOAA version 1.3) now report sun glint over land and this ends up masking most of the NDVI and EVI products.

See https://github.com/ssec/polar2grid/issues/768 for details.

Note: I made these edits using github's editor so I have no idea if the tests pass or if there are other formatting issues. Let's check what CI has to say.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
