### PR TITLE
Update some VIIRS composite definitions to match WMO recommendations

### DIFF
--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -394,9 +394,15 @@ composites:
   night_microphysics:
     compositor: !!python/name:satpy.composites.core.GenericCompositor
     prerequisites:
-    - hncc_dnb
-    - M12
-    - M15
+      - compositor: !!python/name:satpy.composites.arithmetic.DifferenceCompositor
+        prerequisites:
+          - M16
+          - M15
+      - compositor: !!python/name:satpy.composites.arithmetic.DifferenceCompositor
+        prerequisites:
+          - M15
+          - M12
+      - M15
     standard_name: night_microphysics
 
   day_microphysics:

--- a/satpy/etc/composites/viirs.yaml
+++ b/satpy/etc/composites/viirs.yaml
@@ -608,6 +608,8 @@ composites:
     high_resolution_band: red
 
   cloud_phase_distinction:
+    deprecation_warning: >
+      'cloud_phase_distinction' is deprecated. Use of 'day_cloud_type_distinction' is recommended instead.
     description: >
       Day Cloud Phase Distinction RGB, for GOESR: NASA, NOAA
       Cloud Type RGB, for  EUMETSAT (https://www.eumetsat.int/website/home/Images/ImageLibrary/DAT_3958037.html)
@@ -624,7 +626,26 @@ composites:
         modifiers: [sunz_corrected_iband]
     standard_name: cloud_phase_distinction
 
+  day_cloud_type_distinction:
+    description: >
+      Day Cloud Type Distinction RGB, for GOESR: NASA, NOAA
+      Cloud Type RGB, for  EUMETSAT (https://www.eumetsat.int/website/home/Images/ImageLibrary/DAT_3958037.html)
+    references:
+      CIRA Quick Guide: https://rammb.cira.colostate.edu/training/visit/quick_guides/QuickGuide_DayCloudPhaseDistinction_final_v2.pdf
+      Cloud Type recipe and typical colours: https://www.eumetsat.int/fr/media/45659
+    ## it uses the enhancement in etc/enhancements/abi.yaml for this standard_name
+    compositor: !!python/name:satpy.composites.core.GenericCompositor
+    prerequisites:
+      - name: M15
+      - name: I01
+        modifiers: [sunz_corrected_iband, rayleigh_corrected]
+      - name: I03
+        modifiers: [sunz_corrected_iband]
+    standard_name: day_cloud_type_distinction
+
   cloud_phase_distinction_raw:
+    deprecation_warning: >
+      'cloud_phase_distinction_raw' is deprecated. Use of 'day_cloud_type_distinction_raw' is recommended instead.
     description: >
       same as cloud_phase_distinction
     compositor: !!python/name:satpy.composites.core.GenericCompositor
@@ -633,6 +654,33 @@ composites:
       - name: I01
       - name: I03
     standard_name: cloud_phase_distinction
+
+  day_cloud_type_distinction_raw:
+    description: >
+      same as day_cloud_type_distinction
+    compositor: !!python/name:satpy.composites.core.GenericCompositor
+    prerequisites:
+      - name: M15
+      - name: I01
+      - name: I03
+    standard_name: day_cloud_type_distinction
+
+  day_cloud_type:
+    description: >
+      Day Cloud Type RGB, for GOESR: NASA, NOAA
+      Cloud Type RGB, for  EUMETSAT (https://www.eumetsat.int/website/home/Images/ImageLibrary/DAT_3958037.html)
+    references:
+      Quick Guide: http://cimss.ssec.wisc.edu/goes/OCLOFactSheetPDFs/ABIQuickGuide_Day_Cloud_Type_RGB.pdf
+      EUMeTrain Guide: https://resources.eumetrain.org/data/7/736/navmenu.php?tab=3&page=1.0.0
+    ## it uses the enhancement in etc/enhancements/abi.yaml for this standard_name
+    compositor: !!python/name:satpy.composites.core.GenericCompositor
+    prerequisites:
+      - name: M09
+      - name: I01
+        modifiers: [sunz_corrected_iband, rayleigh_corrected]
+      - name: I03
+        modifiers: [sunz_corrected_iband]
+    standard_name: day_cloud_type
 
   cloud_phase:
     description: >

--- a/satpy/etc/enhancements/viirs.yaml
+++ b/satpy/etc/enhancements/viirs.yaml
@@ -98,3 +98,27 @@ enhancements:
         kwargs:
           palettes:
             - { colors: greys, min_value: 190, max_value: 295 }
+
+  day_cloud_type_distinction:
+    standard_name: day_cloud_type_distinction
+    operations:
+      - name: stretch
+        method: !!python/name:satpy.enhancements.contrast.stretch
+        kwargs:
+          stretch: crude
+          min_stretch: [280.7, 0, 1]
+          max_stretch: [219.6, 78, 59]
+
+  day_cloud_type:
+    standard_name: day_cloud_type_distinction
+    operations:
+      - name: stretch
+        method: !!python/name:satpy.enhancements.contrast.stretch
+        kwargs:
+          stretch: crude
+          min_stretch: [0.0, 0.0, 1.0]
+          max_stretch: [10.0, 78.0, 59.0]
+      - name: gamma
+        method: !!python/name:satpy.enhancements.contrast.gamma
+        kwargs:
+          gamma: [1.5, 1.0, 1.0]


### PR DESCRIPTION
This PR:

* Adds `day_cloud_type_distinction`
* Deprecates `cloud_phase_distinction` in favor of `day_cloud_type_distinction` variables
* Adds `day_cloud_type`
* Replaces `night_microphysics` recipe with `night_fog` recipe

I think this matches WMO suggestions from the RGB Workshop. @adybbroe I'd like your approval on the night microphysics change.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
