### PR TITLE
Added readers for the new cloud base height (CBH) product and all day optical thickness (ADCOT) in PPS

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -53,6 +53,7 @@ The following people have made contributions to this project:
 - [Johannes Johansson (JohannesSMHI)](https://github.com/JohannesSMHI)
 - [Sauli Joro (sjoro)](https://github.com/sjoro)
 - [Przemyslaw Juda (pjuda)](https://github.com/pjuda)
+- [Inderpreet Kaur](https://github.com/ikaur17)
 - [Pouria Khalaj](https://github.com/pkhalaj)
 - [Janne Kotro (jkotro)](https://github.com/jkotro)
 - [Beke Kremmling (bkremmli)](https://github.com/bkremmli) - Deutscher Wetterdienst

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -599,6 +599,43 @@ enhancements:
           - dataset: ctth_tempe_pal
             color_scale: 255
 
+  cloud_base_height:
+    standard_name: cloud_base_height
+    operations:
+    - name: colorize
+      method: !!python/name:satpy.enhancements.colormap.colorize
+      kwargs:
+        palettes:
+          - dataset: cbh_alti_pal
+  
+  cloud_base_pressure:
+    standard_name: cloud_base_pressure
+    operations:
+    - name: colorize
+      method: !!python/name:satpy.enhancements.colormap.colorize
+      kwargs:
+        palettes:
+          - dataset: cbh_pres_pal
+
+  cloud_base_height_in_hectofeet:
+    standard_name: cloud_base_height_in_hectofeet
+    operations:
+    - name: colorize
+      method: !!python/name:satpy.enhancements.colormap.colorize
+      kwargs:
+        palettes:
+          - dataset: cbh_hfeet_pal
+
+  cloud_base_temperature:
+    standard_name: cloud_base_temperature
+    operations:
+    - name: colorize
+      method: !!python/name:satpy.enhancements.colormap.palettize
+      kwargs:
+        palettes:
+          - dataset: cbh_tempe_pal     
+            color_scale: 255
+
   cloud_top_phase:
     standard_name: cloud_top_phase
     operations:

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -607,7 +607,7 @@ enhancements:
       kwargs:
         palettes:
           - dataset: cbh_alti_pal
-  
+
   cloud_base_pressure:
     standard_name: cloud_base_pressure
     operations:

--- a/satpy/etc/enhancements/generic.yaml
+++ b/satpy/etc/enhancements/generic.yaml
@@ -633,8 +633,17 @@ enhancements:
       method: !!python/name:satpy.enhancements.colormap.palettize
       kwargs:
         palettes:
-          - dataset: cbh_tempe_pal     
+          - dataset: cbh_tempe_pal
             color_scale: 255
+
+  adcot:
+    standard_name: adcot
+    operations:
+    - name: colorize
+      method: !!python/name:satpy.enhancements.colormap.colorize
+      kwargs:
+        palettes:
+          - dataset: adcot_pal
 
   cloud_top_phase:
     standard_name: cloud_top_phase

--- a/satpy/etc/readers/nwcsaf-pps_nc.yaml
+++ b/satpy/etc/readers/nwcsaf-pps_nc.yaml
@@ -420,3 +420,14 @@ datasets:
     name: cbh_hfeet_pal
     scale_offset_dataset: cbh_hfeet
     file_type: nc_nwcsaf_cbh
+
+# -------------------------------------
+  adcot:
+    name: adcot
+    file_type: nc_nwcsaf_adcot
+    coordinates: [lon, lat]
+
+  adcot_pal:
+    name: adcot_pal
+    scale_offset_dataset: adcot
+    file_type: nc_nwcsaf_adcot

--- a/satpy/etc/readers/nwcsaf-pps_nc.yaml
+++ b/satpy/etc/readers/nwcsaf-pps_nc.yaml
@@ -45,6 +45,15 @@ file_types:
         file_patterns: ['S_NWC_CMIC_{platform_id}_{orbit_number}_{start_time:%Y%m%dT%H%M%S%f}Z_{end_time:%Y%m%dT%H%M%S%f}Z.nc']
         file_key_prefix: cmic_
 
+    nc_nwcsaf_cbh:
+        file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
+        file_patterns: ['S_NWC_CBH_{platform_id}_{orbit_number}_{start_time:%Y%m%dT%H%M%S%f}Z_{end_time:%Y%m%dT%H%M%S%f}Z.nc']
+
+    nc_nwcsaf_adcot:
+        file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
+        file_patterns: ['S_NWC_ADCOT_{platform_id}_{orbit_number}_{start_time:%Y%m%dT%H%M%S%f}Z_{end_time:%Y%m%dT%H%M%S%f}Z.nc']    
+    
+
 datasets:
 
   lon:
@@ -53,6 +62,8 @@ datasets:
     - nc_nwcsaf_cma
     - nc_nwcsaf_ct
     - nc_nwcsaf_ctth
+    - nc_nwcsaf_cbh
+    - nc_nwcsaf_adcot
     units: "degrees"
     standard_name: longitude
   lat:
@@ -61,6 +72,8 @@ datasets:
     - nc_nwcsaf_cma
     - nc_nwcsaf_ct
     - nc_nwcsaf_ctth
+    - nc_nwcsaf_cbh
+    - nc_nwcsaf_adcot
     units: "degrees"
     standard_name: latitude
 
@@ -350,3 +363,60 @@ datasets:
     file_key: dcot
     file_type: [nc_nwcsaf_cpp, nc_nwcsaf_cmic]
     coordinates: [lon, lat]
+
+# ---- CBH products ------------
+
+  cbh_alti:
+    name: cbh_alti
+    file_type: nc_nwcsaf_cbh
+    coordinates: [lon, lat]
+
+  cbh_alti_pal:
+    name: cbh_alti_pal
+    scale_offset_dataset: cbh_alti
+    file_type: nc_nwcsaf_cbh
+
+  cbh_quality:
+    name: cbh_quality
+    file_type: nc_nwcsaf_cbh
+    coordinates: [lon, lat]
+
+  cbh_conditions:
+    name: cbh_conditions
+    file_type: nc_nwcsaf_cbh
+    coordinates: [lon, lat]
+
+  cbh_status_flag:
+    name: cbh_status_flag
+    file_type: nc_nwcsaf_cbh
+    coordinates: [lon, lat]
+
+  cbh_pres:
+    name: cbh_pres
+    file_type: nc_nwcsaf_cbh
+    coordinates: [lon, lat]
+
+  cbh_pres_pal:
+    name: cbh_pres_pal
+    scale_offset_dataset: cbh_pres
+    file_type: nc_nwcsaf_cbh
+
+  cbh_tempe:
+    name: cbh_tempe
+    file_type: nc_nwcsaf_cbh
+    coordinates: [lon, lat]
+
+  cbh_tempe_pal:
+    name: cbh_tempe_pal
+    scale_offset_dataset: cbh_tempe
+    file_type: nc_nwcsaf_cbh
+      
+  cbh_hfeet:
+    name: cbh_hfeet
+    file_type: nc_nwcsaf_cbh
+    coordinates: [lon, lat]
+
+  cbh_hfeet_pal:
+    name: cbh_hfeet_pal
+    scale_offset_dataset: cbh_hfeet
+    file_type: nc_nwcsaf_cbh

--- a/satpy/etc/readers/nwcsaf-pps_nc.yaml
+++ b/satpy/etc/readers/nwcsaf-pps_nc.yaml
@@ -51,8 +51,8 @@ file_types:
 
     nc_nwcsaf_adcot:
         file_reader: !!python/name:satpy.readers.nwcsaf_nc.NcNWCSAF
-        file_patterns: ['S_NWC_ADCOT_{platform_id}_{orbit_number}_{start_time:%Y%m%dT%H%M%S%f}Z_{end_time:%Y%m%dT%H%M%S%f}Z.nc']    
-    
+        file_patterns: ['S_NWC_ADCOT_{platform_id}_{orbit_number}_{start_time:%Y%m%dT%H%M%S%f}Z_{end_time:%Y%m%dT%H%M%S%f}Z.nc']
+
 
 datasets:
 
@@ -410,7 +410,7 @@ datasets:
     name: cbh_tempe_pal
     scale_offset_dataset: cbh_tempe
     file_type: nc_nwcsaf_cbh
-      
+
   cbh_hfeet:
     name: cbh_hfeet
     file_type: nc_nwcsaf_cbh


### PR DESCRIPTION
This PR adds readers for new NWCSAF-PPS products: cloud base height/pressure/height_in _hectorfeet/temperature
 - [x] Fully documented
 - [x] Add your name to `AUTHORS.md` if not there already
