### PR TITLE
Skip EUM L2 BUFR tests in windows using pytest.skip

### DIFF
--- a/satpy/tests/reader_tests/test_eum_l2_bufr.py
+++ b/satpy/tests/reader_tests/test_eum_l2_bufr.py
@@ -29,7 +29,7 @@ from pyresample import geometry
 from satpy.tests.utils import make_dataid
 
 if sys.platform.startswith("win"):
-    pytest.skip("'eccodes' not supported on Windows")
+    pytest.skip("'eccodes' not supported on Windows", allow_module_level=True)
 
 AREA_DEF_MSG_IODC = geometry.AreaDefinition(
     "msg_seviri_iodc_48km",


### PR DESCRIPTION
The EUM L2 BUFR tests were using `@unittest.skipIf` in the fake data class `__init__` to skip tests in Windows. This was failing, and this PR changes the skipping to what is suggested by `pytest` in https://docs.pytest.org/en/stable/how-to/skipping.html#skipping-test-functions.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
