### PR TITLE
Fix lookup table enhancement removing transparency (NaNs)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -115,3 +115,4 @@ The following people have made contributions to this project:
 - [Albert Brotzer](https://github.com/albertbrotzer)
 - [Alexandra Melzer](https://github.com/armelzer)
 - [Francesc Lucas Carbó (cesclc)](https://github.com/cesclc)
+- [Göte Kleringer (Grukank)](https://github.com/Grukank)

--- a/satpy/enhancements/colormap.py
+++ b/satpy/enhancements/colormap.py
@@ -34,24 +34,23 @@ LOG = logging.getLogger(__name__)
 def lookup(img, **kwargs):
     """Assign values to channels based on a table."""
     luts = np.array(kwargs["luts"], dtype=np.float32) / 255.0
-    # Preserve NaNs
-    nans = np.isfinite(img.data)
-    _lookup_table(img.data, luts=luts)
-    # Replace lost NaNs
-    img.data = img.data.where(nans, np.nan)
-    return
+    return _lookup_table(img.data, luts=luts)
 
 
 @exclude_alpha
 @on_separate_bands
 @using_map_blocks
 def _lookup_table(band_data, luts=None, index=-1):
+    # Save positions of NaNs
+    nans = np.isfinite(band_data)
     # NaN/null values will become 0
     lut = luts[:, index] if len(luts.shape) == 2 else luts
     band_data = band_data.clip(0, lut.size - 1)
     # Convert to uint8, with NaN/null values changed into 0
     band_data = np.nan_to_num(band_data).astype(np.uint8)
-    return lut[band_data]
+    # Lookup data, but with replaced NaNs from saved positions
+    res = np.where(nans, lut[band_data], np.nan)
+    return res
 
 
 def colorize(img, **kwargs):  # noqa: D417

--- a/satpy/enhancements/colormap.py
+++ b/satpy/enhancements/colormap.py
@@ -36,7 +36,6 @@ def lookup(img, **kwargs):
     luts = np.array(kwargs["luts"], dtype=np.float32) / 255.0
     # Preserve NaNs
     nans = np.isfinite(img.data)
-    
     _lookup_table(img.data, luts=luts)
     # Replace lost NaNs
     img.data = img.data.where(nans, np.nan)

--- a/satpy/enhancements/colormap.py
+++ b/satpy/enhancements/colormap.py
@@ -34,7 +34,13 @@ LOG = logging.getLogger(__name__)
 def lookup(img, **kwargs):
     """Assign values to channels based on a table."""
     luts = np.array(kwargs["luts"], dtype=np.float32) / 255.0
-    return _lookup_table(img.data, luts=luts)
+    # Preserve NaNs
+    nans = np.isfinite(img.data)
+    
+    _lookup_table(img.data, luts=luts)
+    # Replace lost NaNs
+    img.data = img.data.where(nans, np.nan)
+    return
 
 
 @exclude_alpha

--- a/satpy/tests/enhancement_tests/test_colormap.py
+++ b/satpy/tests/enhancement_tests/test_colormap.py
@@ -42,16 +42,16 @@ class TestEnhancementsConvolution:
         """Test the lookup enhancement function."""
         from satpy.enhancements.colormap import lookup
         expected = np.array([[
-            [0., 0., 0., 0.333333, 0.705882],
+            [np.nan, 0., 0., 0.333333, 0.705882],
             [1., 1., 1., 1., 1.]]])
         lut = np.arange(256.)
         run_and_check_enhancement(lookup, self.ch1, expected, luts=lut)
 
-        expected = np.array([[[0., 0., 0., 0.333333, 0.705882],
+        expected = np.array([[[np.nan, 0., 0., 0.333333, 0.705882],
                               [1., 1., 1., 1., 1.]],
-                             [[0., 0., 0., 0.333333, 0.705882],
+                             [[np.nan, 0., 0., 0.333333, 0.705882],
                               [1., 1., 1., 1., 1.]],
-                             [[0., 0., 0., 0.333333, 0.705882],
+                             [[np.nan, 0., 0., 0.333333, 0.705882],
                               [1., 1., 1., 1., 1.]]])
         lut = np.arange(256.)
         lut = np.vstack((lut, lut, lut)).T


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
In colormap.py in Enhancements, preserves the NaN values lost during lookup and replaces them again where they were lost. For SMHI only relevant for snow_age.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [x] Tests added/updated <!-- for all bug fixes or enhancements -->
 - [x] Add your name to `AUTHORS.md` if not there already
