### PR TITLE
Add missing cloud_top_height dataset in reader ahi_l2_nc

### DIFF
--- a/satpy/etc/readers/ahi_l2_nc.yaml
+++ b/satpy/etc/readers/ahi_l2_nc.yaml
@@ -93,6 +93,11 @@ datasets:
       file_key: CldTopEmss
       file_type: [ ahi_l2_height ]
 
+  cloud_top_height:
+    name: cloud_top_height
+    file_key: CldTopHght
+    file_type: [ ahi_l2_height ]
+
   cloud_top_pressure:
       name: cloud_top_pressure
       file_key: CldTopPres


### PR DESCRIPTION
fixes #3232

There was only a missing entry for the cloud top height for AHI L2 "height" files.

 - [ ] Closes #3232 
 - [ ] Fully documented ?

