### PR TITLE
Add workaround to sphinx-autodoc-typehints warning

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -93,6 +93,16 @@ nitpick_ignore_regex = [
 ]
 autoclass_content = "both"  # append class __init__ docstring to the class docstring
 
+# sphinx-autodoc-typehints executes the body of every ``if TYPE_CHECKING:`` block it finds so the names
+# inside become resolvable, then warns about any statement that will not run. A guard exists precisely so
+# its contents need not be runtime-valid, so third-party guards we do not control routinely trip this:
+# upath imports pydantic, trollsift imports _typeshed, xarray writes TypeVar(bound="DataArray" | Dataset).
+# None are actionable here. Read the Docs builds with ``fail_on_warning: true``, so the warnings would
+# break the build; suppress them there and leave them visible locally, where they cost nothing.
+# See https://github.com/tox-dev/sphinx-autodoc-typehints/issues/741 -- drop this once a release fixes it.
+if os.environ.get("READTHEDOCS") == "True":
+    suppress_warnings = ["sphinx_autodoc_typehints.guarded_import"]
+
 # auto generate reader table from reader config files
 with open("reader_table.rst", mode="w") as f:
     f.write(generate_reader_table())


### PR DESCRIPTION
Remove when https://github.com/tox-dev/sphinx-autodoc-typehints/issues/741 is completely resolved.

The sphinx-autodoc-typehints latest releases got smarter and more advanced at finding types for dependencies of a project (at least that's my understanding). However, this is a problem for us as many of our dependencies have type annotations that are incompatible with the way this sphinx tool parses them. The biggest one is xarray which has syntax in an `if TYPE_CHECKING:` block that is valid for type checkers like mypy but not valid for a normal interpreter. The `sphinx-autodoc-typehints` package parses these blocks as normal python currently and fails to parse xarray's types.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
