### PR TITLE
Fix inconsistent docstring of correction limit in sunz modifiers

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -108,3 +108,4 @@ The following people have made contributions to this project:
 - [Yufei Zhu (yufeizhu600)](https://github.com/yufeizhu600)
 - [Clément (ludwigvonkoopa)](https://github.com/ludwigVonKoopa)
 - [Xuanhan Lai (sgxl)](https://github.com/sgxl)
+- [Nalin Parihar(Nalin7parihar](https://github.com/Nalin7parihar)

--- a/satpy/modifiers/geometry.py
+++ b/satpy/modifiers/geometry.py
@@ -101,8 +101,9 @@ class SunZenithCorrector(SunZenithCorrectorBase):
 
         Args:
             correction_limit (float): Maximum solar zenith angle to apply the
-                correction in degrees. Pixels beyond this limit have a
-                constant correction applied. Default 88.
+                correction in degrees. If ``max_sza`` is ``None``, pixels beyond this limit have a
+                constant correction applied.Otherwise, the correction is gradually reduced to 0 at
+                ``max_sza``. Default 88.
             max_sza (float): Maximum solar zenith angle in degrees that is
                 considered valid and correctable. Default 95.0.
 
@@ -147,8 +148,9 @@ class EffectiveSolarPathLengthCorrector(SunZenithCorrectorBase):
 
         Args:
             correction_limit (float): Maximum solar zenith angle to apply the
-                correction in degrees. Pixels beyond this limit have a
-                constant correction applied. Default 88.
+                correction in degrees. If ``max_sza`` is ``None``, pixels beyond this limit have a
+                constant correction applied.Otherwise, the correction is gradually reduced to 0 at
+                ``max_sza``. Default 88.
             max_sza (float): Maximum solar zenith angle in degrees that is
                 considered valid and correctable. Default 95.0.
 

--- a/satpy/modifiers/geometry.py
+++ b/satpy/modifiers/geometry.py
@@ -102,7 +102,7 @@ class SunZenithCorrector(SunZenithCorrectorBase):
         Args:
             correction_limit (float): Maximum solar zenith angle to apply the
                 correction in degrees. If ``max_sza`` is ``None``, pixels beyond this limit have a
-                constant correction applied.Otherwise, the correction is gradually reduced to 0 at
+                constant correction applied. Otherwise, the correction is gradually reduced to 0 at
                 ``max_sza``. Default 88.
             max_sza (float): Maximum solar zenith angle in degrees that is
                 considered valid and correctable. Default 95.0.
@@ -149,7 +149,7 @@ class EffectiveSolarPathLengthCorrector(SunZenithCorrectorBase):
         Args:
             correction_limit (float): Maximum solar zenith angle to apply the
                 correction in degrees. If ``max_sza`` is ``None``, pixels beyond this limit have a
-                constant correction applied.Otherwise, the correction is gradually reduced to 0 at
+                constant correction applied. Otherwise, the correction is gradually reduced to 0 at
                 ``max_sza``. Default 88.
             max_sza (float): Maximum solar zenith angle in degrees that is
                 considered valid and correctable. Default 95.0.


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
This PR fixes inconsistent documentation for the `correction_limit` argument in the `__init__` docstrings of the `SunZenithCorrector` and `EffectiveSolarPathlengthCorrector` classes.

Previously:
- The **class-level docstrings** correctly explained that beyond `correction_limit` the correction is *gradually reduced to 0 at* `max_sza`, and is *constant only if* `max_sza=None`.
- The **`__init__` docstrings**, however, stated that the correction was always constant beyond `correction_limit`, which contradicted the actual behavior.

This PR updates the `__init__` docstrings to match the class-level explanation, ensuring clarity and avoiding confusion for users (especially those reading docstrings via IDEs or `help()`).

---

- [x] Closes #3033 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
- [ ] Tests added <!-- for all bug fixes or enhancements -->
- [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
- [x] Add your name to `AUTHORS.md` if not there already
