### PR TITLE
Report pytroll dependencies in check_satpy

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -117,3 +117,4 @@ The following people have made contributions to this project:
 - [Alexandra Melzer](https://github.com/armelzer)
 - [Francesc Lucas Carbó (cesclc)](https://github.com/cesclc)
 - [Göte Kleringer (Grukank)](https://github.com/Grukank)
+- [Sammy Dabbas (Sammy-Dabbas)](https://github.com/Sammy-Dabbas)

--- a/satpy/tests/test_utils.py
+++ b/satpy/tests/test_utils.py
@@ -286,10 +286,14 @@ class TestCheckSatpy:
 class TestShowVersions:
     """Test the 'show_versions' function."""
 
-    def test_basic_show_versions(self):
+    def test_basic_show_versions(self, capsys):
         """Test 'check_satpy' basic functionality."""
         from satpy.utils import show_versions
         show_versions()
+        out, _ = capsys.readouterr()
+        for package_name in ("pyresample", "pykdtree", "trollimage", "trollsift",
+                             "pycoast", "pydecorate", "python-geotiepoints"):
+            assert f"{package_name}:" in out
 
     def test_show_specific_version(self, capsys):
         """Test 'show_version' works with installed package."""

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -521,11 +521,18 @@ def show_versions(packages=None):
             "gdal",
             "rasterio",
             "pyproj",
+            "pyresample",
+            "pykdtree",
+            "trollimage",
+            "trollsift",
             "netcdf4",
             "h5py",
             "pyhdf",
             "h5netcdf",
             "fsspec",
+            "pycoast",
+            "pydecorate",
+            "python-geotiepoints",
         )
         if packages is None
         else packages


### PR DESCRIPTION
Report the core and optional pytroll dependencies in `show_versions`, which `check_satpy` delegates to: pyresample, pykdtree, trollimage, trollsift, plus the optional pycoast, pydecorate, and python-geotiepoints. python-geotiepoints uses its distribution name so `importlib.metadata.version` resolves it correctly instead of reporting it as not installed.

 - [x] Closes #3116
 - [x] Tests added
 - [x] Fully documented
 - [x] Add your name to `AUTHORS.md` if not there already
