### PR TITLE
Add file type for OMPS total SO2 (V8TOS) in `omps_edr` reader

### DIFF
--- a/satpy/etc/readers/omps_edr.yaml
+++ b/satpy/etc/readers/omps_edr.yaml
@@ -13,6 +13,10 @@ file_types:
     # Product description: https://www.star.nesdis.noaa.gov/jpss/ozone.php
     file_reader: !!python/name:satpy.readers.omps_edr.EDRFileHandler
     file_patterns: ["V8TOZ-EDR_v{alg_version:d}r{alg_revision:d}_{platform_shortname}_s{start_time:%Y%m%d%H%M%S%f}_e{end_time:%Y%m%d%H%M%S%f}_c{creation_time:%Y%m%d%H%M%S%f}.nc"]
+  omps_total_so2:
+    # Product description: https://www.star.nesdis.noaa.gov/jpss/ozone.php
+    file_reader: !!python/name:satpy.readers.omps_edr.EDRFileHandler
+    file_patterns: ["V8TOS-EDR_v{alg_version:d}r{alg_revision:d}_{platform_shortname}_s{start_time:%Y%m%d%H%M%S%f}_e{end_time:%Y%m%d%H%M%S%f}_c{creation_time:%Y%m%d%H%M%S%f}.nc"]
 
 # all datasets are dynamically determined from 2D variables in the file
 datasets: {}

--- a/satpy/readers/omps_edr.py
+++ b/satpy/readers/omps_edr.py
@@ -20,6 +20,23 @@ of the "ErrorFlag" values.
 By default no filtering is done related to "ErrorFlag". Refer to algorithm
 documentation for more details on the "ErrorFlag" variable.
 
+Negative SO2 Filtering
+^^^^^^^^^^^^^^^^^^^^^^
+
+The Total SO2 files (V8TOS) include column amount variables whose valid range
+includes negative values (retrieval noise around zero). These negative values
+are typically not useful for display or analysis. Passing
+``filter_negative_so2=True`` will set any value below 0 to the fill value (NaN)
+in addition to the normal valid range filtering. At the time of writing the
+affected variables are "s_ColumnamountSO2_PBL", "s_ColumnamountSO2_TRL",
+"s_ColumnamountSO2_TRM", and "s_ColumnamountSO2_STL".
+
+.. code-block:: python
+
+   scn = Scene(reader="omps_edr", filenames=[...], reader_kwargs={"filter_negative_so2": True})
+
+By default no filtering of negative values is done.
+
 """
 
 import logging
@@ -35,20 +52,42 @@ from satpy.readers.core.remote import open_file_or_filename
 LOG = logging.getLogger(__name__)
 
 
+def _rename_unit_attr(attrs: dict) -> dict:
+    """Get a copy of ``attrs`` with the non-standard "Unit" attribute renamed to "units".
+
+    The SO2 variables in the V8TOS files use "Unit" instead of the CF standard
+    "units" used by the rest of the variables.
+
+    """
+    attrs = dict(attrs)
+    unit = attrs.pop("Unit", None)
+    if unit is not None and "units" not in attrs:
+        attrs["units"] = unit
+    return attrs
+
+
 class EDRFileHandler(BaseFileHandler):
     """File handler for NOAA JPSS OMPS EDR files."""
 
     y_dim_name = "nTimes"
     x_dim_name = "nIFOV"
     error_flag_var_name = "ErrorFlag"
+    negative_filter_var_prefix = "s_ColumnamountSO2"
 
     def __init__(
-        self, filename, filename_info, filetype_info, filter_by_error_flag: Sequence[int] | None = None, **kwargs
+        self,
+        filename,
+        filename_info,
+        filetype_info,
+        filter_by_error_flag: Sequence[int] | None = None,
+        filter_negative_so2: bool = False,
+        **kwargs,
     ):
         """Initialize the geo filehandler."""
         super(EDRFileHandler, self).__init__(filename, filename_info, filetype_info)
 
         self.filter_by_error_flag = filter_by_error_flag or []
+        self.filter_negative_so2 = filter_negative_so2
 
         drop_variables = filetype_info.get("drop_variables", None)
         f_obj = open_file_or_filename(self.filename)
@@ -103,7 +142,7 @@ class EDRFileHandler(BaseFileHandler):
     def get_metadata(self, dataset_id, ds_info):
         """Get the metadata."""
         var_path = ds_info.get("file_key", "{}".format(dataset_id["name"]))
-        info = getattr(self.nc[var_path], "attrs", {}).copy()
+        info = _rename_unit_attr(getattr(self.nc[var_path], "attrs", {}))
         info.update(ds_info)
 
         info.update(
@@ -125,6 +164,7 @@ class EDRFileHandler(BaseFileHandler):
         metadata = self.get_metadata(dataset_id, ds_info)
         data_arr = self.nc[var_path]
         data_arr = data_arr.rename({self.y_dim_name: "y", self.x_dim_name: "x"})
+        data_arr.attrs = _rename_unit_attr(data_arr.attrs)
         data_arr = self._mask_invalid(data_arr, metadata)
         data_arr.attrs.update(metadata)
         return data_arr
@@ -141,11 +181,20 @@ class EDRFileHandler(BaseFileHandler):
             ds_info["valid_range"] = valid_range
         if "valid_min" in data_arr.attrs and valid_range is None:
             valid_range = (data_arr.attrs["valid_min"], data_arr.attrs["valid_max"])
+        valid_cond = None
         if valid_range is not None:
+            valid_cond = (valid_range[0] <= data_arr) & (data_arr <= valid_range[1])
+        if self._filters_negative_values(data_arr):
+            neg_cond = data_arr >= 0
+            valid_cond = neg_cond if valid_cond is None else (valid_cond & neg_cond)
+        if valid_cond is not None:
             # NOTE: may modify attrs in place
             fill_value = self._handle_fill_value(data_arr)
-            return data_arr.where((valid_range[0] <= data_arr) & (data_arr <= valid_range[1]), fill_value)
+            return data_arr.where(valid_cond, fill_value)
         return data_arr
+
+    def _filters_negative_values(self, data_arr: xr.DataArray) -> bool:
+        return self.filter_negative_so2 and str(data_arr.name).startswith(self.negative_filter_var_prefix)
 
     def _handle_fill_value(self, data_arr: xr.DataArray) -> Any:
         if "_FillValue" in data_arr.attrs and not np.issubdtype(data_arr.dtype, np.floating):

--- a/satpy/readers/omps_edr.py
+++ b/satpy/readers/omps_edr.py
@@ -79,13 +79,26 @@ class EDRFileHandler(BaseFileHandler):
             "NOAA21": "NOAA-21",
             "NOAA22": "NOAA-22",
             "NOAA23": "NOAA-23",
+            "NOAA-20": "NOAA-20",
+            "NOAA-21": "NOAA-21",
+            "NOAA-22": "NOAA-22",
+            "NOAA-23": "NOAA-23",
+            "J01": "NOAA-20",
+            "J02": "NOAA-21",
+            # J04 will launch before J03
+            "J04": "NOAA-22",
+            "J03": "NOAA-23",
         }
-        return platform_dict[self.nc.platform]
+        if hasattr(self.nc, "platform"):
+            return platform_dict[self.nc.platform]
+        return platform_dict[self.nc.platform_name]
 
     @property
     def sensor_name(self):
         """Get the sensor name."""
-        return self.nc.instrument.lower()
+        if hasattr(self.nc, "instrument"):
+            return self.nc.instrument.lower()
+        return self.nc.instrument_name.lower()
 
     def get_metadata(self, dataset_id, ds_info):
         """Get the metadata."""

--- a/satpy/tests/reader_tests/test_omps_edr.py
+++ b/satpy/tests/reader_tests/test_omps_edr.py
@@ -10,66 +10,139 @@ import xarray as xr
 
 START_TIME1 = datetime.datetime(2025, 1, 1, 0, 0, 0)
 SINGLE_GRAN_SHAPE = (30, 240)
+# location of the negative values in the fake SO2 variables (avoids the "ErrorFlag" row)
+NEGATIVE_ROW = 1
+NUM_NEGATIVES = 5
+# the SO2 variables use the netCDF default float fill value, not the -9999.0 used elsewhere
+SO2_FILL_VALUE = np.float32(-1.2676506e30)
 
 
 def _fake_filename(
-    start_time: datetime.datetime, end_time: datetime.datetime | None = None, prefix: str = "V8TOZ"
+    start_time: datetime.datetime,
+    end_time: datetime.datetime | None = None,
+    prefix: str = "V8TOZ",
+    version: str = "v4r3",
 ) -> str:
     stime_str = f"{start_time:%Y%m%d%H%M%S}0"
     if end_time is None:
         end_time = start_time + datetime.timedelta(seconds=90)
     etime_str = f"{end_time:%Y%m%d%H%M%S}0"
     ctime_str = datetime.datetime.now().strftime("%Y%m%d%H%M%S0")
-    return f"{prefix}-EDR_v4r3_j01_s{stime_str}_e{etime_str}_c{ctime_str}.nc"
+    return f"{prefix}-EDR_{version}_n21_s{stime_str}_e{etime_str}_c{ctime_str}.nc"
+
+
+def _create_base_file(nc, start_time: datetime.datetime, platform: str = "NOAA21") -> tuple:
+    """Add the global attributes and variables common to all OMPS EDR products."""
+    end_time = start_time + datetime.timedelta(seconds=90)
+    rng = np.random.default_rng(12345)
+
+    nc.platform = platform
+    nc.platform_name = "NOAA21"
+    nc.instrument = "OMPS"
+    nc.instrument_name = "OMPS"
+    nc.time_coverage_start = start_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    nc.time_coverage_end = end_time.strftime("%Y-%m-%dT%H:%M:%SZ")
+    nc.start_orbit_number = 43448
+    nc.end_orbit_number = 43448
+
+    shape = SINGLE_GRAN_SHAPE
+    ntimes = nc.createDimension("nTimes", shape[0])
+    nifov = nc.createDimension("nIFOV", shape[1])
+    nwavelength = nc.createDimension("nWavelength", 12)
+    dims = (ntimes, nifov)
+    lon_var = nc.createVariable("Longitude", np.float32, dimensions=dims, fill_value=-9999.0)
+    lon_var.standard_name = "longitude"
+    lon_var.units = "degrees_east"
+    lon_var.valid_range = (-360, 360)
+    lon_var[:] = rng.random(shape).astype(np.float32) * 45.0
+    lat_var = nc.createVariable("Latitude", np.float32, dimensions=dims, fill_value=-9999.0)
+    lat_var.standard_name = "latitude"
+    lat_var.units = "degrees_north"
+    lat_var.valid_range = (-90, 90)
+    lat_var[:] = rng.random(shape).astype(np.float32) * 45.0
+
+    err_flag = nc.createVariable("ErrorFlag", np.int32, dimensions=dims, fill_value=-9999)
+    err_flag.valid_range = (0, 10)
+    err_flag.units = "1"
+    err_data = np.zeros(shape, dtype=np.int32)
+    err_data[0, :10] = np.arange(10, dtype=np.int32)
+    err_flag[:] = err_data
+
+    # non-2D variables that the reader should ignore
+    nvalue = nc.createVariable(
+        "NvalueMeasured", np.float32, dimensions=(ntimes, nifov, nwavelength), fill_value=-9999.0
+    )
+    nvalue.valid_range = (0, 100)
+    nvalue.units = "1"
+    nvalue[:] = rng.random(shape + (12,)).astype(np.float32) * 100
+    wavelengths = nc.createVariable("Wavelengths", np.float32, dimensions=(nwavelength,), fill_value=-9999.0)
+    wavelengths.valid_range = (308, 380)
+    wavelengths.units = "nm"
+    wavelengths[:] = np.linspace(308, 380, 12).astype(np.float32)
+
+    return dims, rng
+
+
+def _create_ozone_variables(nc, dims, rng, o3_units: str = "0.01mm") -> None:
+    """Add the ozone (V8TOZ) variables which are also included in the SO2 (V8TOS) files."""
+    shape = SINGLE_GRAN_SHAPE
+
+    amount_o3 = nc.createVariable("ColumnAmountO3", np.float32, dimensions=dims, fill_value=-9999.0)
+    amount_o3.valid_range = (0, 1000)
+    # the ozone files use "0.01mm" while the SO2 files use "DU" for the same variable
+    amount_o3.units = o3_units
+    amount_o3[:] = rng.random(shape).astype(np.float32) * 1000
+
+    aerosol_idx = nc.createVariable("AerosolIndex", np.float32, dimensions=dims, fill_value=-9999.0)
+    aerosol_idx.valid_range = (-100, 100)
+    aerosol_idx.units = "1"
+    aerosol_idx[:] = rng.random(shape).astype(np.float32) * 200 - 100
+
+    refl331 = nc.createVariable("Reflectivity331", np.float32, dimensions=dims, fill_value=-9999.0)
+    refl331.valid_range = (0, 100)
+    refl331.units = "1"
+    refl331[:] = rng.random(shape).astype(np.float32) * 100
 
 
 def create_v8toz_file(tmp_path: Path, start_time: datetime.datetime) -> Path:
-    """Create a fake file for testing."""
+    """Create a fake total ozone file for testing."""
     from netCDF4 import Dataset
 
     end_time = start_time + datetime.timedelta(seconds=90)
-    filename = tmp_path / _fake_filename(start_time, end_time=end_time, prefix="V8TOZ")
-    rng = np.random.default_rng(12345)
+    filename = tmp_path / _fake_filename(start_time, end_time=end_time, prefix="V8TOZ", version="v4r3")
 
     with Dataset(filename, "w") as nc:
-        nc.platform = "NOAA20"
-        nc.platform_name = "J01"
-        nc.instrument = "OMPS"
-        nc.instrument_name = "OMPS"
-        nc.time_coverage_start = start_time.strftime("%Y-%m-%dT%H:%M:%SZ")
-        nc.time_coverage_end = end_time.strftime("%Y-%m-%dT%H:%M:%SZ")
-        nc.start_orbit_number = 43448
-        nc.end_orbit_number = 43448
+        dims, rng = _create_base_file(nc, start_time, platform="NOAA21")
+        _create_ozone_variables(nc, dims, rng)
 
-        shape = SINGLE_GRAN_SHAPE
-        ntimes = nc.createDimension("nTimes", shape[0])
-        nifov = nc.createDimension("nIFOV", shape[1])
-        lon_var = nc.createVariable("Longitude", np.float32, dimensions=(ntimes, nifov), fill_value=-9999.0)
-        lon_var[:] = rng.random(shape).astype(np.float32) * 45.0
-        lat_var = nc.createVariable("Latitude", np.float32, dimensions=(ntimes, nifov), fill_value=-9999.0)
-        lat_var[:] = rng.random(shape).astype(np.float32) * 45.0
+    return filename
 
-        amount_o3 = nc.createVariable("ColumnAmountO3", np.float32, dimensions=(ntimes, nifov), fill_value=-9999.0)
-        amount_o3.valid_range = (0, 1000)
-        amount_o3.units = "0.01mm"
-        amount_o3[:] = rng.random(shape).astype(np.float32) * 1000
 
-        aerosol_idx = nc.createVariable("AerosolIndex", np.float32, dimensions=(ntimes, nifov), fill_value=-9999.0)
-        aerosol_idx.valid_range = (-100, 100)
-        aerosol_idx.units = "1"
-        aerosol_idx[:] = rng.random(shape).astype(np.float32) * 200 - 100
+def create_v8tos_file(tmp_path: Path, start_time: datetime.datetime) -> Path:
+    """Create a fake total SO2 file for testing."""
+    from netCDF4 import Dataset
 
-        refl331 = nc.createVariable("Reflectivity331", np.float32, dimensions=(ntimes, nifov), fill_value=-9999.0)
-        refl331.valid_range = (0, 1000)
-        refl331.units = "1"
-        refl331[:] = rng.random(shape).astype(np.float32) * 100
+    end_time = start_time + datetime.timedelta(seconds=90)
+    filename = tmp_path / _fake_filename(start_time, end_time=end_time, prefix="V8TOS", version="v4r5")
+    shape = SINGLE_GRAN_SHAPE
 
-        err_flag = nc.createVariable("ErrorFlag", np.int32, dimensions=(ntimes, nifov), fill_value=-9999)
-        err_flag.valid_range = (0, 10)
-        err_flag.units = "1"
-        err_data = np.zeros(shape, dtype=np.int32)
-        err_data[0, :10] = np.arange(10, dtype=np.int32)
-        err_flag[:] = err_data
+    with Dataset(filename, "w") as nc:
+        # the SO2 files use the dashed platform name and include the ozone product variables
+        dims, rng = _create_base_file(nc, start_time, platform="NOAA-21")
+        _create_ozone_variables(nc, dims, rng, o3_units="DU")
+
+        for suffix in ("PBL", "TRL", "TRM", "STL"):
+            so2_var = nc.createVariable(
+                f"s_ColumnamountSO2_{suffix}", np.float32, dimensions=dims, fill_value=SO2_FILL_VALUE
+            )
+            # valid range includes negatives so they are only removed by "filter_negative_so2"
+            so2_var.valid_range = (-300, 1000) if suffix == "PBL" else (-10, 2000)
+            # SO2 variables use a non-standard "Unit" attribute instead of "units"
+            so2_var.Unit = "Dobson"
+            so2_var.without_data = -9999.0
+            so2_data = rng.random(shape).astype(np.float32) * 100
+            so2_data[NEGATIVE_ROW, :NUM_NEGATIVES] = -5.0
+            so2_var[:] = so2_data
 
     return filename
 
@@ -98,13 +171,20 @@ def test_available_datasets(tmp_path):
     assert "Reflectivity331" in avail_datasets
     assert "AerosolIndex" in avail_datasets
     assert "ColumnAmountO3" in avail_datasets
+    # only 2D (nTimes, nIFOV) variables are provided
+    assert "NvalueMeasured" not in avail_datasets
+    assert "Wavelengths" not in avail_datasets
 
 
 @pytest.mark.parametrize(
-    "vars_to_load",
+    ("file_func", "vars_to_load"),
     [
-        ["Reflectivity331", "AerosolIndex", "ColumnAmountO3"],
-        ["Reflectivity331"],
+        (create_v8toz_file, ["Reflectivity331", "AerosolIndex", "ColumnAmountO3"]),
+        (create_v8toz_file, ["Reflectivity331"]),
+        (
+            create_v8tos_file,
+            ["s_ColumnamountSO2_PBL", "s_ColumnamountSO2_TRL", "Reflectivity331", "AerosolIndex", "ColumnAmountO3"],
+        ),
     ],
 )
 @pytest.mark.parametrize(
@@ -116,40 +196,49 @@ def test_available_datasets(tmp_path):
         [0, 1, 2, 3],
     ],
 )
-def test_basic_load(tmp_path, vars_to_load, filter_by_error_flag):
+@pytest.mark.parametrize("filter_negative_so2", [False, True])
+def test_basic_load(tmp_path, file_func, vars_to_load, filter_by_error_flag, filter_negative_so2):
     """Test basic load from multiple files."""
-    one_file = create_v8toz_file(tmp_path, START_TIME1)
-    two_file = create_v8toz_file(tmp_path, START_TIME1 + datetime.timedelta(seconds=90))
-    reader = omps_reader_gen([one_file, two_file], reader_kwargs={"filter_by_error_flag": filter_by_error_flag})
+    one_file = file_func(tmp_path, START_TIME1)
+    two_file = file_func(tmp_path, START_TIME1 + datetime.timedelta(seconds=90))
+    reader_kwargs = {"filter_by_error_flag": filter_by_error_flag, "filter_negative_so2": filter_negative_so2}
+    reader = omps_reader_gen([one_file, two_file], reader_kwargs=reader_kwargs)
     loaded_dict = reader.load(vars_to_load)
     assert len(loaded_dict) == len(vars_to_load)
 
     for var_name in vars_to_load:
-        _check_expected_array(loaded_dict[var_name], num_granules=2, filter_by_error_flag=filter_by_error_flag)
+        _check_expected_array(
+            loaded_dict[var_name],
+            num_granules=2,
+            filter_by_error_flag=filter_by_error_flag,
+            filter_negative_so2=filter_negative_so2,
+        )
 
 
 def _check_expected_array(
-    data_arr: xr.DataArray, num_granules: int = 2, filter_by_error_flag: None | Iterable[int] = None
+    data_arr: xr.DataArray,
+    num_granules: int = 2,
+    filter_by_error_flag: None | Iterable[int] = None,
+    filter_negative_so2: bool = False,
 ) -> None:
     from pyresample.geometry import SwathDefinition
 
     assert data_arr.dims == ("y", "x")
     assert data_arr.shape == (SINGLE_GRAN_SHAPE[0] * num_granules, SINGLE_GRAN_SHAPE[1])
     assert data_arr.dtype.type == np.float32
+    # the non-standard "Unit" attribute of the SO2 variables is renamed to "units"
     assert "units" in data_arr.attrs
+    assert "Unit" not in data_arr.attrs
+    assert data_arr.attrs["platform_name"] == "NOAA-21"
+    assert data_arr.attrs["sensor"] == "omps"
 
     data_np = data_arr.data.compute()
     assert data_np.dtype == data_arr.dtype
-    if not filter_by_error_flag:
-        assert not np.isnan(data_np).any()
-    else:
-        assert not np.isnan(data_np[1:SINGLE_GRAN_SHAPE[0]]).any()
-        assert not np.isnan(data_np[0, 10:]).any()
-        for filt_val in range(10):
-            if filt_val in filter_by_error_flag:
-                assert not np.isnan(data_np[0, filt_val])
-            else:
-                assert np.isnan(data_np[0, filt_val])
+    is_so2 = data_arr.attrs["name"].startswith("s_ColumnamountSO2")
+    expected_nans = _expected_nan_mask(
+        num_granules, filter_by_error_flag, filter_negative_so2 and is_so2
+    )
+    np.testing.assert_array_equal(np.isnan(data_np), expected_nans)
 
     area = data_arr.attrs["area"]
     assert isinstance(area, SwathDefinition)
@@ -157,3 +246,16 @@ def _check_expected_array(
 
     if "valid_range" in data_arr.attrs:
         assert isinstance(data_arr.attrs["valid_range"], list)
+
+
+def _expected_nan_mask(
+    num_granules: int, filter_by_error_flag: None | Iterable[int], expect_negative_filtering: bool
+) -> np.ndarray:
+    """Get the boolean mask of pixels expected to be NaN after all filtering."""
+    gran_mask = np.zeros(SINGLE_GRAN_SHAPE, dtype=bool)
+    if filter_by_error_flag:
+        for filt_val in range(10):
+            gran_mask[0, filt_val] = filt_val not in filter_by_error_flag
+    if expect_negative_filtering:
+        gran_mask[NEGATIVE_ROW, :NUM_NEGATIVES] = True
+    return np.tile(gran_mask, (num_granules, 1))


### PR DESCRIPTION
This PR adds support for the SO2 EDR files for the OMPS reader (`omps_edr`). The basic functionality was easy to add, but getting filtering to do something useful and remove noise took some time. There were differences between what the file says to do: _FillValue/valid_ragne versus other non-CF values versus what the algorithm developer said should be done versus what was actually done on the JSTAR Mapper website to get the data prepared for visualization. More detailed discussion can be found in the Polar2Grid issue related to this (https://github.com/ssec/polar2grid/issues/820). What we landed on was something in between what the algorithm developer said to do and what JSTAR Mapper was doing with IDL code. The basic idea is that there is an `ErrorFlag` variable that can be used for basic quality filtering but for SO2 variables it seems to do very little. The other filtering option is to remove any negative values from the SO2 column amount fields. JSTAR Mapper chooses to remove anything below 1, but we didn't quite agree with remove real values between 0 and 1. Both these types of filtering are off by default in Satpy (we'll the negative filter on by default in P2G).

This PR also rewrites some of the tests for this reader as Claude discovered some inconsistencies with real files and between the Ozone files and the SO2 files.

CC @kathys

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
