### PR TITLE
Fix MVIRI test failures

### DIFF
--- a/satpy/readers/mviri_l1b_fiduceo_nc.py
+++ b/satpy/readers/mviri_l1b_fiduceo_nc.py
@@ -505,7 +505,7 @@ class _DatasetPreprocessor:
         time = ds["time"]
         time_dec = (time + time.attrs["add_offset"]).astype("datetime64[s]").astype("datetime64[ns]")
         is_fill_value = time == time.attrs["_FillValue"]
-        return xr.where(is_fill_value, np.datetime64("NaT"), time_dec)
+        return xr.where(is_fill_value, np.datetime64("NaT", "ns"), time_dec)
 
     def _fix_duplicate_dimensions(self, ds):
         """Rename dimensions as duplicate dimensions names are not supported by xarray."""

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -125,9 +125,6 @@ u_vis_refl_exp = xr.DataArray(
         dtype=np.float32
     ),
     dims=("y", "x"),
-    coords={
-        "acq_time": ("y", acq_time_vis_exp),
-    },
     attrs=attrs_exp
 )
 
@@ -216,9 +213,6 @@ quality_pixel_bitmask_exp = xr.DataArray(
         dtype=np.uint8
     ),
     dims=("y", "x"),
-    coords={
-        "acq_time": ("y", acq_time_vis_exp),
-    },
     attrs=attrs_exp
 )
 sza_vis_exp = xr.DataArray(
@@ -288,18 +282,18 @@ def fixture_fake_dataset(time_fake_dataset):
             dtype=np.uint8
         )
     )
-
     cov = da.from_array([[1, 2], [3, 4]])
-
+    vis_refl = (vis_refl_exp.dims, vis_refl_exp.data / 100)
+    u_vis_refl = (u_vis_refl_exp.dims, u_vis_refl_exp.data / 100)
     with ignore_dup_dim_warning(), xr.set_options(keep_attrs=False):
         ds = xr.Dataset(
             data_vars={
                 "count_vis": (("y", "x"), count_vis),
                 "count_wv": (("y_ir_wv", "x_ir_wv"), count_wv),
                 "count_ir": (("y_ir_wv", "x_ir_wv"), count_ir),
-                "toa_bidirectional_reflectance_vis": vis_refl_exp / 100,
-                "u_independent_toa_bidirectional_reflectance": u_vis_refl_exp / 100,
-                "u_structured_toa_bidirectional_reflectance": u_vis_refl_exp / 100,
+                "toa_bidirectional_reflectance_vis": vis_refl,
+                "u_independent_toa_bidirectional_reflectance": u_vis_refl,
+                "u_structured_toa_bidirectional_reflectance": u_vis_refl,
                 "quality_pixel_bitmask": (("y", "x"), mask),
                 "solar_zenith_angle": (("y_tie", "x_tie"), sza),
                 "time_ir_wv": (("y_ir_wv", "x_ir_wv"), time_fake_dataset),

--- a/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
+++ b/satpy/tests/reader_tests/test_mviri_l1b_fiduceo_nc.py
@@ -66,10 +66,10 @@ attrs_refl_exp.update(
     {"sun_earth_distance_correction_applied": True,
      "sun_earth_distance_correction_factor": 1.}
 )
-acq_time_vis_exp = [np.datetime64("NaT").astype("datetime64[ns]"),
-                    np.datetime64("NaT").astype("datetime64[ns]"),
-                    np.datetime64("1970-01-01 02:30").astype("datetime64[ns]"),
-                    np.datetime64("1970-01-01 02:30").astype("datetime64[ns]")]
+acq_time_vis_exp = [np.datetime64("NaT", "ns"),
+                    np.datetime64("NaT", "ns"),
+                    np.datetime64("1970-01-01 02:30", "ns"),
+                    np.datetime64("1970-01-01 02:30", "ns")]
 vis_counts_exp = xr.DataArray(
     np.array(
         [[0., 17., 34., 51.],
@@ -130,8 +130,8 @@ u_vis_refl_exp = xr.DataArray(
 
 u_struct_refl_exp = u_vis_refl_exp.copy()
 
-acq_time_ir_wv_exp = [np.datetime64("NaT"),
-                      np.datetime64("1970-01-01 02:30").astype("datetime64[ns]")]
+acq_time_ir_wv_exp = [np.datetime64("NaT", "ns"),
+                      np.datetime64("1970-01-01 02:30", "ns")]
 wv_counts_exp = xr.DataArray(
     np.array(
         [[0, 85],
@@ -631,7 +631,7 @@ class TestDatasetPreprocessor:
                 "covariance_spectral_response_function_vis": (("srf_size_1", "srf_size_2"), [[1, 2], [3, 4]]),
                 "channel_correlation_matrix_independent": (("channel_1", "channel_2"), [[1, 2], [3, 4]]),
                 "channel_correlation_matrix_structured": (("channel_1", "channel_2"), [[1, 2], [3, 4]]),
-                "time": (("y", "x"), [[time_exp, np.datetime64("NaT")], [time_exp, time_exp]])
+                "time": (("y", "x"), [[time_exp, np.datetime64("NaT", "ns")], [time_exp, time_exp]])
             },
             coords={
                 "y": [0, 1],
@@ -653,29 +653,29 @@ class TestInterpolator:
         """Returns time_ir_wv."""
         time_ir_wv = xr.DataArray(
             [
-              [np.datetime64("1970-01-01 01:00"), np.datetime64("1970-01-01 02:00")],
-              [np.datetime64("1970-01-01 03:00"), np.datetime64("1970-01-01 04:00")],
-              [np.datetime64("NaT"), np.datetime64("1970-01-01 06:00")],
-              [np.datetime64("NaT"), np.datetime64("NaT")],
+              [np.datetime64("1970-01-01 01:00", "ns"), np.datetime64("1970-01-01 02:00", "ns")],
+              [np.datetime64("1970-01-01 03:00", "ns"), np.datetime64("1970-01-01 04:00", "ns")],
+              [np.datetime64("NaT", "ns"), np.datetime64("1970-01-01 06:00", "ns")],
+              [np.datetime64("NaT", "ns"), np.datetime64("NaT", "ns")],
             ],
             dims=("y", "x"),
             coords={"y": [1, 3, 5, 7]}
         )
-        return time_ir_wv.astype("datetime64[ns]")
+        return time_ir_wv
 
     @pytest.fixture(name="acq_time_exp")
     def fixture_acq_time_exp(self):
         """Returns acq_time_vis_exp."""
         vis = xr.DataArray(
             [
-                np.datetime64("1970-01-01 01:30"),
-                np.datetime64("1970-01-01 01:30"),
-                np.datetime64("1970-01-01 03:30"),
-                np.datetime64("1970-01-01 03:30"),
-                np.datetime64("1970-01-01 06:00"),
-                np.datetime64("1970-01-01 06:00"),
-                np.datetime64("NaT"),
-                np.datetime64("NaT")
+                np.datetime64("1970-01-01 01:30", "ns"),
+                np.datetime64("1970-01-01 01:30", "ns"),
+                np.datetime64("1970-01-01 03:30", "ns"),
+                np.datetime64("1970-01-01 03:30", "ns"),
+                np.datetime64("1970-01-01 06:00", "ns"),
+                np.datetime64("1970-01-01 06:00", "ns"),
+                np.datetime64("NaT", "ns"),
+                np.datetime64("NaT", "ns")
             ],
             dims="y",
             coords={"y": [1, 2, 3, 4, 5, 6, 7, 8]}
@@ -683,10 +683,10 @@ class TestInterpolator:
 
         ir = xr.DataArray(
             [
-                np.datetime64("1970-01-01 01:30"),
-                np.datetime64("1970-01-01 03:30"),
-                np.datetime64("1970-01-01 06:00"),
-                np.datetime64("NaT"),
+                np.datetime64("1970-01-01 01:30", "ns"),
+                np.datetime64("1970-01-01 03:30", "ns"),
+                np.datetime64("1970-01-01 06:00", "ns"),
+                np.datetime64("NaT", "ns"),
             ],
             dims="y",
             coords={"y": [1, 3, 5, 7]}


### PR DESCRIPTION
<!-- Describe what your PR does, and why -->
Fix MVIRI test failures by 
- Removing `acq_time` coordinate which was erroneously added to the stub file (pulled in from variable `vis_refl_exp`)
- Removing `acq_time` coordinate from expected angles and quality flags

Also, use explicit datetime64 units to fix some numpy deprecation warnings about "generic" time units.

<!-- For works in progress choose "Create draft pull request" from the drop-down green button. -->

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
