### PR TITLE
Add vis/ir cloud composite for FCI

### DIFF
--- a/satpy/etc/composites/fci.yaml
+++ b/satpy/etc/composites/fci.yaml
@@ -619,3 +619,95 @@ composites:
           - name: nir_16
           - name: vis_06
     standard_name: day_severe_storms_tropical
+
+  _vis_06_crude:
+    compositor: !!python/name:satpy.composites.core.SingleBandCompositor
+    description: Special version of vis_06 for use in vis_with_ir_cloud_overlay
+    standard_name: vis-crude
+    prerequisites:
+      - name: vis_06
+        modifiers: [sunz_corrected]
+
+  _ir105:
+    compositor: !!python/name:satpy.composites.core.SingleBandCompositor
+    description: Special version of ir_105 for use in vis_with_ir_cloud_overlay
+    standard_name: ir-crude
+    prerequisites:
+      - name: ir_105
+
+  _vis_with_ir:
+    compositor: !!python/name:satpy.composites.fill.DayNightCompositor
+    standard_name: image_ready
+    lim_low: 85.0
+    lim_high: 88.0
+    prerequisites:
+      - _vis_06_crude
+      - _ir105
+
+  vis_with_ir_cloud_overlay:
+    compositor: !!python/name:satpy.composites.mask.MaskingCompositor
+    standard_name: image_ready
+    prerequisites:
+    - _vis_with_ir
+    - cloud_type
+    conditions:
+      - method: equal
+        value: Not processed (no or corrupt data)
+        transparency: 100
+      - method: equal
+        value: Cloud free land (no cloud, snow or ice)
+        transparency: 100
+      - method: equal
+        value: Cloud free sea (no cloud, snow or ice)
+        transparency: 100
+      - method: equal
+        value: Land with snow or ice
+        transparency: 100
+      - method: equal
+        value: Sea with snow or ice
+        transparency: 100
+      - method: equal
+        value: Cloud very low opaque
+        transparency: 0
+      - method: equal
+        value: Cloud low opaque
+        transparency: 0
+      - method: equal
+        value: Cloud medium opaque
+        transparency: 0
+      - method: equal
+        value: Cloud high opaque
+        transparency: 0
+      - method: equal
+        value: Cloud very high opaque
+        transparency: 0
+      - method: equal
+        value: Cloud semi-transparent high thin
+        transparency: 50
+      - method: equal
+        value: Cloud semi-transparent high mean thick
+        transparency: 50
+      - method: equal
+        value: Cloud semi-transparent high thick
+        transparency: 50
+      - method: equal
+        value: Cloud semi-transparent high above low medium cloud
+        transparency: 50
+      - method: equal
+        value: Cloud fractional
+        transparency: 50
+      - method: equal
+        value: Dust contaminated
+        transparency: 100
+      - method: equal
+        value: Dust opaque
+        transparency: 100
+      - method: equal
+        value: Ash contaminated
+        transparency: 100
+      - method: equal
+        value: Ash opaque
+        transparency: 100
+      - method: equal
+        value: Undefined by Cloud Mask
+        transparency: 100

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -1468,3 +1468,25 @@ enhancements:
       method: !!python/name:satpy.enhancements.contrast.gamma
       kwargs:
         gamma: [1.5, 1.2, 1.2]
+
+  vis-crude:
+    description: stretching vis between 0 and 100
+    standard_name: vis-crude
+    operations:
+    - name: stretch
+      method: !!python/name:satpy.enhancements.contrast.stretch
+      kwargs:
+        stretch: crude
+        min_stretch: 0
+        max_stretch: 100
+
+  ir-crude:
+    description: IR white clouds, stretched between 215 and 300
+    standard_name: ir-crude
+    operations:
+    - name: stretch
+      method: !!python/name:satpy.enhancements.contrast.stretch
+      kwargs:
+        stretch: crude
+        min_stretch: 300
+        max_stretch: 215


### PR DESCRIPTION
First attempt of a VIS/IR cloud composite for FCI, based on the CLM product from EUMETSAT.

Usage example:

```python
import hdf5plugin
from satpy import Scene
from glob import glob
import os
sc = Scene(
        filenames=
            {"fci_l2_nc": ["W_XX-EUMETSAT-Darmstadt,IMG+SAT,MTI1+FCI-2-CT--FD------NC4E_C_EUMT_20260105164431_L2PF_OPE_20260105163000_20260105164000_N__C_0100_0000.nc"],
             "fci_l1c_nc": glob("*FDHSI*BODY*20260105*O_0100_*.nc")})
sc.load(["vis_06", "ir_105", "_vis_with_ir",
         "_vis_06_crude", "_ir105", "vis_with_ir_cloud_overlay"])
ls = sc.resample("eurol", resampler="nearest", radius_of_influence=20000) ls.save_datasets(
        filename="{platform_name}-{sensor}-{area.area_id}-{name}-{start_time:%Y%m%d%H%M%S}-{end_time:%Y%m%d%H%M%S}.tif",
        fill_value=0)
```

Result for `_vis-with-ir` (no overlay) for 2026-01-05 16:30:

<img width="2560" height="2048" alt="Meteosat-12-fci-eurol-_vis_with_ir-20260105163000-20260105164000" src="https://github.com/user-attachments/assets/40fc0009-cb9e-4d1b-8660-105e78fe659b" />

Result for `vis_with_ir_cloud_overlay`:

<img width="2560" height="2048" alt="Meteosat-12-fci-eurol-vis_with_ir_cloud_overlay-20260105163000-20260105164000" src="https://github.com/user-attachments/assets/6249ea02-7596-4053-a6e5-7bb8fb3b08ff" />

NB: Transparency may show as black or white depending on the background, or when viewed in a client not supporting transparency.  This is how irfanview shows it:

<img width="2439" height="2090" alt="image" src="https://github.com/user-attachments/assets/7ca3621a-e915-41d5-b42a-dd3ba215347d" />

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
