### PR TITLE
Fix 'valid_range' in OMPS EDR reader being a numpy array

### DIFF
--- a/satpy/readers/omps_edr.py
+++ b/satpy/readers/omps_edr.py
@@ -139,6 +139,10 @@ class EDRFileHandler(BaseFileHandler):
             data_arr.data = np.where(ef_mask, data_arr.data, np.nan)
         # xarray auto mask and scale handled any fills from the file
         valid_range = ds_info.get("valid_range", data_arr.attrs.get("valid_range"))
+        if isinstance(valid_range, np.ndarray):
+            valid_range = valid_range.tolist()
+            # data array attrs are updated with ds_info later
+            ds_info["valid_range"] = valid_range
         if "valid_min" in data_arr.attrs and valid_range is None:
             valid_range = (data_arr.attrs["valid_min"], data_arr.attrs["valid_max"])
         if valid_range is not None:

--- a/satpy/tests/reader_tests/test_omps_edr.py
+++ b/satpy/tests/reader_tests/test_omps_edr.py
@@ -171,3 +171,6 @@ def _check_expected_array(
     area = data_arr.attrs["area"]
     assert isinstance(area, SwathDefinition)
     assert area.shape == (SINGLE_GRAN_SHAPE[0] * num_granules, SINGLE_GRAN_SHAPE[1])
+
+    if "valid_range" in data_arr.attrs:
+        assert isinstance(data_arr.attrs["valid_range"], list)


### PR DESCRIPTION
Some parts of Satpy including the 'awips_tiled' writer assumes `.attrs["valid_range"]` is a list/tuple, but the OMPS EDR reader was returning a numpy array which made conditions like `if data_arr.attrs["valid_range"]` fail. This PR fixes the reader to be more consistent with other readers.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
