### PR TITLE
Bugfix for SLSTR reader to enable support for F1 data in baseline 003

### DIFF
--- a/satpy/etc/readers/slstr_l1b.yaml
+++ b/satpy/etc/readers/slstr_l1b.yaml
@@ -257,7 +257,7 @@ datasets:
     wavelength: [3.55, 3.74, 3.93]
     resolution: 1000
     view: [nadir, oblique]
-    stripe: f
+    stripe: [f, i]
     calibration:
       brightness_temperature:
         standard_name: toa_brightness_temperature

--- a/satpy/readers/slstr_l1b.py
+++ b/satpy/readers/slstr_l1b.py
@@ -36,11 +36,13 @@ logger = logging.getLogger(__name__)
 CHUNK_SIZE = get_legacy_chunk_size()
 
 PLATFORM_NAMES = {"S3A": "Sentinel-3A",
-                  "S3B": "Sentinel-3B"}
+                  "S3B": "Sentinel-3B",
+                  "S3C": "Sentinel-3C",
+                  "S3D": "Sentinel-3D"}
 
 # These are the default channel adjustment factors.
-# Defined in the product notice: S3.PN-SLSTR-L1.08
-# https://sentinel.esa.int/documents/247904/2731673/Sentinel-3A-and-3B-SLSTR-Product-Notice-Level-1B-SL-1-RBT-at-NRT-and-NTC.pdf
+# Defined in the product notice: S3.PN-SLSTR-L1.10
+# https://user.eumetsat.int/s3/eup-strapi-media/S3_PN_SLSTR_L1_10_i1r0_SLSTR_L1_PB_SL_L1_004_05_00_fbf01b8813.pdf
 CHANCALIB_FACTORS = {"S1_nadir": 0.97,
                      "S2_nadir": 0.98,
                      "S3_nadir": 0.98,


### PR DESCRIPTION
As discussed in #3251 there is an issue reading `F1` data from older SLSTR granules. After investigation, this is due to the `geodetic_fn.nc` (as well as various other files) not being present in the older data. This is described in the [product notice](https://user.eumetsat.int/s3/eup-strapi-media/pdf_s3a_pn_slstr_l1_07_1_1_d0eac450ba.pdf). 
Any files with processing baseline `003` or earlier will therefore fail in the SLSTR reader when loading `F1`.

This PR fixes the issue, falling back to the `i` stripe grid if the `f` stripe is not present.

In addition, I add S3C and S3D to the list of platforms in preparation for their launches in the coming years. I also update the link to the product notice.

 - [ ] Closes #3251
 - [ ] Fully documented 
