### PR TITLE
Get the bounding box from the HDF EOS level-1 files and pass it to the array attributes

### DIFF
--- a/satpy/readers/core/hdfeos.py
+++ b/satpy/readers/core/hdfeos.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2019 Satpy developers
+# Copyright (c) 2019-2026 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -122,6 +122,7 @@ class HDFEOSBaseFileReader(BaseFileHandler):
                 continue
             else:
                 metadata.update(self.read_mda(str_val))
+
         return metadata
 
     @classmethod
@@ -225,6 +226,7 @@ class HDFEOSBaseFileReader(BaseFileHandler):
         dataset = self._read_dataset_in_file(dataset_name)
         chunks = self._chunks_for_variable(dataset)
         dask_arr = from_sds(dataset, self.filename, chunks=chunks)
+        #breakpoint()
         dims = ("y", "x") if dask_arr.ndim == 2 else None
         data = xr.DataArray(dask_arr, dims=dims,
                             attrs=dataset.attributes())
@@ -384,6 +386,11 @@ class HDFEOSGeoReader(HDFEOSBaseFileReader):
             if key in dataset_info:
                 data.attrs[key] = dataset_info[key]
         self._add_satpy_metadata(dataset_id, data)
+
+        # mask = (~data.isnull().all(dim="x")).compute()
+        # idx = np.where(mask.values)[0]
+        # data_reduced = data.isel(y=idx)
+        # print(data_reduced.shape)
 
         return data
 

--- a/satpy/readers/modis_l1b.py
+++ b/satpy/readers/modis_l1b.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2010-2017 Satpy developers
+# Copyright (c) 2010-2026 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -104,6 +104,14 @@ class HDFEOSBandReader(HDFEOSBaseFileReader):
         super().__init__(filename, filename_info, filetype_info, **kwargs)
         self._mask_saturated = mask_saturated
 
+        gringpoint = self.metadata["INVENTORYMETADATA"]["SPATIALDOMAINCONTAINER"][
+            "HORIZONTALSPATIALDOMAINCONTAINER"]["GPOLYGON"]["GPOLYGONCONTAINER"]["GRINGPOINT"]
+        bbox = {"longitudes": gringpoint["GRINGPOINTLONGITUDE"]["VALUE"],
+                "latitudes": gringpoint["GRINGPOINTLATITUDE"]["VALUE"]}
+        self._boundingbox = bbox
+        # Add the sub-satellite track geolocation as well if available? FIXME!
+        # Seems this is repeated for every HDF-EOS file being read.
+
         ds = self.metadata["INVENTORYMETADATA"][
             "COLLECTIONDESCRIPTIONCLASS"]["SHORTNAME"]["VALUE"]
         self.resolution = self.res[ds[-3]]
@@ -126,37 +134,17 @@ class HDFEOSBandReader(HDFEOSBaseFileReader):
             array = self._fill_saturated(array, valid_max)
         array = self._mask_invalid(array, valid_min, valid_max)
         array = self._mask_uncertain_pixels(array, uncertainty, band_index)
+        # array = self._mask_rows_all_nan(array)
+        info["boundingbox"] = self._boundingbox
         projectable = self._calibrate_data(key, info, array, var_attrs, band_index)
 
-        # if ((platform_name == 'Aqua' and key['name'] in ["6", "27", "36"]) or
-        #         (platform_name == 'Terra' and key['name'] in ["29"])):
-        #     height, width = projectable.shape
-        #     row_indices = projectable.mask.sum(1) == width
-        #     if row_indices.sum() != height:
-        #         projectable.mask[row_indices, :] = True
-
-        # Get the orbit number
-        # if not satscene.orbit:
-        #     mda = self.data.attributes()["CoreMetadata.0"]
-        #     orbit_idx = mda.index("ORBITNUMBER")
-        #     satscene.orbit = mda[orbit_idx + 111:orbit_idx + 116]
-
-        # Trimming out dead sensor lines (detectors) on terra:
-        # (in addition channel 27, 30, 34, 35, and 36 are nosiy)
-        # if satscene.satname == "terra":
-        #     for band in ["29"]:
-        #         if not satscene[band].is_loaded() or satscene[band].data.mask.all():
-        #             continue
-        #         width = satscene[band].data.shape[1]
-        #         height = satscene[band].data.shape[0]
-        #         indices = satscene[band].data.mask.sum(1) < width
-        #         if indices.sum() == height:
-        #             continue
-        #         satscene[band] = satscene[band].data[indices, :]
-        #         satscene[band].area = geometry.SwathDefinition(
-        #             lons=satscene[band].area.lons[indices, :],
-        #             lats=satscene[band].area.lats[indices, :])
         self._add_satpy_metadata(key, projectable)
+
+        # mask = (~projectable.isnull().all(dim="x")).compute()
+        # idx = np.where(mask.values)[0]
+        # data_reduced = projectable.isel(y=idx)
+        # print(data_reduced.shape)
+
         return projectable
 
     def _get_band_variable_name_and_index(self, band_name):
@@ -213,10 +201,16 @@ class HDFEOSBandReader(HDFEOSBaseFileReader):
     def _mask_uncertain_pixels(self, array, uncertainty, band_index):
         if not self._mask_saturated:
             return array
+
         uncertainty_chunks = self._chunks_for_variable(uncertainty)
         band_uncertainty = from_sds(uncertainty, self.filename, chunks=uncertainty_chunks)[band_index, :, :]
         array = array.where(band_uncertainty < 15)
         return array
+
+    def _mask_rows_all_nan(self, array):
+        """Mask rows where all values are NaN."""
+        arr_reduced = array.dropna(dim="y", how="all")
+        return arr_reduced
 
     def _calibrate_data(self, key, info, array, var_attrs, index):
         if key["calibration"] == "brightness_temperature":

--- a/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
+++ b/satpy/tests/reader_tests/modis_tests/_modis_fixtures.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# Copyright (c) 2021 Satpy developers
+# Copyright (c) 2021-2026 Satpy developers
 #
 # This file is part of satpy.
 #
@@ -331,7 +331,21 @@ def _create_core_metadata(file_shortname: str) -> str:
                           f"VALUE = {file_shortname!r}\nEND_OBJECT = SHORTNAME\n\n" \
                           "OBJECT = VERSIONID\nNUM_VAL = 1\nVALUE = 6\nEND_OBJECT = VERSIONID\n\n" \
                           "END_GROUP = COLLECTIONDESCRIPTIONCLASS\n\n"
-    core_metadata_header += "\n\n" + inst_metadata + collection_metadata
+
+    gring_metadata = "GROUP = SPATIALDOMAINCONTAINER\n\n GROUP = HORIZONTALSPATIALDOMAINCONTAINER\n\n "\
+        'GROUP = GPOLYGON\n\n OBJECT = GPOLYGONCONTAINER\n CLASS = "1"\n\n '\
+        'GROUP = GRING\n CLASS = "1"\n\n  OBJECT = EXCLUSIONGRINGFLAG\n NUM_VAL = 1\n '\
+        'CLASS = "1"\n VALUE = "N"\n  END_OBJECT = EXCLUSIONGRINGFLAG\n\n END_GROUP = GRING\n\n '\
+        'GROUP = GRINGPOINT\n CLASS = "1"\n\n OBJECT = GRINGPOINTLONGITUDE\n NUM_VAL = 4\n '\
+        'CLASS = "1"\n VALUE = (37.5053242268888, 6.38401236692491, -48.2870137383305, 36.7762332873298)\n '\
+        'END_OBJECT = GRINGPOINTLONGITUDE\n\n OBJECT = GRINGPOINTLATITUDE\n NUM_VAL = 4\n CLASS = "1"\n '\
+        "VALUE = (34.5168084728086, 30.695318900416, 70.1120029478276, 83.8447003025456)\n "\
+        "END_OBJECT = GRINGPOINTLATITUDE\n\n OBJECT = GRINGPOINTSEQUENCENO\n NUM_VAL = 4\n "\
+        'CLASS = "1"\n VALUE = (1, 2, 3, 4)\n END_OBJECT = GRINGPOINTSEQUENCENO\n\n '\
+        "END_GROUP = GRINGPOINT\n\n  END_OBJECT = GPOLYGONCONTAINER\n\n  END_GROUP = GPOLYGON\n\n "\
+        "END_GROUP = HORIZONTALSPATIALDOMAINCONTAINER\n\n END_GROUP = SPATIALDOMAINCONTAINER\n\n"
+
+    core_metadata_header += "\n\n" + inst_metadata + collection_metadata + gring_metadata
     return core_metadata_header
 
 


### PR DESCRIPTION
Get the gringpoint (bounding box) data from the HDF EOS level-1 files, and pass it to the projectabe channel data array object.

<!-- Describe what your PR does, and why -->
<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #3391 
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already

It can be debated if this PR really closes the issue referenced above. It will then also require Pyresample being enhanced, as suggested in a recent PR there:
https://github.com/pytroll/pyresample/pull/724

If solving the issue without a Pyresample upgrade one should clip the NaN arrays upon reading as discussed in the issue.
 
There is at least one issue I would like to hear your opinion on: When loading the MODIS data the `HDFEOSBandReader` init is invoked three times, ones for each radiance file (1km, half km and quarter km), in my example case these are:
```
MYD021km_A26131_134600_2026131140033.hdf
MYD02Hkm_A26131_134600_2026131140033.hdf
MYD02Qkm_A26131_134600_2026131140033.hdf
```

So, the bounding box is read and set three times. Bounding box is exactly the same in all three as far as I can see...

