### PR TITLE
Fix handling of nans in lookup table enhancement

### DIFF
--- a/satpy/enhancements/colormap.py
+++ b/satpy/enhancements/colormap.py
@@ -43,7 +43,9 @@ def lookup(img, **kwargs):
 def _lookup_table(band_data, luts=None, index=-1):
     # NaN/null values will become 0
     lut = luts[:, index] if len(luts.shape) == 2 else luts
-    band_data = band_data.clip(0, lut.size - 1).astype(np.uint8)
+    band_data = band_data.clip(0, lut.size - 1)
+    # Convert to uint8, with NaN/null values changed into 0
+    band_data = np.nan_to_num(band_data).astype(np.uint8)
     return lut[band_data]
 
 


### PR DESCRIPTION
The incorrect handling of nans in the lookup table enhancement function causes warning messages in almost all architectures while an error is raised on riscv64.

Patch kindly provided by Aurelien Jarno in
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1121879

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [X] Closes #2934 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
