### PR TITLE
Preserve FCI time units from source files

### DIFF
--- a/satpy/etc/readers/fci_l1c_nc.yaml
+++ b/satpy/etc/readers/fci_l1c_nc.yaml
@@ -778,7 +778,6 @@ datasets:
 
   vis_04_time:
     name: vis_04_time
-    units: s
     sensor: fci
     resolution:
       1000: { file_type: fci_l1c_fdhsi }
@@ -786,7 +785,6 @@ datasets:
 
   vis_05_time:
     name: vis_05_time
-    units: s
     sensor: fci
     resolution:
       1000: { file_type: fci_l1c_fdhsi }
@@ -794,7 +792,6 @@ datasets:
 
   vis_06_time:
     name: vis_06_time
-    units: s
     sensor: fci
     resolution:
       500: { file_type: fci_l1c_hrfi }
@@ -803,7 +800,6 @@ datasets:
 
   vis_08_time:
     name: vis_08_time
-    units: s
     sensor: fci
     resolution:
       1000: { file_type: fci_l1c_fdhsi }
@@ -811,7 +807,6 @@ datasets:
 
   vis_09_time:
     name: vis_09_time
-    units: s
     sensor: fci
     resolution:
       1000: { file_type: fci_l1c_fdhsi }
@@ -819,7 +814,6 @@ datasets:
 
   nir_13_time:
     name: nir_13_time
-    units: s
     sensor: fci
     resolution:
       1000: { file_type: fci_l1c_fdhsi }
@@ -827,7 +821,6 @@ datasets:
 
   nir_16_time:
     name: nir_16_time
-    units: s
     sensor: fci
     resolution:
       1000: { file_type: fci_l1c_fdhsi }
@@ -835,7 +828,6 @@ datasets:
 
   nir_22_time:
     name: nir_22_time
-    units: s
     sensor: fci
     resolution:
       500: { file_type: fci_l1c_hrfi }
@@ -844,7 +836,6 @@ datasets:
 
   ir_38_time:
     name: ir_38_time
-    units: s
     sensor: fci
     resolution:
       1000: { file_type: fci_l1c_hrfi }
@@ -853,7 +844,6 @@ datasets:
 
   wv_63_time:
     name: wv_63_time
-    units: s
     sensor: fci
     resolution:
       2000: { file_type: fci_l1c_fdhsi }
@@ -861,7 +851,6 @@ datasets:
 
   wv_73_time:
     name: wv_73_time
-    units: s
     sensor: fci
     resolution:
       2000: { file_type: fci_l1c_fdhsi }
@@ -869,7 +858,6 @@ datasets:
 
   ir_87_time:
     name: ir_87_time
-    units: s
     sensor: fci
     resolution:
       2000: { file_type: fci_l1c_fdhsi }
@@ -877,7 +865,6 @@ datasets:
 
   ir_97_time:
     name: ir_97_time
-    units: s
     sensor: fci
     resolution:
       2000: { file_type: fci_l1c_fdhsi }
@@ -885,7 +872,6 @@ datasets:
 
   ir_105_time:
     name: ir_105_time
-    units: s
     sensor: fci
     resolution:
       1000: { file_type: fci_l1c_hrfi }
@@ -894,7 +880,6 @@ datasets:
 
   ir_123_time:
     name: ir_123_time
-    units: s
     sensor: fci
     resolution:
       2000: { file_type: fci_l1c_fdhsi }
@@ -902,7 +887,6 @@ datasets:
 
   ir_133_time:
     name: ir_133_time
-    units: s
     sensor: fci
     resolution:
       2000: { file_type: fci_l1c_fdhsi }

--- a/satpy/tests/reader_tests/test_fci_l1c_nc.py
+++ b/satpy/tests/reader_tests/test_fci_l1c_nc.py
@@ -832,6 +832,28 @@ class ModuleTestFCIL1cNcReader:
 class TestFCIL1cNCReader(ModuleTestFCIL1cNcReader):
     """Test FCI L1c NetCDF reader with nominal data."""
 
+    def test_time_units_are_preserved_from_file(self, reader_configs, FakeFCIFileHandlerFDHSI_fixture):
+        """Test that full CF time units from the source file are preserved."""
+        fh_param = FakeFCIFileHandlerFDHSI_fixture
+        reader = _get_reader_with_filehandlers(fh_param["filenames"], reader_configs)
+        file_handler = reader.file_handlers[fh_param["filetype"]][0]
+        expected_units = "seconds since 2000-01-01 00:00:00.0"
+        source_time = xr.DataArray([0.0], attrs={"units": expected_units})
+
+        time_datasets = [(data_id, info) for data_id, info in reader.all_ids.items()
+                         if data_id["name"].endswith("_time")]
+        assert len(time_datasets) == 36
+        assert {data_id["name"] for data_id, _ in time_datasets} == {
+            f"{channel}_time" for channel in LIST_TOTAL_CHANNEL}
+        for data_id, info in time_datasets:
+            loaded_time = source_time.copy()
+            loaded_time.attrs = file_handler._set_and_cleanup_attributes(
+                loaded_time.attrs, info=info)
+            assert loaded_time.attrs["units"] == expected_units
+
+        reflectance_id = reader.get_dataset_key("vis_06", calibration="reflectance", resolution=1000)
+        assert reader.all_ids[reflectance_id]["units"] == "%"
+
     @pytest.mark.parametrize("filenames", [TEST_FILENAMES[filename] for filename in TEST_FILENAMES.keys()])
     def test_file_pattern(self, reader_configs, filenames):
         """Test file pattern matching."""


### PR DESCRIPTION
## Summary

- remove static `s` overrides from FCI time-dataset configuration
- preserve complete CF reference-time units supplied by the source NetCDF file
- cover every generated FCI time dataset while confirming non-time units remain unchanged

- [x] Closes #3349
- [x] Tests added
- [x] Author entry is already included in open Draft #3427; no duplicate `AUTHORS.md` change is made here

## Validation

- preserved task-owned evidence for this exact upstream base and patch: focused regression 1 passed; full FCI reader module 259 passed; adjacent attribute-cleanup coverage 2 passed; ruff and `git diff --check` passed
- current worktree: `git diff --check`, Python byte-compilation of the changed test, and non-constructing YAML syntax parsing passed

The current checkout is not installed as a package, so a fresh pytest collection stops at the repository's generated `satpy.version` import; `ruff` is also unavailable in this environment. No dependency was installed.

## AI assistance disclosure

This patch, tests, commit message, and pull request text were developed and checked with OpenAI Codex assistance. No independent human self-review is claimed; maintainer review is requested before merge.