### PR TITLE
Update MetImage readers to produce scan-based dask chunks

### DIFF
--- a/satpy/readers/core/metimage.py
+++ b/satpy/readers/core/metimage.py
@@ -15,5 +15,9 @@ C2 = 1.4387863e+4  # [K·µm]
 TIE_POINTS_FACTOR = 8    # Sub-sampling factor of tie points wrt pixel points
 SCAN_ALT_TIE_POINTS = 4  # Number of tie points along the satellite track for each scan
 
+# Number of pixel rows per instrument scan. The tie points of a scan bound
+# ``SCAN_ALT_TIE_POINTS - 1`` intervals of ``TIE_POINTS_FACTOR`` pixels each.
+ROWS_PER_SCAN = (SCAN_ALT_TIE_POINTS - 1) * TIE_POINTS_FACTOR
+
 # MEAN EARTH RADIUS AS DEFINED BY IUGG
 MEAN_EARTH_RADIUS = 6371008.7714  # [m]

--- a/satpy/readers/core/metimage_nc.py
+++ b/satpy/readers/core/metimage_nc.py
@@ -5,13 +5,25 @@
 import datetime as dt
 import logging
 
+import numpy as np
 import xarray as xr
 from geotiepoints.viiinterpolator import tie_points_geo_interpolation, tie_points_interpolation
 
-from satpy.readers.core.metimage import PLATFORM_NAME_TRANSLATE, SCAN_ALT_TIE_POINTS, TIE_POINTS_FACTOR
+from satpy.readers.core.metimage import (
+    PLATFORM_NAME_TRANSLATE,
+    ROWS_PER_SCAN,
+    SCAN_ALT_TIE_POINTS,
+    TIE_POINTS_FACTOR,
+)
 from satpy.readers.core.netcdf import NetCDF4FileHandler
+from satpy.utils import normalize_low_res_chunks
 
 logger = logging.getLogger(__name__)
+
+# Row/column dimension name pairs used by the various METimage products. The
+# equivalent renaming is done by ``METimageNCBaseFileHandler._standardize_dims``.
+PIXEL_DIMS = (("num_lines", "num_pixels"), ("num_points_alt", "num_points_act"))
+TIE_POINT_DIMS = ("num_tie_points_alt", "num_tie_points_act")
 
 
 class METimageNCBaseFileHandler(NetCDF4FileHandler):
@@ -37,6 +49,13 @@ class METimageNCBaseFileHandler(NetCDF4FileHandler):
         """Prepare the class for dataset reading."""
         super().__init__(filename, filename_info, filetype_info, auto_maskandscale=True)
 
+        # Chunk whole rows of pixels so that dask chunks are aligned to the
+        # on-disk chunks and to the scans of the instrument.
+        # Hold on to row_chunks so we can use it for rechunking interpolated arrays later
+        self._row_chunks, chunks = self._chunks_for_file()
+        if chunks:
+            self._xarray_kwargs["chunks"] = chunks
+
         # Saves the orthorectification flag
         self.orthorect = orthorect and filetype_info.get("orthorect", True)
 
@@ -49,12 +68,88 @@ class METimageNCBaseFileHandler(NetCDF4FileHandler):
 
             if self.interpolate:
                 self.longitude, self.latitude = self._perform_geo_interpolation(longitude, latitude)
+                self.longitude = self._rechunk_to_pixel_grid(self.longitude)
+                self.latitude = self._rechunk_to_pixel_grid(self.latitude)
             else:
                 self.longitude, self.latitude = longitude, latitude
 
         except KeyError:
             logger.warning("Cached longitude and/or latitude datasets are not correctly defined in YAML file")
             self.longitude, self.latitude = None, None
+
+    def _chunks_for_file(self):
+        """Determine a scan-aligned, whole-row dask chunk size for each dimension.
+
+        Returns:
+            Tuple of the number of pixel rows per chunk and a mapping of
+            dimension name to chunk size suitable for ``xarray.open_dataset``.
+            Both are ``None`` if the file does not use any known pixel
+            dimension names.
+
+        """
+        dim_sizes = self._collect_dim_sizes()
+        row_chunks = num_rows = None
+        # Map dimension names to chunk sizes
+        chunks = {}
+        # Look through all possible 2D image array dims (L1b or L2)
+        for row_dim, col_dim in PIXEL_DIMS:
+            if row_dim not in dim_sizes or col_dim not in dim_sizes:
+                continue
+            num_rows, num_cols = dim_sizes[row_dim], dim_sizes[col_dim]
+            # Use a single dtype for every variable so that all of them are
+            # chunked the same way regardless of their on-disk dtype.
+            row_chunks = normalize_low_res_chunks(
+                ("auto", -1),
+                (num_rows, num_cols),
+                (ROWS_PER_SCAN, num_cols),
+                (1, 1),
+                np.float32,
+            )[0]
+            chunks[row_dim] = row_chunks
+            chunks[col_dim] = -1
+
+        if row_chunks is None:
+            return None, None
+
+        tie_alt, tie_act = TIE_POINT_DIMS
+        if tie_alt in dim_sizes and tie_act in dim_sizes:
+            # Interpolating tie points produces one pixel chunk per tie point
+            # chunk, so scale the tie point chunks down by the same factor.
+            chunks[tie_alt] = max(row_chunks * dim_sizes[tie_alt] // num_rows, 1)
+            chunks[tie_act] = -1
+
+        return row_chunks, chunks
+
+    def _collect_dim_sizes(self) -> dict[str, int]:
+        """Map dimension name to size for every dimension used by a variable.
+
+        ``NetCDF4FileHandler.collect_dimensions`` does not recurse into groups,
+        so the dimensions of a grouped product are not in ``file_content``.
+        The per-variable shape and dimension entries always are.
+
+        """
+        suffix = "/dimensions"
+        dim_sizes: dict[str, int] = {}
+        for key, dim_names in self.file_content.items():
+            if not key.endswith(suffix):
+                continue
+            shape = self.file_content.get(key[:-len(suffix)] + "/shape")
+            if shape is not None and len(shape) == len(dim_names):
+                dim_sizes.update(zip(dim_names, shape))
+        return dim_sizes
+
+    def _rechunk_to_pixel_grid(self, variable):
+        """Chunk an interpolated variable the same way as the pixel variables.
+
+        Interpolation is done with :meth:`xarray.DataArray.interp`, which
+        divides the interpolated dimension evenly by the number of tie point
+        chunks. That does not respect the scans of the instrument, so the
+        result has to be chunked explicitly to match the pixel variables.
+
+        """
+        if self._row_chunks is None:
+            return variable
+        return variable.chunk({"num_lines": self._row_chunks, "num_pixels": -1})
 
     def _standardize_dims(self, variable):
         """Standardize dims to y, x."""
@@ -85,6 +180,7 @@ class METimageNCBaseFileHandler(NetCDF4FileHandler):
             # If the dataset is marked for interpolation, perform the interpolation from tie points to pixels
             if dataset_info.get("interpolate", False) and self.interpolate:
                 variable = self._perform_interpolation(variable)
+                variable = self._rechunk_to_pixel_grid(variable)
 
             # Perform the calibration if required
             if dataset_info.get("calibration") is not None:
@@ -196,7 +292,7 @@ class METimageNCBaseFileHandler(NetCDF4FileHandler):
             "filename_start_time": self.filename_info["sensing_start_time"],
             "filename_end_time": self.filename_info["sensing_end_time"],
             "platform_name": self.spacecraft_name,
-            "rows_per_scan": 24
+            "rows_per_scan": ROWS_PER_SCAN
         }
 
         # Add a "quality_group" item to the dictionary with all the variables and attributes

--- a/satpy/tests/reader_tests/test_metimage_base_nc.py
+++ b/satpy/tests/reader_tests/test_metimage_base_nc.py
@@ -84,8 +84,10 @@ class TestMETimageNCBaseFileHandler(unittest.TestCase):
             var[:] = [7.0, 8.0]
 
         # Create longitude and latitude "interpolated" arrays
-        interp_longitude = xr.DataArray(np.ones((10, 100)) * 250, name="longitude")
-        interp_latitude = xr.DataArray(np.ones((10, 100)) * 2., name="latitude")
+        interp_longitude = xr.DataArray(np.ones((10, 100)) * 250, name="longitude",
+                                        dims=("num_pixels", "num_lines"))
+        interp_latitude = xr.DataArray(np.ones((10, 100)) * 2., name="latitude",
+                                       dims=("num_pixels", "num_lines"))
         pgi_.return_value = (interp_longitude, interp_latitude)
 
         # Filename info valid for all readers

--- a/satpy/tests/reader_tests/test_metimage_l1b_nc.py
+++ b/satpy/tests/reader_tests/test_metimage_l1b_nc.py
@@ -6,9 +6,6 @@ This version tests the readers for METimage.
 
 
 import datetime
-import os
-import unittest
-import uuid
 
 import dask
 import dask.array as da
@@ -24,8 +21,6 @@ from satpy.readers.core.metimage import (
     TIE_POINTS_FACTOR,
 )
 from satpy.readers.metimage_l1b_nc import METimageL1BNCFileHandler
-
-TEST_FILE = "test_file_vii_l1b_nc.nc"
 
 NUM_SCANS = 25
 NUM_TIE_POINTS_ACT = 10
@@ -107,91 +102,23 @@ def _make_handler(path):
     )
 
 
-class TestMETimageL1bNCFileHandler(unittest.TestCase):
-    """Test the METimageL1BNCFileHandler reader."""
-
-    def setUp(self):
-        """Set up the test."""
-        # Easiest way to test the reader is to create a test netCDF file on the fly
-        # uses a UUID to avoid permission conflicts during execution of tests in parallel
-        self.test_file_name = TEST_FILE + str(uuid.uuid1()) + ".nc"
-        _create_l1b_file(self.test_file_name)
-
-        self.reader = _make_handler(self.test_file_name)
-
-    def tearDown(self):
-        """Remove the previously created test file."""
-        # Catch Windows PermissionError for removing the created test file.
-        try:
-            os.remove(self.test_file_name)
-        except OSError:
-            pass
-
-    def test_calibration_functions(self):
-        """Test the calibration functions."""
-        radiance = np.array([[1.0, 2.0, 5.0], [7.0, 10.0, 20.0]])
-
-        cw = 13.0
-        a = 3.0
-        b = 100.0
-        bt = self.reader._calibrate_bt(radiance, cw, a, b)
-        expected_bt = np.array([[675.04993213, 753.10301462, 894.93149648],
-                                [963.20401882, 1048.95086402, 1270.95546218]])
-        assert np.allclose(bt, expected_bt)
-
-        isi = 2.0
-        refl = self.reader._calibrate_refl(radiance, isi)
-        expected_refl = np.array([[157.07963268, 314.15926536, 785.3981634],
-                                  [1099.55742876, 1570.79632679, 3141.59265359]])
-        assert np.allclose(refl, expected_refl)
-
-    def test_functions(self):
-        """Test the functions."""
-        # Checks that the _perform_orthorectification function is correctly executed
-        variable = xr.DataArray(
-            dims=("num_lines", "num_pixels"),
-            name="test_name",
-            attrs={
-                "key_1": "value_1",
-                "key_2": "value_2"
-            },
-            data=da.from_array(np.ones((NUM_LINES, NUM_PIXELS)))
-        )
-
-        orthorect_variable = self.reader._perform_orthorectification(variable, "data/measurement_data/delta_lat")
-        expected_values = (np.degrees(np.ones((NUM_LINES, NUM_PIXELS)) / MEAN_EARTH_RADIUS)
-                           + np.ones((NUM_LINES, NUM_PIXELS)))
-        assert np.allclose(orthorect_variable.values, expected_values)
-
-        # Checks that the _perform_calibration function is correctly executed in all cases
-        # radiance calibration: return value is simply a copy of the variable
-        return_variable = self.reader._perform_calibration(variable, {"calibration": "radiance"})
-        assert np.all(return_variable == variable)
-
-        # invalid calibration: raises a ValueError
-        with pytest.raises(ValueError, match="Unknown calibration invalid for dataset test"):
-            self.reader._perform_calibration(variable,
-                                             {"calibration": "invalid", "name": "test"})
-
-        # brightness_temperature calibration: checks that the return value is correct
-        calibrated_variable = self.reader._perform_calibration(variable,
-                                                               {"calibration": "brightness_temperature",
-                                                                "chan_thermal_index": 3})
-        expected_values = np.full((NUM_LINES, NUM_PIXELS), 1237.52069907)
-        assert np.allclose(calibrated_variable.values, expected_values)
-
-        # reflectance calibration: checks that the return value is correct
-        calibrated_variable = self.reader._perform_calibration(variable,
-                                                               {"calibration": "reflectance",
-                                                                "wavelength": [0.658, 0.668, 0.678],
-                                                                "chan_solar_index": 2})
-        expected_values = np.full((NUM_LINES, NUM_PIXELS), 104.71975512)
-        assert np.allclose(calibrated_variable.values, expected_values)
+def _make_variable():
+    """Create a dataset of ones with the shape and dims the reader produces."""
+    return xr.DataArray(
+        dims=("num_lines", "num_pixels"),
+        name="test_name",
+        attrs={
+            "key_1": "value_1",
+            "key_2": "value_2"
+        },
+        data=da.ones((NUM_LINES, NUM_PIXELS), chunks=(ROWS_PER_SCAN, NUM_PIXELS))
+    )
 
 
 # NOTE:
-# The tests below use the following fixture, defined in this module:
+# The tests below use the following fixtures, defined in this module:
 #   metimage_l1b_file - path to a small but structurally realistic L1B netCDF file
+#   reader - a METimageL1BNCFileHandler for that file
 
 
 @pytest.fixture
@@ -200,6 +127,87 @@ def metimage_l1b_file(tmp_path):
     path = tmp_path / "metimage_l1b.nc"
     _create_l1b_file(path)
     return path
+
+
+@pytest.fixture
+def reader(metimage_l1b_file):
+    """Create a file handler for a small METimage L1B file."""
+    return _make_handler(metimage_l1b_file)
+
+
+def test_calibrate_bt():
+    """Test the brightness temperature calibration function."""
+    radiance = np.array([[1.0, 2.0, 5.0], [7.0, 10.0, 20.0]])
+
+    bt = METimageL1BNCFileHandler._calibrate_bt(radiance, 13.0, 3.0, 100.0)
+
+    expected_bt = np.array([[675.04993213, 753.10301462, 894.93149648],
+                            [963.20401882, 1048.95086402, 1270.95546218]])
+    np.testing.assert_allclose(bt, expected_bt)
+
+
+def test_calibrate_refl():
+    """Test the reflectance calibration function."""
+    radiance = np.array([[1.0, 2.0, 5.0], [7.0, 10.0, 20.0]])
+
+    refl = METimageL1BNCFileHandler._calibrate_refl(radiance, 2.0)
+
+    expected_refl = np.array([[157.07963268, 314.15926536, 785.3981634],
+                              [1099.55742876, 1570.79632679, 3141.59265359]])
+    np.testing.assert_allclose(refl, expected_refl)
+
+
+def test_perform_orthorectification(reader):
+    """Test that the orthorectification offsets the variable by the delta in degrees."""
+    variable = _make_variable()
+
+    orthorect_variable = reader._perform_orthorectification(variable, "data/measurement_data/delta_lat")
+
+    expected_values = (np.degrees(np.ones((NUM_LINES, NUM_PIXELS)) / MEAN_EARTH_RADIUS)
+                       + np.ones((NUM_LINES, NUM_PIXELS)))
+    np.testing.assert_allclose(orthorect_variable.values, expected_values)
+
+
+def test_radiance_calibration_returns_input(reader):
+    """Test that the radiance calibration returns a copy of the variable."""
+    variable = _make_variable()
+
+    return_variable = reader._perform_calibration(variable, {"calibration": "radiance"})
+
+    xr.testing.assert_equal(return_variable, variable)
+
+
+def test_invalid_calibration_raises(reader):
+    """Test that an unknown calibration raises a ValueError."""
+    variable = _make_variable()
+
+    with pytest.raises(ValueError, match="Unknown calibration invalid for dataset test"):
+        reader._perform_calibration(variable, {"calibration": "invalid", "name": "test"})
+
+
+def test_brightness_temperature_calibration(reader):
+    """Test that the brightness temperature calibration uses the file coefficients."""
+    variable = _make_variable()
+
+    calibrated_variable = reader._perform_calibration(variable,
+                                                      {"calibration": "brightness_temperature",
+                                                       "chan_thermal_index": 3})
+
+    expected_values = np.full((NUM_LINES, NUM_PIXELS), 1237.52069907)
+    np.testing.assert_allclose(calibrated_variable.values, expected_values)
+
+
+def test_reflectance_calibration(reader):
+    """Test that the reflectance calibration uses the file coefficients."""
+    variable = _make_variable()
+
+    calibrated_variable = reader._perform_calibration(variable,
+                                                      {"calibration": "reflectance",
+                                                       "wavelength": [0.658, 0.668, 0.678],
+                                                       "chan_solar_index": 2})
+
+    expected_values = np.full((NUM_LINES, NUM_PIXELS), 104.71975512)
+    np.testing.assert_allclose(calibrated_variable.values, expected_values)
 
 
 # Row chunks the reader is expected to produce for the test file (600 rows of 72 float32 pixels,

--- a/satpy/tests/reader_tests/test_metimage_l1b_nc.py
+++ b/satpy/tests/reader_tests/test_metimage_l1b_nc.py
@@ -10,16 +10,101 @@ import os
 import unittest
 import uuid
 
+import dask
 import dask.array as da
 import numpy as np
 import pytest
 import xarray as xr
 from netCDF4 import Dataset
 
-from satpy.readers.core.metimage import MEAN_EARTH_RADIUS
+from satpy.readers.core.metimage import (
+    MEAN_EARTH_RADIUS,
+    ROWS_PER_SCAN,
+    SCAN_ALT_TIE_POINTS,
+    TIE_POINTS_FACTOR,
+)
 from satpy.readers.metimage_l1b_nc import METimageL1BNCFileHandler
 
 TEST_FILE = "test_file_vii_l1b_nc.nc"
+
+NUM_SCANS = 25
+NUM_TIE_POINTS_ACT = 10
+NUM_LINES = NUM_SCANS * ROWS_PER_SCAN
+NUM_PIXELS = (NUM_TIE_POINTS_ACT - 1) * TIE_POINTS_FACTOR
+NUM_TIE_POINTS_ALT = NUM_SCANS * SCAN_ALT_TIE_POINTS
+
+
+def _create_l1b_file(path, with_tie_points=True):
+    """Write a small METimage L1B file with realistic dimensions and on-disk chunking."""
+    with Dataset(path, "w") as nc:
+        nc.sensing_start_time_utc = "20170920173040.888"
+        nc.sensing_end_time_utc = "20170920174117.555"
+        nc.spacecraft = "SGA1"
+        nc.instrument = "VII"
+
+        data = nc.createGroup("data")
+        data.createDimension("num_chan_solar", 11)
+        data.createDimension("num_chan_thermal", 9)
+        data.createDimension("num_pixels", NUM_PIXELS)
+        data.createDimension("num_lines", NUM_LINES)
+
+        calibration = data.createGroup("calibration_data")
+        for name, dim, size in (("bt_conversion_a", "num_chan_thermal", 9),
+                                ("bt_conversion_b", "num_chan_thermal", 9),
+                                ("channel_cw_thermal", "num_chan_thermal", 9),
+                                ("band_averaged_solar_irradiance", "num_chan_solar", 11)):
+            var = calibration.createVariable(name, np.float32, dimensions=(dim,))
+            var[:] = np.arange(1, size + 1)
+
+        quality = nc.createGroup("quality")
+        quality.createDimension("gap_items", 2)
+        for name in ("duration_of_product", "duration_of_data_present",
+                     "duration_of_data_missing", "duration_of_data_degraded"):
+            quality.createVariable(name, np.double, dimensions=())[:] = 1.0
+        for name in ("gap_start_time_utc", "gap_end_time_utc"):
+            quality.createVariable(name, np.double, dimensions=("gap_items",))[:] = [0.0, 0.0]
+
+        measurement = data.createGroup("measurement_data")
+        # The real files store one full row of pixels per on-disk chunk.
+        radiance = measurement.createVariable("vii_668", np.float32,
+                                              dimensions=("num_lines", "num_pixels"),
+                                              chunksizes=(1, NUM_PIXELS))
+        radiance[:] = np.arange(NUM_LINES * NUM_PIXELS).reshape(NUM_LINES, NUM_PIXELS)
+        delta_lat = measurement.createVariable("delta_lat", np.float32,
+                                               dimensions=("num_lines", "num_pixels"),
+                                               chunksizes=(1, NUM_PIXELS))
+        delta_lat[:] = 1.0
+
+        if not with_tie_points:
+            return
+
+        measurement.createDimension("num_tie_points_act", NUM_TIE_POINTS_ACT)
+        measurement.createDimension("num_tie_points_alt", NUM_TIE_POINTS_ALT)
+        tie_shape = (NUM_TIE_POINTS_ALT, NUM_TIE_POINTS_ACT)
+        tie_dims = ("num_tie_points_alt", "num_tie_points_act")
+        lon = measurement.createVariable("longitude", np.float32, dimensions=tie_dims,
+                                         chunksizes=(1, NUM_TIE_POINTS_ACT))
+        lon[:] = np.linspace(-10.0, 10.0, np.prod(tie_shape)).reshape(tie_shape)
+        lat = measurement.createVariable("latitude", np.float32, dimensions=tie_dims,
+                                         chunksizes=(1, NUM_TIE_POINTS_ACT))
+        lat[:] = np.linspace(40.0, 60.0, np.prod(tie_shape)).reshape(tie_shape)
+        # Not used by the reader (yet), but part of the real product.
+        sza = measurement.createVariable("solar_zenith", np.float32, dimensions=tie_dims,
+                                         chunksizes=(1, NUM_TIE_POINTS_ACT))
+        sza[:] = 25.0
+
+
+def _make_handler(path):
+    return METimageL1BNCFileHandler(
+        filename=str(path),
+        filename_info={
+            "creation_time": datetime.datetime(2017, 9, 22, 22, 40, 10),
+            "sensing_start_time": datetime.datetime(2017, 9, 20, 12, 30, 30),
+            "sensing_end_time": datetime.datetime(2017, 9, 20, 18, 30, 50),
+        },
+        filetype_info={"cached_longitude": "data/measurement_data/longitude",
+                       "cached_latitude": "data/measurement_data/latitude"},
+    )
 
 
 class TestMETimageL1bNCFileHandler(unittest.TestCase):
@@ -30,56 +115,9 @@ class TestMETimageL1bNCFileHandler(unittest.TestCase):
         # Easiest way to test the reader is to create a test netCDF file on the fly
         # uses a UUID to avoid permission conflicts during execution of tests in parallel
         self.test_file_name = TEST_FILE + str(uuid.uuid1()) + ".nc"
+        _create_l1b_file(self.test_file_name)
 
-        with Dataset(self.test_file_name, "w") as nc:
-            # Create data group
-            g1 = nc.createGroup("data")
-
-            # Add dimensions to data group
-            g1.createDimension("num_chan_solar", 11)
-            g1.createDimension("num_chan_thermal", 9)
-            g1.createDimension("num_pixels", 72)
-            g1.createDimension("num_lines", 600)
-
-            # Create calibration_data group
-            g1_1 = g1.createGroup("calibration_data")
-
-            # Add variables to data/calibration_data group
-            bt_a = g1_1.createVariable("bt_conversion_a", np.float32, dimensions=("num_chan_thermal",))
-            bt_a[:] = np.arange(9)
-            bt_b = g1_1.createVariable("bt_conversion_b", np.float32, dimensions=("num_chan_thermal",))
-            bt_b[:] = np.arange(9)
-            cw = g1_1.createVariable("channel_cw_thermal", np.float32, dimensions=("num_chan_thermal",))
-            cw[:] = np.arange(9)
-            isi = g1_1.createVariable("band_averaged_solar_irradiance", np.float32, dimensions=("num_chan_solar",))
-            isi[:] = np.arange(11)
-
-            # Create measurement_data group
-            g1_2 = g1.createGroup("measurement_data")
-
-            # Add dimensions to data/measurement_data group
-            g1_2.createDimension("num_tie_points_act", 10)
-            g1_2.createDimension("num_tie_points_alt", 100)
-
-            # Add variables to data/measurement_data group
-            sza = g1_2.createVariable("solar_zenith", np.float32,
-                                      dimensions=("num_tie_points_alt", "num_tie_points_act"))
-            sza[:] = 25.0
-            delta_lat = g1_2.createVariable("delta_lat", np.float32, dimensions=("num_lines", "num_pixels"))
-            delta_lat[:] = 1.0
-
-        self.reader = METimageL1BNCFileHandler(
-            filename=self.test_file_name,
-            filename_info={
-                "creation_time": datetime.datetime(year=2017, month=9, day=22,
-                                                   hour=22, minute=40, second=10),
-                "sensing_start_time": datetime.datetime(year=2017, month=9, day=20,
-                                                        hour=12, minute=30, second=30),
-                "sensing_end_time": datetime.datetime(year=2017, month=9, day=20,
-                                                      hour=18, minute=30, second=50)
-            },
-            filetype_info={}
-        )
+        self.reader = _make_handler(self.test_file_name)
 
     def tearDown(self):
         """Remove the previously created test file."""
@@ -117,11 +155,12 @@ class TestMETimageL1bNCFileHandler(unittest.TestCase):
                 "key_1": "value_1",
                 "key_2": "value_2"
             },
-            data=da.from_array(np.ones((600, 72)))
+            data=da.from_array(np.ones((NUM_LINES, NUM_PIXELS)))
         )
 
         orthorect_variable = self.reader._perform_orthorectification(variable, "data/measurement_data/delta_lat")
-        expected_values = np.degrees(np.ones((600, 72)) / MEAN_EARTH_RADIUS) + np.ones((600, 72))
+        expected_values = (np.degrees(np.ones((NUM_LINES, NUM_PIXELS)) / MEAN_EARTH_RADIUS)
+                           + np.ones((NUM_LINES, NUM_PIXELS)))
         assert np.allclose(orthorect_variable.values, expected_values)
 
         # Checks that the _perform_calibration function is correctly executed in all cases
@@ -138,7 +177,7 @@ class TestMETimageL1bNCFileHandler(unittest.TestCase):
         calibrated_variable = self.reader._perform_calibration(variable,
                                                                {"calibration": "brightness_temperature",
                                                                 "chan_thermal_index": 3})
-        expected_values = np.full((600, 72), 1101.10413712)
+        expected_values = np.full((NUM_LINES, NUM_PIXELS), 1237.52069907)
         assert np.allclose(calibrated_variable.values, expected_values)
 
         # reflectance calibration: checks that the return value is correct
@@ -146,5 +185,67 @@ class TestMETimageL1bNCFileHandler(unittest.TestCase):
                                                                {"calibration": "reflectance",
                                                                 "wavelength": [0.658, 0.668, 0.678],
                                                                 "chan_solar_index": 2})
-        expected_values = np.full((600, 72), 157.07963268)
+        expected_values = np.full((NUM_LINES, NUM_PIXELS), 104.71975512)
         assert np.allclose(calibrated_variable.values, expected_values)
+
+
+# NOTE:
+# The tests below use the following fixture, defined in this module:
+#   metimage_l1b_file - path to a small but structurally realistic L1B netCDF file
+
+
+@pytest.fixture
+def metimage_l1b_file(tmp_path):
+    """Create a small METimage L1B file."""
+    path = tmp_path / "metimage_l1b.nc"
+    _create_l1b_file(path)
+    return path
+
+
+# Row chunks the reader is expected to produce for the test file (600 rows of 72 float32 pixels,
+# 24 rows per scan) at a few dask "array.chunk-size" settings. The test file is small, so small
+# chunk sizes are needed to get more than one chunk out of it. # The 24KiB case is included
+# because its tie point chunking does not line up with whole scans after interpolation.
+CHUNK_CASES = [
+    ("16KiB", (48,) * 12 + (24,)),
+    ("24KiB", (72,) * 8 + (24,)),
+    ("64KiB", (216, 216, 168)),
+]
+
+# Dataset information as the YAML reader builds it from metimage_l1b_nc.yaml. These cover the
+# three ways a dataset reaches the user: read straight from the file, served from the cached
+# interpolated geolocation, and interpolated from tie points on the fly.
+DATASET_INFOS = [
+    {"name": "vii_668", "file_key": "data/measurement_data/vii_668",
+     "calibration": "radiance", "chan_solar_index": 2},
+    {"name": "lon_pixels", "file_key": "cached_longitude", "standard_name": "longitude"},
+    {"name": "lat_pixels", "file_key": "cached_latitude", "standard_name": "latitude"},
+    {"name": "solar_zenith_angle", "file_key": "data/measurement_data/solar_zenith",
+     "standard_name": "solar_zenith_angle", "interpolate": True},
+]
+
+
+@pytest.mark.parametrize(("chunk_size", "expected_row_chunks"), CHUNK_CASES)
+@pytest.mark.parametrize("dataset_info", DATASET_INFOS, ids=lambda info: info["name"])
+def test_datasets_are_chunked_by_whole_scans(metimage_l1b_file, dataset_info,
+                                             chunk_size, expected_row_chunks):
+    """Test that every dataset keeps whole rows of pixels and is chunked in whole scans."""
+    with dask.config.set({"array.chunk-size": chunk_size}):
+        handler = _make_handler(metimage_l1b_file)
+        variable = handler.get_dataset(None, dataset_info)
+
+    assert variable.chunks == (expected_row_chunks, (NUM_PIXELS,))
+
+
+def test_file_without_tie_points_is_still_chunked(tmp_path):
+    """Test that a file without tie point dimensions still chunks its pixel variables."""
+    path = tmp_path / "metimage_l1b_no_tie_points.nc"
+    _create_l1b_file(path, with_tie_points=False)
+
+    with dask.config.set({"array.chunk-size": "64KiB"}):
+        handler = _make_handler(path)
+        variable = handler.get_dataset(None, DATASET_INFOS[0])
+
+    assert handler.longitude is None
+    assert handler.latitude is None
+    assert variable.chunks == ((216, 216, 168), (NUM_PIXELS,))


### PR DESCRIPTION
I've done this type of change in other readers. The idea is to chunk the data aligned with instrument scans for a couple reasons:

1. Align dask chunks with on-disk file chunks (better loading performance)
2. Align chunks between resolutions/bands/data types. Makes comparisons and compositing have better performance (in theory) as they don't require rechunking.
3. Making chunks scan-based helps some other operations like the EWA resampling where it rechunks to scan boundaries.

This PR includes rewriting the l1b tests to use pytest.

Code was written by Claude AI but reviewed by me. I'm not a huge fan of the refactored tests, but it is also the right move I think since previously a single test was doing a lot of work. I'm tempted to rewrite the calibration logic to be a separate class with coefficients and things passed in so it is easier to test, but that seems like too much for this PR.

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
