### PR TITLE
Fix enhancement paths in fire_temperature_fci_contrast_tuned

### DIFF
--- a/satpy/etc/enhancements/fci.yaml
+++ b/satpy/etc/enhancements/fci.yaml
@@ -40,13 +40,13 @@ enhancements:
       Intra-fire distiction is improved by lowering the maximum tresholds for yellow and white signals.
     operations:
       - name: stretch
-        method: !!python/name:satpy.enhancements.stretch
+        method: !!python/name:satpy.enhancements.contrast.stretch
         kwargs:
           stretch: crude
           min_stretch: [293.15, 0.0, 0.0]
           max_stretch: [333.15, 50.0, 60.0]
       - name: gamma
-        method: !!python/name:satpy.enhancements.gamma
+        method: !!python/name:satpy.enhancements.contrast.gamma
         kwargs:
           gamma: [0.2, 1, 1]
 


### PR DESCRIPTION
A simple fix to the FCI enhancement YAML where the legacy paths were used in one composite definition causing log messages.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
