### PR TITLE
Add pyresample, trollimage, trollsift and pykdtree to show_versions defaults

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -55,6 +55,7 @@ The following people have made contributions to this project:
 - [Przemyslaw Juda (pjuda)](https://github.com/pjuda)
 - [Inderpreet Kaur](https://github.com/ikaur17)
 - [Pouria Khalaj](https://github.com/pkhalaj)
+- [Bilel Khlaifia (khlaifiabilel)](https://github.com/khlaifiabilel)
 - [Janne Kotro (jkotro)](https://github.com/jkotro)
 - [Beke Kremmling (bkremmli)](https://github.com/bkremmli) - Deutscher Wetterdienst
 - [Ralph Kuehn (ralphk11)](https://github.com/ralphk11)

--- a/satpy/utils.py
+++ b/satpy/utils.py
@@ -526,6 +526,10 @@ def show_versions(packages=None):
             "pyhdf",
             "h5netcdf",
             "fsspec",
+            "pyresample",
+            "trollimage",
+            "trollsift",
+            "pykdtree",
         )
         if packages is None
         else packages


### PR DESCRIPTION
﻿Adds the four Pytroll packages requested in #3116 to the default package list of `satpy.utils.show_versions`, so `check_satpy()` output includes them.

Happy to also add `pycoast`, `pydecorate`, and `geotiepoints` here if desired - they were floated in the issue but not confirmed.

 - [x] Closes #3116
 - [ ] Tests added - existing `show_versions`/`check_satpy` tests already exercise the default list
 - [x] Add your name to `AUTHORS.md` if not there already
