### PR TITLE
Add support for COG and check remote support in SAR reader

### DIFF
--- a/satpy/etc/readers/sar-c_safe.yaml
+++ b/satpy/etc/readers/sar-c_safe.yaml
@@ -38,21 +38,27 @@ reader:
       transitive: false
 
 file_types:
-    safe_measurement:
-        file_patterns: ['{fmission_id:3s}_{fsar_mode:2s}_{fproduct_type:3s}{fresolution:1s}_{fprocessing_level:1s}{fproduct_class:1s}{fpolarization:2s}_{fstart_time:%Y%m%dT%H%M%S}_{fend_time:%Y%m%dT%H%M%S}_{forbit_number:6d}_{fmission_data_take_id:6s}_{fproduct_unique_id:4s}.SAFE/measurement/{mission_id:3s}-{swath_id:2s}-{product_type:3s}-{polarization:2s}-{start_time:%Y%m%dt%H%M%S}-{end_time:%Y%m%dt%H%M%S}-{orbit_number:6d}-{mission_data_take_id:6s}-{image_number:3s}.tiff']
-        requires: [safe_calibration, safe_noise, safe_annotation]
-    safe_calibration:
-        file_patterns: ['{fmission_id:3s}_{fsar_mode:2s}_{fproduct_type:3s}{fresolution:1s}_{fprocessing_level:1s}{fproduct_class:1s}{fpolarization:2s}_{fstart_time:%Y%m%dT%H%M%S}_{fend_time:%Y%m%dT%H%M%S}_{forbit_number:6d}_{fmission_data_take_id:6s}_{fproduct_unique_id:4s}.SAFE/annotation/calibration/calibration-{mission_id:3s}-{swath_id:2s}-{product_type:3s}-{polarization:2s}-{start_time:%Y%m%dt%H%M%S}-{end_time:%Y%m%dt%H%M%S}-{orbit_number:6d}-{mission_data_take_id:6s}-{image_number:3s}.xml']
-        requires: [safe_annotation]
-    safe_noise:
-        file_patterns: ['{fmission_id:3s}_{fsar_mode:2s}_{fproduct_type:3s}{fresolution:1s}_{fprocessing_level:1s}{fproduct_class:1s}{fpolarization:2s}_{fstart_time:%Y%m%dT%H%M%S}_{fend_time:%Y%m%dT%H%M%S}_{forbit_number:6d}_{fmission_data_take_id:6s}_{fproduct_unique_id:4s}.SAFE/annotation/calibration/noise-{mission_id:3s}-{swath_id:2s}-{product_type:3s}-{polarization:2s}-{start_time:%Y%m%dt%H%M%S}-{end_time:%Y%m%dt%H%M%S}-{orbit_number:6d}-{mission_data_take_id:6s}-{image_number:3s}.xml']
-        requires: [safe_annotation]
-    safe_annotation:
-        file_patterns: ['{fmission_id:3s}_{fsar_mode:2s}_{fproduct_type:3s}{fresolution:1s}_{fprocessing_level:1s}{fproduct_class:1s}{fpolarization:2s}_{fstart_time:%Y%m%dT%H%M%S}_{fend_time:%Y%m%dT%H%M%S}_{forbit_number:6d}_{fmission_data_take_id:6s}_{fproduct_unique_id:4s}.SAFE/annotation/{mission_id:3s}-{swath_id:2s}-{product_type:3s}-{polarization:2s}-{start_time:%Y%m%dt%H%M%S}-{end_time:%Y%m%dt%H%M%S}-{orbit_number:6d}-{mission_data_take_id:6s}-{image_number:3s}.xml']
-
+  safe_measurement:
+    file_patterns:
+      - "{fmission_id:3s}_{fsar_mode:2s}_{fproduct_type:3s}{fresolution:1s}_{fprocessing_level:1s}{fproduct_class:1s}{fpolarization:2s}_{fstart_time:%Y%m%dT%H%M%S}_{fend_time:%Y%m%dT%H%M%S}_{forbit_number:6d}_{fmission_data_take_id:6s}_{fproduct_unique_id:4s}.SAFE/measurement/{mission_id:3s}-{swath_id:2s}-{product_type:3s}-{polarization:2s}-{start_time:%Y%m%dt%H%M%S}-{end_time:%Y%m%dt%H%M%S}-{orbit_number:6d}-{mission_data_take_id:6s}-{image_number:3s}.tiff"
+      - "{fmission_id:3s}_{fsar_mode:2s}_{fproduct_type:3s}{fresolution:1s}_{fprocessing_level:1s}{fproduct_class:1s}{fpolarization:2s}_{fstart_time:%Y%m%dT%H%M%S}_{fend_time:%Y%m%dT%H%M%S}_{forbit_number:6d}_{fmission_data_take_id:6s}_{fproduct_unique_id:4s}_COG.SAFE/measurement/{mission_id:3s}-{swath_id:2s}-{product_type:3s}-{polarization:2s}-{start_time:%Y%m%dt%H%M%S}-{end_time:%Y%m%dt%H%M%S}-{orbit_number:6d}-{mission_data_take_id:6s}-{image_number:3s}-cog.tiff"
+    requires: [safe_calibration, safe_noise, safe_annotation]
+  safe_calibration:
+    file_patterns:
+      - "{fmission_id:3s}_{fsar_mode:2s}_{fproduct_type:3s}{fresolution:1s}_{fprocessing_level:1s}{fproduct_class:1s}{fpolarization:2s}_{fstart_time:%Y%m%dT%H%M%S}_{fend_time:%Y%m%dT%H%M%S}_{forbit_number:6d}_{fmission_data_take_id:6s}_{fproduct_unique_id:4s}.SAFE/annotation/calibration/calibration-{mission_id:3s}-{swath_id:2s}-{product_type:3s}-{polarization:2s}-{start_time:%Y%m%dt%H%M%S}-{end_time:%Y%m%dt%H%M%S}-{orbit_number:6d}-{mission_data_take_id:6s}-{image_number:3s}.xml"
+      - "{fmission_id:3s}_{fsar_mode:2s}_{fproduct_type:3s}{fresolution:1s}_{fprocessing_level:1s}{fproduct_class:1s}{fpolarization:2s}_{fstart_time:%Y%m%dT%H%M%S}_{fend_time:%Y%m%dT%H%M%S}_{forbit_number:6d}_{fmission_data_take_id:6s}_{fproduct_unique_id:4s}_COG.SAFE/annotation/calibration/calibration-{mission_id:3s}-{swath_id:2s}-{product_type:3s}-{polarization:2s}-{start_time:%Y%m%dt%H%M%S}-{end_time:%Y%m%dt%H%M%S}-{orbit_number:6d}-{mission_data_take_id:6s}-{image_number:3s}-cog.xml"
+    requires: [safe_annotation]
+  safe_noise:
+    file_patterns:
+      - "{fmission_id:3s}_{fsar_mode:2s}_{fproduct_type:3s}{fresolution:1s}_{fprocessing_level:1s}{fproduct_class:1s}{fpolarization:2s}_{fstart_time:%Y%m%dT%H%M%S}_{fend_time:%Y%m%dT%H%M%S}_{forbit_number:6d}_{fmission_data_take_id:6s}_{fproduct_unique_id:4s}.SAFE/annotation/calibration/noise-{mission_id:3s}-{swath_id:2s}-{product_type:3s}-{polarization:2s}-{start_time:%Y%m%dt%H%M%S}-{end_time:%Y%m%dt%H%M%S}-{orbit_number:6d}-{mission_data_take_id:6s}-{image_number:3s}.xml"
+      - "{fmission_id:3s}_{fsar_mode:2s}_{fproduct_type:3s}{fresolution:1s}_{fprocessing_level:1s}{fproduct_class:1s}{fpolarization:2s}_{fstart_time:%Y%m%dT%H%M%S}_{fend_time:%Y%m%dT%H%M%S}_{forbit_number:6d}_{fmission_data_take_id:6s}_{fproduct_unique_id:4s}_COG.SAFE/annotation/calibration/noise-{mission_id:3s}-{swath_id:2s}-{product_type:3s}-{polarization:2s}-{start_time:%Y%m%dt%H%M%S}-{end_time:%Y%m%dt%H%M%S}-{orbit_number:6d}-{mission_data_take_id:6s}-{image_number:3s}-cog.xml"
+    requires: [safe_annotation]
+  safe_annotation:
+    file_patterns:
+      - "{fmission_id:3s}_{fsar_mode:2s}_{fproduct_type:3s}{fresolution:1s}_{fprocessing_level:1s}{fproduct_class:1s}{fpolarization:2s}_{fstart_time:%Y%m%dT%H%M%S}_{fend_time:%Y%m%dT%H%M%S}_{forbit_number:6d}_{fmission_data_take_id:6s}_{fproduct_unique_id:4s}.SAFE/annotation/{mission_id:3s}-{swath_id:2s}-{product_type:3s}-{polarization:2s}-{start_time:%Y%m%dt%H%M%S}-{end_time:%Y%m%dt%H%M%S}-{orbit_number:6d}-{mission_data_take_id:6s}-{image_number:3s}.xml"
+      - "{fmission_id:3s}_{fsar_mode:2s}_{fproduct_type:3s}{fresolution:1s}_{fprocessing_level:1s}{fproduct_class:1s}{fpolarization:2s}_{fstart_time:%Y%m%dT%H%M%S}_{fend_time:%Y%m%dT%H%M%S}_{forbit_number:6d}_{fmission_data_take_id:6s}_{fproduct_unique_id:4s}_COG.SAFE/annotation/{mission_id:3s}-{swath_id:2s}-{product_type:3s}-{polarization:2s}-{start_time:%Y%m%dt%H%M%S}-{end_time:%Y%m%dt%H%M%S}-{orbit_number:6d}-{mission_data_take_id:6s}-{image_number:3s}-cog.xml"
 
 datasets:
-
   latitude:
     name: latitude
     resolution: 80
@@ -76,7 +82,6 @@ datasets:
     standard_name: altitude
     polarization: [hh, hv, vv, vh]
     units: meter
-
 
   measurement:
     name: measurement
@@ -105,11 +110,11 @@ datasets:
     polarization: [hh, hv, vv, vh]
     file_type: safe_noise
     xml_item:
-    - noiseVector
-    - noiseRangeVector
+      - noiseVector
+      - noiseRangeVector
     xml_tag:
-    - noiseLut
-    - noiseRangeLut
+      - noiseLut
+      - noiseRangeLut
 
   sigma:
     name: sigma_squared

--- a/satpy/etc/readers/sar-c_safe.yaml
+++ b/satpy/etc/readers/sar-c_safe.yaml
@@ -4,7 +4,7 @@ reader:
   long_name: Sentinel-1 A and B SAR-C data in SAFE format
   description: SAFE Reader for SAR-C data
   status: Nominal
-  supports_fsspec: false
+  supports_fsspec: true
   sensors: [sar-c]
   reader: !!python/name:satpy.readers.sar_c_safe.SAFESARReader
   data_identification_keys:

--- a/satpy/readers/sar_c_safe.py
+++ b/satpy/readers/sar_c_safe.py
@@ -41,7 +41,6 @@ import warnings
 from collections import defaultdict
 from datetime import timezone as tz
 from functools import cached_property
-from pathlib import Path
 from threading import Lock
 
 import defusedxml.ElementTree as ET
@@ -52,6 +51,7 @@ import xarray as xr
 from dask import array as da
 from geotiepoints.geointerpolator import lonlat2xyz, xyz2lonlat
 from geotiepoints.interpolator import MultipleSplineInterpolator
+from upath import UPath
 from xarray import DataArray
 
 from satpy.dataset.data_dict import DatasetDict
@@ -112,7 +112,7 @@ class SAFEXML(BaseFileHandler):
         self._end_time = filename_info["end_time"].replace(tzinfo=tz.utc)
         self._polarization = filename_info["polarization"]
         if isinstance(self.filename, str):
-            self.filename = Path(self.filename)
+            self.filename = UPath(self.filename)
         with self.filename.open() as fd:
             self.root = ET.parse(fd)
         self._image_shape = image_shape

--- a/satpy/tests/reader_tests/test_sar_c_safe.py
+++ b/satpy/tests/reader_tests/test_sar_c_safe.py
@@ -222,7 +222,7 @@ def measurement_filehandler(request, noise_filehandler, calibration_filehandler)
                    "polarization": "vv"}
   filetype_info = None
   from satpy.readers.sar_c_safe import SAFEGRD
-  filehandler =  SAFEGRD(request.getfixturevalue(request.param),
+  filehandler = SAFEGRD(request.getfixturevalue(request.param),
                          filename_info,
                          filetype_info,
                          calibration_filehandler,

--- a/satpy/tests/reader_tests/test_sar_c_safe.py
+++ b/satpy/tests/reader_tests/test_sar_c_safe.py
@@ -77,7 +77,7 @@ def zipped_annotation_file(annotation_file, data_directory):
   """Create a zipped annotation file."""
   zip_file = data_directory / "annotation.zip"
   with ZipFile(zip_file, mode="w") as archive:
-    basename = os.path.join(*os.path.normpath(annotation_file).split(os.path.sep)[-3:])
+    basename = "/".join(*os.path.normpath(annotation_file).split(os.path.sep)[-3:])
     archive.write(annotation_file, basename)
   fname = f"zip://{basename}::file://{zip_file.as_posix()}"
   return fname
@@ -198,7 +198,7 @@ def zipped_measurement_file(measurement_file, data_directory):
   """Create a zipped measurement file."""
   zip_file = data_directory / "measurement.zip"
   with ZipFile(zip_file, mode="w") as archive:
-    basename = os.path.join(*os.path.normpath(measurement_file).split(os.path.sep)[-3:])
+    basename = "/".join(*os.path.normpath(measurement_file).split(os.path.sep)[-3:])
     archive.write(measurement_file, basename)
   return f"zip://{basename}::file://{zip_file.as_posix()}"
 

--- a/satpy/tests/reader_tests/test_sar_c_safe.py
+++ b/satpy/tests/reader_tests/test_sar_c_safe.py
@@ -77,7 +77,7 @@ def zipped_annotation_file(annotation_file, data_directory):
   """Create a zipped annotation file."""
   zip_file = data_directory / "annotation.zip"
   with ZipFile(zip_file, mode="w") as archive:
-    basename = "/".join(*os.path.normpath(annotation_file).split(os.path.sep)[-3:])
+    basename = "/".join(os.path.normpath(annotation_file).split(os.path.sep)[-3:])
     archive.write(annotation_file, basename)
   fname = f"zip://{basename}::file://{zip_file.as_posix()}"
   return fname
@@ -198,7 +198,7 @@ def zipped_measurement_file(measurement_file, data_directory):
   """Create a zipped measurement file."""
   zip_file = data_directory / "measurement.zip"
   with ZipFile(zip_file, mode="w") as archive:
-    basename = "/".join(*os.path.normpath(measurement_file).split(os.path.sep)[-3:])
+    basename = "/".join(os.path.normpath(measurement_file).split(os.path.sep)[-3:])
     archive.write(measurement_file, basename)
   return f"zip://{basename}::file://{zip_file.as_posix()}"
 

--- a/satpy/tests/reader_tests/test_sar_c_safe.py
+++ b/satpy/tests/reader_tests/test_sar_c_safe.py
@@ -77,7 +77,7 @@ def zipped_annotation_file(annotation_file, data_directory):
   """Create a zipped annotation file."""
   zip_file = data_directory / "annotation.zip"
   with ZipFile(zip_file, mode="w") as archive:
-    basename = os.path.join(*os.path.normpath(annotation_file).split(os.path.sep)[-3:])
+    basename = str(annotation_file.relative_to(data_directory))
     archive.write(annotation_file, basename)
   fname = f"zip://{basename}::file://{zip_file.as_posix()}"
   return fname

--- a/satpy/tests/reader_tests/test_sar_c_safe.py
+++ b/satpy/tests/reader_tests/test_sar_c_safe.py
@@ -77,7 +77,7 @@ def zipped_annotation_file(annotation_file, data_directory):
   """Create a zipped annotation file."""
   zip_file = data_directory / "annotation.zip"
   with ZipFile(zip_file, mode="w") as archive:
-    basename = str(annotation_file.relative_to(data_directory))
+    basename = os.path.join(*os.path.normpath(annotation_file).split(os.path.sep)[-3:])
     archive.write(annotation_file, basename)
   fname = f"zip://{basename}::file://{zip_file.as_posix()}"
   return fname
@@ -198,7 +198,7 @@ def zipped_measurement_file(measurement_file, data_directory):
   """Create a zipped measurement file."""
   zip_file = data_directory / "measurement.zip"
   with ZipFile(zip_file, mode="w") as archive:
-    basename = str(measurement_file.relative_to(data_directory))
+    basename = os.path.join(*os.path.normpath(measurement_file).split(os.path.sep)[-3:])
     archive.write(measurement_file, basename)
   return f"zip://{basename}::file://{zip_file.as_posix()}"
 

--- a/satpy/tests/reader_tests/test_sar_c_safe.py
+++ b/satpy/tests/reader_tests/test_sar_c_safe.py
@@ -198,7 +198,7 @@ def zipped_measurement_file(measurement_file, data_directory):
   """Create a zipped measurement file."""
   zip_file = data_directory / "measurement.zip"
   with ZipFile(zip_file, mode="w") as archive:
-    basename = os.path.join(*os.path.normpath(measurement_file).split(os.path.sep)[-3:])
+    basename = str(measurement_file.relative_to(data_directory))
     archive.write(measurement_file, basename)
   return f"zip://{basename}::file://{zip_file.as_posix()}"
 


### PR DESCRIPTION
This PR adds the filename patterns for the COG versions of the GRD datasets (as distributed by Copernicus Dataspace), and adds tests to check support for FSFiles and UPath.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->