### PR TITLE
Make sure FCI L2 reader returns cloud type and other categorical data as int

### DIFF
--- a/satpy/readers/fci_l2_nc.py
+++ b/satpy/readers/fci_l2_nc.py
@@ -233,7 +233,7 @@ class FciL2NCFileHandler(FciL2CommonFunctions, BaseFileHandler):
         if dataset_info["file_type"] == "nc_fci_test_clm":
             variable = self._decode_clm_test_data(variable, dataset_info)
 
-        if "fill_value" in dataset_info:
+        if "fill_value" in dataset_info and np.issubdtype(variable.dtype, np.inexact):
             variable = self._mask_data(variable, dataset_info["fill_value"])
 
         variable = self._set_attributes(variable, dataset_info)

--- a/satpy/tests/reader_tests/test_fci_l2_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l2_nc.py
@@ -234,7 +234,6 @@ class TestFciL2NCFileHandler(unittest.TestCase):
         assert attributes["flag_values"] == [0,1]
         assert "flag_meanings" in attributes
         assert attributes["flag_meanings"] == ["False","True"]
-        assert dataset.dtype == np.uint8
 
     def test_enum_with_fill_value_remains_int(self):
         """Test that enum with a fill value (such as cloud type) remains uint8."""
@@ -244,7 +243,7 @@ class TestFciL2NCFileHandler(unittest.TestCase):
                                        "file_type": "test_file_type",
                                        "import_enum_information": True,
                                        "fill_value": -127})
-        assert dataset.dtype == np.int8
+        assert np.issubdtype(dataset.dtype, np.integer)
 
     def test_units_from_file(self):
         """Test units extraction from NetCDF file."""


### PR DESCRIPTION
Make sure that the FCI L2 reader returns categorical data, such as cloud type, cloud phase, cloud mask, pixel quality etc. as an exact dtype, de facto an integer dtype (in the source data those are enum).

This change may break backwards compatibility for users expecting a cloud mask or a cloud type as a float.

 - [x] Closes #3338<!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
