### PR TITLE
Fix datatype of default time encoding

### DIFF
--- a/satpy/cf/encoding.py
+++ b/satpy/cf/encoding.py
@@ -68,7 +68,9 @@ def _set_default_time_encoding(encoding, dataset):
             dtnp64 = dataset["time"].data
 
         default = CFDatetimeCoder().encode(xr.DataArray(dtnp64))
-        time_enc = {"units": default.attrs["units"], "calendar": default.attrs["calendar"]}
+        time_enc = {"units": default.attrs["units"],
+                    "dtype": "float64",
+                    "calendar": default.attrs["calendar"]}
         time_enc.update(encoding.get("time", {}))
         bounds_enc = {"units": time_enc["units"],
                       "dtype": "float64",

--- a/satpy/cf/encoding.py
+++ b/satpy/cf/encoding.py
@@ -71,6 +71,7 @@ def _set_default_time_encoding(encoding, dataset):
         time_enc = {"units": default.attrs["units"], "calendar": default.attrs["calendar"]}
         time_enc.update(encoding.get("time", {}))
         bounds_enc = {"units": time_enc["units"],
+                      "dtype": "float64",
                       "calendar": time_enc["calendar"],
                       "_FillValue": None}
         encoding["time"] = time_enc

--- a/satpy/tests/cf_tests/test_encoding.py
+++ b/satpy/tests/cf_tests/test_encoding.py
@@ -113,8 +113,10 @@ class TestUpdateEncoding:
             "bar": {"chunksizes": (1, 1, 1)},
             "time": {"_FillValue": None,
                      "calendar": "proleptic_gregorian",
+                     "dtype": "float64",
                      "units": "days since 2009-07-01 12:15:00"},
             "time_bnds": {"_FillValue": None,
+                          "dtype": "float64",
                           "calendar": "proleptic_gregorian",
                           "units": "days since 2009-07-01 12:15:00"}
         }


### PR DESCRIPTION
Fix datatype of default time encoding. It silences warning of this type:

```
python3.12/site-packages/satpy/writers/cf_writer.py:309: UserWarning: Times can't be serialized faithfully to int64 with requested units 'days since 1981-03-30T04:23:58.206000'. Resolution of 'milliseconds' needed. Serializing times to floating point instead. Set encoding['dtype'] to integer dtype to serialize to int64. Set encoding['dtype'] to floating point dtype to silence this warning.
    res = ds.to_netcdf(filename,
```

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
