### PR TITLE
Add new filename pattern for MSG CRM product

### DIFF
--- a/satpy/etc/readers/seviri_l2_grib.yaml
+++ b/satpy/etc/readers/seviri_l2_grib.yaml
@@ -49,6 +49,7 @@ file_types:
       - 'CRMEncProd_{start_time:%Y%m%d%H%M%S}Z_00_{server:8s}_{spacecraft:5s}_{scan_mode:3s}_{sub_sat:5s}'
       - '{spacecraft:4s}-SEVI-MSGCRMN-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}'
       - '{spacecraft:4s}-SEVI-MSGCRMN-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.grb'
+      - '{spacecraft:4s}-SEVI-MSGCRMN-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-{product_creation_time:%Y%m%d%H%M%S}-{ord_num:7s}.nat'
       - '{spacecraft:4s}-SEVI-MSGCRMN-{id1:4s}-{id2:4s}-{start_time:%Y%m%d%H%M%S}.000000000Z-NA.grb'
 
   # EUMETSAT MSG SEVIRI L2 Active Fire Monitoring product


### PR DESCRIPTION
This tiny PR simply adds another filename pattern (extension) for the MSG SEVIRI Clear-sky Reflectance Map (CRM) product in order to support files downloaded from the EUMETSAT archive, which use `.nat` as filename extension.

Example filename: `MSG3-SEVI-MSGCRMN-0100-0100-20260517120000.000000000Z-20260517121352-4891512.nat`