### PR TITLE
Change Scene iteration to return DataIDs instead of DataArrays

### DIFF
--- a/doc/source/config.rst
+++ b/doc/source/config.rst
@@ -246,6 +246,45 @@ will download and cache any necessary data files to :ref:`data_dir_setting`
 when needed. If ``False`` then pre-downloaded files will be used, but any
 other files will not be downloaded or checked for validity.
 
+.. _scene_iter_keys_setting:
+
+Scene Iteration Keys
+^^^^^^^^^^^^^^^^^^^^
+
+* **Environment variable**: ``SATPY_SCENE_ITER_KEYS``
+* **YAML/Config Key**: ``scene_iter_keys``
+* **Default**: ``None``
+
+Whether iterating over a :class:`~satpy.scene.Scene` (ex. ``for x in scn``) should
+produce the :class:`~satpy.dataset.dataid.DataID` keys of the datasets it contains.
+Historically a ``Scene`` produced the ``xarray.DataArray`` objects it contained, which
+is inconsistent with the dictionary-like behavior of the rest of the ``Scene``
+interface (``scn["my_data"]``, ``"my_data" in scn``, ``scn.keys()``, ``scn.values()``).
+Starting in Satpy 1.0 iteration will produce ``DataID`` keys instead.
+
+The accepted values are:
+
+* ``None`` (default): Produce ``DataArray`` objects (the historical behavior) and issue
+  a warning that this is going to change.
+* ``True``: Produce ``DataID`` keys. This is the behavior that becomes the default in
+  Satpy 1.0.
+* ``False``: Produce ``DataArray`` objects (the historical behavior) without any
+  warning.
+
+Use :meth:`Scene.values() <satpy.scene.Scene.values>` if you want the ``DataArray``
+objects regardless of this setting; it is unaffected by this option and is the
+recommended replacement for the historical iteration behavior.
+
+When setting this as an environment variable, this should be set with the
+string equivalent of the Python boolean values ``="True"`` or ``="False"``.
+
+.. warning::
+
+    This option exists only to ease the transition. The default becomes ``True`` in
+    Satpy 1.0 and the option will be removed in a later release. After that ``False``
+    will no longer be honored and iterating over a ``Scene`` will always produce
+    ``DataID`` keys.
+
 Sensor Angles Position Preference
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/satpy/_config.py
+++ b/satpy/_config.py
@@ -33,6 +33,7 @@ _CONFIG_DEFAULTS = {
     "data_dir": _satpy_dirs.user_data_dir,
     "demo_data_dir": ".",
     "download_aux": True,
+    "scene_iter_keys": None,
     "sensor_angles_position_preference": "actual",
     "readers": {
         "clip_negative_radiances": False,

--- a/satpy/scene.py
+++ b/satpy/scene.py
@@ -12,6 +12,7 @@ import xarray as xr
 from pyresample.geometry import AreaDefinition, BaseDefinition, CoordinateDefinition, SwathDefinition
 from xarray import DataArray
 
+import satpy
 from satpy.area import get_area_def
 from satpy.composites.config_loader import load_compositor_configs_for_sensors
 from satpy.composites.core import IncompatibleAreas
@@ -22,6 +23,16 @@ from satpy.readers.core.loading import load_readers
 from satpy.utils import convert_remote_files_to_fsspec, get_storage_options_from_reader_kwargs
 
 LOG = logging.getLogger(__name__)
+
+_SCENE_ITER_WARNING = (
+    "Iterating over a Scene currently produces the DataArrays it contains. In Satpy 1.0 this will "
+    "change to produce the DataID keys instead, like a dictionary. Use 'Scene.values()' to keep the "
+    "current behavior, or set 'satpy.config.set(scene_iter_keys=True)' to opt in to the new behavior "
+    "now. Set 'satpy.config.set(scene_iter_keys=False)' to keep the current behavior and silence this "
+    "warning; note that the 'scene_iter_keys' option is temporary and will be removed after Satpy 1.0, "
+    "at which point iteration will always produce DataID keys. See "
+    "https://satpy.readthedocs.io/en/stable/config.html#scene-iteration-keys"
+)
 
 
 def _get_area_resolution(area):
@@ -532,9 +543,26 @@ class Scene:
         return "\n".join(res)
 
     def __iter__(self):
-        """Iterate over the datasets."""
-        for x in self._datasets.values():
-            yield x
+        """Iterate over the :class:`~satpy.dataset.dataid.DataID` keys of the datasets in this Scene.
+
+        .. warning::
+
+            Historically this iterated over the ``DataArray`` objects contained in the
+            Scene. Starting in Satpy 1.0 it will iterate over the
+            :class:`~satpy.dataset.dataid.DataID` keys instead, like a dictionary.
+            Which behavior is used can be controlled during the transition with the
+            :ref:`scene_iter_keys <scene_iter_keys_setting>` configuration option. That
+            option is itself temporary and will be removed after Satpy 1.0. Use
+            :meth:`values` if you want the ``DataArray`` objects.
+
+        """
+        iter_keys = satpy.config.get("scene_iter_keys")
+        if iter_keys is None:
+            warnings.warn(_SCENE_ITER_WARNING, UserWarning, stacklevel=2)
+            iter_keys = False
+        if iter_keys:
+            return iter(self._datasets.keys())
+        return iter(self._datasets.values())
 
     def iter_by_area(self):
         """Generate datasets grouped by Area.
@@ -542,7 +570,7 @@ class Scene:
         :return: generator of (area_obj, list of dataset objects)
         """
         datasets_by_area = {}
-        for ds in self:
+        for ds in self._datasets.values():
             a = ds.attrs.get("area")
             dsid = DataID.from_dataarray(ds)
             datasets_by_area.setdefault(a, []).append(dsid)

--- a/satpy/tests/reader_tests/test_ascat_l2_soilmoisture_bufr.py
+++ b/satpy/tests/reader_tests/test_ascat_l2_soilmoisture_bufr.py
@@ -147,7 +147,7 @@ class TesitAscatL2SoilmoistureBufr(unittest.TestCase):
         scn = Scene(reader="ascat_l2_soilmoisture_bufr", filenames=[fname])
         assert "surface_soil_moisture" in scn.available_dataset_names()
         scn.load(scn.available_dataset_names())
-        loaded = [dataset.name for dataset in scn]
+        loaded = [dataset.name for dataset in scn.values()]
         assert sorted(loaded) == sorted(scn.available_dataset_names())
 
     @unittest.skipIf(sys.platform.startswith("win"), "'eccodes' not supported on Windows")

--- a/satpy/tests/scene_tests/test_data_access.py
+++ b/satpy/tests/scene_tests/test_data_access.py
@@ -1,4 +1,5 @@
 """Unit tests for data access methods and properties of the Scene class."""
+import contextlib
 import math
 
 import numpy as np
@@ -6,13 +7,23 @@ import pytest
 import xarray as xr
 from dask import array as da
 
+import satpy
 from satpy import Scene
-from satpy.dataset.dataid import default_id_keys_config
+from satpy.dataset.dataid import DataID, default_id_keys_config
 from satpy.tests.utils import FAKE_FILEHANDLER_END, FAKE_FILEHANDLER_START, make_cid, make_dataid
 
 # NOTE:
 # The following fixtures are not defined in this file, but are used and injected by Pytest:
 # - include_test_etc
+
+
+def _scene_with_three_datasets():
+    """Create a Scene with three simple 1D datasets in it."""
+    scene = Scene()
+    scene["1"] = xr.DataArray(np.arange(5))
+    scene["2"] = xr.DataArray(np.arange(5))
+    scene["3"] = xr.DataArray(np.arange(5))
+    return scene
 
 
 @pytest.mark.usefixtures("include_test_etc")
@@ -54,14 +65,25 @@ class TestDataAccessMethods:
         scene["my_ds"] = xr.DataArray([], attrs={"sensor": added_sensor})
         assert scene.sensor_names == exp_sensors
 
-    def test_iter(self):
-        """Test iteration over the scene."""
-        scene = Scene()
-        scene["1"] = xr.DataArray(np.arange(5))
-        scene["2"] = xr.DataArray(np.arange(5))
-        scene["3"] = xr.DataArray(np.arange(5))
-        for x in scene:
-            assert isinstance(x, xr.DataArray)
+    @pytest.mark.parametrize(
+        ("iter_keys", "exp_type", "exp_deprecated"),
+        [
+            (None, xr.DataArray, True),
+            (False, xr.DataArray, False),
+            (True, DataID, False),
+        ]
+    )
+    def test_iter(self, iter_keys, exp_type, exp_deprecated):
+        """Test iteration over the scene for each 'scene_iter_keys' config value."""
+        scene = _scene_with_three_datasets()
+        exp_objs = list(scene.keys()) if exp_type is DataID else list(scene.values())
+        exp_warning = contextlib.nullcontext()
+        if exp_deprecated:
+            exp_warning = pytest.warns(UserWarning, match="Satpy 1.0")
+        with satpy.config.set(scene_iter_keys=iter_keys), exp_warning:
+            objs = list(scene)
+        assert [type(obj) for obj in objs] == [exp_type] * 3
+        assert all(obj is exp_obj for obj, exp_obj in zip(objs, exp_objs, strict=True))
 
     def test_iter_by_area_swath(self):
         """Test iterating by area on a swath."""

--- a/satpy/tests/writer_tests/test_mitiff.py
+++ b/satpy/tests/writer_tests/test_mitiff.py
@@ -228,10 +228,10 @@ def _get_test_dataset_calibration(bands=6):
                               dims=("y", "x"),
                               attrs={"calibration": "reflectance"})
 
-    data = xr.concat(scene, "bands", coords="minimal")
+    data = xr.concat(scene.values(), "bands", coords="minimal")
     bands = []
     calibration = []
-    for p in scene:
+    for p in scene.values():
         calibration.append(p.attrs["calibration"])
         bands.append(p.attrs["name"])
     data["bands"] = list(bands)
@@ -298,7 +298,7 @@ def _get_test_dataset_calibration_one_dataset(bands=1):
 
     data = scene["4"]
     calibration = []
-    for p in scene:
+    for p in scene.values():
         calibration.append(p.attrs["calibration"])
     new_attrs = {"name": "datasets",
                  "start_time": dt.datetime.now(dt.timezone.utc),


### PR DESCRIPTION
This PR prepares the `Scene.__iter__` method to act more like a dictionary/xarray Dataset/xarray DataTree. Currently iterating over a `Scene` (ex. `for x in scn:`) yield the underlying `DataArray`s rather than the `DataID` keys. This does not match the dict-like container nature of the `Scene`. This was mentioned back in #1419 but is not completely closed by this.

This PR adds a config option to control what behavior Scene iteration should have and includes a deprecation warning. If `None`, the default, then the existing behavior is used but a warning is logged. If the user uses `False` then you get existing behavior but no warning. If `True` then you get the new Satpy 1.0 behavior of DataIDs being yielded.

Claude was used for most of this work.

 - [x] Tests added <!-- for all bug fixes or enhancements -->
 - [x] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
