### PR TITLE
Fix 'omps_edr' not handling an empty list of filters

### DIFF
--- a/satpy/aux_download.py
+++ b/satpy/aux_download.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License along with
 # satpy.  If not, see <http://www.gnu.org/licenses/>.
 """Functions and utilities for downloading ancillary data."""
+from __future__ import annotations
 
 import logging
 import os
@@ -24,8 +25,8 @@ import satpy
 
 logger = logging.getLogger(__name__)
 
-_FILE_REGISTRY = {}
-_FILE_URLS = {}
+_FILE_REGISTRY: dict[str, str | None] = {}
+_FILE_URLS: dict[str, str] = {}
 RUNNING_TESTS = False
 
 

--- a/satpy/readers/omps_edr.py
+++ b/satpy/readers/omps_edr.py
@@ -65,7 +65,7 @@ class EDRFileHandler(BaseFileHandler):
         """Initialize the geo filehandler."""
         super(EDRFileHandler, self).__init__(filename, filename_info, filetype_info)
 
-        self.filter_by_error_flag = filter_by_error_flag
+        self.filter_by_error_flag = filter_by_error_flag or []
 
         drop_variables = filetype_info.get("drop_variables", None)
         f_obj = open_file_or_filename(self.filename)
@@ -134,7 +134,7 @@ class EDRFileHandler(BaseFileHandler):
         return data_arr
 
     def _mask_invalid(self, data_arr: xr.DataArray, ds_info: dict) -> xr.DataArray:
-        if self.filter_by_error_flag is not None:
+        if self.filter_by_error_flag:
             ef_mask = np.isin(self.nc[self.error_flag_var_name].data, self.filter_by_error_flag)
             data_arr.data = np.where(ef_mask, data_arr.data, np.nan)
         # xarray auto mask and scale handled any fills from the file

--- a/satpy/tests/reader_tests/test_omps_edr.py
+++ b/satpy/tests/reader_tests/test_omps_edr.py
@@ -128,6 +128,7 @@ def test_available_datasets(tmp_path):
     "filter_by_error_flag",
     [
         None,
+        [],
         [0, 1],
         [0, 1, 2, 3],
     ],
@@ -156,7 +157,7 @@ def _check_expected_array(
 
     data_np = data_arr.data.compute()
     assert data_np.dtype == data_arr.dtype
-    if filter_by_error_flag is None:
+    if not filter_by_error_flag:
         assert not np.isnan(data_np).any()
     else:
         assert not np.isnan(data_np[1:SINGLE_GRAN_SHAPE[0]]).any()


### PR DESCRIPTION
I'm trying to use the filtering option in the OMPS EDR reader from the command line, but it gets annoying and really difficult that the reader doesn't handle an empty list. This PR fixes that. This also fixes a complaint from mypy on something in aux_download.py.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
