### PR TITLE
Ignore None dataset timestamps in Scene bounds

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -117,3 +117,4 @@ The following people have made contributions to this project:
 - [Alexandra Melzer](https://github.com/armelzer)
 - [Francesc Lucas Carbó (cesclc)](https://github.com/cesclc)
 - [Göte Kleringer (Grukank)](https://github.com/Grukank)
+- [sapunyangkut](https://github.com/sapunyangkut)

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -214,7 +214,7 @@ class Scene:
 
         """
         start_times = [data_arr.attrs["start_time"] for data_arr in self.values()
-                       if "start_time" in data_arr.attrs]
+                       if "start_time" in data_arr.attrs and data_arr.attrs["start_time"] is not None]
         if not start_times:
             start_times = self._reader_times("start_time")
         if not start_times:
@@ -231,7 +231,7 @@ class Scene:
 
         """
         end_times = [data_arr.attrs["end_time"] for data_arr in self.values()
-                     if "end_time" in data_arr.attrs]
+                     if "end_time" in data_arr.attrs and data_arr.attrs["end_time"] is not None]
         if not end_times:
             end_times = self._reader_times("end_time")
         if not end_times:

--- a/satpy/tests/scene_tests/test_init.py
+++ b/satpy/tests/scene_tests/test_init.py
@@ -22,6 +22,7 @@ from copy import deepcopy
 from unittest import mock
 
 import pytest
+import xarray as xr
 
 import satpy
 from satpy import Scene
@@ -54,6 +55,32 @@ class TestScene:
         scene = Scene(filenames=["fake1_1.txt"], reader="fake1")
         assert scene.start_time == FAKE_FILEHANDLER_START
         assert scene.end_time == FAKE_FILEHANDLER_END
+
+    @pytest.mark.parametrize(
+        ("property_name", "expected"),
+        [("start_time", FAKE_FILEHANDLER_START), ("end_time", FAKE_FILEHANDLER_END)],
+    )
+    def test_start_end_times_ignore_none_dataset_times(self, property_name, expected):
+        """Test that missing dataset times don't hide valid dataset times."""
+        scene = Scene()
+        scene["timed"] = xr.DataArray([], attrs={
+            "start_time": FAKE_FILEHANDLER_START,
+            "end_time": FAKE_FILEHANDLER_END,
+        })
+        scene["untimed"] = xr.DataArray([], attrs={"start_time": None, "end_time": None})
+
+        assert getattr(scene, property_name) == expected
+
+    def test_start_end_times_fallback_when_dataset_times_are_none(self):
+        """Test reader and None fallbacks when all dataset times are missing."""
+        scene = Scene(filenames=["fake1_1.txt"], reader="fake1")
+        scene["untimed"] = xr.DataArray([], attrs={"start_time": None, "end_time": None})
+        assert scene.start_time == FAKE_FILEHANDLER_START
+        assert scene.end_time == FAKE_FILEHANDLER_END
+
+        scene._readers = {}
+        assert scene.start_time is None
+        assert scene.end_time is None
 
     def test_init_preserve_reader_kwargs(self):
         """Test that the initialization preserves the kwargs."""


### PR DESCRIPTION
## Summary

- ignore `None` dataset timestamps before calculating `Scene.start_time` and `Scene.end_time`
- fall back to reader times when every dataset timestamp is missing
- cover mixed valid/missing timestamps and all-missing fallback behavior

Closes #2883.

## Validation

- focused regression cases: 3 passed on the exact upstream base and patch
- complete scene initialization module: 21 passed on the exact upstream base and patch
- adjacent configuration checks: 2 passed on the exact upstream base and patch
- `git diff --check`, reverse patch validation, and a bounded manual security review passed
- the current publication environment could not recollect pytest because `pathlib_abc` is not installed; no dependencies were installed for this submission

## Checklist

- [x] Closes #2883
- [x] Tests added
- [x] Added `sapunyangkut` to `AUTHORS.md`

## AI assistance disclosure

This change was prepared and tested with OpenAI Codex. It is intentionally opened as a Draft for maintainer review. No automated issue/PR comments or Ready transition will be made.