### PR TITLE
Static geo color stretching

### DIFF
--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -1036,8 +1036,8 @@ enhancements:
         method: !!python/name:satpy.enhancements.contrast.stretch
         kwargs:
           stretch: crude
-          min_stretch: [300, 0]
-          max_stretch: [215, 1]
+          min_stretch: [310, 0]
+          max_stretch: [190, 1]
 
   geo_color_low_clouds:
     standard_name: geo_color_low_clouds


### PR DESCRIPTION
This PR makes the GeoColor use static stretching for `geo_color_high_clouds` sub-composite and remove the dynamic stretching of `geo_color_low_clouds` sub-composite that already is in the range `[0, 1]`.

There is now real difference in processing time, but the memory usage is lower.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
