### PR TITLE
Fix `h5netcdf` backend variable caching

### DIFF
--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -245,7 +245,7 @@ class NetCDF4FileHandler(BaseFileHandler):
                 in self.file_content.items()
                 if self.accessor.is_variable(var)
                 and isinstance(var.dtype, np.dtype)  # vlen may be str
-                and var.size * var.dtype.itemsize < cache_var_size]
+                and np.prod(var.shape) * var.dtype.itemsize < cache_var_size]
 
     def __getitem__(self, key):
         """Get item for given key."""


### PR DESCRIPTION
This PR fixes the variable caching for `h5netcdf` backend. The difference in the variable handling was missed in the refactoring done in https://github.com/pytroll/satpy/pull/3256

 - [x] Closes #3358  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 