### PR TITLE
Fix avhrr_l1b_gaclac tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
         #   compatibility issues with numpy 2. When conda-forge has numpy 2 available
         #   this shouldn't be needed.
         run: |
-          python -m pip install versioneer extension-helpers setuptools-scm configobj pkgconfig hatchling hatch-vcs
+          python -m pip install versioneer extension-helpers setuptools-scm configobj pkgconfig hatchling hatch-vcs hatch-cython
           python -m pip install \
           --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/ \
           --trusted-host pypi.anaconda.org \

--- a/satpy/readers/hrpt.py
+++ b/satpy/readers/hrpt.py
@@ -205,7 +205,7 @@ class HRPTFile(BaseFileHandler):
 
     def calibrate_thermal_channel(self, data, key):
         """Calibrate a thermal channel."""
-        from pygac.calibration import calibrate_thermal
+        from pygac.calibration.noaa import calibrate_thermal
         line_numbers = (
             np.round((self.times - self.times[-1]) /
                      np.timedelta64(166666667, "ns"))).astype(int)
@@ -219,7 +219,7 @@ class HRPTFile(BaseFileHandler):
 
     def calibrate_solar_channel(self, data, key):
         """Calibrate a solar channel."""
-        from pygac.calibration import calibrate_solar
+        from pygac.calibration.noaa import calibrate_solar
         julian_days = ((np.datetime64(self.start_time)
                         - np.datetime64(str(self.year) + "-01-01T00:00:00"))
                        / np.timedelta64(1, "D"))
@@ -230,7 +230,7 @@ class HRPTFile(BaseFileHandler):
     @cached_property
     def calibrator(self):
         """Create a calibrator for the data."""
-        from pygac.calibration import Calibrator
+        from pygac.calibration.noaa import Calibrator
         pg_spacecraft = "".join(self.platform_name.split()).lower()
         return Calibrator(pg_spacecraft)
 

--- a/satpy/tests/reader_tests/test_avhrr_l0_hrpt.py
+++ b/satpy/tests/reader_tests/test_avhrr_l0_hrpt.py
@@ -189,7 +189,6 @@ def to_timecode(dt_time):
 
 def test_time_seconds():
     """Test conversion of timecode to datetime64."""
-    current = datetime.now()
-    current = current.replace(microsecond=round(current.microsecond, -3))
-    timecode, year = to_timecode(current)
-    assert time_seconds(np.array([timecode], "u2"), year) == np.datetime64(current)
+    dtime = datetime(2026, 5, 20, 14, 2, 28, 999000)
+    timecode, year = to_timecode(dtime)
+    assert time_seconds(np.array([timecode], "u2"), year) == np.datetime64(dtime)

--- a/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
+++ b/satpy/tests/reader_tests/test_avhrr_l1b_gaclac.py
@@ -252,9 +252,10 @@ class FakeDataGenerator:
         )
 
         scans = np.ones(num_lines, dtype=pygac.gac_pod.scanline)
+
         scans["scan_line_number"] = np.arange(num_lines)
         scans["time_code"] = times_enc
-        scans["telemetry"] = 100 * np.arange(35 * num_lines).reshape((num_lines, 35))
+        scans["telemetry"] = FakeDataGenerator._get_telemetry(num_lines)
         scans["quality_indicators"] = np.empty(num_lines, np.uint16(qual_flag))
 
         hdr0 = np.zeros(1, dtype=pygac.pod_reader.header0)
@@ -266,6 +267,32 @@ class FakeDataGenerator:
 
         spare = np.zeros(pygac.gac_pod.GACPODReader().offset - (hdr0.itemsize + hdr3.itemsize), dtype="u1")
         return [hdr0, hdr3, spare, scans]
+
+    @staticmethod
+    def _get_telemetry(num_scans):
+        """Get encoded telemetry.
+
+        The PRT threshold in Pygac is hardcoded to 50, so this method creates
+        an encoded telemetry array that yields PRT values between 40 and 60 when
+        decoded.
+
+        This is how pygac.pod_reader.PODReader.get_telemetry decodes telemetry:
+
+        number_of_scans = self.scans["telemetry"].shape[0]
+        decode_tele = np.zeros((int(number_of_scans), 105))
+        decode_tele[:, ::3] = (self.scans["telemetry"] >> 20) & 1023
+        decode_tele[:, 1::3] = (self.scans["telemetry"] >> 10) & 1023
+        decode_tele[:, 2::3] = self.scans["telemetry"] & 1023
+
+        Each telemetry word is a 32-bit integer that packs three 10-bit values.
+        We need 35 words in order to satisfy 3*num_words == 105.
+        """
+        num_words = 35
+        desired = np.linspace(60, 40, num_scans).astype(int)
+        desired_enc = (desired << 20) | (desired << 10) | desired
+        # For simplicity, assign the same value to all words
+        telemetry = np.repeat(desired_enc, num_words).reshape((num_scans, num_words))
+        return telemetry
 
 
 def encode_timestamps_pod(year: np.ndarray, jday: np.ndarray, msec: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Fix avhrr_l1b_gaclac tests by adapting imports to the latest Pygac release and creating a more realistic telemetry array. Claude helped me understanding the 10bit encoding.

