### PR TITLE
Fix 'awips_tiled' writer tests producing warnings on some hosts

### DIFF
--- a/satpy/tests/writer_tests/test_awips_tiled.py
+++ b/satpy/tests/writer_tests/test_awips_tiled.py
@@ -158,6 +158,17 @@ def _get_test_lcc_data(dask_arr, area_def, extra_attrs=None):
     return _update_resampled_coords(ds, ds, area_def)
 
 
+@pytest.fixture(autouse=True)
+def short_prod_location(monkeypatch):
+    """Force the environment variable used for "production_location" to a short string.
+
+    If not set, the writer would use the current hostname, but some CI runners
+    may have a long hostname and trigger warnings that we'd like to avoid.
+
+    """
+    monkeypatch.setenv("ORGANIZATION", "ABC")
+
+
 class TestAWIPSTiledWriter:
     """Test basic functionality of AWIPS Tiled writer."""
 
@@ -466,10 +477,11 @@ class TestAWIPSTiledWriter:
             {"environment_prefix": "BB", "filename": "{environment_prefix}_{name}_GLM_T{tile_number:04d}.nc"},
         ]
     )
-    def test_multivar_numbered_tiles_glm(self, sector, extra_kwargs, tmp_path):
+    def test_multivar_numbered_tiles_glm(self, sector, extra_kwargs, tmp_path, monkeypatch):
         """Test creating a tiles with multiple variables."""
         from satpy.writers.awips_tiled import AWIPSTiledWriter
-        os.environ["ORGANIZATION"] = "1" * 50
+
+        monkeypatch.setenv("ORGANIZATION", "1" * 50)
         w = AWIPSTiledWriter(base_dir=tmp_path, compress=True)
         data = _get_test_data()
         area_def = _get_test_area()


### PR DESCRIPTION
While trying to reduce warnings generated while running tests I noticed that on some CI environments there are sometimes warnings from the AWIPS tiled writer. In the writer code, one of the global attributes produced defaults to the hostname of the current system. On some github runner systems the hostname is long enough to trigger a warning in the writer for this particular attribute being greater than 31 characters. To fix this, this PR forces the override environment variable to a short string in a pytest autouse fixture.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
