### PR TITLE
Update URLs to CREFL ancillary HDF4 files

### DIFF
--- a/satpy/etc/composites/abi.yaml
+++ b/satpy/etc/composites/abi.yaml
@@ -3,7 +3,7 @@ sensor_name: visir/abi
 modifiers:
   rayleigh_corrected_crefl:
     modifier: !!python/name:satpy.modifiers.atmosphere.ReflectanceCorrector
-    url: "https://www.ssec.wisc.edu/~davidh/polar2grid/viirs_crefl/CMGDEM.hdf"
+    url: "https://bin.ssec.wisc.edu/pub/CSPP/p2g/data/CMGDEM.hdf"
     known_hash: "sha256:f33f1f867d79fff4fafe128f61c154236dd74fcc97bf418ea1437977a38d0604"
     optional_prerequisites:
       - name: satellite_azimuth_angle

--- a/satpy/etc/composites/modis.yaml
+++ b/satpy/etc/composites/modis.yaml
@@ -2,7 +2,7 @@ sensor_name: visir/modis
 modifiers:
   rayleigh_corrected_crefl:
     modifier: !!python/name:satpy.modifiers.atmosphere.ReflectanceCorrector
-    url: "https://www.ssec.wisc.edu/~davidh/polar2grid/modis_crefl/tbase.hdf"
+    url: "https://bin.ssec.wisc.edu/pub/CSPP/p2g/data/tbase.hdf"
     known_hash: "sha256:ed5183cddce905361c1cac8ae6e3a447212875ea421a05747751efe76f8a068e"
     dem_sds: "Elevation"
     prerequisites:

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -3,7 +3,7 @@ sensor_name: visir/viirs
 modifiers:
   rayleigh_corrected_crefl:
     modifier: !!python/name:satpy.modifiers.atmosphere.ReflectanceCorrector
-    url: "https://www.ssec.wisc.edu/~davidh/polar2grid/viirs_crefl/CMGDEM.hdf"
+    url: "https://bin.ssec.wisc.edu/pub/CSPP/p2g/data/CMGDEM.hdf"
     known_hash: "sha256:f33f1f867d79fff4fafe128f61c154236dd74fcc97bf418ea1437977a38d0604"
     prerequisites:
     - name: satellite_azimuth_angle
@@ -17,7 +17,7 @@ modifiers:
 
   rayleigh_corrected_crefl_iband:
     modifier: !!python/name:satpy.modifiers.atmosphere.ReflectanceCorrector
-    url: "https://www.ssec.wisc.edu/~davidh/polar2grid/viirs_crefl/CMGDEM.hdf"
+    url: "https://bin.ssec.wisc.edu/pub/CSPP/p2g/data/CMGDEM.hdf"
     known_hash: "sha256:f33f1f867d79fff4fafe128f61c154236dd74fcc97bf418ea1437977a38d0604"
     prerequisites:
     - name: satellite_azimuth_angle


### PR DESCRIPTION
SSEC has changed its policy and there are no longer custom user websites so everything under my `~davidh` has been moved/removed. This PR updates references to some HDF4 files used by the CREFL modifiers.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
