### PR TITLE
Exclude pytest 9.1.0 from CI

### DIFF
--- a/continuous_integration/environment.yaml
+++ b/continuous_integration/environment.yaml
@@ -43,7 +43,7 @@ dependencies:
   - python-eccodes
   # 2.19.1 seems to cause library linking issues
   - eccodes>=2.20
-  - pytest
+  - pytest!=9.1.0
   - pytest-cov
   - fsspec
   - universal_pathlib


### PR DESCRIPTION
Pytest 9.1.0 seems to cause problems with CI.

Links:
* https://github.com/pytest-dev/pytest/issues/13974
* https://github.com/scikit-build/scikit-build-core/pull/1329
