### PR TITLE
Update URLs for Black Marble images

### DIFF
--- a/satpy/etc/composites/visir.yaml
+++ b/satpy/etc/composites/visir.yaml
@@ -536,13 +536,13 @@ composites:
   _night_background:
     compositor: !!python/name:satpy.composites.aux_data.StaticImageCompositor
     standard_name: night_background
-    url: "https://neo.gsfc.nasa.gov/archive/blackmarble/2016/global/BlackMarble_2016_01deg_geo.tif"
+    url: "https://assets.science.nasa.gov/content/dam/science/esd/eo/images/imagerecords/144000/144898/BlackMarble_2016_01deg_geo.tif"
     known_hash: "sha256:146c116962677ae113d9233374715686737ff97141a77cc5da69a9451315a685"  # optional
 
   _night_background_hires:
     compositor: !!python/name:satpy.composites.aux_data.StaticImageCompositor
     standard_name: night_background
-    url: "https://neo.gsfc.nasa.gov/archive/blackmarble/2016/global/BlackMarble_2016_3km_geo.tif"
+    url: "https://assets.science.nasa.gov/content/dam/science/esd/eo/images/imagerecords/144000/144898/BlackMarble_2016_3km_geo.tif"
     known_hash: "sha256:e915ef2a20d84e2a59e1547d3ad564463ad4bcf22bfa02e0e0b8ed1cd722e9c0"  # optional
 
   cloud_phase_distinction:


### PR DESCRIPTION
This PR fixes the locations for the two Black Marble images used as night-time backrounds for GeoColor composite.

 - [x] Closes #3400  <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 