### PR TITLE
Introduce composite tags

### DIFF
--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -495,6 +495,164 @@ image) for both of the static images::
           min_stretch: [0, 0, 0]
           max_stretch: [255, 255, 255]
 
+.. _composite_variants:
+
+Composite variants
+------------------
+
+.. versionadded:: 0.60
+
+Satpy supports defining multiple *variants* of a composite (e.g., one that
+applies WMO-recommended recipe and one that does not).  This feature is controlled by optional
+fields in the composite YAML configuration.
+
+Tagging composite variants
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A composite can carry a list of **tags** that describe which processing variant
+it represents.  Tags are plain strings (e.g., ``wmo``, ``crefl``,
+``nocorr``) and have no special meaning to Satpy beyond being matched during
+compositor lookup.
+
+.. code-block:: yaml
+
+    sensor_name: visir
+
+    composites:
+      true_color_wmo:
+        compositor: !!python/name:satpy.composites.SomeCompositor
+        prerequisites:
+          - name: red
+            modifiers: [rayleigh_corrected_wmo]
+          - name: green
+          - name: blue
+        standard_name: true_color
+        tags: [wmo]
+
+      true_color_crefl:
+        compositor: !!python/name:satpy.composites.SomeCompositor
+        prerequisites:
+          - name: red
+            modifiers: [rayleigh_corrected_crefl]
+          - name: green
+          - name: blue
+        standard_name: true_color
+        tags: [crefl]
+
+      true_color:                          # default, no tags
+        compositor: !!python/name:satpy.composites.SomeCompositor
+        prerequisites:
+          - name: red
+          - name: green
+          - name: blue
+        standard_name: true_color
+
+The ``standard_name`` field acts as the *base name* shared by all variants.
+Tag-based resolution searches for a compositor whose ``standard_name`` matches
+and whose ``tags`` list contains the requested tag.
+
+Loading a tagged variant explicitly
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Append ``:<tag>`` to the composite name when calling :meth:`~satpy.scene.Scene.load`:
+
+.. code-block:: python
+
+    scene.load(["true_color:wmo"])   # loads true_color_wmo
+
+This syntax is interpreted as: "find a compositor with
+``standard_name='true_color'`` that has ``'wmo'`` in its ``tags``".  It never
+performs a plain string match, so ``true_color:wmo`` will not accidentally
+resolve to a compositor named ``true_color`` or ``true_color_wmo``.
+
+Multiple tags can be combined with additional colons.  All listed tags must be
+present on the compositor (AND semantics):
+
+.. code-block:: python
+
+    scene.load(["true_color:wmo:pyspectral"])  # compositor must carry wmo AND pyspectral
+    scene.load(["true_color:wmo"])             # also matches a compositor with tags [wmo, pyspectral]
+
+A single-tag request is a subset match, so requesting ``"true_color:wmo"``
+will find a compositor tagged ``["wmo", "pyspectral"]`` just as readily as one
+tagged ``["wmo"]`` alone.
+
+Session-wide tag preferences
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+You can configure an **ordered** list of preferred tags so that loading an
+unqualified name like ``"true_color"`` automatically selects a tagged variant
+when one is available:
+
+.. code-block:: python
+
+    import satpy
+    with satpy.config.set(preferred_composite_tags=["crefl", "wmo"]):
+        scene.load(["true_color"])   # picks true_color_crefl (crefl listed first)
+
+Resolution order for ``preferred_composite_tags``:
+
+1. Try each tag in the list, in order, looking for a compositor with matching
+   ``standard_name`` and that tag.
+2. If no tagged variant is found, fall back to the normal name-based lookup.
+
+An explicit ``name:tag`` in the load call always overrides the session-wide
+preference for that specific dataset.
+
+The setting can also be provided as an environment variable (comma-separated):
+
+.. code-block:: bash
+
+    export SATPY_PREFERRED_COMPOSITE_TAGS=crefl,wmo
+
+Or as a YAML configuration key:
+
+.. code-block:: yaml
+
+    preferred_composite_tags:
+      - crefl
+      - wmo
+
+Enhancements for tagged variants
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+No extra configuration is needed on the enhancement side.  The enhancement
+decision tree already matches by composite ``name`` (the YAML key) *before*
+it falls back to ``standard_name``.  A composite named ``true_color_wmo`` will
+therefore automatically pick up an enhancement entry keyed ``true_color_wmo``
+if one exists, and fall back to the ``standard_name: true_color`` entry
+otherwise.
+
+Deprecating a composite
+------------------------
+
+To emit a warning when a composite is used, add a ``warnings`` mapping to the
+composite YAML entry.  Each key is a Python warning category name and the
+value is the warning message:
+
+.. code-block:: yaml
+
+    composites:
+      old_true_color:
+        compositor: !!python/name:satpy.composites.SomeCompositor
+        prerequisites:
+          - name: red
+          - name: green
+          - name: blue
+        standard_name: true_color
+        warnings:
+          DeprecationWarning: "old_true_color is deprecated, use true_color_wmo instead."
+
+The warning is emitted only when the compositor is actually *loaded* (i.e.
+when :meth:`~satpy.scene.Scene.load` is called with the deprecated name), not
+during composite discovery calls such as
+:meth:`~satpy.scene.Scene.available_dataset_names`.
+
+Supported warning categories are any that exist in the Python ``builtins``
+module (e.g., ``DeprecationWarning``, ``FutureWarning``,
+``PendingDeprecationWarning``, ``UserWarning``).  If a category name is not
+recognised, ``UserWarning`` is used as a fallback.
+
 .. _enhancing-the-images:
 
 Enhancing the images

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -558,12 +558,39 @@ Append ``:<tag>`` to the composite name when calling :meth:`~satpy.scene.Scene.l
 
 .. code-block:: python
 
-    scene.load(["true_color:wmo"])   # loads true_color_wmo
+    scene.load(["true_color:wmo"])
+
+    # The dataset is stored and accessible using the same tag syntax:
+    data = scene["true_color:wmo"]
 
 This syntax is interpreted as: "find a compositor with
 ``standard_name='true_color'`` that has ``'wmo'`` in its ``tags``".  It never
 performs a plain string match, so ``true_color:wmo`` will not accidentally
 resolve to a compositor named ``true_color`` or ``true_color_wmo``.
+
+Accessing tag-loaded datasets
+""""""""""""""""""""""""""""""
+
+The dataset is stored in the Scene under the *requested* name (including the
+tag suffix) rather than the compositor's internal YAML key.  Use the same
+tag syntax to retrieve it:
+
+.. code-block:: python
+
+    scene.load(["true_color:wmo"])
+    data = scene["true_color:wmo"]
+
+The compositor's YAML key name (e.g. ``"true_color_wmo"``) is preserved in
+``data.attrs["_satpy_compositor_name"]`` and is used automatically for
+enhancement lookups (see below).
+
+This also means that :attr:`~satpy.scene.Scene.missing_datasets` is empty
+after a successful load, and that writing the scene with any writer will use
+``"true_color:wmo"`` as the dataset name.
+
+The same rule applies when a tagged variant is selected automatically via
+``preferred_composite_tags``: the dataset is stored under the plain requested
+name (e.g. ``"true_color"``), not under the compositor's YAML key name.
 
 Multiple tags can be combined with additional colons.  All listed tags must be
 present on the compositor (AND semantics):
@@ -616,12 +643,26 @@ Or as a YAML configuration key:
 Enhancements for tagged variants
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-No extra configuration is needed on the enhancement side.  The enhancement
-decision tree already matches by composite ``name`` (the YAML key) *before*
-it falls back to ``standard_name``.  A composite named ``true_color_wmo`` will
-therefore automatically pick up an enhancement entry keyed ``true_color_wmo``
-if one exists, and fall back to the ``standard_name: true_color`` entry
-otherwise.
+No extra configuration is needed on the enhancement side.  When a dataset is
+loaded via tag syntax, its ``attrs["_satpy_compositor_name"]`` carries the
+compositor's YAML key name (e.g. ``"true_color_wmo"``).  The enhancement
+lookup tries that name first before falling back to the requested name and
+then to ``standard_name``.
+
+This means an enhancement entry written for ``true_color_wmo`` is picked up
+automatically when loading ``"true_color:wmo"``, and enhancements written
+against ``standard_name: true_color`` serve as a fallback for all variants.
+
+.. code-block:: yaml
+
+    # In an enhancement YAML file:
+    true_color_wmo:          # matched via _satpy_compositor_name
+      name: true_color_wmo
+      operations: [...]
+
+    true_color_default:      # fallback for any true_color variant
+      standard_name: true_color
+      operations: [...]
 
 Deprecating a composite
 ------------------------

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -509,25 +509,26 @@ fields in the composite YAML configuration.
 Tagging composite variants
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-A composite can carry a list of **tags** that describe which processing variant
-it represents.  Tags are plain strings (e.g., ``wmo``, ``crefl``,
-``nocorr``) and have no special meaning to Satpy beyond being matched during
-compositor lookup.
+A compositor variant carries a ``name`` and an optional ``tag`` that together
+form its :class:`~satpy.dataset.DataID`.  The YAML section key (e.g.
+``true_color_wmo``) is only used to avoid naming collisions inside the YAML
+file; what matters for loading and Scene access is the ``name`` and ``tag``
+fields.
 
 .. code-block:: yaml
 
     sensor_name: visir
 
     composites:
-      true_color_wmo:
+      true_color_wmo:               # YAML key, unique within this file only
         compositor: !!python/name:satpy.composites.SomeCompositor
         prerequisites:
           - name: red
             modifiers: [rayleigh_corrected_wmo]
           - name: green
           - name: blue
-        standard_name: true_color
-        tags: [wmo]
+        name: true_color            # DataID name, used for loading and Scene access
+        tag: wmo                    # DataID tag, used with the colon syntax
 
       true_color_crefl:
         compositor: !!python/name:satpy.composites.SomeCompositor
@@ -536,20 +537,19 @@ compositor lookup.
             modifiers: [rayleigh_corrected_crefl]
           - name: green
           - name: blue
-        standard_name: true_color
-        tags: [crefl]
+        name: true_color
+        tag: crefl
 
-      true_color:                          # default, no tags
+      true_color:                   # default variant, no tag field
         compositor: !!python/name:satpy.composites.SomeCompositor
         prerequisites:
           - name: red
           - name: green
           - name: blue
-        standard_name: true_color
 
-The ``standard_name`` field acts as the *base name* shared by all variants.
-Tag-based resolution searches for a compositor whose ``standard_name`` matches
-and whose ``tags`` list contains the requested tag.
+If no ``name:`` is given, the YAML section key is used as the ``name``.  All
+three composites above therefore share the same base name ``true_color``; the
+``tag`` field distinguishes the variants.
 
 Loading a tagged variant explicitly
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -560,49 +560,30 @@ Append ``:<tag>`` to the composite name when calling :meth:`~satpy.scene.Scene.l
 
     scene.load(["true_color:wmo"])
 
-    # The dataset is stored and accessible using the same tag syntax:
+    # Access the result with the same tag syntax:
     data = scene["true_color:wmo"]
 
-This syntax is interpreted as: "find a compositor with
-``standard_name='true_color'`` that has ``'wmo'`` in its ``tags``".  It never
-performs a plain string match, so ``true_color:wmo`` will not accidentally
-resolve to a compositor named ``true_color`` or ``true_color_wmo``.
+    # The DataID has separate name and tag fields:
+    assert data.attrs["_satpy_id"]["name"] == "true_color"
+    assert data.attrs["_satpy_id"]["tag"] == "wmo"
 
-Accessing tag-loaded datasets
-""""""""""""""""""""""""""""""
+``"true_color:wmo"`` is syntactic sugar for
+``DataQuery(name="true_color", tag="wmo")``.  It performs a direct DataID
+lookup, so it will never accidentally resolve to a compositor whose YAML section
+key happens to be ``"true_color_wmo"``.
 
-The dataset is stored in the Scene under the *requested* name (including the
-tag suffix) rather than the compositor's internal YAML key.  Use the same
-tag syntax to retrieve it:
+Loading a compositor without a tag (``scene.load(["true_color"])``) finds only
+the variant whose DataID has no tag set.  Tagged variants are not included in
+plain-name lookups unless ``preferred_composite_tags`` is configured (see
+below).
 
-.. code-block:: python
+Dataset name and file output
+"""""""""""""""""""""""""""""
 
-    scene.load(["true_color:wmo"])
-    data = scene["true_color:wmo"]
-
-The compositor's YAML key name (e.g. ``"true_color_wmo"``) is preserved in
-``data.attrs["_satpy_compositor_name"]`` and is used automatically for
-enhancement lookups (see below).
-
-This also means that :attr:`~satpy.scene.Scene.missing_datasets` is empty
-after a successful load, and that writing the scene with any writer will use
-``"true_color:wmo"`` as the dataset name.
-
-The same rule applies when a tagged variant is selected automatically via
-``preferred_composite_tags``: the dataset is stored under the plain requested
-name (e.g. ``"true_color"``), not under the compositor's YAML key name.
-
-Multiple tags can be combined with additional colons.  All listed tags must be
-present on the compositor (AND semantics):
-
-.. code-block:: python
-
-    scene.load(["true_color:wmo:pyspectral"])  # compositor must carry wmo AND pyspectral
-    scene.load(["true_color:wmo"])             # also matches a compositor with tags [wmo, pyspectral]
-
-A single-tag request is a subset match, so requesting ``"true_color:wmo"``
-will find a compositor tagged ``["wmo", "pyspectral"]`` just as readily as one
-tagged ``["wmo"]`` alone.
+The ``tag`` is a separate field in the DataID, not part of the dataset name.
+Writers that use ``{name}`` in their file patterns therefore produce
+``true_color.tif``, not ``true_color:wmo.tif``.  If you need to distinguish
+output files by tag, use a pattern such as ``{name}_{tag}.tif``.
 
 Session-wide tag preferences
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -615,12 +596,13 @@ when one is available:
 
     import satpy
     with satpy.config.set(preferred_composite_tags=["crefl", "wmo"]):
-        scene.load(["true_color"])   # picks true_color_crefl (crefl listed first)
+        scene.load(["true_color"])   # picks the crefl variant (listed first)
+        data = scene["true_color:crefl"]  # stored under name="true_color", tag="crefl"
 
 Resolution order for ``preferred_composite_tags``:
 
 1. Try each tag in the list, in order, looking for a compositor with matching
-   ``standard_name`` and that tag.
+   ``name`` and that ``tag``.
 2. If no tagged variant is found, fall back to the normal name-based lookup.
 
 An explicit ``name:tag`` in the load call always overrides the session-wide
@@ -643,26 +625,27 @@ Or as a YAML configuration key:
 Enhancements for tagged variants
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-No extra configuration is needed on the enhancement side.  When a dataset is
-loaded via tag syntax, its ``attrs["_satpy_compositor_name"]`` carries the
-compositor's YAML key name (e.g. ``"true_color_wmo"``).  The enhancement
-lookup tries that name first before falling back to the requested name and
-then to ``standard_name``.
-
-This means an enhancement entry written for ``true_color_wmo`` is picked up
-automatically when loading ``"true_color:wmo"``, and enhancements written
-against ``standard_name: true_color`` serve as a fallback for all variants.
+Enhancement entries can optionally specify a ``tag`` field to target a specific
+composite variant.  The enhancement tree tries the most specific match first
+(name + tag), then falls back to name-only or standard_name-only entries.
 
 .. code-block:: yaml
 
     # In an enhancement YAML file:
-    true_color_wmo:          # matched via _satpy_compositor_name
-      name: true_color_wmo
-      operations: [...]
+    enhancements:
+      true_color_wmo:
+        name: true_color
+        tag: wmo               # only applied when tag="wmo"
+        operations: [...]      # WMO-specific stretch
 
-    true_color_default:      # fallback for any true_color variant
-      standard_name: true_color
-      operations: [...]
+      true_color_crefl:
+        name: true_color
+        tag: crefl             # only applied when tag="crefl"
+        operations: [...]      # crefl-specific stretch
+
+      true_color_default:
+        name: true_color       # fallback for any tag (or no tag)
+        operations: [...]
 
 Deprecating a composite
 ------------------------

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -500,10 +500,10 @@ image) for both of the static images::
 Composite variants
 ------------------
 
-.. versionadded:: 0.60
+.. versionadded:: 0.61
 
 Satpy supports defining multiple *variants* of a composite (e.g., one that
-applies WMO-recommended recipe and one that does not).  This feature is controlled by optional
+applies the WMO-recommended recipe and one that does not).  This feature is controlled by optional
 fields in the composite YAML configuration.
 
 Tagging composite variants
@@ -575,15 +575,41 @@ key happens to be ``"true_color_wmo"``.
 Loading a compositor without a tag (``scene.load(["true_color"])``) finds only
 the variant whose DataID has no tag set.  Tagged variants are not included in
 plain-name lookups unless ``preferred_composite_tags`` is configured (see
-below).
+below).  If a composite exists *only* in tagged form, loading it by plain name
+raises a ``KeyError`` listing the available tagged variants (e.g.
+``true_color:wmo``).
+
+The explicit ``name:tag`` syntax is therefore the *strict* way to request a
+variant — it either loads exactly that variant or fails — while
+``preferred_composite_tags`` is the *lenient* way: each composite falls back
+to the untagged variant when no preferred tag matches.
+
+Tagged variants can also be used as prerequisites of other composites:
+
+.. code-block:: yaml
+
+    composites:
+      my_overlay:
+        compositor: !!python/name:satpy.composites.SomeCompositor
+        prerequisites:
+          - true_color:wmo        # depends on the wmo variant explicitly
+          - cloud_mask
+
+A plain-name prerequisite (e.g. ``- true_color``) is resolved through
+``preferred_composite_tags`` as well, so a site-wide preference reaches nested
+composites too.
 
 Dataset name and file output
 """""""""""""""""""""""""""""
 
 The ``tag`` is a separate field in the DataID, not part of the dataset name.
 Writers that use ``{name}`` in their file patterns therefore produce
-``true_color.tif``, not ``true_color:wmo.tif``.  If you need to distinguish
-output files by tag, use a pattern such as ``{name}_{tag}.tif``.
+``true_color.tif``, not ``true_color:wmo.tif``.  This is deliberate: switching
+the preferred variant keeps downstream filenames stable.  If you save several
+variants of the same composite side by side, use a pattern such as
+``{name}_{tag}.tif`` — but note that untagged datasets have no ``tag``
+attribute, so such a pattern only works when everything in that save call is
+tagged (save untagged products in a separate call).
 
 Session-wide tag preferences
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -607,6 +633,14 @@ Resolution order for ``preferred_composite_tags``:
 
 An explicit ``name:tag`` in the load call always overrides the session-wide
 preference for that specific dataset.
+
+:meth:`~satpy.scene.Scene.available_composite_names` and
+:meth:`~satpy.scene.Scene.all_composite_names` list one *loadable* spelling per
+composite: the plain name when an untagged variant exists, or the ``name:tag``
+spelling for composites that exist only in tagged form.  Everything these
+methods return can be passed directly to :meth:`~satpy.scene.Scene.load`, and
+scripts that load every available composite keep getting a single product per
+composite name.
 
 The setting can also be provided as an environment variable (comma-separated):
 
@@ -665,7 +699,7 @@ value is the warning message:
           - name: blue
         standard_name: true_color
         warnings:
-          DeprecationWarning: "old_true_color is deprecated, use true_color_wmo instead."
+          DeprecationWarning: "old_true_color is deprecated, use true_color:wmo instead."
 
 The warning is emitted only when the compositor is actually *loaded* (i.e.
 when :meth:`~satpy.scene.Scene.load` is called with the deprecated name), not

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -279,6 +279,46 @@ Clipping of negative radiances is currently implemented for the following reader
 * ``abi_l1b``, ``ami_l1b``, ``fci_l1c_nc``
 
 
+Preferred Composite Tags
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+* **Environment variable**: ``SATPY_PREFERRED_COMPOSITE_TAGS``
+* **YAML/Config Key**: ``preferred_composite_tags``
+* **Default**: ``[]``
+
+Ordered list of composite variant tags that Satpy should prefer when resolving
+an unqualified composite name.  When a user requests a composite such as
+``"true_color"`` and this list is non-empty, Satpy will first search for a
+compositor whose ``standard_name`` matches and whose ``tags`` list contains
+the first tag in the preference list, then the second tag, and so on.  If no
+tagged variant is found the normal name-based lookup is used as a fallback.
+
+For example, to prefer Pyspectral-based variants:
+
+.. code-block:: python
+
+    import satpy
+    satpy.config.set(preferred_composite_tags=["pyspectral"])
+
+Or to prefer CREFL Rayleigh correction over Pyspectral:
+
+.. code-block:: python
+
+    satpy.config.set(preferred_composite_tags=["crefl", "pyspectral"])
+
+An explicit ``name:tag`` syntax in the ``scene.load()`` call always overrides
+this setting for that specific dataset.
+
+When setting this as an environment variable, it should be a comma-separated
+list of tag names, for example:
+
+.. code-block:: bash
+
+    export SATPY_PREFERRED_COMPOSITE_TAGS=crefl,pyspectral
+
+See :ref:`composite_variants` for a full description of
+composite tagging and the ``name:tag`` load syntax.
+
 Temporary Directory
 ^^^^^^^^^^^^^^^^^^^
 

--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -288,10 +288,13 @@ Preferred Composite Tags
 
 Ordered list of composite variant tags that Satpy should prefer when resolving
 an unqualified composite name.  When a user requests a composite such as
-``"true_color"`` and this list is non-empty, Satpy will first search for a
-compositor whose ``standard_name`` matches and whose ``tags`` list contains
-the first tag in the preference list, then the second tag, and so on.  If no
-tagged variant is found the normal name-based lookup is used as a fallback.
+``"true_color"`` and this list is non-empty, Satpy tries each tag in the list,
+in order, looking for a compositor with that ``name`` and ``tag``.  If no
+tagged variant is found the untagged variant is used as a fallback.  The
+resolution is done per composite, so a preference like ``["chmi", "wmo"]``
+picks the ``chmi`` variant where one exists, the ``wmo`` variant otherwise,
+and the untagged composite as a last resort.  The preference also applies when
+resolving a composite's plain-name prerequisites.
 
 For example, to prefer Pyspectral-based variants:
 

--- a/doc/source/dev_guide/satpy_internals.rst
+++ b/doc/source/dev_guide/satpy_internals.rst
@@ -85,6 +85,13 @@ arrays. Under each of this, a few options are available:
  - `transitive`: whether the key is to be passed when looking for dependencies of composites/modifiers.
    Here for example, a composite that has in a given calibration type will pass this calibration
    type requirement to its dependencies.
+ - `match_empty`: whether a ``None`` (absent) value in a ``DataID`` counts as a wildcard when matching
+   against a ``DataQuery``. Defaults to ``True`` (standard wildcard behaviour). When set to ``False``,
+   ``None`` is treated as a concrete "no value" and a ``DataQuery`` that requests a specific value for
+   this key will *not* match a ``DataID`` whose value is ``None``; likewise a ``DataID`` with a set
+   value will not match a query that does not mention the key at all. This is useful for discriminating
+   keys like ``tag``, where ``DataID(name='true_color')`` and ``DataID(name='true_color', tag='wmo')``
+   should be considered distinct datasets rather than one being a less-specific version of the other.
 
 
 If the definition of the metadata keys need to be done in python rather than in a yaml file, it will

--- a/doc/source/enhancements.rst
+++ b/doc/source/enhancements.rst
@@ -93,11 +93,12 @@ that looks at specific metadata keys one at a time. In particular, the current
 implementation depends on the following keys:
 
 1. ``name``
-2. ``reader``
-3. ``platform_name``
-4. ``sensor``
-5. ``standard_name``
-6. ``units``
+2. ``tag``
+3. ``reader``
+4. ``platform_name``
+5. ``sensor``
+6. ``standard_name``
+7. ``units``
 
 For low-level implementation details see the
 :class:`~satpy.enhancements.enhancer.EnhancementDecisionTree` class.
@@ -262,20 +263,18 @@ on trace log messages with:
 You should then see log messages like the following::
 
     TRACE    : Checking 'name' level for 'cloud_type': True
-    TRACE    :   Checking 'reader' level for 'abi_l1b': False
-    TRACE    :   Checking 'reader' level for <wildcard>: False
-    TRACE    : Checking 'name' level for <wildcard>: True
-    TRACE    :   Checking 'reader' level for 'abi_l1b': False
-    TRACE    :   Checking 'reader' level for <wildcard>: True
-    TRACE    :     Checking 'platform_name' level for 'GOES-16': False
-    TRACE    :     Checking 'platform_name' level for <wildcard>: True
-    TRACE    :       Checking 'sensor' level for 'abi': True
-    TRACE    :         Checking 'standard_name' level for 'cloud_type': True
-    TRACE    :           Match key 'units' not in query dict
-    TRACE    :           Checking 'units' level for <wildcard>: True
-    TRACE    :             Found match!
-    TRACE    :             | sensor=abi
-    TRACE    :             | standard_name=cloud_type
+    TRACE    :   Checking 'tag' level for <wildcard>: True
+    TRACE    :     Checking 'reader' level for 'abi_l1b': False
+    TRACE    :     Checking 'reader' level for <wildcard>: True
+    TRACE    :       Checking 'platform_name' level for 'GOES-16': False
+    TRACE    :       Checking 'platform_name' level for <wildcard>: True
+    TRACE    :         Checking 'sensor' level for 'abi': True
+    TRACE    :           Checking 'standard_name' level for 'cloud_type': True
+    TRACE    :             Match key 'units' not in query dict
+    TRACE    :             Checking 'units' level for <wildcard>: True
+    TRACE    :               Found match!
+    TRACE    :               | sensor=abi
+    TRACE    :               | standard_name=cloud_type
 
 Additionally, you can directly load the :class:`~satpy.enhancements.enhancer.Enhancer`
 object used by Satpy and print the entire "tree" and attempt to follow the
@@ -292,36 +291,38 @@ path to match your particular DataArray's metadata:
 This would produce (long) output similar to::
 
     name=<wildcard>
-      reader=<wildcard>
-        platform_name=<wildcard>
-          sensor=<wildcard>
-            standard_name=<wildcard>
-              units=<wildcard>
-                | <global wildcard match>
-            standard_name=toa_bidirectional_reflectance
-              units=<wildcard>
-                | standard_name=toa_bidirectional_reflectance
-            standard_name=surface_bidirectional_reflectance
-              units=<wildcard>
-                | standard_name=surface_bidirectional_reflectance
-            standard_name=true_color
-              units=<wildcard>
-                | standard_name=true_color
-      reader=clavrx
-        platform_name=<wildcard>
-          sensor=<wildcard>
-            standard_name=cloud_mask
-              units=<wildcard>
-                | reader=clavrx
-                | standard_name=cloud_mask
+      tag=<wildcard>
+        reader=<wildcard>
+          platform_name=<wildcard>
+            sensor=<wildcard>
+              standard_name=<wildcard>
+                units=<wildcard>
+                  | <global wildcard match>
+              standard_name=toa_bidirectional_reflectance
+                units=<wildcard>
+                  | standard_name=toa_bidirectional_reflectance
+              standard_name=surface_bidirectional_reflectance
+                units=<wildcard>
+                  | standard_name=surface_bidirectional_reflectance
+              standard_name=true_color
+                units=<wildcard>
+                  | standard_name=true_color
+        reader=clavrx
+          platform_name=<wildcard>
+            sensor=<wildcard>
+              standard_name=cloud_mask
+                units=<wildcard>
+                  | reader=clavrx
+                  | standard_name=cloud_mask
     name=true_color_crefl
-      reader=<wildcard>
-        platform_name=<wildcard>
-          sensor=<wildcard>
-            standard_name=true_color
-              units=<wildcard>
-                | name=true_color_crefl
-                | standard_name=true_color
+      tag=<wildcard>
+        reader=<wildcard>
+          platform_name=<wildcard>
+            sensor=<wildcard>
+              standard_name=true_color
+                units=<wildcard>
+                  | name=true_color_crefl
+                  | standard_name=true_color
 
 Built-in enhancement methods
 ----------------------------

--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -50,6 +50,7 @@ _CONFIG_DEFAULTS = {
     "data_dir": _satpy_dirs.user_data_dir,
     "demo_data_dir": ".",
     "download_aux": True,
+    "preferred_composite_tags": [],
     "sensor_angles_position_preference": "actual",
     "readers": {
         "clip_negative_radiances": False,

--- a/satpy/composites/config_loader.py
+++ b/satpy/composites/config_loader.py
@@ -102,7 +102,7 @@ class _CompositeConfigHelper:
 
     def _load_config_composites(self, configured_composites):
         for composite_name, composite_info in configured_composites.items():
-            composite_info["name"] = composite_name
+            composite_info.setdefault("name", composite_name)
             self._load_config_composite(composite_info)
 
     def parse_config(self, configured_composites, composite_configs):

--- a/satpy/dataset/dataid.py
+++ b/satpy/dataset/dataid.py
@@ -279,7 +279,8 @@ minimal_default_keys_config = {"name": {
                               },
                                "resolution": {
                                    "transitive": True,
-                               }
+                               },
+                              "tag": {"transitive": False, "match_empty": False},
                               }
 
 
@@ -493,6 +494,18 @@ def _generalize_value_for_comparison(val):
     raise NotImplementedError("Don't know how to generalize " + str(type(val)))
 
 
+def parse_dataset_key(key):
+    """Parse a string dataset key into a DataQuery.
+
+    Supports plain names (``"true_color"``) and tag syntax (``"true_color:wmo"``).
+    A colon separates the name from the tag; the tag is a single string.
+    """
+    if ":" in key:
+        name, tag = key.split(":", 1)
+        return DataQuery(name=name, tag=tag)
+    return DataQuery(name=key)
+
+
 class DataQuery:
     """The data query object.
 
@@ -585,11 +598,25 @@ class DataQuery:
         """Match the dataid with the current query."""
         if self._shares_required_keys(dataid):
             keys_to_check = set(dataid.keys()) & set(self._fields)
+            non_empty_keys = self._non_nullable_keys(dataid)
+            # Keys with match_empty=False and a set value in the DataID must be
+            # matched explicitly: if the query doesn't mention such a key, the
+            # DataID is not a match.
+            for key in non_empty_keys:
+                if dataid.get(key) is not None and key not in self._fields:
+                    return False
+            keys_to_check |= non_empty_keys & set(self._fields)
         else:
             keys_to_check = set(dataid._id_keys.keys()) & set(self._fields)
         if not keys_to_check:
             return False
         return all(self._match_query_value(key, dataid.get(key)) for key in keys_to_check)
+
+    @staticmethod
+    def _non_nullable_keys(dataid):
+        """Return keys for which None is not a wildcard (i.e. keys where match_empty is false)."""
+        return {k for k, cfg in dataid._id_keys.items()
+                if isinstance(cfg, dict) and not cfg.get("match_empty", True)}
 
     def _shares_required_keys(self, dataid):
         """Check if dataid shares required keys with the current query."""
@@ -744,7 +771,7 @@ def _create_id_dict_from_any_key(dataset_key):
         ds_dict = dataset_key.to_dict()
     except AttributeError:
         if isinstance(dataset_key, str):
-            ds_dict = {"name": dataset_key}
+            ds_dict = parse_dataset_key(dataset_key).to_dict()
         elif isinstance(dataset_key, numbers.Number):
             ds_dict = {"wavelength": dataset_key}
         else:

--- a/satpy/dependency_tree.py
+++ b/satpy/dependency_tree.py
@@ -550,7 +550,7 @@ class DependencyTree(Tree):
             return preferred
         # Explicit-tag requests fall back to the first candidate; plain-name requests
         # return None so that normal name-based lookup can proceed.
-        return candidates[0] if required_tags else None
+        return candidates[0] if (required_tags and candidates) else None
 
     def _find_tag_candidates(self, standard_name, required_tags):
         """Return compositors whose standard_name matches and that carry all required_tags."""

--- a/satpy/dependency_tree.py
+++ b/satpy/dependency_tree.py
@@ -19,10 +19,13 @@
 
 from __future__ import annotations
 
+import builtins
+import warnings
 from typing import Container, Iterable, Optional
 
 import numpy as np
 
+import satpy
 from satpy import DataID, DatasetDict
 from satpy.dataset import ModifierTuple, create_filtered_query
 from satpy.dataset.data_dict import TooManyResults, get_key
@@ -492,14 +495,80 @@ class DependencyTree(Tree):
         return dep_key.from_dict(orig_dict)
 
     def get_compositor(self, key):
-        """Get a compositor."""
-        for sensor_name in sorted(self.compositors):
-            try:
-                return self.compositors[sensor_name][key]
-            except KeyError:
-                continue
+        """Get a compositor.
 
-        raise KeyError("Could not find compositor '{}'".format(key))
+        Resolves in order:
+        1. Tag-based: explicit ``name:tag`` syntax or ``preferred_composite_tags`` config.
+        2. Normal name-based lookup in the compositor registry.
+
+        If the compositor has a ``warnings`` attribute dict, those warnings are emitted here.
+        """
+        compositor = self._get_compositor_by_tag(key)
+        if compositor is None:
+            for sensor_name in sorted(self.compositors):
+                try:
+                    compositor = self.compositors[sensor_name][key]
+                    break
+                except KeyError:
+                    continue
+
+        if compositor is None:
+            raise KeyError("Could not find compositor '{}'".format(key))
+
+        self._emit_compositor_warnings(compositor)
+        return compositor
+
+    @staticmethod
+    def _emit_compositor_warnings(compositor):
+        for category_name, message in compositor.attrs.get("warnings", {}).items():
+            category = getattr(builtins, category_name, UserWarning)
+            warnings.warn(message, category, stacklevel=4)
+
+    def _get_compositor_by_tag(self, key):
+        """Find a compositor by tag syntax (``'name:tag1:tag2'``) or ``preferred_composite_tags`` config.
+
+        For explicit tag syntax the returned compositor must carry all listed tags; among
+        multiple matches the ``preferred_composite_tags`` config is used as a tiebreaker,
+        falling back to the first candidate in alphabetical sensor order.
+
+        For plain names (no colon) each entry in ``preferred_composite_tags`` is tried in
+        order; ``None`` is returned when none match so that normal name-based lookup can
+        proceed.
+        """
+        try:
+            name = key["name"]
+        except (KeyError, TypeError):
+            return None
+        if not isinstance(name, str):
+            return None
+
+        parts = name.split(":")
+        standard_name, required_tags = parts[0], set(parts[1:])
+        candidates = self._find_tag_candidates(standard_name, required_tags)
+        preferred = self._pick_preferred_candidate(candidates)
+        if preferred is not None:
+            return preferred
+        # Explicit-tag requests fall back to the first candidate; plain-name requests
+        # return None so that normal name-based lookup can proceed.
+        return candidates[0] if required_tags else None
+
+    def _find_tag_candidates(self, standard_name, required_tags):
+        """Return compositors whose standard_name matches and that carry all required_tags."""
+        return [
+            comp
+            for sensor_name in sorted(self.compositors)
+            for comp in self.compositors[sensor_name].values()
+            if comp.attrs.get("standard_name") == standard_name
+            and required_tags.issubset(set(comp.attrs.get("tags", [])))
+        ]
+
+    def _pick_preferred_candidate(self, candidates):
+        """Return the first candidate that matches any preferred_composite_tags entry, in order."""
+        for tag in satpy.config.get("preferred_composite_tags", []):
+            for comp in candidates:
+                if tag in comp.attrs.get("tags", []):
+                    return comp
+        return None
 
     def get_modifier(self, comp_id):
         """Get a modifer."""

--- a/satpy/dependency_tree.py
+++ b/satpy/dependency_tree.py
@@ -446,6 +446,7 @@ class DependencyTree(Tree):
 
         root = CompositorNode(compositor)
         composite_id = root.name
+        root.name = self._composite_id_with_requested_name(composite_id, dataset_key)
 
         prerequisite_filter = composite_id.create_filter_query_without_required_fields(dataset_key)
 
@@ -464,6 +465,25 @@ class DependencyTree(Tree):
         root.add_optional_nodes(optionals)
 
         return root
+
+    @staticmethod
+    def _composite_id_with_requested_name(composite_id, dataset_key):
+        """Return a DataID matching composite_id but with the name taken from dataset_key.
+
+        This ensures the node in the dependency tree (and eventually the entry in
+        scene._datasets) uses the name the caller actually requested, including any
+        tag suffix such as "true_color:high_res", rather than the compositor's
+        own YAML key name.
+        """
+        try:
+            requested_name = dataset_key["name"]
+        except (KeyError, TypeError):
+            return composite_id
+        if not isinstance(requested_name, str) or requested_name == composite_id["name"]:
+            return composite_id
+        new_id_dict = composite_id.to_dict()
+        new_id_dict["name"] = requested_name
+        return composite_id.from_dict(new_id_dict)
 
     def _create_implicit_dependency_subtree(self, dataset_key, query):
         new_prereq = dataset_key.create_less_modified_query()

--- a/satpy/dependency_tree.py
+++ b/satpy/dependency_tree.py
@@ -19,15 +19,12 @@
 
 from __future__ import annotations
 
-import builtins
-import warnings
 from typing import Container, Iterable, Optional
 
 import numpy as np
 
-import satpy
 from satpy import DataID, DatasetDict
-from satpy.dataset import ModifierTuple, create_filtered_query
+from satpy.dataset import DataQuery, ModifierTuple, create_filtered_query
 from satpy.dataset.data_dict import TooManyResults, get_key
 from satpy.node import EMPTY_LEAF_NAME, CompositorNode, MissingDependencies, Node, ReaderNode
 from satpy.utils import get_logger
@@ -446,7 +443,6 @@ class DependencyTree(Tree):
 
         root = CompositorNode(compositor)
         composite_id = root.name
-        root.name = self._composite_id_with_requested_name(composite_id, dataset_key)
 
         prerequisite_filter = composite_id.create_filter_query_without_required_fields(dataset_key)
 
@@ -465,25 +461,6 @@ class DependencyTree(Tree):
         root.add_optional_nodes(optionals)
 
         return root
-
-    @staticmethod
-    def _composite_id_with_requested_name(composite_id, dataset_key):
-        """Return a DataID matching composite_id but with the name taken from dataset_key.
-
-        This ensures the node in the dependency tree (and eventually the entry in
-        scene._datasets) uses the name the caller actually requested, including any
-        tag suffix such as "true_color:high_res", rather than the compositor's
-        own YAML key name.
-        """
-        try:
-            requested_name = dataset_key["name"]
-        except (KeyError, TypeError):
-            return composite_id
-        if not isinstance(requested_name, str) or requested_name == composite_id["name"]:
-            return composite_id
-        new_id_dict = composite_id.to_dict()
-        new_id_dict["name"] = requested_name
-        return composite_id.from_dict(new_id_dict)
 
     def _create_implicit_dependency_subtree(self, dataset_key, query):
         new_prereq = dataset_key.create_less_modified_query()
@@ -518,77 +495,57 @@ class DependencyTree(Tree):
         """Get a compositor.
 
         Resolves in order:
-        1. Tag-based: explicit ``name:tag`` syntax or ``preferred_composite_tags`` config.
-        2. Normal name-based lookup in the compositor registry.
+        1. ``preferred_composite_tags`` config: for plain-name queries, try each preferred tag first.
+        2. Direct DataID matching (handles explicit tag queries and plain untagged lookups).
 
         If the compositor has a ``warnings`` attribute dict, those warnings are emitted here.
         """
-        compositor = self._get_compositor_by_tag(key)
-        if compositor is None:
-            for sensor_name in sorted(self.compositors):
-                try:
-                    compositor = self.compositors[sensor_name][key]
-                    break
-                except KeyError:
-                    continue
+        compositor = self._find_compositor_via_preferred_tags(key)
+        if compositor is not None:
+            return compositor
 
-        if compositor is None:
-            raise KeyError("Could not find compositor '{}'".format(key))
+        for sensor_name in sorted(self.compositors):
+            try:
+                compositor = self.compositors[sensor_name][key]
+                self._emit_compositor_warnings(compositor)
+                return compositor
+            except KeyError:
+                continue
 
-        self._emit_compositor_warnings(compositor)
-        return compositor
+        raise KeyError("Could not find compositor '{}'".format(key))
 
-    @staticmethod
-    def _emit_compositor_warnings(compositor):
-        for category_name, message in compositor.attrs.get("warnings", {}).items():
-            category = getattr(builtins, category_name, UserWarning)
-            warnings.warn(message, category, stacklevel=4)
+    def _find_compositor_via_preferred_tags(self, key):
+        """Try each preferred tag in order and return the first matching compositor.
 
-    def _get_compositor_by_tag(self, key):
-        """Find a compositor by tag syntax (``'name:tag1:tag2'``) or ``preferred_composite_tags`` config.
-
-        For explicit tag syntax the returned compositor must carry all listed tags; among
-        multiple matches the ``preferred_composite_tags`` config is used as a tiebreaker,
-        falling back to the first candidate in alphabetical sensor order.
-
-        For plain names (no colon) each entry in ``preferred_composite_tags`` is tried in
-        order; ``None`` is returned when none match so that normal name-based lookup can
-        proceed.
+        Only applies to plain-name queries (no ``tag`` set).  Returns ``None`` if
+        no preferred-tag variant is found, so the caller can fall through to the
+        normal name-based lookup.
         """
+        import satpy
         try:
             name = key["name"]
         except (KeyError, TypeError):
             return None
-        if not isinstance(name, str):
+        if key.get("tag") is not None:
             return None
-
-        parts = name.split(":")
-        standard_name, required_tags = parts[0], set(parts[1:])
-        candidates = self._find_tag_candidates(standard_name, required_tags)
-        preferred = self._pick_preferred_candidate(candidates)
-        if preferred is not None:
-            return preferred
-        # Explicit-tag requests fall back to the first candidate; plain-name requests
-        # return None so that normal name-based lookup can proceed.
-        return candidates[0] if (required_tags and candidates) else None
-
-    def _find_tag_candidates(self, standard_name, required_tags):
-        """Return compositors whose standard_name matches and that carry all required_tags."""
-        return [
-            comp
-            for sensor_name in sorted(self.compositors)
-            for comp in self.compositors[sensor_name].values()
-            if comp.attrs.get("standard_name") == standard_name
-            and required_tags.issubset(set(comp.attrs.get("tags", [])))
-        ]
-
-    def _pick_preferred_candidate(self, candidates):
-        """Return the first candidate that matches any preferred_composite_tags entry, in order."""
         for tag in satpy.config.get("preferred_composite_tags", []):
-            for comp in candidates:
-                if tag in comp.attrs.get("tags", []):
-                    return comp
+            tagged_query = DataQuery(name=name, tag=tag)
+            for sensor_name in sorted(self.compositors):
+                try:
+                    compositor = self.compositors[sensor_name][tagged_query]
+                    self._emit_compositor_warnings(compositor)
+                    return compositor
+                except KeyError:
+                    continue
         return None
+
+    @staticmethod
+    def _emit_compositor_warnings(compositor):
+        import builtins
+        import warnings
+        for category_name, message in compositor.attrs.get("warnings", {}).items():
+            category = getattr(builtins, category_name, UserWarning)
+            warnings.warn(message, category, stacklevel=4)
 
     def get_modifier(self, comp_id):
         """Get a modifer."""

--- a/satpy/dependency_tree.py
+++ b/satpy/dependency_tree.py
@@ -512,7 +512,34 @@ class DependencyTree(Tree):
             except KeyError:
                 continue
 
-        raise KeyError("Could not find compositor '{}'".format(key))
+        raise KeyError(self._compositor_not_found_message(key))
+
+    def _compositor_not_found_message(self, key):
+        """Build the error message for a failed compositor lookup, listing tagged variants if any exist."""
+        message = "Could not find compositor '{}'".format(key)
+        tagged_variants = self._matching_tagged_variants(key)
+        if tagged_variants:
+            message += ". Tagged variants are available: {}".format(", ".join(tagged_variants))
+        return message
+
+    @staticmethod
+    def _query_name(key):
+        """Return the query's name, or None if the key has no name field."""
+        try:
+            return key["name"]
+        except (KeyError, TypeError):
+            return None
+
+    def _matching_tagged_variants(self, key):
+        """List the 'name:tag' spellings of tagged compositors whose name matches the given query."""
+        name = self._query_name(key)
+        if name is None:
+            return []
+        variants = {"{}:{}".format(cid["name"], cid["tag"])
+                    for sensor_compositors in self.compositors.values()
+                    for cid in sensor_compositors
+                    if cid.get("name") == name and cid.get("tag") is not None}
+        return sorted(variants)
 
     def _find_compositor_via_preferred_tags(self, key):
         """Try each preferred tag in order and return the first matching compositor.
@@ -522,11 +549,8 @@ class DependencyTree(Tree):
         normal name-based lookup.
         """
         import satpy
-        try:
-            name = key["name"]
-        except (KeyError, TypeError):
-            return None
-        if key.get("tag") is not None:
+        name = self._query_name(key)
+        if name is None or key.get("tag") is not None:
             return None
         for tag in satpy.config.get("preferred_composite_tags", []):
             tagged_query = DataQuery(name=name, tag=tag)

--- a/satpy/enhancements/enhancer.py
+++ b/satpy/enhancements/enhancer.py
@@ -84,11 +84,23 @@ class EnhancementDecisionTree(DecisionTree):
         return enhancement_section
 
     def find_match(self, **query_dict):
-        """Find a match."""
+        """Find a match, preferring the YAML compositor key name when available.
+
+        When a dataset was loaded via tag syntax (e.g. ``"true_color:wmo"``), its
+        ``_satpy_compositor_name`` attribute carries the YAML key name of the compositor
+        that generated it (e.g. ``"true_color_wmo"``).  Enhancement entries are written
+        against YAML key names, so we try a lookup with that name first before falling
+        back to the requested name stored in ``name``.
+        """
+        compositor_name = query_dict.get("_satpy_compositor_name")
+        if compositor_name:
+            try:
+                return super().find_match(**{**query_dict, "name": compositor_name})
+            except KeyError:
+                pass
         try:
-            return super(EnhancementDecisionTree, self).find_match(**query_dict)
+            return super().find_match(**query_dict)
         except KeyError:
-            # give a more understandable error message
             raise KeyError("No enhancement configuration found for %s" %
                            (query_dict.get("uid", None),))
 

--- a/satpy/enhancements/enhancer.py
+++ b/satpy/enhancements/enhancer.py
@@ -84,23 +84,11 @@ class EnhancementDecisionTree(DecisionTree):
         return enhancement_section
 
     def find_match(self, **query_dict):
-        """Find a match, preferring the YAML compositor key name when available.
-
-        When a dataset was loaded via tag syntax (e.g. ``"true_color:wmo"``), its
-        ``_satpy_compositor_name`` attribute carries the YAML key name of the compositor
-        that generated it (e.g. ``"true_color_wmo"``).  Enhancement entries are written
-        against YAML key names, so we try a lookup with that name first before falling
-        back to the requested name stored in ``name``.
-        """
-        compositor_name = query_dict.get("_satpy_compositor_name")
-        if compositor_name:
-            try:
-                return super().find_match(**{**query_dict, "name": compositor_name})
-            except KeyError:
-                pass
+        """Find a match."""
         try:
-            return super().find_match(**query_dict)
+            return super(EnhancementDecisionTree, self).find_match(**query_dict)
         except KeyError:
+            # give a more understandable error message
             raise KeyError("No enhancement configuration found for %s" %
                            (query_dict.get("uid", None),))
 

--- a/satpy/enhancements/enhancer.py
+++ b/satpy/enhancements/enhancer.py
@@ -36,6 +36,7 @@ class EnhancementDecisionTree(DecisionTree):
         """Init the decision tree."""
         match_keys = kwargs.pop("match_keys",
                                 ("name",
+                                 "tag",
                                  "reader",
                                  "platform_name",
                                  "sensor",

--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -4,6 +4,9 @@ composite_identification_keys:
     required: true
   resolution:
     transitive: false
+  tag:
+    transitive: false
+    match_empty: false
 
 modifiers:
   sunz_corrected:

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1631,6 +1631,7 @@ class Scene:
                                    optional_datasets=optional_datasets,
                                    **comp_node.name.to_dict())
             cid = DataID.new_id_from_dataarray(composite)
+            cid = self._apply_requested_name(comp_node.name, composite, cid)
             self._datasets[cid] = composite
 
             # update the node with the computed DataID
@@ -1648,6 +1649,25 @@ class Scene:
             # might be needed in other compositors
             keepables.add(comp_node.name)
             return
+
+    @staticmethod
+    def _apply_requested_name(requested_id, composite, cid):
+        """Rename the composite DataArray to the requested name when the compositor overwrote it.
+
+        Compositors write their YAML key name into the output DataArray's ``name`` attr,
+        overwriting the name that was passed in via ``**comp_node.name.to_dict()``.  When this
+        happens we restore the requested name (which may include a tag suffix such as
+        ``"true_color:high_res"``) and preserve the YAML key name in
+        ``attrs["_satpy_compositor_name"]`` so that enhancement lookups can still match entries
+        written for the YAML key.
+        """
+        requested_name = requested_id.get("name")
+        yaml_name = cid.get("name")
+        if requested_name is None or requested_name == yaml_name:
+            return cid
+        composite.attrs["_satpy_compositor_name"] = yaml_name
+        composite.attrs["name"] = requested_name
+        return DataID.new_id_from_dataarray(composite)
 
     def _get_prereq_datasets(self, comp_id, prereq_nodes, keepables, skip=False):
         """Get a composite's prerequisites, generating them if needed.

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -1631,7 +1631,6 @@ class Scene:
                                    optional_datasets=optional_datasets,
                                    **comp_node.name.to_dict())
             cid = DataID.new_id_from_dataarray(composite)
-            cid = self._apply_requested_name(comp_node.name, composite, cid)
             self._datasets[cid] = composite
 
             # update the node with the computed DataID
@@ -1649,25 +1648,6 @@ class Scene:
             # might be needed in other compositors
             keepables.add(comp_node.name)
             return
-
-    @staticmethod
-    def _apply_requested_name(requested_id, composite, cid):
-        """Rename the composite DataArray to the requested name when the compositor overwrote it.
-
-        Compositors write their YAML key name into the output DataArray's ``name`` attr,
-        overwriting the name that was passed in via ``**comp_node.name.to_dict()``.  When this
-        happens we restore the requested name (which may include a tag suffix such as
-        ``"true_color:high_res"``) and preserve the YAML key name in
-        ``attrs["_satpy_compositor_name"]`` so that enhancement lookups can still match entries
-        written for the YAML key.
-        """
-        requested_name = requested_id.get("name")
-        yaml_name = cid.get("name")
-        if requested_name is None or requested_name == yaml_name:
-            return cid
-        composite.attrs["_satpy_compositor_name"] = yaml_name
-        composite.attrs["name"] = requested_name
-        return DataID.new_id_from_dataarray(composite)
 
     def _get_prereq_datasets(self, comp_id, prereq_nodes, keepables, skip=False):
         """Get a composite's prerequisites, generating them if needed.

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -66,6 +66,14 @@ class DelayedGeneration(KeyError):
     pass
 
 
+def _loadable_composite_names(composite_ids):
+    """List one loadable spelling per composite: the plain name, or ``name:tag`` for tagged-only ones."""
+    untagged_names = {x["name"] for x in composite_ids if x.get("tag") is None}
+    tagged_only_spellings = {f"{x['name']}:{x['tag']}" for x in composite_ids
+                             if x.get("tag") is not None and x["name"] not in untagged_names}
+    return sorted(untagged_names | tagged_only_spellings)
+
+
 class Scene:
     """The Almighty Scene Class.
 
@@ -528,16 +536,24 @@ class Scene:
         return self._check_known_composites(available_only=True)
 
     def available_composite_names(self):
-        """Names of all configured composites known to this Scene."""
-        return sorted(set(x["name"] for x in self.available_composite_ids()))
+        """Names of all configured composites known to this Scene, one loadable spelling each.
+
+        Composites with an untagged variant are listed once by their plain name; composites
+        that exist only in tagged form are listed by their loadable ``name:tag`` spelling.
+        """
+        return _loadable_composite_names(self.available_composite_ids())
 
     def all_composite_ids(self):
         """Get all IDs for configured composites."""
         return self._check_known_composites()
 
     def all_composite_names(self):
-        """Get all names for all configured composites."""
-        return sorted(set(x["name"] for x in self.all_composite_ids()))
+        """Get all names for all configured composites, one loadable spelling each.
+
+        Composites with an untagged variant are listed once by their plain name; composites
+        that exist only in tagged form are listed by their loadable ``name:tag`` spelling.
+        """
+        return _loadable_composite_names(self.all_composite_ids())
 
     def all_modifier_names(self):
         """Get names of configured modifier objects."""

--- a/satpy/tests/compositor_tests/test_config_loader.py
+++ b/satpy/tests/compositor_tests/test_config_loader.py
@@ -56,3 +56,75 @@ def _create_fake_composite_config(yaml_filename: str):
         },
             comp_file,
         )
+
+
+def test_composite_warning_is_emitted_on_compositor_use(tmp_path):
+    """Test that composite 'warnings' fires when the compositor is fetched, not when configs are loaded."""
+    import pytest
+
+    from satpy.composites.config_loader import load_compositor_configs_for_sensors
+    from satpy.dataset import DataQuery
+    from satpy.dependency_tree import DependencyTree
+
+    comp_dir = tmp_path / "composites"
+    comp_dir.mkdir()
+    _create_fake_composite_config_with_warnings(comp_dir / "fake_sensor.yaml")
+
+    with satpy.config.set(config_path=[tmp_path]):
+        comps, _ = load_compositor_configs_for_sensors(["fake_sensor"])   # no warning here
+
+    tree = DependencyTree({}, comps, {})
+    with pytest.warns(DeprecationWarning, match="Use new_composite instead"):
+        tree.get_compositor(DataQuery(name="old_composite"))
+
+
+def _create_fake_composite_config_with_warnings(yaml_filename):
+    import yaml
+
+    from satpy.composites.aux_data import StaticImageCompositor
+
+    with open(yaml_filename, "w") as comp_file:
+        yaml.dump({
+            "sensor_name": "fake_sensor",
+            "composites": {
+                "old_composite": {
+                    "compositor": StaticImageCompositor,
+                    "url": "http://example.com/image.png",
+                    "warnings": {"DeprecationWarning": "Use new_composite instead"},
+                },
+            },
+        }, comp_file)
+
+
+def test_composite_tags_stored_on_compositor(tmp_path):
+    """Test that a composite with 'tags' in its YAML has those tags stored in its attrs."""
+    from satpy.composites.config_loader import load_compositor_configs_for_sensors
+
+    comp_dir = tmp_path / "composites"
+    comp_dir.mkdir()
+    comp_yaml = comp_dir / "fake_sensor.yaml"
+    _create_fake_composite_config_with_tags(comp_yaml, tags=["wmo"])
+
+    with satpy.config.set(config_path=[tmp_path]):
+        comps, _ = load_compositor_configs_for_sensors(["fake_sensor"])
+
+    compositor = next(iter(comps["fake_sensor"].values()))
+    assert compositor.attrs.get("tags") == ["wmo"]
+
+
+def _create_fake_composite_config_with_tags(yaml_filename, tags):
+    import yaml
+
+    from satpy.composites.aux_data import StaticImageCompositor
+
+    with open(yaml_filename, "w") as comp_file:
+        yaml.dump({
+            "sensor_name": "fake_sensor",
+            "composites": {
+                "tagged_composite": {
+                    "compositor": StaticImageCompositor,
+                    "url": "http://example.com/image.png",
+                    "tags": tags,
+                },
+            },
+        }, comp_file)

--- a/satpy/tests/compositor_tests/test_config_loader.py
+++ b/satpy/tests/compositor_tests/test_config_loader.py
@@ -128,3 +128,38 @@ def _create_fake_composite_config_with_tags(yaml_filename, tags):
                 },
             },
         }, comp_file)
+
+
+def test_compositor_keyed_by_name_and_tag_when_yaml_has_tag_field(tmp_path):
+    """When a compositor YAML has explicit 'name' and 'tag' fields, its DataID key uses those."""
+    from satpy.composites.config_loader import load_compositor_configs_for_sensors
+
+    comp_dir = tmp_path / "composites"
+    comp_dir.mkdir()
+    _create_composite_config_with_name_and_tag(comp_dir / "fake_sensor.yaml")
+
+    with satpy.config.set(config_path=[tmp_path]):
+        comps, _ = load_compositor_configs_for_sensors(["fake_sensor"])
+
+    key = next(iter(comps["fake_sensor"]))
+    assert key["name"] == "true_color"
+    assert key["tag"] == "wmo"
+
+
+def _create_composite_config_with_name_and_tag(yaml_filename):
+    import yaml
+
+    from satpy.composites.aux_data import StaticImageCompositor
+
+    with open(yaml_filename, "w") as comp_file:
+        yaml.dump({
+            "sensor_name": "fake_sensor",
+            "composites": {
+                "true_color_wmo": {
+                    "compositor": StaticImageCompositor,
+                    "name": "true_color",
+                    "tag": "wmo",
+                    "url": "http://example.com/image.png",
+                },
+            },
+        }, comp_file)

--- a/satpy/tests/enhancement_tests/test_enhancer.py
+++ b/satpy/tests/enhancement_tests/test_enhancer.py
@@ -479,3 +479,39 @@ enhancements:
         img = self._get_enhanced_image(data_arr, test_configs_path)
         # no reader available, should use default no specified reader
         np.testing.assert_allclose(img.data.values[0], data_arr.data / 50.0)
+
+
+class TestCompositorNameEnhancementLookup:
+    """Test that _satpy_compositor_name is used to find enhancement entries keyed by the YAML compositor name."""
+
+    YAML_KEY_NAME = "true_color_wmo"
+    REQUESTED_NAME = "true_color:wmo"
+
+    @pytest.fixture
+    def enh_tree(self):
+        """Build an EnhancementDecisionTree with an entry keyed by the YAML compositor name only.
+
+        When passing a dict directly, the 'enhancements' wrapper is NOT stripped (unlike YAML files),
+        so entries must be at the top level.
+        """
+        from satpy.enhancements.enhancer import EnhancementDecisionTree
+        config = {
+            self.YAML_KEY_NAME: {
+                "name": self.YAML_KEY_NAME,
+                "operations": [{"method": lambda img: None, "args": [], "kwargs": {}}],
+            },
+        }
+        return EnhancementDecisionTree(config)
+
+    def test_requested_name_alone_does_not_match_yaml_key_entry(self, enh_tree):
+        """Check that requested tag-syntax name alone cannot match a YAML-key-name enhancement entry."""
+        with pytest.raises(KeyError):
+            enh_tree.find_match(name=self.REQUESTED_NAME)
+
+    def test_find_match_via_compositor_name(self, enh_tree):
+        """Check that enhancement entry for YAML key is found when _satpy_compositor_name is set on the dataset."""
+        result = enh_tree.find_match(
+            name=self.REQUESTED_NAME,
+            _satpy_compositor_name=self.YAML_KEY_NAME,
+        )
+        assert result is not None

--- a/satpy/tests/enhancement_tests/test_enhancer.py
+++ b/satpy/tests/enhancement_tests/test_enhancer.py
@@ -67,8 +67,8 @@ class TestEnhancer:
         lines = stdout.splitlines()
         assert lines[0].startswith("name=<wildcard>")
         # make sure lines are indented
-        assert lines[1].startswith("  reader=")
-        assert lines[2].startswith("    platform_name=")
+        assert lines[1].startswith("  tag=")
+        assert lines[2].startswith("    reader=")
 
 
 def test_xrimage_1d():
@@ -479,3 +479,38 @@ enhancements:
         img = self._get_enhanced_image(data_arr, test_configs_path)
         # no reader available, should use default no specified reader
         np.testing.assert_allclose(img.data.values[0], data_arr.data / 50.0)
+
+
+class TestTagEnhancementLookup:
+    """Test that enhancement entries can be differentiated by tag."""
+
+    def test_tag_specific_enhancement_is_selected(self):
+        """Enhancement entry with matching tag is preferred over generic name entry."""
+        from satpy.enhancements.enhancer import EnhancementDecisionTree
+
+        config = {
+            "true_color_wmo": {
+                "name": "true_color",
+                "tag": "wmo",
+                "operations": [{"method": lambda img: img.crude_stretch(0, 50)}],
+            },
+            "true_color_crefl": {
+                "name": "true_color",
+                "tag": "crefl",
+                "operations": [{"method": lambda img: img.crude_stretch(0, 200)}],
+            },
+            "true_color_generic": {
+                "name": "true_color",
+                "operations": [{"method": lambda img: img.crude_stretch(0, 100)}],
+            },
+        }
+
+        tree = EnhancementDecisionTree(config)
+
+        wmo_match = tree.find_match(name="true_color", tag="wmo")
+        crefl_match = tree.find_match(name="true_color", tag="crefl")
+        generic_match = tree.find_match(name="true_color")
+
+        assert wmo_match is not crefl_match
+        assert wmo_match is not generic_match
+        assert crefl_match is not generic_match

--- a/satpy/tests/enhancement_tests/test_enhancer.py
+++ b/satpy/tests/enhancement_tests/test_enhancer.py
@@ -479,39 +479,3 @@ enhancements:
         img = self._get_enhanced_image(data_arr, test_configs_path)
         # no reader available, should use default no specified reader
         np.testing.assert_allclose(img.data.values[0], data_arr.data / 50.0)
-
-
-class TestCompositorNameEnhancementLookup:
-    """Test that _satpy_compositor_name is used to find enhancement entries keyed by the YAML compositor name."""
-
-    YAML_KEY_NAME = "true_color_wmo"
-    REQUESTED_NAME = "true_color:wmo"
-
-    @pytest.fixture
-    def enh_tree(self):
-        """Build an EnhancementDecisionTree with an entry keyed by the YAML compositor name only.
-
-        When passing a dict directly, the 'enhancements' wrapper is NOT stripped (unlike YAML files),
-        so entries must be at the top level.
-        """
-        from satpy.enhancements.enhancer import EnhancementDecisionTree
-        config = {
-            self.YAML_KEY_NAME: {
-                "name": self.YAML_KEY_NAME,
-                "operations": [{"method": lambda img: None, "args": [], "kwargs": {}}],
-            },
-        }
-        return EnhancementDecisionTree(config)
-
-    def test_requested_name_alone_does_not_match_yaml_key_entry(self, enh_tree):
-        """Check that requested tag-syntax name alone cannot match a YAML-key-name enhancement entry."""
-        with pytest.raises(KeyError):
-            enh_tree.find_match(name=self.REQUESTED_NAME)
-
-    def test_find_match_via_compositor_name(self, enh_tree):
-        """Check that enhancement entry for YAML key is found when _satpy_compositor_name is set on the dataset."""
-        result = enh_tree.find_match(
-            name=self.REQUESTED_NAME,
-            _satpy_compositor_name=self.YAML_KEY_NAME,
-        )
-        assert result is not None

--- a/satpy/tests/etc/composites/fake_sensor.yaml
+++ b/satpy/tests/etc/composites/fake_sensor.yaml
@@ -62,6 +62,12 @@ composites:
     compositor: !!python/name:satpy.tests.utils.FakeCompositor
     prerequisites:
       - ds1
+  comp1_wmo:
+    compositor: !!python/name:satpy.tests.utils.FakeCompositor
+    prerequisites:
+      - ds1
+    standard_name: comp1
+    tags: [wmo]
   comp2:
     compositor: !!python/name:satpy.tests.utils.FakeCompositor
     prerequisites:

--- a/satpy/tests/etc/composites/fake_sensor.yaml
+++ b/satpy/tests/etc/composites/fake_sensor.yaml
@@ -66,8 +66,8 @@ composites:
     compositor: !!python/name:satpy.tests.utils.FakeCompositor
     prerequisites:
       - ds1
-    standard_name: comp1
-    tags: [wmo]
+    name: comp1
+    tag: wmo
   comp2:
     compositor: !!python/name:satpy.tests.utils.FakeCompositor
     prerequisites:

--- a/satpy/tests/etc/composites/fake_sensor.yaml
+++ b/satpy/tests/etc/composites/fake_sensor.yaml
@@ -68,6 +68,16 @@ composites:
       - ds1
     name: comp1
     tag: wmo
+  comp_tagged_only_wmo:
+    compositor: !!python/name:satpy.tests.utils.FakeCompositor
+    prerequisites:
+      - ds1
+    name: comp_tagged_only
+    tag: wmo
+  comp_uses_tagged:
+    compositor: !!python/name:satpy.tests.utils.FakeCompositor
+    prerequisites:
+      - comp1:wmo
   comp2:
     compositor: !!python/name:satpy.tests.utils.FakeCompositor
     prerequisites:

--- a/satpy/tests/scene_tests/test_load.py
+++ b/satpy/tests/scene_tests/test_load.py
@@ -84,7 +84,7 @@ class TestSceneAllAvailableDatasets:
         num_reader_ds = 21 + 6
         assert len(id_list) == num_reader_ds
         id_list = scene.all_dataset_ids(composites=True)
-        assert len(id_list) == num_reader_ds + 33
+        assert len(id_list) == num_reader_ds + 34
 
     def test_all_datasets_multiple_reader(self):
         """Test all datasets for multiple readers."""
@@ -94,8 +94,8 @@ class TestSceneAllAvailableDatasets:
         assert len(id_list) == 2
         id_list = scene.all_dataset_ids(composites=True)
         # ds1 and ds2 => 2
-        # composites that use these two datasets => 11
-        assert len(id_list) == 2 + 11
+        # composites that use these two datasets => 12
+        assert len(id_list) == 2 + 12
 
     def test_available_datasets_one_reader(self):
         """Test the available datasets for one reader."""
@@ -104,8 +104,8 @@ class TestSceneAllAvailableDatasets:
         id_list = scene.available_dataset_ids()
         assert len(id_list) == 1
         id_list = scene.available_dataset_ids(composites=True)
-        # ds1, comp1, comp14, comp16, static_image, comp26
-        assert len(id_list) == 6
+        # ds1, comp1, comp1_wmo, comp14, comp16, static_image, comp26
+        assert len(id_list) == 7
 
     def test_available_composite_ids_missing_available(self):
         """Test available_composite_ids when a composites dep is missing."""
@@ -316,6 +316,20 @@ class TestLoadingComposites:
             assert loaded_ids[0]["name"] == exp_id_or_name
         else:
             assert loaded_ids[0] == exp_id_or_name
+
+    def test_load_composite_by_tag_syntax(self):
+        """Check that loading with tag syntax stores the dataset under the requested name and makes it accessible.
+
+        The compositor's self.attrs['name'] (the YAML key, e.g. 'comp1_wmo') overwrites the
+        requested name in the output attrs — exactly as GenericCompositor does.
+        _generate_composite must restore the requested name ('comp1:wmo') and preserve the
+        original YAML key in _satpy_compositor_name for enhancement lookups.
+        """
+        scene = Scene(filenames=["fake1_1.txt"], reader="fake1")
+        scene.load(["comp1:wmo"])
+        assert not scene.missing_datasets
+        data = scene["comp1:wmo"]
+        assert data.attrs["_satpy_compositor_name"] == "comp1_wmo"
 
     def test_load_multiple_resolutions(self):
         """Test loading a dataset has multiple resolutions available with different resolutions."""

--- a/satpy/tests/scene_tests/test_load.py
+++ b/satpy/tests/scene_tests/test_load.py
@@ -318,18 +318,34 @@ class TestLoadingComposites:
             assert loaded_ids[0] == exp_id_or_name
 
     def test_load_composite_by_tag_syntax(self):
-        """Check that loading with tag syntax stores the dataset under the requested name and makes it accessible.
+        """Check that loading with tag syntax stores the dataset under a DataID with name and tag.
 
-        The compositor's self.attrs['name'] (the YAML key, e.g. 'comp1_wmo') overwrites the
-        requested name in the output attrs — exactly as GenericCompositor does.
-        _generate_composite must restore the requested name ('comp1:wmo') and preserve the
-        original YAML key in _satpy_compositor_name for enhancement lookups.
+        'comp1:wmo' is syntactic sugar for DataQuery(name='comp1', tag='wmo').
+        The dataset should be accessible via scene['comp1:wmo'] and its DataID
+        should have name='comp1' and tag='wmo'.
         """
         scene = Scene(filenames=["fake1_1.txt"], reader="fake1")
         scene.load(["comp1:wmo"])
         assert not scene.missing_datasets
         data = scene["comp1:wmo"]
-        assert data.attrs["_satpy_compositor_name"] == "comp1_wmo"
+        assert data.attrs["_satpy_id"]["name"] == "comp1"
+        assert data.attrs["_satpy_id"]["tag"] == "wmo"
+
+    def test_load_composite_by_preferred_tags(self):
+        """Check that preferred_composite_tags causes a plain load to resolve to the tagged variant.
+
+        With preferred_composite_tags=['wmo'], loading 'comp1' selects the DataID(name='comp1', tag='wmo')
+        compositor.  The resulting dataset is stored under that tagged DataID and is accessible
+        via the tag syntax 'comp1:wmo'.
+        """
+        import satpy
+        scene = Scene(filenames=["fake1_1.txt"], reader="fake1")
+        with satpy.config.set(preferred_composite_tags=["wmo"]):
+            scene.load(["comp1"])
+        assert not scene.missing_datasets
+        data = scene["comp1:wmo"]
+        assert data.attrs["_satpy_id"]["name"] == "comp1"
+        assert data.attrs["_satpy_id"]["tag"] == "wmo"
 
     def test_load_multiple_resolutions(self):
         """Test loading a dataset has multiple resolutions available with different resolutions."""

--- a/satpy/tests/scene_tests/test_load.py
+++ b/satpy/tests/scene_tests/test_load.py
@@ -84,7 +84,7 @@ class TestSceneAllAvailableDatasets:
         num_reader_ds = 21 + 6
         assert len(id_list) == num_reader_ds
         id_list = scene.all_dataset_ids(composites=True)
-        assert len(id_list) == num_reader_ds + 34
+        assert len(id_list) == num_reader_ds + 36
 
     def test_all_datasets_multiple_reader(self):
         """Test all datasets for multiple readers."""
@@ -94,8 +94,8 @@ class TestSceneAllAvailableDatasets:
         assert len(id_list) == 2
         id_list = scene.all_dataset_ids(composites=True)
         # ds1 and ds2 => 2
-        # composites that use these two datasets => 12
-        assert len(id_list) == 2 + 12
+        # composites that use these two datasets => 14
+        assert len(id_list) == 2 + 14
 
     def test_available_datasets_one_reader(self):
         """Test the available datasets for one reader."""
@@ -104,8 +104,41 @@ class TestSceneAllAvailableDatasets:
         id_list = scene.available_dataset_ids()
         assert len(id_list) == 1
         id_list = scene.available_dataset_ids(composites=True)
-        # ds1, comp1, comp1_wmo, comp14, comp16, static_image, comp26
-        assert len(id_list) == 7
+        # ds1, comp1, comp1_wmo, comp_tagged_only_wmo, comp_uses_tagged, comp14, comp16, static_image, comp26
+        assert len(id_list) == 9
+
+    def test_available_composite_names_lists_each_name_once(self):
+        """Check that tagged variants don't duplicate entries in the composite name list.
+
+        'comp1' exists both untagged and with tag='wmo'; the default name listing must
+        contain 'comp1' exactly once so that load(available_composite_names()) chains
+        don't silently start computing every variant.
+        """
+        scene = Scene(filenames=["fake1_1.txt"], reader="fake1")
+        names = scene.available_composite_names()
+        assert names.count("comp1") == 1
+
+    def test_available_composite_names_show_tagged_only_composites_as_loadable(self):
+        """Check that tagged-only composites are listed by their loadable tagged spelling.
+
+        'comp_tagged_only' exists only as tag='wmo'; a plain 'comp_tagged_only' entry
+        would fail to load, so the listing must show 'comp_tagged_only:wmo' instead.
+        """
+        scene = Scene(filenames=["fake1_1.txt"], reader="fake1")
+        names = scene.available_composite_names()
+        assert "comp_tagged_only:wmo" in names
+        assert "comp_tagged_only" not in names
+
+    def test_all_composite_names_show_tagged_only_composites_as_loadable(self):
+        """Check that all_composite_names uses the same loadable spellings as the available listing.
+
+        'comp_tagged_only' exists only as tag='wmo', so the all-composites listing must show
+        'comp_tagged_only:wmo' and not the plain name that scene.load rejects.
+        """
+        scene = Scene(filenames=["fake1_1.txt"], reader="fake1")
+        names = scene.all_composite_names()
+        assert "comp_tagged_only:wmo" in names
+        assert "comp_tagged_only" not in names
 
     def test_available_composite_ids_missing_available(self):
         """Test available_composite_ids when a composites dep is missing."""
@@ -346,6 +379,50 @@ class TestLoadingComposites:
         data = scene["comp1:wmo"]
         assert data.attrs["_satpy_id"]["name"] == "comp1"
         assert data.attrs["_satpy_id"]["tag"] == "wmo"
+
+    def test_load_plain_name_prefers_untagged_variant(self):
+        """Check that a plain-name load picks the untagged variant when tagged ones also exist.
+
+        Both 'comp1' (untagged) and the tag='wmo' variant are defined; with no tag in the
+        query and no preferred_composite_tags configured, the untagged compositor wins.
+        """
+        scene = Scene(filenames=["fake1_1.txt"], reader="fake1")
+        scene.load(["comp1"])
+        assert not scene.missing_datasets
+        data = scene["comp1"]
+        assert data.attrs["_satpy_id"]["name"] == "comp1"
+        assert data.attrs["_satpy_id"].get("tag") is None
+
+    def test_load_plain_name_fails_when_only_tagged_variants_exist(self):
+        """Check that a plain-name load fails when the composite exists only in tagged form.
+
+        'comp_tagged_only' is defined only with tag='wmo'; loading it without a tag
+        (and without preferred_composite_tags) must raise, not silently pick a variant.
+        """
+        scene = Scene(filenames=["fake1_1.txt"], reader="fake1")
+        with pytest.raises(KeyError):
+            scene.load(["comp_tagged_only"])
+
+    def test_loaded_tagged_composite_exposes_tag_in_attrs(self):
+        """Check that a loaded tagged composite carries its tag in the plain attrs.
+
+        Writer filename patterns like '{name}_{tag}.tif' read from the dataset attrs,
+        so the tag must be present there, not only inside the '_satpy_id'.
+        """
+        scene = Scene(filenames=["fake1_1.txt"], reader="fake1")
+        scene.load(["comp1:wmo"])
+        assert scene["comp1:wmo"].attrs["tag"] == "wmo"
+
+    def test_load_composite_with_tagged_prerequisite(self):
+        """Check that a composite can depend on the tagged variant of another composite.
+
+        'comp_uses_tagged' lists 'comp1:wmo' as a prerequisite; loading it must resolve
+        that dependency to the DataID(name='comp1', tag='wmo') compositor and succeed.
+        """
+        scene = Scene(filenames=["fake1_1.txt"], reader="fake1")
+        scene.load(["comp_uses_tagged"])
+        assert not scene.missing_datasets
+        assert "comp_uses_tagged" in scene
 
     def test_load_multiple_resolutions(self):
         """Test loading a dataset has multiple resolutions available with different resolutions."""

--- a/satpy/tests/test_dataset.py
+++ b/satpy/tests/test_dataset.py
@@ -1015,3 +1015,48 @@ def test_wavelength_range_cf_roundtrip():
 
     assert WavelengthRange.from_cf(wr.to_cf()) == wr
     assert WavelengthRange.from_cf([str(item) for item in wr]) == wr
+
+
+class TestParseDatasetKey:
+    """Test parse_dataset_key string-to-DataQuery conversion."""
+
+    def test_plain_name_returns_query_with_name_only(self):
+        """A plain name string produces a DataQuery with only the name set."""
+        from satpy.dataset.dataid import parse_dataset_key
+        result = parse_dataset_key("true_color")
+        assert result == DataQuery(name="true_color")
+
+    def test_name_with_tag_returns_query_with_name_and_tag(self):
+        """A 'name:tag' string produces a DataQuery with both name and tag."""
+        from satpy.dataset.dataid import parse_dataset_key
+        result = parse_dataset_key("true_color:wmo")
+        assert result == DataQuery(name="true_color", tag="wmo")
+
+    def test_tag_field_in_minimal_dataid(self):
+        """DataID with minimal keys should accept a tag field."""
+        did = DataID(minimal_default_keys_config, name="true_color", tag="wmo")
+        assert did["tag"] == "wmo"
+
+    def test_dataid_tag_matched_by_dataquery(self):
+        """DataQuery(name='true_color', tag='wmo') should match DataID with same name and tag."""
+        did = DataID(minimal_default_keys_config, name="true_color", tag="wmo")
+        query = DataQuery(name="true_color", tag="wmo")
+        assert query._match_dataid(did)
+
+    def test_untagged_dataid_does_not_match_tagged_query(self):
+        """DataID with no tag should not match a DataQuery specifying a tag (tag is a discriminator)."""
+        untagged = DataID(minimal_default_keys_config, name="true_color")
+        tagged_query = DataQuery(name="true_color", tag="wmo")
+        assert not tagged_query._match_dataid(untagged)
+
+    def test_tagged_dataid_does_not_match_untagged_query(self):
+        """DataID with a tag should not match a DataQuery without a tag (tag is a discriminator)."""
+        tagged = DataID(minimal_default_keys_config, name="true_color", tag="wmo")
+        untagged_query = DataQuery(name="true_color")
+        assert not untagged_query._match_dataid(tagged)
+        """A 'name:tag' string used as a DatasetDict key resolves to the DataID with that name and tag."""
+        from satpy.dataset.data_dict import DatasetDict
+        ds = DatasetDict()
+        did = DataID(minimal_default_keys_config, name="true_color", tag="wmo")
+        ds[did] = "value"
+        assert ds["true_color:wmo"] == "value"

--- a/satpy/tests/test_dependency_tree.py
+++ b/satpy/tests/test_dependency_tree.py
@@ -139,6 +139,13 @@ class TestGetCompositorByTag:
             "comp1_crefl",
             id="preferred_tags_for_plain_name",
         ),
+        pytest.param(
+            {"comp1": []},
+            ["wmo"],
+            "comp1",
+            "comp1",
+            id="preferred_tag_unavailable_falls_back_to_plain",
+        ),
     ])
     def test_get_compositor_by_tag(self, compositors_spec, preferred_tags, query, expected_name):
         """Test compositor resolution using tag syntax and preferred_composite_tags config."""
@@ -154,6 +161,23 @@ class TestGetCompositorByTag:
             result = tree.get_compositor(DataQuery(name=query))
 
         assert result.attrs["name"] == expected_name
+
+    def test_get_compositor_raises_when_explicit_tag_not_found(self):
+        """Test that requesting a tagged variant that doesn't exist raises KeyError."""
+        comp = FakeCompositor(name="comp1", prerequisites=[], standard_name="comp1", tags=[])
+        compositors = {"fake_sensor": DatasetDict({make_cid(name="comp1"): comp})}
+        tree = DependencyTree({}, compositors, {})
+
+        with pytest.raises(KeyError):
+            tree.get_compositor(DataQuery(name="comp1:wmo"))
+
+    def test_get_compositor_by_tag_skips_non_string_name(self):
+        """Test that a non-string name returns None instead of raising TypeError.
+
+        Without the isinstance guard, name.split(":") on None would crash.
+        """
+        tree = DependencyTree({}, {}, {})
+        assert tree._get_compositor_by_tag({"name": None}) is None
 
 
 class TestMissingDependencies(unittest.TestCase):

--- a/satpy/tests/test_dependency_tree.py
+++ b/satpy/tests/test_dependency_tree.py
@@ -18,8 +18,12 @@
 import os
 import unittest
 
+import pytest
+
+import satpy
+from satpy.dataset import DataQuery, DatasetDict
 from satpy.dependency_tree import DependencyTree
-from satpy.tests.utils import make_cid, make_dataid
+from satpy.tests.utils import FakeCompositor, make_cid, make_dataid
 
 
 class TestDependencyTree(unittest.TestCase):
@@ -99,89 +103,57 @@ class TestDependencyTree(unittest.TestCase):
 class TestGetCompositorByTag:
     """Test tag-based compositor resolution via 'name:tag' syntax."""
 
-    def test_get_compositor_finds_tagged_variant(self):
-        """Test that 'name:tag' in get_compositor finds a compositor with matching standard_name and tag."""
-        from satpy.dataset import DataQuery, DatasetDict
-        from satpy.tests.utils import FakeCompositor, make_cid
-
-        comp_wmo = FakeCompositor(name="comp1_wmo", prerequisites=[], standard_name="comp1", tags=["wmo"])
-        compositors = {"fake_sensor": DatasetDict({make_cid(name="comp1_wmo"): comp_wmo})}
-
-        tree = DependencyTree({}, compositors, {})
-        result = tree.get_compositor(DataQuery(name="comp1:wmo"))
-        assert result is comp_wmo
-
-
-    def test_get_compositor_finds_multi_tag_variant(self):
-        """Test that 'name:tag1:tag2' finds a compositor carrying all listed tags."""
-        from satpy.dataset import DataQuery, DatasetDict
-        from satpy.tests.utils import FakeCompositor, make_cid
-
-        comp = FakeCompositor(name="comp1_wmo_pyspectral", prerequisites=[],
-                              standard_name="comp1", tags=["wmo", "pyspectral"])
-        compositors = {"fake_sensor": DatasetDict({make_cid(name="comp1_wmo_pyspectral"): comp})}
-
-        tree = DependencyTree({}, compositors, {})
-        result = tree.get_compositor(DataQuery(name="comp1:wmo:pyspectral"))
-        assert result is comp
-
-    def test_single_tag_request_matches_multi_tag_compositor(self):
-        """Test that 'name:tag' matches a compositor that carries that tag plus others."""
-        from satpy.dataset import DataQuery, DatasetDict
-        from satpy.tests.utils import FakeCompositor, make_cid
-
-        comp = FakeCompositor(name="comp1_wmo_pyspectral", prerequisites=[],
-                              standard_name="comp1", tags=["wmo", "pyspectral"])
-        compositors = {"fake_sensor": DatasetDict({make_cid(name="comp1_wmo_pyspectral"): comp})}
-
-        tree = DependencyTree({}, compositors, {})
-        result = tree.get_compositor(DataQuery(name="comp1:wmo"))
-        assert result is comp
-
-    def test_explicit_tag_respects_preferred_tags_as_tiebreaker(self):
-        """Test that preferred_composite_tags breaks ties among compositors all matching an explicit tag.
-
-        When 'true_color:wmo' is requested and both true_color_wmo (tags=[wmo]) and
-        true_color_wmo_pyspectral (tags=[wmo, pyspectral]) are available, the compositor
-        whose extra tags include the preferred tag should win.
-        """
-        import satpy
-        from satpy.dataset import DataQuery, DatasetDict
-        from satpy.tests.utils import FakeCompositor, make_cid
-
-        comp_wmo = FakeCompositor(name="comp1_wmo", prerequisites=[],
-                                  standard_name="comp1", tags=["wmo"])
-        comp_wmo_pyspectral = FakeCompositor(name="comp1_wmo_pyspectral", prerequisites=[],
-                                             standard_name="comp1", tags=["wmo", "pyspectral"])
-        compositors = {"fake_sensor": DatasetDict({
-            make_cid(name="comp1_wmo"): comp_wmo,
-            make_cid(name="comp1_wmo_pyspectral"): comp_wmo_pyspectral,
-        })}
+    @pytest.mark.parametrize(("compositors_spec", "preferred_tags", "query", "expected_name"), [
+        pytest.param(
+            {"comp1_wmo": ["wmo"]},
+            [],
+            "comp1:wmo",
+            "comp1_wmo",
+            id="single_explicit_tag",
+        ),
+        pytest.param(
+            {"comp1_wmo_pyspectral": ["wmo", "pyspectral"]},
+            [],
+            "comp1:wmo:pyspectral",
+            "comp1_wmo_pyspectral",
+            id="multi_explicit_tags",
+        ),
+        pytest.param(
+            {"comp1_wmo_pyspectral": ["wmo", "pyspectral"]},
+            [],
+            "comp1:wmo",
+            "comp1_wmo_pyspectral",
+            id="single_tag_matches_multi_tag_compositor",
+        ),
+        pytest.param(
+            {"comp1_wmo": ["wmo"], "comp1_wmo_pyspectral": ["wmo", "pyspectral"]},
+            ["pyspectral"],
+            "comp1:wmo",
+            "comp1_wmo_pyspectral",
+            id="preferred_tags_tiebreaker_for_explicit_tag",
+        ),
+        pytest.param(
+            {"comp1_wmo": ["wmo"], "comp1_crefl": ["crefl"]},
+            ["crefl", "wmo"],
+            "comp1",
+            "comp1_crefl",
+            id="preferred_tags_for_plain_name",
+        ),
+    ])
+    def test_get_compositor_by_tag(self, compositors_spec, preferred_tags, query, expected_name):
+        """Test compositor resolution using tag syntax and preferred_composite_tags config."""
+        compositors = {
+            "fake_sensor": DatasetDict({
+                make_cid(name=name): FakeCompositor(name=name, prerequisites=[], standard_name="comp1", tags=tags)
+                for name, tags in compositors_spec.items()
+            })
+        }
         tree = DependencyTree({}, compositors, {})
 
-        with satpy.config.set(preferred_composite_tags=["pyspectral"]):
-            result = tree.get_compositor(DataQuery(name="comp1:wmo"))
+        with satpy.config.set(preferred_composite_tags=preferred_tags):
+            result = tree.get_compositor(DataQuery(name=query))
 
-        assert result is comp_wmo_pyspectral
-
-    def test_preferred_tags_selects_first_matching_compositor(self):
-        """Test that preferred_composite_tags config selects the first matching tagged compositor."""
-        import satpy
-        from satpy.dataset import DataQuery, DatasetDict
-        from satpy.tests.utils import FakeCompositor, make_cid
-
-        comp_wmo = FakeCompositor(name="comp1_wmo", prerequisites=[], standard_name="comp1", tags=["wmo"])
-        comp_crefl = FakeCompositor(name="comp1_crefl", prerequisites=[], standard_name="comp1", tags=["crefl"])
-        compositors = {"fake_sensor": DatasetDict({
-            make_cid(name="comp1_wmo"): comp_wmo,
-            make_cid(name="comp1_crefl"): comp_crefl,
-        })}
-        tree = DependencyTree({}, compositors, {})
-
-        with satpy.config.set(preferred_composite_tags=["crefl", "wmo"]):
-            result = tree.get_compositor(DataQuery(name="comp1"))
-
-        assert result is comp_crefl
+        assert result.attrs["name"] == expected_name
 
 
 class TestMissingDependencies(unittest.TestCase):

--- a/satpy/tests/test_dependency_tree.py
+++ b/satpy/tests/test_dependency_tree.py
@@ -180,6 +180,35 @@ class TestGetCompositorByTag:
         assert tree._get_compositor_by_tag({"name": None}) is None
 
 
+class TestFindCompositorNodeNaming:
+    """Test that compositor nodes are named after the requested dataset key."""
+
+    def test_tag_request_names_node_after_request(self):
+        """Check that a tag-syntax request resolves to a node named after the requested key, not the YAML key."""
+        comp = FakeCompositor(name="comp1_wmo", prerequisites=[], standard_name="comp1", tags=["wmo"])
+        compositors = {"fake_sensor": DatasetDict({make_cid(name="comp1_wmo"): comp})}
+        tree = DependencyTree({}, compositors, {})
+
+        requested = {DataQuery(name="comp1:wmo")}
+        tree.populate_with_keys(requested)
+
+        resolved_name = next(iter(requested))
+        assert resolved_name["name"] == "comp1:wmo"
+
+    def test_preferred_tag_resolution_names_node_after_plain_request(self):
+        """Check that a plain request resolved via preferred_composite_tags is named after the plain request."""
+        comp_wmo = FakeCompositor(name="comp1_wmo", prerequisites=[], standard_name="comp1", tags=["wmo"])
+        compositors = {"fake_sensor": DatasetDict({make_cid(name="comp1_wmo"): comp_wmo})}
+        tree = DependencyTree({}, compositors, {})
+
+        requested = {DataQuery(name="comp1")}
+        with satpy.config.set(preferred_composite_tags=["wmo"]):
+            tree.populate_with_keys(requested)
+
+        resolved_name = next(iter(requested))
+        assert resolved_name["name"] == "comp1"
+
+
 class TestMissingDependencies(unittest.TestCase):
     """Test the MissingDependencies exception."""
 

--- a/satpy/tests/test_dependency_tree.py
+++ b/satpy/tests/test_dependency_tree.py
@@ -96,6 +96,94 @@ class TestDependencyTree(unittest.TestCase):
         assert self.dependency_tree.empty_node is new_dependency_tree.empty_node
 
 
+class TestGetCompositorByTag:
+    """Test tag-based compositor resolution via 'name:tag' syntax."""
+
+    def test_get_compositor_finds_tagged_variant(self):
+        """Test that 'name:tag' in get_compositor finds a compositor with matching standard_name and tag."""
+        from satpy.dataset import DataQuery, DatasetDict
+        from satpy.tests.utils import FakeCompositor, make_cid
+
+        comp_wmo = FakeCompositor(name="comp1_wmo", prerequisites=[], standard_name="comp1", tags=["wmo"])
+        compositors = {"fake_sensor": DatasetDict({make_cid(name="comp1_wmo"): comp_wmo})}
+
+        tree = DependencyTree({}, compositors, {})
+        result = tree.get_compositor(DataQuery(name="comp1:wmo"))
+        assert result is comp_wmo
+
+
+    def test_get_compositor_finds_multi_tag_variant(self):
+        """Test that 'name:tag1:tag2' finds a compositor carrying all listed tags."""
+        from satpy.dataset import DataQuery, DatasetDict
+        from satpy.tests.utils import FakeCompositor, make_cid
+
+        comp = FakeCompositor(name="comp1_wmo_pyspectral", prerequisites=[],
+                              standard_name="comp1", tags=["wmo", "pyspectral"])
+        compositors = {"fake_sensor": DatasetDict({make_cid(name="comp1_wmo_pyspectral"): comp})}
+
+        tree = DependencyTree({}, compositors, {})
+        result = tree.get_compositor(DataQuery(name="comp1:wmo:pyspectral"))
+        assert result is comp
+
+    def test_single_tag_request_matches_multi_tag_compositor(self):
+        """Test that 'name:tag' matches a compositor that carries that tag plus others."""
+        from satpy.dataset import DataQuery, DatasetDict
+        from satpy.tests.utils import FakeCompositor, make_cid
+
+        comp = FakeCompositor(name="comp1_wmo_pyspectral", prerequisites=[],
+                              standard_name="comp1", tags=["wmo", "pyspectral"])
+        compositors = {"fake_sensor": DatasetDict({make_cid(name="comp1_wmo_pyspectral"): comp})}
+
+        tree = DependencyTree({}, compositors, {})
+        result = tree.get_compositor(DataQuery(name="comp1:wmo"))
+        assert result is comp
+
+    def test_explicit_tag_respects_preferred_tags_as_tiebreaker(self):
+        """Test that preferred_composite_tags breaks ties among compositors all matching an explicit tag.
+
+        When 'true_color:wmo' is requested and both true_color_wmo (tags=[wmo]) and
+        true_color_wmo_pyspectral (tags=[wmo, pyspectral]) are available, the compositor
+        whose extra tags include the preferred tag should win.
+        """
+        import satpy
+        from satpy.dataset import DataQuery, DatasetDict
+        from satpy.tests.utils import FakeCompositor, make_cid
+
+        comp_wmo = FakeCompositor(name="comp1_wmo", prerequisites=[],
+                                  standard_name="comp1", tags=["wmo"])
+        comp_wmo_pyspectral = FakeCompositor(name="comp1_wmo_pyspectral", prerequisites=[],
+                                             standard_name="comp1", tags=["wmo", "pyspectral"])
+        compositors = {"fake_sensor": DatasetDict({
+            make_cid(name="comp1_wmo"): comp_wmo,
+            make_cid(name="comp1_wmo_pyspectral"): comp_wmo_pyspectral,
+        })}
+        tree = DependencyTree({}, compositors, {})
+
+        with satpy.config.set(preferred_composite_tags=["pyspectral"]):
+            result = tree.get_compositor(DataQuery(name="comp1:wmo"))
+
+        assert result is comp_wmo_pyspectral
+
+    def test_preferred_tags_selects_first_matching_compositor(self):
+        """Test that preferred_composite_tags config selects the first matching tagged compositor."""
+        import satpy
+        from satpy.dataset import DataQuery, DatasetDict
+        from satpy.tests.utils import FakeCompositor, make_cid
+
+        comp_wmo = FakeCompositor(name="comp1_wmo", prerequisites=[], standard_name="comp1", tags=["wmo"])
+        comp_crefl = FakeCompositor(name="comp1_crefl", prerequisites=[], standard_name="comp1", tags=["crefl"])
+        compositors = {"fake_sensor": DatasetDict({
+            make_cid(name="comp1_wmo"): comp_wmo,
+            make_cid(name="comp1_crefl"): comp_crefl,
+        })}
+        tree = DependencyTree({}, compositors, {})
+
+        with satpy.config.set(preferred_composite_tags=["crefl", "wmo"]):
+            result = tree.get_compositor(DataQuery(name="comp1"))
+
+        assert result is comp_crefl
+
+
 class TestMissingDependencies(unittest.TestCase):
     """Test the MissingDependencies exception."""
 

--- a/satpy/tests/test_dependency_tree.py
+++ b/satpy/tests/test_dependency_tree.py
@@ -101,112 +101,66 @@ class TestDependencyTree(unittest.TestCase):
 
 
 class TestGetCompositorByTag:
-    """Test tag-based compositor resolution via 'name:tag' syntax."""
+    """Test compositor resolution via tag syntax and preferred_composite_tags config."""
 
-    @pytest.mark.parametrize(("compositors_spec", "preferred_tags", "query", "expected_name"), [
-        pytest.param(
-            {"comp1_wmo": ["wmo"]},
-            [],
-            "comp1:wmo",
-            "comp1_wmo",
-            id="single_explicit_tag",
-        ),
-        pytest.param(
-            {"comp1_wmo_pyspectral": ["wmo", "pyspectral"]},
-            [],
-            "comp1:wmo:pyspectral",
-            "comp1_wmo_pyspectral",
-            id="multi_explicit_tags",
-        ),
-        pytest.param(
-            {"comp1_wmo_pyspectral": ["wmo", "pyspectral"]},
-            [],
-            "comp1:wmo",
-            "comp1_wmo_pyspectral",
-            id="single_tag_matches_multi_tag_compositor",
-        ),
-        pytest.param(
-            {"comp1_wmo": ["wmo"], "comp1_wmo_pyspectral": ["wmo", "pyspectral"]},
-            ["pyspectral"],
-            "comp1:wmo",
-            "comp1_wmo_pyspectral",
-            id="preferred_tags_tiebreaker_for_explicit_tag",
-        ),
-        pytest.param(
-            {"comp1_wmo": ["wmo"], "comp1_crefl": ["crefl"]},
-            ["crefl", "wmo"],
-            "comp1",
-            "comp1_crefl",
-            id="preferred_tags_for_plain_name",
-        ),
-        pytest.param(
-            {"comp1": []},
-            ["wmo"],
-            "comp1",
-            "comp1",
-            id="preferred_tag_unavailable_falls_back_to_plain",
-        ),
-    ])
-    def test_get_compositor_by_tag(self, compositors_spec, preferred_tags, query, expected_name):
-        """Test compositor resolution using tag syntax and preferred_composite_tags config."""
-        compositors = {
-            "fake_sensor": DatasetDict({
-                make_cid(name=name): FakeCompositor(name=name, prerequisites=[], standard_name="comp1", tags=tags)
-                for name, tags in compositors_spec.items()
-            })
-        }
-        tree = DependencyTree({}, compositors, {})
+    def _make_tree(self, compositors_by_id):
+        """Build a DependencyTree with the given {DataID: FakeCompositor} mapping."""
+        compositors = {"fake_sensor": DatasetDict(compositors_by_id)}
+        return DependencyTree({}, compositors, {})
 
-        with satpy.config.set(preferred_composite_tags=preferred_tags):
-            result = tree.get_compositor(DataQuery(name=query))
+    def test_explicit_tag_query_finds_tagged_compositor(self):
+        """DataQuery with explicit tag finds the matching tagged compositor."""
+        comp = FakeCompositor(name="comp1", tag="wmo", prerequisites=[])
+        tree = self._make_tree({make_cid(name="comp1", tag="wmo"): comp})
 
-        assert result.attrs["name"] == expected_name
+        result = tree.get_compositor(DataQuery(name="comp1", tag="wmo"))
 
-    def test_get_compositor_raises_when_explicit_tag_not_found(self):
-        """Test that requesting a tagged variant that doesn't exist raises KeyError."""
-        comp = FakeCompositor(name="comp1", prerequisites=[], standard_name="comp1", tags=[])
-        compositors = {"fake_sensor": DatasetDict({make_cid(name="comp1"): comp})}
-        tree = DependencyTree({}, compositors, {})
+        assert result.attrs["name"] == "comp1"
+        assert result.attrs["tag"] == "wmo"
+
+    def test_explicit_tag_not_found_raises(self):
+        """Requesting a tagged compositor that does not exist raises KeyError."""
+        comp = FakeCompositor(name="comp1", prerequisites=[])
+        tree = self._make_tree({make_cid(name="comp1"): comp})
 
         with pytest.raises(KeyError):
-            tree.get_compositor(DataQuery(name="comp1:wmo"))
+            tree.get_compositor(DataQuery(name="comp1", tag="wmo"))
 
-    def test_get_compositor_by_tag_skips_non_string_name(self):
-        """Test that a non-string name returns None instead of raising TypeError.
+    def test_preferred_tags_for_plain_name(self):
+        """Plain name query resolves to a tagged compositor via preferred_composite_tags."""
+        comp = FakeCompositor(name="comp1", tag="wmo", prerequisites=[])
+        tree = self._make_tree({make_cid(name="comp1", tag="wmo"): comp})
 
-        Without the isinstance guard, name.split(":") on None would crash.
-        """
-        tree = DependencyTree({}, {}, {})
-        assert tree._get_compositor_by_tag({"name": None}) is None
-
-
-class TestFindCompositorNodeNaming:
-    """Test that compositor nodes are named after the requested dataset key."""
-
-    def test_tag_request_names_node_after_request(self):
-        """Check that a tag-syntax request resolves to a node named after the requested key, not the YAML key."""
-        comp = FakeCompositor(name="comp1_wmo", prerequisites=[], standard_name="comp1", tags=["wmo"])
-        compositors = {"fake_sensor": DatasetDict({make_cid(name="comp1_wmo"): comp})}
-        tree = DependencyTree({}, compositors, {})
-
-        requested = {DataQuery(name="comp1:wmo")}
-        tree.populate_with_keys(requested)
-
-        resolved_name = next(iter(requested))
-        assert resolved_name["name"] == "comp1:wmo"
-
-    def test_preferred_tag_resolution_names_node_after_plain_request(self):
-        """Check that a plain request resolved via preferred_composite_tags is named after the plain request."""
-        comp_wmo = FakeCompositor(name="comp1_wmo", prerequisites=[], standard_name="comp1", tags=["wmo"])
-        compositors = {"fake_sensor": DatasetDict({make_cid(name="comp1_wmo"): comp_wmo})}
-        tree = DependencyTree({}, compositors, {})
-
-        requested = {DataQuery(name="comp1")}
         with satpy.config.set(preferred_composite_tags=["wmo"]):
-            tree.populate_with_keys(requested)
+            result = tree.get_compositor(DataQuery(name="comp1"))
 
-        resolved_name = next(iter(requested))
-        assert resolved_name["name"] == "comp1"
+        assert result.attrs["name"] == "comp1"
+        assert result.attrs["tag"] == "wmo"
+
+    def test_preferred_tags_respects_order(self):
+        """First matching preferred tag wins when multiple tagged variants exist."""
+        comp_crefl = FakeCompositor(name="comp1", tag="crefl", prerequisites=[])
+        comp_wmo = FakeCompositor(name="comp1", tag="wmo", prerequisites=[])
+        tree = self._make_tree({
+            make_cid(name="comp1", tag="crefl"): comp_crefl,
+            make_cid(name="comp1", tag="wmo"): comp_wmo,
+        })
+
+        with satpy.config.set(preferred_composite_tags=["crefl", "wmo"]):
+            result = tree.get_compositor(DataQuery(name="comp1"))
+
+        assert result.attrs["tag"] == "crefl"
+
+    def test_preferred_tag_unavailable_falls_back_to_plain(self):
+        """When no preferred-tag variant exists the plain (untagged) compositor is returned."""
+        comp = FakeCompositor(name="comp1", prerequisites=[])
+        tree = self._make_tree({make_cid(name="comp1"): comp})
+
+        with satpy.config.set(preferred_composite_tags=["wmo"]):
+            result = tree.get_compositor(DataQuery(name="comp1"))
+
+        assert result.attrs["name"] == "comp1"
+        assert result.attrs.get("tag") is None
 
 
 class TestMissingDependencies(unittest.TestCase):

--- a/satpy/tests/test_dependency_tree.py
+++ b/satpy/tests/test_dependency_tree.py
@@ -118,6 +118,18 @@ class TestGetCompositorByTag:
         assert result.attrs["name"] == "comp1"
         assert result.attrs["tag"] == "wmo"
 
+    def test_plain_query_error_mentions_available_tagged_variants(self):
+        """A failing plain-name lookup names the tagged variants that do exist.
+
+        When 'comp1' exists only as tag='wmo', the KeyError for a plain 'comp1'
+        query should point the user at 'comp1:wmo'.
+        """
+        comp = FakeCompositor(name="comp1", tag="wmo", prerequisites=[])
+        tree = self._make_tree({make_cid(name="comp1", tag="wmo"): comp})
+
+        with pytest.raises(KeyError, match="comp1:wmo"):
+            tree.get_compositor(DataQuery(name="comp1"))
+
     def test_explicit_tag_not_found_raises(self):
         """Requesting a tagged compositor that does not exist raises KeyError."""
         comp = FakeCompositor(name="comp1", prerequisites=[])
@@ -150,6 +162,28 @@ class TestGetCompositorByTag:
             result = tree.get_compositor(DataQuery(name="comp1"))
 
         assert result.attrs["tag"] == "crefl"
+
+    def test_preferred_tags_apply_to_nested_plain_prerequisites(self):
+        """A composite's plain-name prerequisite resolves through preferred_composite_tags.
+
+        comp_parent depends on plain 'comp1'; with preferred_composite_tags=['wmo'] that
+        dependency resolves to the tag='wmo' variant of comp1, so a site-wide preference
+        reaches nested composites too.
+        """
+        parent = FakeCompositor(name="comp_parent", prerequisites=["comp1"])
+        comp1_plain = FakeCompositor(name="comp1", prerequisites=[])
+        comp1_wmo = FakeCompositor(name="comp1", tag="wmo", prerequisites=[])
+        tree = self._make_tree({
+            make_cid(name="comp_parent"): parent,
+            make_cid(name="comp1"): comp1_plain,
+            make_cid(name="comp1", tag="wmo"): comp1_wmo,
+        })
+
+        with satpy.config.set(preferred_composite_tags=["wmo"]):
+            tree.populate_with_keys({"comp_parent"})
+
+        comp1_ids = [node.name for node in tree.trunk() if node.name["name"] == "comp1"]
+        assert comp1_ids == [make_cid(name="comp1", tag="wmo")]
 
     def test_preferred_tag_unavailable_falls_back_to_plain(self):
         """When no preferred-tag variant exists the plain (untagged) compositor is returned."""

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -662,3 +662,30 @@ def test_flatten_dict():
                 "b_d_e": 1,
                 "b_d_f_g": [1, 2]}
     assert flatten_dict(d) == expected
+
+
+class TestFakeCompositor:
+    """Test that FakeCompositor metadata priority is consistent with real compositors."""
+
+    def test_yaml_name_wins_over_kwargs_name(self):
+        """FakeCompositor output attrs['name'] must equal self.attrs['name'], not the kwargs name.
+
+        Real compositors (GenericCompositor) do new_attrs.update(self.attrs) last, so
+        self.attrs["name"] (the YAML key) always overwrites any name passed as a kwarg.
+        FakeCompositor must follow the same rule.
+        """
+        from unittest.mock import MagicMock
+
+        from satpy.tests.utils import FakeCompositor
+
+        area = MagicMock()
+        comp = FakeCompositor(name="comp1_wmo", prerequisites=["prereq"], standard_name="comp1")
+        prereq = xr.DataArray(
+            da.zeros((4, 5)),
+            dims=["y", "x"],
+            attrs={"area": area},
+        )
+        result = comp([prereq], name="comp1:wmo")
+        assert result.attrs["name"] == "comp1_wmo", (
+            "FakeCompositor must use self.attrs['name'] (the YAML key), not the kwargs name"
+        )

--- a/satpy/tests/utils.py
+++ b/satpy/tests/utils.py
@@ -199,7 +199,6 @@ class FakeCompositor(GenericCompositor):
         if len(projectables) != len(self.attrs["prerequisites"]):
             raise ValueError("Not enough prerequisite datasets passed")
 
-        info.update(kwargs)
         if projectables:
             info["area"] = projectables[0].attrs["area"]
             dim_sizes = projectables[0].sizes


### PR DESCRIPTION
This PR introduce a system of tagging for composites, allowing switching preferred variants at load time or by configuration.

For example, having the following config:
```yaml
  true_color_crefl:
    tags: ["crefl"]
    compositor: !!python/name:satpy.composites.resolution.SelfSharpenedRGB
    prerequisites: ...
    standard_name: true_color

  true_color_raw:
    tags: ["raw"]
    compositor: !!python/name:satpy.composites.resolution.SelfSharpenedRGB
    prerequisites: ...
    standard_name: true_color

  true_color:
    compositor: !!python/name:satpy.composites.resolution.SelfSharpenedRGB
    prerequisites: ...
    standard_name: true_color

  true_color_nocorr:
    tags: ["nocorr"]
    compositor: !!python/name:satpy.composites.resolution.SelfSharpenedRGB
    prerequisites: ...
    standard_name: true_color
```

We can then load `scn.load(["true_color:crefl"])` directly to load "true_color_crefl". Alternatively, we can set the config with `SATPY_PREFERRED_COMPOSITE_TAGS=crefl` so that `scn.load(["true_color"])` loads "true_color_crefl" by default.

This is needed in order implement WMO RGB recommendations in a backwards- and forwards-compatible manner.


Also, possibility to warn for composites at load time has been added.

Disclaimer: AI was used in the design and implementation of this PR.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
