### PR TITLE
Switch MultiScene blend functions to a public satpy.multiscene.blend_funcs module

### DIFF
--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -113,7 +113,7 @@ when the satellite zenith angle is small.
 
     >>> from satpy import Scene, MultiScene,  DataQuery
     >>> from functools import partial
-    >>> from satpy.multiscene import stack
+    >>> from satpy.multiscene.blend_funcs import stack
     >>> from satpy.resample import get_area_def
     >>> areaid = get_area_def("myarea")
     >>> geo_scene = Scene(filenames=glob('/data/to/nwcsaf/geo/files/*nc'), reader='nwcsaf-geo')
@@ -182,7 +182,7 @@ together with the :meth:`~satpy.scene.Scene.to_geoviews` method, creation of
 interactive timeseries Bokeh plots is possible.
 
     >>> from satpy import Scene, MultiScene
-    >>> from satpy.multiscene import timeseries
+    >>> from satpy.multiscene.blend_funcs import timeseries
     >>> from glob import glob
     >>> from pyresample.geometry import AreaDefinition
     >>> my_area = AreaDefinition(...)

--- a/satpy/multiscene/__init__.py
+++ b/satpy/multiscene/__init__.py
@@ -1,4 +1,23 @@
 """Functions and classes related to MultiScene functionality."""
+from __future__ import annotations
 
-from ._blend_funcs import stack, temporal_rgb, timeseries  # noqa
+from typing import Any
+
+from satpy.utils import _import_and_warn_new_location
+
 from ._multiscene import MultiScene  # noqa
+
+IMPORT_PATHS = {
+    "stack": "satpy.multiscene.blend_funcs",
+    "temporal_rgb": "satpy.multiscene.blend_funcs",
+    "timeseries": "satpy.multiscene.blend_funcs",
+}
+
+
+def __getattr__(name: str) -> Any:
+    new_module = IMPORT_PATHS.get(name)
+
+    if new_module is None:
+        raise AttributeError(f"module {__name__} has no attribute '{name}'")
+
+    return _import_and_warn_new_location(new_module, name)

--- a/satpy/multiscene/_multiscene.py
+++ b/satpy/multiscene/_multiscene.py
@@ -350,7 +350,7 @@ class MultiScene(object):
         """
         if blend_function is None:
             # delay importing blend funcs until now in case they aren't used
-            from ._blend_funcs import stack
+            from .blend_funcs import stack
             blend_function = stack
 
         new_scn = Scene()

--- a/satpy/multiscene/blend_funcs.py
+++ b/satpy/multiscene/blend_funcs.py
@@ -1,3 +1,4 @@
+"""Various functions to use with the :meth:`MultiScene.blend <satpy.multiscene._multiscene.MultiScene.blend>` method."""
 from __future__ import annotations
 
 from typing import Callable, Iterable, Mapping, Optional, Sequence

--- a/satpy/tests/multiscene_tests/test_blend.py
+++ b/satpy/tests/multiscene_tests/test_blend.py
@@ -28,7 +28,7 @@ import xarray as xr
 from pyresample.geometry import AreaDefinition
 
 from satpy import DataQuery, Scene
-from satpy.multiscene import stack, timeseries
+from satpy.multiscene.blend_funcs import stack, timeseries
 from satpy.tests.multiscene_tests.test_utils import (
     DEFAULT_SHAPE,
     _create_test_area,
@@ -412,7 +412,7 @@ class TestTemporalRGB:
 
     def test_nominal(self, nominal_data, expected_result):
         """Test that nominal usage with 3 datasets works."""
-        from satpy.multiscene import temporal_rgb
+        from satpy.multiscene.blend_funcs import temporal_rgb
 
         res = temporal_rgb(nominal_data)
 
@@ -420,10 +420,19 @@ class TestTemporalRGB:
 
     def test_extra_datasets(self, nominal_data, expected_result):
         """Test that only the first three arrays affect the usage."""
-        from satpy.multiscene import temporal_rgb
+        from satpy.multiscene.blend_funcs import temporal_rgb
 
         da4 = xr.DataArray([0, 0, 1], attrs={"start_time": dt.datetime(2023, 5, 22, 12, 0, 0)})
 
         res = temporal_rgb(nominal_data + [da4,])
 
         self._assert_results(res, nominal_data[-1].attrs["start_time"], expected_result)
+
+
+@pytest.mark.parametrize("func", ["stack", "temporal_rgb", "timeseries"])
+def test_blend_funcs_warns(func):
+    """Test that there's a warning when importing from ABI base from the old location."""
+    from satpy import multiscene
+
+    with pytest.warns(UserWarning, match=".*has been moved.*"):
+        getattr(multiscene, func)


### PR DESCRIPTION
In an effort towards removing a lot of "alias" imports (see #3123), this PR makes the MultiScene blend funcs module public and deprecates their "alias" imports in `satpy/multiscene/__init__.py`. This PR retains the `satpy.multiscene.MultiScene` alias import from `satpy/multiscene/_multiscene.py` as I couldn't think of a better one and @pnuu had mentioned that it seemed reasonable on slack (if I understood his statement correctly).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
