### PR TITLE
Fix incorrect file pattern for ABI L2 GFLS files

### DIFF
--- a/satpy/etc/readers/abi_l2_nc.yaml
+++ b/satpy/etc/readers/abi_l2_nc.yaml
@@ -583,5 +583,5 @@ file_types:
     file_reader: !!python/name:satpy.readers.abi_l2_nc.NC_ABI_L2
     file_patterns:
      # NDE scheme: ABI-L2-GFLSC-M6_v3r1_g16_s202306071931181_e202306071933554_c202306071934440.nc
-     - '{mission_id:3s}-L2-GFLS{scene_abbr:s}-{scan_mode:2s}_v{sw_version:d}r{sw_revision:d}_{platform_shortname:3s}_s{start_time:%Y%j%H%M%S%f}_e{end_time:%Y%j%H%M%S%f}_c{creation_time:%Y%j%H%M%S%f}.nc'
+     - '{mission_id:3s}-L2-GFLS{scene_abbr:s}-{scan_mode:2s}_v{sw_version:d}r{sw_revision:d}_{platform_shortname:3s}_s{start_time:%Y%m%d%H%M%S%f}_e{end_time:%Y%m%d%H%M%S%f}_c{creation_time:%Y%m%d%H%M%S%f}.nc'
     observation_type: "GFLS"


### PR DESCRIPTION
PUG files use YYYYJJJ, but the fog files (GFLS) do not follow PUG format so they are YYYYMMDD. This PR fixes it.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
