### PR TITLE
Adjust logging level when selecting NetCDF backend

### DIFF
--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -391,7 +391,7 @@ def get_accessor_and_filehandle_from_engines(filename, *engines):
     """Choose an accessor from the first possible engine, and return in along with the file handle."""
     for engine in engines:
         try:
-            LOG.info(f"Trying reading nc file with {engine} engine…")
+            LOG.debug(f"Trying reading nc file with {engine} engine…")
             return get_accessor_and_filehandle_from_engine(filename, engine)
         except Exception as err:
             LOG.warning(f"Cannot use {engine} engine to read nc file.")


### PR DESCRIPTION
This PR changes the logging level of NetCDF4 backend selection from `INFO` to `DEBUG`. It is unnecessary to print 80 times `Trying reading nc file with netcdf4 engine…` for an FCI scene.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
