### PR TITLE
Remove unused default_channels from readers

### DIFF
--- a/satpy/etc/readers/abi_l1b.yaml
+++ b/satpy/etc/readers/abi_l1b.yaml
@@ -15,7 +15,6 @@ reader:
   status: Nominal
   supports_fsspec: true
   sensors: [abi]
-  default_channels:
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
   # file pattern keys to sort files by with 'satpy.utils.group_files'
   group_keys: ['start_time', 'platform_shortname', 'scene_abbr']

--- a/satpy/etc/readers/abi_l1b_scmi.yaml
+++ b/satpy/etc/readers/abi_l1b_scmi.yaml
@@ -6,7 +6,6 @@ reader:
   status: Beta
   supports_fsspec: false
   sensors: []
-  default_channels:
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 # Typical filenames from Unidata THREDDS server:

--- a/satpy/etc/readers/agri_fy4a_l1.yaml
+++ b/satpy/etc/readers/agri_fy4a_l1.yaml
@@ -10,7 +10,6 @@ reader:
   status: Beta
   supports_fsspec: false
   sensors: [agri]
-  default_channels:
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/agri_fy4b_l1.yaml
+++ b/satpy/etc/readers/agri_fy4b_l1.yaml
@@ -10,7 +10,6 @@ reader:
   status: Nominal
   supports_fsspec: true
   sensors: [agri]
-  default_channels:
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/ami_l1b.yaml
+++ b/satpy/etc/readers/ami_l1b.yaml
@@ -9,7 +9,6 @@ reader:
   sensors: [ami]
   status: Beta
   supports_fsspec: true
-  default_channels:
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
   # file pattern keys to sort files by with 'satpy.utils.group_files'
   group_keys: ['start_time', 'platform_shortname', 'sensor', 'sector_info']

--- a/satpy/etc/readers/amsr2_l1b.yaml
+++ b/satpy/etc/readers/amsr2_l1b.yaml
@@ -8,7 +8,6 @@ reader:
   # could this be a python hook ?
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
   sensors: [amsr2]
-  default_channels: []
 
 datasets:
   btemp_10.7v:

--- a/satpy/etc/readers/amsub_l1c_aapp.yaml
+++ b/satpy/etc/readers/amsub_l1c_aapp.yaml
@@ -7,7 +7,6 @@ reader:
   supports_fsspec: false
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
   sensors: [amsub,]
-  default_channels: [16, 17, 18, 19, 20]
 
   data_identification_keys:
     name:

--- a/satpy/etc/readers/avhrr_l0_hrpt.yaml
+++ b/satpy/etc/readers/avhrr_l0_hrpt.yaml
@@ -7,7 +7,6 @@ reader:
   supports_fsspec: false
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
   sensors: [avhrr-3, avhrr-2]
-  default_channels: [1, 2, 3a, 3b, 4, 5]
 
 datasets:
   "1":

--- a/satpy/etc/readers/avhrr_l1b_aapp.yaml
+++ b/satpy/etc/readers/avhrr_l1b_aapp.yaml
@@ -7,7 +7,6 @@ reader:
     supports_fsspec: false
     reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
     sensors: [avhrr-3,]
-    default_channels: [1, 2, 3a, 3b, 4, 5]
 
 datasets:
     '1':

--- a/satpy/etc/readers/avhrr_l1b_eps.yaml
+++ b/satpy/etc/readers/avhrr_l1b_eps.yaml
@@ -7,7 +7,6 @@ reader:
     supports_fsspec: false
     reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
     sensors: [avhrr-3]
-    default_channels: [1, 2, 3a, 3b, 4, 5]
 
 datasets:
     '1':

--- a/satpy/etc/readers/cmsaf-claas2_l2_nc.yaml
+++ b/satpy/etc/readers/cmsaf-claas2_l2_nc.yaml
@@ -12,7 +12,6 @@ reader:
   supports_fsspec: false
   sensors: [seviri]
   doi: doi:10.5676/EUM_SAF_CM/CLAAS/V002.
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 # CMSAF naming convention:

--- a/satpy/etc/readers/electrol_hrit.yaml
+++ b/satpy/etc/readers/electrol_hrit.yaml
@@ -6,7 +6,6 @@ reader:
   status: Nominal
   supports_fsspec: false
   sensors: [msu-gs]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/epic_l1b_h5.yaml
+++ b/satpy/etc/readers/epic_l1b_h5.yaml
@@ -8,7 +8,6 @@ reader:
   status: Beta
   supports_fsspec: false
   sensors: [epic]
-  default_channels: [B317, B325, B340, B388, B443, B551, B680, B688, B764, B780]
   reader: !!python/name:satpy.readers.core.yaml_reader.GEOFlippableFileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/fci_l2_bufr.yaml
+++ b/satpy/etc/readers/fci_l2_bufr.yaml
@@ -6,7 +6,6 @@ reader:
   status: Alpha
   supports_fsspec: false
   sensors: [fci]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.GEOFlippableFileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/generic_image.yaml
+++ b/satpy/etc/readers/generic_image.yaml
@@ -7,7 +7,6 @@ reader:
     supports_fsspec: true
     reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
     sensors: [images]
-    default_channels: [image]
 
 datasets:
   image:

--- a/satpy/etc/readers/ghi_l1.yaml
+++ b/satpy/etc/readers/ghi_l1.yaml
@@ -10,7 +10,6 @@ reader:
   status: Nominal
   supports_fsspec: false
   sensors: [ghi]
-  default_channels:
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/ghrsst_l2.yaml
+++ b/satpy/etc/readers/ghrsst_l2.yaml
@@ -6,7 +6,6 @@ reader:
   status: Beta
   supports_fsspec: false
   sensors: ['slstr', 'avhrr/3', 'viirs']
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/gms5-vissr_l1b.yaml
+++ b/satpy/etc/readers/gms5-vissr_l1b.yaml
@@ -11,7 +11,6 @@ reader:
   status: Alpha
   supports_fsspec: true
   sensors: [gms5-vissr]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/goes-imager_hrit.yaml
+++ b/satpy/etc/readers/goes-imager_hrit.yaml
@@ -6,7 +6,6 @@ reader:
   status: Nominal
   supports_fsspec: false
   sensors: [goes_imager]
-  default_channels: [00_7, 03_9, 06_6, 10_7]
   reader: !!python/name:satpy.readers.core.yaml_reader.GEOSegmentYAMLReader
 
 # eg.

--- a/satpy/etc/readers/goes-imager_nc.yaml
+++ b/satpy/etc/readers/goes-imager_nc.yaml
@@ -12,7 +12,6 @@ reader:
   status: Beta
   supports_fsspec: false
   sensors: [goes_imager]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 

--- a/satpy/etc/readers/gpm_imerg.yaml
+++ b/satpy/etc/readers/gpm_imerg.yaml
@@ -6,7 +6,6 @@ reader:
   status: Nominal
   supports_fsspec: false
   sensors: [multiple]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/insat3d_img_l1b_h5.yaml
+++ b/satpy/etc/readers/insat3d_img_l1b_h5.yaml
@@ -8,7 +8,6 @@ reader:
   status: Beta, navigation still off
   supports_fsspec: false
   sensors: [insat3d_img]
-  default_channels: [VIS, WV, TIR1, TIR2, SWIR, MIR]
   reader: !!python/name:satpy.readers.core.yaml_reader.GEOFlippableFileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/jami_hrit.yaml
+++ b/satpy/etc/readers/jami_hrit.yaml
@@ -14,7 +14,6 @@ reader:
   status: Beta
   supports_fsspec: false
   sensors: [jami]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/meris_nc_sen3.yaml
+++ b/satpy/etc/readers/meris_nc_sen3.yaml
@@ -6,7 +6,6 @@ reader:
   status: Beta
   supports_fsspec: false
   sensors: [meris]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/mhs_l1c_aapp.yaml
+++ b/satpy/etc/readers/mhs_l1c_aapp.yaml
@@ -7,7 +7,6 @@ reader:
   supports_fsspec: false
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
   sensors: [mhs,]
-  default_channels: []
 
   data_identification_keys:
     name:

--- a/satpy/etc/readers/msi_safe.yaml
+++ b/satpy/etc/readers/msi_safe.yaml
@@ -6,7 +6,6 @@ reader:
   status: Nominal
   supports_fsspec: false
   sensors: [sen2_msi]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/msi_safe_l2a.yaml
+++ b/satpy/etc/readers/msi_safe_l2a.yaml
@@ -6,7 +6,6 @@ reader:
   status: Nominal
   supports_fsspec: false
   sensors: [msi]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
   data_identification_keys:
     name:

--- a/satpy/etc/readers/msu_gsa_l1b.yaml
+++ b/satpy/etc/readers/msu_gsa_l1b.yaml
@@ -6,7 +6,6 @@ reader:
   status: Beta
   supports_fsspec: false
   sensors: [msu_gsa]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 

--- a/satpy/etc/readers/mtsat2-imager_hrit.yaml
+++ b/satpy/etc/readers/mtsat2-imager_hrit.yaml
@@ -14,7 +14,6 @@ reader:
   status: Beta
   supports_fsspec: false
   sensors: [mtsat2_imager]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.GEOSegmentYAMLReader
 
 file_types:

--- a/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
+++ b/satpy/etc/readers/mviri_l1b_fiduceo_nc.yaml
@@ -13,7 +13,6 @@ reader:
   status: Beta
   supports_fsspec: false
   sensors: [mviri]
-  default_channels: [VIS, WV, IR]
   reader: !!python/name:satpy.readers.core.yaml_reader.GEOFlippableFileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/mws_l1b_nc.yaml
+++ b/satpy/etc/readers/mws_l1b_nc.yaml
@@ -6,7 +6,6 @@ reader:
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
   sensors: [mws,]
   status: Beta
-  default_channels: []
 
   data_identification_keys:
     name:

--- a/satpy/etc/readers/nwcsaf-geo.yaml
+++ b/satpy/etc/readers/nwcsaf-geo.yaml
@@ -6,7 +6,6 @@ reader:
   status: Alpha
   supports_fsspec: false
   sensors: [seviri, abi, ahi]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/nwcsaf-msg2013-hdf5.yaml
+++ b/satpy/etc/readers/nwcsaf-msg2013-hdf5.yaml
@@ -6,7 +6,6 @@ reader:
   status: Defunct
   supports_fsspec: false
   sensors: [seviri]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/nwcsaf-pps_nc.yaml
+++ b/satpy/etc/readers/nwcsaf-pps_nc.yaml
@@ -6,7 +6,6 @@ reader:
   status: Alpha, only standard swath based ouput supported (remapped netCDF and CPP products not supported yet)
   supports_fsspec: false
   sensors: ['avhrr-3', 'viirs', 'modis']
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/oceancolorcci_l3_nc.yaml
+++ b/satpy/etc/readers/oceancolorcci_l3_nc.yaml
@@ -5,7 +5,6 @@ reader:
   description: NetCDF Reader for ESA Oceancolor CCI data
   status: Nominal
   supports_fsspec: false
-  default_channels: []
   sensors: [merged]
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 

--- a/satpy/etc/readers/olci_l1b.yaml
+++ b/satpy/etc/readers/olci_l1b.yaml
@@ -6,7 +6,6 @@ reader:
   status: Nominal
   supports_fsspec: true
   sensors: [olci]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/olci_l2.yaml
+++ b/satpy/etc/readers/olci_l2.yaml
@@ -6,7 +6,6 @@ reader:
   status: Nominal
   supports_fsspec: true
   sensors: [olci]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/oli_tirs_l1_tif.yaml
+++ b/satpy/etc/readers/oli_tirs_l1_tif.yaml
@@ -6,7 +6,6 @@ reader:
   status: Beta
   supports_fsspec: true
   sensors: oli_tirs
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/osisaf_nc.yaml
+++ b/satpy/etc/readers/osisaf_nc.yaml
@@ -11,7 +11,6 @@ reader:
   status: Beta
   supports_fsspec: true
   sensors: [osisaf]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/pace_oci_l1b_nc.yaml
+++ b/satpy/etc/readers/pace_oci_l1b_nc.yaml
@@ -6,7 +6,6 @@ reader:
   status: Nominal
   supports_fsspec: true
   sensors: [oci]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/safe_sar_l2_ocn.yaml
+++ b/satpy/etc/readers/safe_sar_l2_ocn.yaml
@@ -6,7 +6,6 @@ reader:
   status: Defunct
   supports_fsspec: false
   sensors: [sar-c]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/sar-c_safe.yaml
+++ b/satpy/etc/readers/sar-c_safe.yaml
@@ -6,7 +6,6 @@ reader:
   status: Nominal
   supports_fsspec: false
   sensors: [sar-c]
-  default_channels: []
   reader: !!python/name:satpy.readers.sar_c_safe.SAFESARReader
   data_identification_keys:
     name:

--- a/satpy/etc/readers/satpy_cf_nc.yaml
+++ b/satpy/etc/readers/satpy_cf_nc.yaml
@@ -7,7 +7,6 @@ reader:
     supports_fsspec: false
     reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
     sensors: [many]
-    default_channels: []
 
 #datasets:
 

--- a/satpy/etc/readers/seviri_l1b_hrit.yaml
+++ b/satpy/etc/readers/seviri_l1b_hrit.yaml
@@ -12,7 +12,6 @@ reader:
   status: Nominal
   supports_fsspec: true
   sensors: [seviri]
-  default_channels: [HRV, IR_016, IR_039, IR_087, IR_097, IR_108, IR_120, IR_134, VIS006, VIS008, WV_062, WV_073]
   reader: !!python/name:satpy.readers.core.yaml_reader.GEOSegmentYAMLReader
 
 file_types:

--- a/satpy/etc/readers/seviri_l1b_icare.yaml
+++ b/satpy/etc/readers/seviri_l1b_icare.yaml
@@ -12,7 +12,6 @@ reader:
   status: Defunct
   supports_fsspec: false
   sensors: [seviri]
-  default_channels: [HRV, IR_016, IR_039, IR_087, IR_097, IR_108, IR_120, IR_134, VIS006, VIS008, WV_062, WV_073]
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/seviri_l1b_native.yaml
+++ b/satpy/etc/readers/seviri_l1b_native.yaml
@@ -7,7 +7,6 @@ reader:
   status: Nominal
   supports_fsspec: true
   sensors: [seviri]
-  default_channels: [HRV, IR_016, IR_039, IR_087, IR_097, IR_108, IR_120, IR_134, VIS006, VIS008, WV_062, WV_073]
   reader: !!python/name:satpy.readers.core.yaml_reader.GEOFlippableFileYAMLReader
   # file pattern keys to sort files by with 'satpy.utils.group_files'
   group_keys: ['end_time', 'satid']

--- a/satpy/etc/readers/seviri_l2_bufr.yaml
+++ b/satpy/etc/readers/seviri_l2_bufr.yaml
@@ -6,7 +6,6 @@ reader:
   status: Alpha
   supports_fsspec: false
   sensors: [seviri]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.GEOFlippableFileYAMLReader
 
 file_types:

--- a/satpy/etc/readers/sgli_l1b.yaml
+++ b/satpy/etc/readers/sgli_l1b.yaml
@@ -7,7 +7,6 @@ reader:
   supports_fsspec: false
   reference: https://gportal.jaxa.jp/gpr/assets/mng_upload/GCOM-C/SGLI_Level1_Product_Format_Description_en.pdf
   sensors: [sgli]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
   data_identification_keys:

--- a/satpy/etc/readers/slstr_l1b.yaml
+++ b/satpy/etc/readers/slstr_l1b.yaml
@@ -6,7 +6,6 @@ reader:
   status: Alpha
   supports_fsspec: false
   sensors: [slstr]
-  default_channels: []
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 
   data_identification_keys:

--- a/satpy/tests/test_yaml_reader.py
+++ b/satpy/tests/test_yaml_reader.py
@@ -42,7 +42,6 @@ MHS_YAML_READER_DICT = {
     "reader": {"name": "mhs_l1c_aapp",
                "description": "AAPP l1c Reader for AMSU-B/MHS data",
                "sensors": ["mhs"],
-               "default_channels": [1, 2, 3, 4, 5],
                "data_identification_keys": {"name": {"required": True},
                                             "frequency_double_sideband":
                                                 {"type": FrequencyDoubleSideBand},


### PR DESCRIPTION
Many readers contained a key 'default_channels' that was not used inside or outside satpy.  Remove this.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
