### PR TITLE
Deprecate VIIRS EDR Flood (viirs_edr_flood) HDF4 reader

### DIFF
--- a/satpy/etc/readers/viirs_edr_flood.yaml
+++ b/satpy/etc/readers/viirs_edr_flood.yaml
@@ -3,7 +3,7 @@ reader:
     short_name: VIIRS flood
     long_name: VIIRS EDR Flood data in HDF4 format
     description: VIIRS flood HDF4 reader
-    status: Beta
+    status: Defunct
     supports_fsspec: false
     reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
     sensors: [viirs]


### PR DESCRIPTION
The VIIRS Flood Algorithm is now NetCDF4 only. The old HDF4 files are no longer supported or created by any of the algorithm software. This PR marks the `viirs_edr_flood` reader as "Defunct".

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
