### PR TITLE
Fix segfault from opening netCDF files once per variable

### DIFF
--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -1,6 +1,7 @@
 """Helpers for reading netcdf-based files."""
 
 import logging
+import os
 from contextlib import suppress
 
 import dask.array as da
@@ -60,7 +61,27 @@ class NetCDF4FileHandler(BaseFileHandler):
     variable, a dask array will be created "manually". This may be useful if
     you have a dataset distributed over many files, such as for FCI. Note
     that the coordinates will be missing in this case. If you use this option,
-    ``xarray_kwargs`` will have no effect.
+    ``xarray_kwargs`` will have no effect (unless ``xarray_open_strategy`` is
+    ``"file_handle"``, see below).
+
+    When variables are read with xarray, ``xarray_open_strategy`` selects how
+    the ``xarray.Dataset`` for a group is created. Every strategy holds the
+    datasets open for the lifetime of this file handler:
+
+    - ``"per_group"`` (default): ``xarray.open_dataset(filename, group=...)``
+      for every group that is accessed. Each call opens the file again and
+      takes its own slot in xarray's global file cache
+      (``xarray.set_options(file_cache_maxsize=...)``, 128 by default).
+    - ``"datatree"``: ``xarray.open_datatree(filename)`` once, opening (and
+      decoding) every group in the file, and serve groups from that tree.
+    - ``"shared_store"``: open the file once as an xarray backend store and
+      derive a child store per accessed group, so all groups share one file
+      cache slot and only the accessed groups are decoded.
+    - ``"file_handle"``: like ``"shared_store"`` but wrap the netCDF4/h5netcdf
+      handle that is already open thanks to ``cache_handle=True`` (required)
+      instead of opening the file again. Variables are then read with xarray
+      rather than being wrapped in a dask array "manually". Note that arrays
+      created this way can't be pickled (e.g. for dask distributed workers).
 
     Args:
         filename (str): File to read.
@@ -72,6 +93,8 @@ class NetCDF4FileHandler(BaseFileHandler):
         cache_handle (bool): Keep files open for lifetime of filehandler.
         engine (str or list of str): The engine to use for reading, either "netcdf4" or "h5netcdf". As a list, will try
             each engine until one works.
+        xarray_open_strategy (str): How to open ``xarray.Dataset`` objects for the groups of the file. One of
+            "per_group" (default), "datatree", "shared_store" or "file_handle". See above.
 
     """
 
@@ -79,15 +102,21 @@ class NetCDF4FileHandler(BaseFileHandler):
     # ``xarray.Dataset`` objects held open for the lifetime of this file
     # handler, keyed by group name. See ``_open_xr_dataset``.
     _open_datasets = None
+    # Backend store or datatree the datasets above are derived from for the
+    # "shared_store"/"file_handle" and "datatree" open strategies.
+    _root_store = None
+    _datatree = None
 
     def __init__(self, filename, filename_info, filetype_info,
                  auto_maskandscale=False, xarray_kwargs=None,
-                 cache_var_size=0, cache_handle=False, engine="netcdf4"):
+                 cache_var_size=0, cache_handle=False, engine="netcdf4",
+                 xarray_open_strategy="per_group"):
         """Initialize object."""
         super().__init__(filename, filename_info, filetype_info)
         self.file_content = {}
         self.cached_file_content = {}
         self.engine = engine
+        self._xarray_open_strategy = _validate_xarray_open_strategy(xarray_open_strategy, cache_handle)
         try:
             self.accessor, file_handle = self.get_accessor_and_filehandle()
         except IOError:
@@ -205,13 +234,18 @@ class NetCDF4FileHandler(BaseFileHandler):
         self.close()
 
     def _close_open_datasets(self):
-        """Close the datasets held open by ``_open_xr_dataset``."""
-        if not self._open_datasets:
-            return
-        for nc in self._open_datasets.values():
+        """Close the datasets held open by ``_open_xr_dataset`` and what they were derived from."""
+        for nc in (self._open_datasets or {}).values():
             with suppress(RuntimeError):
                 nc.close()
-        self._open_datasets.clear()
+        if self._open_datasets:
+            self._open_datasets.clear()
+        for obj in (self._datatree, self._root_store):
+            if obj is not None:
+                with suppress(RuntimeError):
+                    obj.close()
+        self._datatree = None
+        self._root_store = None
 
     def _collect_global_attrs(self, obj):
         """Collect all the global attributes for the provided file object."""
@@ -294,7 +328,7 @@ class NetCDF4FileHandler(BaseFileHandler):
             group, key = parts
         else:
             group = None
-        if self.file_handle is not None:
+        if self.file_handle is not None and self._xarray_open_strategy != "file_handle":
             val = self._get_var_from_filehandle(group, key)
         else:
             val = self._get_var_from_xr(group, key)
@@ -315,9 +349,39 @@ class NetCDF4FileHandler(BaseFileHandler):
         if self._open_datasets is None:
             self._open_datasets = {}
         if group not in self._open_datasets:
-            self._open_datasets[group] = xr.open_dataset(
-                self.filename, group=group, **self._xarray_kwargs)
+            self._open_datasets[group] = self._open_xr_dataset_for_group(group)
         return self._open_datasets[group]
+
+    def _open_xr_dataset_for_group(self, group):
+        """Open the dataset for ``group`` following ``xarray_open_strategy``."""
+        strategy = self._xarray_open_strategy
+        if strategy == "per_group":
+            return xr.open_dataset(self.filename, group=group, **self._xarray_kwargs)
+        if strategy == "datatree":
+            if self._datatree is None:
+                self._datatree = xr.open_datatree(self.filename, **self._xarray_kwargs)
+            return self._datatree[group or "/"].to_dataset(inherit=False)
+        # "shared_store" and "file_handle": one backend store for the whole
+        # file, child stores share its file manager (and file cache slot).
+        if self._root_store is None:
+            self._root_store = self._create_root_store()
+        store = self._root_store.get_child_store(group) if group else self._root_store
+        kwargs = {key: val for key, val in self._xarray_kwargs.items() if key != "engine"}
+        return xr.open_dataset(store, **kwargs)
+
+    def _create_root_store(self):
+        """Create the xarray backend store of the whole file for the store based open strategies."""
+        from xarray.backends import H5NetCDFStore, NetCDF4DataStore
+
+        store_cls = NetCDF4DataStore if self.accessor.engine == "netcdf4" else H5NetCDFStore
+        if self._xarray_open_strategy == "file_handle":
+            # xarray wraps the already open handle instead of opening the file again
+            return store_cls(self.file_handle)
+        filename = open_file_or_filename(self.filename) if store_cls is H5NetCDFStore else self.filename
+        if isinstance(filename, os.PathLike):
+            # xarray only uses its (cached) file manager for string paths
+            filename = os.fspath(filename)
+        return store_cls.open(filename, mode="r")
 
     def _get_group(self, key, val):
         """Get a group from the netcdf file."""
@@ -389,6 +453,17 @@ class NetCDF4FileHandler(BaseFileHandler):
 
     def _get_object_attrs(self, obj):
         return self.accessor.get_object_attrs(obj)
+
+XARRAY_OPEN_STRATEGIES = ("per_group", "datatree", "shared_store", "file_handle")
+
+
+def _validate_xarray_open_strategy(strategy, cache_handle):
+    if strategy not in XARRAY_OPEN_STRATEGIES:
+        raise ValueError(f"Unknown xarray_open_strategy {strategy!r}, expected one of {XARRAY_OPEN_STRATEGIES}")
+    if strategy == "file_handle" and not cache_handle:
+        raise ValueError("xarray_open_strategy='file_handle' requires cache_handle=True")
+    return strategy
+
 
 def _compose_replacement_names(variable_name_replacements, var, variable_names):
     for key in variable_name_replacements:

--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -370,6 +370,11 @@ class NetCDF4FileHandler(BaseFileHandler):
         v = self.file_content[var_name]
         if isinstance(v, xr.DataArray):
             val = v
+        elif self.file_handle is None and self.accessor.is_variable(v):
+            # The variable object belongs to the file handle that was closed
+            # at the end of ``__init__`` (``cache_handle=False``) and can't be
+            # read from anymore. Read the data through xarray instead.
+            val = self[var_name].load()
         else:
             try:
                 val = get_data_as_xarray(v)

--- a/satpy/readers/core/netcdf.py
+++ b/satpy/readers/core/netcdf.py
@@ -41,9 +41,11 @@ class NetCDF4FileHandler(BaseFileHandler):
 
         wrapper["/attrs"]
 
-    Note that loading datasets requires reopening the original file
-    (unless those datasets are cached, see below), but to get just the
-    shape of the dataset append "/shape" to the item string:
+    Note that loading datasets requires opening the original file with
+    ``xarray`` (unless those datasets are cached, see below). That dataset is
+    then held open for the lifetime of this file handler; call ``close`` to
+    release it sooner. To get just the shape of the dataset append "/shape" to
+    the item string:
 
         wrapper["group/subgroup/var_name/shape"]
 
@@ -74,6 +76,9 @@ class NetCDF4FileHandler(BaseFileHandler):
     """
 
     file_handle = None
+    # ``xarray.Dataset`` objects held open for the lifetime of this file
+    # handler, keyed by group name. See ``_open_xr_dataset``.
+    _open_datasets = None
 
     def __init__(self, filename, filename_info, filetype_info,
                  auto_maskandscale=False, xarray_kwargs=None,
@@ -183,11 +188,30 @@ class NetCDF4FileHandler(BaseFileHandler):
                 variable_names.append(var)
         return variable_names
 
-    def __del__(self):
-        """Delete the file handler."""
+    def close(self):
+        """Close every file object this file handler is holding open.
+
+        Called automatically when the file handler is deleted. Call it directly
+        to release the file before then, for example to write to it.
+
+        """
         if self.file_handle is not None:
             with suppress(RuntimeError):
                 self.file_handle.close()
+        self._close_open_datasets()
+
+    def __del__(self):
+        """Delete the file handler."""
+        self.close()
+
+    def _close_open_datasets(self):
+        """Close the datasets held open by ``_open_xr_dataset``."""
+        if not self._open_datasets:
+            return
+        for nc in self._open_datasets.values():
+            with suppress(RuntimeError):
+                nc.close()
+        self._open_datasets.clear()
 
     def _collect_global_attrs(self, obj):
         """Collect all the global attributes for the provided file object."""
@@ -276,29 +300,43 @@ class NetCDF4FileHandler(BaseFileHandler):
             val = self._get_var_from_xr(group, key)
         return val
 
+    def _open_xr_dataset(self, group):
+        """Get the dataset for ``group``, opening and remembering it if needed.
+
+        The dataset is held open for the lifetime of this file handler. Opening
+        and closing it once per variable instead would give every returned lazy
+        array its own ``CachingFileManager``, and every manager its own entry in
+        xarray's global file cache. That cache is an LRU of ``file_cache_maxsize``
+        entries (128 by default), so reading more variables than that starts
+        evicting entries and closing netCDF4 handles that sibling arrays of the
+        same file are still reading through, which segfaults in libhdf5.
+
+        """
+        if self._open_datasets is None:
+            self._open_datasets = {}
+        if group not in self._open_datasets:
+            self._open_datasets[group] = xr.open_dataset(
+                self.filename, group=group, **self._xarray_kwargs)
+        return self._open_datasets[group]
+
     def _get_group(self, key, val):
         """Get a group from the netcdf file."""
         # Full groups are conveniently read with xr even if file_handle is available
-        with xr.open_dataset(self.filename, group=key,
-                             **self._xarray_kwargs) as nc:
-            val = nc
-        return val
+        # Copied so callers can modify metadata without touching the shared dataset.
+        return self._open_xr_dataset(key).copy()
 
     def _get_var_from_xr(self, group, key):
-        with xr.open_dataset(self.filename, group=group,
-                             **self._xarray_kwargs) as nc:
-            val = nc[key]
-            # Even though `chunks` is specified in the kwargs, xarray
-            # uses dask.arrays only for data variables that have at least
-            # one dimension; for zero-dimensional data variables (scalar),
-            # it uses its own lazy loading for scalars.  When those are
-            # accessed after file closure, xarray reopens the file without
-            # closing it again.  This will leave potentially many open file
-            # objects (which may in turn trigger a Segmentation Fault:
-            # https://github.com/pydata/xarray/issues/2954#issuecomment-491221266
-            if not val.chunks:
-                val.load()
-        return val
+        nc = self._open_xr_dataset(group)
+        val = nc[key]
+        # Even though `chunks` is specified in the kwargs, xarray
+        # uses dask.arrays only for data variables that have at least
+        # one dimension; for zero-dimensional data variables (scalar),
+        # it uses its own lazy loading for scalars.  Loading them now keeps
+        # them usable once this file handler and its datasets are gone.
+        if not val.chunks:
+            val.load()
+        # Copied so callers can modify metadata without touching the shared dataset.
+        return val.copy(deep=False)
 
     def _get_var_from_filehandle(self, group, key):
         # Not getting coordinates as this is more work, therefore more

--- a/satpy/tests/reader_tests/test_metimage_base_nc.py
+++ b/satpy/tests/reader_tests/test_metimage_base_nc.py
@@ -222,6 +222,10 @@ class TestMETimageNCBaseFileHandler(unittest.TestCase):
             ),
         ]
 
+        # the readers created in setUp hold the file open for reading
+        self.reader.close()
+        self.reader_2.close()
+
         for start_str, expected_start, end_str, expected_end in time_cases:
             with Dataset(self.test_file_name, "r+") as nc:
                 nc.sensing_start_time_utc = start_str
@@ -238,6 +242,10 @@ class TestMETimageNCBaseFileHandler(unittest.TestCase):
 
     def test_bad_start_end_time(self):
         """Test parsing a bad datetime format."""
+        # the readers created in setUp hold the file open for reading
+        self.reader.close()
+        self.reader_2.close()
+
         with Dataset(self.test_file_name, "r+") as nc:
             nc.sensing_start_time_utc = "201709201730"
             nc.sensing_end_time_utc = "201709201740"

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -266,6 +266,88 @@ class TestNetCDF4FileHandler:
         data2 = file_handler.get_and_cache_npxr("test_group/ds1_f")
         assert np.all(data == data2)
 
+    def test_file_opened_once_per_group(self, netcdf_file, monkeypatch):
+        """Test that reading many variables only opens each group once.
+
+        Opening (and closing) the file for every variable gives each returned
+        lazy array its own entry in xarray's global file cache. Once that LRU
+        cache overflows it closes handles that sibling arrays are still reading
+        through, which segfaults in libhdf5.
+
+        """
+        import xarray as xr
+
+        from satpy.readers.core.netcdf import NetCDF4FileHandler
+
+        groups = []
+        real_open_dataset = xr.open_dataset
+
+        def counting_open_dataset(*args, **kwargs):
+            groups.append(kwargs.get("group"))
+            return real_open_dataset(*args, **kwargs)
+
+        monkeypatch.setattr(xr, "open_dataset", counting_open_dataset)
+        file_handler = NetCDF4FileHandler(netcdf_file, {}, {})
+        for var in ("test_group/ds1_f", "test_group/ds1_i", "ds2_f", "ds2_i", "ds2_s"):
+            for _ in range(3):
+                file_handler[var]
+
+        assert set(groups) == {None, "test_group"}
+        assert len(groups) == 2
+
+    def test_file_cache_does_not_grow_with_variables(self, netcdf_file):
+        """Test that repeated variable access does not fill xarray's file cache."""
+        from xarray.backends.file_manager import FILE_CACHE
+
+        from satpy.readers.core.netcdf import NetCDF4FileHandler
+
+        file_handler = NetCDF4FileHandler(netcdf_file, {}, {})
+        file_handler["ds2_f"]
+        num_cached = len(FILE_CACHE)
+        for _ in range(20):
+            file_handler["ds2_f"]
+            file_handler["ds2_i"]
+
+        assert len(FILE_CACHE) == num_cached
+
+    def test_variable_attrs_are_not_shared(self, netcdf_file):
+        """Test that modifying a returned variable does not affect later reads."""
+        from satpy.readers.core.netcdf import NetCDF4FileHandler
+
+        file_handler = NetCDF4FileHandler(netcdf_file, {}, {})
+        first = file_handler["ds2_f"]
+        first.attrs["test_attr_str"] = "modified"
+        first.attrs["extra_attr"] = "added"
+
+        second = file_handler["ds2_f"]
+        assert second.attrs["test_attr_str"] == "test_string"
+        assert "extra_attr" not in second.attrs
+
+    def test_close_releases_open_datasets(self, netcdf_file):
+        """Test that close() releases the datasets held open for reading."""
+        from satpy.readers.core.netcdf import NetCDF4FileHandler
+
+        file_handler = NetCDF4FileHandler(netcdf_file, {}, {})
+        file_handler["ds2_f"]
+        assert file_handler._open_datasets
+
+        file_handler.close()
+
+        assert not file_handler._open_datasets
+        # the variable is still readable, the file is simply reopened
+        assert file_handler["ds2_f"].shape == (10, 100)
+
+    def test_group_attrs_are_not_shared(self, netcdf_file):
+        """Test that modifying a returned group does not affect later reads."""
+        from satpy.readers.core.netcdf import NetCDF4FileHandler
+
+        file_handler = NetCDF4FileHandler(netcdf_file, {}, {})
+        first = file_handler["test_group"]
+        first.attrs["extra_attr"] = "added"
+
+        second = file_handler["test_group"]
+        assert "extra_attr" not in second.attrs
+
 class TestNetCDF4FsspecFileHandler:
     """Test the remote reading class."""
 

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -361,6 +361,47 @@ class TestNetCDF4FileHandler:
         # the variable is still readable, the file is simply reopened
         assert file_handler["ds2_f"].shape == (10, 100)
 
+    @pytest.mark.parametrize("engine", ["netcdf4", "h5netcdf"])
+    @pytest.mark.parametrize(("strategy", "cache_handle", "exp_new_cache_entries"), [
+        ("per_group", False, 2),
+        ("datatree", False, 1),
+        ("shared_store", False, 1),
+        ("file_handle", True, 0),
+    ])
+    def test_xarray_open_strategies(self, netcdf_file, engine, strategy, cache_handle, exp_new_cache_entries):
+        """Test that every xarray open strategy reads the same data and holds the expected number of files open."""
+        from xarray.backends.file_manager import FILE_CACHE
+
+        from satpy.readers.core.netcdf import NetCDF4FileHandler
+
+        num_cached_before = len(FILE_CACHE)
+        file_handler = NetCDF4FileHandler(netcdf_file, {}, {}, cache_handle=cache_handle, engine=engine,
+                                          xarray_open_strategy=strategy)
+        expected = np.arange(10. * 100).reshape((10, 100))
+        for var_name in ("test_group/ds1_f", "ds2_f"):
+            data = file_handler[var_name]
+            assert data.dims == ("rows", "cols")
+            assert data.attrs["test_attr_str"] == "test_string"
+            np.testing.assert_array_equal(data.values, expected)
+        # a second access must not open anything new
+        file_handler["ds2_i"]
+        assert len(FILE_CACHE) - num_cached_before == exp_new_cache_entries
+
+        file_handler.close()
+        assert len(FILE_CACHE) == num_cached_before
+        assert not file_handler._open_datasets
+        assert file_handler._root_store is None
+        assert file_handler._datatree is None
+
+    def test_invalid_xarray_open_strategy(self, netcdf_file):
+        """Test that unknown or incompatible open strategies are rejected."""
+        from satpy.readers.core.netcdf import NetCDF4FileHandler
+
+        with pytest.raises(ValueError, match="Unknown xarray_open_strategy"):
+            NetCDF4FileHandler(netcdf_file, {}, {}, xarray_open_strategy="magic")
+        with pytest.raises(ValueError, match="requires cache_handle=True"):
+            NetCDF4FileHandler(netcdf_file, {}, {}, cache_handle=False, xarray_open_strategy="file_handle")
+
     def test_group_attrs_are_not_shared(self, netcdf_file):
         """Test that modifying a returned group does not affect later reads."""
         from satpy.readers.core.netcdf import NetCDF4FileHandler

--- a/satpy/tests/reader_tests/test_netcdf_utils.py
+++ b/satpy/tests/reader_tests/test_netcdf_utils.py
@@ -266,6 +266,30 @@ class TestNetCDF4FileHandler:
         data2 = file_handler.get_and_cache_npxr("test_group/ds1_f")
         assert np.all(data == data2)
 
+    @pytest.mark.parametrize("engine", ["netcdf4", "h5netcdf"])
+    @pytest.mark.parametrize(("var_name", "expected"), [
+        ("test_group/ds1_f", np.arange(10. * 100).reshape((10, 100))),
+        ("ds2_s", np.arange(10)),
+        ("ds2_sc", 42),
+    ])
+    def test_get_and_cache_npxr_without_file_handle(self, netcdf_file, engine, var_name, expected):
+        """Test that get_and_cache_npxr() reads variables after the file handle was closed.
+
+        With ``cache_handle=False`` the variable objects collected in
+        ``__init__`` belong to a closed file, so the data has to be read
+        through xarray instead.
+        """
+        import xarray as xr
+
+        from satpy.readers.core.netcdf import NetCDF4FileHandler
+        file_handler = NetCDF4FileHandler(netcdf_file, {}, {}, cache_handle=False, engine=engine)
+
+        data = file_handler.get_and_cache_npxr(var_name)
+        assert isinstance(data, xr.DataArray)
+        assert data.chunks is None
+        np.testing.assert_array_equal(data.values, expected)
+        assert var_name in file_handler.cached_file_content
+
     def test_file_opened_once_per_group(self, netcdf_file, monkeypatch):
         """Test that reading many variables only opens each group once.
 


### PR DESCRIPTION
I was getting a seg fault when processing a large METimage pass. It's getting late here so I had Claude put together a commit with a fix in case anyone wanted to take a look. It isn't noted here but it seems tied to vlen strings (which there is only one in the file) that puts HDF5 into a bad state. I plan on filing an xarray issue tomorrow. Below is Claude's commenting.

**I HAVE NOT REVIEWED THIS YET**

### Claude:

NetCDF4FileHandler opened the file with xarray for every variable and closed it again immediately, returning lazy arrays that reopen it at compute time. Every one of those opens builds its own CachingFileManager, and CachingFileManager._make_key() includes a per-manager id, so no two of them ever share an entry in xarray's global FILE_CACHE. Reading more variables than file_cache_maxsize (128 by default) therefore makes that LRU cache evict and close netCDF4 handles while sibling arrays of the same file are still reading through them, which segfaults in libhdf5.

Keep one xarray.Dataset open per group instead, for the lifetime of the file handler, and hand out copies so callers can still modify metadata. Add a close() method to release the datasets before the file handler is deleted, which the METimage base tests need in order to reopen their test file for writing.


Claude-Session: https://claude.ai/code/session_01TKR5WimPBvwWpVgcJ52TNv

 - [ ] Closes #xxxx <!-- remove if there is no corresponding issue, which should only be the case for minor changes -->
 - [ ] Tests added <!-- for all bug fixes or enhancements -->
 - [ ] Fully documented <!-- remove if this change should not be visible to users, e.g., if it is an internal clean-up, or if this is part of a larger project that will be documented later -->
 - [ ] Add your name to `AUTHORS.md` if not there already
