### PR TITLE
Update references to geoviews Image type

### DIFF
--- a/satpy/_scene_converters.py
+++ b/satpy/_scene_converters.py
@@ -56,7 +56,7 @@ def to_geoviews(
             scn: Satpy Scene.
             gvtype:
                 One of gv.Image, gv.LineContours, gv.FilledContours, gv.Points
-                Default to ``geoviews.Image``.
+                Default to :class:`geoviews.Image <geoviews.element.geo.Image>`.
                 See Geoviews documentation for details.
             datasets: Limit included products to these datasets
             vdims:

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1049,7 +1049,7 @@ class Scene:
             scn: Satpy Scene.
             gvtype:
                 One of gv.Image, gv.LineContours, gv.FilledContours, gv.Points
-                Default to ``geoviews.Image``.
+                Default to :class:`geoviews.Image <geoviews.element.geo.Image>`.
                 See Geoviews documentation for details.
             datasets: Limit included products to these datasets
             vdims:


### PR DESCRIPTION
Geoviews now includes API documentation that we can reference with intersphinx. I'm not confident enough to replace the type annotation to be a specific geoviews type versus `Any`.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
