### PR TITLE
Add `fsspec` support to `msi_safe` reader

### DIFF
--- a/satpy/etc/readers/msi_safe.yaml
+++ b/satpy/etc/readers/msi_safe.yaml
@@ -4,7 +4,7 @@ reader:
   long_name: Sentinel-2 A and B MSI L1C data in SAFE format
   description: SAFE Reader for MSI L1C data (Sentinel-2)
   status: Nominal
-  supports_fsspec: false
+  supports_fsspec: true
   sensors: [sen2_msi]
   reader: !!python/name:satpy.readers.core.yaml_reader.FileYAMLReader
 

--- a/satpy/readers/msi_safe.py
+++ b/satpy/readers/msi_safe.py
@@ -49,6 +49,7 @@ from pyresample import geometry
 
 from satpy._compat import cached_property
 from satpy.readers.core.file_handlers import BaseFileHandler
+from satpy.readers.core.remote import open_file_or_filename
 from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
@@ -94,7 +95,7 @@ class SAFEMSIL1C(BaseFileHandler):
         return proj
 
     def _read_from_file(self, key):
-        proj = xr.open_dataset(self.filename, engine="rasterio", chunks=CHUNK_SIZE)["band_data"]
+        proj = xr.open_dataset(open_file_or_filename(self.filename), engine="rasterio", chunks=CHUNK_SIZE)["band_data"]
         proj = proj.squeeze("band")
         if key["calibration"] == "reflectance":
             return self._mda.calibrate_to_reflectances(proj, self._channel)
@@ -145,7 +146,7 @@ class SAFEMSIXMLMetadata(BaseFileHandler):
         super().__init__(filename, filename_info, filetype_info)
         self._start_time = filename_info["observation_time"]
         self._end_time = filename_info["observation_time"]
-        self.root = ET.parse(self.filename)
+        self.root = ET.parse(open_file_or_filename(self.filename))
         self.tile = filename_info["dtile_number"]
         self.process_level = filename_info["process_level"]
         self.platform_name = PLATFORMS[filename_info["fmission_id"]]


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

The changes added in this PR are nearly identical to #3173

Zip archives are still the default distribution format for Sentinel-2 MSI_SAFE imagery, however, now SatPy `msi_safe` reader does not support it.

`fsspec` can be used to read data from archives, or, e.g. remote data sources like AWS or Planetary Computer.

The msi_safe reader file reading functionality is nearly identical to the one of Landsat readers, so I tried to implement fsspec support the same way.

However, I am stuck on adding tests, because in the current testing workflow no files are being used. For `XML` files the `StringIO` and `BytesIO` objects are being used (_however, we can write the content of these objects to files in the fsspec filesystem to test if it works_). For `jp2` files no reading is performed at all, instead of actual reading the function is just being mocked by `mock.path`, which returns the pre-defined fake data instead of loading something from file (_so, we either have to just leave it as-is or add actual loading functionality to the tests_).

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
