### PR TITLE
Install cftime package in CI

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -58,6 +58,7 @@ dependencies:
   - ephem
   - bokeh
   - pytest-xdist
+  - cftime
   - pip:
       - pytest-lazy-fixtures
       - trollsift


### PR DESCRIPTION
Lets see if this addition of `cftime` package to the test environment fixes the unstable CI failure which emerged in https://github.com/pytroll/satpy/pull/3396
