### PR TITLE
Fix VII (METimage) reader angles names

### DIFF
--- a/satpy/etc/composites/vii.yaml
+++ b/satpy/etc/composites/vii.yaml
@@ -5,22 +5,9 @@ modifiers:
     prerequisites:
       - name: 'vii_10690'
     optional_prerequisites:
-      - solar_zenith
+      - solar_zenith_angle
       - name: 'vii_13345'
     sunz_threshold: 85.0
-
-  rayleigh_corrected:
-    modifier: !!python/name:satpy.modifiers.PSPRayleighReflectance
-    atmosphere: us-standard
-    aerosol_type: rayleigh_only
-    prerequisites:
-      - wavelength: 0.67
-        modifiers: [ sunz_corrected ]
-    optional_prerequisites:
-      - observation_azimuth
-      - observation_zenith
-      - solar_azimuth
-      - solar_zenith
 
 composites:
   true_color_uncorrected:

--- a/satpy/etc/composites/vii.yaml
+++ b/satpy/etc/composites/vii.yaml
@@ -105,6 +105,7 @@ composites:
       day_night: day_only
       prerequisites:
         - true_color
+        - solar_zenith_angle
 
   true_color_daytime_uncorrected:
       description: >
@@ -116,6 +117,7 @@ composites:
       day_night: day_only
       prerequisites:
         - true_color_uncorrected
+        - solar_zenith_angle
 
   night_ir_alpha:
     compositor: !!python/name:satpy.composites.core.GenericCompositor

--- a/satpy/etc/readers/vii_l1b_nc.yaml
+++ b/satpy/etc/readers/vii_l1b_nc.yaml
@@ -339,47 +339,47 @@ datasets:
     file_key: data/measurement_data/solar_azimuth
     coordinates: [lat_tie_points, lon_tie_points]
 
-  observation_zenith_tie_points:
-    name: observation_zenith_tie_points
-    standard_name: sensor_zenith_angle
+  satellite_zenith_angle_tie_points:
+    name: satellite_zenith_angle_tie_points
+    standard_name: satellite_zenith_angle
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/observation_zenith
     coordinates: [lat_tie_points, lon_tie_points]
 
-  observation_azimuth_tie_points:
-    name: observation_azimuth_tie_points
-    standard_name: sensor_azimuth_angle
+  satellite_azimuth_angle_tie_points:
+    name: satellite_azimuth_angle_tie_points
+    standard_name: satellite_azimuth_angle
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/observation_azimuth
     coordinates: [lat_tie_points, lon_tie_points]
 
-  solar_zenith:
-    name: solar_zenith
+  solar_zenith_angle:
+    name: solar_zenith_angle
     standard_name: solar_zenith_angle
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/solar_zenith
     interpolate: True
     coordinates: [lat_pixels, lon_pixels]
 
-  solar_azimuth:
-    name: solar_azimuth
+  solar_azimuth_angle:
+    name: solar_azimuth_angle
     standard_name: solar_azimuth_angle
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/solar_azimuth
     interpolate: True
     coordinates: [lat_pixels, lon_pixels]
 
-  observation_zenith:
-    name: observation_zenith
-    standard_name: sensor_zenith_angle
+  satellite_zenith_angle:
+    name: satellite_zenith_angle
+    standard_name: satellite_zenith_angle
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/observation_zenith
     interpolate: True
     coordinates: [lat_pixels, lon_pixels]
 
-  observation_azimuth:
-    name: observation_azimuth
-    standard_name: sensor_azimuth_angle
+  satellite_azimuth_angle:
+    name: satellite_azimuth_angle
+    standard_name: satellite_azimuth_angle
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/observation_azimuth
     interpolate: True


### PR DESCRIPTION
This PR fixes the names of satellite and solar angles in the yaml file of the VII/METimage reader, so that they adhere to the convention and are correctly used in predefined modifiers, such as the `sunz_corrected` defined in `generic.yaml`. As discussed in https://pytroll.slack.com/archives/C0LNH7LMB/p1765897278746739 . 

Before this PR, the sunz_correction was not using the in-file angles as they could not be found due to the different name, causing issues when correcting Scenes with granules that were far apart in time; see the bright overcorrection over Europe, solved by this PR:  
before  
<img width="362" height="478" alt="image" src="https://github.com/user-attachments/assets/f641369b-d3ae-4556-8816-93b97dc6ad76" />
after  
<img width="362" height="479" alt="image" src="https://github.com/user-attachments/assets/8598cf36-da3b-4d2a-a56f-919a117df4c6" />



