### PR TITLE
Update SLSTR L1b reader to support updated processing baseline

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -77,7 +77,7 @@ The following people have made contributions to this project:
 - [Christian Peters (peters77)](https://github.com/peters77)
 - [Pepe Phillips (pepephillips)](https://github.com/pepephillips)
 - [Ghislain Picard (ghislainp)](https://github.com/ghislainp)
-- [Simon R. Proud (simonrp84)](https://github.com/simonrp84)
+- [Simon Proud (simon-sat)](https://github.com/simon-sat)
 - [Martin Radenz (martin-rdz)](https://github.com/martin-rdz)
 - [Lars Ørum Rasmussen (loerum)](https://github.com/loerum)
 - [Martin Raspaud (mraspaud)](https://github.com/mraspaud)

--- a/satpy/etc/readers/slstr_l1b.yaml
+++ b/satpy/etc/readers/slstr_l1b.yaml
@@ -57,19 +57,19 @@ reader:
 file_types:
     esa_l1b_refl:
         file_reader: !!python/name:satpy.readers.slstr_l1b.NCSLSTR1B
-        file_patterns: ['{mission_id:3s}_SL_{processing_level:1s}_{datatype_id:_<6s}_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{creation_time:%Y%m%dT%H%M%S}_{duration:4d}_{cycle:3d}_{relative_orbit:3d}_{frame:4s}_{centre:3s}_{mode:1s}_{timeliness:2s}_{collection:3s}.SEN3/{dataset_name}_radiance_{stripe:1s}{view:1s}.nc']
+        file_patterns: ['{mission_id:3s}_SL_{processing_level:1s}_{datatype_id:_<6s}_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{creation_time:%Y%m%dT%H%M%S}_{duration:4d}_{cycle:3d}_{relative_orbit:3d}_{frame:4s}_{centre:3s}_{mode:1s}_{timeliness:2s}_{baseline:3d}.SEN3/{dataset_name}_radiance_{stripe:1s}{view:1s}.nc']
     esa_l1b_tir:
         file_reader: !!python/name:satpy.readers.slstr_l1b.NCSLSTR1B
-        file_patterns: ['{mission_id:3s}_SL_{processing_level:1s}_{datatype_id:_<6s}_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{creation_time:%Y%m%dT%H%M%S}_{duration:4d}_{cycle:3d}_{relative_orbit:3d}_{frame:4s}_{centre:3s}_{mode:1s}_{timeliness:2s}_{collection:3s}.SEN3/{dataset_name}_BT_{stripe:1s}{view:1s}.nc']
+        file_patterns: ['{mission_id:3s}_SL_{processing_level:1s}_{datatype_id:_<6s}_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{creation_time:%Y%m%dT%H%M%S}_{duration:4d}_{cycle:3d}_{relative_orbit:3d}_{frame:4s}_{centre:3s}_{mode:1s}_{timeliness:2s}_{baseline:3d}.SEN3/{dataset_name}_BT_{stripe:1s}{view:1s}.nc']
     esa_angles:
         file_reader: !!python/name:satpy.readers.slstr_l1b.NCSLSTRAngles
-        file_patterns: ['{mission_id:3s}_SL_{processing_level:1s}_{datatype_id:_<6s}_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{creation_time:%Y%m%dT%H%M%S}_{duration:4d}_{cycle:3d}_{relative_orbit:3d}_{frame:4s}_{centre:3s}_{mode:1s}_{timeliness:2s}_{collection:3s}.SEN3/geometry_t{view:1s}.nc']
+        file_patterns: ['{mission_id:3s}_SL_{processing_level:1s}_{datatype_id:_<6s}_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{creation_time:%Y%m%dT%H%M%S}_{duration:4d}_{cycle:3d}_{relative_orbit:3d}_{frame:4s}_{centre:3s}_{mode:1s}_{timeliness:2s}_{baseline:3d}.SEN3/geometry_t{view:1s}.nc']
     esa_geo:
         file_reader: !!python/name:satpy.readers.slstr_l1b.NCSLSTRGeo
-        file_patterns: ['{mission_id:3s}_SL_{processing_level:1s}_{datatype_id:_<6s}_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{creation_time:%Y%m%dT%H%M%S}_{duration:4d}_{cycle:3d}_{relative_orbit:3d}_{frame:4s}_{centre:3s}_{mode:1s}_{timeliness:2s}_{collection:3s}.SEN3/geodetic_{stripe:1s}{view:1s}.nc']
+        file_patterns: ['{mission_id:3s}_SL_{processing_level:1s}_{datatype_id:_<6s}_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{creation_time:%Y%m%dT%H%M%S}_{duration:4d}_{cycle:3d}_{relative_orbit:3d}_{frame:4s}_{centre:3s}_{mode:1s}_{timeliness:2s}_{baseline:3d}.SEN3/geodetic_{stripe:1s}{view:1s}.nc']
     esa_l1b_flag:
         file_reader: !!python/name:satpy.readers.slstr_l1b.NCSLSTRFlag
-        file_patterns: ['{mission_id:3s}_SL_{processing_level:1s}_{datatype_id:_<6s}_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{creation_time:%Y%m%dT%H%M%S}_{duration:4d}_{cycle:3d}_{relative_orbit:3d}_{frame:4s}_{centre:3s}_{mode:1s}_{timeliness:2s}_{collection:3s}.SEN3/flags_{stripe:1s}{view:1s}.nc']
+        file_patterns: ['{mission_id:3s}_SL_{processing_level:1s}_{datatype_id:_<6s}_{start_time:%Y%m%dT%H%M%S}_{end_time:%Y%m%dT%H%M%S}_{creation_time:%Y%m%dT%H%M%S}_{duration:4d}_{cycle:3d}_{relative_orbit:3d}_{frame:4s}_{centre:3s}_{mode:1s}_{timeliness:2s}_{baseline:3d}.SEN3/flags_{stripe:1s}{view:1s}.nc']
 
 datasets:
   longitude:

--- a/satpy/readers/slstr_l1b.py
+++ b/satpy/readers/slstr_l1b.py
@@ -198,11 +198,8 @@ class NCSLSTR1B(BaseFileHandler):
                 self.view != key["view"].name):
             return
         logger.debug("Reading %s.", key["name"])
-        if key["calibration"] == "brightness_temperature":
-            variable = self.nc["{}_BT_{}{}".format(self.channel, self.stripe, self.view[0])]
-        else:
-chan_type = "BT" if key["calibration"] == "brightness_temperature" else "radiance"
-variable = self.nc[f"{self.channel}_{chan_type}_{self.stripe}{self.view[0]}"]
+        chan_type = "BT" if key["calibration"] == "brightness_temperature" else "radiance"
+        variable = self.nc[f"{self.channel}_{chan_type}_{self.stripe}{self.view[0]}"]
         # Processing baseline version 005 and above already include the radiance adjustment factor
         # Therefore, unless user supplies their own, do not apply here.
         if self.baseline < 5 or self.usercalib is not None:

--- a/satpy/readers/slstr_l1b.py
+++ b/satpy/readers/slstr_l1b.py
@@ -201,7 +201,8 @@ class NCSLSTR1B(BaseFileHandler):
         if key["calibration"] == "brightness_temperature":
             variable = self.nc["{}_BT_{}{}".format(self.channel, self.stripe, self.view[0])]
         else:
-            variable = self.nc["{}_radiance_{}{}".format(self.channel, self.stripe, self.view[0])]
+chan_type = "BT" if key["calibration"] == "brightness_temperature" else "radiance"
+variable = self.nc[f"{self.channel}_{chan_type}_{self.stripe}{self.view[0]}"]
         # Processing baseline version 005 and above already include the radiance adjustment factor
         # Therefore, unless user supplies their own, do not apply here.
         if self.baseline < 5 or self.usercalib is not None:

--- a/satpy/readers/slstr_l1b.py
+++ b/satpy/readers/slstr_l1b.py
@@ -138,6 +138,7 @@ class NCSLSTR1B(BaseFileHandler):
                                   chunks={"columns": CHUNK_SIZE,
                                           "rows": CHUNK_SIZE})
         self.nc = self.nc.rename({"columns": "x", "rows": "y"})
+        self.baseline = filename_info["baseline"]
         self.channel = filename_info["dataset_name"]
         self.stripe = filename_info["stripe"]
         views = {"n": "nadir", "o": "oblique"}
@@ -201,7 +202,12 @@ class NCSLSTR1B(BaseFileHandler):
             variable = self.nc["{}_BT_{}{}".format(self.channel, self.stripe, self.view[0])]
         else:
             variable = self.nc["{}_radiance_{}{}".format(self.channel, self.stripe, self.view[0])]
-        radiances = self._apply_radiance_adjustment(variable)
+        # Processing baseline version 005 and above already include the radiance adjustment factor
+        # Therefore, unless user supplies their own, do not apply here.
+        if self.baseline < 5 or self.usercalib is not None:
+            radiances = self._apply_radiance_adjustment(variable)
+        else:
+            radiances = variable
         units = variable.attrs["units"]
         if key["calibration"] == "reflectance":
             # TODO take into account sun-earth distance

--- a/satpy/tests/reader_tests/test_slstr_l1b.py
+++ b/satpy/tests/reader_tests/test_slstr_l1b.py
@@ -182,7 +182,7 @@ class TestSLSTRReader(TestSLSTRL1B):
                                 stripe="a", view="nadir", resolution=500)
         filename_info = {"mission_id": "S3A", "dataset_name": "foo",
                          "start_time": 0, "end_time": 0,
-                         "stripe": "a", "view": "n"}
+                         "stripe": "a", "view": "n", "baseline":4}
         test = NCSLSTR1B("somedir/S1_radiance_an.nc", filename_info, "c")
         assert test.view == "nadir"
         assert test.stripe == "a"
@@ -195,7 +195,7 @@ class TestSLSTRReader(TestSLSTRL1B):
 
         filename_info = {"mission_id": "S3A", "dataset_name": "foo",
                          "start_time": 0, "end_time": 0,
-                         "stripe": "c", "view": "o"}
+                         "stripe": "c", "view": "o", "baseline": 4}
         test = NCSLSTR1B("somedir/S1_radiance_co.nc", filename_info, "c")
         assert test.view == "oblique"
         assert test.stripe == "c"
@@ -207,7 +207,7 @@ class TestSLSTRReader(TestSLSTRL1B):
 
         filename_info = {"mission_id": "S3A", "dataset_name": "foo",
                          "start_time": 0, "end_time": 0,
-                         "stripe": "a", "view": "n"}
+                         "stripe": "a", "view": "n", "baseline": 4}
         test = NCSLSTRGeo("somedir/geometry_an.nc", filename_info, "c")
         test.get_dataset(ds_id, dict(filename_info, **{"file_key": "latitude_{stripe:1s}{view:1s}"}))
         assert test.start_time == good_start
@@ -246,7 +246,7 @@ class TestSLSTRCalibration(TestSLSTRL1B):
                             stripe="a", view="nadir")
         filename_info = {"mission_id": "S3A", "dataset_name": "foo",
                          "start_time": 0, "end_time": 0,
-                         "stripe": "a", "view": "n"}
+                         "stripe": "a", "view": "n", "baseline": 4}
 
         test = NCSLSTR1B("somedir/S1_radiance_co.nc", filename_info, "c")
         # Check warning is raised if we don't have calibration
@@ -267,6 +267,29 @@ class TestSLSTRCalibration(TestSLSTRL1B):
         np.testing.assert_allclose(data.values,
                                    self.base_data * CHANCALIB_FACTORS["S5_nadir"])
 
+
+    @mock.patch("satpy.readers.slstr_l1b.xr")
+    def test_apply_radiance_adjustment_called(self, xr_):
+        """Test radiance adjustment with old processing baselines."""
+        xr_.open_dataset.return_value = self.fake_dataset
+
+        ds_id = make_dataid(name="S5", calibration="radiance",
+                            stripe="a", view="nadir")
+        filename_info = {"mission_id": "S3A", "dataset_name": "S5",
+                         "start_time": 0, "end_time": 0,
+                         "stripe": "a", "view": "n", "baseline": 5}
+
+        test = NCSLSTR1B("somedir/S5_radiance_co.nc", filename_info, "c")
+        with mock.patch.object(test, "_apply_radiance_adjustment", wraps=test._apply_radiance_adjustment) as mock_apply:
+            test.get_dataset(ds_id, dict(filename_info, **{"file_key": "S5"}))
+            mock_apply.assert_not_called()
+
+        filename_info["baseline"] = 4
+        test = NCSLSTR1B("somedir/S5_radiance_co.nc", filename_info, "c")
+        with mock.patch.object(test, "_apply_radiance_adjustment", wraps=test._apply_radiance_adjustment) as mock_apply:
+            test.get_dataset(ds_id, dict(filename_info, **{"file_key": "S5"}))
+            mock_apply.assert_called()
+
     @mock.patch("satpy.readers.slstr_l1b.xr")
     @mock.patch("satpy.readers.slstr_l1b.da")
     def test_reflectance_calibration(self, da_, xr_):
@@ -275,7 +298,7 @@ class TestSLSTRCalibration(TestSLSTRL1B):
         da_.map_blocks.return_value = self.rad / 100.
         filename_info = {"mission_id": "S3A", "dataset_name": "S5",
                          "start_time": 0, "end_time": 0,
-                         "stripe": "a", "view": "n"}
+                         "stripe": "a", "view": "n", "baseline": 4}
         ds_id = make_dataid(name="S5", calibration="reflectance", stripe="a", view="nadir")
         test = NCSLSTR1B("somedir/S1_radiance_an.nc", filename_info, "c")
         data = test.get_dataset(ds_id, dict(filename_info, **{"file_key": "S5"}))
@@ -314,7 +337,7 @@ class TestSLSTRAngles(TestSLSTRL1B):
         ds_id = make_dataid(name="solar_azimuth_angle", view="nadir")
         filename_info = {"mission_id": "S3A", "dataset_name": "solar_azimuth_angle",
                          "start_time": 0, "end_time": 0,
-                         "stripe": "t", "view": "n"}
+                         "stripe": "t", "view": "n", "baseline": 4}
 
         test = NCSLSTRAngles("somedir/geometry_tn.nc", filename_info, "c")
         data = test.get_dataset(ds_id, dict(filename_info, **{"file_key": "solar_azimuth_tn"}))


### PR DESCRIPTION
As discussed in #3417, the new SLSTR processing baseline applies the radiance adjustment factors by default rather than expecting the user to do so themselves. Therefore, data processed with satpy is "double-corrected", as satpy automatically applies these coefficients also.

This PR updates the SLSTR reader to intelligently apply the adjustment factors when an old processing baseline is detected, but not to apply with the latest baseline.

 - [ ] Closes #3417 
 - [ ] Tests added 
 - [ ] Fully documented
