### PR TITLE
Fix NIRReflectance not matching optional inputs against required inputs

### DIFF
--- a/satpy/modifiers/spectral.py
+++ b/satpy/modifiers/spectral.py
@@ -66,7 +66,9 @@ class NIRReflectance(ModifierBase):
 
         Not supposed to be used for wavelength outside [3, 4] µm.
         """
-        projectables = self.match_data_arrays(projectables)
+        matched_data_arrs = self.match_data_arrays(projectables + optional_datasets)
+        projectables = matched_data_arrs[:len(projectables)]
+        optional_datasets = matched_data_arrs[len(projectables):]
         inputs = self._get_nir_inputs(projectables, optional_datasets)
         return self._get_reflectance_as_dataarray(*inputs)
 

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -254,21 +254,18 @@ class TestNIRReflectance:
                          "area": area,
                          "start_time": self.start_time}
 
-        self.nir_arr = nir_arr = np.array([[273.15, 275.15], [277.15, 279.15]], dtype=np.float32)
+        self.nir_arr = nir_arr = np.array([[283.15, 285.15], [287.15, 289.15]], dtype=np.float32)
         self.nir = xr.DataArray(da.from_array(nir_arr), dims=["y", "x"])
         self.nir.attrs.update(self.metadata)
 
-        ir_arr = np.array([[283.15, 285.15], [287.15, 289.15]], dtype=np.float32)
-        self.ir_ = xr.DataArray(da.from_array(ir_arr), dims=["y", "x"])
-        self.ir_.attrs["area"] = area
+        ir_arr = np.array([[273.15, 275.15], [277.15, 279.15]], dtype=np.float32)
+        self.ir_ = xr.DataArray(da.from_array(ir_arr), dims=["y", "x"], attrs={"area": area})
 
-        self.sunz_arr = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
-        self.da_sunz = da.from_array(self.sunz_arr)
-        self.sunz = xr.DataArray(self.da_sunz, dims=["y", "x"])
-        self.sunz.attrs["standard_name"] = "solar_zenith_angle"
-        self.sunz.attrs["area"] = area
+        self.sunz_arr = np.array([[1.0, 20.0], [40.0, 60.0]], dtype=np.float32)
+        self.sunz = xr.DataArray(da.from_array(self.sunz_arr), dims=["y", "x"],
+                                 attrs={"standard_name": "solar_zenith_angle", "area": area})
 
-        co2_arr = np.array([[300.0, 301.0], [302.0, 303.0]], dtype=np.float32)
+        co2_arr = np.array([[240.0, 241.0], [242.0, 243.0]], dtype=np.float32)
         self.co2 = xr.DataArray(
             da.from_array(co2_arr),
             dims=("y", "x"),
@@ -283,9 +280,9 @@ class TestNIRReflectance:
     @pytest.mark.parametrize(
         ("include_sunz", "include_co2", "exp_res"),
         [
-            (False, False, np.array([[-4.56851, -5.000861], [-5.472561, -5.989477]], dtype=np.float32)),
-            (True, False, np.array([[-4.164202, -4.555971], [-4.985142, -5.456021]], dtype=np.float32)),
-            (False, True, np.array([[-5.350111, -5.811294], [-6.309603, -6.850538]], dtype=np.float32)),
+            (False, False, np.array([[4.3689156, 4.762686], [5.1886106, 5.6510105]], dtype=np.float32)),
+            (True, False, np.array([[3.9977279, 4.6561675], [6.348353, 11.350167]], dtype=np.float32)),
+            (False, True, np.array([[5.170569, 5.6666946], [6.205907, 6.79378]], dtype=np.float32)),
         ]
     )
     def test_basic_call(self, include_sunz, include_co2, exp_res):

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -261,7 +261,7 @@ class TestNIRReflectance:
         ir_arr = np.array([[273.15, 275.15], [277.15, 279.15]], dtype=np.float32)
         self.ir_ = xr.DataArray(da.from_array(ir_arr), dims=["y", "x"], attrs={"area": area})
 
-        self.sunz_arr = np.array([[1.0, 20.0], [40.0, 60.0]], dtype=np.float32)
+        self.sunz_arr = np.array([[1.0, 20.0], [87.0, 89.0]], dtype=np.float32)
         self.sunz = xr.DataArray(da.from_array(self.sunz_arr), dims=["y", "x"],
                                  attrs={"standard_name": "solar_zenith_angle", "area": area})
 
@@ -281,7 +281,7 @@ class TestNIRReflectance:
         ("include_sunz", "include_co2", "exp_res"),
         [
             (False, False, np.array([[4.3689156, 4.762686], [5.1886106, 5.6510105]], dtype=np.float32)),
-            (True, False, np.array([[3.9977279, 4.6561675], [6.348353, 11.350167]], dtype=np.float32)),
+            (True, False, np.array([[3.9977279, 4.6561675], [384.3708, np.nan]], dtype=np.float32)),
             (False, True, np.array([[5.170569, 5.6666946], [6.205907, 6.79378]], dtype=np.float32)),
         ]
     )

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -227,10 +227,10 @@ class TestSunZenithReducer:
             SunZenithReducer(name="sza_reduction_test_invalid", modifiers=tuple(), max_sza=None)
 
 
-class TestNIRReflectance(unittest.TestCase):
+class TestNIRReflectance:
     """Test NIR reflectance compositor."""
 
-    def setUp(self):
+    def setup_method(self):
         """Set up the test case for the NIRReflectance compositor."""
         self.get_lonlats = mock.MagicMock()
         self.lons, self.lats = 1, 2
@@ -325,7 +325,13 @@ class TestNIRReflectance(unittest.TestCase):
         comp = NIRReflectance(name="test")
         info = {"modifiers": None}
         co2_arr = RANDOM_GEN.random((2, 2))
-        co2 = xr.DataArray(da.from_array(co2_arr), dims=["y", "x"])
+        co2 = xr.DataArray(
+            da.from_array(co2_arr),
+            dims=["y", "x"],
+            attrs={
+                "area": self.nir.attrs["area"],
+                "start_time": self.start_time,
+            })
         co2.attrs["wavelength"] = [12.0, 13.0, 14.0]
         co2.attrs["units"] = "K"
         res = comp([self.nir, self.ir_], optional_datasets=[co2], **info)


### PR DESCRIPTION
@tommyjasmin ran into an issue where he was getting a ValueError from some NIRReflectance modifier usage. This was caused by the `optional_prerequisites` not being included in the call to `self.match_data_arrays`. This method is meant to check resolution and array size and make sure that inputs are compatible with each other and if not raise an `IncompatibleAreas` exception so the `Scene` can warn the user that resampling will be needed to generate the composites they want.

~TODO: Rewrite tests to use pytest instead of unittest and remove most (if not all) mocking.~

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
