### PR TITLE
Remove valid_min/max attributes from MetImage DataArrays

### DIFF
--- a/satpy/readers/core/metimage_nc.py
+++ b/satpy/readers/core/metimage_nc.py
@@ -120,6 +120,10 @@ class METimageNCBaseFileHandler(NetCDF4FileHandler):
         # Manage the attributes of the dataset
         variable.attrs.setdefault("units", None)
 
+        # Remove possibly incorrect attributes
+        for possible_invalid_attr in ("valid_min", "valid_max"):
+            variable.attrs.pop(possible_invalid_attr, None)
+
         variable.attrs.update(dataset_info)
         variable.attrs.update(self._get_global_attributes())
         variable = self._standardize_dims(variable)

--- a/satpy/tests/reader_tests/test_metimage_base_nc.py
+++ b/satpy/tests/reader_tests/test_metimage_base_nc.py
@@ -69,6 +69,8 @@ class TestMETimageNCBaseFileHandler(unittest.TestCase):
             tpw = g1_1.createVariable("tpw", np.float32, dimensions=("num_pixels", "num_lines"))
             tpw[:] = 1.
             tpw.test_attr = "attr"
+            tpw.valid_min = -10.0
+            tpw.valid_max = 10.0
             lon = g1_1.createVariable("longitude",
                                       np.float32,
                                       dimensions=("num_tie_points_act", "num_tie_points_alt"))
@@ -376,6 +378,7 @@ class TestMETimageNCBaseFileHandler(unittest.TestCase):
         assert variable.dims == ("y", "x")
         assert variable.attrs["test_attr"] == "attr"
         assert variable.attrs["units"] is None
+        assert "valid_min" not in variable.attrs
 
         # Checks the correct execution of the get_dataset function with a valid file_key
         # and required calibration and interpolation


### PR DESCRIPTION
The metimage reader(s) don't remove valid_min and valid_max attributes which causes issues for me later in the writers (ex. AWIPS tiled writer). These attributes, once the data is scaled, are no longer valid so there should be no harm removing them...at least I think. An alternative solution would be to scale them just like the data values are scaled so they are in the same unit space.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
