### PR TITLE
Address h5netcdf scalar issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,7 @@ jobs:
         shell: bash -l {0}
         run: |
           export LD_PRELOAD=${{ env.LD_PRELOAD }};
-          pytest -n auto --cov=satpy satpy/tests --cov-report=xml --cov-report=
+          pytest --forked -n auto --cov=satpy satpy/tests --cov-report=xml --cov-report=
 
       - name: Upload unittest coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,7 @@ jobs:
         shell: bash -l {0}
         run: |
           export LD_PRELOAD=${{ env.LD_PRELOAD }};
-          pytest --forked -n auto --cov=satpy satpy/tests --cov-report=xml --cov-report=
+          pytest -n auto --cov=satpy satpy/tests --cov-report=xml --cov-report=
 
       - name: Upload unittest coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -58,7 +58,6 @@ dependencies:
   - ephem
   - bokeh
   - pytest-xdist
-  - pytest-forked
   - pip:
       - pytest-lazy-fixtures
       - trollsift

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -58,11 +58,12 @@ dependencies:
   - ephem
   - bokeh
   - pytest-xdist
+  - pytest-forked
   - pip:
-    - pytest-lazy-fixtures
-    - trollsift
-    - trollimage>=1.24
-    - pyspectral
-    - pyorbital
-    - pyPublicDecompWT
-    - pygac
+      - pytest-lazy-fixtures
+      - trollsift
+      - trollimage>=1.24
+      - pyspectral
+      - pyorbital
+      - pyPublicDecompWT
+      - pygac

--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -107,12 +107,12 @@ if _ancpath is not None and _data_dir is None:
 config = Config("satpy", defaults=[_CONFIG_DEFAULTS], paths=_CONFIG_PATHS)
 
 
-def get_config_path_safe():
+def get_config_path_safe() -> list[str]:
     """Get 'config_path' and check for proper 'list' type."""
     config_path = config.get("config_path")
     if not isinstance(config_path, list):
-        raise ValueError("Satpy config option 'config_path' must be a "
-                         "list, not '{}'".format(type(config_path)))
+        raise ValueError("Satpy config option 'config_path' must be a " +
+                         f"list, not '{type(config_path)}'.")
     return config_path
 
 
@@ -155,7 +155,7 @@ def _entry_point_module(entry_point):
         return entry_point.value.split(":")[0].strip()
 
 
-def config_search_paths(filename, search_dirs=None, **kwargs):
+def config_search_paths(filename: str, search_dirs: list[str]|None = None, **kwargs) -> list[str]:
     """Get series of configuration base paths where Satpy configs are located."""
     if search_dirs is None:
         search_dirs = get_config_path_safe()[::-1]

--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -155,7 +155,7 @@ def _entry_point_module(entry_point):
         return entry_point.value.split(":")[0].strip()
 
 
-def config_search_paths(filename: str, search_dirs: list[str]|None = None, **kwargs) -> list[str]:
+def config_search_paths(filename: str, search_dirs: list[str] | None = None, **kwargs) -> list[str]:
     """Get series of configuration base paths where Satpy configs are located."""
     if search_dirs is None:
         search_dirs = get_config_path_safe()[::-1]

--- a/satpy/conftest.py
+++ b/satpy/conftest.py
@@ -37,3 +37,9 @@ def pytest_unconfigure(config):
 def session_tmp_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Generate a single temp path to use for the entire session."""
     return tmp_path_factory.mktemp("data")
+
+
+@pytest.fixture(scope="module")
+def module_tmp_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Generate a single temp path to use for the entire session."""
+    return tmp_path_factory.mktemp("data")

--- a/satpy/conftest.py
+++ b/satpy/conftest.py
@@ -16,6 +16,8 @@
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Pytest configuration and setup functions."""
+from pathlib import Path
+
 import pytest
 
 
@@ -32,6 +34,6 @@ def pytest_unconfigure(config):
 
 
 @pytest.fixture(scope="session")
-def session_tmp_path(tmp_path_factory):
+def session_tmp_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Generate a single temp path to use for the entire session."""
     return tmp_path_factory.mktemp("data")

--- a/satpy/readers/core/loading.py
+++ b/satpy/readers/core/loading.py
@@ -63,7 +63,7 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None):
         loadables = reader_instance.select_files_from_pathnames(readers_files)
         if loadables:
             # WARN: This is very confusing, but it seems to work: The reader_kwargs, when passed without a reader key,
-            # are pud into a dictionary where keys are individual letters of the reader name, and the value is the
+            # are put into a dictionary where keys are individual letters of the reader name, and the value is the
             # reader kwargs; however, notice the `reader[idx]` part in the call here, as idx is 0 and thus the first
             # letter of the reader is used to index `reader_kwargs_without_filter`, thus retrieving the correct
             # reader_kwargs.

--- a/satpy/readers/core/loading.py
+++ b/satpy/readers/core/loading.py
@@ -62,6 +62,11 @@ def load_readers(filenames=None, reader=None, reader_kwargs=None):
 
         loadables = reader_instance.select_files_from_pathnames(readers_files)
         if loadables:
+            # WARN: This is very confusing, but it seems to work: The reader_kwargs, when passed without a reader key,
+            # are pud into a dictionary where keys are individual letters of the reader name, and the value is the
+            # reader kwargs; however, notice the `reader[idx]` part in the call here, as idx is 0 and thus the first
+            # letter of the reader is used to index `reader_kwargs_without_filter`, thus retrieving the correct
+            # reader_kwargs.
             reader_instance.create_storage_items(
                     loadables,
                     fh_kwargs=reader_kwargs_without_filter[None if reader is None else reader[idx]])

--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -391,9 +391,11 @@ def get_accessor_and_filehandle_from_engines(filename, *engines):
     """Choose an accessor from the first possible engine, and return in along with the file handle."""
     for engine in engines:
         try:
+            LOG.info(f"Trying reading nc file with {engine} engine…")
             return get_accessor_and_filehandle_from_engine(filename, engine)
         except Exception as err:
-            LOG.warning(str(err))
+            LOG.warning(f"Cannot use {engine} engine to read nc file.")
+            LOG.debug(f"The error is: {str(err)}")
             continue
     else:
         raise RuntimeError("Could not work out an appropriate engine to open netCDF4 files")

--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -4,6 +4,7 @@ import logging
 from contextlib import suppress
 
 import dask.array as da
+import netCDF4
 import numpy as np
 import xarray as xr
 
@@ -405,19 +406,19 @@ class NetCDF4Accessor:
 
     def create_file_handle(self, filename):
         """Create a file handle."""
-        import netCDF4
+        # import netCDF4
         return netCDF4.Dataset(filename, "r")
 
     @staticmethod
     def is_variable(obj):
         """Check if obj is a variable."""
-        import netCDF4
+        # import netCDF4
         return isinstance(obj, netCDF4.Variable)
 
     @staticmethod
     def is_group(obj):
         """Check if obj is a group."""
-        import netCDF4
+        # import netCDF4
         return isinstance(obj, netCDF4.Group)
 
     @staticmethod

--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -332,14 +332,7 @@ class NetCDF4FileHandler(BaseFileHandler):
             val = v
         else:
             try:
-                val = v[:]
-                val = xr.DataArray(val, dims=v.dimensions,
-                                   attrs=self.accessor.get_object_attrs(v),
-                                   name=v.name)
-            except (ValueError, IndexError):
-                # Handle scalars
-                val = v.__array__().item()
-                val = xr.DataArray(val, dims=(), attrs={}, name=var_name)
+                val = get_data_as_xarray(v)
             except AttributeError:
                 # Handle strings
                 val = v

--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -48,24 +48,24 @@ class NetCDF4FileHandler(BaseFileHandler):
         wrapper["group/subgroup/var_name/shape"]
 
     If your file has many small data variables that are frequently accessed,
-    you may choose to cache some of them.  You can do this by passing a number,
+    you may choose to cache some of them. You can do this by passing a number,
     any variable smaller than this number in bytes will be read into RAM.
     Warning, this part of the API is provisional and subject to change.
 
-    You may get an additional speedup by passing ``cache_handle=True``.  This
+    You may get an additional speedup by passing ``cache_handle=True``. This
     will keep the netCDF4 dataset handles open throughout the lifetime of the
     object, and instead of using `xarray.open_dataset` to open every data
-    variable, a dask array will be created "manually".  This may be useful if
-    you have a dataset distributed over many files, such as for FCI.  Note
-    that the coordinates will be missing in this case.  If you use this option,
+    variable, a dask array will be created "manually". This may be useful if
+    you have a dataset distributed over many files, such as for FCI. Note
+    that the coordinates will be missing in this case. If you use this option,
     ``xarray_kwargs`` will have no effect.
 
     Args:
-        filename (str): File to read
-        filename_info (dict): Dictionary with filename information
-        filetype_info (dict): Dictionary with filetype information
-        auto_maskandscale (bool): Apply mask and scale factors
-        xarray_kwargs (dict): Addition arguments to `xarray.open_dataset`
+        filename (str): File to read.
+        filename_info (dict): Dictionary with filename information.
+        filetype_info (dict): Dictionary with filetype information.
+        auto_maskandscale (bool): Apply mask and scale factors.
+        xarray_kwargs (dict): Addition arguments to `xarray.open_dataset`.
         cache_var_size (int): Cache variables smaller than this size.
         cache_handle (bool): Keep files open for lifetime of filehandler.
         engine (str or list of str): The engine to use for reading, either "netcdf4" or "h5netcdf". As a list, will try

--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -4,7 +4,6 @@ import logging
 from contextlib import suppress
 
 import dask.array as da
-import netCDF4
 import numpy as np
 import xarray as xr
 
@@ -406,19 +405,19 @@ class NetCDF4Accessor:
 
     def create_file_handle(self, filename):
         """Create a file handle."""
-        # import netCDF4
+        import netCDF4
         return netCDF4.Dataset(filename, "r")
 
     @staticmethod
     def is_variable(obj):
         """Check if obj is a variable."""
-        # import netCDF4
+        import netCDF4
         return isinstance(obj, netCDF4.Variable)
 
     @staticmethod
     def is_group(obj):
         """Check if obj is a group."""
-        # import netCDF4
+        import netCDF4
         return isinstance(obj, netCDF4.Group)
 
     @staticmethod

--- a/satpy/readers/fci_l1c_nc.py
+++ b/satpy/readers/fci_l1c_nc.py
@@ -203,10 +203,11 @@ class FCIL1cNCFileHandler(NetCDF4FsspecFileHandler):
     def __init__(self, filename, filename_info, filetype_info,
                  clip_negative_radiances=None, **kwargs):
         """Initialize file handler."""
+        kwargs.setdefault("cache_var_size", 0)
+        kwargs.setdefault("cache_handle", True)
         super().__init__(filename, filename_info,
                          filetype_info,
-                         cache_var_size=0,
-                         cache_handle=True)
+                         **kwargs)
         logger.debug("Reading: {}".format(self.filename))
         logger.debug("Start: {}".format(self.start_time))
         logger.debug("End: {}".format(self.end_time))

--- a/satpy/readers/geocat.py
+++ b/satpy/readers/geocat.py
@@ -37,7 +37,7 @@ import numpy as np
 from pyproj import Proj
 from pyresample import geometry
 
-from satpy.readers.core.netcdf import NetCDF4FileHandler, netCDF4
+from satpy.readers.core.netcdf import NetCDF4FileHandler
 
 LOG = logging.getLogger(__name__)
 
@@ -204,7 +204,7 @@ class GEOCATFileHandler(NetCDF4FileHandler):
         for var_name, val in self.file_content.items():
             if var_name in handled_variables:
                 continue
-            if isinstance(val, netCDF4.Variable):
+            if self.accessor.is_variable(val):
                 ds_info = {
                     "file_type": self.filetype_info["file_type"],
                     "resolution": res,

--- a/satpy/readers/mimic_TPW2_nc.py
+++ b/satpy/readers/mimic_TPW2_nc.py
@@ -38,7 +38,7 @@ import numpy as np
 import xarray as xr
 from pyresample.geometry import AreaDefinition
 
-from satpy.readers.core.netcdf import NetCDF4FileHandler, netCDF4
+from satpy.readers.core.netcdf import NetCDF4FileHandler
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +85,7 @@ class MimicTPW2FileHandler(NetCDF4FileHandler):
         # Iterate over dataset contents
         for var_name, val in self.file_content.items():
             # Only evaluate variables
-            if isinstance(val, netCDF4.Variable):
+            if self.accessor.is_variable(val):
                 logger.debug("Evaluating new variable: %s", var_name)
                 var_shape = self[var_name + "/shape"]
                 logger.debug("Dims:{}".format(var_shape))

--- a/satpy/readers/smos_l2_wind.py
+++ b/satpy/readers/smos_l2_wind.py
@@ -30,7 +30,7 @@ import logging
 import numpy as np
 from pyresample.geometry import AreaDefinition
 
-from satpy.readers.core.netcdf import NetCDF4FileHandler, netCDF4
+from satpy.readers.core.netcdf import NetCDF4FileHandler
 
 logger = logging.getLogger(__name__)
 
@@ -81,7 +81,7 @@ class SMOSL2WINDFileHandler(NetCDF4FileHandler):
         # Iterate over dataset contents
         for var_name, val in self.file_content.items():
             # Only evaluate variables
-            if not isinstance(val, netCDF4.Variable):
+            if not self.accessor.is_variable(val):
                 continue
             if (var_name in handled_variables):
                 logger.debug("Already handled, skipping: %s", var_name)

--- a/satpy/readers/smos_l2_wind.py
+++ b/satpy/readers/smos_l2_wind.py
@@ -136,7 +136,7 @@ class SMOSL2WINDFileHandler(NetCDF4FileHandler):
 
     def get_dataset(self, dataset_id, ds_info):
         """Get dataset."""
-        if  dataset_id["name"] == "lon":
+        if dataset_id["name"] == "lon":
             lon = self.centered_lon
             return lon.rename(dict(lon="x"))
         elif dataset_id["name"] == "lat":

--- a/satpy/readers/smos_l2_wind.py
+++ b/satpy/readers/smos_l2_wind.py
@@ -189,7 +189,7 @@ class SMOSL2WINDFileHandler(NetCDF4FileHandler):
         return (lower_left_x, lower_left_y, upper_right_x, upper_right_y)
 
     def get_area_def(self, dsid):
-        """Define AreaDefinition with a note."""
+        """Define AreaDefinition."""
         width = self["lon/shape"][0]
         height = self["lat/shape"][0] - 2
         area_extent = self._create_area_extent(width, height)

--- a/satpy/readers/smos_l2_wind.py
+++ b/satpy/readers/smos_l2_wind.py
@@ -147,7 +147,11 @@ class SMOSL2WINDFileHandler(NetCDF4FileHandler):
             # As this is data over open sea these has no values.
             data = data.where((data.y > -90.0) & (data.y < 90.0), drop=True)
         elif len(data.dims) == 1 and "y" in data.dims:
-            data = data.where((data.y > 0) & (data.y < len(data.y) - 1), drop=True)
+            if ds_id["name"] == "lat":
+                data = data.where((data > -90.0) & (data < 90.0), drop=True)
+            else:
+                # Is there such a case?
+                data = data.where((data.y > 0) & (data.y < len(data.y) - 1), drop=True)
         return data
 
     def _create_area_extent(self, width, height):

--- a/satpy/readers/tropomi_l2.py
+++ b/satpy/readers/tropomi_l2.py
@@ -36,7 +36,7 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 
-from satpy.readers.core.netcdf import NetCDF4FileHandler, netCDF4
+from satpy.readers.core.netcdf import NetCDF4FileHandler
 from satpy.utils import get_legacy_chunk_size
 
 logger = logging.getLogger(__name__)
@@ -139,7 +139,7 @@ class TROPOMIL2FileHandler(NetCDF4FileHandler):
         """
         for var_name, val in self.file_content.items():
             # Only evaluate variables
-            if isinstance(val, netCDF4.Variable):
+            if self.accessor.is_variable(val):
                 logger.debug("Evaluating new variable: %s", var_name)
                 var_shape = self[var_name + "/shape"]
                 logger.debug("Dims:{}".format(var_shape))

--- a/satpy/tests/reader_tests/test_geocat.py
+++ b/satpy/tests/reader_tests/test_geocat.py
@@ -35,26 +35,26 @@ DEFAULT_LON_DATA = np.linspace(5, 45, DEFAULT_FILE_SHAPE[1]).astype(DEFAULT_FILE
 DEFAULT_LON_DATA = np.repeat([DEFAULT_LON_DATA], DEFAULT_FILE_SHAPE[0], axis=0)
 
 
-@pytest.fixture(scope="session")
-def g13_file(session_tmp_path: Path) -> Path:
+@pytest.fixture(scope="module")
+def g13_file(module_tmp_path: Path) -> Path:
     """Create a GOES 13 geocat file."""
     platform_shortname = "GOES-13"
-    filename = session_tmp_path / "geocatL2.GOES-13.2015143.234500.nc"
+    filename = module_tmp_path / "geocatL2.GOES-13.2015143.234500.nc"
     return _create_geocat_file(filename, platform_shortname)
 
 
-@pytest.fixture(scope="session")
-def h8_file(session_tmp_path: Path) -> Path:
+@pytest.fixture(scope="module")
+def h8_file(module_tmp_path: Path) -> Path:
     """Create a HIMAWARI 8 geocat file."""
     platform_shortname = "HIMAWARI-8"
-    filename = session_tmp_path / "geocatL2.HIMAWARI-8.2017092.210730.R304.R20.nc"
+    filename = module_tmp_path / "geocatL2.HIMAWARI-8.2017092.210730.R304.R20.nc"
     return _create_geocat_file(filename, platform_shortname)
 
 
-@pytest.fixture(scope="session")
-def g17_file(session_tmp_path: Path) -> Path:
+@pytest.fixture(scope="module")
+def g17_file(module_tmp_path: Path) -> Path:
     """Create a GOES 17 geocat file."""
-    filename = session_tmp_path / "geocatL2.GOES-17.CONUS.2020041.163130.hdf"
+    filename = module_tmp_path / "geocatL2.GOES-17.CONUS.2020041.163130.hdf"
     return _create_geocat_file(filename, platform_shortname="GOES-17")
 
 

--- a/satpy/tests/reader_tests/test_mimic_TPW2_lowres.py
+++ b/satpy/tests/reader_tests/test_mimic_TPW2_lowres.py
@@ -41,10 +41,10 @@ date_variables = ["timeAwayGridPrior", "timeAwayGridSubseq"]
 ubyte_variables = ["satGridPrior", "satGridSubseq"]
 
 
-@pytest.fixture(scope="session")
-def mimic_file(session_tmp_path: Path) -> Path:
+@pytest.fixture(scope="module")
+def mimic_file(module_tmp_path: Path) -> Path:
     """Mimic a real data file."""
-    filename = session_tmp_path / "comp20190619.130000.nc"
+    filename = module_tmp_path / "comp20190619.130000.nc"
     file_type = "mimicTPW2_comp"
     dt_s = DEFAULT_DATE
     dt_e = DEFAULT_DATE

--- a/satpy/tests/reader_tests/test_mimic_TPW2_lowres.py
+++ b/satpy/tests/reader_tests/test_mimic_TPW2_lowres.py
@@ -18,20 +18,17 @@
 # Satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Module for testing the satpy.readers.tropomi_l2 module."""
 
-import datetime as dt
-import itertools
 import os
-import unittest
-from unittest import mock
+from datetime import datetime
+from pathlib import Path
 
 import numpy as np
+import pytest
 import xarray as xr
-
-from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
 
 DEFAULT_FILE_DTYPE = np.float32
 DEFAULT_FILE_SHAPE = (721, 1440)
-DEFAULT_DATE = dt.datetime(2019, 6, 19, 13, 0)
+DEFAULT_DATE = datetime(2019, 6, 19, 13, 0)
 DEFAULT_LAT = np.linspace(-90, 90, DEFAULT_FILE_SHAPE[0], dtype=DEFAULT_FILE_DTYPE)
 DEFAULT_LON = np.linspace(-180, 180, DEFAULT_FILE_SHAPE[1], dtype=DEFAULT_FILE_DTYPE)
 DEFAULT_FILE_FLOAT_DATA = np.arange(DEFAULT_FILE_SHAPE[0] * DEFAULT_FILE_SHAPE[1],
@@ -42,110 +39,83 @@ DEFAULT_FILE_UBYTE_DATA = np.arange(DEFAULT_FILE_SHAPE[0] * DEFAULT_FILE_SHAPE[1
 float_variables = ["tpwGrid", "tpwGridPrior", "tpwGridSubseq", "footGridPrior", "footGridSubseq"]
 date_variables = ["timeAwayGridPrior", "timeAwayGridSubseq"]
 ubyte_variables = ["satGridPrior", "satGridSubseq"]
-file_content_attr = dict()
 
 
-class FakeNetCDF4FileHandlerMimicLow(FakeNetCDF4FileHandler):
-    """Swap-in NetCDF4 File Handler."""
+@pytest.fixture(scope="session")
+def mimic_file(session_tmp_path: Path) -> Path:
+    """Mimic a real data file."""
+    filename = session_tmp_path / "comp20190619.130000.nc"
+    file_type = "mimicTPW2_comp"
+    dt_s = DEFAULT_DATE
+    dt_e = DEFAULT_DATE
 
-    def get_test_content(self, filename, filename_info, filetype_info):
-        """Mimic reader input file content for lower resolution files."""
-        dt_s = filename_info.get("start_time", DEFAULT_DATE)
-        dt_e = filename_info.get("end_time", DEFAULT_DATE)
+    dt = xr.DataTree()
+    dt.attrs["start_time"] = dt_s.strftime("%Y%m%d.%H%M%S")
+    dt.attrs["end_time"] = dt_e.strftime("%Y%m%d.%H%M%S")
+    dt.attrs["platform_shortname"] = "aggregated microwave"
+    dt.attrs["sensor"] ="mimic"
 
-        if filetype_info["file_type"] == "mimicTPW2_comp":
-            file_content = {
-                "/attr/start_time": dt_s.strftime("%Y%m%d.%H%M%S"),
-                "/attr/end_time": dt_e.strftime("%Y%m%d.%H%M%S"),
-                "/attr/platform_shortname": "aggregated microwave",
-                "/attr/sensor": "mimic",
-            }
-            file_content["latArr"] = DEFAULT_LAT
-            file_content["latArr/shape"] = (DEFAULT_FILE_SHAPE[0],)
-            file_content["latArr/attr/units"] = "degress_north"
+    dt["latArr"] = xr.DataArray(DEFAULT_LAT,
+                                attrs={"units": "degress_north"},
+                                dims=("lat",))
 
-            file_content["lonArr"] = DEFAULT_LON
-            file_content["lonArr/shape"] = (DEFAULT_FILE_SHAPE[1],)
-            file_content["lonArr/attr/units"] = "degrees_east"
+    dt["lonArr"] = xr.DataArray(DEFAULT_LON,
+                                attrs={"units": "degress_east"},
+                                dims=("lon",))
 
-            file_content["/dimension/lat"] = DEFAULT_FILE_SHAPE[0]
-            file_content["/dimension/lon"] = DEFAULT_FILE_SHAPE[1]
+    for float_var in float_variables:
+        dt[float_var] = xr.DataArray(DEFAULT_FILE_FLOAT_DATA.reshape(DEFAULT_FILE_SHAPE),
+                                     attrs={"units":"mm",
+                                            "_FillValue": -999.0,
+                                            "name": float_var,
+                                            "file_key": float_var,
+                                            "file_type": file_type},
+                                     dims=("y", "x"))
+    for date_var in date_variables:
+        dt[date_var] = xr.DataArray(DEFAULT_FILE_DATE_DATA.reshape(DEFAULT_FILE_SHAPE),
+                                    attrs=dict(units="minutes"),
+                                    dims=("y", "x"))
+    for ubyte_var in ubyte_variables:
+        dt[ubyte_var] = xr.DataArray(DEFAULT_FILE_UBYTE_DATA.reshape(DEFAULT_FILE_SHAPE),
+                                     attrs={"source_key": ("Key: 0: None, 1: NOAA-N, 2: NOAA-P, 3: Metop-A, "
+                                                           "4: Metop-B, 5: SNPP, 6: SSMI-17, 7: SSMI-18"),
+                                            "_FillValue": 255,
+                                            "name": ubyte_var,
+                                            "file_key": ubyte_var,
+                                            "file_type": file_type},
+                                     dims=("y", "x"))
 
-            for float_var in float_variables:
-                file_content[float_var] = DEFAULT_FILE_FLOAT_DATA.reshape(DEFAULT_FILE_SHAPE)
-                file_content["{}/shape".format(float_var)] = DEFAULT_FILE_SHAPE
-                file_content_attr[float_var] = {"units": "mm"}
-            for date_var in date_variables:
-                file_content[date_var] = DEFAULT_FILE_DATE_DATA.reshape(DEFAULT_FILE_SHAPE)
-                file_content["{}/shape".format(date_var)] = DEFAULT_FILE_SHAPE
-                file_content_attr[date_var] = {"units": "minutes"}
-            for ubyte_var in ubyte_variables:
-                file_content[ubyte_var] = DEFAULT_FILE_UBYTE_DATA.reshape(DEFAULT_FILE_SHAPE)
-                file_content["{}/shape".format(ubyte_var)] = DEFAULT_FILE_SHAPE
-                file_content_attr[ubyte_var] = {"source_key": "Key: 0: None, 1: NOAA-N, 2: NOAA-P, 3: Metop-A, \
-                                                              4: Metop-B, 5: SNPP, 6: SSMI-17, 7: SSMI-18"}
-
-            # convert to xarrays
-            for key, val in file_content.items():
-                if key == "lonArr" or key == "latArr":
-                    file_content[key] = xr.DataArray(val)
-                elif isinstance(val, np.ndarray):
-                    if val.ndim > 1:
-                        file_content[key] = xr.DataArray(val, dims=("y", "x"), attrs=file_content_attr[key])
-                    else:
-                        file_content[key] = xr.DataArray(val)
-            for key in itertools.chain(float_variables, ubyte_variables):
-                file_content[key].attrs["_FillValue"] = -999.0
-                file_content[key].attrs["name"] = key
-                file_content[key].attrs["file_key"] = key
-                file_content[key].attrs["file_type"] = self.filetype_info["file_type"]
-        else:
-            msg = "Wrong Test Reader for file_type {}".format(filetype_info["file_type"])
-            raise AssertionError(msg)
-
-        return file_content
+    dt.to_netcdf(filename)
+    return filename
 
 
-class TestMimicTPW2Reader(unittest.TestCase):
+class TestMimicTPW2Reader:
     """Test Mimic Reader."""
 
     yaml_file = "mimicTPW2_comp.yaml"
 
-    def setUp(self):
+    def setup_method(self):
         """Wrap NetCDF4 file handler with our own fake handler."""
         from satpy._config import config_search_paths
-        from satpy.readers.mimic_TPW2_nc import MimicTPW2FileHandler
         self.reader_configs = config_search_paths(os.path.join("readers", self.yaml_file))
-        # http://stackoverflow.com/questions/12219967/how-to-mock-a-base-class-with-python-mock-library
-        self.p = mock.patch.object(MimicTPW2FileHandler, "__bases__", (FakeNetCDF4FileHandlerMimicLow,))
-        self.fake_handler = self.p.start()
-        self.p.is_local = True
 
-    def tearDown(self):
-        """Stop wrapping the NetCDF4 file handler."""
-        self.p.stop()
 
-    def test_init(self):
+    def test_init(self, mimic_file):
         """Test basic initialization of this reader."""
         from satpy.readers.core.loading import load_reader
         r = load_reader(self.reader_configs)
-        loadables = r.select_files_from_pathnames([
-            "comp20190619.130000.nc",
-        ])
+        loadables = r.select_files_from_pathnames([mimic_file])
         assert len(loadables) == 1
         r.create_filehandlers(loadables)
         # make sure we have some files
         assert r.file_handlers
 
-    def test_load_mimic_float(self):
+    def test_load_mimic_float(self, mimic_file):
         """Load TPW mimic float data."""
         from satpy.readers.core.loading import load_reader
         r = load_reader(self.reader_configs)
-        with mock.patch("satpy.readers.mimic_TPW2_nc.netCDF4.Variable", xr.DataArray):
-            loadables = r.select_files_from_pathnames([
-                "comp20190619.130000.nc",
-            ])
-            r.create_filehandlers(loadables)
+        loadables = r.select_files_from_pathnames([mimic_file])
+        r.create_filehandlers(loadables)
         ds = r.load(float_variables)
         assert len(ds) == len(float_variables)
         for d in ds.values():
@@ -155,15 +125,12 @@ class TestMimicTPW2Reader(unittest.TestCase):
             assert "area" in d.attrs
             assert d.attrs["area"] is not None
 
-    def test_load_mimic_timedelta(self):
+    def test_load_mimic_timedelta(self, mimic_file):
         """Load TPW mimic timedelta data (data latency variables)."""
         from satpy.readers.core.loading import load_reader
         r = load_reader(self.reader_configs)
-        with mock.patch("satpy.readers.mimic_TPW2_nc.netCDF4.Variable", xr.DataArray):
-            loadables = r.select_files_from_pathnames([
-                "comp20190619.130000.nc",
-            ])
-            r.create_filehandlers(loadables)
+        loadables = r.select_files_from_pathnames([mimic_file])
+        r.create_filehandlers(loadables)
         ds = r.load(date_variables)
         assert len(ds) == len(date_variables)
         for d in ds.values():
@@ -174,15 +141,12 @@ class TestMimicTPW2Reader(unittest.TestCase):
             assert d.attrs["area"] is not None
             assert d.dtype == DEFAULT_FILE_DTYPE
 
-    def test_load_mimic_ubyte(self):
+    def test_load_mimic_ubyte(self, mimic_file):
         """Load TPW mimic sensor grids."""
         from satpy.readers.core.loading import load_reader
         r = load_reader(self.reader_configs)
-        with mock.patch("satpy.readers.mimic_TPW2_nc.netCDF4.Variable", xr.DataArray):
-            loadables = r.select_files_from_pathnames([
-                "comp20190619.130000.nc",
-            ])
-            r.create_filehandlers(loadables)
+        loadables = r.select_files_from_pathnames([mimic_file])
+        r.create_filehandlers(loadables)
         ds = r.load(ubyte_variables)
         assert len(ds) == len(ubyte_variables)
         for d in ds.values():

--- a/satpy/tests/reader_tests/test_mimic_TPW2_nc.py
+++ b/satpy/tests/reader_tests/test_mimic_TPW2_nc.py
@@ -22,6 +22,7 @@
 import os
 from datetime import datetime
 from pathlib import Path
+from typing import final
 
 import numpy as np
 import pytest
@@ -64,17 +65,19 @@ def mimic_file(session_tmp_path: Path) -> Path:
     return filename
 
 
+@final
 class TestMimicTPW2Reader:
     """Test Mimic Reader."""
 
-    yaml_file = "mimicTPW2_comp.yaml"
+    yaml_file: str = "mimicTPW2_comp.yaml"
+    reader_configs = None
 
     def setup_method(self):
         """Wrap NetCDF4 file handler with our own fake handler."""
         from satpy._config import config_search_paths
         self.reader_configs = config_search_paths(os.path.join("readers", self.yaml_file))
 
-    def test_init(self, mimic_file):
+    def test_init(self, mimic_file: Path):
         """Test basic initialization of this reader."""
         from satpy.readers.core.loading import load_reader
         r = load_reader(self.reader_configs)

--- a/satpy/tests/reader_tests/test_mimic_TPW2_nc.py
+++ b/satpy/tests/reader_tests/test_mimic_TPW2_nc.py
@@ -36,10 +36,10 @@ DEFAULT_FILE_DATA = np.arange(DEFAULT_FILE_SHAPE[0] * DEFAULT_FILE_SHAPE[1],
                               dtype=DEFAULT_FILE_DTYPE).reshape(DEFAULT_FILE_SHAPE)
 
 
-@pytest.fixture(scope="session")
-def mimic_file(session_tmp_path: Path) -> Path:
+@pytest.fixture(scope="module")
+def mimic_file(module_tmp_path: Path) -> Path:
     """Mimic a real data file."""
-    filename = session_tmp_path / "comp20190619.130000.nc"
+    filename = module_tmp_path / "comp20190619.130000.nc"
     dt_s = datetime(2019, 6, 19, 13, 0)
     dt_e = datetime(2019, 6, 19, 13, 0)
 

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -18,6 +18,7 @@
 """Module for testing the satpy.readers.core.netcdf module."""
 
 import os
+from contextlib import closing
 
 import numpy as np
 import pytest
@@ -68,22 +69,30 @@ class FakeNetCDF4FileHandler(NetCDF4FileHandler):
 @pytest.fixture
 def netcdf_file(tmp_path):
     """Create a test NetCDF4 file."""
-    from netCDF4 import Dataset
     filename = tmp_path / "test.nc"
-    with Dataset(filename, "w") as nc:
+    from multiprocessing import Process
+    p = Process(target=_create_netcdf_file, args=(filename, ))
+    p.start()
+    p.join()
+    return filename
+
+
+def _create_netcdf_file(filename):
+    from netCDF4 import Dataset
+    with closing(Dataset(filename, "w")) as nc:
         # Create dimensions
         nc.createDimension("rows", 10)
         nc.createDimension("cols", 100)
 
         # Create Group
         g1 = nc.createGroup("test_group")
-
         # Add datasets
         ds1_f = g1.createVariable("ds1_f", np.float32,
                                   dimensions=("rows", "cols"))
         ds1_f[:] = np.arange(10. * 100).reshape((10, 100))
         ds1_i = g1.createVariable("ds1_i", np.int32,
                                   dimensions=("rows", "cols"))
+        ds1_f.set_auto_scale(True)
         ds1_i[:] = np.arange(10 * 100).reshape((10, 100))
         ds2_f = nc.createVariable("ds2_f", np.float32,
                                   dimensions=("rows", "cols"))
@@ -95,7 +104,7 @@ def netcdf_file(tmp_path):
                                   dimensions=("rows",))
         ds2_s[:] = np.arange(10)
         ds2_sc = nc.createVariable("ds2_sc", np.int8, dimensions=())
-        ds2_sc[:] = 42
+        ds2_sc[:] = np.int8(42)
 
         # Add attributes
         nc.test_attr_str = "test_string"
@@ -230,21 +239,34 @@ class TestNetCDF4FileHandler:
         with pytest.raises(IOError, match=".*(No such file or directory|Unknown file format).*"):
             NetCDF4FileHandler("/thisfiledoesnotexist.nc", {}, {})
 
-    def test_get_and_cache_npxr_is_xr(self, netcdf_file):
+    @pytest.mark.parametrize("engine", ["netcdf4", "h5netcdf"])
+    def test_get_and_cache_npxr_is_xr(self, netcdf_file, engine):
         """Test that get_and_cache_npxr() returns xr.DataArray."""
         import xarray as xr
 
         from satpy.readers.core.netcdf import NetCDF4FileHandler
-        file_handler = NetCDF4FileHandler(netcdf_file, {}, {}, cache_handle=True)
+        file_handler = NetCDF4FileHandler(netcdf_file, {}, {}, cache_handle=True, engine=engine)
 
         data = file_handler.get_and_cache_npxr("test_group/ds1_f")
         assert isinstance(data, xr.DataArray)
 
-    def test_get_and_cache_npxr_data_is_cached(self, netcdf_file):
+    @pytest.mark.parametrize("engine", ["netcdf4", "h5netcdf"])
+    def test_get_and_cache_npxr_for_scalar(self, netcdf_file, engine):
+        """Test that get_and_cache_npxr() returns xr.DataArray."""
+        from satpy.readers.core.netcdf import NetCDF4FileHandler
+        file_handler = NetCDF4FileHandler(netcdf_file, {}, {}, cache_handle=True, engine=engine)
+
+        data = file_handler.get_and_cache_npxr("ds2_sc")
+        # WARN: h5netcdf returns an int64!
+        assert data.dtype in [np.int8, np.int64], "Scalar should be of type int8"
+        assert data == 42
+
+    @pytest.mark.parametrize("engine", ["netcdf4", "h5netcdf"])
+    def test_get_and_cache_npxr_data_is_cached(self, netcdf_file, engine):
         """Test that the data are cached when get_and_cache_npxr() is called."""
         from satpy.readers.core.netcdf import NetCDF4FileHandler
 
-        file_handler = NetCDF4FileHandler(netcdf_file, {}, {}, cache_handle=True)
+        file_handler = NetCDF4FileHandler(netcdf_file, {}, {}, cache_handle=True, engine=engine)
         data = file_handler.get_and_cache_npxr("test_group/ds1_f")
 
         # Delete the dataset from the file content dict, it should be available from the cache

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -18,7 +18,6 @@
 """Module for testing the satpy.readers.core.netcdf module."""
 
 import os
-from contextlib import closing
 
 import numpy as np
 import pytest
@@ -66,12 +65,12 @@ class FakeNetCDF4FileHandler(NetCDF4FileHandler):
         raise NotImplementedError("Fake File Handler subclass must implement 'get_test_content'")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def netcdf_file(tmp_path_factory):
     """Create a test NetCDF4 file."""
     from netCDF4 import Dataset
     filename = tmp_path_factory.mktemp("data") / "test.nc"
-    with closing(Dataset(filename, "w")) as nc:
+    with Dataset(filename, "w") as nc:
         # Create dimensions
         nc.createDimension("rows", 10)
         nc.createDimension("cols", 100)

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -81,10 +81,12 @@ def netcdf_file(tmp_path_factory):
         ds1_f = g1.createVariable("ds1_f", np.float32,
                                   dimensions=("rows", "cols"))
         ds1_f[:] = np.arange(10. * 100).reshape((10, 100))
+        ds1_f.set_auto_scale(True)
+
         ds1_i = g1.createVariable("ds1_i", np.int32,
                                   dimensions=("rows", "cols"))
-        ds1_f.set_auto_scale(True)
         ds1_i[:] = np.arange(10 * 100).reshape((10, 100))
+
         ds2_f = nc.createVariable("ds2_f", np.float32,
                                   dimensions=("rows", "cols"))
         ds2_f[:] = np.arange(10. * 100).reshape((10, 100))

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -66,19 +66,11 @@ class FakeNetCDF4FileHandler(NetCDF4FileHandler):
         raise NotImplementedError("Fake File Handler subclass must implement 'get_test_content'")
 
 
-@pytest.fixture
-def netcdf_file(tmp_path):
+@pytest.fixture(scope="session")
+def netcdf_file(tmp_path_factory):
     """Create a test NetCDF4 file."""
-    filename = tmp_path / "test.nc"
-    from multiprocessing import Process
-    p = Process(target=_create_netcdf_file, args=(filename, ))
-    p.start()
-    p.join()
-    return filename
-
-
-def _create_netcdf_file(filename):
     from netCDF4 import Dataset
+    filename = tmp_path_factory.mktemp("data") / "test.nc"
     with closing(Dataset(filename, "w")) as nc:
         # Create dimensions
         nc.createDimension("rows", 10)

--- a/satpy/tests/reader_tests/test_smos_l2_wind.py
+++ b/satpy/tests/reader_tests/test_smos_l2_wind.py
@@ -135,12 +135,12 @@ class TestSMOSL2WINDReader:
         from satpy.readers.smos_l2_wind import SMOSL2WINDFileHandler
         smos_l2_wind_fh = SMOSL2WINDFileHandler(smos_l2_file,
                                                 {}, filetype_info={"file_type": "smos_l2_wind"})
-        data = DataArray(np.arange(0., 360., 0.25), dims=("lon"))
-        adjusted = smos_l2_wind_fh._adjust_lon_coord(data)
-        expected = DataArray(np.concatenate((np.arange(0, 180., 0.25),
-                                             np.arange(-180.0, 0, 0.25))),
-                             dims=("lon"))
-        assert adjusted.data.tolist() == expected.data.tolist()
+        lon = DataArray(np.arange(0., 360., 0.25), dims=("lon"))
+        data = DataArray(np.empty_like(lon.data), dims=("lon"), coords=dict(lon=lon))
+        adjusted = smos_l2_wind_fh._normalize_lon_coord(data)
+        expected = np.concatenate((np.arange(0, 180., 0.25),
+                                   np.arange(-180.0, 0, 0.25)))
+        assert adjusted.lon.data.tolist() == expected.tolist()
 
     def test_roll_dataset(self, smos_l2_file):
         """Load roll of dataset along the lon coordinate."""
@@ -149,8 +149,9 @@ class TestSMOSL2WINDReader:
         from satpy.readers.smos_l2_wind import SMOSL2WINDFileHandler
         smos_l2_wind_fh = SMOSL2WINDFileHandler(smos_l2_file,
                                                 {}, filetype_info={"file_type": "smos_l2_wind"})
-        data = DataArray(np.arange(0., 360., 0.25), dims=("lon"))
-        data = smos_l2_wind_fh._adjust_lon_coord(data)
+        lon = DataArray(np.arange(0., 360., 0.25), dims=("lon"))
+        data = DataArray(np.empty_like(lon.data), dims=("lon"), coords=dict(lon=lon))
+        data = smos_l2_wind_fh._normalize_lon_coord(data)
         adjusted = smos_l2_wind_fh._roll_dataset_lon_coord(data)
         expected = np.arange(-180., 180., 0.25)
-        assert adjusted.data.tolist() == expected.tolist()
+        assert adjusted.lon.data.tolist() == expected.tolist()

--- a/satpy/tests/reader_tests/test_smos_l2_wind.py
+++ b/satpy/tests/reader_tests/test_smos_l2_wind.py
@@ -26,10 +26,10 @@ import pytest
 import xarray as xr
 
 
-@pytest.fixture(scope="session")
-def smos_l2_file(session_tmp_path):
+@pytest.fixture(scope="module")
+def smos_l2_file(module_tmp_path):
     """Create a real dummy file for testing."""
-    filename = session_tmp_path / "SM_OPER_MIR_SCNFSW_20200420T021649_20200420T035013_110_001_7.nc"
+    filename = module_tmp_path / "SM_OPER_MIR_SCNFSW_20200420T021649_20200420T035013_110_001_7.nc"
     file_content = xr.DataTree()
 
 

--- a/satpy/tests/reader_tests/test_smos_l2_wind.py
+++ b/satpy/tests/reader_tests/test_smos_l2_wind.py
@@ -18,103 +18,75 @@
 # Satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Module for testing the satpy.readers.smos_l2_wind module."""
 
-import datetime as dt
 import os
-import unittest
-from unittest import mock
+from datetime import datetime
 
 import numpy as np
+import pytest
 import xarray as xr
 
-from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
+
+@pytest.fixture(scope="session")
+def smos_l2_file(session_tmp_path):
+    """Create a real dummy file for testing."""
+    filename = session_tmp_path / "SM_OPER_MIR_SCNFSW_20200420T021649_20200420T035013_110_001_7.nc"
+    file_content = xr.DataTree()
 
 
-class FakeNetCDF4FileHandlerSMOSL2WIND(FakeNetCDF4FileHandler):
-    """Swap-in NetCDF4 File Handler."""
+    dt_s = datetime(2020, 4, 22, 12, 0, 0)
+    dt_e = datetime(2020, 4, 22, 12, 0, 0)
 
-    def get_test_content(self, filename, filename_info, filetype_info):
-        """Mimic reader input file content."""
-        from xarray import DataArray
-        dt_s = filename_info.get("start_time", dt.datetime(2020, 4, 22, 12, 0, 0))
-        dt_e = filename_info.get("end_time", dt.datetime(2020, 4, 22, 12, 0, 0))
+    file_content.attrs["time_coverage_start"] = dt_s.strftime("%Y-%m-%dT%H:%M:%S Z")
+    file_content.attrs["time_coverage_end"] = dt_e.strftime("%Y-%m-%dT%H:%M:%S Z")
+    file_content.attrs["platform_shortname"] = "SM"
+    file_content.attrs["platform"] = "SMOS"
+    file_content.attrs["instrument"] = "MIRAS"
+    file_content.attrs["processing_level"] = "L2"
+    file_content.attrs["geospatial_bounds_vertical_crs"] = "EPSG:4623"
 
-        if filetype_info["file_type"] == "smos_l2_wind":
-            file_content = {
-                "/attr/time_coverage_start": dt_s.strftime("%Y-%m-%dT%H:%M:%S Z"),
-                "/attr/time_coverage_end": dt_e.strftime("%Y-%m-%dT%H:%M:%S Z"),
-                "/attr/platform_shortname": "SM",
-                "/attr/platform": "SMOS",
-                "/attr/instrument": "MIRAS",
-                "/attr/processing_level": "L2",
-                "/attr/geospatial_bounds_vertical_crs": "EPSG:4623",
-            }
+    file_content["lat"] = xr.DataArray(np.arange(-90., 90.25, 0.25), dims=("lat"))
+    file_content["lat"].attrs["_FillValue"] = -999.0
 
-            file_content["lat"] = np.arange(-90., 90.25, 0.25)
-            file_content["lat/shape"] = (len(file_content["lat"]),)
-            file_content["lat"] = DataArray(file_content["lat"], dims=("lat"))
-            file_content["lat"].attrs["_FillValue"] = -999.0
+    file_content["lon"] = xr.DataArray(np.arange(0., 360., 0.25), dims=("lon"))
+    file_content["lon"].attrs["_FillValue"] = -999.0
 
-            file_content["lon"] = np.arange(0., 360., 0.25)
-            file_content["lon/shape"] = (len(file_content["lon"]),)
-            file_content["lon"] = DataArray(file_content["lon"], dims=("lon"))
-            file_content["lon"].attrs["_FillValue"] = -999.0
+    file_content["wind_speed"] = xr.DataArray(np.ndarray(shape=(1,  # Time dimension
+                                                         len(file_content["lat"]),
+                                                         len(file_content["lon"]))),
+                                              dims=("time", "lat", "lon"),
+                                              coords=[[1], file_content["lat"], file_content["lon"]])
+    file_content["wind_speed"].attrs["_FillValue"] = -999.0
+    file_content.to_netcdf(filename)
 
-            file_content["wind_speed"] = np.ndarray(shape=(1,  # Time dimension
-                                                           len(file_content["lat"]),
-                                                           len(file_content["lon"])))
-            file_content["wind_speed/shape"] = (1,
-                                                len(file_content["lat"]),
-                                                len(file_content["lon"]))
-            file_content["wind_speed"] = DataArray(file_content["wind_speed"], dims=("time", "lat", "lon"),
-                                                   coords=[[1], file_content["lat"], file_content["lon"]])
-            file_content["wind_speed"].attrs["_FillValue"] = -999.0
-
-        else:
-            raise AssertionError()
-
-        return file_content
+    return filename
 
 
-class TestSMOSL2WINDReader(unittest.TestCase):
+class TestSMOSL2WINDReader:
     """Test SMOS L2 WINDReader."""
 
     yaml_file = "smos_l2_wind.yaml"
 
-    def setUp(self):
+    def setup_method(self):
         """Wrap NetCDF4 file handler with our own fake handler."""
         from satpy._config import config_search_paths
-        from satpy.readers.smos_l2_wind import SMOSL2WINDFileHandler
         self.reader_configs = config_search_paths(os.path.join("readers", self.yaml_file))
-        # http://stackoverflow.com/questions/12219967/how-to-mock-a-base-class-with-python-mock-library
-        self.p = mock.patch.object(SMOSL2WINDFileHandler, "__bases__", (FakeNetCDF4FileHandlerSMOSL2WIND,))
-        self.fake_handler = self.p.start()
-        self.p.is_local = True
 
-    def tearDown(self):
-        """Stop wrapping the NetCDF4 file handler."""
-        self.p.stop()
-
-    def test_init(self):
+    def test_init(self, smos_l2_file):
         """Test basic initialization of this reader."""
         from satpy.readers.core.loading import load_reader
         r = load_reader(self.reader_configs)
-        loadables = r.select_files_from_pathnames([
-            "SM_OPER_MIR_SCNFSW_20200420T021649_20200420T035013_110_001_7.nc",
-        ])
+        loadables = r.select_files_from_pathnames([smos_l2_file])
         assert len(loadables) == 1
         r.create_filehandlers(loadables)
         # make sure we have some files
         assert r.file_handlers
 
-    def test_load_wind_speed(self):
+    def test_load_wind_speed(self, smos_l2_file):
         """Load wind_speed dataset."""
         from satpy.readers.core.loading import load_reader
         r = load_reader(self.reader_configs)
-        with mock.patch("satpy.readers.smos_l2_wind.netCDF4.Variable", xr.DataArray):
-            loadables = r.select_files_from_pathnames([
-                "SM_OPER_MIR_SCNFSW_20200420T021649_20200420T035013_110_001_7.nc",
-            ])
-            r.create_filehandlers(loadables)
+        loadables = r.select_files_from_pathnames([smos_l2_file])
+        r.create_filehandlers(loadables)
         ds = r.load(["wind_speed"])
         assert len(ds) == 1
         for d in ds.values():
@@ -128,15 +100,12 @@ class TestSMOSL2WINDReader(unittest.TestCase):
             assert d.y[0].data == -89.75
             assert d.y[d.shape[0] - 1].data == 89.75
 
-    def test_load_lat(self):
+    def test_load_lat(self, smos_l2_file):
         """Load lat dataset."""
         from satpy.readers.core.loading import load_reader
         r = load_reader(self.reader_configs)
-        with mock.patch("satpy.readers.smos_l2_wind.netCDF4.Variable", xr.DataArray):
-            loadables = r.select_files_from_pathnames([
-                "SM_OPER_MIR_SCNFSW_20200420T021649_20200420T035013_110_001_7.nc",
-            ])
-            r.create_filehandlers(loadables)
+        loadables = r.select_files_from_pathnames([smos_l2_file])
+        r.create_filehandlers(loadables)
         ds = r.load(["lat"])
         assert len(ds) == 1
         for d in ds.values():
@@ -145,15 +114,12 @@ class TestSMOSL2WINDReader(unittest.TestCase):
             assert d.data[0] == -89.75
             assert d.data[d.shape[0] - 1] == 89.75
 
-    def test_load_lon(self):
+    def test_load_lon(self, smos_l2_file):
         """Load lon dataset."""
         from satpy.readers.core.loading import load_reader
         r = load_reader(self.reader_configs)
-        with mock.patch("satpy.readers.smos_l2_wind.netCDF4.Variable", xr.DataArray):
-            loadables = r.select_files_from_pathnames([
-                "SM_OPER_MIR_SCNFSW_20200420T021649_20200420T035013_110_001_7.nc",
-            ])
-            r.create_filehandlers(loadables)
+        loadables = r.select_files_from_pathnames([smos_l2_file])
+        r.create_filehandlers(loadables)
         ds = r.load(["lon"])
         assert len(ds) == 1
         for d in ds.values():
@@ -162,12 +128,12 @@ class TestSMOSL2WINDReader(unittest.TestCase):
             assert d.data[0] == -180.0
             assert d.data[d.shape[0] - 1] == 179.75
 
-    def test_adjust_lon(self):
+    def test_adjust_lon(self, smos_l2_file):
         """Load adjust longitude dataset."""
         from xarray import DataArray
 
         from satpy.readers.smos_l2_wind import SMOSL2WINDFileHandler
-        smos_l2_wind_fh = SMOSL2WINDFileHandler("SM_OPER_MIR_SCNFSW_20200420T021649_20200420T035013_110_001_7.nc",
+        smos_l2_wind_fh = SMOSL2WINDFileHandler(smos_l2_file,
                                                 {}, filetype_info={"file_type": "smos_l2_wind"})
         data = DataArray(np.arange(0., 360., 0.25), dims=("lon"))
         adjusted = smos_l2_wind_fh._adjust_lon_coord(data)
@@ -176,12 +142,12 @@ class TestSMOSL2WINDReader(unittest.TestCase):
                              dims=("lon"))
         assert adjusted.data.tolist() == expected.data.tolist()
 
-    def test_roll_dataset(self):
+    def test_roll_dataset(self, smos_l2_file):
         """Load roll of dataset along the lon coordinate."""
         from xarray import DataArray
 
         from satpy.readers.smos_l2_wind import SMOSL2WINDFileHandler
-        smos_l2_wind_fh = SMOSL2WINDFileHandler("SM_OPER_MIR_SCNFSW_20200420T021649_20200420T035013_110_001_7.nc",
+        smos_l2_wind_fh = SMOSL2WINDFileHandler(smos_l2_file,
                                                 {}, filetype_info={"file_type": "smos_l2_wind"})
         data = DataArray(np.arange(0., 360., 0.25), dims=("lon"))
         data = smos_l2_wind_fh._adjust_lon_coord(data)

--- a/satpy/tests/reader_tests/test_tropomi_l2.py
+++ b/satpy/tests/reader_tests/test_tropomi_l2.py
@@ -63,10 +63,10 @@ def tropomi_base_data() -> xr.DataTree:
     return ds
 
 
-@pytest.fixture(scope="session")
-def tropomi_no2_file(session_tmp_path: Path) -> Path:
+@pytest.fixture(scope="module")
+def tropomi_no2_file(module_tmp_path: Path) -> Path:
     """Create a NO2 tropomi file."""
-    fn = session_tmp_path / "S5P_OFFL_L2__NO2____20180709T170334_20180709T184504_03821_01_010002_20180715T184729.nc"
+    fn = module_tmp_path / "S5P_OFFL_L2__NO2____20180709T170334_20180709T184504_03821_01_010002_20180715T184729.nc"
     ds = tropomi_base_data()
     ds["/PRODUCT/nitrogen_dioxide_total_column"] = xr.DataArray(DEFAULT_FILE_DATA, dims=("scanline", "ground_pixel"))
     ds["/PRODUCT/nitrogen_dioxide_total_column"].attrs["_FillValue"] = -999.0
@@ -75,10 +75,10 @@ def tropomi_no2_file(session_tmp_path: Path) -> Path:
     return fn
 
 
-@pytest.fixture(scope="session")
-def tropomi_so2_file(session_tmp_path: Path) -> Path:
+@pytest.fixture(scope="module")
+def tropomi_so2_file(module_tmp_path: Path) -> Path:
     """Create a SO2 tropomi file."""
-    fn = session_tmp_path / "S5P_OFFL_L2__SO2____20180709T170334_20180709T184504_03821_01_010002_20180715T184729.nc"
+    fn = module_tmp_path / "S5P_OFFL_L2__SO2____20180709T170334_20180709T184504_03821_01_010002_20180715T184729.nc"
     ds = tropomi_base_data()
     ds["/PRODUCT/sulfurdioxide_total_vertical_column"] = xr.DataArray(DEFAULT_FILE_DATA,
                                                                       dims=("scanline", "ground_pixel"))

--- a/satpy/tests/reader_tests/test_tropomi_l2.py
+++ b/satpy/tests/reader_tests/test_tropomi_l2.py
@@ -21,15 +21,14 @@
 
 import datetime as dt
 import os
-import unittest
-from unittest import mock
+from pathlib import Path
+from typing import final
 
 import numpy as np
+import pytest
 import xarray as xr
 
-from satpy.tests.reader_tests.test_netcdf_utils import FakeNetCDF4FileHandler
-
-DEFAULT_FILE_DTYPE = np.uint16
+DEFAULT_FILE_DTYPE = np.int16
 DEFAULT_FILE_SHAPE = (3246, 450)
 DEFAULT_FILE_DATA = np.arange(DEFAULT_FILE_SHAPE[0] * DEFAULT_FILE_SHAPE[1],
                               dtype=DEFAULT_FILE_DTYPE).reshape(DEFAULT_FILE_SHAPE)
@@ -37,106 +36,85 @@ DEFAULT_BOUND_DATA = np.arange(DEFAULT_FILE_SHAPE[0] * DEFAULT_FILE_SHAPE[1] * 4
                                dtype=DEFAULT_FILE_DTYPE).reshape(DEFAULT_FILE_SHAPE+(4,))
 
 
-class FakeNetCDF4FileHandlerTL2(FakeNetCDF4FileHandler):
-    """Swap-in NetCDF4 File Handler."""
+def tropomi_base_data() -> xr.DataTree:
+    """Create the base datatree for tropomi data."""
+    dt_s = dt.datetime(2018, 7, 9, 17, 3, 34)
+    dt_e = dt.datetime(2018, 7, 9, 18, 45, 4)
+    ds = xr.DataTree()
+    ds.attrs["time_coverage_start"] = (dt_s+dt.timedelta(minutes=22)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    ds.attrs["time_coverage_end"] = (dt_e-dt.timedelta(minutes=22)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    ds.attrs["platform_shortname"] = "S5P"
+    ds.attrs["sensor"] = "TROPOMI"
 
-    def get_test_content(self, filename, filename_info, filetype_info):
-        """Mimic reader input file content."""
-        dt_s = filename_info.get("start_time", dt.datetime(2016, 1, 1, 12, 0, 0))
-        dt_e = filename_info.get("end_time", dt.datetime(2016, 1, 1, 12, 0, 0))
+    ds["/PRODUCT/latitude"] = xr.DataArray(DEFAULT_FILE_DATA, dims=("scanline", "ground_pixel"))
+    ds["/PRODUCT/latitude"].attrs["_FillValue"] = -999.0
 
-        if filetype_info["file_type"] == "tropomi_l2":
-            file_content = {
-                "/attr/time_coverage_start": (dt_s+dt.timedelta(minutes=22)).strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "/attr/time_coverage_end": (dt_e-dt.timedelta(minutes=22)).strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "/attr/platform_shortname": "S5P",
-                "/attr/sensor": "TROPOMI",
-            }
+    ds["/PRODUCT/longitude"] = xr.DataArray(DEFAULT_FILE_DATA, dims=("scanline", "ground_pixel"))
+    ds["/PRODUCT/longitude"].attrs["_FillValue"] = -999.0
 
-            file_content["PRODUCT/latitude"] = DEFAULT_FILE_DATA
-            file_content["PRODUCT/longitude"] = DEFAULT_FILE_DATA
-            file_content["PRODUCT/SUPPORT_DATA/GEOLOCATIONS/latitude_bounds"] = DEFAULT_BOUND_DATA
-            file_content["PRODUCT/SUPPORT_DATA/GEOLOCATIONS/longitude_bounds"] = DEFAULT_BOUND_DATA
+    ds["/PRODUCT/SUPPORT_DATA/GEOLOCATIONS/latitude_bounds"] = xr.DataArray(DEFAULT_BOUND_DATA,
+                                                                            dims=("scanline", "ground_pixel", "corner"))
+    ds["/PRODUCT/SUPPORT_DATA/GEOLOCATIONS/latitude_bounds"].attrs["_FillValue"] = -999.0
+    ds["/PRODUCT/SUPPORT_DATA/GEOLOCATIONS/longitude_bounds"] = xr.DataArray(DEFAULT_BOUND_DATA,
+                                                                             dims=("scanline", "ground_pixel",
+                                                                                   "corner"))
+    ds["/PRODUCT/SUPPORT_DATA/GEOLOCATIONS/longitude_bounds"].attrs["_FillValue"] = -999.0
 
-            if "NO2" in filename:
-                file_content["PRODUCT/nitrogen_dioxide_total_column"] = DEFAULT_FILE_DATA
-            if "SO2" in filename:
-                file_content["PRODUCT/sulfurdioxide_total_vertical_column"] = DEFAULT_FILE_DATA
-
-            for k in list(file_content.keys()):
-                if not k.startswith("PRODUCT"):
-                    continue
-                file_content[k + "/shape"] = DEFAULT_FILE_SHAPE
-
-            self._convert_data_content_to_dataarrays(file_content)
-            file_content["PRODUCT/latitude"].attrs["_FillValue"] = -999.0
-            file_content["PRODUCT/longitude"].attrs["_FillValue"] = -999.0
-            file_content["PRODUCT/SUPPORT_DATA/GEOLOCATIONS/latitude_bounds"].attrs["_FillValue"] = -999.0
-            file_content["PRODUCT/SUPPORT_DATA/GEOLOCATIONS/longitude_bounds"].attrs["_FillValue"] = -999.0
-            if "NO2" in filename:
-                file_content["PRODUCT/nitrogen_dioxide_total_column"].attrs["_FillValue"] = -999.0
-            if "SO2" in filename:
-                file_content["PRODUCT/sulfurdioxide_total_vertical_column"].attrs["_FillValue"] = -999.0
-
-        else:
-            raise NotImplementedError("Test data for file types other than "
-                                      "'tropomi_l2' are not supported.")
-
-        return file_content
-
-    def _convert_data_content_to_dataarrays(self, file_content):
-        """Convert data content to xarray's dataarrays."""
-        from xarray import DataArray
-        for key, val in file_content.items():
-            if isinstance(val, np.ndarray):
-                if 1 < val.ndim <= 2:
-                    file_content[key] = DataArray(val, dims=("scanline", "ground_pixel"))
-                elif val.ndim > 2:
-                    file_content[key] = DataArray(val, dims=("scanline", "ground_pixel", "corner"))
-                else:
-                    file_content[key] = DataArray(val)
+    return ds
 
 
-class TestTROPOMIL2Reader(unittest.TestCase):
+@pytest.fixture(scope="session")
+def tropomi_no2_file(session_tmp_path: Path) -> Path:
+    """Create a NO2 tropomi file."""
+    fn = session_tmp_path / "S5P_OFFL_L2__NO2____20180709T170334_20180709T184504_03821_01_010002_20180715T184729.nc"
+    ds = tropomi_base_data()
+    ds["/PRODUCT/nitrogen_dioxide_total_column"] = xr.DataArray(DEFAULT_FILE_DATA, dims=("scanline", "ground_pixel"))
+    ds["/PRODUCT/nitrogen_dioxide_total_column"].attrs["_FillValue"] = -999.0
+
+    ds.to_netcdf(fn)
+    return fn
+
+
+@pytest.fixture(scope="session")
+def tropomi_so2_file(session_tmp_path: Path) -> Path:
+    """Create a SO2 tropomi file."""
+    fn = session_tmp_path / "S5P_OFFL_L2__SO2____20180709T170334_20180709T184504_03821_01_010002_20180715T184729.nc"
+    ds = tropomi_base_data()
+    ds["/PRODUCT/sulfurdioxide_total_vertical_column"] = xr.DataArray(DEFAULT_FILE_DATA,
+                                                                      dims=("scanline", "ground_pixel"))
+    ds["/PRODUCT/sulfurdioxide_total_vertical_column"].attrs["_FillValue"] = -999.0
+
+    ds.to_netcdf(fn)
+    return fn
+
+
+@final
+class TestTROPOMIL2Reader:
     """Test TROPOMI L2 Reader."""
 
     yaml_file = "tropomi_l2.yaml"
 
-    def setUp(self):
-        """Wrap NetCDF4 file handler with our own fake handler."""
+    def setup_method(self):
+        """Fetch reader configs."""
         from satpy._config import config_search_paths
-        from satpy.readers.tropomi_l2 import TROPOMIL2FileHandler
         self.reader_configs = config_search_paths(os.path.join("readers", self.yaml_file))
-        # http://stackoverflow.com/questions/12219967/how-to-mock-a-base-class-with-python-mock-library
-        self.p = mock.patch.object(TROPOMIL2FileHandler, "__bases__", (FakeNetCDF4FileHandlerTL2,))
-        self.fake_handler = self.p.start()
-        self.p.is_local = True
 
-    def tearDown(self):
-        """Stop wrapping the NetCDF4 file handler."""
-        self.p.stop()
-
-    def test_init(self):
+    def test_init(self, tropomi_no2_file):
         """Test basic initialization of this reader."""
         from satpy.readers.core.loading import load_reader
         r = load_reader(self.reader_configs)
-        loadables = r.select_files_from_pathnames([
-            "S5P_OFFL_L2__NO2____20180709T170334_20180709T184504_03821_01_010002_20180715T184729.nc",
-        ])
+        loadables = r.select_files_from_pathnames([tropomi_no2_file])
         assert len(loadables) == 1
         r.create_filehandlers(loadables)
         # make sure we have some files
         assert r.file_handlers
 
-    def test_load_no2(self):
+    def test_load_no2(self, tropomi_no2_file: Path):
         """Load NO2 dataset."""
         from satpy.readers.core.loading import load_reader
         r = load_reader(self.reader_configs)
-        with mock.patch("satpy.readers.tropomi_l2.netCDF4.Variable", xr.DataArray):
-            loadables = r.select_files_from_pathnames([
-                "S5P_OFFL_L2__NO2____20180709T170334_20180709T184504_03821_01_010002_20180715T184729.nc",
-            ])
-            r.create_filehandlers(loadables)
+        loadables = r.select_files_from_pathnames([tropomi_no2_file])
+        r.create_filehandlers(loadables)
         ds = r.load(["nitrogen_dioxide_total_column"])
         assert len(ds) == 1
         for d in ds.values():
@@ -149,15 +127,12 @@ class TestTROPOMIL2Reader(unittest.TestCase):
             assert "y" in d.dims
             assert "x" in d.dims
 
-    def test_load_so2(self):
+    def test_load_so2(self, tropomi_so2_file: Path):
         """Load SO2 dataset."""
         from satpy.readers.core.loading import load_reader
         r = load_reader(self.reader_configs)
-        with mock.patch("satpy.readers.tropomi_l2.netCDF4.Variable", xr.DataArray):
-            loadables = r.select_files_from_pathnames([
-                "S5P_OFFL_L2__SO2____20181224T055107_20181224T073237_06198_01_010105_20181230T150634.nc",
-            ])
-            r.create_filehandlers(loadables)
+        loadables = r.select_files_from_pathnames([tropomi_so2_file])
+        r.create_filehandlers(loadables)
         ds = r.load(["sulfurdioxide_total_vertical_column"])
         assert len(ds) == 1
         for d in ds.values():
@@ -167,15 +142,12 @@ class TestTROPOMIL2Reader(unittest.TestCase):
             assert "y" in d.dims
             assert "x" in d.dims
 
-    def test_load_bounds(self):
+    def test_load_bounds(self, tropomi_no2_file: Path):
         """Load bounds dataset."""
         from satpy.readers.core.loading import load_reader
         r = load_reader(self.reader_configs)
-        with mock.patch("satpy.readers.tropomi_l2.netCDF4.Variable", xr.DataArray):
-            loadables = r.select_files_from_pathnames([
-                "S5P_OFFL_L2__NO2____20180709T170334_20180709T184504_03821_01_010002_20180715T184729.nc",
-            ])
-            r.create_filehandlers(loadables)
+        loadables = r.select_files_from_pathnames([tropomi_no2_file])
+        r.create_filehandlers(loadables)
         keys = ["latitude_bounds", "longitude_bounds"]
         ds = r.load(keys)
         assert len(ds) == 2
@@ -188,9 +160,7 @@ class TestTROPOMIL2Reader(unittest.TestCase):
             left = np.vstack([ds[key][:, :, 0], ds[key][-1:, :, 3]])
             right = np.vstack([ds[key][:, -1:, 1], ds[key][-1:, -1:, 2]])
             dest = np.hstack([left, right])
-            dest = xr.DataArray(dest,
-                                dims=("y", "x")
-                                )
+            dest = xr.DataArray(dest, dims=("y", "x"))
             dest.attrs = ds[key].attrs
             assert dest.attrs["platform_shortname"] == "S5P"
             assert "y" in dest.dims


### PR DESCRIPTION
This PR address caching scalar values in the netcdf util when using h5netcdf >= 1.7.0.
The solution (catching a ValueError on top of the IndexError) was already available, but in a duplicated part of the code that was not used for the caching part.

While setting up the test case corresponding to this issue and adding more h5netcdf engine tests (through simply parametrising existing tests to also use that engine), it became clear that netcdf4 and h5netcdf cannot be imported at the same time in some environments, hence the changes in the netcdf file creation fixture, the removal of netcdf4 as top level import, and the usage of pytest-forked in ci. For information, I am running on my RHEL9 laptop inside a uv environment with python 3.14.

 - [x] Tests added <!-- for all bug fixes or enhancements -->