### PR TITLE
Restrict writers to specific return value types

### DIFF
--- a/satpy/multiscene/_multiscene.py
+++ b/satpy/multiscene/_multiscene.py
@@ -402,7 +402,7 @@ class MultiScene(object):
 
         for scene in scenes_iter:
             delayeds = scene.save_datasets(compute=False, **kwargs)
-            sources, targets, delayeds = split_results(delayeds)
+            sources, targets, delayeds = split_results([delayeds])
             if len(sources) > 0:
                 # TODO Make this work for (source, target) datasets
                 # given a target, source combination

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1291,7 +1291,9 @@ class Scene:
             computed with `delayed.compute()` or a two element tuple of
             sources and targets to be passed to :func:`dask.array.store`. If
             `targets` is provided then it is the caller's responsibility to
-            close any objects that have a "close" method.
+            close any objects that have a "close" method. It is recommended to
+            use the utility function
+            :func:`~satpy.writers.core.compute.compute_writer_results`.
 
         """
         from satpy._scene_converters import _get_dataarrays_from_identifiers

--- a/satpy/tests/multiscene_tests/test_save_animation.py
+++ b/satpy/tests/multiscene_tests/test_save_animation.py
@@ -249,7 +249,7 @@ class TestMultiSceneSave(unittest.TestCase):
         source_mock.__class__ = da.Array
         target_mock = mock.MagicMock()
         with mock.patch("satpy.multiscene._multiscene.Scene.save_datasets") as save_datasets:
-            save_datasets.return_value = [(source_mock, target_mock)]  # some arbitrary return value
+            save_datasets.return_value = ([source_mock], [target_mock])  # some arbitrary return value
             # force order of datasets by specifying them
             with pytest.raises(NotImplementedError):
                 mscn.save_datasets(base_dir=self.base_dir, client=client_mock, datasets=["ds1", "ds2", "ds3"],

--- a/satpy/tests/reader_tests/test_acspo.py
+++ b/satpy/tests/reader_tests/test_acspo.py
@@ -36,7 +36,7 @@ DEFAULT_FILE_SHAPE = (10, 300)
 class FakeNetCDF4FileHandler2(FakeNetCDF4FileHandler):
     """Swap-in NetCDF4 File Handler."""
 
-    def get_test_content(self, filename, filename_info, filetype_info):
+    def get_test_content(self, filename: str, filename_info: dict, filetype_info: dict) -> dict:
         """Mimic reader input file content."""
         DEFAULT_FILE_DTYPE = np.uint16
         DEFAULT_FILE_DATA = np.arange(DEFAULT_FILE_SHAPE[0] * DEFAULT_FILE_SHAPE[1],

--- a/satpy/tests/writer_tests/test_core/test_compute.py
+++ b/satpy/tests/writer_tests/test_core/test_compute.py
@@ -214,5 +214,5 @@ class TestComputeWriterResults:
             chunks=(1, 1),
         )
 
-        compute_writer_results([res1, res2])
+        compute_writer_results([[res1], [res2]])
         assert compute_count == 2

--- a/satpy/tests/writer_tests/test_core/test_compute.py
+++ b/satpy/tests/writer_tests/test_core/test_compute.py
@@ -14,11 +14,11 @@
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Tests for the writer compute module."""
+
 from __future__ import annotations
 
 import datetime as dt
 import os
-import shutil
 
 import dask
 import numpy as np
@@ -41,29 +41,32 @@ def test_group_results_by_output_file(tmp_path):
 
     from satpy.tests.utils import make_fake_scene
     from satpy.writers.core.compute import group_results_by_output_file
+
     x = 10
     fake_area = create_area_def("sargasso", 4326, resolution=1, width=x, height=x, center=(0, 0))
     fake_scene = make_fake_scene(
-        {"dragon_top_height": (dat := xr.DataArray(
-            dims=("y", "x"),
-            data=da.arange(x*x).reshape((x, x)))),
-         "penguin_bottom_height": dat,
-         "kraken_depth": dat},
+        {
+            "dragon_top_height": (dat := xr.DataArray(dims=("y", "x"), data=da.arange(x * x).reshape((x, x)))),
+            "penguin_bottom_height": dat,
+            "kraken_depth": dat,
+        },
         daskify=True,
         area=fake_area,
-        common_attrs={"start_time": dt.datetime(2022, 11, 16, 13, 27)})
+        common_attrs={"start_time": dt.datetime(2022, 11, 16, 13, 27)},
+    )
     # NB: even if compute=False, ``save_datasets`` creates (empty) files
     (sources, targets) = fake_scene.save_datasets(
-            filename=os.fspath(tmp_path / "test-{name}.tif"),
-            writer="ninjogeotiff",
-            compress="NONE",
-            fill_value=0,
-            compute=False,
-            ChannelID="x",
-            DataType="x",
-            PhysicUnit="K",
-            PhysicValue="Temperature",
-            SatelliteNameID="x")
+        filename=os.fspath(tmp_path / "test-{name}.tif"),
+        writer="ninjogeotiff",
+        compress="NONE",
+        fill_value=0,
+        compute=False,
+        ChannelID="x",
+        DataType="x",
+        PhysicUnit="K",
+        PhysicValue="Temperature",
+        SatelliteNameID="x",
+    )
 
     grouped = group_results_by_output_file(sources, targets)
 
@@ -77,137 +80,121 @@ def test_group_results_by_output_file(tmp_path):
     assert targets[10:] == grouped[2][1]
 
 
-class TestComputeWriterResults:
-    """Test compute_writer_results()."""
+@pytest.fixture
+def fake_scene():
+    """Create a fake Scene object for testing computing delayed results."""
+    from pyresample.geometry import AreaDefinition
 
-    def setup_method(self):
-        """Create temporary directory to save files to and a mock scene."""
-        import tempfile
+    from satpy.scene import Scene
 
-        from pyresample.geometry import AreaDefinition
+    adef = AreaDefinition(
+        "test",
+        "test",
+        "test",
+        "EPSG:4326",
+        100,
+        200,
+        (-180.0, -90.0, 180.0, 90.0),
+    )
+    ds1 = xr.DataArray(
+        da.arange(100 * 200).reshape((100, 200)).rechunk(50),
+        dims=("y", "x"),
+        attrs={"name": "test", "start_time": dt.datetime(2018, 1, 1, 0, 0, 0), "area": adef},
+    )
+    scn = Scene()
+    scn["test"] = ds1
+    return scn
 
-        from satpy.scene import Scene
 
-        adef = AreaDefinition(
-            "test", "test", "test", "EPSG:4326",
-            100, 200, (-180., -90., 180., 90.),
-        )
-        ds1 = xr.DataArray(
-            da.arange(100 * 200).reshape((100, 200)).rechunk(50),
-            dims=("y", "x"),
-            attrs={"name": "test",
-                   "start_time": dt.datetime(2018, 1, 1, 0, 0, 0),
-                   "area": adef}
-        )
-        self.scn = Scene()
-        self.scn["test"] = ds1
+def test_simple_image(tmp_path, fake_scene):
+    """Test writing to PNG file."""
+    fname = str(tmp_path / "simple_image.png")
+    res = fake_scene.save_datasets(
+        filename=fname,
+        datasets=["test"],
+        writer="simple_image",
+        compute=False,
+    )
+    compute_writer_results([res])
+    assert os.path.isfile(fname)
 
-        # Temp dir
-        self.base_dir = tempfile.mkdtemp()
 
-    def teardown_method(self):
-        """Remove the temporary directory created for a test."""
-        try:
-            shutil.rmtree(self.base_dir, ignore_errors=True)
-        except OSError:
-            pass
+def test_geotiff(tmp_path, fake_scene):
+    """Test writing to mitiff file."""
+    fname = str(tmp_path / "geotiff.tif")
+    res = fake_scene.save_datasets(filename=fname, datasets=["test"], writer="geotiff", compute=False)
+    compute_writer_results([res])
+    assert os.path.isfile(fname)
 
-    def test_simple_image(self):
-        """Test writing to PNG file."""
-        fname = os.path.join(self.base_dir, "simple_image.png")
-        res = self.scn.save_datasets(filename=fname,
-                                     datasets=["test"],
-                                     writer="simple_image",
-                                     compute=False)
-        compute_writer_results([res])
-        assert os.path.isfile(fname)
 
-    def test_geotiff(self):
-        """Test writing to mitiff file."""
-        fname = os.path.join(self.base_dir, "geotiff.tif")
-        res = self.scn.save_datasets(filename=fname,
-                                     datasets=["test"],
-                                     writer="geotiff", compute=False)
-        compute_writer_results([res])
-        assert os.path.isfile(fname)
+def test_multiple_geotiff(tmp_path, fake_scene):
+    """Test writing to mitiff file."""
+    fname1 = str(tmp_path / "geotiff1.tif")
+    res1 = fake_scene.save_datasets(filename=fname1, datasets=["test"], writer="geotiff", compute=False)
+    fname2 = str(tmp_path / "geotiff2.tif")
+    res2 = fake_scene.save_datasets(filename=fname2, datasets=["test"], writer="geotiff", compute=False)
+    compute_writer_results([res1, res2])
+    assert os.path.isfile(fname1)
+    assert os.path.isfile(fname2)
 
-    def test_multiple_geotiff(self):
-        """Test writing to mitiff file."""
-        fname1 = os.path.join(self.base_dir, "geotiff1.tif")
-        res1 = self.scn.save_datasets(filename=fname1,
-                                      datasets=["test"],
-                                      writer="geotiff", compute=False)
-        fname2 = os.path.join(self.base_dir, "geotiff2.tif")
-        res2 = self.scn.save_datasets(filename=fname2,
-                                      datasets=["test"],
-                                      writer="geotiff", compute=False)
-        compute_writer_results([res1, res2])
-        assert os.path.isfile(fname1)
-        assert os.path.isfile(fname2)
 
-    def test_multiple_simple(self):
-        """Test writing to geotiff files."""
-        fname1 = os.path.join(self.base_dir, "simple_image1.png")
-        res1 = self.scn.save_datasets(filename=fname1,
-                                      datasets=["test"],
-                                      writer="simple_image", compute=False)
-        fname2 = os.path.join(self.base_dir, "simple_image2.png")
-        res2 = self.scn.save_datasets(filename=fname2,
-                                      datasets=["test"],
-                                      writer="simple_image", compute=False)
-        compute_writer_results([res1, res2])
-        assert os.path.isfile(fname1)
-        assert os.path.isfile(fname2)
+def test_multiple_simple(tmp_path, fake_scene):
+    """Test writing to geotiff files."""
+    fname1 = str(tmp_path / "simple_image1.png")
+    res1 = fake_scene.save_datasets(filename=fname1, datasets=["test"], writer="simple_image", compute=False)
+    fname2 = str(tmp_path / "simple_image2.png")
+    res2 = fake_scene.save_datasets(filename=fname2, datasets=["test"], writer="simple_image", compute=False)
+    compute_writer_results([res1, res2])
+    assert os.path.isfile(fname1)
+    assert os.path.isfile(fname2)
 
-    def test_mixed(self):
-        """Test writing to multiple mixed-type files."""
-        fname1 = os.path.join(self.base_dir, "simple_image3.png")
-        res1 = self.scn.save_datasets(filename=fname1,
-                                      datasets=["test"],
-                                      writer="simple_image", compute=False)
-        fname2 = os.path.join(self.base_dir, "geotiff3.tif")
-        res2 = self.scn.save_datasets(filename=fname2,
-                                      datasets=["test"],
-                                      writer="geotiff", compute=False)
-        res3 = []
-        compute_writer_results([res1, res2, res3])
-        assert os.path.isfile(fname1)
-        assert os.path.isfile(fname2)
 
-    def test_source_only(self):
-        """Test writers who only return dask arrays with no targets.
+def test_mixed(tmp_path, fake_scene):
+    """Test writing to multiple mixed-type files."""
+    fname1 = str(tmp_path / "simple_image3.png")
+    res1 = fake_scene.save_datasets(filename=fname1, datasets=["test"], writer="simple_image", compute=False)
+    fname2 = str(tmp_path / "geotiff3.tif")
+    res2 = fake_scene.save_datasets(filename=fname2, datasets=["test"], writer="geotiff", compute=False)
+    res3 = []
+    compute_writer_results([res1, res2, res3])
+    assert os.path.isfile(fname1)
+    assert os.path.isfile(fname2)
 
-        With newer versions of dask it is recommended to not pass Arrays to
-        Delayed functions as the tasks aren't properly/completely optimized.
-        The alternative is to reduce the Array into a single array-like operation
-        with map_blocks, blockwise, or some other reduction function.
-        """
-        compute_count = 0
 
-        def reduced_map_blocks(_: np.ndarray) -> str:
-            nonlocal compute_count
-            compute_count += 1
-            return "abc"
+def test_source_only():
+    """Test writers who only return dask arrays with no targets.
 
-        arr1 = da.zeros((5, 5))
-        arr2 = da.ones((5, 5))
-        res1 = da.map_blocks(
-            reduced_map_blocks,
-            arr1.rechunk(arr1.shape),
-            dtype=str,
-            meta=np.ndarray((), dtype=str),
-            chunks=(1, 1),
-        )
-        res2 = da.map_blocks(
-            reduced_map_blocks,
-            arr2.rechunk(arr2.shape),
-            dtype=str,
-            meta=np.ndarray((), dtype=str),
-            chunks=(1, 1),
-        )
+    With newer versions of dask it is recommended to not pass Arrays to
+    Delayed functions as the tasks aren't properly/completely optimized.
+    The alternative is to reduce the Array into a single array-like operation
+    with map_blocks, blockwise, or some other reduction function.
+    """
+    compute_count = 0
 
-        compute_writer_results([[res1], [res2]])
-        assert compute_count == 2
+    def reduced_map_blocks(_: np.ndarray) -> str:
+        nonlocal compute_count
+        compute_count += 1
+        return "abc"
+
+    arr1 = da.zeros((5, 5))
+    arr2 = da.ones((5, 5))
+    res1 = da.map_blocks(
+        reduced_map_blocks,
+        arr1.rechunk(arr1.shape),
+        dtype=str,
+        meta=np.ndarray((), dtype=str),
+        chunks=(1, 1),
+    )
+    res2 = da.map_blocks(
+        reduced_map_blocks,
+        arr2.rechunk(arr2.shape),
+        dtype=str,
+        meta=np.ndarray((), dtype=str),
+        chunks=(1, 1),
+    )
+
+    compute_writer_results([[res1], [res2]])
+    assert compute_count == 2
 
 
 @pytest.mark.parametrize(
@@ -215,7 +202,7 @@ class TestComputeWriterResults:
     [
         [],
         [[]],
-    ]
+    ],
 )
 def test_empty(results):
     """Test empty result list."""
@@ -228,20 +215,20 @@ def test_empty(results):
 
 
 class _Writable:
-    def __setitem__(self, window_slice, data):
-        ...
+    def __setitem__(self, window_slice, data): ...
 
 
 TEST_TARGET = _Writable()
 TEST_SRC = da.zeros((5, 5), chunks=2)
 
+
 @pytest.mark.parametrize(
     "results",
     [
-        # (TEST_SRC, TEST_TARGET),
-        # [(TEST_SRC, TEST_TARGET)],
+        (TEST_SRC, TEST_TARGET),
+        [(TEST_SRC, TEST_TARGET)],
         [dask.delayed(TEST_SRC)],
-    ]
+    ],
 )
 def test_legacy_return_values(results):
     """Test old ways that writers can return things produces a warning."""

--- a/satpy/tests/writer_tests/test_geotiff.py
+++ b/satpy/tests/writer_tests/test_geotiff.py
@@ -153,7 +153,8 @@ class TestGeoTIFFWriter:
         datasets = _get_test_datasets_2d()
         w = GeoTIFFWriter(base_dir=tmp_path, enhance=False)
         with mock.patch("trollimage.xrimage.XRImage.save") as save_method:
-            save_method.return_value = None
+            # compute is False in `save_datasets` so we need to return something dask-like
+            save_method.return_value = da.zeros((1, 1))
             w.save_datasets(datasets, compute=False)
             assert save_method.call_args[1]["dtype"] == np.float32
 
@@ -163,7 +164,8 @@ class TestGeoTIFFWriter:
         datasets = _get_test_datasets_2d()
         w = GeoTIFFWriter(base_dir=tmp_path, enhance=False, dtype=np.uint8)
         with mock.patch("trollimage.xrimage.XRImage.save") as save_method:
-            save_method.return_value = None
+            # compute is False in `save_datasets` so we need to return something dask-like
+            save_method.return_value = da.zeros((1, 1))
             w.save_datasets(datasets, compute=False)
             assert save_method.call_args[1]["dtype"] == np.uint8
 
@@ -174,7 +176,8 @@ class TestGeoTIFFWriter:
         w = GeoTIFFWriter(base_dir=tmp_path)
         w.info["fill_value"] = 128
         with mock.patch("trollimage.xrimage.XRImage.save") as save_method:
-            save_method.return_value = None
+            # compute is False in `save_datasets` so we need to return something dask-like
+            save_method.return_value = da.zeros((1, 1))
             w.save_datasets(datasets, compute=False)
             assert save_method.call_args[1]["fill_value"] == 128
 
@@ -185,7 +188,8 @@ class TestGeoTIFFWriter:
         w = GeoTIFFWriter(tags={"test1": 1}, base_dir=tmp_path)
         w.info["fill_value"] = 128
         with mock.patch("trollimage.xrimage.XRImage.save") as save_method:
-            save_method.return_value = None
+            # compute is False in `save_datasets` so we need to return something dask-like
+            save_method.return_value = da.zeros((1, 1))
             w.save_datasets(datasets, tags={"test2": 2}, compute=False)
             called_tags = save_method.call_args[1]["tags"]
             assert called_tags == {"test1": 1, "test2": 2}
@@ -212,7 +216,8 @@ class TestGeoTIFFWriter:
         w = GeoTIFFWriter(tags={"test1": 1}, base_dir=tmp_path)
         w.info["fill_value"] = 128
         with mock.patch("trollimage.xrimage.XRImage.save") as save_method:
-            save_method.return_value = None
+            # compute is False in `save_datasets` so we need to return something dask-like
+            save_method.return_value = da.zeros((1, 1))
             w.save_datasets(datasets, tags={"test2": 2}, compute=False, **save_kwargs)
         kwarg_name = "include_scale_offset_tags" if "include_scale_offset" in save_kwargs else "scale_offset_tags"
         kwarg_value = save_method.call_args[1].get(kwarg_name)
@@ -224,7 +229,8 @@ class TestGeoTIFFWriter:
         datasets = _get_test_datasets_2d()
         w = GeoTIFFWriter(base_dir=tmp_path)
         with mock.patch("trollimage.xrimage.XRImage.save") as save_method:
-            save_method.return_value = None
+            # compute is False in `save_datasets` so we need to return something dask-like
+            save_method.return_value = da.zeros((1, 1))
             w.save_datasets(datasets, compute=False)
             assert save_method.call_args[1]["tiled"]
 

--- a/satpy/tests/writer_tests/test_ninjotiff.py
+++ b/satpy/tests/writer_tests/test_ninjotiff.py
@@ -95,7 +95,7 @@ class TestNinjoTIFFWriter(unittest.TestCase):
         nt.save.assert_called()
         assert nt.save.mock_calls[0][2]["compute"] is False
         assert nt.save.mock_calls[0][2]["ch_min_measurement_unit"] < nt.save.mock_calls[0][2]["ch_max_measurement_unit"]
-        assert ret == nt.save.return_value
+        assert ret == [nt.save.return_value]
 
     def test_convert_units_self(self):
         """Test that unit conversion to themselves do nothing."""

--- a/satpy/tests/writer_tests/test_simple_image.py
+++ b/satpy/tests/writer_tests/test_simple_image.py
@@ -64,6 +64,7 @@ class TestPillowWriter(unittest.TestCase):
 
     def test_simple_delayed_write(self):
         """Test writing datasets with delayed computation."""
+        import dask.array as da
         from dask.delayed import Delayed
 
         from satpy.writers.core.compute import compute_writer_results
@@ -72,6 +73,8 @@ class TestPillowWriter(unittest.TestCase):
         w = PillowWriter(base_dir=self.base_dir)
         res = w.save_datasets(datasets, compute=False)
         for r__ in res:
-            assert isinstance(r__, Delayed)
+            # trollimage 1.27.0+ returns Arrays
+            # trollimage <1.27.0 returns Delayed objects
+            assert isinstance(r__, (Delayed, da.Array))
             r__.compute()
-        compute_writer_results(res)
+        compute_writer_results([res])

--- a/satpy/writers/core/compute.py
+++ b/satpy/writers/core/compute.py
@@ -35,7 +35,7 @@ def split_results(
     results collected from one or more writers. This function will treat dask
     Arrays and Delayed objects with no targets as dask collections to be
     computed. Otherwise dask Arrays can be supplied with an associated target
-    array-like file object and will be passed to :func:`dask.array.core.store`.
+    array-like file object and will be passed to :func:`dask.array.store`.
 
     We assume that the provided input is a list containing any combination of:
 
@@ -130,19 +130,19 @@ def group_results_by_output_file(sources, targets):
 def compute_writer_results(
         results: Iterable[list[da.Array | Delayed] | tuple[list[da.Array], list[Any]]],
 ) -> list[np.ndarray | str | os.PathLike | None]:
-    """Compute all the given dask graphs `results` so that the files are saved.
+    """Compute all the given dask graphs ``results`` so that the files are saved.
 
     Args:
         results: Iterable of dask collections resulting from calls to
-        ``scn.save_datasets(..., compute=False)``. The iterable passed
-        should always **contain** the results of the writer/save_datasets
-        call, not be the results themselves. Each collection of results from
-        a writer should be either a list of dask containers to be computed
-        (ex. Array or Delayed) or a 2-element tuple where the first element
-        is a list of dask Array objects and the second element is a list of
-        target file-like objects supporting ``__setitem__`` syntax. In the
-        case of the 2-element tuple, these lists will be passed to
-        :func:`dask.array.core.store` to write the Arrays to the targets.
+            ``scn.save_datasets(..., compute=False)``. The iterable passed
+            should always **contain** the results of the writer/save_datasets
+            call, not be the results themselves. Each collection of results from
+            a writer should be either a list of dask containers to be computed
+            (ex. Array or Delayed) or a 2-element tuple where the first element
+            is a list of dask Array objects and the second element is a list of
+            target file-like objects supporting ``__setitem__`` syntax. In the
+            case of the 2-element tuple, these lists will be passed to
+            :func:`dask.array.store` to write the Arrays to the targets.
 
     Returns:
         A list of the computed results. These are typically string or Path

--- a/satpy/writers/core/compute.py
+++ b/satpy/writers/core/compute.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import os
 import warnings
-from collections.abc import Iterable, Sized
+from collections.abc import Iterable
 from typing import Any
 
 import dask
@@ -53,8 +53,6 @@ def split_results(
     delayeds_or_arrays: list[da.Array | Delayed] = []
 
     for result in results:
-        if isinstance(result, Sized) and len(result) == 0:
-            continue
         if isinstance(result, tuple) and len(result) == 2 and isinstance(result[0], list):
             sources.extend(result[0])
             targets.extend(result[1])

--- a/satpy/writers/core/compute.py
+++ b/satpy/writers/core/compute.py
@@ -16,38 +16,52 @@
 """Utilities for writers."""
 from __future__ import annotations
 
+import os
+from collections.abc import Iterable
+from typing import Any
+
 import dask
+import numpy as np
 from dask import array as da
+from dask.delayed import Delayed
 
 
-def split_results(results):
+def split_results(
+        results: Iterable[list[da.Array | Delayed] | tuple[list[da.Array], list[Any]]],
+) -> tuple[list[da.Array], list[Any], list[da.Array | Delayed]]:
     """Split results.
 
-    Get sources, targets and delayed objects to separate lists from a list of
-    results collected from (multiple) writer(s).
+    Get sources, targets, and objects to be computed into separate lists from a list of
+    results collected from one or more writers. This function will treat dask
+    Arrays and Delayed objects with no targets as dask collections to be
+    computed. Otherwise dask Arrays can be supplied with an associated target
+    array-like file object and will be passed to :func:`dask.array.core.store`.
+
+    We assume that the provided input is a list containing any combination of:
+
+    1. List of dask Arrays (to be computed, not stored).
+    2. List of Delayed objects.
+    3. A two-element tuple where the first element is a collection of dask
+       Arrays and the second is a collection of array-like file objects of
+       the same size.
+    4. A list made up of the above.
+
     """
-    from dask.delayed import Delayed
-
-    def flatten(results):
-        out = []
-        if isinstance(results, (list, tuple)):
-            for itm in results:
-                out.extend(flatten(itm))
-            return out
-        return [results]
-
     sources = []
     targets = []
-    delayeds = []
+    delayeds_or_arrays: list[da.Array | Delayed] = []
 
-    for res in flatten(results):
-        if isinstance(res, da.Array):
-            sources.append(res)
-        elif isinstance(res, Delayed):
-            delayeds.append(res)
+    for result in results:
+        if not result:
+            continue
+        if isinstance(result, tuple) and len(result) == 2:
+            sources.extend(result[0])
+            targets.extend(result[1])
+        elif isinstance(result, list):
+            delayeds_or_arrays.extend(result)
         else:
-            targets.append(res)
-    return sources, targets, delayeds
+            raise ValueError(f"Unexpected result from Satpy writer: {result!r}")
+    return sources, targets, delayeds_or_arrays
 
 
 def group_results_by_output_file(sources, targets):
@@ -113,35 +127,52 @@ def group_results_by_output_file(sources, targets):
     return list(ofs.values())
 
 
-def compute_writer_results(results):
+def compute_writer_results(
+        results: Iterable[list[da.Array | Delayed] | tuple[list[da.Array], list[Any]]],
+) -> list[np.ndarray | str | os.PathLike | None]:
     """Compute all the given dask graphs `results` so that the files are saved.
 
     Args:
-        results (Iterable): Iterable of dask graphs resulting from calls to
-                            `scn.save_datasets(..., compute=False)`
-    """
-    if not results:
-        return
+        results: Iterable of dask collections resulting from calls to
+        ``scn.save_datasets(..., compute=False)``. The iterable passed
+        should always **contain** the results of the writer/save_datasets
+        call, not be the results themselves. Each collection of results from
+        a writer should be either a list of dask containers to be computed
+        (ex. Array or Delayed) or a 2-element tuple where the first element
+        is a list of dask Array objects and the second element is a list of
+        target file-like objects supporting ``__setitem__`` syntax. In the
+        case of the 2-element tuple, these lists will be passed to
+        :func:`dask.array.core.store` to write the Arrays to the targets.
 
-    sources, targets, delayeds = split_results(results)
+    Returns:
+        A list of the computed results. These are typically string or Path
+        filenames that were created or None if the ``store`` function
+        (see above) was called. If the dask collection to be computed
+        is an array then the computed array will be in the returned list.
+
+    """
+    computed_results: list[np.ndarray | str | os.PathLike | None] = []
+    if not results:
+        return computed_results
+
+    sources, targets, delayeds_or_arrays = split_results(results)
 
     # one or more writers have targets that we need to close in the future
     if targets:
-        delayeds.append(da.store(sources, targets, compute=False))
-    elif sources:
-        # array-like only, no targets (ex. reduce to a single map_blocks/blockwise func call)
-        da.compute(sources)
+        delayeds_or_arrays.append(da.store(sources, targets, compute=False))
 
-    if delayeds:
+    if delayeds_or_arrays:
         # replace Delayed's graph optimization function with the Array function
         # since a Delayed object here is only from the writer but the rest of
         # the tasks are dask array operations we want to fully optimize all
         # array operations. At the time of writing Array optimizations seem to
         # include the optimizations done for Delayed objects alone.
         with dask.config.set(delayed_optimization=dask.config.get("array_optimize", da.optimize)):
-            da.compute(delayeds)
+            computed_results.extend(da.compute(delayeds_or_arrays))
 
     if targets:
         for target in targets:
             if hasattr(target, "close"):
                 target.close()
+
+    return computed_results

--- a/satpy/writers/core/image.py
+++ b/satpy/writers/core/image.py
@@ -22,6 +22,12 @@ from satpy.enhancements.enhancer import get_enhanced_image
 from satpy.writers.core.base import Writer
 
 if typing.TYPE_CHECKING:
+    from os import PathLike
+    from typing import Any
+
+    import dask.array as da
+    import xarray as xr
+    from dask.delayed import Delayed
     from trollimage.xrimage import XRImage
 
 
@@ -92,8 +98,17 @@ class ImageWriter(Writer):
                 init_kwargs[kw] = kwargs.pop(kw)
         return init_kwargs, kwargs
 
-    def save_dataset(self, dataset, filename=None, fill_value=None,
-                     overlay=None, decorate=None, compute=True, units=None, **kwargs):
+    def save_dataset(
+        self,
+        dataset: xr.DataArray,
+        filename: str | None = None,
+        fill_value: float | int | None = None,
+        compute: bool = True,
+        units: str | None = None,
+        overlay: dict | None = None,
+        decorate: dict | None = None,
+        **kwargs,
+    ) -> list[da.Array | Delayed] | tuple[list[da.Array], list[Any]] | list[str | PathLike | None]:
         """Save the ``dataset`` to a given ``filename``.
 
         This method creates an enhanced image using :func:`~satpy.enhancements.enhancer.get_enhanced_image`.
@@ -114,7 +129,7 @@ class ImageWriter(Writer):
             filename: str | None = None,
             compute: bool = True,
             **kwargs
-    ):
+    ) -> list[da.Array | Delayed] | tuple[list[da.Array], list[Any]] | list[str | PathLike | None]:
         """Save Image object to a given ``filename``.
 
         Args:

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -294,14 +294,7 @@ class GeoTIFFWriter(ImageWriter):
                        overviews_minsize=overviews_minsize,
                        tiled=tiled,
                        **gdal_options)
-        # in old trollimage <1.27.0: result is either None or (sources_list, targets_list) or (source, target)
-        # in new trollimage: result is either str or Path or (sources_list, targets_list)
-        if isinstance(res, tuple):
-            if isinstance(res[0], da.Array):
-                # convert old trollimage single (source, target) to ([source], [target])
-                res = ([res[0]], [res[1]])
-            return res
-        return [res]
+        return _trollimage_res_to_satpy_res(res)
 
     def _get_gdal_options(self, kwargs):
         # Update global GDAL options with these specific ones
@@ -310,3 +303,14 @@ class GeoTIFFWriter(ImageWriter):
             if k in self.GDAL_OPTIONS:
                 gdal_options[k] = kwargs[k]
         return gdal_options
+
+
+def _trollimage_res_to_satpy_res(res):
+    # in old trollimage <1.27.0: result is either None or (sources_list, targets_list) or (source, target)
+    # in new trollimage: result is either str or Path or (sources_list, targets_list)
+    if isinstance(res, tuple):
+        if isinstance(res[0], da.Array):
+            # convert old trollimage single (source, target) to ([source], [target])
+            res = ([res[0]], [res[1]])
+        return res
+    return [res]

--- a/satpy/writers/geotiff.py
+++ b/satpy/writers/geotiff.py
@@ -313,4 +313,8 @@ def _trollimage_res_to_satpy_res(res):
             # convert old trollimage single (source, target) to ([source], [target])
             res = ([res[0]], [res[1]])
         return res
+    if isinstance(res, list) and len(res) == 2 and isinstance(res[0], tuple):
+        # old trollimage with dask-based tags specified (see ninjogeotiff writer)
+        # returns [(tuple of sources), (tuple of targets)], this swaps those types:
+        return list(res[0]), list(res[1])
     return [res]

--- a/satpy/writers/ninjotiff.py
+++ b/satpy/writers/ninjotiff.py
@@ -175,7 +175,7 @@ class NinjoTIFFWriter(ImageWriter):
                     )
         if img.mode.startswith("P"):
             img.data = img.data.astype(np.uint8)
-        return nt.save(img, filename, data_is_scaled_01=True, compute=compute, **kwargs)
+        return [nt.save(img, filename, data_is_scaled_01=True, compute=compute, **kwargs)]
 
     def save_dataset(
         self, dataset, filename=None, fill_value=None, compute=True,

--- a/satpy/writers/simple_image.py
+++ b/satpy/writers/simple_image.py
@@ -16,10 +16,20 @@
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Generic PIL/Pillow image format writer."""
+from __future__ import annotations
 
 import logging
+import typing
 
 from satpy.writers.core.image import ImageWriter
+
+if typing.TYPE_CHECKING:
+    from os import PathLike
+    from typing import Any
+
+    import dask.array as da
+    from dask.delayed import Delayed
+    from trollimage.xrimage import XRImage
 
 LOG = logging.getLogger(__name__)
 
@@ -34,19 +44,25 @@ class PillowWriter(ImageWriter):
             default_config_filename="writers/simple_image.yaml",
             **kwargs)
 
-    def save_image(self, img, filename=None, compute=True, **kwargs):
+    def save_image(
+        self,
+        img: XRImage,
+        filename: str | None = None,
+        compute: bool = True,
+        **kwargs,
+    ) -> list[da.Array | Delayed] | tuple[list[da.Array], list[Any]] | list[str | PathLike | None]:
         """Save Image object to a given ``filename``.
 
         Args:
-            img (trollimage.xrimage.XRImage): Image object to save to disk.
-            filename (str): Optionally specify the filename to save this
-                            dataset to. It may include string formatting
-                            patterns that will be filled in by dataset
-                            attributes.
-            compute (bool): If `True` (default), compute and save the dataset.
-                            If `False` return either a `dask.delayed.Delayed`
-                            object or tuple of (source, target). See the
-                            return values below for more information.
+            img: Image object to save to disk.
+            filename: Optionally specify the filename to save this
+                dataset to. It may include string formatting
+                patterns that will be filled in by dataset
+                attributes.
+            compute: If `True` (default), compute and save the dataset.
+                If `False` return either a `dask.delayed.Delayed`
+                object or tuple of (source, target). See the
+                return values below for more information.
             **kwargs: Keyword arguments to pass to the images `save` method.
 
         Returns:
@@ -64,4 +80,7 @@ class PillowWriter(ImageWriter):
         filename = filename or self.get_filename(**img.data.attrs)
 
         LOG.debug("Saving to image: %s", filename)
-        return img.save(filename, compute=compute, **kwargs)
+        res = img.save(filename, compute=compute, **kwargs)
+        # old trollimage <1.27.0: res is None or Delayed
+        # new trollimage: res is str | Path or dask Array
+        return [res]


### PR DESCRIPTION
## How do I migrate my code?

The short answer for what to do:

If you were calling:

```python
some_result = scn.save_datasets(...)
compute_writer_results(some_result)
```

do:

```python
compute_writer_results([some_result])
```

If you have a custom writer, you must return one of:

1. `return list_of_sources, list_of_targets`
2. `return list_of_delayed_results`
3. `return list_of_dask_arrays_to_compute`

If you have problems with this please comment in this PR or file a new issue with details on your situation.

## Overview

This PR modifies the Satpy builtin writers and utility functions for handling writer results. Recent changes in trollimage (see https://github.com/pytroll/trollimage/pull/203) and Satpy's AWIPS tiled (`awips_tiled`) writer, where a series of dask arrays are returned, have made the `compute_writer_results` and `split_results` functions in Satpy break in cases where multiple writers are involved (see below for details). This PR attempts to fix that in a backwards compatible way or at least as close as possible (for now I've labeled this PR as backwards-incompatible).

Note that the changes in the above mentioned writer cases are due to changes in dask where passing dask Arrays to delayed functions no longer performs well and can result in dask tasks being needlessly recomputed.

I'm asking for review from a lot of people (@gerritholl @ameraner @strandgren especially) because there is a chance that people have custom writer's that I'm not aware of and may need updates in the long run (Satpy 1.0+).

## Broken Case

It is possible in Satpy to pass `compute=False` to `scn.save_datasets`, combine all the results from multiple calls, then pass them to `compute_writer_results`. This computes all the writes at the same time allowing dask to cache and reuse completed tasks. This `compute_writer_results` function works by flattening all lists provided by writers and splitting them into sources (dask Arrays to be written to disk), targets (array-like file objects supporting `__setitem__`), and delayeds (Delayed function results that write to disk). In the case of source and targets, these are passed to dask's `store` function to compute and write "source" arrays to the "target" object (to disk).

In a recent update I made it so if the writer only returns dask Arrays and no targets then they are computed directly and not with the `store` function. However, if a writer that returns results in this way is combined with a writer who returns sources + targets, then there is no way for current Satpy to tell if a dask Array is a "source" or supposed to be computed "by itself".

## My solution

To solve the above problem, I went about rewriting the `compute_writer_results` and it's `split_results` function to be a bit "smarter". A simple flattening of the results wouldn't work anymore. I quickly realized this wasn't really possible with the way Satpy writers are written right now and revealed how inconsistent the return types of Satpy writers is. Some would return a `(single_source, single_target)` tuple, or `([list of sources], [list of targets])`, or a single Delayed object, or a list of Delayed objects, or a list of Arrays, or a single Array (in the case of my new trollimage PR). So I limited the expected return types of individual writers in the `compute=False` case to:

1. A list of dask Arrays
2. A list of delayed function results
4. A two-element tuple of a list of sources (dask Arrays) and a list of targets (anything).

And I updated the builtin writers and associated tests where needed. The code is *much* simpler to understand.

## The Compute Case

In the case where the user doesn't specify `compute=False` the default is `compute=True`. In these cases the type annotations I added expected to get a list of one of these types:

* numpy arrays
* strings
* Path-like objects
* None

This is an effort towards my "behind the scenes" (no github issue) goal of allowing writers to return what filenames they've created. I mention it a couple times in my AWIPS tiled PR [here](https://github.com/pytroll/satpy/pull/3187).

Edit: The numpy arrays being returned is because the new "list of dask arrays" return case means there have to be arrays, but in the cases I've implemented this is a numpy array of 1 element and that element is a filename string.

## Remaining TODO

- [ ] Replace `ValueError` case in `split_results` with backwards-compatible "flatten" solution
- [ ] Ensure backwards compatibility with old trollimage and my new trollimage PR. Old Satpy and new trollimage will likely not work together.
- [ ] Start migration documentation?

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
