### PR TITLE
Add pyresample, trollimage, trollsift, pykdtree to show_versions/chec…

### DIFF
--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -526,6 +526,10 @@ def show_versions(packages=None):
             "pyhdf",
             "h5netcdf",
             "fsspec",
+            "pyresample",
+            "trollimage",
+            "trollsift",
+            "pykdtree",
         )
         if packages is None
         else packages

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -530,6 +530,9 @@ def show_versions(packages=None):
             "trollimage",
             "trollsift",
             "pykdtree",
+            "pycoast",
+            "pydecorate",
+            "python-geotiepoints",
         )
         if packages is None
         else packages


### PR DESCRIPTION
Adds `pyresample`, `trollimage`, `trollsift`, and `pykdtree` to the package
list checked by `show_versions()` (and therefore `check_satpy()`, which
calls it internally).

- [x] Closes #3116
- [ ] Tests added
- [ ] Fully documented
- [ ] Add your name to `AUTHORS.md` if not there already