### PR TITLE
Move fci_l1c_fdhsi and viirs_l2_cloud_mask_nc to full deprecation

### DIFF
--- a/satpy/readers/core/config.py
+++ b/satpy/readers/core/config.py
@@ -30,7 +30,7 @@ from satpy.readers.core.yaml_reader import load_yaml_configs as load_yaml_reader
 LOG = logging.getLogger(__name__)
 
 # Old Name -> New Name
-PENDING_OLD_READER_NAMES = {}
+PENDING_OLD_READER_NAMES: dict[str, str] = {}
 OLD_READER_NAMES: dict[str, str] = {
     "slstr_l2": "ghrsst_l2",
     "fci_l1c_fdhsi": "fci_l1c_nc",


### PR DESCRIPTION
This PR moves two readers that were pending deprecation since 4 years (FCI https://github.com/pytroll/satpy/issues/1713) and 2 years (VIIRS, https://github.com/pytroll/satpy/commit/65511ecf98a89346ab161c749e135ddebfcd38fe, https://github.com/pytroll/satpy/pull/2531) to full deprecation.

Now, instead of a warning, a ValueError will be raised, still pointing to the new reader name.

 - [x] Closes https://github.com/pytroll/satpy/issues/1713<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
