### PR TITLE
fix(writers): accept fmt as an alias for to_netcdf format

### DIFF
--- a/satpy/tests/writer_tests/test_cf.py
+++ b/satpy/tests/writer_tests/test_cf.py
@@ -72,6 +72,19 @@ class TestCFWriter:
                 expected_prereq = ("DataQuery(name='hej')")
                 assert f["test-array"].attrs["prerequisites"] == expected_prereq
 
+    def test_save_array_fmt_nc_alias(self):
+        """Test that the ``fmt`` alias for ``format`` works when saving (#2685)."""
+        scn = Scene()
+        start_time = dt.datetime(2018, 5, 30, 10, 0)
+        end_time = dt.datetime(2018, 5, 30, 10, 15)
+        scn["test-array"] = xr.DataArray(da.from_array([1.0, 2.0, 3.0]),
+                                         attrs=dict(start_time=start_time,
+                                                    end_time=end_time))
+        with TempFile() as filename:
+            scn.save_datasets(filename=filename, writer="cf", fmt="nc")
+            with xr.open_dataset(filename) as f:
+                np.testing.assert_array_equal(f["test-array"][:], [1, 2, 3])
+
     def test_save_array_coords(self):
         """Test saving array with coordinates."""
         scn = Scene()

--- a/satpy/writers/cf_writer.py
+++ b/satpy/writers/cf_writer.py
@@ -271,6 +271,13 @@ class CFWriter(Writer):
         # - This kwargs can contain encoding dictionary
         to_netcdf_kwargs = _sanitize_writer_kwargs(to_netcdf_kwargs)
 
+        # Accept ``fmt`` as an alias for xarray's ``format`` kwarg (issue #2685).
+        fmt = to_netcdf_kwargs.pop("fmt", None)
+        if fmt is not None:
+            if "format" in to_netcdf_kwargs and to_netcdf_kwargs["format"] != fmt:
+                raise ValueError("Both 'fmt' and 'format' were specified with different values")
+            to_netcdf_kwargs["format"] = "NETCDF4" if fmt == "nc" else fmt
+
         # If writing grouped netCDF, create an empty "root" netCDF file
         # - Add the global attributes
         # - All groups will be appended in the for loop below


### PR DESCRIPTION
## What

Fixes #2685: `save_datasets(writer='cf', fmt='nc', ...)` raised `TypeError: Dataset.to_netcdf() got an unexpected keyword argument 'fmt'`. The `fmt` kwarg was forwarded verbatim into xarray's `Dataset.to_netcdf()`, which expects `format`, not `fmt`.

## Change

`CFWriter.save_datasets` now pops `fmt` from the forwarded kwargs and passes it through as `format`, mapping the common `'nc'` shorthand to `'NETCDF4'`. Passing both `fmt` and `format` with different values raises a clear error.

## Tests

- New `test_save_array_fmt_nc_alias`: saves with `fmt='nc'` and verifies the file round-trips. Fails on the previous implementation (TypeError; verified) and passes with the fix.
- Full `test_cf.py`: 32 passed. ruff clean.