### PR TITLE
Fix VIIRS ERFDNB composite not properly rechunking data before map_blocks call

### DIFF
--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -230,8 +230,7 @@ class ERFDNB(CompositeBase):
                                                 False)
         super(ERFDNB, self).__init__(*args, **kwargs)
 
-    def _saturation_correction(self, dnb_data, unit_factor, min_val,
-                               max_val):
+    def _saturation_correction(self, dnb_data, min_val, max_val, unit_factor):
         saturation_pct = float(np.count_nonzero(dnb_data >
                                                 max_val)) / dnb_data.size
         LOG.debug("Dynamic DNB saturation percentage: %f", saturation_pct)
@@ -305,9 +304,9 @@ class ERFDNB(CompositeBase):
             output_data = da.map_blocks(
                 self._saturation_correction,
                 output_dataset.data.rechunk(output_dataset.shape),
+                min_val.rechunk(output_dataset.shape),
+                max_val.rechunk(output_dataset.shape),
                 unit_factor,
-                min_val,
-                max_val,
                 dtype=output_dataset.dtype,
                 meta=np.ndarray((), dtype=output_dataset.dtype),
             )

--- a/satpy/tests/compositor_tests/test_viirs.py
+++ b/satpy/tests/compositor_tests/test_viirs.py
@@ -51,7 +51,7 @@ class TestVIIRSComposites:
         dnb = np.zeros(area.shape) + 0.25
         dnb[3, :] += 0.25
         dnb[4:, :] += 0.5
-        dnb = da.from_array(dnb, chunks=25)
+        dnb = da.from_array(dnb, chunks=2)
         c01 = xr.DataArray(dnb,
                            dims=("y", "x"),
                            attrs={"name": "DNB", "area": area,
@@ -65,7 +65,7 @@ class TestVIIRSComposites:
         sza = np.zeros(area.shape) + 70.0
         sza[:, 3] += 20.0
         sza[:, 4:] += 45.0
-        sza = da.from_array(sza, chunks=25)
+        sza = da.from_array(sza, chunks=2)
         c02 = xr.DataArray(sza,
                            dims=("y", "x"),
                            attrs={"name": "solar_zenith_angle", "area": area,
@@ -78,7 +78,7 @@ class TestVIIRSComposites:
         lza = np.zeros(area.shape) + 70.0
         lza[:, 3] += 20.0
         lza[:, 4:] += 45.0
-        lza = da.from_array(lza, chunks=25)
+        lza = da.from_array(lza, chunks=2)
         c03 = xr.DataArray(lza,
                            dims=("y", "x"),
                            attrs={"name": "lunar_zenith_angle", "area": area,
@@ -185,7 +185,7 @@ class TestVIIRSComposites:
         dnb[4:, :] += 0.5
         if dnb_units == "W cm-2 sr-1":
             dnb /= 10000.0
-        dnb = da.from_array(dnb, chunks=25)
+        dnb = da.from_array(dnb, chunks=2)
         c01 = xr.DataArray(dnb,
                            dims=("y", "x"),
                            attrs={"name": "DNB", "area": area, "units": dnb_units})


### PR DESCRIPTION
Test data was not sufficiently chunked to reveal an issue in the chunking before the map_blocks call. This used to be a Delayed function call but was switched recently to map_blocks and at the time I didn't realize that `min_val` and `max_val` were arrays. I assumed they were scalars. The tests were using a single chunk for the test data which allowed things to "just work" until @kathys tried using the compositor with real data.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
