### PR TITLE
Fix NaN handling in NDVIHybridGreen calculation

### DIFF
--- a/satpy/composites/spectral.py
+++ b/satpy/composites/spectral.py
@@ -166,7 +166,10 @@ class NDVIHybridGreen(SpectralBlender):
         ndvi = (projectables[2] - projectables[1]) / (projectables[2] + projectables[1])
 
         ndvi = ndvi.clip(self.ndvi_min, self.ndvi_max)
-        ndvi.data = np.nan_to_num(ndvi.data)
+        # dask nan_to_num does not accept kwargs (see https://github.com/dask/dask/issues/12350)
+        # Second argument maps to `copy` kwarg, third maps to `nan` kwarg.
+        # Copy should remain `True` as dask operations require copies to be made
+        ndvi.data = np.nan_to_num(ndvi.data, True, self.ndvi_min)
 
         # Introduce non-linearity to ndvi for non-linear scaling to NIR blend fraction
         if self.strength != 1.0:  # self._apply_strength() has no effect if strength = 1.0 -> no non-linear behaviour

--- a/satpy/composites/spectral.py
+++ b/satpy/composites/spectral.py
@@ -17,6 +17,8 @@
 
 import logging
 
+import numpy as np
+
 from satpy.composites.core import GenericCompositor
 from satpy.dataset import combine_metadata
 
@@ -110,7 +112,7 @@ class NDVIHybridGreen(SpectralBlender):
     """Construct a NDVI-weighted hybrid green channel.
 
     This green band correction follows the same approach as the HybridGreen compositor, but with a dynamic blend
-    factor `f` that depends on the pixel-level Normalized Differece Vegetation Index (NDVI). The higher the NDVI, the
+    factor `f` that depends on the pixel-level Normalized Difference Vegetation Index (NDVI). The higher the NDVI, the
     smaller the contribution from the nir channel will be, following a liner (default) or non-linear relationship
     between the two ranges `[ndvi_min, ndvi_max]` and `limits`.
 
@@ -163,7 +165,7 @@ class NDVIHybridGreen(SpectralBlender):
 
         ndvi = (projectables[2] - projectables[1]) / (projectables[2] + projectables[1])
 
-        ndvi = ndvi.clip(self.ndvi_min, self.ndvi_max)
+        ndvi = np.nan_to_num(ndvi.clip(self.ndvi_min, self.ndvi_max), nan=self.ndvi_min)
 
         # Introduce non-linearity to ndvi for non-linear scaling to NIR blend fraction
         if self.strength != 1.0:  # self._apply_strength() has no effect if strength = 1.0 -> no non-linear behaviour
@@ -181,7 +183,7 @@ class NDVIHybridGreen(SpectralBlender):
         """Introduce non-linearity by applying strength factor.
 
         The method introduces non-linearity to the ndvi for a non-linear scaling from ndvi to blend fraction in
-        `_compute_blend_fraction`. This can be used for a slower or faster transision to higher/lower fractions
+        `_compute_blend_fraction`. This can be used for a slower or faster transition to higher/lower fractions
         at the ndvi extremes. If strength equals 1.0, this operation has no effect on the ndvi.
         """
         ndvi = ndvi ** self.strength / (ndvi ** self.strength + (1 - ndvi) ** self.strength)

--- a/satpy/composites/spectral.py
+++ b/satpy/composites/spectral.py
@@ -165,7 +165,8 @@ class NDVIHybridGreen(SpectralBlender):
 
         ndvi = (projectables[2] - projectables[1]) / (projectables[2] + projectables[1])
 
-        ndvi = np.nan_to_num(ndvi.clip(self.ndvi_min, self.ndvi_max), nan=self.ndvi_min)
+        ndvi = ndvi.clip(self.ndvi_min, self.ndvi_max)
+        ndvi.data = np.nan_to_num(ndvi.data)
 
         # Introduce non-linearity to ndvi for non-linear scaling to NIR blend fraction
         if self.strength != 1.0:  # self._apply_strength() has no effect if strength = 1.0 -> no non-linear behaviour

--- a/satpy/tests/compositor_tests/test_spectral.py
+++ b/satpy/tests/compositor_tests/test_spectral.py
@@ -76,16 +76,17 @@ class TestNdviHybridGreenCompositor:
 
     def setup_method(self):
         """Initialize channels."""
-        coord_val = [1.0, 2.0]
+        y_coord_val = [1.0, 2.0, 3.0]
+        x_coord_val = [1.0, 2.0]
         self.c01 = xr.DataArray(
-            da.from_array(np.array([[0.25, 0.30], [0.20, 0.30]], dtype=np.float32), chunks=25),
-            dims=("y", "x"), coords=[coord_val, coord_val], attrs={"name": "C02"})
+            da.from_array(np.array([[0.25, 0.30], [0.20, 0.30], [0.0, 0.3]], dtype=np.float32), chunks=25),
+            dims=("y", "x"), coords=[y_coord_val, x_coord_val], attrs={"name": "C02"})
         self.c02 = xr.DataArray(
-            da.from_array(np.array([[0.25, 0.30], [0.25, 0.35]], dtype=np.float32), chunks=25),
-            dims=("y", "x"), coords=[coord_val, coord_val], attrs={"name": "C03"})
+            da.from_array(np.array([[0.25, 0.30], [0.25, 0.35], [0.0, 0.0]], dtype=np.float32), chunks=25),
+            dims=("y", "x"), coords=[y_coord_val, x_coord_val], attrs={"name": "C03"})
         self.c03 = xr.DataArray(
-            da.from_array(np.array([[0.35, 0.35], [0.28, 0.65]], dtype=np.float32), chunks=25),
-            dims=("y", "x"), coords=[coord_val, coord_val], attrs={"name": "C04"})
+            da.from_array(np.array([[0.35, 0.35], [0.28, 0.65], [0.0, 0.0]], dtype=np.float32), chunks=25),
+            dims=("y", "x"), coords=[y_coord_val, x_coord_val], attrs={"name": "C04"})
 
     def test_ndvi_hybrid_green(self):
         """Test General functionality with linear scaling from ndvi to blend fraction."""
@@ -100,7 +101,10 @@ class TestNdviHybridGreenCompositor:
         assert res.attrs["name"] == "ndvi_hybrid_green"
         assert res.attrs["standard_name"] == "toa_bidirectional_reflectance"
         data = res.values
-        np.testing.assert_array_almost_equal(data, np.array([[0.2633, 0.3071], [0.2115, 0.3420]]), decimal=4)
+        np.testing.assert_array_almost_equal(
+            data,
+            np.array([[0.2633, 0.3071], [0.2115, 0.3420], [0.0, 0.255]]),
+            decimal=4)
 
     def test_ndvi_hybrid_green_dtype(self):
         """Test that the datatype is not altered by the compositor."""
@@ -120,7 +124,10 @@ class TestNdviHybridGreenCompositor:
         res_np = res.data.compute()
         assert res.dtype == res_np.dtype
         assert res.dtype == np.float32
-        np.testing.assert_array_almost_equal(res.data, np.array([[0.2646, 0.3075], [0.2120, 0.3471]]), decimal=4)
+        np.testing.assert_array_almost_equal(
+            res.data,
+            np.array([[0.2646, 0.3075], [0.2120, 0.3471], [0.0, 0.255]]),
+            decimal=4)
 
     def test_invalid_strength(self):
         """Test using invalid `strength` term for non-linear scaling."""
@@ -138,9 +145,9 @@ class TestNdviHybridGreenCompositor:
                                standard_name="toa_bidirectional_reflectance")
 
         c02_bad_shape = self.c02.copy()
-        c02_bad_shape.coords["y"] = [1.1, 2.]
+        c02_bad_shape.coords["y"] = [1.1, 2.0, 3.0]
         res = comp((self.c01, c02_bad_shape, self.c03))
-        assert res.shape == (2, 2)
+        assert res.shape == (3, 2)
 
 
 class TestNaturalEnhCompositor(unittest.TestCase):


### PR DESCRIPTION
While working on generating FCI true colors @kathys noticed that the night portion of the image was always transparent instead of black like other instruments' true colors. I tracked it down to the NDVI Hybrid Green correction. The "problem" comes down to NDVI having `/ 0` in some cases which in numpy results in NaNs. This results in the correction/contribution fraction being NaN and the resulting green pixel value being NaN. In this PR I do an additional "clip" on the NDVI to convert NaNs to the minimum allowed NDVI as configured by the user. Given that the current result is different than what the regular hybrid compositor produces (ex. AHI's current default, black night pixels) and how simple the fix is I think this is the right way to go.

I still need to add a test, but wanted to get people's opinion.

### Old

<img width="1670" height="1670" alt="true_color_20260329_063000 old" src="https://github.com/user-attachments/assets/0e44a149-1ac0-429a-aab9-989684de82ad" />

### New

<img width="1670" height="1670" alt="true_color_20260329_063000 new" src="https://github.com/user-attachments/assets/50c2d88b-c9c4-4dc5-aa23-bf10b5220485" />

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
