### PR TITLE
Cleanup session-scoped pytest fixtures to be more narrowly scoped

### DIFF
--- a/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
+++ b/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
@@ -393,7 +393,7 @@ def _create_header_metadata() -> str:
     return archive_metadata_header
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l1b_nasa_mod021km_file(tmpdir_factory) -> list[str]:
     """Create a single MOD021KM file following standard NASA file scheme."""
     filename = generate_nasa_l1b_filename("MOD021km")
@@ -411,7 +411,7 @@ def modis_l1b_nasa_mod021km_file(tmpdir_factory) -> list[str]:
     return [full_path]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l1b_imapp_1000m_file(tmpdir_factory) -> list[str]:
     """Create a single MOD021KM file following IMAPP file scheme."""
     filename = generate_imapp_filename("1000m")
@@ -429,7 +429,7 @@ def modis_l1b_imapp_1000m_file(tmpdir_factory) -> list[str]:
     return [full_path]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l1b_nasa_mod02hkm_file(tmpdir_factory) -> list[str]:
     """Create a single MOD02HKM file following standard NASA file scheme."""
     filename = generate_nasa_l1b_filename("MOD02Hkm")
@@ -459,7 +459,7 @@ def modis_l1b_nasa_mod02qkm_file(tmpdir_factory) -> list[str]:
     return [full_path]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l1b_nasa_mod03_file(tmpdir_factory) -> list[str]:
     """Create a single MOD03 file following standard NASA file scheme."""
     filename = generate_nasa_l1b_filename("MOD03")
@@ -473,7 +473,7 @@ def modis_l1b_nasa_mod03_file(tmpdir_factory) -> list[str]:
     return [full_path]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l1b_imapp_geo_file(tmpdir_factory) -> list[str]:
     """Create a single geo file following standard IMAPP file scheme."""
     filename = generate_imapp_filename("geo")
@@ -487,7 +487,7 @@ def modis_l1b_imapp_geo_file(tmpdir_factory) -> list[str]:
     return [full_path]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l1b_nasa_1km_mod03_files(modis_l1b_nasa_mod021km_file, modis_l1b_nasa_mod03_file) -> list[str]:
     """Create input files including the 1KM and MOD03 files."""
     return modis_l1b_nasa_mod021km_file + modis_l1b_nasa_mod03_file
@@ -646,7 +646,7 @@ def generate_nasa_l3_tile_filename(prefix: str) -> str:
     now = dt.datetime.now()
     return f"{prefix}.A{now:%Y}001.h34v07.061.{now:%Y%j%H%M%S}.hdf"
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l2_nasa_mod35_file(tmpdir_factory) -> list[str]:
     """Create a single MOD35 L2 HDF4 file with headers."""
     filename = generate_nasa_l2_filename("MOD35")
@@ -660,7 +660,7 @@ def modis_l2_nasa_mod35_file(tmpdir_factory) -> list[str]:
                             _create_header_metadata())
     return [full_path]
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l3_nasa_mcd12q1_file(tmpdir_factory) -> list[str]:
     """Create a single MOD35 L2 HDF4 file with headers."""
     filename = generate_nasa_l3_tile_filename("MCD12Q1")
@@ -705,7 +705,7 @@ def modis_l3_file(tmpdir_factory, f_prefix, var_name, f_short):
     return [full_path]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l3_nasa_mod09_file(tmpdir_factory) -> list[str]:
     """Create a single MOD09 L3 HDF4 file with headers."""
     return modis_l3_file(tmpdir_factory,
@@ -714,7 +714,7 @@ def modis_l3_nasa_mod09_file(tmpdir_factory) -> list[str]:
                          "MOD09")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l3_nasa_mod43_file(tmpdir_factory) -> list[str]:
     """Create a single MVCD43 L3 HDF4 file with headers."""
     return modis_l3_file(tmpdir_factory,
@@ -723,13 +723,13 @@ def modis_l3_nasa_mod43_file(tmpdir_factory) -> list[str]:
                          "MCD43C1")
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l2_nasa_mod35_mod03_files(modis_l2_nasa_mod35_file, modis_l1b_nasa_mod03_file) -> list[str]:
     """Create a MOD35 L2 HDF4 file and MOD03 L1b geolocation file."""
     return modis_l2_nasa_mod35_file + modis_l1b_nasa_mod03_file
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l2_nasa_mod06_file(tmpdir_factory) -> list[str]:
     """Create a single MOD06 L2 HDF4 file with headers."""
     filename = generate_nasa_l2_filename("MOD06")
@@ -745,7 +745,7 @@ def modis_l2_nasa_mod06_file(tmpdir_factory) -> list[str]:
                             _create_header_metadata())
     return [full_path]
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l2_nasa_mod99_file(tmpdir_factory) -> list[str]:
     """Create an "artificial" MOD99 L2 HDF4 file with headers.
 
@@ -763,7 +763,7 @@ def modis_l2_nasa_mod99_file(tmpdir_factory) -> list[str]:
                             _create_header_metadata())
     return [full_path]
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l2_imapp_snowmask_file(tmpdir_factory) -> list[str]:
     """Create a single IMAPP snowmask L2 HDF4 file with headers."""
     filename = generate_imapp_filename("snowmask")
@@ -774,13 +774,13 @@ def modis_l2_imapp_snowmask_file(tmpdir_factory) -> list[str]:
     return [full_path]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l2_imapp_snowmask_geo_files(modis_l2_imapp_snowmask_file, modis_l1b_nasa_mod03_file) -> list[str]:
     """Create the IMAPP snowmask and geo HDF4 files."""
     return modis_l2_imapp_snowmask_file + modis_l1b_nasa_mod03_file
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l2_imapp_mask_byte1_file(tmpdir_factory) -> list[str]:
     """Create a single IMAPP mask_byte1 L2 HDF4 file with headers."""
     filename = generate_imapp_filename("mask_byte1")
@@ -791,7 +791,7 @@ def modis_l2_imapp_mask_byte1_file(tmpdir_factory) -> list[str]:
     return [full_path]
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="package")
 def modis_l2_imapp_mask_byte1_geo_files(modis_l2_imapp_mask_byte1_file, modis_l1b_nasa_mod03_file) -> list[str]:
     """Create the IMAPP mask_byte1 and geo HDF4 files."""
     return modis_l2_imapp_mask_byte1_file + modis_l1b_nasa_mod03_file

--- a/satpy/tests/reader_tests/test_gerb_l2_hr_h5.py
+++ b/satpy/tests/reader_tests/test_gerb_l2_hr_h5.py
@@ -43,7 +43,7 @@ def write_h5_null_string_att(loc_id, name, s):
     at.write(np.array(s, dtype=f"|S{len(s)+1}"))
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def gerb_l2_hr_h5_dummy_file(tmp_path_factory):
     """Create a dummy HDF5 file for the GERB L2 HR product."""
     filename = tmp_path_factory.mktemp("data") / FNAME

--- a/satpy/tests/reader_tests/test_goci2_l2_nc.py
+++ b/satpy/tests/reader_tests/test_goci2_l2_nc.py
@@ -78,7 +78,7 @@ def _create_bad_lon_lat():
     return ds
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def ac_file(tmp_path_factory):
     """Create a fake atmospheric correction product."""
     data = RANDOM_GEN.random((10, 10))

--- a/satpy/tests/reader_tests/test_hsaf_h5.py
+++ b/satpy/tests/reader_tests/test_hsaf_h5.py
@@ -17,7 +17,7 @@ AREA_X_OFFSET = 1211
 AREA_Y_OFFSET = 62
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def sc_h5_file(tmp_path_factory):
     """Create a fake HSAF SC HDF5 file."""
     filename = tmp_path_factory.mktemp("data") / "h10_20221115_day_merged.H5"

--- a/satpy/tests/reader_tests/test_msi_ec_l1c.py
+++ b/satpy/tests/reader_tests/test_msi_ec_l1c.py
@@ -56,7 +56,7 @@ def _setup_science_data(N_BANDS, N_SCANS, N_COLS):
     return data
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def msi_ec_l1c_dummy_file(tmp_path_factory):
     """Create a fake insat MSI 1C file."""
     filename = tmp_path_factory.mktemp("data") / "ECA_EXAA_MSI_RGR_1C_20250625T005649Z_20250625T024013Z_42043E.h5"

--- a/satpy/tests/reader_tests/test_nwcsaf_nc.py
+++ b/satpy/tests/reader_tests/test_nwcsaf_nc.py
@@ -115,7 +115,7 @@ COT_ARRAY = RANDOM_GEN.integers(0, 65535, size=(928, 1530), dtype=np.uint16)
 PAL_ARRAY = RANDOM_GEN.integers(0, 255, size=(250, 3), dtype=np.uint8)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def nwcsaf_geo_ct_filename(tmp_path_factory):
     """Create a CT file and return the filename."""
     return create_nwcsaf_geo_ct_file(tmp_path_factory.mktemp("data"))
@@ -159,7 +159,7 @@ def nwcsaf_geo_ct_filehandler(nwcsaf_geo_ct_filename):
     return NcNWCSAF(nwcsaf_geo_ct_filename, {}, {})
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def nwcsaf_geo_v2025_ct_filename(tmp_path_factory):
     """Create a CT file in the v2025 format and return the filename."""
     return create_nwcsaf_geo_v2025_ct_file(tmp_path_factory.mktemp("data"))
@@ -178,7 +178,7 @@ def nwcsaf_geo_v2025_ct_filehandler(nwcsaf_geo_v2025_ct_filename):
     return NcNWCSAF(nwcsaf_geo_v2025_ct_filename, {}, {})
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def nwcsaf_pps_cmic_filename(tmp_path_factory):
     """Create a CMIC file."""
     attrs = global_attrs.copy()
@@ -189,7 +189,7 @@ def nwcsaf_pps_cmic_filename(tmp_path_factory):
     return filename
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def nwcsaf_pps_ctth_filename(tmp_path_factory):
     """Create a CTTH file."""
     attrs = global_attrs.copy()
@@ -235,7 +235,7 @@ def nwcsaf_pps_ctth_filehandler(nwcsaf_pps_ctth_filename):
     return NcNWCSAF(nwcsaf_pps_ctth_filename, {}, {})
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def nwcsaf_pps_cpp_filename(tmp_path_factory):
     """Create a CPP file."""
     filename = create_cmic_file(tmp_path_factory.mktemp("data"), filetype="cpp")
@@ -291,7 +291,7 @@ def nwcsaf_pps_cpp_filehandler(nwcsaf_pps_cpp_filename):
     return NcNWCSAF(nwcsaf_pps_cpp_filename, {}, {"file_key_prefix": "cpp_"})
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def nwcsaf_old_geo_ct_filename(tmp_path_factory):
     """Create a CT file and return the filename."""
     attrs = global_attrs_geo.copy()

--- a/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_hrit.py
@@ -508,17 +508,16 @@ class TestHRITMSGCalibration(TestFileHandlerCalibrationBase):
         xr.testing.assert_equal(res, expected)
 
 
-@pytest.fixture(scope="session")
-def prologue_file(session_tmp_path, prologue_header_contents):
+@pytest.fixture(scope="module")
+def prologue_file(session_tmp_path):
     """Create a dummy prologue file."""
     from satpy.readers.seviri_l1b_native_hdr import hrit_prologue
-    header = prologue_header_contents
+    header = prologue_header_contents()
     contents = np.void(1, dtype=hrit_prologue)
     contents["SatelliteStatus"]["SatelliteDefinition"]["SatelliteId"] = 324
     return create_file(session_tmp_path / "prologue", header + [contents])
 
 
-@pytest.fixture(scope="session")
 def prologue_header_contents():
     """Get the contents of the header."""
     return [
@@ -536,16 +535,15 @@ def prologue_header_contents():
     ]
 
 
-@pytest.fixture(scope="session")
-def epilogue_file(session_tmp_path, epilogue_header_contents):
+@pytest.fixture(scope="module")
+def epilogue_file(session_tmp_path):
     """Create a dummy epilogue file."""
     from satpy.readers.seviri_l1b_native_hdr import hrit_epilogue
-    header = epilogue_header_contents
+    header = epilogue_header_contents()
     contents = np.void(1, dtype=hrit_epilogue)
     return create_file(session_tmp_path / "epilogue", header + [contents])
 
 
-@pytest.fixture(scope="session")
 def epilogue_header_contents():
     """Get the contents of the header."""
     return [
@@ -568,7 +566,7 @@ def create_file(filename, file_contents):
     return filename
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def segment_file(session_tmp_path):
     """Create a segment_file."""
     cols = 3712
@@ -621,7 +619,7 @@ def test_read_real_segment(prologue_file, epilogue_file, segment_file):
     res.compute()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def compressed_seviri_hrit_files(session_tmp_path, prologue_file, epilogue_file, segment_file):
     """Return the fsspec paths to the given seviri hrit files inside a zip file."""
     zip_full_path = session_tmp_path / "test_seviri_hrit.zip"

--- a/satpy/tests/reader_tests/test_seviri_l1b_native.py
+++ b/satpy/tests/reader_tests/test_seviri_l1b_native.py
@@ -1271,7 +1271,7 @@ def test_read_header():
     assert actual == expected
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def tmp_seviri_nat_filename(session_tmp_path):
     """Create a fully-qualified filename for a seviri native format file."""
     full_file_path = session_tmp_path / "MSG4-SEVI-MSG15-0100-NA-20210528075743.722000000Z-N.nat"
@@ -1279,7 +1279,7 @@ def tmp_seviri_nat_filename(session_tmp_path):
     return full_file_path
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def compressed_seviri_native_file(tmp_seviri_nat_filename, session_tmp_path):
     """Return the fsspec path to the given seviri native file inside a zip file."""
     zip_full_path = session_tmp_path / "test_seviri_native.zip"

--- a/satpy/tests/test_modifiers.py
+++ b/satpy/tests/test_modifiers.py
@@ -73,21 +73,21 @@ def _get_ds1(attrs):
     return ds1
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def sunz_ds1():
     """Generate fake dataset for sunz tests."""
     attrs = _shared_sunz_attrs(_sunz_area_def())
     return _get_ds1(attrs)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def sunz_ds1_stacked():
     """Generate fake dataset for sunz tests."""
     attrs = _shared_sunz_attrs(_sunz_stacked_area_def())
     return _get_ds1(attrs)
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def sunz_ds2():
     """Generate larger fake dataset for sunz tests."""
     attrs = _shared_sunz_attrs(_sunz_bigger_area_def())
@@ -97,7 +97,7 @@ def sunz_ds2():
     return ds2
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def sunz_sza():
     """Generate fake solar zenith angle data array for testing."""
     sza = xr.DataArray(


### PR DESCRIPTION
While working on another PR I noticed that there were some pytest fixtures that were session-scoped that were only used in their defining module or in the sub-package where they were defined. This PR re-scopes these fixtures to be more accurate for how they are used.

The end result should be no really difference as most of these are files on disk that pytest keeps those around between testing sessions anyway.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
