### PR TITLE
Cleanup warnings in documentation building

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v4
+        uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-version: latest
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,7 +59,7 @@ jobs:
         id: cache
 
       - name: Update environment
-        run: mamba env update -n test-environment -f continuous_integration/environment.yaml
+        run: conda env update -n test-environment -f continuous_integration/environment.yaml
         if: steps.cache.outputs.cache-hit != 'true'
 
       - name: Install unstable dependencies

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,9 +36,9 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
-          miniforge-version: 26.1.1-3
+          miniforge-version: latest
           python-version: ${{ matrix.python-version }}
           activate-environment: test-environment
           channels: conda-forge

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Setup Conda Environment
         uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-version: latest
+          miniforge-version: 26.1.1-3
           python-version: ${{ matrix.python-version }}
           activate-environment: test-environment
           channels: conda-forge

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ concurrency:
 on: [push, pull_request]
 
 env:
-  CACHE_NUMBER: 0
+  CACHE_NUMBER: 1
 
 jobs:
   test:

--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -9,7 +9,7 @@ dependencies:
   - donfig
   - platformdirs
   - toolz
-  - Cython
+  - cython
   - numba
   - sphinx
   - cartopy

--- a/doc/rtd_environment.yml
+++ b/doc/rtd_environment.yml
@@ -2,7 +2,7 @@ name: readthedocs
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
+  - python=3.13
   - pip
   - platformdirs
   - dask

--- a/doc/source/composites.rst
+++ b/doc/source/composites.rst
@@ -548,9 +548,10 @@ enhancement functions in Satpy.
    the default, in case the default should change in future versions of
    Satpy.
 
-   The compositors :class:`DayNightCompositor`,
-   :class:`BackgroundCompositor`, :class:`SandwichCompositor` and
-   :class:`LuminanceSharpeningCompositor` enhance their input datasets.
+   The compositors :class:`~satpy.composites.fill.DayNightCompositor`,
+   :class:`~satpy.composites.fill.BackgroundCompositor`,
+   :class:`~satpy.composites.resolution.SandwichCompositor` and
+   :class:`~satpy.composites.resolution.LuminanceSharpeningCompositor` enhance their input datasets.
    Therefore, composites using those compositors should almost certainly
    use ``standard_name: image_ready`` or an equivalent noop enhancement
    to avoid enhancing the data twice.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -72,7 +72,7 @@ for mod_name in MOCK_MODULES:
 
 autodoc_mock_imports = ["cf", "glymur", "h5netcdf", "holoviews", "imageio", "mipp", "netCDF4",
                         "pygac", "pygrib", "pyhdf", "pyninjotiff",
-                        "pyorbital", "pyspectral", "rasterio", "trollimage",
+                        "pyorbital", "pyspectral", "rasterio", "trollimage", "rioxarray",
                         "zarr"]
 autodoc_type_aliases = {
     "ArrayLike": "numpy.typing.ArrayLike",
@@ -87,6 +87,9 @@ nitpick_ignore_regex = [
     ("py:class", r"numpy\.uint8"),
     ("py:class", r"numpy\.uint16"),
     ("py:class", r"numpy\.uint32"),
+    ("py:data", r"typing\.Union"),
+    ("py:class", r"pathlib\._local\.Path"),
+    ("py:class", r"upath\.core\.UPath"),
 ]
 autoclass_content = "both"  # append class __init__ docstring to the class docstring
 

--- a/doc/source/multiscene.rst
+++ b/doc/source/multiscene.rst
@@ -67,7 +67,7 @@ Stacking scenes
 
 The code below uses the :meth:`MultiScene.blend <satpy.multiscene._multiscene.MultiScene.blend>` method of
 the ``MultiScene`` object to stack two separate orbits from a VIIRS sensor. By
-default the ``blend`` method will use the :func:`satpy.multiscene.stack <satpy.multiscene._blend_funcs.stack>`
+default the ``blend`` method will use the :func:`satpy.multiscene.stack <satpy.multiscene.blend_funcs.stack>`
 function which uses the first dataset as the base of the image and then
 iteratively overlays the remaining datasets on top.
 
@@ -101,8 +101,8 @@ frequent.
 This weighted blending can be accomplished via the use of the builtin
 :func:`~functools.partial` function (see `Partial
 <https://docs.python.org/3/library/functools.html#partial-objects>`_) and the
-default :func:`satpy.multiscene.stack <satpy.multiscene._blend_funcs.stack>` function. The
-:func:`satpy.multiscene.stack <satpy.multiscene._blend_funcs.stack>` function can take the optional argument
+default :func:`satpy.multiscene.stack <satpy.multiscene.blend_funcs.stack>` function. The
+:func:`satpy.multiscene.stack <satpy.multiscene.blend_funcs.stack>` function can take the optional argument
 `weights` (`None` on default) which should be a sequence (of length equal to
 the number of scenes being blended) of arrays with pixel weights.
 
@@ -175,7 +175,7 @@ Timeseries
 **********
 
 Using the :meth:`MultiScene.blend <satpy.multiscene._multiscene.MultiScene.blend>` method with the
-:func:`satpy.multiscene.timeseries <satpy.multiscene._blend_funcs.timeseries>` function will combine
+:func:`satpy.multiscene.timeseries <satpy.multiscene.blend_funcs.timeseries>` function will combine
 multiple scenes from different time slots by time. A single `Scene` with each
 dataset/channel extended by the time dimension will be returned. If used
 together with the :meth:`~satpy.scene.Scene.to_geoviews` method, creation of

--- a/satpy/modifiers/_crefl_utils.py
+++ b/satpy/modifiers/_crefl_utils.py
@@ -63,7 +63,7 @@ The original CREFL code is similar to what is described in appendix A1 (page
 from __future__ import annotations
 
 import logging
-from typing import Optional, Type, Union
+from typing import Optional, Type
 
 import dask.array as da
 import numpy as np
@@ -94,7 +94,7 @@ class _Coefficients:
     LUTS: list[np.ndarray] = []
     # resolution -> wavelength -> coefficient index
     # resolution -> band name -> coefficient index
-    COEFF_INDEX_MAP: dict[int, dict[Union[tuple, str], int]] = {}
+    COEFF_INDEX_MAP: dict[int, dict[tuple | str, int]] = {}
 
     def __init__(self, wavelength_range, resolution=0):
         self._wv_range = wavelength_range

--- a/satpy/modifiers/angles.py
+++ b/satpy/modifiers/angles.py
@@ -25,7 +25,7 @@ import shutil
 import warnings
 from functools import update_wrapper
 from glob import glob
-from typing import Any, Callable, Optional, Union
+from typing import Any, Callable, Optional, TypeAlias
 
 import dask
 import numpy as np
@@ -39,7 +39,7 @@ from pyresample.geometry import AreaDefinition, StackedAreaDefinition, SwathDefi
 import satpy
 from satpy.utils import PerformanceWarning, get_satpos, ignore_invalid_float_warnings
 
-PRGeometry = Union[SwathDefinition, AreaDefinition, StackedAreaDefinition]
+PRGeometry: TypeAlias = SwathDefinition | AreaDefinition | StackedAreaDefinition
 
 # Arbitrary time used when computing sensor angles that is passed to
 # pyorbital's get_observer_look function.
@@ -131,7 +131,7 @@ class ZarrCacheHelper:
         for zarr_dir in glob(os.path.join(cache_dir, zarr_pattern)):
             shutil.rmtree(zarr_dir, ignore_errors=True)
 
-    def _zarr_pattern(self, arg_hash, cache_version: Union[None, int, str] = None) -> str:
+    def _zarr_pattern(self, arg_hash, cache_version: None | int | str = None) -> str:
         if cache_version is None:
             cache_version = self._cache_version
         return f"{self._func.__name__}_v{cache_version}" + "_{}_" + f"{arg_hash}.zarr"
@@ -432,7 +432,7 @@ def get_cos_sza(data_arr: xr.DataArray) -> xr.DataArray:
 
 
 @cache_to_zarr_if("cache_lonlats", sanitize_args_func=_sanitize_args_with_chunks)
-def _get_valid_lonlats(area: PRGeometry, chunks: Union[int, str, tuple] = "auto") -> tuple[da.Array, da.Array]:
+def _get_valid_lonlats(area: PRGeometry, chunks: int | str | tuple = "auto") -> tuple[da.Array, da.Array]:
     with ignore_invalid_float_warnings():
         # NOTE: This defaults to 64-bit floats due to needed precision for X/Y coordinates
         lons, lats = area.get_lonlats(chunks=chunks)

--- a/satpy/multiscene/_multiscene.py
+++ b/satpy/multiscene/_multiscene.py
@@ -336,9 +336,9 @@ class MultiScene(object):
         dataset (:class:`xarray.DataArray` object).  The blend method
         then assigns those datasets to the blended scene.
 
-        Blending functions provided in this module are :func:`satpy.multiscene._blend_funcs.stack`
-        (the default), :func:`satpy.multiscene._blend_funcs.timeseries`, and
-        :func:`satpy.multiscene._blend_funcs.temporal_rgb`, but the Python built-in
+        Blending functions provided in this module are :func:`satpy.multiscene.blend_funcs.stack`
+        (the default), :func:`satpy.multiscene.blend_funcs.timeseries`, and
+        :func:`satpy.multiscene.blend_funcs.temporal_rgb`, but the Python built-in
         function :func:`sum` also works and may be appropriate for
         some types of data.
 

--- a/satpy/readers/core/file_handlers.py
+++ b/satpy/readers/core/file_handlers.py
@@ -16,20 +16,21 @@
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Interface for BaseFileHandlers."""
+from __future__ import annotations
 
 import numpy as np
 import xarray as xr
 from pyresample.geometry import SwathDefinition
 
 from satpy.dataset import combine_metadata
-from satpy.readers.core.remote import open_file_or_filename
+from satpy.readers.core.remote import FSFile, open_file_or_filename
 
 
-def open_dataset(filename, *args, **kwargs):  # noqa: D417
+def open_dataset(filename: str | FSFile, *args, **kwargs):  # noqa: D417
     """Open a file with xarray.
 
     Args:
-       filename (Union[str, FSFile]):
+       filename:
            The path to the file to open. Can be a `string` or
            :class:`~satpy.readers.core.remote.FSFile` object which allows using
            `fsspec` or `s3fs` like files.


### PR DESCRIPTION
This might close #3387. Mostly I'm fixing other warnings I encountered. Generating the docs on Python 3.13 locally and I didn't run into the FAQ reference issue so maybe it just works better in newer python? :man_shrugging: Let's see how the RTD CI job builds and renders.

Other fixes:

* Sphinx really doesn't like the `Union` and `Path` types. From what I can tell this is a bug in the python documentation itself based on the issues I found.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
