### PR TITLE
Remove pyspectral downloading from tests and fail if used

### DIFF
--- a/satpy/readers/hrpt.py
+++ b/satpy/readers/hrpt.py
@@ -127,7 +127,7 @@ class HRPTFile(BaseFileHandler):
         self.channels = {i: None for i in AVHRR_CHANNEL_NAMES}
         self.units = {i: "counts" for i in AVHRR_CHANNEL_NAMES}
 
-        self.year = filename_info.get("start_time", dt.datetime.now(dt.timezone.utc)).year
+        self.year = filename_info["start_time"].year
 
     @cached_property
     def times(self):

--- a/satpy/tests/conftest.py
+++ b/satpy/tests/conftest.py
@@ -21,7 +21,6 @@ This module is executed automatically by pytest.
 
 """
 import os
-from unittest import mock
 
 import pytest
 
@@ -60,7 +59,7 @@ def include_test_etc():
 
 @pytest.fixture(autouse=True, scope="session")
 def _forbid_pyspectral_downloads():
-    with mock.patch("pyspectral.utils.requests") as mock_requests:
-        mock_requests.get.side_effect = RuntimeError(
-            "Pyspectral is attempting a download during tests. Mock pyspectral as necessary to avoid this.")
+    from pyspectral.testing import forbid_pyspectral_downloads
+
+    with forbid_pyspectral_downloads():
         yield

--- a/satpy/tests/conftest.py
+++ b/satpy/tests/conftest.py
@@ -21,6 +21,7 @@ This module is executed automatically by pytest.
 
 """
 import os
+from unittest import mock
 
 import pytest
 
@@ -55,3 +56,11 @@ def include_test_etc():
     """Tell Satpy to use the config 'etc' directory from the tests directory."""
     with satpy.config.set(config_path=[TEST_ETC_DIR]):
         yield TEST_ETC_DIR
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _forbid_pyspectral_downloads():
+    with mock.patch("pyspectral.utils.requests") as mock_requests:
+        mock_requests.get.side_effect = RuntimeError(
+            "Pyspectral is attempting a download during tests. Mock pyspectral as necessary to avoid this.")
+        yield

--- a/satpy/tests/writer_tests/test_core/test_base.py
+++ b/satpy/tests/writer_tests/test_core/test_base.py
@@ -68,7 +68,7 @@ class TestBaseWriter:
 
     def test_save_dataset_static_filename(self):
         """Test saving a dataset with a static filename specified."""
-        self.scn.save_datasets(base_dir=self.base_dir, filename="geotiff.tif")
+        self.scn.save_datasets(datasets=["test"], base_dir=self.base_dir, filename="geotiff.tif")
         assert os.path.isfile(os.path.join(self.base_dir, "geotiff.tif"))
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
I noticed while working on other PRs that some of the CI tests were failing with HTTP hiccups trying to download pyspectral LUTs. Turns out this has been happening for years and is a major waste of resources even though it was nice to have the full processing being tested, it isn't "right" in my opinion. This PR:

* Mocks and removes the usage of pyspectral so it never downloads anything. Additionally it uses `autospec` so Satpy's usage will always match upstream pyspectral.
* Adds an autouse fixture for *ALL* of satpy to mock pyspectral's usage of the `requests` library so tests fail if they make pyspectral download anything.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
