### PR TITLE
Fix AWIPS Tiled writer failing if valid_range missing

### DIFF
--- a/satpy/resample/kdtree.py
+++ b/satpy/resample/kdtree.py
@@ -28,6 +28,7 @@ BIL_COORDINATES = {"bilinear_s": ("x1", ),
                    "out_coords_x": ("x2", ),
                    "out_coords_y": ("y2", )}
 
+
 class KDTreeResampler(PRBaseResampler):
     """Resample using a KDTree-based nearest neighbor algorithm.
 

--- a/satpy/writers/awips_tiled.py
+++ b/satpy/writers/awips_tiled.py
@@ -1493,7 +1493,8 @@ class AWIPSTiledWriter(Writer):
     def _get_tile_data_info(self, data_arrs, creation_time, source_name):
         # use the first data array as a "representative" for the group
         ds_info = data_arrs[0].attrs.copy()
-        del ds_info["valid_range"]  # remove variable-specific metadata that may contain dask arrays
+        for possible_dask_attr in ("valid_range", "valid_min", "valid_max"):
+            ds_info.pop(possible_dask_attr, None)  # remove variable-specific metadata that may contain dask arrays
         # we want to use our own creation_time
         ds_info["creation_time"] = creation_time
         if source_name is not None:


### PR DESCRIPTION
While trying to work with MetImage data in the AWIPS tiled writer I got an error because the writer assumed all datasets have a `valid_range` attribute. In MetImage's case it has a valid_min/valid_max. I will make another PR where I'll remove the attributes.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
