### PR TITLE
Scanline acq time cache

### DIFF
--- a/satpy/readers/seviri_l1b_native.py
+++ b/satpy/readers/seviri_l1b_native.py
@@ -683,23 +683,27 @@ class NativeMSGFileHandler(BaseFileHandler):
         acq_time = get_cds_time(days=tline["Days"], msecs=tline["Milliseconds"])
         add_scanline_acq_time(dataset, acq_time)
 
+    @cached_property
+    def _acq_time_hrv(self):
+        tline = self._dask_array["hrv"]["acq_time"].compute()
+        return tline.reshape(self.mda["hrv_number_of_lines"])
+
+    @cached_property
+    def _acq_time_visir(self):
+        return self._dask_array["visir"]["acq_time"].compute()
+
     def _get_acq_time_hrv(self):
         """Get raw acquisition time for HRV channel."""
-        tline = self._dask_array["hrv"]["acq_time"]
-        tline0 = tline[:, 0]
-        tline1 = tline[:, 1]
-        tline2 = tline[:, 2]
-        return da.stack((tline0, tline1, tline2), axis=1).reshape(
-            self.mda["hrv_number_of_lines"]).compute()
+        return self._acq_time_hrv
 
     def _get_acq_time_visir(self, dataset_id):
         """Get raw acquisition time for VIS/IR channels."""
         # Check if there is only 1 channel in the list as a change
         # is needed in the array assignment, i.e. channel id is not present
         if len(self.mda["channel_list"]) == 1:
-            return self._dask_array["visir"]["acq_time"].compute()
+            return self._acq_time_visir
         i = self.mda["channel_list"].index(dataset_id["name"])
-        return self._dask_array["visir"]["acq_time"][:, i].compute()
+        return self._acq_time_visir[:, i]
 
     def _update_attrs(self, dataset, dataset_info):
         """Update dataset attributes."""

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1007,6 +1007,20 @@ class TestNativeMSGDataset:
         assert file_handler.end_time == dt.datetime(2006, 1, 1, 12, 30, 0)
         assert_attrs_equal(xarr.attrs, expected.attrs, tolerance=1e-4)
 
+    def test_get_acq_time_visir_uses_cached_values(self, file_handler):
+        """Test VISIR acquisition-time reuse from cache."""
+        file_handler._get_acq_time_visir({"name": "VIS006"})
+        assert file_handler._acq_time_visir is not None
+
+        cached = np.empty_like(file_handler._acq_time_visir)
+        cached["Days"] = 42
+        cached["Milliseconds"] = 123456
+        file_handler._acq_time_visir = cached
+
+        tline = file_handler._get_acq_time_visir({"name": "IR_108"})
+        np.testing.assert_array_equal(tline["Days"], np.full(tline.shape, 42))
+        np.testing.assert_array_equal(tline["Milliseconds"], np.full(tline.shape, 123456))
+
     def test_time(self, file_handler):
         """Test start/end nominal/observation time handling."""
         assert dt.datetime(2006, 1, 1, 12, 15, 9, 304888) == file_handler.observation_start_time


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

Related to https://github.com/pytroll/satpy/pull/3343

Turns out a lot of time is spent on per-channel acq_time computations while small cache (+250KB with MSG2-SEVI-MSG15-0100-NA-20130728130917.624000000Z-NA.nat) avoids repeated complexity and boosts performance:

  - Direct VISIR acq-time full pass (11 channels):
      - before: mean 0.6991s
      - after: mean 0.0713s (~9.8x faster)
  - Scene load, 11 VISIR channels, include_scanline_acq_time=True:
      - before: mean 0.8139s
      - after: mean 0.2152s (~73.6% faster)
  - Scene load, 4 channels (VIS006, IR_108, IR_120, HRV), include_scanline_acq_time=True:
      - before: mean 0.3086s
      - after: mean 0.2016s (~34.7% faster)

 - [x] Tests added <!-- for all bug fixes or enhancements -->

