### PR TITLE
Fix test to not save two geotiffs with the same name

### DIFF
--- a/satpy/tests/writer_tests/test_core/test_base.py
+++ b/satpy/tests/writer_tests/test_core/test_base.py
@@ -68,7 +68,7 @@ class TestBaseWriter:
 
     def test_save_dataset_static_filename(self):
         """Test saving a dataset with a static filename specified."""
-        self.scn.save_datasets(base_dir=self.base_dir, filename="geotiff.tif")
+        self.scn.save_datasets(datasets=["test"], base_dir=self.base_dir, filename="geotiff.tif")
         assert os.path.isfile(os.path.join(self.base_dir, "geotiff.tif"))
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
Windows started failing in CI because this test was trying to save 2 DataArrays to the same output filename. That is not a use case we want to support, but I think was done accidentally as the test class evolved. This PR updates the test to be explicit about what dataset is being saved and Windows CI passes now.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
