### PR TITLE
Fix Metop-SG-A1 to Metop-SGA1 naming scheme

### DIFF
--- a/satpy/readers/core/metimage.py
+++ b/satpy/readers/core/metimage.py
@@ -19,9 +19,12 @@
 """Utilities for the management of METimage (VII) products."""
 
 PLATFORM_NAME_TRANSLATE = {
-    "SGA1": "Metop-SG-A1",
-    "SGA2": "Metop-SG-A2",
-    "SGA3": "Metop-SG-A3"
+    "SGA1": "Metop-SGA1",
+    "SGA2": "Metop-SGA2",
+    "SGA3": "Metop-SGA3",
+    "D": "Metop-D",
+    "E": "Metop-E",
+    "F": "Metop-F",
 }
 
 # PLANCK COEFFICIENTS FOR CALIBRATION AS DEFINED BY EUMETSAT

--- a/satpy/tests/reader_tests/test_metimage_base_nc.py
+++ b/satpy/tests/reader_tests/test_metimage_base_nc.py
@@ -168,7 +168,7 @@ class TestMETimageNCBaseFileHandler(unittest.TestCase):
                                               hour=17, minute=41, second=17, microsecond=555000)
         assert self.reader.end_time == expected_end_time
 
-        assert self.reader.spacecraft_name == "Metop-SG-A1"
+        assert self.reader.spacecraft_name == "Metop-SGA1"
         # the netCDF instrument attribute is VII, so we hardcode metimage instead
         assert self.reader.sensor == "metimage"
         assert self.reader.ssp_lon is None
@@ -178,14 +178,14 @@ class TestMETimageNCBaseFileHandler(unittest.TestCase):
             "filename": self.test_file_name,
             "start_time": expected_start_time,
             "end_time": expected_end_time,
-            "spacecraft_name": "Metop-SG-A1",
+            "spacecraft_name": "Metop-SGA1",
             "ssp_lon": None,
             "sensor": "metimage",
             "filename_start_time": datetime.datetime(year=2017, month=9, day=20,
                                                      hour=12, minute=30, second=30),
             "filename_end_time": datetime.datetime(year=2017, month=9, day=20,
                                                    hour=18, minute=30, second=50),
-            "platform_name": "Metop-SG-A1",
+            "platform_name": "Metop-SGA1",
             "quality_group": {
                 "duration_of_product": 1.,
                 "duration_of_data_present": 2.,


### PR DESCRIPTION
Also add entries for D/E/F in the hopes that the spacecraft global attribute will be changed when the instrument is operational.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
