### PR TITLE
Fix projection handling for NWC GEO v2025 data

### DIFF
--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -405,6 +405,29 @@ class NcNWCSAF(BaseFileHandler):
         except TypeError:
             proj_str = self.nc.attrs["gdal_projection"].decode()
 
+        crs, area_extent = self._get_crs_and_extent_from_proj_str(proj_str)
+
+        return crs, area_extent
+
+    def _get_crs_and_extent_from_proj_str(self, proj_str):
+        if "v2025" in self.sw_version:
+            proj_str, scale = self._get_v2025_proj_str_and_scale(proj_str)
+        else:
+            proj_str, scale = self._get_legacy_proj_str_and_scale(proj_str)
+
+        area_extent = (float(self.nc.attrs["gdal_xgeo_up_left"]) / scale,
+                    float(self.nc.attrs["gdal_ygeo_low_right"]) / scale,
+                    float(self.nc.attrs["gdal_xgeo_low_right"]) / scale,
+                    float(self.nc.attrs["gdal_ygeo_up_left"]) / scale)
+
+        crs = CRS.from_string(proj_str)
+
+        return crs, area_extent
+
+    def _get_v2025_proj_str_and_scale(self, proj_str):
+        return "", 1.0
+
+    def _get_legacy_proj_str_and_scale(self, proj_str):
         # Check the a/b/h units
         radius_a = proj_str.split("+a=")[-1].split()[0]
         if float(radius_a) > 10e3:
@@ -416,14 +439,7 @@ class NcNWCSAF(BaseFileHandler):
 
         if "units" not in proj_str:
             proj_str = proj_str + " +units=" + units
-
-        area_extent = (float(self.nc.attrs["gdal_xgeo_up_left"]) / scale,
-                       float(self.nc.attrs["gdal_ygeo_low_right"]) / scale,
-                       float(self.nc.attrs["gdal_xgeo_low_right"]) / scale,
-                       float(self.nc.attrs["gdal_ygeo_up_left"]) / scale)
-
-        crs = CRS.from_string(proj_str)
-        return crs, area_extent
+        return proj_str, scale
 
 
 def remove_empties(variable):

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -412,11 +412,10 @@ class NcNWCSAF(BaseFileHandler):
         return crs, area_extent
 
     def _get_crs_and_extent_from_proj_str(self, proj_str):
-        scale = 1.0
-        if "v2025" in self.sw_version:
-            proj_str, scale = self._get_v2025_proj_str_and_scale(proj_str)
-
-        proj_str, scale = self._check_units(proj_str, scale)
+        if self.sw_version.split(" ")[-1] >= "v2025":
+            proj_str, scale = self._get_proj_str_and_scale(proj_str)
+        else:
+            proj_str, scale = self._get_legacy_proj_str_and_scale(proj_str)
 
         area_extent = (
             round(float(self.nc.attrs["gdal_xgeo_up_left"]) * scale, 3),
@@ -428,7 +427,7 @@ class NcNWCSAF(BaseFileHandler):
 
         return crs, area_extent
 
-    def _get_v2025_proj_str_and_scale(self, proj_str):
+    def _get_proj_str_and_scale(self, proj_str):
         scaled_proj_str = ""
         for elt in proj_str.split():
             if elt.startswith("+h="):

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -412,10 +412,10 @@ class NcNWCSAF(BaseFileHandler):
         return crs, area_extent
 
     def _get_crs_and_extent_from_proj_str(self, proj_str):
+        scale = 1.0
         if self.sw_version.split(" ")[-1] >= "v2025":
             proj_str, scale = self._get_proj_str_and_scale(proj_str)
-        else:
-            proj_str, scale = self._get_legacy_proj_str_and_scale(proj_str)
+        proj_str, scale = self._check_units(proj_str, scale)
 
         area_extent = (
             round(float(self.nc.attrs["gdal_xgeo_up_left"]) * scale, 3),

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -43,6 +43,8 @@ logger = logging.getLogger(__name__)
 
 CHUNK_SIZE = get_chunk_size_limit()
 
+V2025_PERSPECTIVE_POINT_HEIGHT = 35786400.0
+
 SENSOR = {
     "NOAA-19": "avhrr-3",
     "NOAA-18": "avhrr-3",
@@ -415,17 +417,32 @@ class NcNWCSAF(BaseFileHandler):
         else:
             proj_str, scale = self._get_legacy_proj_str_and_scale(proj_str)
 
-        area_extent = (float(self.nc.attrs["gdal_xgeo_up_left"]) / scale,
-                    float(self.nc.attrs["gdal_ygeo_low_right"]) / scale,
-                    float(self.nc.attrs["gdal_xgeo_low_right"]) / scale,
-                    float(self.nc.attrs["gdal_ygeo_up_left"]) / scale)
+        area_extent = (
+            round(float(self.nc.attrs["gdal_xgeo_up_left"]) / scale, 3),
+            round(float(self.nc.attrs["gdal_ygeo_low_right"]) / scale, 3),
+            round(float(self.nc.attrs["gdal_xgeo_low_right"]) / scale, 3),
+            round(float(self.nc.attrs["gdal_ygeo_up_left"]) / scale, 3))
 
         crs = CRS.from_string(proj_str)
 
         return crs, area_extent
 
     def _get_v2025_proj_str_and_scale(self, proj_str):
-        return "", 1.0
+        scaled_proj_str = ""
+        for elt in proj_str.split():
+            if elt.startswith("+h="):
+                height = round(V2025_PERSPECTIVE_POINT_HEIGHT * float(elt.split("=")[-1]), 3)
+                scaled_proj_str += f"+h={height} "
+            elif elt.startswith("+a="):
+                radius_a = round(V2025_PERSPECTIVE_POINT_HEIGHT * float(elt.split("=")[-1]), 3)
+                scaled_proj_str += f"+a={radius_a} "
+            elif elt.startswith("+b="):
+                radius_b = round(V2025_PERSPECTIVE_POINT_HEIGHT * float(elt.split("=")[-1]), 3)
+                scaled_proj_str += f"+b={radius_b} "
+            else:
+                scaled_proj_str += elt + " "
+        proj_str = scaled_proj_str.strip()
+        return proj_str, 1.0
 
     def _get_legacy_proj_str_and_scale(self, proj_str):
         # Check the a/b/h units

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -412,10 +412,11 @@ class NcNWCSAF(BaseFileHandler):
         return crs, area_extent
 
     def _get_crs_and_extent_from_proj_str(self, proj_str):
+        scale = 1.0
         if "v2025" in self.sw_version:
             proj_str, scale = self._get_v2025_proj_str_and_scale(proj_str)
-        else:
-            proj_str, scale = self._get_legacy_proj_str_and_scale(proj_str)
+
+        proj_str, scale = self._check_units(proj_str, scale)
 
         area_extent = (
             round(float(self.nc.attrs["gdal_xgeo_up_left"]) * scale, 3),
@@ -444,18 +445,18 @@ class NcNWCSAF(BaseFileHandler):
         proj_str = scaled_proj_str.strip()
         return proj_str, V2025_PERSPECTIVE_POINT_HEIGHT
 
-    def _get_legacy_proj_str_and_scale(self, proj_str):
+    def _check_units(self, proj_str, scale):
         # Check the a/b/h units
         radius_a = proj_str.split("+a=")[-1].split()[0]
         if float(radius_a) > 10e3:
             units = "m"
-            scale = 1.0
         else:
             units = "km"
-            scale = 1e-3
+            scale *= 1e-3
 
         if "units" not in proj_str:
             proj_str = proj_str + " +units=" + units
+
         return proj_str, scale
 
 

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -442,7 +442,7 @@ class NcNWCSAF(BaseFileHandler):
             else:
                 scaled_proj_str += elt + " "
         proj_str = scaled_proj_str.strip()
-        return proj_str, 1.0
+        return proj_str, 1.0 / V2025_PERSPECTIVE_POINT_HEIGHT
 
     def _get_legacy_proj_str_and_scale(self, proj_str):
         # Check the a/b/h units

--- a/satpy/readers/nwcsaf_nc.py
+++ b/satpy/readers/nwcsaf_nc.py
@@ -418,10 +418,10 @@ class NcNWCSAF(BaseFileHandler):
             proj_str, scale = self._get_legacy_proj_str_and_scale(proj_str)
 
         area_extent = (
-            round(float(self.nc.attrs["gdal_xgeo_up_left"]) / scale, 3),
-            round(float(self.nc.attrs["gdal_ygeo_low_right"]) / scale, 3),
-            round(float(self.nc.attrs["gdal_xgeo_low_right"]) / scale, 3),
-            round(float(self.nc.attrs["gdal_ygeo_up_left"]) / scale, 3))
+            round(float(self.nc.attrs["gdal_xgeo_up_left"]) * scale, 3),
+            round(float(self.nc.attrs["gdal_ygeo_low_right"]) * scale, 3),
+            round(float(self.nc.attrs["gdal_xgeo_low_right"]) * scale, 3),
+            round(float(self.nc.attrs["gdal_ygeo_up_left"]) * scale, 3))
 
         crs = CRS.from_string(proj_str)
 
@@ -442,7 +442,7 @@ class NcNWCSAF(BaseFileHandler):
             else:
                 scaled_proj_str += elt + " "
         proj_str = scaled_proj_str.strip()
-        return proj_str, 1.0 / V2025_PERSPECTIVE_POINT_HEIGHT
+        return proj_str, V2025_PERSPECTIVE_POINT_HEIGHT
 
     def _get_legacy_proj_str_and_scale(self, proj_str):
         # Check the a/b/h units
@@ -452,7 +452,7 @@ class NcNWCSAF(BaseFileHandler):
             scale = 1.0
         else:
             units = "km"
-            scale = 1e3
+            scale = 1e-3
 
         if "units" not in proj_str:
             proj_str = proj_str + " +units=" + units

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -43,10 +43,10 @@ PROJ = {
 PROJ_V2025 = {
     "gdal_projection": \
         f"+proj=geos +a=6378137.0 +b=6356751.999 +lon_0=0.000000 +h={V2025_PERSPECTIVE_POINT_HEIGHT:.1f}",
-    "gdal_xgeo_up_left": -5568000.0,
-    "gdal_ygeo_up_left": 5480000.0,
-    "gdal_xgeo_low_right": 1856000.2,
-    "gdal_ygeo_low_right": 3623999.9,
+    "gdal_xgeo_up_left": -0.1555898,
+    "gdal_ygeo_up_left": 0.1531308,
+    "gdal_xgeo_low_right": 0.05186328,
+    "gdal_ygeo_low_right": 0.1012675,
 }
 
 dimensions_v2021 = {
@@ -602,10 +602,11 @@ def _check_filehandler_area_def(file_handler, dsid, version="v2021"):
 
     if version == "v2025":
         expected_crs = CRS(PROJ_V2025["gdal_projection"])
-        correct_extent = (PROJ_V2025["gdal_xgeo_up_left"],
-                          PROJ_V2025["gdal_ygeo_low_right"],
-                          PROJ_V2025["gdal_xgeo_low_right"],
-                          PROJ_V2025["gdal_ygeo_up_left"])
+        correct_extent = (
+            round(V2025_PERSPECTIVE_POINT_HEIGHT * float(PROJ_V2025["gdal_xgeo_up_left"]), 3),
+            round(V2025_PERSPECTIVE_POINT_HEIGHT * float(PROJ_V2025["gdal_ygeo_low_right"]), 3),
+            round(V2025_PERSPECTIVE_POINT_HEIGHT * float(PROJ_V2025["gdal_xgeo_low_right"]), 3),
+            round(V2025_PERSPECTIVE_POINT_HEIGHT * float(PROJ_V2025["gdal_ygeo_up_left"]), 3))
     else:
         expected_crs = CRS(PROJ["gdal_projection"])
         correct_extent = (PROJ["gdal_xgeo_up_left"],

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -21,7 +21,7 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from satpy.readers.nwcsaf_nc import NcNWCSAF, read_nwcsaf_time
+from satpy.readers.nwcsaf_nc import V2025_PERSPECTIVE_POINT_HEIGHT, NcNWCSAF, read_nwcsaf_time
 from satpy.tests.utils import RANDOM_GEN
 
 PROJ_KM = {"gdal_projection": "+proj=geos +a=6378.137000 +b=6356.752300 +lon_0=0.000000 +h=35785.863000",
@@ -32,12 +32,22 @@ PROJ_KM = {"gdal_projection": "+proj=geos +a=6378.137000 +b=6356.752300 +lon_0=0
 
 NOMINAL_ALTITUDE = 35785863.0
 
-PROJ = {"gdal_projection": f"+proj=geos +a=6378137.000 +b=6356752.300 +lon_0=0.000000 +h={NOMINAL_ALTITUDE:.3f}",
-        "gdal_xgeo_up_left": -5569500.0,
-        "gdal_ygeo_up_left": 5437500.0,
-        "gdal_xgeo_low_right": 5566500.0,
-        "gdal_ygeo_low_right": 2653500.0}
+PROJ = {
+    "gdal_projection": f"+proj=geos +a=6378137.000 +b=6356752.300 +lon_0=0.000000 +h={NOMINAL_ALTITUDE:.3f}",
+    "gdal_xgeo_up_left": -5569500.0,
+    "gdal_ygeo_up_left": 5437500.0,
+    "gdal_xgeo_low_right": 5566500.0,
+    "gdal_ygeo_low_right": 2653500.0,
+}
 
+PROJ_V2025 = {
+    "gdal_projection": \
+        f"+proj=geos +a=6378137.0 +b=6356751.999 +lon_0=0.000000 +h={V2025_PERSPECTIVE_POINT_HEIGHT:.1f}",
+    "gdal_xgeo_up_left": -5568000.0,
+    "gdal_ygeo_up_left": 5480000.0,
+    "gdal_xgeo_low_right": 1856000.2,
+    "gdal_ygeo_low_right": 3623999.9,
+}
 
 dimensions_v2021 = {
     "nx": 1530,
@@ -76,6 +86,7 @@ global_attrs_geo_v2025 = {
     "time_coverage_start": "2025-09-23T13:07:53Z",
     "time_coverage_end": "2025-09-23T13:09:29Z",
 }
+global_attrs_geo_v2025.update(PROJ_V2025)
 
 CTTH_PALETTE_MEANINGS = ("0 500 1000 1500")
 
@@ -126,11 +137,16 @@ def _create_nwcsaf_cf_file(filename, attrs, version):
             chunks = (1, 256, 256)
             dimensions = dimensions_v2025
             shape = (1, 928, 1530)
+            nc_file.attrs["source"] = "NWC/GEO version v2025.1"
+            gdal_projection = "+proj=geos +a=0.1782279581 +b=0.1776303847 +lon_0=0.000000 +h=1.000000 +sweep=y"
         else:
             dim_names = ("ny", "nx")
             chunks = (256, 256)
             dimensions = dimensions_v2021
             shape = (928, 1530)
+            gdal_projection = \
+                "+proj=geos +a=6378137.000000 +b=6356752.300000 +lon_0=0.000000 +h=35785863.000000 +sweep=y"
+        nc_file.attrs["gdal_projection"] = gdal_projection
         nc_file.dimensions = dimensions
         var = nc_file.create_variable(var_name, dim_names, np.uint8,
                                       chunks=chunks)
@@ -421,6 +437,11 @@ class TestNcNWCSAFGeo:
         data = nwcsaf_geo_v2025_ct_filehandler.get_dataset(dsid, ds_info)
         assert data.dims == ("y", "x")
 
+    def test_v2025_area_def(self, nwcsaf_geo_v2025_ct_filehandler):
+        """Test that the filehandler can read the area definition from a v2025 file."""
+        dsid = {"name": "ct"}
+        _check_filehandler_area_def(nwcsaf_geo_v2025_ct_filehandler, dsid, version="v2025")
+
 
 class TestNcNWCSAFPPS:
     """Test the NcNWCSAF reader for PPS products."""
@@ -574,16 +595,23 @@ class TestNcNWCSAFFileKeyPrefix:
         np.testing.assert_allclose(res.attrs["palette_meanings"], palette_meanings * COT_SCALE + COT_OFFSET)
 
 
-def _check_filehandler_area_def(file_handler, dsid):
+def _check_filehandler_area_def(file_handler, dsid, version="v2021"):
     from pyproj import CRS
 
     area_definition = file_handler.get_area_def(dsid)
 
-    expected_crs = CRS(PROJ["gdal_projection"])
-    assert area_definition.crs == expected_crs
+    if version == "v2025":
+        expected_crs = CRS(PROJ_V2025["gdal_projection"])
+        correct_extent = (PROJ_V2025["gdal_xgeo_up_left"],
+                          PROJ_V2025["gdal_ygeo_low_right"],
+                          PROJ_V2025["gdal_xgeo_low_right"],
+                          PROJ_V2025["gdal_ygeo_up_left"])
+    else:
+        expected_crs = CRS(PROJ["gdal_projection"])
+        correct_extent = (PROJ["gdal_xgeo_up_left"],
+                          PROJ["gdal_ygeo_low_right"],
+                          PROJ["gdal_xgeo_low_right"],
+                          PROJ["gdal_ygeo_up_left"])
 
-    correct_extent = (PROJ["gdal_xgeo_up_left"],
-                      PROJ["gdal_ygeo_low_right"],
-                      PROJ["gdal_xgeo_low_right"],
-                      PROJ["gdal_ygeo_up_left"])
+    assert area_definition.crs == expected_crs
     assert area_definition.area_extent == correct_extent

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -41,7 +41,7 @@ PROJ = {
 }
 
 PROJ_V2025 = {
-    "gdal_projection": \
+    "gdal_projection":
         f"+proj=geos +a=6378137.0 +b=6356751.999 +lon_0=0.000000 +h={V2025_PERSPECTIVE_POINT_HEIGHT:.1f}",
     "gdal_xgeo_up_left": -0.1555898,
     "gdal_ygeo_up_left": 0.1531308,


### PR DESCRIPTION
This PR fixes the projection handling of NWC SAF GEO v2025 data in `nwcsaf-geo` reader. The `a`, `b` and `h` parameters of the `proj_string` and the area extent are now scaled (de-scaled?) with the *hard-coded* value of `projection_definition:perspective_point_height`, which can't be accessed from the attributes given by `xr.open_dataset()`. The struct(?) can't be accessed with `netCDF4`, `h5netcdf` nor `h5py` either (in a simple way in any case) with the use.

@strandgren can you give this a go to see how well the geolocation actually matches?

 - [x] Closes #3366  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
