### PR TITLE
add raw counts calibration type to Metop-SG A1 reader (vii_l1b_nc.py)

### DIFF
--- a/satpy/etc/readers/vii_l1b_nc.yaml
+++ b/satpy/etc/readers/vii_l1b_nc.yaml
@@ -54,6 +54,9 @@ datasets:
     file_key: data/measurement_data/vii_443
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
@@ -68,6 +71,9 @@ datasets:
     file_key: data/measurement_data/vii_555
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
@@ -82,6 +88,9 @@ datasets:
     file_key: data/measurement_data/vii_668
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
@@ -96,6 +105,9 @@ datasets:
     file_key: data/measurement_data/vii_752
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
@@ -109,7 +121,7 @@ datasets:
     file_type: nc_vii_l1b_rad
     file_key: data/measurement_data/vii_763
     coordinates: [lat_pixels, lon_pixels]
-    calibration: [reflectance, radiance]
+    calibration: [counts, reflectance, radiance]
     chan_solar_index: 4
     wavelength: [0.75695, 0.7627, 0.76845]
 
@@ -119,6 +131,9 @@ datasets:
     file_key: data/measurement_data/vii_865
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
@@ -133,6 +148,9 @@ datasets:
     file_key: data/measurement_data/vii_914
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
@@ -147,6 +165,9 @@ datasets:
     file_key: data/measurement_data/vii_1240
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
@@ -161,6 +182,9 @@ datasets:
     file_key: data/measurement_data/vii_1375
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
@@ -175,6 +199,9 @@ datasets:
     file_key: data/measurement_data/vii_1630
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
@@ -189,6 +216,9 @@ datasets:
     file_key: data/measurement_data/vii_2250
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       reflectance:
         standard_name: toa_bidirectional_reflectance
         units: "%"
@@ -203,6 +233,9 @@ datasets:
     file_key: data/measurement_data/vii_3740
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
@@ -217,6 +250,9 @@ datasets:
     file_key: data/measurement_data/vii_3959
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
@@ -231,6 +267,9 @@ datasets:
     file_key: data/measurement_data/vii_4050
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
@@ -245,6 +284,9 @@ datasets:
     file_key: data/measurement_data/vii_6725
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
@@ -259,6 +301,9 @@ datasets:
     file_key: data/measurement_data/vii_7325
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
@@ -273,6 +318,9 @@ datasets:
     file_key: data/measurement_data/vii_8540
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
@@ -287,6 +335,9 @@ datasets:
     file_key: data/measurement_data/vii_10690
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
@@ -301,6 +352,9 @@ datasets:
     file_key: data/measurement_data/vii_12020
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"
@@ -315,6 +369,9 @@ datasets:
     file_key: data/measurement_data/vii_13345
     coordinates: [lat_pixels, lon_pixels]
     calibration:
+      counts:
+        standard_name: counts
+        units: "count"
       brightness_temperature:
         standard_name: toa_brightness_temperature
         units: "K"

--- a/satpy/readers/vii_l1b_nc.py
+++ b/satpy/readers/vii_l1b_nc.py
@@ -49,10 +49,10 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
         self._bt_conversion_b = self["data/calibration_data/bt_conversion_b"].values
         self._channel_cw_thermal = self["data/calibration_data/channel_cw_thermal"].values
         # Test data has been seen for both variants below...
-        try:
-            self._integrated_solar_irradiance = self["data/calibration_data/band_averaged_solar_irradiance"].values
-        except:
-            self._integrated_solar_irradiance = self["data/calibration_data/Band_averaged_solar_irradiance"].values
+        try:
+            self._integrated_solar_irradiance = self["data/calibration_data/band_averaged_solar_irradiance"].values
+        except KeyError:
+            self._integrated_solar_irradiance = self["data/calibration_data/Band_averaged_solar_irradiance"].values
         # Computes the angle factor for reflectance calibration as inverse of cosine of solar zenith angle
         # (the values in the product file are on tie points and in degrees,
         # therefore interpolation and conversion to radians are required)

--- a/satpy/readers/vii_l1b_nc.py
+++ b/satpy/readers/vii_l1b_nc.py
@@ -48,7 +48,11 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
         self._bt_conversion_a = self["data/calibration_data/bt_conversion_a"].values
         self._bt_conversion_b = self["data/calibration_data/bt_conversion_b"].values
         self._channel_cw_thermal = self["data/calibration_data/channel_cw_thermal"].values
-        self._integrated_solar_irradiance = self["data/calibration_data/band_averaged_solar_irradiance"].values
+        # Test data has been seen for both variants below...
+        try:
+            self._integrated_solar_irradiance = self["data/calibration_data/band_averaged_solar_irradiance"].values
+        except:
+            self._integrated_solar_irradiance = self["data/calibration_data/Band_averaged_solar_irradiance"].values
         # Computes the angle factor for reflectance calibration as inverse of cosine of solar zenith angle
         # (the values in the product file are on tie points and in degrees,
         # therefore interpolation and conversion to radians are required)
@@ -83,6 +87,19 @@ class ViiL1bNCFileHandler(ViiNCBaseFileHandler):
             calibrated_variable.attrs = variable.attrs
         elif calibration_name == "radiance":
             calibrated_variable = variable
+        elif calibration_name == "counts":
+            # xarray automatically applies scale_factor and add_offset when reading the netCDF.
+            # To get raw counts, reverse this process using the original parameters.
+            scale_factor = variable.encoding.get("scale_factor", variable.attrs.get("scale_factor", 1.0))
+            add_offset = variable.encoding.get("add_offset", variable.attrs.get("add_offset", 0.0))
+
+            calibrated_variable = (variable - add_offset) / scale_factor
+
+            # Cast back to the original integer datatype (e.g., uint16) for strict counts
+            original_dtype = variable.encoding.get("dtype", variable.dtype)
+            calibrated_variable = calibrated_variable.astype(original_dtype)
+
+            calibrated_variable.attrs = variable.attrs
         else:
             raise ValueError("Unknown calibration %s for dataset %s" % (calibration_name, dataset_info["name"]))
 


### PR DESCRIPTION
Some SSEC applications depend on raw counts from the sensor, which several satpy readers already support. This adds a counts calibration to the METimage (VII) L1B reader, benefiting the SSEC PyADDE project.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [x] Add your name to `AUTHORS.md` if not there already
