### PR TITLE
Fix indentation error in area def list

### DIFF
--- a/doc/source/generate_area_def_list.py
+++ b/doc/source/generate_area_def_list.py
@@ -37,7 +37,7 @@ TEMPLATE = '''
 
 .. raw:: html
 
-    {{ resources }}
+    {{ resources | indent(5) }}
     {{ pyr_icons_svg | indent(5) }}
     <style>
     {{ pyr_css_style | indent(5) }}


### PR DESCRIPTION
Not sure how this ever worked but this seems to fix the warnings/errors in my local environment.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
