### PR TITLE
Fix parallax tests after PROJ 9.8.0/1 updates

### DIFF
--- a/satpy/tests/modifier_tests/test_parallax.py
+++ b/satpy/tests/modifier_tests/test_parallax.py
@@ -657,7 +657,7 @@ class TestParallaxCorrectionModifier:
         cloud_location = {
                 "foroyar": {
                     7500: (197, 202, 152, 172),
-                    15000: (238, 243, 164, 184)},
+                    15000: (239, 244, 165, 185)},
                 "ouagadougou": {
                     7500: (159, 164, 140, 160),
                     15000: (163, 168, 141, 161)}}


### PR DESCRIPTION
The EPSG 4087 was affected by this PROJ PR https://github.com/OSGeo/PROJ/pull/4656 which adds spherical `eqc` formulas. The end result is that one of the grids in the parallax tests shifted north by a bit and made the hardcoded pixel offsets incorrect. Claude offered to make the tests smarter and more flexible, but this fix was simpler. It does require PROJ 9.8+ to pass though.

 - [x] Closes #3441 <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
