### PR TITLE
Cleanup up composite utility 'add_bands' function

### DIFF
--- a/satpy/composites/core.py
+++ b/satpy/composites/core.py
@@ -350,7 +350,9 @@ def _check_alpha_band(data: xr.DataArray, bands: Sequence) -> xr.DataArray:
         new_data = [data.sel(bands=band) for band in data["bands"].data]
         # Create alpha band based on a copy of the first "real" band
         alpha = new_data[0].copy()
-        # TODO: This will be all 1s as floats, but this is not accurate for integer data. Right?
+        # WARN: This will be all 1s as floats, but this is not accurate for
+        # integer data. Integer data needing an alpha channel is not currently
+        # supported.
         alpha.data = da.ones(
             (data.sizes["y"], data.sizes["x"]),
             dtype=new_data[0].dtype,

--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -89,26 +89,26 @@ class HistogramDNB(CompositeBase):
         output_dataset.attrs = info
         return output_dataset
 
-    def _run_dnb_normalization(self, dnb_data_np: np.ndarray, sza_data_np: np.ndarray) -> np.ndarray:
+    def _run_dnb_normalization(self, dnb_data: np.ndarray, sza_data: np.ndarray) -> np.ndarray:
         """Scale the DNB data using a histogram equalization method.
 
         Args:
-            dnb_data_np: Day/Night Band data numpy array
-            sza_data_np: Solar Zenith Angle data numpy array
+            dnb_data: Day/Night Band data numpy array
+            sza_data: Solar Zenith Angle data numpy array
 
         """
         # convert dask arrays to DataArray objects
-        dnb_data = xr.DataArray(dnb_data_np, dims=("y", "x"))
-        sza_data = xr.DataArray(sza_data_np, dims=("y", "x"))
+        dnb_data_arr = xr.DataArray(dnb_data, dims=("y", "x"))
+        sza_data_arr = xr.DataArray(sza_data, dims=("y", "x"))
 
-        good_mask = ~(dnb_data.isnull() | sza_data.isnull())
-        output_dataset = dnb_data.where(good_mask)
+        good_mask = ~(dnb_data_arr.isnull() | sza_data_arr.isnull())
+        output_data_arr = dnb_data_arr.where(good_mask)
         # we only need the numpy array
-        output_dataset_np = output_dataset.values.copy()
-        dnb_data_np = dnb_data.values
-        sza_data_np = sza_data.values
-        self._normalize_dnb_for_mask(dnb_data_np, sza_data_np, good_mask, output_dataset_np)
-        return output_dataset_np
+        output_data = output_data_arr.values.copy()
+        dnb_data = dnb_data_arr.values
+        sza_data = sza_data_arr.values
+        self._normalize_dnb_for_mask(dnb_data, sza_data, good_mask, output_data)
+        return output_data
 
     def _normalize_dnb_for_mask(self, dnb_data, sza_data, good_mask, output_dataset):
         day_mask, mixed_mask, night_mask = make_day_night_masks(

--- a/satpy/composites/viirs.py
+++ b/satpy/composites/viirs.py
@@ -89,26 +89,26 @@ class HistogramDNB(CompositeBase):
         output_dataset.attrs = info
         return output_dataset
 
-    def _run_dnb_normalization(self, dnb_data: np.ndarray, sza_data: np.ndarray) -> np.ndarray:
+    def _run_dnb_normalization(self, dnb_data_np: np.ndarray, sza_data_np: np.ndarray) -> np.ndarray:
         """Scale the DNB data using a histogram equalization method.
 
         Args:
-            dnb_data: Day/Night Band data array
-            sza_data: Solar Zenith Angle data array
+            dnb_data_np: Day/Night Band data numpy array
+            sza_data_np: Solar Zenith Angle data numpy array
 
         """
         # convert dask arrays to DataArray objects
-        dnb_data = xr.DataArray(dnb_data, dims=("y", "x"))
-        sza_data = xr.DataArray(sza_data, dims=("y", "x"))
+        dnb_data = xr.DataArray(dnb_data_np, dims=("y", "x"))
+        sza_data = xr.DataArray(sza_data_np, dims=("y", "x"))
 
         good_mask = ~(dnb_data.isnull() | sza_data.isnull())
         output_dataset = dnb_data.where(good_mask)
         # we only need the numpy array
-        output_dataset = output_dataset.values.copy()
-        dnb_data = dnb_data.values
-        sza_data = sza_data.values
-        self._normalize_dnb_for_mask(dnb_data, sza_data, good_mask, output_dataset)
-        return output_dataset
+        output_dataset_np = output_dataset.values.copy()
+        dnb_data_np = dnb_data.values
+        sza_data_np = sza_data.values
+        self._normalize_dnb_for_mask(dnb_data_np, sza_data_np, good_mask, output_dataset_np)
+        return output_dataset_np
 
     def _normalize_dnb_for_mask(self, dnb_data, sza_data, good_mask, output_dataset):
         day_mask, mixed_mask, night_mask = make_day_night_masks(


### PR DESCRIPTION
See the conversation in #3333 (CC @SalimMessaad1). The summary is that the `add_bands` utility function in `satpy.composites.core` is a little confusing to follow. Mostly, it isn't clear due to the lack of documentation what the second argument should be. If we look at the actual uses of it in Satpy the second argument should always be `some_data_arr.coords["bands"]`. However, there was a `bands = bands.compute()` call to work around a dask bug so it kind of seemed like it should be a regular image data `DataArray` that is passed. But I don't think a "bands" coordinate has any reason to ever be a dask array (versus a numpy array) so I'm not sure why this was ever needed. Additionally, all the tests (either added by @mraspaud or @pnuu, or maybe just refactored to the current location :man_shrugging: ) always pass a `DataArray` where the bands information is in the `.data` part, not just the `.coords["bands"]`. This is never the way this function is used in Satpy.

So this PR:

* Adds docstring information
* Adds type annotations
* Allows "bands" (the second argument) to be a Sequenced (ex. list) or a DataArray and describes in the docstring that the DataArray should come from `.coords["bands"]` of an image array.
* Remove the dask workaround of `bands = bands.compute()` as it is from a 2020 bug and never should have been needed(?)
* Tests have been parametrized
* Tests now properly use the `.coords["bands"]` for the bands argument
* Tests enforce no dask computation
* Fix other various mypy issues (mostly satpy.composites.viirs)

Remaining question for (@mraspaud @gerritholl @pnuu):

The tests use 32-bit float input and make sure it remains 32-bit float data. I think this is reasonable as the actual use cases in Satpy are all with pre-enhanced data I think. So everything is normalized to 0-1 floating point numbers except for maybe some edge cases with integers. In the cases where an Alpha band is added it is set to all 1s. Do we want to support the case of integers where alpha is set to max-int for that integer type? Or maybe we just fail for now and handle/update the code when someone has a legitimate use case for that?

 - [x] Closes #3333 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
