### PR TITLE
Fix AMSR2 L2 GAASP reader compatibility with newer xarray (no timedelta decoding)

### DIFF
--- a/satpy/readers/amsr2_l2_gaasp.py
+++ b/satpy/readers/amsr2_l2_gaasp.py
@@ -164,14 +164,13 @@ class GAASPFileHandler(BaseFileHandler):
             return np.timedelta64("NaT")
         if np.issubdtype(data_arr_dtype, np.datetime64):
             return np.datetime64("NaT")
-        return np.float32(np.nan)
+        return np.nan
 
     def _fill_data(self, data_arr, attrs):
         fill_value = attrs.pop("_FillValue", None)
         is_int = np.issubdtype(data_arr.dtype, np.integer)
         has_flag_comment = "comment" in attrs
-        is_timedelta = attrs.get("units", "") in ("seconds",)
-        if is_int and (has_flag_comment or is_timedelta):
+        if is_int and has_flag_comment:
             # category or timedelta product
             fill_out = fill_value
             attrs["_FillValue"] = fill_out

--- a/satpy/readers/amsr2_l2_gaasp.py
+++ b/satpy/readers/amsr2_l2_gaasp.py
@@ -101,6 +101,7 @@ class GAASPFileHandler(BaseFileHandler):
                   self.y_dims + self.x_dims + self.time_dims}
         nc = xr.open_dataset(self.filename,
                              decode_cf=True,
+                             decode_timedelta=False,
                              mask_and_scale=False,
                              chunks=chunks)
 
@@ -163,19 +164,21 @@ class GAASPFileHandler(BaseFileHandler):
             return np.timedelta64("NaT")
         if np.issubdtype(data_arr_dtype, np.datetime64):
             return np.datetime64("NaT")
-        return np.nan
+        return np.float32(np.nan)
 
     def _fill_data(self, data_arr, attrs):
         fill_value = attrs.pop("_FillValue", None)
         is_int = np.issubdtype(data_arr.dtype, np.integer)
         has_flag_comment = "comment" in attrs
-        if is_int and has_flag_comment:
-            # category product
+        is_timedelta = attrs.get("units", "") in ("seconds",)
+        if is_int and (has_flag_comment or is_timedelta):
+            # category or timedelta product
             fill_out = fill_value
             attrs["_FillValue"] = fill_out
         else:
             fill_out = self._nan_for_dtype(data_arr.dtype)
         if fill_value is not None:
+            data_arr.data.compute().astype("float32")
             data_arr = data_arr.where(data_arr != fill_value, fill_out)
         return data_arr, attrs
 

--- a/satpy/tests/reader_tests/test_amsr2_l2_gaasp.py
+++ b/satpy/tests/reader_tests/test_amsr2_l2_gaasp.py
@@ -301,6 +301,9 @@ class TestGAASPReader:
         if "int" in data_id["name"]:
             assert data_arr.attrs["_FillValue"] == 100
             assert np.issubdtype(data_arr.dtype, np.integer)
+        elif data_id["name"].startswith("latency"):
+            assert data_arr.attrs["_FillValue"] == -9999
+            assert np.issubdtype(data_arr.dtype, np.integer)
         else:
             assert "_FillValue" not in data_arr.attrs
             if np.issubdtype(data_arr.dtype, np.floating):

--- a/satpy/tests/reader_tests/test_amsr2_l2_gaasp.py
+++ b/satpy/tests/reader_tests/test_amsr2_l2_gaasp.py
@@ -301,12 +301,12 @@ class TestGAASPReader:
         if "int" in data_id["name"]:
             assert data_arr.attrs["_FillValue"] == 100
             assert np.issubdtype(data_arr.dtype, np.integer)
-        elif data_id["name"].startswith("latency"):
-            assert data_arr.attrs["_FillValue"] == -9999
-            assert np.issubdtype(data_arr.dtype, np.integer)
         else:
             assert "_FillValue" not in data_arr.attrs
-            if np.issubdtype(data_arr.dtype, np.floating):
+            if data_id["name"].startswith("latency"):
+                # timedelta only fits in 64-bit float
+                assert data_arr.dtype.type == np.float64
+            elif np.issubdtype(data_arr.dtype, np.floating):
                 # we started with float32, it should stay that way
                 assert data_arr.dtype.type == np.float32
 


### PR DESCRIPTION
In unstable xarray the long deprecated functionality of decoding timedelta NetCDF variables by default has been removed. This breaks expectations in the 'amsr2_l2_gaasp' reader which assumes the timedelta64 type but it is now int64. However, this gets more complicated that int32 can't be converted to float32 but instead numpy chooses float64. I considered keeping them as integers but think that may cause more issues since they aren't actually a category product which is what we normally think of in Satpy when we get integers. Instead I expect 64-bit floats.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
